### PR TITLE
Quick fix context bug

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
@@ -71,6 +71,8 @@ export function useCopilotChat({
   });
 
   // TODO: This is a hack to update the system message with the correct context string.
+  // It's problematic because it's mutating the internal state of the useChat hook by
+  // changing the messages array.
   // Fix this properly by replacing useChat with a custom hook
   messages[0].content = initialMessagesWithContext[0].content;
 

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
@@ -70,6 +70,10 @@ export function useCopilotChat({
     },
   });
 
+  // TODO: This is a hack to update the system message with the correct context string.
+  // Fix this properly by replacing useChat with a custom hook
+  messages[0].content = initialMessagesWithContext[0].content;
+
   const visibleMessages = messages.filter(
     (message) => message.role === "user" || message.role === "assistant",
   );


### PR DESCRIPTION
This fixes a bug where the context is not updated correctly because the `initialMessages` parameter of `useChat` uses these messages only for initialization. Subsequent updates are ignored by useChat.

I verified the bugfix with the WaterBnb and HelloWorld demos- the context was changing as expected.