### PR TITLE
fix: hot reload when dependencies change in dev

### DIFF
--- a/CopilotKit/packages/backend/package.json
+++ b/CopilotKit/packages/backend/package.json
@@ -8,11 +8,13 @@
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "exports": "./dist/index.mjs",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake",
+    "build": "tsup --treeshake --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/backend/tsup.config.ts
+++ b/CopilotKit/packages/backend/tsup.config.ts
@@ -2,10 +2,9 @@ import { defineConfig, Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
   entry: ["src/**/*.{ts,tsx}"],
-  format: ["esm"],
+  format: ["esm", "cjs"],
   dts: true,
   minify: false,
-  clean: true,
   external: [],
   sourcemap: true,
   exclude: [

--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake",
+    "build": "tsup --treeshake --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-core/tsup.config.ts
+++ b/CopilotKit/packages/react-core/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig((options: Options) => ({
   format: ["esm", "cjs"],
   dts: true,
   minify: false,
-  clean: true,
   external: ["react"],
   sourcemap: true,
   exclude: [

--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake",
+    "build": "tsup --treeshake --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/text-insertion-prompt-box/hovering-insertion-prompt-box-core.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/text-insertion-prompt-box/hovering-insertion-prompt-box-core.tsx
@@ -1,5 +1,4 @@
 import useAutosizeTextArea from "../../../hooks/misc/use-autosize-textarea";
-import { MinimalChatGPTMessage } from "../../../types";
 import {
   EditingEditorState,
   Generator_InsertionOrEditingSuggestion,

--- a/CopilotKit/packages/react-textarea/tsup.config.ts
+++ b/CopilotKit/packages/react-textarea/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig((options: Options) => ({
   format: ["esm", "cjs"],
   dts: true,
   minify: false,
-  clean: true,
   external: ["react"],
   sourcemap: true,
   exclude: [

--- a/CopilotKit/packages/react-ui/package.json
+++ b/CopilotKit/packages/react-ui/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake",
+    "build": "tsup --treeshake --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-ui/tsup.config.ts
+++ b/CopilotKit/packages/react-ui/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig((options: Options) => ({
   format: ["esm", "cjs"],
   dts: true,
   minify: false,
-  clean: true,
   external: ["react"],
   sourcemap: true,
   exclude: [

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake",
+    "build": "tsup --treeshake --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/shared/tsup.config.ts
+++ b/CopilotKit/packages/shared/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig((options: Options) => ({
   format: ["esm", "cjs"],
   dts: true,
   minify: false,
-  clean: true,
   external: [],
   sourcemap: true,
   exclude: [


### PR DESCRIPTION
# The Problem
The `dev` script was using the same `tssup.config.ts` script as `build`.

Whenever you'd make a change to any dependency, `clean: true` causes the removal of the entire `dist` folder. This results in a few miliseconds where the dependency cannot be found, enough to cause an error.

# The Fix
Removing `clean: true` from `tsup.config.ts` and specifying it as a `--clean` flag specifically for `build`.