### PR TITLE
fix: import issues related to treeshaking

### DIFF
--- a/CopilotKit/packages/backend/package.json
+++ b/CopilotKit/packages/backend/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup  --clean",
+    "build": "tsup --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/backend/package.json
+++ b/CopilotKit/packages/backend/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake --clean",
+    "build": "tsup  --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup  --clean",
+    "build": "tsup --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake --clean",
+    "build": "tsup  --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake --clean",
+    "build": "tsup --clean --no-splitting",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --clean --no-splitting",
+    "build": "tsup --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-ui/package.json
+++ b/CopilotKit/packages/react-ui/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup  --clean",
+    "build": "tsup --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/react-ui/package.json
+++ b/CopilotKit/packages/react-ui/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake --clean",
+    "build": "tsup  --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup  --clean",
+    "build": "tsup --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "tsup --treeshake --clean",
+    "build": "tsup  --clean",
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",


### PR DESCRIPTION
Still not entirely sure why this only happens with `<CopilotTextarea>`, but seems that removing the tsup `--treeshake` flag solves the issue. There are still type issues that show up in the IDE, will tackle in a separate PR. 