### PR TITLE
Add CopilotTask class

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useCopilotContext } from "@copilotkit/react-core";
+import { CopilotTask } from "@copilotkit/react-core";
 import {
   CopilotKit,
   useMakeCopilotActionable,
@@ -12,6 +14,7 @@ const HelloWorld = () => {
   return (
     <CopilotKit url="/api/copilotkit/openai">
       <CopilotSidebar
+        clickOutsideToClose={false}
         defaultOpen={true}
         labels={{
           title: "Presentation Copilot",
@@ -63,7 +66,25 @@ const Presentation = () => {
     [],
   );
 
-  return <Slide {...state} />;
+  const context = useCopilotContext();
+
+  return (
+    <div className="relative">
+      <Slide {...state} />
+      <button
+        className="absolute bottom-0 left-0 mb-4 ml-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        onClick={async () => {
+          const task = new CopilotTask({
+            instructions: "Make a random slide",
+            context: context,
+          });
+          await task.run();
+        }}
+      >
+        Make random slide
+      </button>
+    </div>
+  );
 };
 
 type SlideProps = {

--- a/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
@@ -67,8 +67,9 @@ const Presentation = () => {
 
   const randomSlideTask = new CopilotTask({
     instructions: "Make a random slide",
-    context: useCopilotContext(),
   });
+
+  const context = useCopilotContext();
 
   const [randomSlideTaskRunning, setRandomSlideTaskRunning] = useState(false);
 
@@ -82,7 +83,7 @@ const Presentation = () => {
         onClick={async () => {
           try {
             setRandomSlideTaskRunning(true);
-            await randomSlideTask.run();
+            await randomSlideTask.run(context);
           } finally {
             setRandomSlideTaskRunning(false);
           }

--- a/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
@@ -66,22 +66,30 @@ const Presentation = () => {
     [],
   );
 
-  const context = useCopilotContext();
+  const randomSlideTask = new CopilotTask({
+    instructions: "Make a random slide",
+    context: useCopilotContext(),
+  });
+
+  const [randomSlideTaskRunning, setRandomSlideTaskRunning] = useState(false);
 
   return (
     <div className="relative">
       <Slide {...state} />
       <button
-        className="absolute bottom-0 left-0 mb-4 ml-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        disabled={randomSlideTaskRunning}
+        className={`absolute bottom-0 left-0 mb-4 ml-4 bg-blue-500 text-white font-bold py-2 px-4 rounded
+        ${randomSlideTaskRunning ? "opacity-50 cursor-not-allowed" : "hover:bg-blue-700"}`}
         onClick={async () => {
-          const task = new CopilotTask({
-            instructions: "Make a random slide",
-            context: context,
-          });
-          await task.run();
+          try {
+            setRandomSlideTaskRunning(true);
+            await randomSlideTask.run();
+          } finally {
+            setRandomSlideTaskRunning(false);
+          }
         }}
       >
-        Make random slide
+        {randomSlideTaskRunning ? "Generating slide..." : "Make random slide"}
       </button>
     </div>
   );

--- a/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/helloworld/page.tsx
@@ -14,7 +14,6 @@ const HelloWorld = () => {
   return (
     <CopilotKit url="/api/copilotkit/openai">
       <CopilotSidebar
-        clickOutsideToClose={false}
         defaultOpen={true}
         labels={{
           title: "Presentation Copilot",

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -115,13 +115,19 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
     [removeElement],
   );
 
-  const getChatCompletionFunctionDescriptions = useCallback(() => {
-    return entryPointsToChatCompletionFunctions(Object.values(entryPoints));
-  }, [entryPoints]);
+  const getChatCompletionFunctionDescriptions = useCallback(
+    (customEntryPoints?: Record<string, AnnotatedFunction<any[]>>) => {
+      return entryPointsToChatCompletionFunctions(Object.values(customEntryPoints || entryPoints));
+    },
+    [entryPoints],
+  );
 
-  const getFunctionCallHandler = useCallback(() => {
-    return entryPointsToFunctionCallHandler(Object.values(entryPoints));
-  }, [entryPoints]);
+  const getFunctionCallHandler = useCallback(
+    (customEntryPoints?: Record<string, AnnotatedFunction<any[]>>) => {
+      return entryPointsToFunctionCallHandler(Object.values(customEntryPoints || entryPoints));
+    },
+    [entryPoints],
+  );
 
   const getDocumentsContext = useCallback(
     (categories: string[]) => {

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -49,8 +49,12 @@ export interface CopilotContextParams {
   entryPoints: Record<string, AnnotatedFunction<any[]>>;
   setEntryPoint: (id: string, entryPoint: AnnotatedFunction<any[]>) => void;
   removeEntryPoint: (id: string) => void;
-  getChatCompletionFunctionDescriptions: () => Function[];
-  getFunctionCallHandler: () => FunctionCallHandler;
+  getChatCompletionFunctionDescriptions: (
+    customEntryPoints?: Record<string, AnnotatedFunction<any[]>>,
+  ) => Function[];
+  getFunctionCallHandler: (
+    customEntryPoints?: Record<string, AnnotatedFunction<any[]>>,
+  ) => FunctionCallHandler;
 
   // text context
   addContext: (context: string, parentId?: string, categories?: string[]) => TreeNodeId;

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -100,6 +100,10 @@ const emptyCopilotContext: CopilotContextParams = {
 
 export const CopilotContext = React.createContext<CopilotContextParams>(emptyCopilotContext);
 
+export function useCopilotContext(): CopilotContextParams {
+  return React.useContext(CopilotContext);
+}
+
 function returnAndThrowInDebug<T>(value: T): T {
   throw new Error("Remember to wrap your app in a `<CopilotKit> {...} </CopilotKit>` !!!");
   return value;

--- a/CopilotKit/packages/react-core/src/context/index.ts
+++ b/CopilotKit/packages/react-core/src/context/index.ts
@@ -1,3 +1,3 @@
-export { CopilotContext } from "./copilot-context";
+export { CopilotContext, useCopilotContext } from "./copilot-context";
 export type { CopilotContextParams } from "./copilot-context";
 export type { CopilotApiConfig } from "./copilot-context";

--- a/CopilotKit/packages/react-core/src/index.tsx
+++ b/CopilotKit/packages/react-core/src/index.tsx
@@ -3,6 +3,7 @@ export * from "./context";
 export * from "./hooks";
 export * from "./types";
 export * from "./openai-assistants";
+export * from "./lib";
 export {
   type FetchChatCompletionParams,
   fetchChatCompletion,

--- a/CopilotKit/packages/react-core/src/lib/copilot-task.ts
+++ b/CopilotKit/packages/react-core/src/lib/copilot-task.ts
@@ -66,6 +66,8 @@ export class CopilotTask {
       console.warn(
         "You provided both a context and functions to CopilotTask. The functions will be ignored.",
       );
+    } else if (!this.context && !config.functions?.length) {
+      throw new Error("No context or functions provided for CopilotTask");
     }
 
     if (this.context) {
@@ -82,15 +84,6 @@ export class CopilotTask {
     }
   }
 
-  addFunction(func: AnnotatedFunction<any[]>): void {
-    this.removeFunction(func.name);
-    this.functions.push(func);
-  }
-
-  removeFunction(funcName: string): void {
-    this.functions = this.functions.filter((f) => f.name !== funcName);
-  }
-
   async run(): Promise<void> {
     const functions = this.functions.map(annotatedFunctionToChatCompletionFunction);
     let contextString = "";
@@ -102,10 +95,6 @@ export class CopilotTask {
 
     if (this.context) {
       contextString += this.context.getContextString([], defaultCopilotContextCategories);
-    }
-
-    if (this.functions.length === 0) {
-      throw new Error("No functions defined for CopilotTask");
     }
 
     const systemMessage: Message = {

--- a/CopilotKit/packages/react-core/src/lib/copilot-task.ts
+++ b/CopilotKit/packages/react-core/src/lib/copilot-task.ts
@@ -27,22 +27,20 @@ export interface CopilotTaskConfig {
   includeCopilotActionable?: boolean;
 }
 
-export class CopilotTask {
+export class CopilotTask<T = any> {
   private instructions: string;
-  private data?: any;
   private functions: AnnotatedFunction<any[]>[];
   private includeCopilotReadable: boolean;
   private includeCopilotActionable: boolean;
 
   constructor(config: CopilotTaskConfig) {
     this.instructions = config.instructions;
-    this.data = config.data;
     this.functions = config.functions || [];
     this.includeCopilotReadable = config.includeCopilotReadable || true;
     this.includeCopilotActionable = config.includeCopilotActionable || true;
   }
 
-  async run(context: CopilotContextParams): Promise<void> {
+  async run(context: CopilotContextParams, data?: T): Promise<void> {
     const entryPoints = this.includeCopilotActionable ? Object.assign({}, context.entryPoints) : {};
 
     // merge functions into entry points
@@ -52,9 +50,8 @@ export class CopilotTask {
 
     let contextString = "";
 
-    if (this.data) {
-      contextString =
-        (typeof this.data === "string" ? this.data : JSON.stringify(this.data)) + "\n\n";
+    if (data) {
+      contextString = (typeof data === "string" ? data : JSON.stringify(data)) + "\n\n";
     }
 
     if (this.includeCopilotReadable) {

--- a/CopilotKit/packages/react-core/src/lib/copilot-task.ts
+++ b/CopilotKit/packages/react-core/src/lib/copilot-task.ts
@@ -1,0 +1,215 @@
+import {
+  AnnotatedFunction,
+  FunctionCall,
+  Message,
+  Role,
+  annotatedFunctionToChatCompletionFunction,
+} from "@copilotkit/shared";
+import { CopilotApiConfig, CopilotContextParams } from "../context";
+import { defaultCopilotContextCategories } from "../components";
+import { fetchAndDecodeChatCompletion } from "../utils/fetch-chat-completion";
+
+export interface CopilotTaskConfig {
+  /**
+   * The instructions to be given to the assistant.
+   */
+  instructions: string;
+  /**
+   * The data to use for the task.
+   */
+  data?: any;
+  /**
+   * An optional context object to use for the task.
+   */
+  context?: CopilotContextParams;
+  /**
+   * Function definitions to be sent to the API.
+   */
+  functions?: AnnotatedFunction<any[]>[];
+  /**
+   * The API endpoint that accepts a `{ messages: Message[] }` object and returns
+   */
+  url?: string;
+  /**
+   * HTTP headers to be sent with the API request.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Extra body object to be sent with the API request.
+   * @example
+   * Send a `sessionId` to the API along with the messages.
+   * ```js
+   * useChat({
+   *   body: {
+   *     sessionId: '123',
+   *   }
+   * })
+   * ```
+   */
+  body?: object;
+}
+
+export class CopilotTask {
+  private instructions: string;
+  private data?: any;
+  private context?: CopilotContextParams;
+  private functions: AnnotatedFunction<any[]>[];
+  private copilotConfig: CopilotApiConfig;
+
+  constructor(config: CopilotTaskConfig) {
+    this.instructions = config.instructions;
+    this.data = config.data;
+    this.context = config.context;
+    this.functions = config.functions || [];
+
+    if (this.context && config.functions?.length) {
+      console.warn(
+        "You provided both a context and functions to CopilotTask. The functions will be ignored.",
+      );
+    }
+
+    if (this.context) {
+      this.copilotConfig = this.context.copilotApiConfig;
+    } else if (config.url) {
+      this.copilotConfig = {
+        chatApiEndpoint: config.url,
+        chatApiEndpointV2: config.url, // TODO remove
+        headers: config.headers || {},
+        body: config.body || {},
+      };
+    } else {
+      throw new Error("No context or url provided for CopilotTask");
+    }
+  }
+
+  addFunction(func: AnnotatedFunction<any[]>): void {
+    this.removeFunction(func.name);
+    this.functions.push(func);
+  }
+
+  removeFunction(funcName: string): void {
+    this.functions = this.functions.filter((f) => f.name !== funcName);
+  }
+
+  async run(): Promise<void> {
+    const functions = this.functions.map(annotatedFunctionToChatCompletionFunction);
+    let contextString = "";
+
+    if (this.data) {
+      contextString =
+        (typeof this.data === "string" ? this.data : JSON.stringify(this.data)) + "\n\n";
+    }
+
+    if (this.context) {
+      contextString += this.context.getContextString([], defaultCopilotContextCategories);
+    }
+
+    if (this.functions.length === 0) {
+      throw new Error("No functions defined for CopilotTask");
+    }
+
+    const systemMessage: Message = {
+      id: "system",
+      content: taskSystemMessage(contextString, this.instructions),
+      role: "system",
+    };
+
+    const messages = [systemMessage];
+
+    const response = await fetchAndDecodeChatCompletion({
+      copilotConfig: this.copilotConfig,
+      messages: messages,
+      functions: this.context ? this.context.getChatCompletionFunctionDescriptions() : functions,
+      headers: this.copilotConfig.headers,
+    });
+
+    if (!response.events) {
+      throw new Error("Failed to execute task");
+    }
+
+    const reader = response.events.getReader();
+    let functionCall: FunctionCall | undefined;
+
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      if (value.type === "function") {
+        functionCall = {
+          name: value.name,
+          arguments: JSON.stringify(value.arguments),
+        };
+        break;
+      }
+    }
+
+    if (!functionCall) {
+      throw new Error("No function call occurred");
+    }
+
+    if (this.context) {
+      // use the function call handler of the context
+      const functionCallHandler = this.context.getFunctionCallHandler();
+      await functionCallHandler(messages, functionCall);
+    } else {
+      // manually call function
+      await callFunction(this.functions, functionCall);
+    }
+  }
+}
+
+// TODO move this to shared
+async function callFunction(entryPoints: AnnotatedFunction<any[]>[], functionCall: FunctionCall) {
+  let entrypointsByFunctionName: Record<string, AnnotatedFunction<any[]>> = {};
+  for (let entryPoint of entryPoints) {
+    entrypointsByFunctionName[entryPoint.name] = entryPoint;
+  }
+
+  const entryPointFunction = entrypointsByFunctionName[functionCall.name || ""];
+  if (entryPointFunction) {
+    let functionCallArguments: Record<string, any>[] = [];
+    if (functionCall.arguments) {
+      functionCallArguments = JSON.parse(functionCall.arguments);
+    }
+
+    const paramsInCorrectOrder: any[] = [];
+    for (let arg of entryPointFunction.argumentAnnotations) {
+      paramsInCorrectOrder.push(
+        functionCallArguments[arg.name as keyof typeof functionCallArguments],
+      );
+    }
+
+    await entryPointFunction.implementation(...paramsInCorrectOrder);
+  } else {
+    throw new Error(`No function found with name ${functionCall.name}`);
+  }
+}
+
+function taskSystemMessage(contextString: string, instructions: string): string {
+  return `
+Please act as an efficient, competent, conscientious, and industrious professional assistant.
+
+Help the user achieve their goals, and you do so in a way that is as efficient as possible, without unnecessary fluff, but also without sacrificing professionalism.
+Always be polite and respectful, and prefer brevity over verbosity.
+
+The user has provided you with the following context:
+\`\`\`
+${contextString}
+\`\`\`
+
+They have also provided you with functions you can call to initiate actions on their behalf.
+
+Please assist them as best you can.
+
+This is not a conversation, so please do not ask questions. Just call a function without saying anything else.
+
+The user has given you the following task to complete:
+
+\`\`\`
+${instructions}
+\`\`\`
+`;
+}

--- a/CopilotKit/packages/react-core/src/lib/index.ts
+++ b/CopilotKit/packages/react-core/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./copilot-task";


### PR DESCRIPTION
This adds `CopilotTask`, a class for running custom tasks (function calling) without chat.

`instructions` tells the GPT what to do.

There is an optional `data` parameter to provide context.

In addition, it can take the current state and functions from an optional `context` object (using data and functions previously defined via `useMakeCopilotReadable` and `useMakeCopilotActionable`.

It can also take an array of `functions` (type: `AnnotatedFunction`) to make an independent, standalone task.

Example:

```ts
const context = useCopilotContext();
const randomSlideTask = new CopilotTask({
  instructions: "Make a random slide",
});
await randomSlideTask.run(context);
```

