### PR TITLE
Fix: OpenAI gets instantiated before running constructor

### DIFF
--- a/CopilotKit/packages/backend/src/lib/openai-adapter.ts
+++ b/CopilotKit/packages/backend/src/lib/openai-adapter.ts
@@ -13,13 +13,11 @@ export interface OpenAIAdapterParams {
 }
 
 export class OpenAIAdapter implements CopilotKitServiceAdapter {
-  private openai: OpenAI = new OpenAI({});
+  private openai: OpenAI;
   private model: string = DEFAULT_MODEL;
   private debug: boolean = false;
   constructor(params?: OpenAIAdapterParams) {
-    if (params?.openai) {
-      this.openai = params.openai;
-    }
+    this.openai = params?.openai || new OpenAI({});
     if (params?.model) {
       this.model = params.model;
     }


### PR DESCRIPTION
Fixes #193 

The problem was that the default for the `openai` instance var gets instantiated before the constructor is run, thus resulting in an error when the env variable is missing.