### PR TITLE
Implement Backend-Only Properties for Enhanced Parameter Handling

### DIFF
--- a/CopilotKit/packages/backend/src/lib/copilotkit-backend.ts
+++ b/CopilotKit/packages/backend/src/lib/copilotkit-backend.ts
@@ -31,6 +31,15 @@ export class CopilotBackend {
     forwardedProps: any,
     serviceAdapter: CopilotKitServiceAdapter,
   ): Promise<ReadableStream> {
+    // get keys backendOnlyPropsKeys in order to remove them from the forwardedProps
+    const backendOnlyPropsKeys = forwardedProps.backend_only_props_keys;
+    if (backendOnlyPropsKeys) {
+      backendOnlyPropsKeys.forEach((key: string) => {
+        delete forwardedProps[key];
+      });
+      delete forwardedProps["backend_only_props_keys"];
+    }
+
     const mergedTools = mergeServerSideTools(
       this.functions.map(annotatedFunctionToChatCompletionFunction),
       forwardedProps.tools,

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -39,4 +39,16 @@ export interface CopilotKitProps {
    * The children to be rendered within the CopilotKit.
    */
   children: ReactNode;
+
+  /**
+   * Backend only props that will be combined to body params to be sent with the request
+   * @default {}
+   * @example
+   * ```
+   * {
+   *   'user_id': 'users_id',
+   * }
+   * ```
+   */
+  backendOnlyProps?: Record<string, any>;
 }

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -156,7 +156,10 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
     props.url,
     `${props.url}/v2`,
     props.headers || {},
-    props.body || {},
+    {
+      ...props.body,
+      ...props.backendOnlyProps,
+    },
   );
 
   return (

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -42,6 +42,18 @@ export interface CopilotApiConfig {
    * ```
    */
   body: Record<string, any>;
+
+  /**
+   * Backend only props that will be combined to body params to be sent with the request
+   * @default {}
+   * @example
+   * ```
+   * {
+   *   'user_id': 'user_id'
+   * }
+   * ```
+   */
+  backendOnlyProps?: Record<string, any>;
 }
 
 export interface CopilotContextParams {

--- a/CopilotKit/packages/react-core/src/utils/fetch-chat-completion.ts
+++ b/CopilotKit/packages/react-core/src/utils/fetch-chat-completion.ts
@@ -54,6 +54,9 @@ export async function fetchChatCompletion({
       ...(temperature ? { temperature } : {}),
       ...(tools.length != 0 ? { tool_choice: "auto" } : {}),
       ...copilotConfig.body,
+      ...copilotConfig.backendOnlyProps,
+      //get backendOnlyPropsKeys to backend to remove them from the forwardedProps
+      backend_only_props_keys: Object.keys(copilotConfig['body'] || {}),
       ...(body ? { ...body } : {}),
     }),
     signal,


### PR DESCRIPTION
This PR introduces the capability to specify backend-only properties in the CopilotKit component. Addressing the issue where passing extra parameters directly to OpenAI (or other underlying LLM providers) results in an error due to their strict parameter validation. By allowing additional parameters to be specified that are intended only for backend use, we can enhance the flexibility and functionality of our requests without affecting the integrity of the data sent to the LLM provider.

**Key Changes:**

- Added backendOnlyProps to the CopilotKit component to allow specifying properties that should not be forwarded to the LLM provider.
- Implemented logic in the backend to exclude these backend-only properties from the properties forwarded to the LLM provider.

**How to Test:**

1. Modification: In src/app/page.tsx, modify the backendOnlyProps within the CopilotKit component to include custom properties. For example:
`   backendOnlyProps={{
     user_id: "test_user_123", 
   }}`
2. Run the Application sent and chat and check the network tab for the user_id prop
3. Backend Verification: On the backend, verify that the backendOnlyProps are received correctly but are not forwarded to the LLM provider. This may require logging or debugging tools to inspect the properties handled by the backend.
4. LLM Provider Error Check: Ensure that no errors are returned from the LLM provider related to unexpected or extra parameters, indicating that the backendOnlyProps were successfully excluded from the forwarded request.