### PR TITLE
fix(react-textarea): Correct `timeoutId` type in Debouncer

### DIFF
--- a/CopilotKit/packages/react-textarea/src/lib/debouncer.ts
+++ b/CopilotKit/packages/react-textarea/src/lib/debouncer.ts
@@ -1,7 +1,7 @@
 export type AsyncFunction<T extends any[]> = (...args: [...T, AbortSignal]) => Promise<void>;
 
 export class Debouncer<T extends any[]> {
-  private timeoutId?: number;
+  private timeoutId?: NodeJS.Timeout;
   private activeAbortController?: AbortController;
 
   constructor(private wait: number) {}

--- a/CopilotKit/packages/react-textarea/src/lib/debouncer.ts
+++ b/CopilotKit/packages/react-textarea/src/lib/debouncer.ts
@@ -1,7 +1,7 @@
 export type AsyncFunction<T extends any[]> = (...args: [...T, AbortSignal]) => Promise<void>;
 
 export class Debouncer<T extends any[]> {
-  private timeoutId?: NodeJS.Timeout;
+  private timeoutId?: ReturnType<typeof setTimeout>;
   private activeAbortController?: AbortController;
 
   constructor(private wait: number) {}


### PR DESCRIPTION
Resolved a type mismatch issue in `debouncer.ts` by changing the `timeoutId` type from `number` to `NodeJS.Timeout`, aligning with the correct return type of `setTimeout` in NodeJS environments.

This was causing a build error