### PR TITLE
add gpt newspaper backed demo

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/api/copilotkit/gpt-newspaper/route.ts
+++ b/CopilotKit/examples/next-openai/src/app/api/copilotkit/gpt-newspaper/route.ts
@@ -1,0 +1,46 @@
+import { CopilotBackend, OpenAIAdapter } from "@copilotkit/backend";
+
+// -----------------
+// To run this example:
+// - clone https://github.com/mme/gpt-newspaper
+// - follow the instructions in NOTES.md
+// -----------------
+
+export const runtime = "edge";
+
+export async function POST(req: Request): Promise<Response> {
+  const copilotKit = new CopilotBackend({
+    functions: [
+      {
+        name: "research",
+        description:
+          "Call this function when the user requests research on a certain topic. After researching, make a presentation.",
+        argumentAnnotations: [
+          {
+            name: "topic",
+            type: "string",
+            description: "The topic to research.",
+            required: true,
+          },
+        ],
+        implementation: async (topic) => {
+          const response = await fetch("http://localhost:8000/generate_newspaper_html", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              topics: [topic],
+              layout: "layout_1.html",
+            }),
+          });
+
+          // return the html from the newspaper generator
+          return await response.text();
+        },
+      },
+    ],
+  });
+
+  return copilotKit.response(req, new OpenAIAdapter());
+}

--- a/CopilotKit/examples/next-openai/src/app/presentation-agent/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/presentation-agent/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCopilotContext } from "@copilotkit/react-core";
+import { CopilotTask } from "@copilotkit/react-core";
+import {
+  CopilotKit,
+  useMakeCopilotActionable,
+  useMakeCopilotReadable,
+} from "@copilotkit/react-core";
+import { CopilotSidebar } from "@copilotkit/react-ui";
+import { useEffect, useState } from "react";
+import Markdown from "react-markdown";
+import "./styles.css";
+
+let globalAudio: any = undefined;
+let globalAudioEnabled = false;
+
+const Demo = () => {
+  return (
+    <CopilotKit url="/api/copilotkit/gpt-newspaper">
+      <CopilotSidebar
+        defaultOpen={true}
+        labels={{
+          title: "Presentation Copilot",
+          initial: "Hi you! 👋 I can give you a presentation on any topic.",
+        }}
+        clickOutsideToClose={false}
+        onSubmitMessage={async (message) => {
+          if (!globalAudioEnabled) {
+            globalAudio.play();
+            globalAudio.pause();
+          }
+          globalAudioEnabled = true;
+        }}
+      >
+        <Presentation />
+      </CopilotSidebar>
+    </CopilotKit>
+  );
+};
+
+const Presentation = () => {
+  const [state, setState] = useState({
+    markdown: `# Hello World!`,
+    backgroundImage: "hello",
+  });
+
+  useEffect(() => {
+    if (!globalAudio) {
+      globalAudio = new Audio();
+    }
+  }, []);
+
+  useMakeCopilotReadable("This is the current slide: " + JSON.stringify(state));
+
+  useMakeCopilotActionable(
+    {
+      name: "presentSlide",
+      description:
+        "Present a slide in the presentation you are giving. Call this function multiple times to present multiple slides.",
+      argumentAnnotations: [
+        {
+          name: "markdown",
+          type: "string",
+          description:
+            "The text to display in the presentation slide. Use simple markdown to outline your speech, like a headline, lists, paragraphs, etc.",
+          required: true,
+        },
+        {
+          name: "backgroundImage",
+          type: "string",
+          description: "What to display in the background of the slide (i.e. 'dog' or 'house').",
+          required: true,
+        },
+        {
+          name: "speech",
+          type: "string",
+          description: "An informative speech about the current slide.",
+          required: true,
+        },
+      ],
+
+      implementation: async (markdown, backgroundImage, speech) => {
+        setState({
+          markdown,
+          backgroundImage,
+        });
+
+        console.log("Presenting slide: ", markdown, backgroundImage, speech);
+
+        const encodedText = encodeURIComponent(speech);
+        const url = `/api/tts?text=${encodedText}`;
+        globalAudio.src = url;
+        await globalAudio.play();
+        await new Promise<void>((resolve) => {
+          globalAudio.onended = function () {
+            resolve();
+          };
+        });
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      },
+    },
+    [],
+  );
+
+  const randomSlideTask = new CopilotTask({
+    instructions: "Make a random slide related to the current topic",
+  });
+
+  const context = useCopilotContext();
+
+  const [randomSlideTaskRunning, setRandomSlideTaskRunning] = useState(false);
+
+  return (
+    <div className="relative">
+      <Slide {...state} />
+      <button
+        disabled={randomSlideTaskRunning}
+        className={`absolute bottom-0 left-0 mb-4 ml-4 bg-blue-500 text-white font-bold py-2 px-4 rounded
+        ${randomSlideTaskRunning ? "opacity-50 cursor-not-allowed" : "hover:bg-blue-700"}`}
+        onClick={async () => {
+          try {
+            setRandomSlideTaskRunning(true);
+            await randomSlideTask.run(context);
+          } finally {
+            setRandomSlideTaskRunning(false);
+          }
+        }}
+      >
+        {randomSlideTaskRunning ? "Generating slide..." : "Make random slide"}
+      </button>
+    </div>
+  );
+};
+
+type SlideProps = {
+  markdown: string;
+  backgroundImage: string;
+};
+
+const Slide = ({ markdown, backgroundImage }: SlideProps) => {
+  backgroundImage =
+    'url("https://source.unsplash.com/featured/?' + encodeURIComponent(backgroundImage) + '")';
+  return (
+    <div
+      className="h-screen w-full flex flex-col justify-center items-center text-5xl text-white bg-cover bg-center bg-no-repeat p-10 text-center"
+      style={{
+        backgroundImage,
+        textShadow: "1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000",
+      }}
+    >
+      <Markdown className="markdown">{markdown}</Markdown>
+    </div>
+  );
+};
+
+export default Demo;

--- a/CopilotKit/examples/next-openai/src/app/presentation-agent/styles.css
+++ b/CopilotKit/examples/next-openai/src/app/presentation-agent/styles.css
@@ -1,0 +1,62 @@
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  font-weight: bold;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+}
+
+.markdown h1 {
+  font-size: 1.5em;
+}
+
+.markdown h2 {
+  font-size: 1.25em;
+  font-weight: 600;
+}
+
+.markdown h3 {
+  font-size: 1.1em;
+}
+
+.markdown h4 {
+  font-size: 1em;
+}
+
+.markdown h5 {
+  font-size: 0.9em;
+}
+
+.markdown h6 {
+  font-size: 0.8em;
+}
+
+.markdown p {
+  margin-bottom: 1.25em;
+  text-align: left;
+}
+
+.markdown pre {
+  margin-bottom: 1.25em;
+}
+
+.markdown ul {
+  list-style-type: disc;
+  padding-left: 20px;
+  overflow: visible;
+  text-align: left;
+  margin-bottom: 1.25em;
+}
+
+.markdown li {
+  list-style-type: inherit;
+  list-style-position: outside;
+  margin-left: 0;
+  padding-left: 0;
+  position: relative;
+  overflow: visible;
+  text-align: left;
+}


### PR DESCRIPTION
A demo with the agent behind GPT Newspaper researching for a presentation.

Utilizes Tavily and LangGraph in the backend.

To run this example:
- clone https://github.com/mme/gpt-newspaper
- follow the instructions in NOTES.md
- go to http://localhost:3000/presentation-agent and ask copilot to research something