### PR TITLE
Preserve whitespace in user input

### DIFF
--- a/CopilotKit/packages/react-ui/src/css/messages.css
+++ b/CopilotKit/packages/react-ui/src/css/messages.css
@@ -40,6 +40,7 @@
   background: var(--copilot-kit-message-user-background-color);
   color: var(--copilot-kit-message-user-color);
   margin-left: auto;
+  white-space: pre-wrap;
 }
 
 .copilotKitMessage.copilotKitAssistantMessage {


### PR DESCRIPTION
Preserve the whitespace in chat user inputs. Fix #294

