### PR TITLE
clear CopilotTextarea on blur

### DIFF
--- a/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
@@ -273,6 +273,7 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
           }}
           className={moddedClassName}
           onBlur={(ev) => {
+            // clear autocompletion on blur
             props.onBlur?.(ev);
             clearAutocompletionsFromEditor(editor);
           }}

--- a/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
@@ -272,6 +272,10 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
             props.onKeyDown?.(event); // forward the event for external use
           }}
           className={moddedClassName}
+          onBlur={(ev) => {
+            props.onBlur?.(ev);
+            clearAutocompletionsFromEditor(editor);
+          }}
           {...propsToForward}
         />
       </Slate>

--- a/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar-components.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar-components.tsx
@@ -54,25 +54,29 @@ export const Icon = React.forwardRef(
 );
 
 export const Menu = React.forwardRef(
-  ({ className, ...props }: PropsWithChildren<BaseProps>, ref: Ref<HTMLDivElement | null>) => (
-    <div
-      {...props}
-      data-test-id="menu"
-      ref={ref as Ref<HTMLDivElement>}
-      className={cx(
-        className,
-        css`
-          & > * {
-            display: inline-block;
-          }
+  ({ className, ...props }: PropsWithChildren<BaseProps>, ref: Ref<HTMLDivElement | null>) => {
+    // TODO figure out why this is necessary (i.e. can't access ref.current without it)
+    const refOrUndefined = (ref as any).current ? (ref as Ref<HTMLDivElement>) : undefined;
+    return (
+      <div
+        {...props}
+        data-test-id="menu"
+        ref={refOrUndefined}
+        className={cx(
+          className,
+          css`
+            & > * {
+              display: inline-block;
+            }
 
-          & > * + * {
-            margin-left: 15px;
-          }
-        `,
-      )}
-    />
-  ),
+            & > * + * {
+              margin-left: 15px;
+            }
+          `,
+        )}
+      />
+    );
+  },
 );
 export const Portal = ({ children }: { children: React.ReactNode }) => {
   return typeof document === "object" ? ReactDOM.createPortal(children, document.body) : null;

--- a/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar-components.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar-components.tsx
@@ -55,13 +55,11 @@ export const Icon = React.forwardRef(
 
 export const Menu = React.forwardRef(
   ({ className, ...props }: PropsWithChildren<BaseProps>, ref: Ref<HTMLDivElement | null>) => {
-    // TODO figure out why this is necessary (i.e. can't access ref.current without it)
-    const refOrUndefined = (ref as any).current ? (ref as Ref<HTMLDivElement>) : undefined;
     return (
       <div
         {...props}
         data-test-id="menu"
-        ref={refOrUndefined}
+        ref={ref as Ref<HTMLDivElement>}
         className={cx(
           className,
           css`

--- a/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
@@ -45,7 +45,7 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
     }
 
     const domSelection = window.getSelection();
-    if (!domSelection) {
+    if (!domSelection || domSelection.rangeCount === 0) {
       return;
     }
 

--- a/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/text-insertion-prompt-box/hovering-insertion-prompt-box-core.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/text-insertion-prompt-box/hovering-insertion-prompt-box-core.tsx
@@ -57,13 +57,7 @@ export const HoveringInsertionPromptBoxCore = ({
 
   // initially focus on the adjustment prompt text area
   useEffect(() => {
-    // Focus in the next tick, making sure the adjustment prompt text area is rendered
-    // TODO: This happens in Safari, but not in Chrome. Need to look further into this,
-    // because focus() should not throw IndexSizeError.
-    // this fixes https://github.com/CopilotKit/CopilotKit/issues/171
-    setTimeout(() => {
-      adjustmentTextAreaRef.current?.focus();
-    }, 0);
+    adjustmentTextAreaRef.current?.focus();
   }, []);
 
   // continuously read the generating suggestion stream and update the edit suggestion


### PR DESCRIPTION
Clear CopilotTextarea on blur.

- [x] Works in Chrome, but there is an index out of bounds area in Safari.
- [x] Safari fixed in a hackish way, needs proper fix