### PR TITLE
Merge changes and ideas from Arnold and Alsong

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/presentation/components/main/Presentation.tsx
+++ b/CopilotKit/examples/next-openai/src/app/presentation/components/main/Presentation.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { useCopilotReadable } from "@copilotkit/react-core";
-import { use, useCallback, useMemo, useState } from "react";
+import { useCopilotContext, useCopilotReadable } from "@copilotkit/react-core";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
 import { Slide } from "./Slide";
 import { Header } from "./Header";
 import useAppendSlide from "../../actions/useAppendSlide";
@@ -13,6 +13,26 @@ interface PresentationProps {
 }
 
 export const Presentation = ({ performResearch, setPerformResearch }: PresentationProps) => {
+  // Load messages from local storage
+
+  // const { messages, setMessages } = useCopilotContext();
+
+  // // save to local storage when messages change
+  // useEffect(() => {
+  //   if (messages.length !== 0) {
+  //     localStorage.setItem("copilotkit-messages", JSON.stringify(messages));
+  //   }
+  // }, [JSON.stringify(messages)]);
+
+  // // initially load from local storage
+  // useEffect(() => {
+  //   const messages = localStorage.getItem("copilotkit-messages");
+  //   if (messages) {
+  //     console.log("got messages from local storage", messages);
+  //     setMessages(JSON.parse(messages));
+  //   }
+  // }, []);
+
   const [slides, setSlides] = useState<SlideModel[]>([
     {
       content: "This is the first slide.",

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -34,7 +34,6 @@
  * </CopilotKit>
 ```
  */
-
 import { Ref, useCallback, useRef, useState } from "react";
 import {
   CopilotContext,

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -5,7 +5,7 @@ import {
   ToolDefinition,
 } from "@copilotkit/shared";
 import { ActionRenderProps, FrontendAction } from "../types/frontend-action";
-import React, { Ref } from "react";
+import React from "react";
 import { TreeNodeId } from "../hooks/use-tree";
 import { DocumentPointer } from "../types";
 

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -1,4 +1,5 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useContext, useEffect } from "react";
+import { CopilotContext } from "../context/copilot-context";
 import {
   Message,
   ToolDefinition,
@@ -123,7 +124,6 @@ export function useChat(options: UseChatOptionsWithCopilotConfig): UseChatHelper
     abortControllerRef.current = abortController;
 
     setMessages([...messages, ...newMessages]);
-
     // add threadId and runId to the body if it exists
     const copilotConfigBody = options.copilotConfig.body || {};
     if (threadIdRef.current) {


### PR DESCRIPTION
Hi @arnoldmukisa @alsong,

We recently moved `messages` to the global context, just in a slightly different way :) This PR merges the existing approach with your PR.

Also nice idea loading/restoring the message history from local storage! Since our users might have different strategies on storing the message history, I cannot enable this for all users. However, since we now gained the capability to access the messages array from the context object, it is now very simple to just load the messages in application code.

```ts
   // Load messages from local storage

   const { messages, setMessages } = useCopilotContext();

   // save to local storage when messages change
   useEffect(() => {
     if (messages.length !== 0) {
       localStorage.setItem("copilotkit-messages", JSON.stringify(messages));
     }
   }, [JSON.stringify(messages)]);

   // initially load from local storage
   useEffect(() => {
     const messages = localStorage.getItem("copilotkit-messages");
     if (messages) {
       console.log("got messages from local storage", messages);
       setMessages(JSON.parse(messages));
     }
   }, []);
```

I added this as an example to the presentation code.

