### PR TITLE
Switch to fixed versioning

### DIFF
--- a/CopilotKit/.changeset/config.json
+++ b/CopilotKit/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@copilotkit/*"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",


### PR DESCRIPTION
Update the changeset config to "fixed" or "locked" versioning. This causes all of our packages to have the same version from the next release onwards.