### PR TITLE
Send API key when editing text

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/textarea/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/textarea/page.tsx
@@ -11,7 +11,7 @@ import { useStateWithLocalStorage } from "../utils";
 
 export default function CopilotTextareaDemo() {
   return (
-    <CopilotKit publicApiKey="co-public-a38d5fd77b506f945b5bc1f655dae16a">
+    <CopilotKit runtimeUrl="/api/copilotkit/openai">
       <TextAreas />
     </CopilotKit>
   );

--- a/CopilotKit/packages/react-textarea/src/hooks/make-autosuggestions-function/use-make-standard-insertion-function.tsx
+++ b/CopilotKit/packages/react-textarea/src/hooks/make-autosuggestions-function/use-make-standard-insertion-function.tsx
@@ -1,4 +1,4 @@
-import { Message } from "@copilotkit/shared";
+import { COPILOT_CLOUD_PUBLIC_API_KEY_HEADER, Message } from "@copilotkit/shared";
 import { CopilotContext } from "@copilotkit/react-core";
 import { useCallback, useContext } from "react";
 import { MinimalChatGPTMessage } from "../../types";
@@ -34,6 +34,11 @@ export function useMakeStandardInsertionOrEditingFunction(
   editingApiConfig: EditingApiConfig,
 ): Generator_InsertionOrEditingSuggestion {
   const { getContextString, copilotApiConfig } = useContext(CopilotContext);
+  const headers = {
+    ...(copilotApiConfig.publicApiKey
+      ? { [COPILOT_CLOUD_PUBLIC_API_KEY_HEADER]: copilotApiConfig.publicApiKey }
+      : {}),
+  };
 
   const insertionFunction = useCallback(
     async (
@@ -74,6 +79,7 @@ export function useMakeStandardInsertionOrEditingFunction(
           ...insertionApiConfig.forwardedParams,
           copilotConfig: copilotApiConfig,
           signal: abortSignal,
+          headers,
         });
         return stream.events!;
       });
@@ -127,6 +133,7 @@ export function useMakeStandardInsertionOrEditingFunction(
           ...editingApiConfig.forwardedParams,
           copilotConfig: copilotApiConfig,
           signal: abortSignal,
+          headers,
         });
         return stream.events!;
       });


### PR DESCRIPTION
This PR fixes a bug where the API key was not sent when editing a textarea via the overlay