### PR TITLE
feat(config): enable accepting suggestion on mobile on tap

### DIFF
--- a/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
@@ -134,9 +134,11 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
       currentAutocompleteSuggestion,
       onChangeHandler: onChangeHandlerForAutocomplete,
       onKeyDownHandler: onKeyDownHandlerForAutocomplete,
+      onTouchStartHandler: onTouchStartHandlerForAutocomplete,
     } = useAutosuggestions(
       autosuggestionsConfig.debounceTime,
       autosuggestionsConfig.shouldAcceptAutosuggestionOnKeyPress,
+      autosuggestionsConfig.shouldAcceptAutosuggestionOnTouch,
       autosuggestionsConfig.apiConfig.autosuggestionsFunction,
       insertText,
       autosuggestionsConfig.disableWhenEmpty,
@@ -270,6 +272,9 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
             onKeyDownHandlerForHoveringEditor(event); // forward the event for internal use
             onKeyDownHandlerForAutocomplete(event); // forward the event for internal use
             props.onKeyDown?.(event); // forward the event for external use
+          }}
+          onTouchStart={(event) => {
+            onTouchStartHandlerForAutocomplete(event); // forward the event for internal use
           }}
           className={moddedClassName}
           onBlur={(ev) => {

--- a/CopilotKit/packages/react-textarea/src/hooks/base-copilot-textarea-implementation/use-autosuggestions.ts
+++ b/CopilotKit/packages/react-textarea/src/hooks/base-copilot-textarea-implementation/use-autosuggestions.ts
@@ -12,11 +12,13 @@ export interface UseAutosuggestionsResult {
   currentAutocompleteSuggestion: AutosuggestionState | null;
   onChangeHandler: (newEditorState: EditorAutocompleteState | null) => void;
   onKeyDownHandler: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+  onTouchStartHandler: (event: React.TouchEvent<HTMLDivElement>) => void;
 }
 
 export function useAutosuggestions(
   debounceTime: number,
   shouldAcceptAutosuggestionOnKeyPress: (event: React.KeyboardEvent<HTMLDivElement>) => boolean,
+  shouldAcceptAutosuggestionOnTouch: (event: React.TouchEvent<HTMLDivElement>) => boolean,
   autosuggestionFunction: AutosuggestionsBareFunction,
   insertAutocompleteSuggestion: (suggestion: AutosuggestionState) => void,
   disableWhenEmpty: boolean,
@@ -108,10 +110,14 @@ export function useAutosuggestions(
     ],
   );
 
-  const keyDownHandler = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
+  const keyDownOrTouchHandler = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
       if (currentAutocompleteSuggestion) {
-        if (shouldAcceptAutosuggestionOnKeyPress(event)) {
+        const shouldAcceptSuggestion =
+          event instanceof KeyboardEvent
+            ? shouldAcceptAutosuggestionOnKeyPress(event as React.KeyboardEvent<HTMLDivElement>)
+            : shouldAcceptAutosuggestionOnTouch(event as React.TouchEvent<HTMLDivElement>);
+        if (shouldAcceptSuggestion) {
           event.preventDefault();
           insertAutocompleteSuggestion(currentAutocompleteSuggestion);
           setCurrentAutocompleteSuggestion(null);
@@ -129,6 +135,7 @@ export function useAutosuggestions(
   return {
     currentAutocompleteSuggestion,
     onChangeHandler: onChange,
-    onKeyDownHandler: keyDownHandler,
+    onKeyDownHandler: keyDownOrTouchHandler,
+    onTouchStartHandler: keyDownOrTouchHandler,
   };
 }

--- a/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
+++ b/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
@@ -30,6 +30,18 @@ import { defaultCopilotContextCategories } from "@copilotkit/react-core";
  * }
  * ```
  *
+ * @property {(event: React.TouchEvent<HTMLDivElement>) => boolean} shouldAcceptAutosuggestionOnTouch - A function that determines whether to accept the current autosuggestion based on a mobile touch event. By default, the touching the end of a suggestion will accept it. Example code:
+ *
+ * ```typescript
+ * const shouldAcceptAutosuggestionOnTouch =  (event: React.TouchEvent<HTMLDivElement>) => {
+ *   // if tab, accept the autosuggestion
+ *   if (event.type === "touchstart") {
+ *     return true;
+ *   }
+ *   return false;
+ * }
+ * ```
+ *
  * @property {(event: React.KeyboardEvent<HTMLDivElement>) => boolean} shouldToggleHoveringEditorOnKeyPress - A function that determines whether to toggle the hovering editor based on a key press event. By default, the Command + K key combination is used to toggle the hovering editor. Example code:
  *
  * ```typescript
@@ -52,6 +64,7 @@ export interface BaseAutosuggestionsConfig {
   disabled: boolean;
   temporarilyDisableWhenMovingCursorWithoutChangingText: boolean;
   shouldAcceptAutosuggestionOnKeyPress: (event: React.KeyboardEvent<HTMLDivElement>) => boolean;
+  shouldAcceptAutosuggestionOnTouch: (event: React.TouchEvent<HTMLDivElement>) => boolean;
   shouldToggleHoveringEditorOnKeyPress: (
     event: React.KeyboardEvent<HTMLDivElement>,
     shortcut: string,
@@ -80,6 +93,8 @@ const defaultShouldAcceptAutosuggestionOnKeyPress = (
   return false;
 };
 
+const defaultShouldAcceptAutosuggestionOnTouch = () => true;
+
 /**
  * Default configuration for the BaseAutosuggestions.
  *
@@ -90,6 +105,7 @@ const defaultShouldAcceptAutosuggestionOnKeyPress = (
  * @property {boolean} temporarilyDisableWhenMovingCursorWithoutChangingText - Whether to temporarily disable the autosuggestions when the cursor is moved without changing the text.
  * @property {(event: React.KeyboardEvent<HTMLDivElement>) => boolean} shouldToggleHoveringEditorOnKeyPress - A function that determines whether to toggle the hovering editor based on a key press event.
  * @property {(event: React.KeyboardEvent<HTMLDivElement>) => boolean} shouldAcceptAutosuggestionOnKeyPress - A function that determines whether to accept the autosuggestion based on a key press event.
+ * @property {() => boolean} defaultShouldAcceptAutosuggestionOnTouch - A function that determines whether to accept the autosuggestion based on a mobile touch event.
  */
 
 export const defaultBaseAutosuggestionsConfig: Omit<
@@ -103,4 +119,5 @@ export const defaultBaseAutosuggestionsConfig: Omit<
   temporarilyDisableWhenMovingCursorWithoutChangingText: true,
   shouldToggleHoveringEditorOnKeyPress: defaultShouldToggleHoveringEditorOnKeyPress,
   shouldAcceptAutosuggestionOnKeyPress: defaultShouldAcceptAutosuggestionOnKeyPress,
+  shouldAcceptAutosuggestionOnTouch: defaultShouldAcceptAutosuggestionOnTouch,
 };


### PR DESCRIPTION
Fixes https://github.com/CopilotKit/CopilotKit/issues/383

This PR sets the foundation to enable "accept suggestion on tap".
The idea here is simply: Allow "accept suggestion" on tap on mobile (`touchstart` event) using the same mechanism that's used to accept suggestions using the tab key.

However, this does not provide a full solution just yet, because setting the added `shouldAcceptAutosuggestionOnTouch` to just "true" means all suggestions will be approved on tap.
One good UX solution to this would be to figure out where the tap has happened, and approve the suggestion if the user tapped at specific locations (to be determined by the developer implementing this and their team).
I already have a solution for this, but I would need to pass several properties when calling `shouldAcceptAutosuggestionOnTouch` in order to allow the developers to run such calculations.
Therefore, I wanted to get your opinions @ataibarkai @mme

If we allow passing the editor ref, an implementation of this config method could then look something like this:
```
const defaultShouldAcceptAutosuggestionOnTouch = (event: React.TouchEvent<HTMLDivElement>, suggestion: AutosuggestionState, editorRef: React.RefObject<ReactEditor>) => {
  if (event.touches.length > 0 && editorRef.current) {
    const { clientX, clientY } = event.touches[0];
    const rect = event.currentTarget.getBoundingClientRect();

    // Calculate the relative position of the touch inside the editor
    const x = clientX - rect.left;
    const y = clientY - rect.top;

    try {
      // Convert touch position to Slate Point
      const touchPoint = ReactEditor.toSlatePoint(editorRef.current, { x, y }, { exactMatch: false });

      // Check if touchPoint is at or near the end of the suggestion
      if (touchPoint.path[0] === suggestion.point.path[0] && touchPoint.offset >= suggestion.point.offset) {
        // Consider the touch to be at the end of the suggestion
        return true;
      }
    } catch (error) {
      // Handle errors, e.g., touch outside of editor bounds
      console.error("Error converting touch to editor point:", error);
    }
  }

  return false;
};
```

Edit: I did not include the `vacation-notes.tsx` example which I already have set up. I will include it in a new commit as soon as there is a decision on the above point.