### PR TITLE
Fix missing any type parameter

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/integrations/shared.ts
+++ b/CopilotKit/packages/runtime/src/lib/integrations/shared.ts
@@ -23,7 +23,7 @@ export type GraphQLContext = YogaInitialContext & {
 };
 
 export interface CreateCopilotRuntimeServerOptions {
-  runtime: CopilotRuntime;
+  runtime: CopilotRuntime<any>;
   serviceAdapter: CopilotServiceAdapter;
   endpoint: string;
   baseUrl?: string;


### PR DESCRIPTION
A missing type parameter was leading to a type error (because the type defaults to an empty array)