### PR TITLE
feat(repo): global link and unlink turbo commands

### DIFF
--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -27,7 +27,9 @@
     "dev": "tsup --watch",
     "test": "jest",
     "check-types": "tsc --noEmit",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
+    "link:global": "pnpm link --global",
+    "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -30,7 +30,9 @@
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
+    "link:global": "pnpm link --global",
+    "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/CopilotKit/packages/react-ui/package.json
+++ b/CopilotKit/packages/react-ui/package.json
@@ -30,7 +30,9 @@
     "dev": "tsup --watch --no-splitting",
     "test": "jest",
     "check-types": "tsc --noEmit",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
+    "link:global": "pnpm link --global",
+    "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/CopilotKit/packages/runtime-client-gql/package.json
+++ b/CopilotKit/packages/runtime-client-gql/package.json
@@ -29,7 +29,9 @@
     "check-types": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
     "graphql-codegen": "graphql-codegen",
-    "graphql-codegen:watch": "graphql-codegen --watch"
+    "graphql-codegen:watch": "graphql-codegen --watch",
+    "link:global": "pnpm link --global",
+    "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -27,7 +27,9 @@
     "dev": "tsup --watch --no-splitting",
     "test": "jest --passWithNoTests",
     "check-types": "tsc --noEmit",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf .next",
+    "link:global": "pnpm link --global",
+    "unlink:global": "pnpm unlink --global"
   },
   "devDependencies": {
     "@types/jest": "^29.5.4",

--- a/CopilotKit/turbo.json
+++ b/CopilotKit/turbo.json
@@ -64,6 +64,14 @@
     },
     "//#freshbuild": {
       "cache": false
+    },
+    "link:global": {
+      "cache": false,
+      "persistent": false
+    },
+    "unlink:global": {
+      "cache": false,
+      "persistent": false
     }
   }
 }


### PR DESCRIPTION
Adds two convenient commands to the monorepo:

```
turbo run link:global
turbo run unlink:global
```

To easily use `pnpm link --global` and `pnpm unlink --global` without having to `cd` into each individual package.