### PR TITLE
fix(message-state): use previous message state when appending new messages

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -128,7 +128,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
 
-    setMessages([...previousMessages, ...newMessages]);
+    setMessages(prevMessages => [...prevMessages, ...newMessages])
 
     const systemMessage = makeSystemMessageCallback();
 
@@ -255,7 +255,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
         }
 
         if (newMessages.length > 0) {
-          setMessages([...previousMessages, ...newMessages]);
+          setMessages(prevMessages => [...prevMessages, ...newMessages])
         }
       }
 
@@ -288,9 +288,9 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
     if (isLoading) {
       return;
     }
-    const newMessages = [...messages, message];
-    setMessages(newMessages);
-    return runChatCompletionAndHandleFunctionCall(newMessages);
+    setMessages(prevMessages => [...prevMessages, message]);
+    // No need to pass new messages here. runChatCompletion uses setState (setMessages) which takes it from prev state
+    return runChatCompletionAndHandleFunctionCall([]);
   };
 
   const reload = async (): Promise<void> => {

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -258,7 +258,10 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
           setMessages((prevMessages) => {
             const prevMessagesList = prevMessages;
             // Since we are streaming, the last message (by the assistant) needs to be constantly replaced
-            if (prevMessages[prevMessages.length - 1]?.role === "assistant") {
+            if (
+              (prevMessages[prevMessages.length - 1] as TextMessage | undefined)?.role ===
+              "assistant"
+            ) {
               prevMessagesList.pop();
             }
 

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -256,13 +256,13 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
 
         if (newMessages.length > 0) {
           setMessages((prevMessages) => {
-            const prevMessagesList = prevMessages
+            const prevMessagesList = prevMessages;
             // Since we are streaming, the last message (by the assistant) needs to be constantly replaced
-            if (prevMessages[prevMessages.length - 1]?.role === 'assistant') {
-              prevMessagesList.pop()
+            if (prevMessages[prevMessages.length - 1]?.role === "assistant") {
+              prevMessagesList.pop();
             }
 
-            return [...prevMessagesList, ...newMessages]
+            return [...prevMessagesList, ...newMessages];
           });
         }
       }

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -255,7 +255,15 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
         }
 
         if (newMessages.length > 0) {
-          setMessages((prevMessages) => [...prevMessages, ...newMessages]);
+          setMessages((prevMessages) => {
+            const prevMessagesList = prevMessages
+            // Since we are streaming, the last message (by the assistant) needs to be constantly replaced
+            if (prevMessages[prevMessages.length - 1]?.role === 'assistant') {
+              prevMessagesList.pop()
+            }
+
+            return [...prevMessagesList, ...newMessages]
+          });
         }
       }
 

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -128,7 +128,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
     const abortController = new AbortController();
     abortControllerRef.current = abortController;
 
-    setMessages(prevMessages => [...prevMessages, ...newMessages])
+    setMessages((prevMessages) => [...prevMessages, ...newMessages]);
 
     const systemMessage = makeSystemMessageCallback();
 
@@ -255,7 +255,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
         }
 
         if (newMessages.length > 0) {
-          setMessages(prevMessages => [...prevMessages, ...newMessages])
+          setMessages((prevMessages) => [...prevMessages, ...newMessages]);
         }
       }
 
@@ -288,7 +288,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
     if (isLoading) {
       return;
     }
-    setMessages(prevMessages => [...prevMessages, message]);
+    setMessages((prevMessages) => [...prevMessages, message]);
     // No need to pass new messages here. runChatCompletion uses setState (setMessages) which takes it from prev state
     return runChatCompletionAndHandleFunctionCall([]);
   };


### PR DESCRIPTION
This draft adds a suggestion on how to fix the first issue described on https://github.com/CopilotKit/CopilotKit/issues/483

## The problem and solution:
When appending messages, there's an update of state going on. Several times for several reasons.
These updates are counting on messages being passed with prop drilling (sort of?) as the "previous messages to append to". I am not sure what causes the latest state to arrive late/not at all, but it doesn't matter, as a good practice of appending to state would be to use the set state method argument directly. It will hold the latest state each time.
So in order to append to the latest messages, it is better to simple `setState(oldMessages => [...oldMessage, newMessage])`.

## So, why is it a draft?
Because there are more problems :(
Maybe it wasn't visible due to how things got overridden with state, and maybe it's intentional(?), but with the nature of keeping the messages in the context, it causes a rerender of the whole tree. which then means, more calls to `appendMessage`. Let me explain.
In order to test my solution, I've done this:
```
  useEffect(() => {
    appendMessage(
      new TextMessage({
        content: "Message 1.",
        role: Role.User,
      })
    );
    setTimeout(() => {
      appendMessage(
        new TextMessage({
          content: "Message 2.",
          role: Role.User,
        })
      );
    }, 5000);
  }, [])
```
So it's an effect that should only run once, and append 2 messages over time.
The problem is, it runs twice, so we end up with double the messages, like so:
<img width="453" alt="Screenshot 2024-07-23 at 1 35 27" src="https://github.com/user-attachments/assets/a92efb10-a367-42f8-ad34-2634914bc5ef">

I will be leaving this solution as a draft like this for now.
Feel free to take over it, or otherwise suggest any change in order to block the re-rendering.

## How to Reproduce:
1. Implement the solution in this draft
2. Go to `CopilotKit/packages/react-ui/src/components/chat/Chat.tsx` and add the above `useEffect`.
3. Add a console log inside the `useEffect` log and you'll see it's being called twice