### PR TITLE
fix: append user message before calling onSubmitMessage

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -276,6 +276,15 @@ export const useCopilotChatLogic = (
   const sendMessage = async (messageContent: string) => {
     abortSuggestions();
     setCurrentSuggestions([]);
+
+    const message: Message = new TextMessage({
+      content: messageContent,
+      role: Role.User,
+    });
+
+    // Append the message immediately to make it visible
+    appendMessage(message);
+
     if (onSubmitMessage) {
       try {
         await onSubmitMessage(messageContent);
@@ -283,11 +292,7 @@ export const useCopilotChatLogic = (
         console.error("Error in onSubmitMessage:", error);
       }
     }
-    const message: Message = new TextMessage({
-      content: messageContent,
-      role: Role.User,
-    });
-    appendMessage(message);
+    
     return message;
   };
 

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -292,7 +292,7 @@ export const useCopilotChatLogic = (
         console.error("Error in onSubmitMessage:", error);
       }
     }
-    
+
     return message;
   };
 


### PR DESCRIPTION
This is based on the issue raised here - #499 

Currently, `onSubmitMessage` is being awaited, then the user message is appended/visible.

I changed this behavior so that the user message is already visible before calling `onSubmitMessage`.

**Changes made -**

1. The message object is created immediately at the beginning of the function.

2. The appendMessage(message) call is moved before the onSubmitMessage call. This ensures that the user's message is visible in the chat interface before any additional processing occurs.