### PR TITLE
fix(config): enable ctrl+k on windows and cmd+k on mac

### DIFF
--- a/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
+++ b/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
@@ -77,7 +77,7 @@ const defaultShouldToggleHoveringEditorOnKeyPress = (
   shortcut: string,
 ) => {
   // if command-k, toggle the hovering editor
-  if (event.key === shortcut && event.metaKey) {
+  if (event.key === shortcut && ((isMacOS() && event.metaKey) || (!isMacOS() && event.ctrlKey))) {
     return true;
   }
   return false;
@@ -121,3 +121,7 @@ export const defaultBaseAutosuggestionsConfig: Omit<
   shouldAcceptAutosuggestionOnKeyPress: defaultShouldAcceptAutosuggestionOnKeyPress,
   shouldAcceptAutosuggestionOnTouch: defaultShouldAcceptAutosuggestionOnTouch,
 };
+
+function isMacOS() {
+  return /Mac|iMac|Macintosh/i.test(navigator.userAgent);
+}


### PR DESCRIPTION
Fixes https://github.com/CopilotKit/CopilotKit/issues/400 to enable the CTRL + K on windows.

Unfortunately, I do not have a windows machine to test this. I will appreciate any suggestion on how to test it.
This is why this PR will remain a draft for the time being.