### PR TITLE
fix(docs): update docs

### DIFF
--- a/CopilotKit/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
@@ -66,14 +66,14 @@
  *   );
  * }
  * ```
- * 
+ *
  * ### Look & Feel
- * 
+ *
  * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
  * ```tsx fileName="YourRootComponent.tsx" {2}
  * ...
  * import "@copilotkit/react-ui/styles.css";
- * 
+ *
  * export function YourRootComponent() {
  *   return (
  *     <CopilotKit>
@@ -105,17 +105,17 @@ export interface CopilotTextareaProps
    * Configuration settings for the autosuggestions feature.
    * Includes a mandatory `textareaPurpose` to guide the autosuggestions.
    *
-   * <PropertyReference name="textareaPurpose" type="string"  > 
+   * <PropertyReference name="textareaPurpose" type="string"  >
    * The purpose of the text area in plain text.
-   * 
+   *
    * Example: *"The body of the email response"*
    * </PropertyReference>
    *
-   * <PropertyReference name="chatApiConfigs" type="ChatApiConfigs" > 
+   * <PropertyReference name="chatApiConfigs" type="ChatApiConfigs" >
    *   The chat API configurations.
-   * 
+   *
    *   <strong>NOTE:</strong> You must provide specify at least one of `suggestionsApiConfig` or `insertionApiConfig`.
-   * 
+   *
    *   <PropertyReference name="suggestionsApiConfig" type="SuggestionsApiConfig">
    *       For full reference, please [click here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-textarea/src/types/autosuggestions-config/suggestions-api-config.tsx#L4).
    *   </PropertyReference>

--- a/CopilotKit/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
@@ -9,7 +9,6 @@
  * In addition, it provides a hovering editor window (available by default via `Cmd + K` on Mac and `Ctrl + K` on Windows) that allows the user to
  * suggest changes to the text, for example providing a summary or rephrasing the text.
  *
- *
  * ## Example
  *
  * ```tsx
@@ -67,6 +66,23 @@
  *   );
  * }
  * ```
+ * 
+ * ### Look & Feel
+ * 
+ * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+ * ```tsx fileName="YourRootComponent.tsx" {2}
+ * ...
+ * import "@copilotkit/react-ui/styles.css";
+ * 
+ * export function YourRootComponent() {
+ *   return (
+ *     <CopilotKit>
+ *       ...
+ *     </CopilotKit>
+ *   );
+ * }
+ * ```
+ * For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
  * */
 import React from "react";
 import { useMakeStandardAutosuggestionFunction } from "../../hooks/make-autosuggestions-function/use-make-standard-autosuggestions-function";
@@ -93,23 +109,22 @@ export interface CopilotTextareaProps
    *
    * ```ts
    * {
-   *  // the purpose of the textarea
-   *  textareaPurpose: string,
-   *  chatApiConfigs: {
-   *    // the config for the suggestions api (optional)
-   *    suggestionsApiConfig: {
-   *      // use this to provide a custom system prompt
-   *      makeSystemPrompt: (textareaPurpose: string, contextString: string) => string;
-   *      // custom few shot messages
-   *      fewShotMessages: Message[];
-   *      // max number of tokens to generate
-   *      maxTokens: number,
-   *      // stop generating when these characters are encountered, e.g. [".", "?", "!"]
-   *      stop: string[],
-   *    },
-   *  },
-   *    insertionApiConfig: //... the similar options as suggestionsApiConfig
-   *  },
+   *   // the purpose of the textarea
+   *   textareaPurpose: string,
+   *   chatApiConfigs: {
+   *     // the config for the suggestions api (optional)
+   *     suggestionsApiConfig: {
+   *       // use this to provide a custom system prompt
+   *       makeSystemPrompt: (textareaPurpose: string, contextString: string) => string;
+   *       // custom few shot messages
+   *       fewShotMessages: Message[];
+   *       // max number of tokens to generate
+   *       maxTokens: number,
+   *       // stop generating when these characters are encountered, e.g. [".", "?", "!"]
+   *       stop: string[],
+   *     },
+   *   },
+   *   insertionApiConfig: //... the similar options as suggestionsApiConfig
    * }
    * ```
    */

--- a/CopilotKit/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
@@ -105,28 +105,24 @@ export interface CopilotTextareaProps
    * Configuration settings for the autosuggestions feature.
    * Includes a mandatory `textareaPurpose` to guide the autosuggestions.
    *
-   * Autosuggestions can be configured as follows:
+   * <PropertyReference name="textareaPurpose" type="string"  > 
+   * The purpose of the text area in plain text.
+   * 
+   * Example: *"The body of the email response"*
+   * </PropertyReference>
    *
-   * ```ts
-   * {
-   *   // the purpose of the textarea
-   *   textareaPurpose: string,
-   *   chatApiConfigs: {
-   *     // the config for the suggestions api (optional)
-   *     suggestionsApiConfig: {
-   *       // use this to provide a custom system prompt
-   *       makeSystemPrompt: (textareaPurpose: string, contextString: string) => string;
-   *       // custom few shot messages
-   *       fewShotMessages: Message[];
-   *       // max number of tokens to generate
-   *       maxTokens: number,
-   *       // stop generating when these characters are encountered, e.g. [".", "?", "!"]
-   *       stop: string[],
-   *     },
-   *   },
-   *   insertionApiConfig: //... the similar options as suggestionsApiConfig
-   * }
-   * ```
+   * <PropertyReference name="chatApiConfigs" type="ChatApiConfigs" > 
+   *   The chat API configurations.
+   * 
+   *   <strong>NOTE:</strong> You must provide specify at least one of `suggestionsApiConfig` or `insertionApiConfig`.
+   * 
+   *   <PropertyReference name="suggestionsApiConfig" type="SuggestionsApiConfig">
+   *       For full reference, please [click here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-textarea/src/types/autosuggestions-config/suggestions-api-config.tsx#L4).
+   *   </PropertyReference>
+   *   <PropertyReference name="insertionApiConfig" type="InsertionApiConfig">
+   *       For full reference, please [click here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-textarea/src/types/autosuggestions-config/insertions-api-config.tsx#L4).
+   *   </PropertyReference>
+   * </PropertyReference>
    */
   autosuggestionsConfig: AutosuggestionsConfigUserSpecified;
 }

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -5,7 +5,15 @@
  * A chatbot panel component for the CopilotKit framework. The component allows for a high degree
  * of customization through various props and custom CSS.
  *
- * ## Example
+ * ## Install Dependencies
+ *
+ * This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
+ *
+ * ```shell npm2yarn \"@copilotkit/react-ui"\
+ * npm install @copilotkit/react-core @copilotkit/react-ui
+ * ```
+ * 
+ * ## Usage
  *
  * ```tsx
  * import { CopilotChat } from "@copilotkit/react-ui";
@@ -18,44 +26,22 @@
  * />
  * ```
  *
- * ## Usage
- *
- * ### Install Dependencies
- *
- * This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
- *
- * ```shell npm2yarn \"@copilotkit/react-ui"\
- * npm install @copilotkit/react-core @copilotkit/react-ui
- * ```
- *
- * ### Custom Styles
- *
- * To opt-in for the built-in styles, make sure to import the following at the root of your application:
- *
- * ```tsx
+ * ### Look & Feel
+ * 
+ * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+ * ```tsx fileName="YourRootComponent.tsx" {2}
+ * ...
  * import "@copilotkit/react-ui/styles.css";
- * ```
- *
- * You can customize the colors of the panel by overriding the CSS variables
- * defined in the [default styles](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/colors.css).
- *
- * For example, to set the primary color to purple:
- *
- * ```tsx
- * <div style={{ "--copilot-kit-primary-color": "#7D5BA6" }}>
- *   <CopilotPopup />
- * </div>
- * ```
- *
- * To further customize the chat window, you can override the CSS classes defined
- * [here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/).
- *
- * For example:
- *
- * ```css
- * .copilotKitButton {
- *   border-radius: 0;
+ * 
+ * export function YourRootComponent() {
+ *   return (
+ *     <CopilotKit>
+ *       ...
+ *     </CopilotKit>
+ *   );
  * }
+ * ```
+ * For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
  */
 
 import {

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -12,7 +12,7 @@
  * ```shell npm2yarn \"@copilotkit/react-ui"\
  * npm install @copilotkit/react-core @copilotkit/react-ui
  * ```
- * 
+ *
  * ## Usage
  *
  * ```tsx
@@ -27,12 +27,12 @@
  * ```
  *
  * ### Look & Feel
- * 
+ *
  * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
  * ```tsx fileName="YourRootComponent.tsx" {2}
  * ...
  * import "@copilotkit/react-ui/styles.css";
- * 
+ *
  * export function YourRootComponent() {
  *   return (
  *     <CopilotKit>

--- a/CopilotKit/packages/react-ui/src/components/chat/Popup.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Popup.tsx
@@ -26,14 +26,14 @@
  *   }}
  * />
  * ```
- * 
+ *
  * ### Look & Feel
- * 
+ *
  * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
  * ```tsx fileName="YourRootComponent.tsx" {2}
  * ...
  * import "@copilotkit/react-ui/styles.css";
- * 
+ *
  * export function YourRootComponent() {
  *   return (
  *     <CopilotKit>

--- a/CopilotKit/packages/react-ui/src/components/chat/Popup.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Popup.tsx
@@ -7,7 +7,14 @@
  *
  * See [CopilotSidebar](/reference/components/CopilotSidebar) for a sidebar version of this component.
  *
- * ## Example
+ * ## Install Dependencies
+ *
+ * This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
+ *
+ * ```shell npm2yarn \"@copilotkit/react-ui"\
+ * npm install @copilotkit/react-core @copilotkit/react-ui
+ * ```
+ * ## Usage
  *
  * ```tsx
  * import { CopilotPopup } from "@copilotkit/react-ui";
@@ -19,46 +26,23 @@
  *   }}
  * />
  * ```
- *
- * ## Usage
- *
- * ### Install Dependencies
- *
- * This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
- *
- * ```shell npm2yarn \"@copilotkit/react-ui"\
- * npm install @copilotkit/react-core @copilotkit/react-ui
- * ```
- *
- * ### Custom Styles
- *
- * To opt-in for the built-in styles, make sure to import the following at the root of your application:
- *
- * ```tsx
+ * 
+ * ### Look & Feel
+ * 
+ * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+ * ```tsx fileName="YourRootComponent.tsx" {2}
+ * ...
  * import "@copilotkit/react-ui/styles.css";
- * ```
- *
- * You can customize the colors of the chat window by overriding the CSS variables
- * defined in the [default styles](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/colors.css).
- *
- * For example, to set the primary color to purple:
- *
- * ```tsx
- * <div style={{ "--copilot-kit-primary-color": "#7D5BA6" }}>
- *   <CopilotPopup />
- * </div>
- * ```
- *
- * To further customize the chat window, you can override the CSS classes defined
- * [here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/).
- *
- * For example:
- *
- * ```css
- * .copilotKitButton {
- *   border-radius: 0;
+ * 
+ * export function YourRootComponent() {
+ *   return (
+ *     <CopilotKit>
+ *       ...
+ *     </CopilotKit>
+ *   );
  * }
  * ```
+ * For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
  */
 
 import { CopilotModal, CopilotModalProps } from "./Modal";

--- a/CopilotKit/packages/react-ui/src/components/chat/Sidebar.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Sidebar.tsx
@@ -6,7 +6,15 @@
  *
  * See [CopilotPopup](/reference/components/CopilotPopup) for a popup version of this component.
  *
- * ## Example
+ * ## Install Dependencies
+ *
+ * This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
+ *
+ * ```shell npm2yarn \"@copilotkit/react-ui"\
+ * npm install @copilotkit/react-core @copilotkit/react-ui
+ * ```
+ * 
+ * ## Usage
  *
  * ```tsx
  * import { CopilotSidebar } from "@copilotkit/react-ui";
@@ -20,46 +28,23 @@
  *   <YourApp/>
  * </CopilotSidebar>
  * ```
- *
- * ## Usage
- *
- * ### Install Dependencies
- *
- * This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
- *
- * ```shell npm2yarn \"@copilotkit/react-ui"\
- * npm install @copilotkit/react-core @copilotkit/react-ui
- * ```
- *
- * ### Custom Styles
- *
- * To opt-in for the built-in styles, make sure to import the following at the root of your application:
- *
- * ```tsx
+ * 
+ * ### Look & Feel
+ * 
+ * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+ * ```tsx fileName="YourRootComponent.tsx" {2}
+ * ...
  * import "@copilotkit/react-ui/styles.css";
- * ```
- *
- * You can customize the colors of the chat window by overriding the CSS variables
- * defined in the [default styles](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/colors.css).
- *
- * For example, to set the primary color to purple:
- *
- * ```jsx
- * <div style={{ "--copilot-kit-primary-color": "#7D5BA6" }}>
- *   <CopilotSidebar />
- * </div>
- * ```
- *
- * To further customize the chat window, you can override the CSS classes defined
- * [here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/).
- *
- * For example:
- *
- * ```css
- * .copilotKitButton {
- *   border-radius: 0;
+ * 
+ * export function YourRootComponent() {
+ *   return (
+ *     <CopilotKit>
+ *       ...
+ *     </CopilotKit>
+ *   );
  * }
  * ```
+ * For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
  */
 import React, { useState } from "react";
 import { CopilotModal, CopilotModalProps } from "./Modal";

--- a/CopilotKit/packages/react-ui/src/components/chat/Sidebar.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Sidebar.tsx
@@ -13,7 +13,7 @@
  * ```shell npm2yarn \"@copilotkit/react-ui"\
  * npm install @copilotkit/react-core @copilotkit/react-ui
  * ```
- * 
+ *
  * ## Usage
  *
  * ```tsx
@@ -28,14 +28,14 @@
  *   <YourApp/>
  * </CopilotSidebar>
  * ```
- * 
+ *
  * ### Look & Feel
- * 
+ *
  * By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
  * ```tsx fileName="YourRootComponent.tsx" {2}
  * ...
  * import "@copilotkit/react-ui/styles.css";
- * 
+ *
  * export function YourRootComponent() {
  *   return (
  *     <CopilotKit>

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -19,7 +19,7 @@ export default withNextra({
       {
         source: "/",
         destination: "/what-is-copilotkit",
-        permanent: true,
+        permanent: false,
       }
     ]
   },

--- a/docs/pages/reference/components/CopilotChat.mdx
+++ b/docs/pages/reference/components/CopilotChat.mdx
@@ -12,7 +12,15 @@ import { Callout } from "nextra/components";
 A chatbot panel component for the CopilotKit framework. The component allows for a high degree
 of customization through various props and custom CSS.
  
-## Example
+## Install Dependencies
+ 
+This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
+ 
+```shell npm2yarn \"@copilotkit/react-ui"\
+npm install @copilotkit/react-core @copilotkit/react-ui
+```
+
+## Usage
  
 ```tsx
 import { CopilotChat } from "@copilotkit/react-ui";
@@ -25,44 +33,22 @@ import { CopilotChat } from "@copilotkit/react-ui";
 />
 ```
  
-## Usage
- 
-### Install Dependencies
- 
-This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
- 
-```shell npm2yarn \"@copilotkit/react-ui"\
-npm install @copilotkit/react-core @copilotkit/react-ui
-```
- 
-### Custom Styles
- 
-To opt-in for the built-in styles, make sure to import the following at the root of your application:
- 
-```tsx
+### Look & Feel
+
+By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+```tsx fileName="YourRootComponent.tsx" {2}
+...
 import "@copilotkit/react-ui/styles.css";
-```
- 
-You can customize the colors of the panel by overriding the CSS variables
-defined in the [default styles](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/colors.css).
- 
-For example, to set the primary color to purple:
- 
-```tsx
-<div style={{ "--copilot-kit-primary-color": "#7D5BA6" }}>
-  <CopilotPopup />
-</div>
-```
- 
-To further customize the chat window, you can override the CSS classes defined
-[here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/).
- 
-For example:
- 
-```css
-.copilotKitButton {
-  border-radius: 0;
+
+export function YourRootComponent() {
+  return (
+    <CopilotKit>
+      ...
+    </CopilotKit>
+  );
 }
+```
+For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
 
 ## Properties
 

--- a/docs/pages/reference/components/CopilotChat.mdx
+++ b/docs/pages/reference/components/CopilotChat.mdx
@@ -19,7 +19,7 @@ This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@
 ```shell npm2yarn \"@copilotkit/react-ui"\
 npm install @copilotkit/react-core @copilotkit/react-ui
 ```
-
+ 
 ## Usage
  
 ```tsx
@@ -34,12 +34,12 @@ import { CopilotChat } from "@copilotkit/react-ui";
 ```
  
 ### Look & Feel
-
+ 
 By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
 ```tsx fileName="YourRootComponent.tsx" {2}
 ...
 import "@copilotkit/react-ui/styles.css";
-
+ 
 export function YourRootComponent() {
   return (
     <CopilotKit>

--- a/docs/pages/reference/components/CopilotPopup.mdx
+++ b/docs/pages/reference/components/CopilotPopup.mdx
@@ -14,7 +14,14 @@ of customization through various props and custom CSS.
  
 See [CopilotSidebar](/reference/components/CopilotSidebar) for a sidebar version of this component.
  
-## Example
+## Install Dependencies
+ 
+This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
+ 
+```shell npm2yarn \"@copilotkit/react-ui"\
+npm install @copilotkit/react-core @copilotkit/react-ui
+```
+## Usage
  
 ```tsx
 import { CopilotPopup } from "@copilotkit/react-ui";
@@ -26,46 +33,23 @@ import { CopilotPopup } from "@copilotkit/react-ui";
   }}
 />
 ```
- 
-## Usage
- 
-### Install Dependencies
- 
-This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
- 
-```shell npm2yarn \"@copilotkit/react-ui"\
-npm install @copilotkit/react-core @copilotkit/react-ui
-```
- 
-### Custom Styles
- 
-To opt-in for the built-in styles, make sure to import the following at the root of your application:
- 
-```tsx
+
+### Look & Feel
+
+By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+```tsx fileName="YourRootComponent.tsx" {2}
+...
 import "@copilotkit/react-ui/styles.css";
-```
- 
-You can customize the colors of the chat window by overriding the CSS variables
-defined in the [default styles](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/colors.css).
- 
-For example, to set the primary color to purple:
- 
-```tsx
-<div style={{ "--copilot-kit-primary-color": "#7D5BA6" }}>
-  <CopilotPopup />
-</div>
-```
- 
-To further customize the chat window, you can override the CSS classes defined
-[here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/).
- 
-For example:
- 
-```css
-.copilotKitButton {
-  border-radius: 0;
+
+export function YourRootComponent() {
+  return (
+    <CopilotKit>
+      ...
+    </CopilotKit>
+  );
 }
 ```
+For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
 
 ## Properties
 

--- a/docs/pages/reference/components/CopilotPopup.mdx
+++ b/docs/pages/reference/components/CopilotPopup.mdx
@@ -33,14 +33,14 @@ import { CopilotPopup } from "@copilotkit/react-ui";
   }}
 />
 ```
-
+ 
 ### Look & Feel
-
+ 
 By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
 ```tsx fileName="YourRootComponent.tsx" {2}
 ...
 import "@copilotkit/react-ui/styles.css";
-
+ 
 export function YourRootComponent() {
   return (
     <CopilotKit>

--- a/docs/pages/reference/components/CopilotSidebar.mdx
+++ b/docs/pages/reference/components/CopilotSidebar.mdx
@@ -13,7 +13,15 @@ A chatbot sidebar component for the CopilotKit framework. Highly customizable th
  
 See [CopilotPopup](/reference/components/CopilotPopup) for a popup version of this component.
  
-## Example
+## Install Dependencies
+ 
+This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
+ 
+```shell npm2yarn \"@copilotkit/react-ui"\
+npm install @copilotkit/react-core @copilotkit/react-ui
+```
+
+## Usage
  
 ```tsx
 import { CopilotSidebar } from "@copilotkit/react-ui";
@@ -27,46 +35,23 @@ import { CopilotSidebar } from "@copilotkit/react-ui";
   <YourApp/>
 </CopilotSidebar>
 ```
- 
-## Usage
- 
-### Install Dependencies
- 
-This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@copilotkit/react-ui) package.
- 
-```shell npm2yarn \"@copilotkit/react-ui"\
-npm install @copilotkit/react-core @copilotkit/react-ui
-```
- 
-### Custom Styles
- 
-To opt-in for the built-in styles, make sure to import the following at the root of your application:
- 
-```tsx
+
+### Look & Feel
+
+By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+```tsx fileName="YourRootComponent.tsx" {2}
+...
 import "@copilotkit/react-ui/styles.css";
-```
- 
-You can customize the colors of the chat window by overriding the CSS variables
-defined in the [default styles](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/colors.css).
- 
-For example, to set the primary color to purple:
- 
-```jsx
-<div style={{ "--copilot-kit-primary-color": "#7D5BA6" }}>
-  <CopilotSidebar />
-</div>
-```
- 
-To further customize the chat window, you can override the CSS classes defined
-[here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-ui/src/css/).
- 
-For example:
- 
-```css
-.copilotKitButton {
-  border-radius: 0;
+
+export function YourRootComponent() {
+  return (
+    <CopilotKit>
+      ...
+    </CopilotKit>
+  );
 }
 ```
+For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
 
 ## Properties
 

--- a/docs/pages/reference/components/CopilotSidebar.mdx
+++ b/docs/pages/reference/components/CopilotSidebar.mdx
@@ -20,7 +20,7 @@ This component is part of the [@copilotkit/react-ui](https://npmjs.com/package/@
 ```shell npm2yarn \"@copilotkit/react-ui"\
 npm install @copilotkit/react-core @copilotkit/react-ui
 ```
-
+ 
 ## Usage
  
 ```tsx
@@ -35,14 +35,14 @@ import { CopilotSidebar } from "@copilotkit/react-ui";
   <YourApp/>
 </CopilotSidebar>
 ```
-
+ 
 ### Look & Feel
-
+ 
 By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
 ```tsx fileName="YourRootComponent.tsx" {2}
 ...
 import "@copilotkit/react-ui/styles.css";
-
+ 
 export function YourRootComponent() {
   return (
     <CopilotKit>

--- a/docs/pages/reference/components/CopilotTextarea.mdx
+++ b/docs/pages/reference/components/CopilotTextarea.mdx
@@ -16,7 +16,6 @@ import { Callout } from "nextra/components";
 In addition, it provides a hovering editor window (available by default via `Cmd + K` on Mac and `Ctrl + K` on Windows) that allows the user to
 suggest changes to the text, for example providing a summary or rephrasing the text.
  
- 
 ## Example
  
 ```tsx
@@ -75,6 +74,23 @@ export function ExampleComponent() {
 }
 ```
 
+### Look & Feel
+
+By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
+```tsx fileName="YourRootComponent.tsx" {2}
+...
+import "@copilotkit/react-ui/styles.css";
+
+export function YourRootComponent() {
+  return (
+    <CopilotKit>
+      ...
+    </CopilotKit>
+  );
+}
+```
+For more information about how to customize the styles, check out the [Customize Look & Feel](/concepts/customize-look-and-feel) guide.
+
 ## Properties
 
 <PropertyReference name="disableBranding" type="boolean"  > 
@@ -117,23 +133,22 @@ Configuration settings for the autosuggestions feature.
  
   ```ts
   {
-   // the purpose of the textarea
-   textareaPurpose: string,
-   chatApiConfigs: {
-     // the config for the suggestions api (optional)
-     suggestionsApiConfig: {
-       // use this to provide a custom system prompt
-       makeSystemPrompt: (textareaPurpose: string, contextString: string) => string;
-       // custom few shot messages
-       fewShotMessages: Message[];
-       // max number of tokens to generate
-       maxTokens: number,
-       // stop generating when these characters are encountered, e.g. [".", "?", "!"]
-       stop: string[],
-     },
-   },
-     insertionApiConfig: //... the similar options as suggestionsApiConfig
-   },
+    // the purpose of the textarea
+    textareaPurpose: string,
+    chatApiConfigs: {
+      // the config for the suggestions api (optional)
+      suggestionsApiConfig: {
+        // use this to provide a custom system prompt
+        makeSystemPrompt: (textareaPurpose: string, contextString: string) => string;
+        // custom few shot messages
+        fewShotMessages: Message[];
+        // max number of tokens to generate
+        maxTokens: number,
+        // stop generating when these characters are encountered, e.g. [".", "?", "!"]
+        stop: string[],
+      },
+    },
+    insertionApiConfig: //... the similar options as suggestionsApiConfig
   }
   ```
 </PropertyReference>

--- a/docs/pages/reference/components/CopilotTextarea.mdx
+++ b/docs/pages/reference/components/CopilotTextarea.mdx
@@ -73,14 +73,14 @@ export function ExampleComponent() {
   );
 }
 ```
-
+ 
 ### Look & Feel
-
+ 
 By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
 ```tsx fileName="YourRootComponent.tsx" {2}
 ...
 import "@copilotkit/react-ui/styles.css";
-
+ 
 export function YourRootComponent() {
   return (
     <CopilotKit>
@@ -129,17 +129,17 @@ The shortcut to use to open the editor popover window. Default is `"Cmd-k"`.
 Configuration settings for the autosuggestions feature.
   Includes a mandatory `textareaPurpose` to guide the autosuggestions.
  
-  <PropertyReference name="textareaPurpose" type="string"  > 
+  <PropertyReference name="textareaPurpose" type="string"  >
   The purpose of the text area in plain text.
-  
+ 
   Example: "The body of the email response"
   </PropertyReference>
  
-  <PropertyReference name="chatApiConfigs" type="ChatApiConfigs" > 
+  <PropertyReference name="chatApiConfigs" type="ChatApiConfigs" >
     The chat API configurations.
-  
+ 
     <strong>NOTE:</strong> You must provide specify at least one of `suggestionsApiConfig` or `insertionApiConfig`.
-  
+ 
     <PropertyReference name="suggestionsApiConfig" type="SuggestionsApiConfig">
         For full reference, please [click here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-textarea/src/types/autosuggestions-config/suggestions-api-config.tsx#L4).
     </PropertyReference>

--- a/docs/pages/reference/components/CopilotTextarea.mdx
+++ b/docs/pages/reference/components/CopilotTextarea.mdx
@@ -129,27 +129,23 @@ The shortcut to use to open the editor popover window. Default is `"Cmd-k"`.
 Configuration settings for the autosuggestions feature.
   Includes a mandatory `textareaPurpose` to guide the autosuggestions.
  
-  Autosuggestions can be configured as follows:
+  <PropertyReference name="textareaPurpose" type="string"  > 
+  The purpose of the text area in plain text.
+  
+  Example: "The body of the email response"
+  </PropertyReference>
  
-  ```ts
-  {
-    // the purpose of the textarea
-    textareaPurpose: string,
-    chatApiConfigs: {
-      // the config for the suggestions api (optional)
-      suggestionsApiConfig: {
-        // use this to provide a custom system prompt
-        makeSystemPrompt: (textareaPurpose: string, contextString: string) => string;
-        // custom few shot messages
-        fewShotMessages: Message[];
-        // max number of tokens to generate
-        maxTokens: number,
-        // stop generating when these characters are encountered, e.g. [".", "?", "!"]
-        stop: string[],
-      },
-    },
-    insertionApiConfig: //... the similar options as suggestionsApiConfig
-  }
-  ```
+  <PropertyReference name="chatApiConfigs" type="ChatApiConfigs" > 
+    The chat API configurations.
+  
+    <strong>NOTE:</strong> You must provide specify at least one of `suggestionsApiConfig` or `insertionApiConfig`.
+  
+    <PropertyReference name="suggestionsApiConfig" type="SuggestionsApiConfig">
+        For full reference, please [click here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-textarea/src/types/autosuggestions-config/suggestions-api-config.tsx#L4).
+    </PropertyReference>
+    <PropertyReference name="insertionApiConfig" type="InsertionApiConfig">
+        For full reference, please [click here](https://github.com/CopilotKit/CopilotKit/blob/main/CopilotKit/packages/react-textarea/src/types/autosuggestions-config/insertions-api-config.tsx#L4).
+    </PropertyReference>
+  </PropertyReference>
 </PropertyReference>
 


### PR DESCRIPTION
- Add "Look & Feel" sections to each reference Component
- Add link to GitHub type definition for `Textarea.autosuggestionsConfig`. Nesting of properties is currently not supported in our docs generator which makes it hard to manually maintain these. Will need to tackle later.