### PR TITLE
chore(docs): Fix grammar and spelling in the "Self Hosting" section

### DIFF
--- a/docs/pages/concepts/self-hosting.mdx
+++ b/docs/pages/concepts/self-hosting.mdx
@@ -27,7 +27,7 @@ You may choose to self-host the Copilot Runtime, or [use Copilot Cloud](https://
 
 ## Service Adapters
 
-Service Adapters are responsible for executive the request with the LLM and standardize the request/resopnse format in a way that the Copilot Runtime can understand.
+Service Adapters are responsible for executing the request with the LLM and standardizing the request/response format in a way that the Copilot Runtime can understand.
 
 Currently, we support the following service providers/adapters:
 


### PR DESCRIPTION
Update grammar and spelling

## Service Adapters

Service Adapters are responsible for executing the request with the LLM and standardizing the request/response format in a way that the Copilot Runtime can understand.