### PR TITLE
Fix: Adjust modal height to prevent fullscreen issues in sidebar

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Modal.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Modal.tsx
@@ -89,24 +89,28 @@ export const CopilotModal = ({
   return (
     <ChatContextProvider icons={icons} labels={labels} open={openState} setOpen={setOpen}>
       {children}
-      <div className={className}>
+      <div className={className} style={{ height: "100%" }}>
         <Button></Button>
         <Window
           clickOutsideToClose={clickOutsideToClose}
           shortcut={shortcut}
           hitEscapeToClose={hitEscapeToClose}
         >
-          <Header />
-          <CopilotChat
-            instructions={instructions}
-            onSubmitMessage={onSubmitMessage}
-            makeSystemMessage={makeSystemMessage}
-            showResponseButton={showResponseButton}
-            onInProgress={onInProgress}
-            Messages={Messages}
-            Input={Input}
-            ResponseButton={ResponseButton}
-          />
+          <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+            <Header />
+            <div style={{ flexGrow: 1, overflowY: "auto" }}>
+              <CopilotChat
+                instructions={instructions}
+                onSubmitMessage={onSubmitMessage}
+                makeSystemMessage={makeSystemMessage}
+                showResponseButton={showResponseButton}
+                onInProgress={onInProgress}
+                Messages={Messages}
+                Input={Input}
+                ResponseButton={ResponseButton}
+              />
+            </div>
+          </div>
         </Window>
       </div>
     </ChatContextProvider>

--- a/CopilotKit/packages/react-ui/src/components/chat/Sidebar.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Sidebar.tsx
@@ -66,9 +66,12 @@ export function CopilotSidebar(props: CopilotModalProps) {
   };
 
   return (
-    <div className={`copilotKitSidebarContentWrapper ${expandedClassName}`}>
+    <div
+      className={`copilotKitSidebarContentWrapper ${expandedClassName}`}
+      style={{ height: "100%" }}
+    >
       <CopilotModal {...props} {...{ onSetOpen }}>
-        {props.children}
+        <div style={{ height: "100%" }}>{props.children}</div>
       </CopilotModal>
     </div>
   );


### PR DESCRIPTION
- Remove fixed height style from modal container
- Allow modal to adapt to parent container dimensions
- Addresses issue #261 where sidebar parent prevented fullscreen child


Resolves #261 