### PR TITLE
Release v1.2.1

### DIFF
--- a/CopilotKit/examples/next-openai/CHANGELOG.md
+++ b/CopilotKit/examples/next-openai/CHANGELOG.md
@@ -1,5 +1,26 @@
 # web
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.2.1
+  - @copilotkit/react-textarea@1.2.1
+  - @copilotkit/react-ui@1.2.1
+  - @copilotkit/runtime@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/examples/next-openai/package.json
+++ b/CopilotKit/examples/next-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-openai",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "example-dev": "next dev",

--- a/CopilotKit/examples/next-pages-router/CHANGELOG.md
+++ b/CopilotKit/examples/next-pages-router/CHANGELOG.md
@@ -1,5 +1,26 @@
 # next-pages-router
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.2.1
+  - @copilotkit/react-textarea@1.2.1
+  - @copilotkit/react-ui@1.2.1
+  - @copilotkit/runtime@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/examples/next-pages-router/package.json
+++ b/CopilotKit/examples/next-pages-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-pages-router",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "example-dev": "next dev",

--- a/CopilotKit/examples/node-express/CHANGELOG.md
+++ b/CopilotKit/examples/node-express/CHANGELOG.md
@@ -1,5 +1,23 @@
 # node
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/runtime@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/examples/node-express/package.json
+++ b/CopilotKit/examples/node-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-express",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "example-start": "node dist/index.js",

--- a/CopilotKit/examples/node-http/CHANGELOG.md
+++ b/CopilotKit/examples/node-http/CHANGELOG.md
@@ -1,5 +1,23 @@
 # node
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/runtime@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/examples/node-http/package.json
+++ b/CopilotKit/examples/node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-http",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "example-start": "node dist/index.js",

--- a/CopilotKit/packages/react-core/CHANGELOG.md
+++ b/CopilotKit/packages/react-core/CHANGELOG.md
@@ -1,5 +1,23 @@
 # ui
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/runtime-client-gql@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/react-textarea/CHANGELOG.md
+++ b/CopilotKit/packages/react-textarea/CHANGELOG.md
@@ -1,5 +1,24 @@
 # ui
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.2.1
+  - @copilotkit/runtime-client-gql@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sideEffects": [
     "**/*.css"
   ],

--- a/CopilotKit/packages/react-ui/CHANGELOG.md
+++ b/CopilotKit/packages/react-ui/CHANGELOG.md
@@ -1,5 +1,24 @@
 # ui
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.2.1
+  - @copilotkit/runtime-client-gql@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/packages/react-ui/package.json
+++ b/CopilotKit/packages/react-ui/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sideEffects": [
     "**/*.css"
   ],

--- a/CopilotKit/packages/runtime-client-gql/CHANGELOG.md
+++ b/CopilotKit/packages/runtime-client-gql/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @copilotkit/runtime-client-gql
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/runtime@1.2.1
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/packages/runtime-client-gql/package.json
+++ b/CopilotKit/packages/runtime-client-gql/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/runtime/CHANGELOG.md
+++ b/CopilotKit/packages/runtime/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @copilotkit/runtime
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
+- Updated dependencies
+  - @copilotkit/shared@1.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/packages/runtime/package.json
+++ b/CopilotKit/packages/runtime/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/shared/CHANGELOG.md
+++ b/CopilotKit/packages/shared/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @copilotkit/shared
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/utilities/eslint-config-custom/CHANGELOG.md
+++ b/CopilotKit/utilities/eslint-config-custom/CHANGELOG.md
@@ -1,5 +1,19 @@
 # eslint-config-custom
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/utilities/eslint-config-custom/package.json
+++ b/CopilotKit/utilities/eslint-config-custom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-custom",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/CopilotKit/utilities/tailwind-config/CHANGELOG.md
+++ b/CopilotKit/utilities/tailwind-config/CHANGELOG.md
@@ -1,5 +1,19 @@
 # tailwind-config
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/utilities/tailwind-config/package.json
+++ b/CopilotKit/utilities/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-config",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "main": "index.js",
   "devDependencies": {

--- a/CopilotKit/utilities/tsconfig/CHANGELOG.md
+++ b/CopilotKit/utilities/tsconfig/CHANGELOG.md
@@ -1,5 +1,19 @@
 # tsconfig
 
+## 1.2.1
+
+### Patch Changes
+
+- inject minified css in bundle
+
+  - removes the need to import `styles.css` manually
+  - empty `styles.css` included in the build for backwards compatibility
+  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
+  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
+  - remove material-ui, and use `react-icons` for icons (same icons as before)
+  - remove unused `IncludedFilesPreview` component
+  - updated docs
+
 ## 1.2.0
 
 ### Minor Changes

--- a/CopilotKit/utilities/tsconfig/package.json
+++ b/CopilotKit/utilities/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsconfig",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
- inject minified css in bundle

  - removes the need to import `styles.css` manually
  - empty `styles.css` included in the build for backwards compatibility
  - uses tsup's `injectStyles` with `postcss` to bundle and minify the CSS, then inject it as a style tag
  - currently uses my fork of `tsup` where I added support for async function in `injectStyles` (must-have for postcss), a PR from my fork to the main library will follow shortly
  - remove material-ui, and use `react-icons` for icons (same icons as before)
  - remove unused `IncludedFilesPreview` component
  - updated docs

- Updated dependencies
  - @copilotkit/runtime@1.2.1
  - @copilotkit/shared@1.2.1