### PR TITLE
Return current thread id from useCopilotChat

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -206,6 +206,8 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
     });
   };
 
+  const [currentThreadId, setCurrentThreadId] = useState<string | null>(null);
+
   return (
     <CopilotContext.Provider
       value={{
@@ -231,6 +233,8 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
         chatInstructions,
         setChatInstructions,
         showDevConsole: props.showDevConsole === undefined ? "auto" : props.showDevConsole,
+        threadId: currentThreadId,
+        setThreadId: setCurrentThreadId,
       }}
     >
       {children}

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -110,6 +110,9 @@ export interface CopilotContextParams {
   copilotApiConfig: CopilotApiConfig;
 
   showDevConsole: boolean | "auto";
+
+  threadId: string | null;
+  setThreadId: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
 const emptyCopilotContext: CopilotContextParams = {
@@ -155,6 +158,10 @@ const emptyCopilotContext: CopilotContextParams = {
   addChatSuggestionConfiguration: () => {},
   removeChatSuggestionConfiguration: () => {},
   showDevConsole: "auto",
+
+  // Add these new properties
+  threadId: null,
+  setThreadId: () => returnAndThrowInDebug(null),
 };
 
 export const CopilotContext = React.createContext<CopilotContextParams>(emptyCopilotContext);

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -19,7 +19,7 @@ import {
   CopilotRequestType,
 } from "@copilotkit/runtime-client-gql";
 
-import { CopilotApiConfig } from "../context";
+import { CopilotApiConfig, useCopilotContext } from "../context";
 
 export type UseChatOptions = {
   /**
@@ -107,6 +107,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
     ...(publicApiKey ? { [COPILOT_CLOUD_PUBLIC_API_KEY_HEADER]: publicApiKey } : {}),
   };
 
+  const { setThreadId } = useCopilotContext();
   const runtimeClient = new CopilotRuntimeClient({
     url: copilotConfig.chatApiEndpoint,
     publicApiKey: copilotConfig.publicApiKey,
@@ -194,6 +195,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
           continue;
         }
 
+        setThreadId(value.generateCopilotResponse.threadId);
         threadIdRef.current = value.generateCopilotResponse.threadId || null;
         runIdRef.current = value.generateCopilotResponse.runId || null;
 

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
@@ -76,6 +76,7 @@ export interface UseCopilotChatReturn {
   reloadMessages: () => Promise<void>;
   stopGeneration: () => void;
   isLoading: boolean;
+  threadId: string | null;
 }
 
 export function useCopilotChat({
@@ -92,6 +93,7 @@ export function useCopilotChat({
     setIsLoading,
     chatInstructions,
     actions,
+    threadId,
   } = useCopilotContext();
 
   // We need to ensure that makeSystemMessageCallback always uses the latest
@@ -178,6 +180,7 @@ export function useCopilotChat({
     stopGeneration: latestStopFunc,
     deleteMessage: latestDeleteFunc,
     isLoading,
+    threadId,
   };
 }
 


### PR DESCRIPTION
Sometimes it may be useful to have access to the current thread id, so it can be used for any purpose (eg.: link specific threads to specific users of your platform).

This PR is preparatory for others I want to submit in the future in order to allow chat restoration (at the moment, every time I refresh the page, a new chat starts)