### PR TITLE
Fix Invalid Link in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ We value all contributions, whether it's through code, documentation, creating d
 Here are a few useful resources to help you get started:
 
 - For code contributions, [check out the contribution guide](https://docs.copilotkit.ai/code-contributions/how-to-contribute?ref=github_readme).
-- For documentation-related contributions, [check out the documentation contributions guide](https://docs.copilotkit.ai/code-contributions/how-to-contribute?ref=github_readme).
+- For documentation-related contributions, [check out the documentation contributions guide](https://docs.copilotkit.ai/documentation-contributions).
 - Want to contribute but not sure how? [Join our Discord](https://discord.gg/6dffbvGU3D) and we'll help you out!
 
 > 💡 **NOTE:** All contributions must be submitted via a pull request and be reviewed by our team. This is to ensure that all contributions are of high quality and align with the project's goals.


### PR DESCRIPTION
updated the link in the [README](https://github.com/CopilotKit/CopilotKit/blob/main/README.md) to point to the correct documentation contributions guide:

Change from: https://docs.copilotkit.ai/code-contributions/how-to-contribute?ref=github_readme
Change to: https://docs.copilotkit.ai/documentation-contributions