### PR TITLE
Fix broken link in quickstart & tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@
 
 There are several easy ways to get started with CopilotKit:
 
-- [**Quickstart: Chatbot:**](https://docs.copilotkit.ai/quickstart-chatbot?ref=github_readme) In just two minutes, add an AI Chatbot to your app with the ability to read application state and take actions.
+- [**Quickstart: Chatbot:**](https://docs.copilotkit.ai/quickstart) In just two minutes, add an AI Chatbot to your app with the ability to read application state and take actions.
 - [**Tutorial: Todo List Copilot:**](https://docs.copilotkit.ai/tutorial-ai-todo-list-copilot/overview?ref=github_readme) For a deeper dive into CopilotKit, take a simple todo list app and supercharge it with an AI chat popup.
-- [**Tutorial: Textarea Autocomplete:**](https://docs.copilotkit.ai/tutorial-textarea/overview?ref=github_readme) For a deeper dive into CopilotKit, we'll take a simple email client app and add an AI-powered textarea with autocompletions and AI insertions/edits.
+- [**Tutorial: Textarea Autocomplete:**](https://docs.copilotkit.ai/tutorials/ai-powered-textarea/overview) For a deeper dive into CopilotKit, we'll take a simple email client app and add an AI-powered textarea with autocompletions and AI insertions/edits.
 
 ### Examples & Starter Templates
 


### PR DESCRIPTION
Fixed broken link in README.md

Quickstart & Tutorials


[Quickstart: Chatbot:](https://docs.copilotkit.ai/quickstart-chatbot?ref=github_readme) 


From : https://docs.copilotkit.ai/quickstart-chatbot?ref=github_readme
![Screenshot 2024-10-05 102609](https://github.com/user-attachments/assets/22bfda57-094f-4a25-95a9-bcad1439527c)


To  : https://docs.copilotkit.ai/quickstart

![Screenshot 2024-10-05 102717](https://github.com/user-attachments/assets/f5f7e0b1-be8b-4771-b5af-c62ee4e16270)



[Tutorial: Textarea Autocomplete:](https://docs.copilotkit.ai/tutorial-textarea/overview?ref=github_readme) 

From : https://docs.copilotkit.ai/tutorial-textarea/overview?ref=github_readme
![Screenshot 2024-10-05 102908](https://github.com/user-attachments/assets/f9592171-312c-4e97-894d-6e66a1469244)

To :  https://docs.copilotkit.ai/tutorials/ai-powered-textarea/overview
![Screenshot 2024-10-05 103024](https://github.com/user-attachments/assets/416b7dee-9d54-4025-a4f8-f2a4b092617c)


