### PR TITLE
fixed_header.css

### DIFF
--- a/CopilotKit/packages/react-ui/src/css/header.css
+++ b/CopilotKit/packages/react-ui/src/css/header.css
@@ -28,7 +28,7 @@
 .copilotKitHeader > button {
   border: 0;
   padding: 0px;
-  position: absolute;
+  position: fixed;
   top: 50%;
   right: 16px;
   transform: translateY(-50%);


### PR DESCRIPTION
Now, no matter how much you scroll the page, the header will stay fixed at the top and will always be visible.