### PR TITLE
Fix: Cards not visible in Dark Mode #713

### DIFF
--- a/docs/components/react/coagents/coagents-features.tsx
+++ b/docs/components/react/coagents/coagents-features.tsx
@@ -26,11 +26,11 @@ export const CoAgentsFeatureToggle: React.FC<{ className?: string }> = ({ classN
   }
 
   const itemCn =
-    "border p-4 rounded-md flex-1 flex flex-col items-center justify-center cursor-pointer bg-white relative overflow-hidden group transition-all";
+    "border dark:text-white dark:bg-neutral-800 p-4 rounded-md flex-1 flex flex-col items-center justify-center cursor-pointer bg-white relative overflow-hidden group transition-all";
   const selectedCn =
-    "ring-1 ring-indigo-400 selected bg-gradient-to-r from-indigo-100/80 to-purple-200 shadow-lg";
+    "ring-1 dark:text-black ring-indigo-400 selected bg-gradient-to-r from-indigo-100/80 to-purple-200 dark:from-indigo-500 dark:to-purple-500 shadow-lg";
   const iconCn =
-    "w-7 h-7 mb-2 opacity-20 group-[.selected]:text-indigo-500 group-[.selected]:opacity-60 transition-all";
+    "w-7 h-7 mb-2 opacity-20 group-[.selected]:text-indigo-500 group-[.selected]:opacity-60  dark:group-[.selected]:text-indigo-100 transition-all";
 
   const features: { id: FeatureMode; title: string; description: string; Icon: React.FC<React.SVGProps<SVGSVGElement>> }[] = [
     {

--- a/docs/content/docs/coagents/index.mdx
+++ b/docs/content/docs/coagents/index.mdx
@@ -187,7 +187,7 @@ Agents can easily and intentionally ask the user questions. With support for:
       <div className="bg-indigo-500 rounded-md w-7 h-7 text-white flex items-center justify-center">
         <TextIcon className="w-4 h-4" />
       </div>
-      <span>Text Feedback</span>
+      <span className="dark:text-black">Text Feedback</span>
     </div>
     <div className="italic py-4">
       <img
@@ -198,10 +198,10 @@ Agents can easily and intentionally ask the user questions. With support for:
   </div>
   <div className="flex-1 border bg-white rounded-lg shadow-md p-4">
     <div className="flex items-center justify-center gap-2 font-semibold">
-      <div className="bg-indigo-500 rounded-md w-7 h-7 text-white flex items-center justify-center">
+      <div className="bg-indigo-500 rounded-md w-7 h-7 text-white  flex items-center justify-center">
         <JsonIcon className="w-5 h-5" />
       </div>
-      <span>Structured (JSON) Feedback</span>
+      <span className="dark:text-black">Structured (JSON) Feedback</span>
     </div>
     <div className="italic py-4">
       <img


### PR DESCRIPTION
Fixes: #713 

The cards which weren't visible in dark mode are visible now.

### Before : 
**In Light Mode** -
![image](https://github.com/user-attachments/assets/a152cc97-40c8-49bc-9129-177c74c93b18)
**In Dark Mode** -
![image](https://github.com/user-attachments/assets/3dc0e82b-b05e-485a-bd80-0eb9e4c63e29)


### After fix:
**In Light Mode** -
![image](https://github.com/user-attachments/assets/195ad423-a928-448f-ad67-4c6c40b8aac9)
**In Dark Mode** -
![image](https://github.com/user-attachments/assets/1b0ae2c6-569b-412f-ad49-5c30a2a8d2d9)


Feel free to ask for more changes if required
