### PR TITLE
fix(debug): fix floating debug button overlapping CopilotKit logo

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/dev-console/console.tsx
+++ b/CopilotKit/packages/react-ui/src/components/dev-console/console.tsx
@@ -229,7 +229,7 @@ export default function DebugMenuButton({
   const context = useCopilotContext();
 
   return (
-    <div className="bg-black fixed top-24 w-52 text-right">
+    <div className="bg-black top-24 w-52 text-right">
       <Menu>
         <MenuButton className={`copilotKitDebugMenuButton ${mode === "compact" ? "compact" : ""}`}>
           {mode == "compact" ? "Debug" : <>Debug {ChevronDownIcon}</>}


### PR DESCRIPTION
A fix to the debug button overlapping the CopilotKit logo in chat, or otherwise floating in unexpected locations in the page