### PR TITLE
fix(docs): docs misalignment fixes

### DIFF
--- a/docs/content/docs/(root)/guides/generative-ui.mdx
+++ b/docs/content/docs/(root)/guides/generative-ui.mdx
@@ -155,14 +155,15 @@ import UseClientCalloutSnippet from "@/snippets/use-client-callout.mdx";
         },
       ],
       // [!code highlight:12]
-      renderAndWait: ({ meeting, date, title, resolve }) => {
+      renderAndWait: ({ args, handler, status }) => {
+        const { meeting, date, title } = args;
         return (
           <MeetingConfirmationDialog
             meeting={meeting}
             date={date}
             title={title}
-            onConfirm={() => resolvePromise(true)}
-            onCancel={() => resolvePromise(false)}
+            onConfirm={() => handler('meeting confirmed')}
+            onCancel={() => handler('meeting canceled')}
           />
         );
       },

--- a/docs/content/docs/reference/hooks/useCopilotAction.mdx
+++ b/docs/content/docs/reference/hooks/useCopilotAction.mdx
@@ -74,6 +74,10 @@ This hooks enables you to dynamically generate UI elements and render them in th
       Pass `true` to disable the action.
     </PropertyReference>
 
+    <PropertyReference name="followUp" type="boolean" default="true">
+        Whether to report the result of a function call to the LLM which will then provide a follow-up response. Pass `false` to disable
+    </PropertyReference>
+
     <PropertyReference name="parameters" type="Parameter[]">
       The parameters of the action. See [Parameter](#parameter).
 


### PR DESCRIPTION
This PR fixes 2 issues with the docs:
- Adding an explanation on the new `followUp` property available for generative UI action
- Aligning the `renderAndWait` method arguments with the actual signature expected