### PR TITLE
fix(examples): coagents host set to 0.0.0.0

### DIFF
--- a/examples/coagents-ai-researcher/agent/ai_researcher/demo.py
+++ b/examples/coagents-ai-researcher/agent/ai_researcher/demo.py
@@ -1,4 +1,5 @@
 """Demo"""
+
 import os
 from dotenv import load_dotenv
 load_dotenv()
@@ -28,9 +29,7 @@ def health():
     """Health check."""
     return {"status": "ok"}
 
-port = int(os.getenv("PORT", "8000"))
-host = "0.0.0.0" if os.getenv("RENDER") else "127.0.0.1"
-
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("ai_researcher.demo:app", host=host, port=port, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("ai_researcher.demo:app", host="0.0.0.0", port=port, reload=True)

--- a/examples/coagents-qa-native/agent/my_agent/demo.py
+++ b/examples/coagents-qa-native/agent/my_agent/demo.py
@@ -1,5 +1,6 @@
 """Demo"""
 
+import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
 
@@ -25,4 +26,5 @@ add_fastapi_endpoint(app, sdk, "/copilotkit")
 
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("my_agent.demo:app", host="127.0.0.1", port=8000, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("my_agent.demo:app", host="0.0.0.0", port=port, reload=True)

--- a/examples/coagents-qa-text/agent/my_agent/demo.py
+++ b/examples/coagents-qa-text/agent/my_agent/demo.py
@@ -1,5 +1,6 @@
 """Demo"""
 
+import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
 
@@ -25,4 +26,5 @@ add_fastapi_endpoint(app, sdk, "/copilotkit")
 
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("my_agent.demo:app", host="127.0.0.1", port=8000, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("my_agent.demo:app", host="0.0.0.0", port=port, reload=True)

--- a/examples/coagents-qa/agent/my_agent/demo.py
+++ b/examples/coagents-qa/agent/my_agent/demo.py
@@ -1,5 +1,6 @@
 """Demo"""
 
+import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
 
@@ -25,4 +26,5 @@ add_fastapi_endpoint(app, sdk, "/copilotkit")
 
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("my_agent.demo:app", host="127.0.0.1", port=8000, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("my_agent.demo:app", host="0.0.0.0", port=port, reload=True)

--- a/examples/coagents-research-canvas/agent/research_canvas/demo.py
+++ b/examples/coagents-research-canvas/agent/research_canvas/demo.py
@@ -1,4 +1,5 @@
 """Demo"""
+
 import os
 from dotenv import load_dotenv 
 load_dotenv()
@@ -29,9 +30,8 @@ def health():
     """Health check."""
     return {"status": "ok"}
 
-port = int(os.getenv("PORT", "8000"))
-host = "0.0.0.0" if os.getenv("RENDER") else "127.0.0.1"
 
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("research_canvas.demo:app", host=host, port=port, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("research_canvas.demo:app", host="0.0.0.0", port=port, reload=True)

--- a/examples/coagents-shared-state/agent/my_agent/demo.py
+++ b/examples/coagents-shared-state/agent/my_agent/demo.py
@@ -1,5 +1,6 @@
 """Demo"""
 
+import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
 
@@ -25,4 +26,5 @@ add_fastapi_endpoint(app, sdk, "/copilotkit")
 
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("my_agent.demo:app", host="127.0.0.1", port=8000, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("my_agent.demo:app", host="0.0.0.0", port=port, reload=True)

--- a/examples/coagents-starter/agent/my_agent/demo.py
+++ b/examples/coagents-starter/agent/my_agent/demo.py
@@ -1,5 +1,6 @@
 """Demo"""
 
+import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
 
@@ -25,4 +26,5 @@ add_fastapi_endpoint(app, sdk, "/copilotkit")
 
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("my_agent.demo:app", host="127.0.0.1", port=8000, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("my_agent.demo:app", host="0.0.0.0", port=port, reload=True)

--- a/examples/coagents-wait-user-input/agent/my_agent/demo.py
+++ b/examples/coagents-wait-user-input/agent/my_agent/demo.py
@@ -1,5 +1,6 @@
 """Demo"""
 
+import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
 
@@ -25,4 +26,5 @@ add_fastapi_endpoint(app, sdk, "/copilotkit")
 
 def main():
     """Run the uvicorn server."""
-    uvicorn.run("my_agent.demo:app", host="127.0.0.1", port=8000, reload=True)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("my_agent.demo:app", host="0.0.0.0", port=port, reload=True)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

For our example apps, the FastAPI host was previously set to `127.0.0.1` which does not allow connection from `localhost`. By setting the host to `0.0.0.0`, we allow connection from anywhere.

## Checklist

- [x] I have read read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation