### PR TITLE
Release v1.3.6

### DIFF
--- a/CopilotKit/examples/next-openai/CHANGELOG.md
+++ b/CopilotKit/examples/next-openai/CHANGELOG.md
@@ -1,5 +1,19 @@
 # web
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.3.6
+  - @copilotkit/react-textarea@1.3.6
+  - @copilotkit/react-ui@1.3.6
+  - @copilotkit/runtime@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/examples/next-openai/package.json
+++ b/CopilotKit/examples/next-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-openai",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "scripts": {
     "example-dev": "next dev",

--- a/CopilotKit/examples/next-pages-router/CHANGELOG.md
+++ b/CopilotKit/examples/next-pages-router/CHANGELOG.md
@@ -1,5 +1,19 @@
 # next-pages-router
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.3.6
+  - @copilotkit/react-textarea@1.3.6
+  - @copilotkit/react-ui@1.3.6
+  - @copilotkit/runtime@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/examples/next-pages-router/package.json
+++ b/CopilotKit/examples/next-pages-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-pages-router",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "scripts": {
     "example-dev": "next dev",

--- a/CopilotKit/examples/node-express/CHANGELOG.md
+++ b/CopilotKit/examples/node-express/CHANGELOG.md
@@ -1,5 +1,16 @@
 # node
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/runtime@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/examples/node-express/package.json
+++ b/CopilotKit/examples/node-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-express",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "scripts": {
     "example-start": "node dist/index.js",

--- a/CopilotKit/examples/node-http/CHANGELOG.md
+++ b/CopilotKit/examples/node-http/CHANGELOG.md
@@ -1,5 +1,16 @@
 # node
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/runtime@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/examples/node-http/package.json
+++ b/CopilotKit/examples/node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-http",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "scripts": {
     "example-start": "node dist/index.js",

--- a/CopilotKit/packages/react-core/CHANGELOG.md
+++ b/CopilotKit/packages/react-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # ui
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/runtime-client-gql@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/react-textarea/CHANGELOG.md
+++ b/CopilotKit/packages/react-textarea/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ui
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.3.6
+  - @copilotkit/runtime-client-gql@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "sideEffects": [
     "**/*.css"
   ],

--- a/CopilotKit/packages/react-ui/CHANGELOG.md
+++ b/CopilotKit/packages/react-ui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ui
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/react-core@1.3.6
+  - @copilotkit/runtime-client-gql@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/packages/react-ui/package.json
+++ b/CopilotKit/packages/react-ui/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "sideEffects": [
     "**/*.css"
   ],

--- a/CopilotKit/packages/runtime-client-gql/CHANGELOG.md
+++ b/CopilotKit/packages/runtime-client-gql/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @copilotkit/runtime-client-gql
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/runtime@1.3.6
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/packages/runtime-client-gql/package.json
+++ b/CopilotKit/packages/runtime-client-gql/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/runtime/CHANGELOG.md
+++ b/CopilotKit/packages/runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @copilotkit/runtime
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
+- Updated dependencies
+  - @copilotkit/shared@1.3.6
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/packages/runtime/package.json
+++ b/CopilotKit/packages/runtime/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/shared/CHANGELOG.md
+++ b/CopilotKit/packages/shared/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @copilotkit/shared
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.5",
+  "version": "1.3.6",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/utilities/eslint-config-custom/CHANGELOG.md
+++ b/CopilotKit/utilities/eslint-config-custom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # eslint-config-custom
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/utilities/eslint-config-custom/package.json
+++ b/CopilotKit/utilities/eslint-config-custom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-custom",
   "private": true,
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/CopilotKit/utilities/tailwind-config/CHANGELOG.md
+++ b/CopilotKit/utilities/tailwind-config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # tailwind-config
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/utilities/tailwind-config/package.json
+++ b/CopilotKit/utilities/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-config",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "main": "index.js",
   "devDependencies": {

--- a/CopilotKit/utilities/tsconfig/CHANGELOG.md
+++ b/CopilotKit/utilities/tsconfig/CHANGELOG.md
@@ -1,5 +1,12 @@
 # tsconfig
 
+## 1.3.6
+
+### Patch Changes
+
+- 1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
+  2. Fixes Nest.js runtime docs
+
 ## 1.3.5
 
 ### Patch Changes

--- a/CopilotKit/utilities/tsconfig/package.json
+++ b/CopilotKit/utilities/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsconfig",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
1. Removes the usage of the `crypto` Node pacakge, instaed uses `uuid`. This ensures that non-Next.js React apps can use CopilotKit.
 2. Fixes Nest.js runtime docs