### PR TITLE
fix(context): split context to avoid excessive re-renders

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
@@ -1,0 +1,23 @@
+/**
+ * An internal context to separate the messages state (which is constantly changing) from the rest of CopilotKit context
+ */
+
+import { useState } from "react";
+import { CopilotMessagesContext } from "../../context/copilot-messages-context";
+import { Message } from "@copilotkit/runtime-client-gql";
+import { CopilotKitProps } from "./copilotkit-props";
+
+export function CopilotMessages({ children, ...props }: CopilotKitProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  return (
+    <CopilotMessagesContext.Provider
+      value={{
+        messages,
+        setMessages,
+      }}
+    >
+      {children}
+    </CopilotMessagesContext.Provider>
+  );
+}

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -170,32 +170,42 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
     }
   }
 
-  let cloud: CopilotCloudConfig | undefined = undefined;
-  if (props.publicApiKey) {
-    cloud = {
-      guardrails: {
-        input: {
-          restrictToTopic: {
-            enabled: props.cloudRestrictToTopic ? true : false,
-            validTopics: props.cloudRestrictToTopic?.validTopics || [],
-            invalidTopics: props.cloudRestrictToTopic?.invalidTopics || [],
+  // get the appropriate CopilotApiConfig from the props
+  const copilotApiConfig: CopilotApiConfig = useMemo(() => {
+    let cloud: CopilotCloudConfig | undefined = undefined;
+    if (props.publicApiKey) {
+      cloud = {
+        guardrails: {
+          input: {
+            restrictToTopic: {
+              enabled: props.cloudRestrictToTopic ? true : false,
+              validTopics: props.cloudRestrictToTopic?.validTopics || [],
+              invalidTopics: props.cloudRestrictToTopic?.invalidTopics || [],
+            },
           },
         },
-      },
-    };
-  }
+      };
+    }
 
-  // get the appropriate CopilotApiConfig from the props
-  const copilotApiConfig: CopilotApiConfig = {
-    publicApiKey: props.publicApiKey,
-    ...(cloud ? { cloud } : {}),
-    chatApiEndpoint: chatApiEndpoint,
-    headers: props.headers || {},
-    properties: props.properties || {},
-    transcribeAudioUrl: props.transcribeAudioUrl,
-    textToSpeechUrl: props.textToSpeechUrl,
-    credentials: props.credentials,
-  };
+    return {
+      publicApiKey: props.publicApiKey,
+      ...(cloud ? { cloud } : {}),
+      chatApiEndpoint: chatApiEndpoint,
+      headers: props.headers || {},
+      properties: props.properties || {},
+      transcribeAudioUrl: props.transcribeAudioUrl,
+      textToSpeechUrl: props.textToSpeechUrl,
+      credentials: props.credentials,
+    };
+  }, [
+    props.publicApiKey,
+    props.headers,
+    props.properties,
+    props.transcribeAudioUrl,
+    props.textToSpeechUrl,
+    props.credentials,
+    props.cloudRestrictToTopic,
+  ]);
 
   const [chatSuggestionConfiguration, setChatSuggestionConfiguration] = useState<{
     [key: string]: CopilotChatSuggestionConfiguration;

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -14,11 +14,10 @@
  * ```
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   CopilotContext,
   CopilotApiConfig,
-  InChatRenderFunction,
   ChatComponentsCache,
   AgentSession,
 } from "../../context/copilot-context";
@@ -30,13 +29,13 @@ import {
   CopilotCloudConfig,
   FunctionCallHandler,
 } from "@copilotkit/shared";
-import { AgentStateMessage, Message } from "@copilotkit/runtime-client-gql";
 
 import { FrontendAction } from "../../types/frontend-action";
 import useFlatCategoryStore from "../../hooks/use-flat-category-store";
 import { CopilotKitProps } from "./copilotkit-props";
 import { CoAgentStateRender } from "../../types/coagent-action";
 import { CoagentState } from "../../types/coagent-state";
+import { CopilotMessages } from "./copilot-messages";
 
 export function CopilotKit({ children, ...props }: CopilotKitProps) {
   // Compute all the functions and properties that we need to pass
@@ -59,7 +58,6 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
     coAgentStateRenders: {},
   });
   const { addElement, removeElement, printTree } = useTree();
-  const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [chatInstructions, setChatInstructions] = useState("");
 
@@ -245,8 +243,6 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
         addDocumentContext,
         removeDocumentContext,
         copilotApiConfig: copilotApiConfig,
-        messages,
-        setMessages,
         isLoading,
         setIsLoading,
         chatSuggestionConfiguration,
@@ -261,7 +257,7 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
         setAgentSession,
       }}
     >
-      {children}
+      <CopilotMessages>{children}</CopilotMessages>
     </CopilotContext.Provider>
   );
 }

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -1,5 +1,4 @@
 import { CopilotCloudConfig, FunctionCallHandler } from "@copilotkit/shared";
-import { Message } from "@copilotkit/runtime-client-gql";
 import { ActionRenderProps, FrontendAction } from "../types/frontend-action";
 import React from "react";
 import { TreeNodeId } from "../hooks/use-tree";
@@ -111,10 +110,6 @@ export interface CopilotContextParams {
   removeDocumentContext: (documentId: string) => void;
   getDocumentsContext: (categories: string[]) => DocumentPointer[];
 
-  // chat
-  messages: Message[];
-  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
-
   isLoading: boolean;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
 
@@ -156,9 +151,6 @@ const emptyCopilotContext: CopilotContextParams = {
   removeContext: () => {},
 
   getFunctionCallHandler: () => returnAndThrowInDebug(async () => {}),
-
-  messages: [],
-  setMessages: () => returnAndThrowInDebug([]),
 
   isLoading: false,
   setIsLoading: () => returnAndThrowInDebug(false),

--- a/CopilotKit/packages/react-core/src/context/copilot-messages-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-messages-context.tsx
@@ -1,0 +1,29 @@
+/**
+ * An internal context to separate the messages state (which is constantly changing) from the rest of CopilotKit context
+ */
+
+import { Message } from "@copilotkit/runtime-client-gql";
+import React from "react";
+
+export interface CopilotMessagesContextParams {
+  messages: Message[];
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+}
+
+const emptyCopilotContext: CopilotMessagesContextParams = {
+  messages: [],
+  setMessages: () => [],
+};
+
+export const CopilotMessagesContext =
+  React.createContext<CopilotMessagesContextParams>(emptyCopilotContext);
+
+export function useCopilotMessagesContext(): CopilotMessagesContextParams {
+  const context = React.useContext(CopilotMessagesContext);
+  if (context === emptyCopilotContext) {
+    throw new Error(
+      "A messages consuming component was not wrapped with `<CopilotMessages> {...} </CopilotMessages>`",
+    );
+  }
+  return context;
+}

--- a/CopilotKit/packages/react-core/src/context/index.ts
+++ b/CopilotKit/packages/react-core/src/context/index.ts
@@ -1,6 +1,8 @@
 export { CopilotContext, useCopilotContext } from "./copilot-context";
+export { CopilotMessagesContext, useCopilotMessagesContext } from "./copilot-messages-context";
 export type {
   CopilotContextParams,
   CoagentInChatRenderFunction,
   CopilotApiConfig,
 } from "./copilot-context";
+export type { CopilotMessagesContextParams } from "./copilot-messages-context";

--- a/CopilotKit/packages/react-core/src/hooks/use-coagent.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-coagent.ts
@@ -1,5 +1,10 @@
 import { useEffect } from "react";
-import { CopilotContextParams, useCopilotContext } from "../context";
+import {
+  CopilotContextParams,
+  CopilotMessagesContextParams,
+  useCopilotContext,
+  useCopilotMessagesContext,
+} from "../context";
 import { CoagentState } from "../types/coagent-state";
 import { useCopilotChat } from "./use-copilot-chat";
 import { AgentStateMessage, Message, Role, TextMessage } from "@copilotkit/runtime-client-gql";
@@ -59,7 +64,9 @@ export function useCoAgent<T = any>(options: UseCoagentOptions<T>): UseCoagentRe
     return "initialState" in options;
   };
 
-  const context = useCopilotContext();
+  const generalContext = useCopilotContext();
+  const messagesContext = useCopilotMessagesContext();
+  const context = { ...generalContext, ...messagesContext };
   const { coagentStates, setCoagentStates } = context;
   const { appendMessage } = useCopilotChat();
 
@@ -147,7 +154,7 @@ function stopAgent(name: string, context: CopilotContextParams) {
 
 async function runAgent(
   name: string,
-  context: CopilotContextParams,
+  context: CopilotContextParams & CopilotMessagesContextParams,
   appendMessage: (message: Message) => Promise<void>,
   hint?: HintFunction,
 ) {

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
@@ -46,6 +46,7 @@ import { useChat } from "./use-chat";
 import { defaultCopilotContextCategories } from "../components";
 import { MessageStatusCode } from "@copilotkit/runtime-client-gql";
 import { CoAgentStateRenderHandlerArguments } from "@copilotkit/shared";
+import { useCopilotMessagesContext } from "../context";
 
 export interface UseCopilotChatOptions {
   /**
@@ -88,8 +89,6 @@ export function useCopilotChat({
     getContextString,
     getFunctionCallHandler,
     copilotApiConfig,
-    messages,
-    setMessages,
     isLoading,
     setIsLoading,
     chatInstructions,
@@ -101,6 +100,7 @@ export function useCopilotChat({
     agentSession,
     setAgentSession,
   } = useCopilotContext();
+  const { messages, setMessages } = useCopilotMessagesContext();
 
   // We need to ensure that makeSystemMessageCallback always uses the latest
   // useCopilotReadable data.

--- a/CopilotKit/packages/react-core/src/utils/extract.ts
+++ b/CopilotKit/packages/react-core/src/utils/extract.ts
@@ -13,7 +13,7 @@ import {
   convertGqlOutputToMessages,
   CopilotRequestType,
 } from "@copilotkit/runtime-client-gql";
-import { CopilotContextParams } from "../context";
+import { CopilotContextParams, CopilotMessagesContextParams } from "../context";
 import { defaultCopilotContextCategories } from "../components";
 import { CopilotRuntimeClient } from "@copilotkit/runtime-client-gql";
 import {
@@ -42,7 +42,7 @@ type StreamHandlerArgs<T extends Parameter[] | [] = []> =
   | CompleteState<T>;
 
 interface ExtractOptions<T extends Parameter[]> {
-  context: CopilotContextParams;
+  context: CopilotContextParams & CopilotMessagesContextParams;
   instructions: string;
   parameters: T;
   include?: IncludeOptions;

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -60,7 +60,12 @@ import { RenderResultMessage as DefaultRenderResultMessage } from "./messages/Re
 import { RenderAgentStateMessage as DefaultRenderAgentStateMessage } from "./messages/RenderAgentStateMessage";
 import { Suggestion } from "./Suggestion";
 import React, { useEffect, useRef, useState } from "react";
-import { SystemMessageFunction, useCopilotChat, useCopilotContext } from "@copilotkit/react-core";
+import {
+  SystemMessageFunction,
+  useCopilotChat,
+  useCopilotContext,
+  useCopilotMessagesContext,
+} from "@copilotkit/react-core";
 import { reloadSuggestions } from "./Suggestion";
 import { CopilotChatSuggestion } from "../../types/suggestions";
 import { Message, Role, TextMessage } from "@copilotkit/runtime-client-gql";
@@ -282,7 +287,9 @@ export const useCopilotChatLogic = (
     suggestionsAbortControllerRef.current = null;
   };
 
-  const context = useCopilotContext();
+  const generalContext = useCopilotContext();
+  const messagesContext = useCopilotMessagesContext();
+  const context = { ...generalContext, ...messagesContext };
 
   useEffect(() => {
     onInProgress?.(isLoading);

--- a/CopilotKit/packages/react-ui/src/components/chat/Suggestion.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Suggestion.tsx
@@ -2,7 +2,7 @@ import {
   CopilotContextParams,
   extract,
   CopilotChatSuggestionConfiguration,
-  useCopilotContext,
+  CopilotMessagesContextParams,
 } from "@copilotkit/react-core";
 import { SuggestionsProps } from "./props";
 import { SmallSpinnerIcon } from "./Icons";
@@ -27,7 +27,7 @@ export function Suggestion({ title, message, onClick, partial, className }: Sugg
 }
 
 export const reloadSuggestions = async (
-  context: CopilotContextParams,
+  context: CopilotContextParams & CopilotMessagesContextParams,
   chatSuggestionConfiguration: { [key: string]: CopilotChatSuggestionConfiguration },
   setCurrentSuggestions: (suggestions: { title: string; message: string }[]) => void,
   abortControllerRef: React.MutableRefObject<AbortController | null>,

--- a/CopilotKit/packages/react-ui/src/components/dev-console/console.tsx
+++ b/CopilotKit/packages/react-ui/src/components/dev-console/console.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCopilotContext } from "@copilotkit/react-core";
+import { useCopilotContext, useCopilotMessagesContext } from "@copilotkit/react-core";
 import {
   getPublishedCopilotKitVersion,
   logActions,
@@ -227,6 +227,7 @@ export default function DebugMenuButton({
   mode: "full" | "compact";
 }) {
   const context = useCopilotContext();
+  const messagesContext = useCopilotMessagesContext();
 
   return (
     <div className="bg-black top-24 w-52 text-right">
@@ -252,7 +253,10 @@ export default function DebugMenuButton({
             </button>
           </MenuItem>
           <MenuItem>
-            <button className="copilotKitDebugMenuItem" onClick={() => logMessages(context)}>
+            <button
+              className="copilotKitDebugMenuItem"
+              onClick={() => logMessages(messagesContext)}
+            >
               Log Messages
             </button>
           </MenuItem>

--- a/CopilotKit/packages/react-ui/src/components/dev-console/utils.ts
+++ b/CopilotKit/packages/react-ui/src/components/dev-console/utils.ts
@@ -1,4 +1,8 @@
-import { CopilotContextParams, defaultCopilotContextCategories } from "@copilotkit/react-core";
+import {
+  CopilotContextParams,
+  CopilotMessagesContextParams,
+  defaultCopilotContextCategories,
+} from "@copilotkit/react-core";
 import { CopilotKitVersion } from "./types";
 import { ActionExecutionMessage, ResultMessage, TextMessage } from "@copilotkit/runtime-client-gql";
 import { AgentStateMessage } from "@copilotkit/runtime-client-gql";
@@ -107,7 +111,7 @@ export function logActions(context: CopilotContextParams) {
   }
 }
 
-export function logMessages(context: CopilotContextParams) {
+export function logMessages(context: CopilotMessagesContextParams) {
   console.log("%cCurrent Messages:", "font-size: 16px; font-weight: bold;");
 
   if (context.messages.length === 0) {

--- a/CopilotKit/packages/react-ui/src/hooks/use-push-to-talk.tsx
+++ b/CopilotKit/packages/react-ui/src/hooks/use-push-to-talk.tsx
@@ -1,4 +1,4 @@
-import { useCopilotContext } from "@copilotkit/react-core";
+import { useCopilotContext, useCopilotMessagesContext } from "@copilotkit/react-core";
 import { Message, TextMessage } from "@copilotkit/runtime-client-gql";
 import { MutableRefObject, useEffect, useRef, useState } from "react";
 
@@ -108,7 +108,9 @@ export const usePushToTalk = ({
   const audioContextRef = useRef<AudioContext | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const recordedChunks = useRef<Blob[]>([]);
-  const context = useCopilotContext();
+  const generalContext = useCopilotContext();
+  const messagesContext = useCopilotMessagesContext();
+  const context = { ...generalContext, ...messagesContext };
   const [startReadingFromMessageId, setStartReadingFromMessageId] = useState<string | null>(null);
 
   useEffect(() => {

--- a/CopilotKit/scripts/release/prerelease.sh
+++ b/CopilotKit/scripts/release/prerelease.sh
@@ -8,24 +8,12 @@ if [ -f .env.local ]; then
   set +a # stop automatically exporting
 fi
 
-# if GH_TOKEN is not set, quit
-if [ -z "$GH_TOKEN" ]; then
-  printf "\e[41m\e[97m!!\e[0m Error: GH_TOKEN is not set\n"
-  exit 1
-fi
-
 # save the current branch
 current_branch=$(git branch --show-current)
 
 # quit if the current branch is main
 if [ "$current_branch" = "main" ]; then
   printf "\e[41m\e[97m!!\e[0m Error: Can't release pre release from main branch\n"
-  exit 1
-fi
-
-# quit if there are uncommitted changes
-if [ -n "$(git status --porcelain)" ]; then
-  printf "\e[41m\e[97m!!\e[0m Error: There are uncommitted changes\n"
   exit 1
 fi
 
@@ -72,29 +60,3 @@ fi
 
 # Stage and commit
 git add -A && git commit -m "Pre release $current_branch" && git push
-
-# Sleep a little so that GitHub picks up the change
-sleep 3
-
-# Manually trigger the CI
-curl -X POST \
-  -H "Accept: application/vnd.github.v3+json" \
-  -H "Authorization: token $GH_TOKEN" \
-  -d "{\"ref\":\"$current_branch\"}" \
-  https://api.github.com/repos/CopilotKit/CopilotKit/actions/workflows/release.yml/dispatches
-
-
-# get out of pre mode
-echo "=================================================="
-echo "!! Automatically exiting pre mode in 30 seconds !!"
-echo "=================================================="
-echo ""
-
-# wait for 30 seconds
-sleep 30
-
-# get out of pre mode
-pnpm changeset pre exit
-
-# push the changes
-git add -A && git commit -m "Pre release $current_branch - exit pre mode" && git push


### PR DESCRIPTION
## What does this PR do?

This PR moves "messages" from the main context to a new cozy home. This is because the frequent update of the messages causes an update to the whole tree of main context.
With such split in place, the update of messages now will not rerender all tree. This is especially important because of how update of messages work: Messages will be updated when the chat streams, therefore, a re-render for almost every token

## Checklist

- [X] I have read read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation