### PR TITLE
fix: update link in documentation

### DIFF
--- a/community/content/README.md
+++ b/community/content/README.md
@@ -51,6 +51,6 @@ Demos will be ranked from 0 to 100 based on:
 ## Need Help?
 
 - **Questions**: Use our [Discord support channel](https://discord.com/invite/6dffbvGU3D) for any questions you have.
-- **Resources**: Visit [CopilotKit documentation](https://docs.copilotkit.ai/what-is-copilotkit) for more helpful documentatation info.
+- **Resources**: Visit [CopilotKit documentation](https://docs.copilotkit.ai/?ref=github_readme) for more helpful documentatation info.
 
 ⭐ Happy coding, and we look forward to your contributions!


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR fixes a broken link in the Resources section of the documentation. Previously, clicking on [CopilotKit documentation](https://docs.copilotkit.ai/what-is-copilotkit) resulted in a 404 error:

<img width="1229" alt="Screenshot 2024-10-29 at 1 03 30 PM" src="https://github.com/user-attachments/assets/9bd34340-540f-4dfd-a123-677eac13aa64">

I’ve updated it to the correct URL.

## Related PRs and Issues

## Checklist

- [x] I have read read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation