### PR TITLE
fix: prevent rerenders by memoizing ui context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __snapshots__
 @generated
 node_modules
+.idea/

--- a/CopilotKit/packages/react-ui/src/components/chat/ChatContext.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/ChatContext.tsx
@@ -141,8 +141,8 @@ export const ChatContextProvider = ({
   open,
   setOpen,
 }: ChatContextProps) => {
-  const context = {
-    labels: {
+  const memoizedLabels = useMemo(
+    () => ({
       ...{
         initial: "",
         title: "CopilotKit",
@@ -152,9 +152,12 @@ export const ChatContextProvider = ({
         regenerateResponse: "Regenerate response",
       },
       ...labels,
-    },
+    }),
+    [labels],
+  );
 
-    icons: {
+  const memoizedIcons = useMemo(
+    () => ({
       ...{
         openIcon: DefaultIcons.OpenIcon,
         closeIcon: DefaultIcons.CloseIcon,
@@ -167,9 +170,19 @@ export const ChatContextProvider = ({
         pushToTalkIcon: DefaultIcons.PushToTalkIcon,
       },
       ...icons,
-    },
-    open,
-    setOpen,
-  };
+    }),
+    [icons],
+  );
+
+  const context = useMemo(
+    () => ({
+      labels: memoizedLabels,
+      icons: memoizedIcons,
+      open,
+      setOpen,
+    }),
+    [memoizedLabels, memoizedIcons, open, setOpen],
+  );
+
   return <ChatContext.Provider value={context}>{children}</ChatContext.Provider>;
 };


### PR DESCRIPTION
## What does this PR do?

This PR introduced further memoization of context items, in order to help prevent, or minimize, some re-renders which are happening one a more advanced use case when customizing the sidebar etc