### PR TITLE
Opening Popover  on windows when we press ctrl + k in textarea

### DIFF
--- a/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
+++ b/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
@@ -76,10 +76,20 @@ const defaultShouldToggleHoveringEditorOnKeyPress = (
   event: React.KeyboardEvent<HTMLDivElement>,
   shortcut: string,
 ) => {
-  // if command-k, toggle the hovering editor
-  if (event.key === shortcut && event.metaKey) {
-    return true;
+  const isWindowsOs = navigator.userAgent.includes("Windows");
+
+  if (isWindowsOs) {
+    // if ctrl-k, toggle the hovering editor on windows
+    if (event.key === shortcut && event.ctrlKey) {
+      return true;
+    }
+  } else {
+    // if command-k, toggle the hovering editor on mac
+    if (event.key === shortcut && event.metaKey) {
+      return true;
+    }
   }
+
   return false;
 };
 


### PR DESCRIPTION
## What does this PR do?
This PR adds functionality to detect when a user presses Ctrl + K on a Windows machine and displays a popup if this specific key combination is used.

Implementation Details:
Key Press Detection: The code checks each keypress event to determine if the user is on a Windows OS and if the Ctrl + K key combination has been pressed.
Popup Trigger: If both conditions (Windows OS and Ctrl + K) are met, a popup is displayed.


## Related PRs and Issues
Fixes #400 
![image](https://github.com/user-attachments/assets/1ac5e8fa-e654-4da1-9ccb-dd7489243222)


## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation