### PR TITLE
fix: change how message chunk type is read

### DIFF
--- a/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.ts
@@ -106,15 +106,15 @@ function getConstructorName(object: any): string {
 }
 
 function isAIMessage(message: any): message is AIMessage {
-  return getConstructorName(message) === "AIMessage";
+  return Object.prototype.toString.call(message) === "[object AIMessage]";
 }
 
 function isAIMessageChunk(message: any): message is AIMessageChunk {
-  return getConstructorName(message) === "AIMessageChunk";
+  return Object.prototype.toString.call(message) === "[object AIMessageChunk]";
 }
 
 function isBaseMessageChunk(message: any): message is BaseMessageChunk {
-  return getConstructorName(message) === "BaseMessageChunk";
+  return Object.prototype.toString.call(message) === "[object BaseMessageChunk]";
 }
 
 function maybeSendActionExecutionResultIsMessage(


### PR DESCRIPTION
## What does this PR do?

The way the type of message chunk is determined when we receive the message stream back, was crooked when the app was deployed and code was minified.
This PR introduced a way of resolving even when the app is minified 