### PR TITLE
fix: enable dynamic parameters in langchain adapter tool call

### DIFF
--- a/CopilotKit/packages/runtime/package.json
+++ b/CopilotKit/packages/runtime/package.json
@@ -42,15 +42,16 @@
     "ts-node": "^10.9.2",
     "tsconfig": "workspace:*",
     "tsup": "^6.7.0",
-    "typescript": "^5.2.3"
+    "typescript": "^5.2.3",
+    "zod-to-json-schema": "^3.23.5"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.27.3",
     "@copilotkit/shared": "workspace:*",
-    "@langchain/google-gauth": "^0.1.0",
     "@graphql-yoga/plugin-defer-stream": "^3.3.1",
     "@langchain/community": "^0.0.53",
     "@langchain/core": "^0.3.13",
+    "@langchain/google-gauth": "^0.1.0",
     "@langchain/openai": "^0.0.28",
     "class-transformer": "^0.5.1",
     "express": "^4.19.2",

--- a/CopilotKit/packages/runtime/src/service-adapters/events.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/events.ts
@@ -260,7 +260,11 @@ async function executeAction(
   // Prepare arguments for function calling
   let args: Record<string, any>[] = [];
   if (actionArguments) {
-    args = JSON.parse(actionArguments);
+    try {
+      args = JSON.parse(actionArguments);
+    } catch (e) {
+      console.warn("Action argument unparsable", { actionArguments });
+    }
   }
 
   // handle LangGraph agents

--- a/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.test.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.test.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+import { convertJsonSchemaToZodSchema } from "./utils";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+describe("convertJsonSchemaToZodSchema", () => {
+  it("should convert a simple JSON schema to a Zod schema", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+      },
+      required: ["name", "age"],
+    };
+
+    const expectedSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+    });
+
+    const result = convertJsonSchemaToZodSchema(jsonSchema, true);
+    const resultSchemaJson = zodToJsonSchema(result);
+    const expectedSchemaJson = zodToJsonSchema(expectedSchema);
+
+    expect(resultSchemaJson).toStrictEqual(expectedSchemaJson);
+  });
+
+  it("should convert a JSON schema with nested objects to a Zod schema", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        address: {
+          type: "object",
+          properties: {
+            street: { type: "string" },
+            city: { type: "string" },
+          },
+          required: ["street", "city"],
+        },
+      },
+      required: ["name", "address"],
+    };
+
+    const expectedSchema = z.object({
+      name: z.string(),
+      address: z.object({
+        street: z.string(),
+        city: z.string(),
+      }),
+    });
+
+    const result = convertJsonSchemaToZodSchema(jsonSchema, true);
+    const resultSchemaJson = zodToJsonSchema(result);
+    const expectedSchemaJson = zodToJsonSchema(expectedSchema);
+
+    expect(resultSchemaJson).toStrictEqual(expectedSchemaJson);
+  });
+
+  it("should convert a JSON schema with arrays to a Zod schema", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        names: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["names"],
+    };
+
+    const expectedSchema = z.object({
+      names: z.array(z.string()),
+    });
+
+    const result = convertJsonSchemaToZodSchema(jsonSchema, true);
+    const resultSchemaJson = zodToJsonSchema(result);
+    const expectedSchemaJson = zodToJsonSchema(expectedSchema);
+
+    expect(resultSchemaJson).toStrictEqual(expectedSchemaJson);
+  });
+
+  it("should convert a JSON schema with optional properties to a Zod schema", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number", required: false },
+      },
+    };
+
+    const expectedSchema = z
+      .object({
+        name: z.string().optional(),
+        age: z.number().optional(),
+      })
+      .optional();
+
+    const result = convertJsonSchemaToZodSchema(jsonSchema, false);
+
+    console.log(convertJsonSchemaToZodSchema(jsonSchema, false));
+
+    const resultSchemaJson = zodToJsonSchema(result);
+    const expectedSchemaJson = zodToJsonSchema(expectedSchema);
+
+    expect(resultSchemaJson).toStrictEqual(expectedSchemaJson);
+  });
+
+  it("should convert a JSON schema with different types to a Zod schema", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+        isAdmin: { type: "boolean" },
+      },
+      required: ["name", "age", "isAdmin"],
+    };
+
+    const expectedSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+      isAdmin: z.boolean(),
+    });
+
+    const result = convertJsonSchemaToZodSchema(jsonSchema, true);
+    const resultSchemaJson = zodToJsonSchema(result);
+    const expectedSchemaJson = zodToJsonSchema(expectedSchema);
+
+    expect(resultSchemaJson).toStrictEqual(expectedSchemaJson);
+  });
+
+  it("should handle edge case where JSON schema has no properties", () => {
+    const jsonSchema = {
+      type: "object",
+    };
+
+    const expectedSchema = z.object({});
+
+    const result = convertJsonSchemaToZodSchema(jsonSchema, true);
+    const resultSchemaJson = zodToJsonSchema(result);
+    const expectedSchemaJson = zodToJsonSchema(expectedSchema);
+
+    expect(resultSchemaJson).toStrictEqual(expectedSchemaJson);
+  });
+
+  it("should handle edge case where JSON schema has no required properties", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+      },
+    };
+
+    const expectedSchema = z
+      .object({
+        name: z.string().optional(),
+        age: z.number().optional(),
+      })
+      .optional();
+
+    const result = convertJsonSchemaToZodSchema(jsonSchema, false);
+    const resultSchemaJson = zodToJsonSchema(result);
+    const expectedSchemaJson = zodToJsonSchema(expectedSchema);
+
+    expect(resultSchemaJson).toStrictEqual(expectedSchemaJson);
+  });
+});

--- a/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.ts
@@ -51,6 +51,11 @@ export function convertMessageToLangChainMessage(message: Message): BaseMessage 
 export function convertJsonSchemaToZodSchema(jsonSchema: any, required: boolean): z.ZodSchema {
   if (jsonSchema.type === "object") {
     const spec: { [key: string]: z.ZodSchema } = {};
+
+    if (!jsonSchema.properties || !Object.keys(jsonSchema.properties).length) {
+      return !required ? z.object(spec).optional() : z.object(spec);
+    }
+
     for (const [key, value] of Object.entries(jsonSchema.properties)) {
       spec[key] = convertJsonSchemaToZodSchema(
         value,
@@ -58,20 +63,20 @@ export function convertJsonSchemaToZodSchema(jsonSchema: any, required: boolean)
       );
     }
     let schema = z.object(spec);
-    return !required ? schema.optional() : schema;
+    return required ? schema : schema.optional();
   } else if (jsonSchema.type === "string") {
     let schema = z.string().describe(jsonSchema.description);
-    return !required ? schema.optional() : schema;
+    return required ? schema : schema.optional();
   } else if (jsonSchema.type === "number") {
     let schema = z.number().describe(jsonSchema.description);
-    return !required ? schema.optional() : schema;
+    return required ? schema : schema.optional();
   } else if (jsonSchema.type === "boolean") {
     let schema = z.boolean().describe(jsonSchema.description);
-    return !required ? schema.optional() : schema;
+    return required ? schema : schema.optional();
   } else if (jsonSchema.type === "array") {
     let itemSchema = convertJsonSchemaToZodSchema(jsonSchema.items, true);
     let schema = z.array(itemSchema);
-    return !required ? schema.optional() : schema;
+    return required ? schema : schema.optional();
   }
 }
 

--- a/CopilotKit/pnpm-lock.yaml
+++ b/CopilotKit/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
       typescript:
         specifier: ^5.2.3
         version: 5.5.4
+      zod-to-json-schema:
+        specifier: ^3.23.5
+        version: 3.23.5(zod@3.23.8)
 
   packages/runtime-client-gql:
     dependencies:
@@ -7890,6 +7893,11 @@ packages:
     peerDependencies:
       zod: ^3.23.3
 
+  zod-to-json-schema@3.23.5:
+    resolution: {integrity: sha512-5wlSS0bXfF/BrL4jPAbz9da5hDlDptdEppYfe+x4eIJ7jioqKG9uUxOwPzqof09u/XeVdrgFu29lZi+8XNDJtA==}
+    peerDependencies:
+      zod: ^3.23.3
+
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
@@ -9823,7 +9831,7 @@ snapshots:
       p-retry: 4.6.2
       uuid: 10.0.0
       zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.23.5(zod@3.23.8)
     transitivePeerDependencies:
       - openai
 
@@ -9847,7 +9855,7 @@ snapshots:
     dependencies:
       '@langchain/core': 0.3.13(openai@4.53.0(encoding@0.1.13))
       uuid: 10.0.0
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.23.5(zod@3.23.8)
     transitivePeerDependencies:
       - zod
 
@@ -9865,7 +9873,7 @@ snapshots:
     dependencies:
       '@google/generative-ai': 0.7.1
       '@langchain/core': 0.3.13(openai@4.53.0(encoding@0.1.13))
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
+      zod-to-json-schema: 3.23.5(zod@3.23.8)
     transitivePeerDependencies:
       - zod
     optional: true
@@ -16393,6 +16401,10 @@ snapshots:
       zod: 3.23.8
 
   zod-to-json-schema@3.23.3(zod@3.23.8):
+    dependencies:
+      zod: 3.23.8
+
+  zod-to-json-schema@3.23.5(zod@3.23.8):
     dependencies:
       zod: 3.23.8
 


### PR DESCRIPTION
## What does this PR do?

When passing parameters for a tool call, it is an option to pass `attributes` for the shape of an object you want the LLM to respond with. It is optional because the LLM can figure the shape on its own if the user wishes.
In this case, the LangChain adapter was failing.
This is the suggested fix