### PR TITLE
fix(langchain-adapter): fix how tool calls are being separated and read

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/components/destination-table.tsx
+++ b/CopilotKit/examples/next-openai/src/app/components/destination-table.tsx
@@ -53,20 +53,20 @@ export function DestinationTable({ destinations, heading }: DestinationTableProp
 
   useCopilotAction(
     {
-      name: `selectDestinations_${toCamelCase(heading)}`,
-      description: `Set the given destinations as 'selected', on the ${heading} table`,
+      name: `selectDestination_${toCamelCase(heading)}`,
+      description: `Set the given destination as 'selected', on the ${heading} table`,
       parameters: [
         {
-          name: "destinationNames",
-          type: "string[]",
-          description: "The names of the destinations to select",
+          name: "destinationName",
+          type: "string",
+          description: "The name of the destination to select",
           required: true,
         },
       ],
-      handler: async ({ destinationNames }) => {
+      handler: async ({ destinationName }) => {
         setCheckedRows((prevState) => {
           const newState = { ...prevState };
-          destinationNames.forEach((destinationName) => {
+          [destinationName].forEach((destinationName) => {
             newState[destinationName] = true;
           });
           return newState;

--- a/CopilotKit/packages/runtime/src/service-adapters/langchain/langchain-adapter.test.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/langchain/langchain-adapter.test.ts
@@ -1,0 +1,58 @@
+import { LangChainAdapter } from "./langchain-adapter";
+import { RuntimeEventSource } from "../events";
+
+describe("LangChainAdapter", () => {
+  let serviceAdapter: LangChainAdapter;
+
+  const chainFn = jest.fn();
+  const chainStreamFn = jest.fn();
+
+  it("should invoke a chain stream FN when the model is streaming", async () => {
+    const eventSource = new RuntimeEventSource();
+    serviceAdapter = new LangChainAdapter({
+      chainStreamFn,
+    });
+
+    await serviceAdapter.process({ messages: [], actions: [], eventSource });
+
+    expect(chainStreamFn).toHaveBeenCalledWith({
+      messages: [],
+      model: undefined,
+      runId: undefined,
+      tools: [],
+    });
+  });
+
+  it("should invoke a chain FN when the model is not streaming", async () => {
+    const eventSource = new RuntimeEventSource();
+    serviceAdapter = new LangChainAdapter({
+      chainFn,
+    });
+
+    await serviceAdapter.process({ messages: [], actions: [], eventSource });
+
+    expect(chainFn).toHaveBeenCalledWith({
+      messages: [],
+      model: undefined,
+      runId: undefined,
+      tools: [],
+    });
+  });
+
+  it("should invoke a chain stream FN as a default", async () => {
+    const eventSource = new RuntimeEventSource();
+    serviceAdapter = new LangChainAdapter({
+      chainFn,
+      chainStreamFn,
+    });
+
+    await serviceAdapter.process({ messages: [], actions: [], eventSource });
+
+    expect(chainStreamFn).toHaveBeenCalledWith({
+      messages: [],
+      model: undefined,
+      runId: undefined,
+      tools: [],
+    });
+  });
+});

--- a/CopilotKit/packages/runtime/src/service-adapters/langchain/types.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/langchain/types.ts
@@ -6,9 +6,7 @@ import {
 
 export type LangChainBaseMessageChunkStream = IterableReadableStream<BaseMessageChunk>;
 export type LangChainAIMessageChunkStream = IterableReadableStreamInterface<AIMessageChunk>;
-export type LangChainReturnType =
+export type LangChainStreamReturnType =
   | LangChainBaseMessageChunkStream
-  | LangChainAIMessageChunkStream
-  | BaseMessageChunk
-  | string
-  | AIMessage;
+  | LangChainAIMessageChunkStream;
+export type LangChainReturnType = LangChainStreamReturnType | BaseMessageChunk | string | AIMessage;

--- a/docs/content/docs/reference/classes/llm-adapters/LangChainAdapter.mdx
+++ b/docs/content/docs/reference/classes/llm-adapters/LangChainAdapter.mdx
@@ -36,7 +36,3 @@ The asynchronous handler function (`chainFn`) can return any of the following:
 
 ## Constructor Parameters
 
-<PropertyReference name="chainFn" type="(parameters: ChainFnParameters) => Promise<LangChainReturnType>" required > 
-A function that uses the LangChain API to generate a response.
-</PropertyReference>
-


### PR DESCRIPTION
Our LangChain adapter was failing to work with a "one at a time" tools. Tools that should be used multiple times with one argument or so.
This PR introduces some changes to make this available, as well as a change to our demo to integrate such action

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation