### PR TITLE
fix(langchain-adapter) distinguish between different consecutive calls to the same tool

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/components/destination-table.tsx
+++ b/CopilotKit/examples/next-openai/src/app/components/destination-table.tsx
@@ -53,20 +53,20 @@ export function DestinationTable({ destinations, heading }: DestinationTableProp
 
   useCopilotAction(
     {
-      name: `selectDestinations_${toCamelCase(heading)}`,
-      description: `Set the given destinations as 'selected', on the ${heading} table`,
+      name: `selectDestination_${toCamelCase(heading)}`,
+      description: `Set the given destination as 'selected', on the ${heading} table`,
       parameters: [
         {
-          name: "destinationNames",
-          type: "string[]",
-          description: "The names of the destinations to select",
+          name: "destinationName",
+          type: "string",
+          description: "The name of the destination to select",
           required: true,
         },
       ],
-      handler: async ({ destinationNames }) => {
+      handler: async ({ destinationName }) => {
         setCheckedRows((prevState) => {
           const newState = { ...prevState };
-          destinationNames.forEach((destinationName) => {
+          [destinationName].forEach((destinationName) => {
             newState[destinationName] = true;
           });
           return newState;

--- a/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/langchain/utils.ts
@@ -201,6 +201,13 @@ export async function streamLangChainResponse({
 
     let mode: "function" | "message" | null = null;
 
+    const toolCallDetails = {
+      name: null,
+      id: null,
+      index: null,
+      prevIndex: null,
+    };
+
     while (true) {
       try {
         const { done, value } = await reader.read();
@@ -208,15 +215,30 @@ export async function streamLangChainResponse({
         let toolCallName: string | undefined = undefined;
         let toolCallId: string | undefined = undefined;
         let toolCallArgs: string | undefined = undefined;
+        let toolCallIndex: number | undefined = undefined;
+        let toolCallPrevIndex: number | undefined = undefined;
         let hasToolCall: boolean = false;
         let content = value?.content as string;
 
         if (isAIMessageChunk(value)) {
           let chunk = value.tool_call_chunks?.[0];
-          toolCallName = chunk?.name;
-          toolCallId = chunk?.id;
           toolCallArgs = chunk?.args;
           hasToolCall = chunk != undefined;
+          if (chunk?.name) toolCallDetails.name = chunk.name;
+          // track different index on the same tool cool
+          if (chunk?.index != null) {
+            toolCallDetails.index = chunk.index; // 1
+            if (toolCallDetails.prevIndex == null) toolCallDetails.prevIndex = chunk.index;
+          }
+          // Differentiate when calling the same tool but with different index
+          if (chunk?.id)
+            toolCallDetails.id = chunk.index != null ? `${chunk.id}-idx-${chunk.index}` : chunk.id;
+
+          // Assign to internal variables that the entire script here knows how to work with
+          toolCallName = toolCallDetails.name;
+          toolCallId = toolCallDetails.id;
+          toolCallIndex = toolCallDetails.index;
+          toolCallPrevIndex = toolCallDetails.prevIndex;
         } else if (isBaseMessageChunk(value)) {
           let chunk = value.additional_kwargs?.tool_calls?.[0];
           toolCallName = chunk?.function?.name;
@@ -242,7 +264,7 @@ export async function streamLangChainResponse({
 
         // If we send a new message type, send the appropriate start event.
         if (mode === null) {
-          if (hasToolCall) {
+          if (hasToolCall && toolCallId && toolCallName) {
             mode = "function";
             eventStream$.sendActionExecutionStart(toolCallId, toolCallName);
           } else if (content) {
@@ -257,6 +279,12 @@ export async function streamLangChainResponse({
             Array.isArray(content) ? (content[0]?.text ?? "") : content,
           );
         } else if (mode === "function" && toolCallArgs) {
+          // For calls of the same tool with different index, we seal last tool call and register a new one
+          if (toolCallIndex !== toolCallPrevIndex) {
+            eventStream$.sendActionExecutionEnd();
+            eventStream$.sendActionExecutionStart(toolCallId, toolCallName);
+            toolCallDetails.prevIndex = toolCallDetails.index;
+          }
           eventStream$.sendActionExecutionArgs(toolCallArgs);
         }
       } catch (error) {


### PR DESCRIPTION
Our LangChain adapter was failing to work with a "one at a time" tools. Tools that should be used multiple times with one argument or so.
This PR introduces some changes to make this available, as well as a change to our demo to integrate such action.

This is about the same fix as https://github.com/CopilotKit/CopilotKit/pull/899
but this time, there is no change to the API and how the adapter should be consumed.

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation