### PR TITLE
docs(backend-actions): add tabs for FastAPI run step

### DIFF
--- a/docs/content/docs/(root)/guides/backend-actions/remote-backend-endpoint.mdx
+++ b/docs/content/docs/(root)/guides/backend-actions/remote-backend-endpoint.mdx
@@ -157,9 +157,23 @@ if __name__ == "__main__":
 
 Since we've added the entry point in `server.py`, you can run your FastAPI server directly by executing the script:
 
-```bash
-python server.py
-```
+<Tabs items={['Poetry', 'pip', 'conda']} default="Poetry">
+    <Tab value="Poetry">
+        ```bash
+        poetry run python3 server.py
+        ```
+    </Tab>
+    <Tab value="pip">
+        ```bash
+        python3 server.py
+        ```
+    </Tab>
+    <Tab value="conda">
+        ```bash
+        python3 server.py
+        ```
+    </Tab>
+</Tabs>
 
 **Note:** Ensure that you're in the same directory as `server.py` when running this command.
 


### PR DESCRIPTION
## What does this PR do?

In the onboarding for the execution step for remote backend endpoints had a command that did not work for Poetry. This PR fixes this by adding in tabs reflecting the tabs previously referenced early in the document.

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation