### PR TITLE
chore: consider possible js deployment url from main config

### DIFF
--- a/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
+++ b/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
@@ -33,7 +33,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               ...config,
               lgcJSDeploymentUrl:
               config.lgcJSDeploymentUrl ??
-                "https://coagents-research-canvas-js-d5ff2a34fa9c5771bb9c71003f38661c.default.us.langgraph.app",
+                "https://coagents-research-canvas-st-08476feebc3a58e5925116da0d3ad635.default.us.langgraph.app",
             },
             variants
           ).forEach((variant) => {

--- a/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
+++ b/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
@@ -32,6 +32,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
             {
               ...config,
               lgcJSDeploymentUrl:
+              config.lgcJSDeploymentUrl ??
                 "https://coagents-research-canvas-js-d5ff2a34fa9c5771bb9c71003f38661c.default.us.langgraph.app",
             },
             variants

--- a/examples/e2e/tests/coagents-qa-native-demo.spec.ts
+++ b/examples/e2e/tests/coagents-qa-native-demo.spec.ts
@@ -32,7 +32,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               ...config,
               lgcJSDeploymentUrl:
                   config.lgcJSDeploymentUrl ??
-                "https://coagents-qa-native-js-lgc-b-937eba63d4a0538e819aeea8cb472a7b.default.us.langgraph.app",
+                "https://coagents-qa-native-stg-js-036615e530e8593286ccf93d3003ffe2.default.us.langgraph.app",
             },
             variants
           ).forEach((variant) => {

--- a/examples/e2e/tests/coagents-qa-native-demo.spec.ts
+++ b/examples/e2e/tests/coagents-qa-native-demo.spec.ts
@@ -31,6 +31,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
             {
               ...config,
               lgcJSDeploymentUrl:
+                  config.lgcJSDeploymentUrl ??
                 "https://coagents-qa-native-js-lgc-b-937eba63d4a0538e819aeea8cb472a7b.default.us.langgraph.app",
             },
             variants

--- a/examples/e2e/tests/coagents-qa-text-demo.spec.ts
+++ b/examples/e2e/tests/coagents-qa-text-demo.spec.ts
@@ -31,7 +31,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               ...config,
               lgcJSDeploymentUrl:
                   config.lgcJSDeploymentUrl ??
-                "https://coagents-qa-text-js-lgc-b-ef9a12d13f5e5f24917eb6bec8994af3.default.us.langgraph.app",
+                "https://coagents-qa-text-stg-js-4d74616e480750d0a5d10d0c3c5d44a4.default.us.langgraph.app",
             },
             variants
           ).forEach((variant) => {

--- a/examples/e2e/tests/coagents-qa-text-demo.spec.ts
+++ b/examples/e2e/tests/coagents-qa-text-demo.spec.ts
@@ -30,6 +30,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
             {
               ...config,
               lgcJSDeploymentUrl:
+                  config.lgcJSDeploymentUrl ??
                 "https://coagents-qa-text-js-lgc-b-ef9a12d13f5e5f24917eb6bec8994af3.default.us.langgraph.app",
             },
             variants

--- a/examples/e2e/tests/coagents-routing-demo.spec.ts
+++ b/examples/e2e/tests/coagents-routing-demo.spec.ts
@@ -32,6 +32,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
             {
               ...config,
               lgcJSDeploymentUrl:
+                  config.lgcJSDeploymentUrl ??
                 "https://coagents-routing-js-lgc-b-e5c57ec4bf66544cafa7739cc0dc0261.default.us.langgraph.app",
             },
             variants

--- a/examples/e2e/tests/coagents-routing-demo.spec.ts
+++ b/examples/e2e/tests/coagents-routing-demo.spec.ts
@@ -33,7 +33,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               ...config,
               lgcJSDeploymentUrl:
                   config.lgcJSDeploymentUrl ??
-                "https://coagents-routing-js-lgc-b-e5c57ec4bf66544cafa7739cc0dc0261.default.us.langgraph.app",
+                "https://coagents-routing-stg-js-4df4be4cab70578ca535df7e1c0b05cf.default.us.langgraph.app",
             },
             variants
           ).forEach((variant) => {


### PR DESCRIPTION
Added the option to possibly provide lgc deployment URLs and not override them hardcoded