### PR TITLE
chore(e2e): test streaming of manually emitted state

### DIFF
--- a/examples/coagents-research-canvas/ui/src/components/Progress.tsx
+++ b/examples/coagents-research-canvas/ui/src/components/Progress.tsx
@@ -20,6 +20,7 @@ export function Progress({
         {logs.map((log, index) => (
           <div
             key={index}
+            data-test-id="progress-step-item"
             className={`flex ${
               log.done || index === logs.findIndex((log) => !log.done)
                 ? ""
@@ -27,7 +28,10 @@ export function Progress({
             }`}
           >
             <div className="w-8">
-              <div className="w-4 h-4 bg-slate-700 flex items-center justify-center rounded-full mt-[10px] ml-[12px]">
+              <div
+                  className="w-4 h-4 bg-slate-700 flex items-center justify-center rounded-full mt-[10px] ml-[12px]"
+                  data-test-id={log.done ? 'progress-step-item_done' : 'progress-step-item_loading'}
+              >
                 {log.done ? (
                   <CheckIcon className="w-3 h-3 text-white" />
                 ) : (

--- a/examples/e2e/lib/helpers.ts
+++ b/examples/e2e/lib/helpers.ts
@@ -1,4 +1,5 @@
 import { Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 export async function sendChatMessage(page: Page, message: string) {
   await page.getByPlaceholder("Type a message...").click();
@@ -6,8 +7,17 @@ export async function sendChatMessage(page: Page, message: string) {
   await page.keyboard.press("Enter");
 }
 
-export async function waitForSteps(page: Page) {
+export async function waitForAndTestSteps(page: Page) {
   await page.waitForSelector('[data-test-id="progress-steps"]');
+  // expect at least one item is loading
+  const loadingItems = await page.$$('[data-test-id="progress-step-item_loading"]');
+  expect(loadingItems.length).toBeGreaterThan(0);
+
+  // wait for all items to transition to done
+  await page.waitForSelector('[data-test-id="progress-step-item_done"]');
+  const doneItems = await page.$$('[data-test-id="progress-step-item_done"]');
+  // expect all items to be in the "done" state
+  expect(doneItems.length).toBeGreaterThan(0);
 }
 
 export async function waitForResponse(page: Page) {

--- a/examples/e2e/lib/helpers.ts
+++ b/examples/e2e/lib/helpers.ts
@@ -7,7 +7,7 @@ export async function sendChatMessage(page: Page, message: string) {
   await page.keyboard.press("Enter");
 }
 
-export async function waitForAndTestSteps(page: Page) {
+export async function waitForStepsAndEnsureStreaming(page: Page) {
   await page.waitForSelector('[data-test-id="progress-steps"]');
   // expect at least one item is loading
   const loadingItems = await page.$$('[data-test-id="progress-step-item_loading"]');

--- a/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
+++ b/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { waitForAndTestSteps, waitForResponse, sendChatMessage } from "../lib/helpers";
+import { waitForStepsAndEnsureStreaming, waitForResponse, sendChatMessage } from "../lib/helpers";
 import {
   getConfigs,
   filterConfigsByProject,
@@ -52,7 +52,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
                 "Conduct research based on my research question, please. DO NOT FORGET TO PRODUCE THE DRAFT AT THE END!"
               );
 
-              await waitForAndTestSteps(page);
+              await waitForStepsAndEnsureStreaming(page);
               await waitForResponse(page);
 
               // Ensure research draft
@@ -69,7 +69,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
                     page,
                     "The draft seems to be empty, please fill it in."
                 );
-                await waitForAndTestSteps(page);
+                await waitForStepsAndEnsureStreaming(page);
                 await waitForResponse(page);
 
                 const draftContent = await researchDraft.textContent();

--- a/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
+++ b/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { waitForSteps, waitForResponse, sendChatMessage } from "../lib/helpers";
+import { waitForAndTestSteps, waitForResponse, sendChatMessage } from "../lib/helpers";
 import {
   getConfigs,
   filterConfigsByProject,
@@ -52,7 +52,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
                 "Conduct research based on my research question, please. DO NOT FORGET TO PRODUCE THE DRAFT AT THE END!"
               );
 
-              await waitForSteps(page);
+              await waitForAndTestSteps(page);
               await waitForResponse(page);
 
               // Ensure research draft
@@ -69,7 +69,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
                     page,
                     "The draft seems to be empty, please fill it in."
                 );
-                await waitForSteps(page);
+                await waitForAndTestSteps(page);
                 await waitForResponse(page);
 
                 const draftContent = await researchDraft.textContent();


### PR DESCRIPTION
Our e2e tests were missing the "emit manual state" for research canvas where searching loading and done states are being emitted manually. This adds test for it