### PR TITLE
chore(coagents-travel): wrong command to run the server

### DIFF
--- a/examples/coagents-travel/agent/README.md
+++ b/examples/coagents-travel/agent/README.md
@@ -17,7 +17,7 @@ GOOGLE_MAPS_API_KEY=...
 From there you can install the dependencies and start the server:
 ```sh
 poetry install
-poetry run server
+poetry run demo
 ```
 
 The server is configured to run on port 8000. If you have any trouble, make sure you're using the same version of Python as specified in the `pyproject.toml` file.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updated README.md, fixes a wrong command to run the server

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation