### PR TITLE
fix: missing packageManager field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
     "danger": "^12.3.3",
     "husky": "^9.1.4"
   },
-  "packageManager": "pnpm@9.14.4"
+  "packageManager": "pnpm@9.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   "devDependencies": {
     "danger": "^12.3.3",
     "husky": "^9.1.4"
-  }
+  },
+  "packageManager": "pnpm@9.14.4"
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Add the missing field `packageManager` in package.json by using vercel codemod

## Related PRs and Issues

#988 

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation