### PR TITLE
chore: use the right name for langgraph platform

### DIFF
--- a/CopilotKit/packages/runtime/src/agents/langgraph/event-source.ts
+++ b/CopilotKit/packages/runtime/src/agents/langgraph/event-source.ts
@@ -37,7 +37,7 @@ export class RemoteLangGraphEventSource {
       scan(
         (acc, event) => {
           if (event.event === LangGraphEventTypes.OnChatModelStream) {
-            // @ts-expect-error -- LangGraph Cloud implementation stores data outside of kwargs
+            // @ts-expect-error -- LangGraph Platform implementation stores data outside of kwargs
             const content = event.data?.chunk?.kwargs?.content ?? event.data?.chunk?.content;
 
             if (typeof content === "string") {
@@ -49,7 +49,7 @@ export class RemoteLangGraphEventSource {
             }
 
             const toolCallChunks =
-              // @ts-expect-error -- LangGraph Cloud implementation stores data outside of kwargs
+              // @ts-expect-error -- LangGraph Platform implementation stores data outside of kwargs
               event.data?.chunk?.kwargs?.tool_call_chunks ?? event.data?.chunk?.tool_call_chunks;
 
             const toolCallMessageId =

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -27,7 +27,7 @@ import {
   setupRemoteActions,
   EndpointDefinition,
   CopilotKitEndpoint,
-  LangGraphCloudEndpoint,
+  LangGraphPlatformEndpoint,
 } from "./remote-actions";
 import { GraphQLContext } from "../integrations/shared";
 import { AgentSessionInput } from "../../graphql/inputs/agent-session.input";
@@ -392,19 +392,19 @@ export function copilotKitEndpoint(config: Omit<CopilotKitEndpoint, "type">): Co
   };
 }
 
-export function langGraphCloudEndpoint(
-  config: Omit<LangGraphCloudEndpoint, "type">,
-): LangGraphCloudEndpoint {
+export function langGraphPlatformEndpoint(
+  config: Omit<LangGraphPlatformEndpoint, "type">,
+): LangGraphPlatformEndpoint {
   return {
     ...config,
-    type: EndpointType.LangGraphCloud,
+    type: EndpointType.LangGraphPlatform,
   };
 }
 
 export function resolveEndpointType(endpoint: EndpointDefinition) {
   if (!endpoint.type) {
     if ("langsmithApiKey" in endpoint && "deploymentUrl" in endpoint && "agents" in endpoint) {
-      return EndpointType.LangGraphCloud;
+      return EndpointType.LangGraphPlatform;
     } else {
       return EndpointType.CopilotKit;
     }

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
@@ -3,7 +3,7 @@ import {
   CopilotKitEndpoint,
   LangGraphAgentHandlerParams,
   RemoteActionInfoResponse,
-  LangGraphCloudEndpoint,
+  LangGraphPlatformEndpoint,
 } from "./remote-actions";
 import { GraphQLContext } from "../integrations";
 import { Logger } from "pino";
@@ -15,7 +15,7 @@ import telemetry from "../telemetry-client";
 import { RemoteLangGraphEventSource } from "../../agents/langgraph/event-source";
 import { Action } from "@copilotkit/shared";
 import { LangGraphEvent } from "../../agents/langgraph/events";
-import { execute } from "./remote-lg-cloud-action";
+import { execute } from "./remote-lg-action";
 
 export function constructLGCRemoteAction({
   endpoint,
@@ -24,7 +24,7 @@ export function constructLGCRemoteAction({
   messages,
   agentStates,
 }: {
-  endpoint: LangGraphCloudEndpoint;
+  endpoint: LangGraphPlatformEndpoint;
   graphqlContext: GraphQLContext;
   logger: Logger;
   messages: Message[];
@@ -41,11 +41,11 @@ export function constructLGCRemoteAction({
       threadId,
       nodeName,
     }: LangGraphAgentHandlerParams): Promise<Observable<RuntimeEvent>> => {
-      logger.debug({ actionName: agent.name }, "Executing LangGraph Cloud agent");
+      logger.debug({ actionName: agent.name }, "Executing LangGraph Platform agent");
 
       telemetry.capture("oss.runtime.remote_action_executed", {
         agentExecution: true,
-        type: "langgraph-cloud",
+        type: "langgraph-platform",
         agentsAmount: endpoint.agents.length,
         hashedLgcKey: createHash("sha256").update(endpoint.langsmithApiKey).digest("hex"),
       });
@@ -82,9 +82,9 @@ export function constructLGCRemoteAction({
       } catch (error) {
         logger.error(
           { url: endpoint.deploymentUrl, status: 500, body: error.message },
-          "Failed to execute LangGraph Cloud agent",
+          "Failed to execute LangGraph Platform agent",
         );
-        throw new Error("Failed to execute LangGraph Cloud agent");
+        throw new Error("Failed to execute LangGraph Platform agent");
       }
     },
   }));

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -12,11 +12,11 @@ import {
   createHeaders,
 } from "./remote-action-constructors";
 
-export type EndpointDefinition = CopilotKitEndpoint | LangGraphCloudEndpoint;
+export type EndpointDefinition = CopilotKitEndpoint | LangGraphPlatformEndpoint;
 
 export enum EndpointType {
   CopilotKit = "copilotKit",
-  LangGraphCloud = "langgraph-cloud",
+  LangGraphPlatform = "langgraph-platform",
 }
 
 export interface BaseEndpointDefinition<TActionType extends EndpointType> {
@@ -30,17 +30,17 @@ export interface CopilotKitEndpoint extends BaseEndpointDefinition<EndpointType.
   };
 }
 
-export interface LangGraphCloudAgent {
+export interface LangGraphPlatformAgent {
   name: string;
   description: string;
   assistantId?: string;
 }
 
-export interface LangGraphCloudEndpoint
-  extends BaseEndpointDefinition<EndpointType.LangGraphCloud> {
+export interface LangGraphPlatformEndpoint
+  extends BaseEndpointDefinition<EndpointType.LangGraphPlatform> {
   deploymentUrl: string;
   langsmithApiKey: string;
-  agents: LangGraphCloudAgent[];
+  agents: LangGraphPlatformAgent[];
 }
 
 export type RemoteActionInfoResponse = {
@@ -127,7 +127,7 @@ export async function setupRemoteActions({
 
   // Remove duplicates of remoteEndpointDefinitions.url
   const filtered = remoteEndpointDefinitions.filter((value, index, self) => {
-    if (value.type === EndpointType.LangGraphCloud) {
+    if (value.type === EndpointType.LangGraphPlatform) {
       return value;
     }
     return index === self.findIndex((t: CopilotKitEndpoint) => t.url === value.url);
@@ -135,8 +135,8 @@ export async function setupRemoteActions({
 
   const result = await Promise.all(
     filtered.map(async (endpoint) => {
-      // Check for properties that can distinguish LG cloud from other actions
-      if (endpoint.type === EndpointType.LangGraphCloud) {
+      // Check for properties that can distinguish LG platform from other actions
+      if (endpoint.type === EndpointType.LangGraphPlatform) {
         return constructLGCRemoteAction({
           endpoint,
           messages,

--- a/CopilotKit/packages/runtime/src/lib/telemetry-client.ts
+++ b/CopilotKit/packages/runtime/src/lib/telemetry-client.ts
@@ -1,5 +1,5 @@
 import { TelemetryClient } from "@copilotkit/shared";
-import { EndpointType, LangGraphCloudEndpoint } from "./runtime/remote-actions";
+import { EndpointType, LangGraphPlatformEndpoint } from "./runtime/remote-actions";
 import { createHash } from "node:crypto";
 import { CopilotRuntime, resolveEndpointType } from "./runtime/copilot-runtime";
 import { RuntimeInstanceCreatedInfo } from "@copilotkit/shared/src/telemetry/events";
@@ -25,9 +25,9 @@ export function getRuntimeInstanceTelemetryInfo(
         };
       }
 
-      if (endpointType === EndpointType.LangGraphCloud) {
+      if (endpointType === EndpointType.LangGraphPlatform) {
         // When type is resolved, recreating a const with casting of type
-        const ep = endpoint as LangGraphCloudEndpoint;
+        const ep = endpoint as LangGraphPlatformEndpoint;
         info = {
           ...info,
           agentsAmount: ep.agents.length,

--- a/CopilotKit/packages/shared/src/telemetry/events.ts
+++ b/CopilotKit/packages/shared/src/telemetry/events.ts
@@ -20,7 +20,7 @@ export interface RuntimeInstanceCreatedInfo {
 
 export interface RemoteActionExecutionInfo {
   agentExecution: boolean;
-  type: "self-hosted" | "langgraph-cloud";
+  type: "self-hosted" | "langgraph-platform";
   agentsAmount?: number | null;
   hashedLgcKey?: string;
 }

--- a/examples/coagents-ai-researcher/ui/app/api/copilotkit-lgc/route.ts
+++ b/examples/coagents-ai-researcher/ui/app/api/copilotkit-lgc/route.ts
@@ -5,7 +5,7 @@ import {
 } from "@copilotkit/runtime";
 import OpenAI from "openai";
 import { NextRequest } from "next/server";
-import { langGraphCloudEndpoint } from "@copilotkit/runtime";
+import { langGraphPlatformEndpoint } from "@copilotkit/runtime";
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const serviceAdapter = new OpenAIAdapter({ openai } as any);
@@ -15,7 +15,7 @@ const langsmithApiKey = process.env.LANGSMITH_API_KEY as string
 
 const runtime = new CopilotRuntime({
   remoteEndpoints: [
-    langGraphCloudEndpoint({
+    langGraphPlatformEndpoint({
       deploymentUrl,
       langsmithApiKey,
       agents: [{

--- a/examples/coagents-qa-native/ui/app/api/copilotkit/route.ts
+++ b/examples/coagents-qa-native/ui/app/api/copilotkit/route.ts
@@ -3,7 +3,7 @@ import {
   CopilotRuntime,
   OpenAIAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
-  langGraphCloudEndpoint,
+  langGraphPlatformEndpoint,
   copilotKitEndpoint,
 } from "@copilotkit/runtime";
 import OpenAI from "openai";
@@ -17,7 +17,7 @@ export const POST = async (req: NextRequest) => {
   const deploymentUrl = searchParams.get("lgcDeploymentUrl");
 
   const remoteEndpoint = deploymentUrl
-    ? langGraphCloudEndpoint({
+    ? langGraphPlatformEndpoint({
         deploymentUrl,
         langsmithApiKey,
         agents: [

--- a/examples/coagents-qa-text/ui/app/api/copilotkit/route.ts
+++ b/examples/coagents-qa-text/ui/app/api/copilotkit/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import {
   CopilotRuntime,
   OpenAIAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint, langGraphCloudEndpoint, copilotKitEndpoint,
+  copilotRuntimeNextJSAppRouterEndpoint, langGraphPlatformEndpoint, copilotKitEndpoint,
 } from "@copilotkit/runtime";
 import OpenAI from "openai";
 
@@ -14,7 +14,7 @@ export const POST = async (req: NextRequest) => {
   const searchParams = req.nextUrl.searchParams
   const deploymentUrl = searchParams.get('lgcDeploymentUrl')
 
-  const remoteEndpoint = deploymentUrl ? langGraphCloudEndpoint({
+  const remoteEndpoint = deploymentUrl ? langGraphPlatformEndpoint({
     deploymentUrl,
     langsmithApiKey,
     agents: [{

--- a/examples/coagents-research-canvas/ui/pnpm-lock.yaml
+++ b/examples/coagents-research-canvas/ui/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@copilotkit/react-core':
-        specifier: 1.4.0-lgc-alpha3.0
-        version: 1.4.0-lgc-alpha3.0(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.4.0-pre-1-4-0.11
+        version: 1.4.0-pre-1-4-0.11(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@copilotkit/react-ui':
-        specifier: 1.4.0-lgc-alpha3.0
-        version: 1.4.0-lgc-alpha3.0(@types/react@18.3.11)(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.4.0-pre-1-4-0.11
+        version: 1.4.0-pre-1-4-0.11(@types/react@18.3.11)(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@copilotkit/runtime':
-        specifier: 1.4.0-lgc-alpha3.0
-        version: 1.4.0-lgc-alpha3.0(class-validator@0.14.1)(google-auth-library@8.9.0)
+        specifier: 1.4.0-pre-1-4-0.11
+        version: 1.4.0-pre-1-4-0.11(class-validator@0.14.1)(google-auth-library@8.9.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -103,27 +103,27 @@ packages:
     resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
     engines: {node: '>=6.9.0'}
 
-  '@copilotkit/react-core@1.4.0-lgc-alpha3.0':
-    resolution: {integrity: sha512-g3tcLaDL3x3q+pZef8HUN18yuZykaGOhXlqP/1+SiKav/EJCdMXGJHo8MzdKHzIHRPp6TdfdKUdfQ8IooI3+hw==}
+  '@copilotkit/react-core@1.4.0-pre-1-4-0.11':
+    resolution: {integrity: sha512-9sUbFwAS8U40qtnCJTXudUIOar1ymsvITPSYHuDClvI96RY/VVh94leG9B3DidYBtpogR3pwKAnUoyc7/9fMyw==}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  '@copilotkit/react-ui@1.4.0-lgc-alpha3.0':
-    resolution: {integrity: sha512-OxzbGXFvEtIAuhEdnFJ/mIaLK+GeXNFtWFtb7oIrtLS7E+FNNztfWzozW6i7MeZzoqAio3Nhwsa3FIXVYlbYCQ==}
+  '@copilotkit/react-ui@1.4.0-pre-1-4-0.11':
+    resolution: {integrity: sha512-f79iVe/3heSQgstPdO+lWglzE4OsguS4ivPkHliiJfZa7ldk+rf1nxVjjuM+hmQJniR9LgQgu0i7kG2lC+Hr9g==}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
 
-  '@copilotkit/runtime-client-gql@1.4.0-lgc-alpha3.0':
-    resolution: {integrity: sha512-ixUwkkEExrDfRSTPVG18dPJX/F1w/riNeGrVyAh/w3gdPTui43d3TMwCtqHSriUEDzdWL2BWer0Ov7KHVcdloQ==}
+  '@copilotkit/runtime-client-gql@1.4.0-pre-1-4-0.11':
+    resolution: {integrity: sha512-2xf8mWZGu7aM5EMbw7W6eQWN335Ka6xj1L7iTtPhJx0gN5OoSQXeonfpkV0IotF9FaQYhrdoyFgl3avbgAOzNA==}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
 
-  '@copilotkit/runtime@1.4.0-lgc-alpha3.0':
-    resolution: {integrity: sha512-f+/xk3du3T7+Mm8hwJ1cKWnfs4dunVetuRsGhL3dNq3ZMRYi7c+eV7zC6d/9KuIl4QRtagnX4kzUFa+P8nGbLA==}
+  '@copilotkit/runtime@1.4.0-pre-1-4-0.11':
+    resolution: {integrity: sha512-wTibv3x4p8gy+29qrbRLIAyw4T6Drxn2IFf05c7kvfjeNWn3F6UPImQwT1QgsrivaOkIHhrf8aNtcLAnrZe0SQ==}
 
-  '@copilotkit/shared@1.4.0-lgc-alpha3.0':
-    resolution: {integrity: sha512-QaUvFiaPZ5VQgeKDvZzWbKV2+xo901OCmXzOoVHE/GfgF3BSkUMXtJz+ObFgBy3OSqf+yhp7QVMyBLK0bk02MQ==}
+  '@copilotkit/shared@1.4.0-pre-1-4-0.11':
+    resolution: {integrity: sha512-/GtxvtoWBK6ChS6q8SbcFG0PAcQ5SL0H7WoRbFuwAsSfmYPIi0XyULohzQAGEAma7qtC89Npdpq0kPDHNiDLCQ==}
 
   '@envelop/core@5.0.2':
     resolution: {integrity: sha512-tVL6OrMe6UjqLosiE+EH9uxh2TQC0469GwF4tE014ugRaDDKKVWwFwZe0TBMlcyHKh5MD4ZxktWo/1hqUxIuhw==}
@@ -3588,10 +3588,10 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@copilotkit/react-core@1.4.0-lgc-alpha3.0(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@copilotkit/react-core@1.4.0-pre-1-4-0.11(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@copilotkit/runtime-client-gql': 1.4.0-lgc-alpha3.0(google-auth-library@8.9.0)(react@18.3.1)
-      '@copilotkit/shared': 1.4.0-lgc-alpha3.0
+      '@copilotkit/runtime-client-gql': 1.4.0-pre-1-4-0.11(google-auth-library@8.9.0)(react@18.3.1)
+      '@copilotkit/shared': 1.4.0-pre-1-4-0.11
       '@scarf/scarf': 1.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -3704,11 +3704,11 @@ snapshots:
       - web-auth-library
       - ws
 
-  '@copilotkit/react-ui@1.4.0-lgc-alpha3.0(@types/react@18.3.11)(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@copilotkit/react-ui@1.4.0-pre-1-4-0.11(@types/react@18.3.11)(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@copilotkit/react-core': 1.4.0-lgc-alpha3.0(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@copilotkit/runtime-client-gql': 1.4.0-lgc-alpha3.0(google-auth-library@8.9.0)(react@18.3.1)
-      '@copilotkit/shared': 1.4.0-lgc-alpha3.0
+      '@copilotkit/react-core': 1.4.0-pre-1-4-0.11(google-auth-library@8.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@copilotkit/runtime-client-gql': 1.4.0-pre-1-4-0.11(google-auth-library@8.9.0)(react@18.3.1)
+      '@copilotkit/shared': 1.4.0-pre-1-4-0.11
       '@headlessui/react': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-markdown: 8.0.7(@types/react@18.3.11)(react@18.3.1)
@@ -3825,10 +3825,10 @@ snapshots:
       - web-auth-library
       - ws
 
-  '@copilotkit/runtime-client-gql@1.4.0-lgc-alpha3.0(google-auth-library@8.9.0)(react@18.3.1)':
+  '@copilotkit/runtime-client-gql@1.4.0-pre-1-4-0.11(google-auth-library@8.9.0)(react@18.3.1)':
     dependencies:
-      '@copilotkit/runtime': 1.4.0-lgc-alpha3.0(class-validator@0.14.1)(google-auth-library@8.9.0)
-      '@copilotkit/shared': 1.4.0-lgc-alpha3.0
+      '@copilotkit/runtime': 1.4.0-pre-1-4-0.11(class-validator@0.14.1)(google-auth-library@8.9.0)
+      '@copilotkit/shared': 1.4.0-pre-1-4-0.11
       '@urql/core': 5.0.6(graphql@16.9.0)
       class-transformer: 0.5.1
       class-validator: 0.14.1
@@ -3945,10 +3945,10 @@ snapshots:
       - web-auth-library
       - ws
 
-  '@copilotkit/runtime@1.4.0-lgc-alpha3.0(class-validator@0.14.1)(google-auth-library@8.9.0)':
+  '@copilotkit/runtime@1.4.0-pre-1-4-0.11(class-validator@0.14.1)(google-auth-library@8.9.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.27.3
-      '@copilotkit/shared': 1.4.0-lgc-alpha3.0
+      '@copilotkit/shared': 1.4.0-pre-1-4-0.11
       '@graphql-yoga/plugin-defer-stream': 3.7.0(graphql-yoga@5.7.0(graphql@16.9.0))(graphql@16.9.0)
       '@langchain/community': 0.0.53(google-auth-library@8.9.0)(openai@4.70.2(zod@3.23.8))
       '@langchain/core': 0.3.16(openai@4.70.2(zod@3.23.8))
@@ -4079,7 +4079,7 @@ snapshots:
       - web-auth-library
       - ws
 
-  '@copilotkit/shared@1.4.0-lgc-alpha3.0':
+  '@copilotkit/shared@1.4.0-pre-1-4-0.11':
     dependencies:
       '@segment/analytics-node': 2.2.0
       chalk: 4.1.2

--- a/examples/coagents-research-canvas/ui/src/app/api/copilotkit/route.ts
+++ b/examples/coagents-research-canvas/ui/src/app/api/copilotkit/route.ts
@@ -2,7 +2,7 @@ import {
   CopilotRuntime,
   OpenAIAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
-  langGraphCloudEndpoint, copilotKitEndpoint,
+  langGraphPlatformEndpoint, copilotKitEndpoint,
 } from "@copilotkit/runtime";
 import OpenAI from "openai";
 import { NextRequest } from "next/server";
@@ -15,7 +15,7 @@ export const POST = async (req: NextRequest) => {
   const searchParams = req.nextUrl.searchParams
   const deploymentUrl = searchParams.get('lgcDeploymentUrl')
 
-  const remoteEndpoint = deploymentUrl ? langGraphCloudEndpoint({
+  const remoteEndpoint = deploymentUrl ? langGraphPlatformEndpoint({
     deploymentUrl,
     langsmithApiKey,
     agents: [

--- a/examples/coagents-routing/ui/src/app/api/copilotkit/route.ts
+++ b/examples/coagents-routing/ui/src/app/api/copilotkit/route.ts
@@ -3,7 +3,7 @@ import {
   CopilotRuntime,
   OpenAIAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
-  langGraphCloudEndpoint,
+  langGraphPlatformEndpoint,
   copilotKitEndpoint,
 } from "@copilotkit/runtime";
 import OpenAI from "openai";
@@ -17,7 +17,7 @@ export const POST = async (req: NextRequest) => {
   const deploymentUrl = searchParams.get("lgcDeploymentUrl");
 
   const remoteEndpoint = deploymentUrl
-    ? langGraphCloudEndpoint({
+    ? langGraphPlatformEndpoint({
         deploymentUrl,
         langsmithApiKey,
         agents: [


### PR DESCRIPTION
LangGraph Cloud has been renamed to LangGraph Platform since we started working on supporting that.
We need to respect the name change while we're still working on this