### PR TITLE
docs(travel-tutorial): change link to download LangGraph Studio

### DIFF
--- a/docs/content/docs/coagents/tutorials/ai-travel-app/step-2-langgraph-agent.mdx
+++ b/docs/content/docs/coagents/tutorials/ai-travel-app/step-2-langgraph-agent.mdx
@@ -21,7 +21,7 @@ Let's walk through the LangGraph agent to understand how it works before we inte
 LangGraph Studio is a tool for visualizing and debugging LangGraph workflows. It is not required for using CopilotKit but it is highly recommended
 for understanding how LangGraph works. 
 
-To install LangGraph Studio, checkout the [setup guide](https://github.com/langchain-ai/langgraph-studio?tab=readme-ov-file#setup).
+To install LangGraph Studio, checkout the [setup guide](https://studio.langchain.com/).
 
 </Step>
 <Step>


### PR DESCRIPTION
## What does this PR do?

This takes the user to the branded page instead of the github now.

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation