### PR TITLE
chore: adjust demo for langgraph async behavior tests

### DIFF
--- a/examples/coagents-research-canvas/agent/poetry.lock
+++ b/examples/coagents-research-canvas/agent/poetry.lock
@@ -1120,18 +1120,18 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10"
 
 [[package]]
 name = "langchain-core"
-version = "0.3.23"
+version = "0.3.24"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "langchain_core-0.3.23-py3-none-any.whl", hash = "sha256:550c0b996990830fa6515a71a1192a8a0343367999afc36d4ede14222941e420"},
-    {file = "langchain_core-0.3.23.tar.gz", hash = "sha256:f9e175e3b82063cc3b160c2ca2b155832e1c6f915312e1204828f97d4aabf6e1"},
+    {file = "langchain_core-0.3.24-py3-none-any.whl", hash = "sha256:97192552ef882a3dd6ae3b870a180a743801d0137a1159173f51ac555eeb7eec"},
+    {file = "langchain_core-0.3.24.tar.gz", hash = "sha256:460851e8145327f70b70aad7dce2cdbd285e144d14af82b677256b941fc99656"},
 ]
 
 [package.dependencies]
 jsonpatch = ">=1.33,<2.0"
-langsmith = ">=0.1.125,<0.2.0"
+langsmith = ">=0.1.125,<0.3"
 packaging = ">=23.2,<25"
 pydantic = [
     {version = ">=2.5.2,<3.0.0", markers = "python_full_version < \"3.12.4\""},
@@ -1189,19 +1189,19 @@ langchain-core = ">=0.3.15,<0.4.0"
 
 [[package]]
 name = "langgraph"
-version = "0.2.52"
+version = "0.2.58"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = "<4.0,>=3.9.0"
 files = [
-    {file = "langgraph-0.2.52-py3-none-any.whl", hash = "sha256:4cec56629b833a4f61678d5395719f7a096b16438bf521c48744e9d0579f3559"},
-    {file = "langgraph-0.2.52.tar.gz", hash = "sha256:d28b58787b44b880fcdd9479a61a35cc9c273d007eb756ee468fb2f5f72c7738"},
+    {file = "langgraph-0.2.58-py3-none-any.whl", hash = "sha256:24e3ab580e5406120d59cdc735b2019aa3d6f0c8d7fee1c3a517b4ecd95e3a1c"},
+    {file = "langgraph-0.2.58.tar.gz", hash = "sha256:a2ef9c40d13ef8973797eefe8832802593d24391cf8f81d0e108d0c336fbd4e6"},
 ]
 
 [package.dependencies]
-langchain-core = ">=0.2.43,<0.3.0 || >0.3.0,<0.3.1 || >0.3.1,<0.3.2 || >0.3.2,<0.3.3 || >0.3.3,<0.3.4 || >0.3.4,<0.3.5 || >0.3.5,<0.3.6 || >0.3.6,<0.3.7 || >0.3.7,<0.3.8 || >0.3.8,<0.3.9 || >0.3.9,<0.3.10 || >0.3.10,<0.3.11 || >0.3.11,<0.3.12 || >0.3.12,<0.3.13 || >0.3.13,<0.3.14 || >0.3.14,<0.4.0"
+langchain-core = ">=0.2.43,<0.3.0 || >0.3.0,<0.3.1 || >0.3.1,<0.3.2 || >0.3.2,<0.3.3 || >0.3.3,<0.3.4 || >0.3.4,<0.3.5 || >0.3.5,<0.3.6 || >0.3.6,<0.3.7 || >0.3.7,<0.3.8 || >0.3.8,<0.3.9 || >0.3.9,<0.3.10 || >0.3.10,<0.3.11 || >0.3.11,<0.3.12 || >0.3.12,<0.3.13 || >0.3.13,<0.3.14 || >0.3.14,<0.3.15 || >0.3.15,<0.3.16 || >0.3.16,<0.3.17 || >0.3.17,<0.3.18 || >0.3.18,<0.3.19 || >0.3.19,<0.3.20 || >0.3.20,<0.3.21 || >0.3.21,<0.3.22 || >0.3.22,<0.4.0"
 langgraph-checkpoint = ">=2.0.4,<3.0.0"
-langgraph-sdk = ">=0.1.32,<0.2.0"
+langgraph-sdk = ">=0.1.42,<0.2.0"
 
 [[package]]
 name = "langgraph-checkpoint"
@@ -1508,13 +1508,13 @@ files = [
 
 [[package]]
 name = "openai"
-version = "1.57.1"
+version = "1.57.2"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "openai-1.57.1-py3-none-any.whl", hash = "sha256:3865686c927e93492d1145938d4a24b634951531c4b2769d43ca5dbd4b25d8fd"},
-    {file = "openai-1.57.1.tar.gz", hash = "sha256:a95f22e04ab3df26e64a15d958342265e802314131275908b3b3e36f8c5d4377"},
+    {file = "openai-1.57.2-py3-none-any.whl", hash = "sha256:f7326283c156fdee875746e7e54d36959fb198eadc683952ee05e3302fbd638d"},
+    {file = "openai-1.57.2.tar.gz", hash = "sha256:5f49fd0f38e9f2131cda7deb45dafdd1aee4f52a637e190ce0ecf40147ce8cee"},
 ]
 
 [package.dependencies]
@@ -2587,4 +2587,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "da71e59c23563721d538a7ce6bc7afb55e2ebe3e29a93cf6eedcb376a79db209"
+content-hash = "e0878c1f43c69de80d72d94e51ae964c165ffadb1e4dd9a6e2cf83aa7375af9c"

--- a/examples/coagents-research-canvas/agent/pyproject.toml
+++ b/examples/coagents-research-canvas/agent/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "research_canvas"
 version = "0.0.1"
 dependencies = [
-  "langgraph==0.2.52",
+  "langgraph",
   "langchain_core",
   "langchain-google-genai",
   "langchain_openai",
@@ -20,7 +20,8 @@ dependencies = [
   "tavily-python",
   "python-dotenv",
   "uvicorn",
-  "html2text"
+  "html2text",
+  "copilotkit"
 ]
 
 [build-system]
@@ -30,7 +31,7 @@ build-backend = "setuptools.build_meta"
 [tool.poetry.dependencies]
 python = "^3.12"
 copilotkit = "0.1.29"
-langgraph = "0.2.52"
+langgraph = "^0.2.58"
 langchain-core = "^0.3.12"
 langchain-openai = "0.2.3"
 langchain-community = "^0.3.1"

--- a/examples/coagents-research-canvas/agent/research_canvas/search.py
+++ b/examples/coagents-research-canvas/agent/research_canvas/search.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from langchain_core.runnables import RunnableConfig
 from langchain_core.messages import AIMessage, ToolMessage, SystemMessage
 from langchain.tools import tool
-from tavily import AsyncTavilyClient
+from tavily import TavilyClient
 from copilotkit.langchain import copilotkit_emit_state, copilotkit_customize_config
 from research_canvas.state import AgentState
 from research_canvas.model import get_model
@@ -23,7 +23,7 @@ class ResourceInput(BaseModel):
 def ExtractResources(resources: List[ResourceInput]): # pylint: disable=invalid-name,unused-argument
     """Extract the 3-5 most relevant resources from a search result."""
 
-tavily_client = AsyncTavilyClient(api_key=os.getenv("TAVILY_API_KEY"))
+tavily_client = TavilyClient(api_key=os.getenv("TAVILY_API_KEY"))
 
 async def search_node(state: AgentState, config: RunnableConfig):
     """
@@ -46,7 +46,7 @@ async def search_node(state: AgentState, config: RunnableConfig):
     search_results = []
 
     for i, query in enumerate(queries):
-        response = await tavily_client.search(query)
+        response = tavily_client.search(query)
         search_results.append(response)
         state["logs"][i]["done"] = True
         await copilotkit_emit_state(config, state)


### PR DESCRIPTION
The following PR overcomes the behaviour of how langgraph emits custom events between asynchronous calls:
https://github.com/CopilotKit/CopilotKit/pull/1063

Having a synchronous call such as using the tavily client (without await. See changes here) is a good way to test this.
This PR utilizes this, so if, at any point, we will run into this again, our e2e testing system should be able to catch it.