### PR TITLE
Make sure agent state is set immediately

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-coagent.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-coagent.ts
@@ -97,7 +97,8 @@ import {
 } from "../context";
 import { CoagentState } from "../types/coagent-state";
 import { useCopilotChat } from "./use-copilot-chat";
-import { AgentStateMessage, Message, Role, TextMessage } from "@copilotkit/runtime-client-gql";
+import { Message } from "@copilotkit/runtime-client-gql";
+import { flushSync } from "react-dom";
 
 interface WithInternalStateManagementAndInitial<T> {
   /**
@@ -239,19 +240,21 @@ export function useCoAgent<T = any>(options: UseCoagentOptions<T>): UseCoagentRe
 
   // if we manage state internally, we need to provide a function to set the state
   const setState = (newState: T | ((prevState: T | undefined) => T)) => {
-    setCoagentStates((prevAgentStates) => {
-      let coagentState: CoagentState = getCoagentState(prevAgentStates, name);
+    flushSync(() => {
+      setCoagentStates((prevAgentStates) => {
+        let coagentState: CoagentState = getCoagentState(prevAgentStates, name);
 
-      const updatedState =
-        typeof newState === "function" ? (newState as Function)(coagentState.state) : newState;
+        const updatedState =
+          typeof newState === "function" ? (newState as Function)(coagentState.state) : newState;
 
-      return {
-        ...prevAgentStates,
-        [name]: {
-          ...coagentState,
-          state: updatedState,
-        },
-      };
+        return {
+          ...prevAgentStates,
+          [name]: {
+            ...coagentState,
+            state: updatedState,
+          },
+        };
+      });
     });
   };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Make sure agent state is set immediately to support `setState()` followed by `run()`

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation