### PR TITLE
docs(lgc): highlight usage of IDs in agents list

### DIFF
--- a/docs/content/docs/(root)/guides/backend-actions/langgraph-platform-endpoint.mdx
+++ b/docs/content/docs/(root)/guides/backend-actions/langgraph-platform-endpoint.mdx
@@ -68,7 +68,7 @@ import { FaCloud, FaServer } from "react-icons/fa";
                                 deploymentUrl: "your-api-url",
                                 langsmithApiKey: "your-langsmith-api-key",
                                 // List of all agents which are available under "graphs" list in your langgraph.json file.
-                                agents: [{ name: 'my_agent', description: 'A helpful LLM agent' }]
+                                agents: [{ name: 'my_agent', description: 'A helpful LLM agent', assistantId: 'ID-of-the-agent' }]
                             }),
                         ],
                     });

--- a/docs/content/docs/coagents/quickstart.mdx
+++ b/docs/content/docs/coagents/quickstart.mdx
@@ -97,6 +97,7 @@ In order for CopilotKit to integrate with your LangGraph agent, it has to be dep
                         {
                           name: 'my_agent', // this name must match one of your graphs defined under the `langgraph.json` file  // [!code highlight]
                           description: 'A helpful LLM agent that should be used whenever the user needs assistance with general queries or tasks.' // [!code highlight]
+                          assistantId: 'your-assistant-ID' // optional
                         }
                       ]
                     }),
@@ -104,8 +105,10 @@ In order for CopilotKit to integrate with your LangGraph agent, it has to be dep
                 });
               ```
               <Callout>
-                The key names under `graphs` in the `langgraph.json` are the agent(s) name(s)<br />
-                Make sure these names are used whenever you have to use an agent name throughout the integration with CopilotKit
+                The key names under `graphs` in the `langgraph.json` are the agent(s) name(s) unless you specified otherwise when creating your agents<br />
+                Make sure these names are used whenever you have to use an agent name throughout the integration with CopilotKit<br/>
+                  <br />
+                Additionally, you can specify assistant IDs, which is an optional, yet more accurate way to specify an agent
               </Callout>
               <Callout>
                 Remember to replace `your-api-url` with your actual LangGraph Platform deployment URL and


### PR DESCRIPTION
Highlighting the optional usage of `assistantId` to target an agent