### PR TITLE
docs: fix the style of lgc deployment details information

### DIFF
--- a/docs/content/docs/coagents/quickstart.mdx
+++ b/docs/content/docs/coagents/quickstart.mdx
@@ -95,9 +95,9 @@ In order for CopilotKit to integrate with your LangGraph agent, it has to be dep
                       langsmithApiKey: process.env.LANGSMITH_API_KEY, // only used in LangGraph Platform deoployments
                       agents: [ // List any agents available under "graphs" list in your langgraph.json file; give each a description explaining when it should be called.
                         {
-                          name: 'my_agent', // this name must match one of your graphs defined under the `langgraph.json` file  // [!code highlight]
-                          description: 'A helpful LLM agent that should be used whenever the user needs assistance with general queries or tasks.' // [!code highlight]
-                          assistantId: 'your-assistant-ID' // optional
+                          name: 'my_agent', // [!code highlight]
+                          description: 'A helpful LLM agent.' // [!code highlight]
+                          assistantId: 'your-assistant-ID' // optional, but recommended! // [!code highlight]
                         }
                       ]
                     }),
@@ -106,8 +106,7 @@ In order for CopilotKit to integrate with your LangGraph agent, it has to be dep
               ```
               <Callout>
                 The key names under `graphs` in the `langgraph.json` are the agent(s) name(s) unless you specified otherwise when creating your agents<br />
-                Make sure these names are used whenever you have to use an agent name throughout the integration with CopilotKit<br/>
-                  <br />
+                Make sure these names are used whenever you have to use an agent name throughout the integration with CopilotKit<br/><br/>
                 Additionally, you can specify assistant IDs, which is an optional, yet more accurate way to specify an agent
               </Callout>
               <Callout>


### PR DESCRIPTION
Some small changes in the docs in terms of spacing, changing of text (nothing with much meaning for the content)