### PR TITLE
fixes paths defined in readact

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/logger.ts
+++ b/CopilotKit/packages/runtime/src/lib/logger.ts
@@ -13,7 +13,7 @@ export function createLogger(options?: { level?: LogLevel; component?: string })
     {
       level: process.env.LOG_LEVEL || level || "error",
       redact: {
-        paths: ["pid", "hostname"],
+        paths: ["*.pid", "*.hostname"],
         remove: true,
       },
     },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The key changes are:

- Changed "pid" to "*.pid"
- Changed "hostname" to "*.hostname"

The * wildcard ensures the redaction works on these fields regardless of their location in the log object structure. Pino expects paths to be specified in this format to properly identify and redact sensitive information across the entire log object.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation