### PR TITLE
fix: prevent sending empty messages via Enter key

### DIFF
--- a/CopilotKit/.changeset/good-eggs-rescue.md
+++ b/CopilotKit/.changeset/good-eggs-rescue.md
@@ -1,0 +1,16 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix: prevent sending empty messages via Enter key
+
+When the input field was empty, pressing Enter would still trigger the
+send() function despite the send button being correctly disabled. Added
+the sendDisabled check to the onKeyDown handler to ensure consistent
+validation between button and keyboard triggers.
+
+- Added validation check to Enter key handler
+- Ensures empty messages can't be sent via keyboard shortcut
+- Makes behavior consistent with disabled send button state
+
+Resolves #1129

--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -50,7 +50,12 @@ export const Input = ({ inProgress, onSend, isVisible = false }: InputProps) => 
     pushToTalkConfigured &&
     (pushToTalkState === "idle" || pushToTalkState === "recording") &&
     !inProgress;
-  const sendDisabled = inProgress || text.length === 0 || pushToTalkState !== "idle";
+
+  const canSend = () => {
+    return !inProgress && text.trim().length > 0 && pushToTalkState === "idle";
+  };
+
+  const sendDisabled = !canSend();
 
   return (
     <div className="copilotKitInput" onClick={handleDivClick}>
@@ -64,7 +69,9 @@ export const Input = ({ inProgress, onSend, isVisible = false }: InputProps) => 
         onKeyDown={(event) => {
           if (event.key === "Enter" && !event.shiftKey) {
             event.preventDefault();
-            send();
+            if (canSend()) {
+              send();
+            }
           }
         }}
       />


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When the input field was empty, pressing Enter would still trigger the send() function despite the send button being correctly disabled. Added the sendDisabled check to the onKeyDown handler to ensure consistent validation between button and keyboard triggers.

- Added validation check to Enter key handler
- Ensures empty messages can't be sent via keyboard shortcut
- Makes behavior consistent with disabled send button state

Resolves #1129


## Related PRs and Issues

- #1129

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation