### PR TITLE
feat: adds `useCopilotAuthenticatedAction` hook

### DIFF
--- a/CopilotKit/.changeset/fuzzy-crabs-sell.md
+++ b/CopilotKit/.changeset/fuzzy-crabs-sell.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+- [CPK-1034] adds `useCopilotAuthenticatedAction`

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -1,5 +1,6 @@
 import { ForwardedParametersInput } from "@copilotkit/runtime-client-gql";
 import { ReactNode } from "react";
+import { AuthState } from "../../context/copilot-context";
 
 /**
  * Props for CopilotKit.
@@ -84,4 +85,13 @@ export interface CopilotKitProps {
    * The forwarded parameters to use for the task.
    */
   forwardedParameters?: Pick<ForwardedParametersInput, "temperature">;
+
+  /**
+   * The auth config to use for the CopilotKit.
+   */
+  authConfig?: {
+    SignInComponent: React.ComponentType<{
+      onSignInComplete: (authState: AuthState) => void;
+    }>;
+  };
 }

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -90,6 +90,15 @@ export interface AgentSession {
   nodeName?: string;
 }
 
+export interface AuthState {
+  status: "authenticated" | "unauthenticated";
+  authHeaders: Record<string, string>;
+  userId?: string;
+  metadata?: Record<string, any>;
+}
+
+export type ActionName = string;
+
 export interface CopilotContextParams {
   // function-calling
   actions: Record<string, FrontendAction<any>>;
@@ -167,6 +176,21 @@ export interface CopilotContextParams {
    * The forwarded parameters to use for the task.
    */
   forwardedParameters?: Pick<ForwardedParametersInput, "temperature">;
+
+  /**
+   * The auth states for the CopilotKit.
+   */
+  authStates?: Record<ActionName, AuthState>;
+  setAuthStates?: React.Dispatch<React.SetStateAction<Record<ActionName, AuthState>>>;
+
+  /**
+   * The auth config for the CopilotKit.
+   */
+  authConfig?: {
+    SignInComponent: React.ComponentType<{
+      onSignInComplete: (authState: AuthState) => void;
+    }>;
+  };
 }
 
 const emptyCopilotContext: CopilotContextParams = {
@@ -239,7 +263,6 @@ export function useCopilotContext(): CopilotContextParams {
   return context;
 }
 
-function returnAndThrowInDebug<T>(value: T): T {
+function returnAndThrowInDebug<T>(_value: T): T {
   throw new Error("Remember to wrap your app in a `<CopilotKit> {...} </CopilotKit>` !!!");
-  return value;
 }

--- a/CopilotKit/packages/react-core/src/hooks/index.ts
+++ b/CopilotKit/packages/react-core/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { type UseChatHelpers } from "./use-chat";
 export { useCopilotReadable } from "./use-copilot-readable";
 export { useCoAgent, type HintFunction, runAgent, startAgent, stopAgent } from "./use-coagent";
 export { useCopilotRuntimeClient } from "./use-copilot-runtime-client";
+export { useCopilotAuthenticatedAction } from "./use-copilot-authenticated-action";

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-authenticated-action.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-authenticated-action.ts
@@ -1,0 +1,60 @@
+import { Parameter } from "@copilotkit/shared";
+import { Fragment, useCallback, useRef } from "react";
+import { useCopilotContext } from "../context/copilot-context";
+import { FrontendAction, ActionRenderProps } from "../types/frontend-action";
+import { useCopilotAction } from "./use-copilot-action";
+import React from "react";
+
+export function useCopilotAuthenticatedAction<T extends Parameter[]>(
+  action: FrontendAction<T>,
+  dependencies?: any[],
+): void {
+  const { authConfig, authStates, setAuthStates } = useCopilotContext();
+  const pendingActionRef = useRef<ActionRenderProps<Parameter[]> | null>(null);
+
+  const executeAction = useCallback(
+    (props: ActionRenderProps<Parameter[]>) => {
+      if (typeof action.render === "function") {
+        return action.render(props);
+      }
+      return action.render || React.createElement(Fragment);
+    },
+    [action],
+  );
+
+  const wrappedRender = useCallback(
+    (props: ActionRenderProps<Parameter[]>): string | React.ReactElement => {
+      const isAuthenticated = Object.values(authStates || {}).some(
+        (state) => state.status === "authenticated",
+      );
+
+      if (!isAuthenticated) {
+        // Store action details for later execution
+        pendingActionRef.current = props;
+
+        return authConfig?.SignInComponent
+          ? React.createElement(authConfig.SignInComponent, {
+              onSignInComplete: (authState) => {
+                setAuthStates?.((prev) => ({ ...prev, [action.name]: authState }));
+                if (pendingActionRef.current) {
+                  executeAction(pendingActionRef.current);
+                  pendingActionRef.current = null;
+                }
+              },
+            })
+          : React.createElement(Fragment);
+      }
+
+      return executeAction(props);
+    },
+    [action, authStates, setAuthStates],
+  );
+
+  useCopilotAction(
+    {
+      ...action,
+      render: wrappedRender,
+    } as FrontendAction<T>,
+    dependencies,
+  );
+}


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## What does this PR do?
Adds `useCopilotAuthenticatedAction` hook to handle authentication within chat/conversation. If not authenticated, it renders the `SignInComponent` and allows resuming the previously requested action upon successful sign-in.

> ⚠️ **Important:** This functionality requires a CopilotKit Cloud account. To use these features:
> 1. Sign up at [cloud.copilotkit.ai](https://cloud.copilotkit.ai/)
> 2. Obtain your `publicApiKey` from the dashboard
> 3. Use this key in your CopilotKit provider configuration

### Example
Provide `AuthConfig` 
```tsx
/**
 * This is an example of how to implement a custom sign-in component.
 */
const authConfig: CopilotKitProps["authConfig"] = {
  SignInComponent: ({ onSignInComplete }) => {
    /*
      sample sign-in service that talks to SSO
     */
    const signInService = async (): Promise<AuthState> => {
      // call SSO service
      // on success, call onSignInComplete
      return Promise.resolve({
        status: "authenticated",
        authHeaders: {
          refreshtoken: "1234567890",
          accessToken: "1234567890",
        },
      });
    };
    const handleSignIn = async () => {
      const authState = await signInService();
      onSignInComplete(authState);
    };
    return (
      <button
        onClick={handleSignIn}
        className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
      >
        Sign in with SSO
      </button>
    );
  },
};
```
Then in your `CopilotKit` provider, use this confi
```tsx
<CopilotKit publicApiKey="..." authConfig={authConfig}>
  <CopilotSidebar>
    <VacationList />
  </CopilotSidebar>
</CopilotKit>
```
Now instead of `useCopilotAction` you can use `useCopilotAuthenticatedAction` for actions that you want to only work if user is authenticated
```tsx
useCopilotAuthenticatedAction({
  name: "AddVisitedDestination",
  description: "Add a new visited destination to the list", 
  parameters: [
    { name: "name", type: "string" },
    { name: "country", type: "string" },
    { name: "image", type: "string" },
    { name: "description", type: "string" },
    { name: "activities", type: "string" }
  ],
  handler: async (dest) => {
    setVisitedDestinations(prev => [...prev, dest]);
  }
});
```
## Related PRs and Issues
- (Direct link to related PR or issue, if relevant)

## Checklist
- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
