### PR TITLE
Implementing Empty Service Adapter

### DIFF
--- a/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
@@ -4,6 +4,16 @@
  * This adapter is meant to preserve adherence to runtime requirements, while doing nothing
  * Ideal if you don't want to connect an LLM the to the runtime, and only use your LangGraph agent.
  * Be aware that Copilot Suggestions will not work if you use this adapter
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { CopilotRuntime, ExperimentalEmptyAdapter } from "@copilotkit/runtime";
+ *
+ * const copilotKit = new CopilotRuntime();
+ *
+ * return new ExperimentalEmptyAdapter();
+ * ```
  */
 import {
   CopilotServiceAdapter,

--- a/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
@@ -1,9 +1,9 @@
 /**
  * CopilotKit Empty Adapter
  *
- * This adapter does nothing
- * Ideal if you want to be sure your front-end doesn't connect to any 3rd party LLM,
- * except your GraphLang chain.
+ * This adapter is meant to preserve adherence to runtime requirements, while doing nothing
+ * Ideal if you don't want to connect an LLM the to the runtime, and only use your LangGraph agent.
+ * Be aware that Copilot Suggestions will not work if you use this adapter
  */
 import {
   CopilotServiceAdapter,

--- a/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
@@ -1,6 +1,6 @@
 /**
  * CopilotKit Empty Adapter
- * 
+ *
  * This adapter does nothing
  * Ideal if you want to be sure your front-end doesn't connect to any 3rd party LLM,
  * except your GraphLang chain.

--- a/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/experimental/empty/empty-adapter.ts
@@ -1,0 +1,23 @@
+/**
+ * CopilotKit Empty Adapter
+ * 
+ * This adapter does nothing
+ * Ideal if you want to be sure your front-end doesn't connect to any 3rd party LLM,
+ * except your GraphLang chain.
+ */
+import {
+  CopilotServiceAdapter,
+  CopilotRuntimeChatCompletionRequest,
+  CopilotRuntimeChatCompletionResponse,
+} from "../../service-adapter";
+import { randomId } from "@copilotkit/shared";
+
+export class ExperimentalEmptyAdapter implements CopilotServiceAdapter {
+  async process(
+    request: CopilotRuntimeChatCompletionRequest,
+  ): Promise<CopilotRuntimeChatCompletionResponse> {
+    return {
+      threadId: request.threadId || randomId(),
+    };
+  }
+}

--- a/CopilotKit/packages/runtime/src/service-adapters/index.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/index.ts
@@ -1,7 +1,7 @@
 export type {
   CopilotRuntimeChatCompletionRequest,
   CopilotRuntimeChatCompletionResponse,
-  CopilotServiceAdapter
+  CopilotServiceAdapter,
 } from "./service-adapter";
 export type { RemoteChainParameters } from "./langchain/langserve";
 export { RemoteChain } from "./langchain/langserve";

--- a/CopilotKit/packages/runtime/src/service-adapters/index.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/index.ts
@@ -1,4 +1,8 @@
-export type { CopilotServiceAdapter } from "./service-adapter";
+export type {
+  CopilotRuntimeChatCompletionRequest,
+  CopilotRuntimeChatCompletionResponse,
+  CopilotServiceAdapter
+} from "./service-adapter";
 export type { RemoteChainParameters } from "./langchain/langserve";
 export { RemoteChain } from "./langchain/langserve";
 export * from "./openai/openai-adapter";
@@ -8,3 +12,5 @@ export * from "./openai/openai-assistant-adapter";
 export * from "./unify/unify-adapter";
 export * from "./groq/groq-adapter";
 export * from "./anthropic/anthropic-adapter";
+export * from "./experimental/ollama/ollama-adapter";
+export * from "./experimental/empty/empty-adapter";


### PR DESCRIPTION
@tylerslaton 

## What does this PR do?

* Implementing Empty Service Adapter (fixes #1157)
* Exporting the adapter for use
* Also exporting the Ollama experimental adapter
* Exporting CopilotRuntimeChatCompletionRequest, CopilotRuntimeChatCompletionResponse to make it easier for someone to implement their own custom adapter

## Related PRs and Issues

- https://github.com/CopilotKit/CopilotKit/issues/1157

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation