### PR TITLE
fix: async agent state fetching

### DIFF
--- a/sdk-python/copilotkit/integrations/fastapi.py
+++ b/sdk-python/copilotkit/integrations/fastapi.py
@@ -81,7 +81,7 @@ async def handler(request: Request, sdk: CopilotKitSDK):
         messages = body_get_or_raise(body, "messages")
         actions = cast(List[ActionDict], body.get("actions", []))
 
-        return handle_execute_agent(
+        return await handle_execute_agent(
             sdk=sdk,
             context=context,
             thread_id=thread_id,
@@ -126,7 +126,7 @@ async def handle_execute_action(
         logger.error("Action execution error: %s", exc)
         return JSONResponse(content={"error": str(exc)}, status_code=500)
 
-def handle_execute_agent( # pylint: disable=too-many-arguments
+async def handle_execute_agent( # pylint: disable=too-many-arguments
         *,
         sdk: CopilotKitSDK,
         context: CopilotKitSDKContext,
@@ -139,7 +139,7 @@ def handle_execute_agent( # pylint: disable=too-many-arguments
     ):
     """Handle continue agent execution request with FastAPI"""
     try:
-        events = sdk.execute_agent(
+        events = await sdk.execute_agent(
             context=context,
             thread_id=thread_id,
             name=name,

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -266,7 +266,7 @@ class LangGraphAgent(Agent):
             "role": "assistant"
         })
 
-    def execute( # pylint: disable=too-many-arguments            
+    async def execute( # pylint: disable=too-many-arguments
         self,
         *,
         state: dict,
@@ -279,7 +279,7 @@ class LangGraphAgent(Agent):
         config["configurable"] = config.get("configurable", {})
         config["configurable"]["thread_id"] = thread_id
 
-        agent_state = self.graph.get_state(config)
+        agent_state = await self.graph.get_state(config)
         state["messages"] = agent_state.values.get("messages", [])
 
         langchain_messages = self.convert_messages(messages)
@@ -295,7 +295,7 @@ class LangGraphAgent(Agent):
         config["configurable"]["thread_id"] = thread_id
 
         if mode == "continue":
-            self.graph.update_state(config, state, as_node=node_name)
+            await self.graph.update_state(config, state, as_node=node_name)
 
         return self._stream_events(
             mode=mode,
@@ -372,7 +372,7 @@ class LangGraphAgent(Agent):
                 # reset the streaming state extractor
                 streaming_state_extractor = _StreamingStateExtractor(emit_intermediate_state)
 
-            updated_state = manually_emitted_state or self.graph.get_state(config).values
+            updated_state = manually_emitted_state or await self.graph.get_state(config).values
 
             if emit_intermediate_state and event_type == "on_chat_model_stream":
                 streaming_state_extractor.buffer_tool_calls(event)
@@ -407,7 +407,7 @@ class LangGraphAgent(Agent):
 
             yield langchain_dumps(event) + "\n"
 
-        state = self.graph.get_state(config)
+        state = await self.graph.get_state(config)
         is_end_node = state.next == ()
 
         node_name = list(state.metadata["writes"].keys())[0]

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -279,7 +279,7 @@ class LangGraphAgent(Agent):
         config["configurable"] = config.get("configurable", {})
         config["configurable"]["thread_id"] = thread_id
 
-        agent_state = await self.graph.get_state(config)
+        agent_state = await self.graph.aget_state(config)
         state["messages"] = agent_state.values.get("messages", [])
 
         langchain_messages = self.convert_messages(messages)
@@ -295,7 +295,7 @@ class LangGraphAgent(Agent):
         config["configurable"]["thread_id"] = thread_id
 
         if mode == "continue":
-            await self.graph.update_state(config, state, as_node=node_name)
+            await self.graph.aupdate_state(config, state, as_node=node_name)
 
         return self._stream_events(
             mode=mode,
@@ -372,7 +372,7 @@ class LangGraphAgent(Agent):
                 # reset the streaming state extractor
                 streaming_state_extractor = _StreamingStateExtractor(emit_intermediate_state)
 
-            updated_state = manually_emitted_state or (await self.graph.get_state(config).values)
+            updated_state = manually_emitted_state or (await self.graph.aget_state(config)).values
 
             if emit_intermediate_state and event_type == "on_chat_model_stream":
                 streaming_state_extractor.buffer_tool_calls(event)
@@ -407,7 +407,7 @@ class LangGraphAgent(Agent):
 
             yield langchain_dumps(event) + "\n"
 
-        state = await self.graph.get_state(config)
+        state = await self.graph.aget_state(config)
         is_end_node = state.next == ()
 
         node_name = list(state.metadata["writes"].keys())[0]

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -372,7 +372,7 @@ class LangGraphAgent(Agent):
                 # reset the streaming state extractor
                 streaming_state_extractor = _StreamingStateExtractor(emit_intermediate_state)
 
-            updated_state = manually_emitted_state or await self.graph.get_state(config).values
+            updated_state = manually_emitted_state or (await self.graph.get_state(config).values)
 
             if emit_intermediate_state and event_type == "on_chat_model_stream":
                 streaming_state_extractor.buffer_tool_calls(event)

--- a/sdk-python/copilotkit/sdk.py
+++ b/sdk-python/copilotkit/sdk.py
@@ -120,7 +120,7 @@ class CopilotKitSDK:
         except Exception as error:
             raise ActionExecutionException(name, error) from error
 
-    def execute_agent( # pylint: disable=too-many-arguments
+    async def execute_agent( # pylint: disable=too-many-arguments
         self,
         *,
         context: CopilotKitSDKContext,
@@ -156,7 +156,7 @@ class CopilotKitSDK:
         logger.info("--------------------------")
 
         try:
-            return agent.execute(
+            return await agent.execute(
                 thread_id=thread_id,
                 node_name=node_name,
                 state=state,

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.31-alpha.1"
+version = "0.1.31-alpha.3"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.31-alpha.0"
+version = "0.1.31-alpha.1"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.30"
+version = "0.1.31-alpha.0"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
We're calling some methods when resolving langgraph agent communication. Some of these should be called async. This PR attempts a fix for that