### PR TITLE
fix: hide abort controller state error

### DIFF
--- a/CopilotKit/packages/react-core/src/components/error-boundary/error-utils.tsx
+++ b/CopilotKit/packages/react-core/src/components/error-boundary/error-utils.tsx
@@ -55,18 +55,20 @@ export function useErrorToast() {
   const { addToast } = useToast();
 
   const isAbortError = (error: Error | GraphQLError): boolean => {
-      if ('networkError' in error && error.name === 'CombinedError') {
-          return Boolean(error.networkError && (error.networkError as { name: string }).name === 'AbortError')
-      }
+    if ("networkError" in error && error.name === "CombinedError") {
+      return Boolean(
+        error.networkError && (error.networkError as { name: string }).name === "AbortError",
+      );
+    }
 
-    return error instanceof DOMException && error.name === 'AbortError';
+    return error instanceof DOMException && error.name === "AbortError";
   };
 
   return useCallback(
     (errors: (Error | GraphQLError)[]) => {
       // Filter out abort errors
-      const nonAbortErrors = errors.filter(err => !isAbortError(err));
-      
+      const nonAbortErrors = errors.filter((err) => !isAbortError(err));
+
       if (nonAbortErrors.length === 0) return;
 
       const errorId = nonAbortErrors

--- a/CopilotKit/packages/react-core/src/components/index.ts
+++ b/CopilotKit/packages/react-core/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./copilot-provider";
+export * from "./error-boundary/error-utils";

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -73,6 +73,7 @@ import { InputProps, MessagesProps, RenderMessageProps, ResponseButtonProps } fr
 import { randomId } from "@copilotkit/shared";
 
 import { CopilotDevConsole } from "../dev-console";
+import { useErrorToast } from "@copilotkit/react-core";
 
 /**
  * Props for CopilotChat component.
@@ -272,6 +273,7 @@ export const useCopilotChatLogic = (
   onInProgress?: (isLoading: boolean) => void,
   onSubmitMessage?: (messageContent: string) => Promise<void> | void,
 ) => {
+  const addErrorToast = useErrorToast();
   const { visibleMessages, appendMessage, reloadMessages, stopGeneration, isLoading } =
     useCopilotChat({
       id: randomId(),
@@ -305,6 +307,7 @@ export const useCopilotChatLogic = (
             context.chatSuggestionConfiguration,
             setCurrentSuggestions,
             suggestionsAbortControllerRef,
+            error => addErrorToast([error])
           );
         }
       },

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -307,7 +307,7 @@ export const useCopilotChatLogic = (
             context.chatSuggestionConfiguration,
             setCurrentSuggestions,
             suggestionsAbortControllerRef,
-            error => addErrorToast([error])
+            (error) => addErrorToast([error]),
           );
         }
       },

--- a/CopilotKit/packages/react-ui/src/components/chat/Suggestion.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Suggestion.tsx
@@ -31,6 +31,7 @@ export const reloadSuggestions = async (
   chatSuggestionConfiguration: { [key: string]: CopilotChatSuggestionConfiguration },
   setCurrentSuggestions: (suggestions: { title: string; message: string }[]) => void,
   abortControllerRef: React.MutableRefObject<AbortController | null>,
+  onError?: (e: Error) => void,
 ) => {
   const abortController = abortControllerRef.current;
 
@@ -115,7 +116,7 @@ export const reloadSuggestions = async (
       });
       allSuggestions.push(...result.suggestions);
     } catch (error) {
-      console.error("Error loading suggestions", error);
+      onError?.(error as Error);
     }
   }
 


### PR DESCRIPTION
There are many reasons why the abort controller will abort suggestions, or something else.
Most of them are more of a "state" than an error. Therefore, these errors will now be hidden