### PR TITLE
fix: wait for renderAndWaitForResponse handler to be ready before rendering

### DIFF
--- a/CopilotKit/.changeset/cold-knives-boil.md
+++ b/CopilotKit/.changeset/cold-knives-boil.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+- fix: wait for renderAndWaitForResponse handler to be ready before rendering


### PR DESCRIPTION
`renderAndWaitForResponse` should run when the status of execution message is "executing". However, in this case, the handler might not be ready yet.
Therefore, this PR waits for it to be ready before rendering