### PR TITLE
chore: validate core ReAct is aware of latest state

### DIFF
--- a/examples/e2e/tests/next-openai.spec.ts
+++ b/examples/e2e/tests/next-openai.spec.ts
@@ -193,18 +193,18 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               // Test destination deselection
               await sendChatMessage(
                 page,
-                "Actually, please deselect New York City."
+                "Actually, please deselect Tokyo."
               );
               await waitForResponse(page);
               await page.waitForTimeout(2000);
 
               await waitForDestinationState(page, {
                 destination: "new-york-city",
-                isChecked: false,
+                isChecked: true,
               });
               await waitForDestinationState(page, {
                 destination: "tokyo",
-                isChecked: true,
+                isChecked: false,
               });
 
               // Test adding new destination
@@ -221,6 +221,24 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               });
               await waitForDestinationImage(page, {
                 destination: "Mumbai India",
+              });
+
+              // Verify new destination is available in state
+              await sendChatMessage(
+                  page,
+                  "Select all destinations in Asia."
+              );
+              await waitForResponse(page);
+              await page.waitForTimeout(3000);
+
+              await waitForDestinationState(page, {
+                destination: "mumbai",
+                isChecked: true,
+              });
+
+              await waitForDestinationState(page, {
+                destination: "tokyo",
+                isChecked: true,
               });
             });
           });


### PR DESCRIPTION
On the basic (non CoAgent) flow, when asking the copilot to make changes, the "state" is changing. We expect that same agent to now be aware of the new state and derive its next actions and knowledge from these.
This PR sets an addition to our e2e tests to verify this