### PR TITLE
fix: add warning when using agents that are not available on agent related hooks

### DIFF
--- a/CopilotKit/.changeset/twenty-dogs-trade.md
+++ b/CopilotKit/.changeset/twenty-dogs-trade.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-core": patch
+"@copilotkit/runtime-client-gql": patch
+"@copilotkit/runtime": patch
+---
+
+- fix: add warning when using agents that are not available on agent related hooks

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -14,7 +14,7 @@
  * ```
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotContext,
   CopilotApiConfig,
@@ -42,6 +42,7 @@ import { ToastProvider } from "../toast/toast-provider";
 import { useCopilotRuntimeClient } from "../../hooks/use-copilot-runtime-client";
 import { shouldShowDevConsole } from "../../utils";
 import { CopilotErrorBoundary } from "../error-boundary/error-boundary";
+import { Agent } from "@copilotkit/runtime-client-gql";
 
 export function CopilotKit({ children, ...props }: CopilotKitProps) {
   const showDevConsole = props.showDevConsole === undefined ? "auto" : props.showDevConsole;
@@ -277,6 +278,7 @@ export function CopilotKitInternal({ children, ...props }: CopilotKitProps) {
     });
   };
 
+  const [availableAgents, setAvailableAgents] = useState<Agent[]>([]);
   const [coagentStates, setCoagentStates] = useState<Record<string, CoagentState>>({});
   const coagentStatesRef = useRef<Record<string, CoagentState>>({});
   const setCoagentStatesWithRef = useCallback(
@@ -293,6 +295,16 @@ export function CopilotKitInternal({ children, ...props }: CopilotKitProps) {
     },
     [],
   );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const result = await runtimeClient.availableAgents();
+      if (result.data?.availableAgents) {
+        setAvailableAgents(result.data.availableAgents.agents);
+      }
+    };
+    void fetchData();
+  }, []);
 
   let initialAgentSession: AgentSession | null = null;
   if (props.agent) {
@@ -349,6 +361,7 @@ export function CopilotKitInternal({ children, ...props }: CopilotKitProps) {
         runId,
         setRunId,
         chatAbortControllerRef,
+        availableAgents,
         authConfig: props.authConfig,
         authStates,
         setAuthStates,

--- a/CopilotKit/packages/react-core/src/components/toast/toast-provider.tsx
+++ b/CopilotKit/packages/react-core/src/components/toast/toast-provider.tsx
@@ -141,7 +141,7 @@ function Toast({
       style={{
         backgroundColor: bgColors[type],
         color: "white",
-        padding: "0.5rem 1rem",
+        padding: "0.5rem 1.5rem",
         borderRadius: "0.25rem",
         boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
         position: "relative",

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -11,6 +11,7 @@ import { CopilotChatSuggestionConfiguration } from "../types/chat-suggestion-con
 import { CoAgentStateRender, CoAgentStateRenderProps } from "../types/coagent-action";
 import { CoagentState } from "../types/coagent-state";
 import { CopilotRuntimeClient, ForwardedParametersInput } from "@copilotkit/runtime-client-gql";
+import { Agent } from "@copilotkit/runtime-client-gql";
 
 /**
  * Interface for the configuration of the Copilot API.
@@ -176,6 +177,7 @@ export interface CopilotContextParams {
    * The forwarded parameters to use for the task.
    */
   forwardedParameters?: Pick<ForwardedParametersInput, "temperature">;
+  availableAgents: Agent[];
 
   /**
    * The auth states for the CopilotKit.
@@ -251,6 +253,7 @@ const emptyCopilotContext: CopilotContextParams = {
   runId: null,
   setRunId: () => {},
   chatAbortControllerRef: { current: null },
+  availableAgents: [],
 };
 
 export const CopilotContext = React.createContext<CopilotContextParams>(emptyCopilotContext);

--- a/CopilotKit/packages/react-core/src/hooks/use-coagent-state-render.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-coagent-state-render.ts
@@ -50,6 +50,7 @@ import { useRef, useContext, useEffect } from "react";
 import { CopilotContext } from "../context/copilot-context";
 import { randomId } from "@copilotkit/shared";
 import { CoAgentStateRender } from "../types/coagent-action";
+import { useToast } from "../components/toast/toast-provider";
 
 /**
  * This hook is used to render agent state with custom UI components or text. This is particularly
@@ -71,8 +72,18 @@ export function useCoAgentStateRender<T = any>(
     removeCoAgentStateRender,
     coAgentStateRenders,
     chatComponentsCache,
+    availableAgents,
   } = useContext(CopilotContext);
   const idRef = useRef<string>(randomId());
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    if (availableAgents?.length && !availableAgents.some((a) => a.name === action.name)) {
+      const message = `(useCoAgentStateRender): Agent "${action.name}" not found. Make sure the agent exists and is properly configured.`;
+      console.warn(message);
+      addToast({ type: "warning", message });
+    }
+  }, [availableAgents]);
 
   const key = `${action.name}-${action.nodeName || "global"}`;
 

--- a/CopilotKit/packages/runtime-client-gql/src/graphql/definitions/queries.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/graphql/definitions/queries.ts
@@ -1,0 +1,13 @@
+import { graphql } from "../@generated/gql";
+
+export const getAvailableAgentsQuery = graphql(/** GraphQL **/ `
+  query availableAgents {
+    availableAgents {
+      agents {
+        name
+        id
+        description
+      }
+    }
+  }
+`);

--- a/CopilotKit/packages/runtime/src/graphql/resolvers/copilot.resolver.ts
+++ b/CopilotKit/packages/runtime/src/graphql/resolvers/copilot.resolver.ts
@@ -42,6 +42,8 @@ import {
 } from "../types/converted";
 import telemetry from "../../lib/telemetry-client";
 import { randomId } from "@copilotkit/shared";
+import { EndpointType, LangGraphPlatformAgent } from "../../lib/runtime/remote-actions";
+import { AgentsResponse } from "../types/agents-response.type";
 
 const invokeGuardrails = async ({
   baseUrl,
@@ -104,6 +106,20 @@ export class CopilotResolver {
   @Query(() => String)
   async hello() {
     return "Hello World";
+  }
+
+  @Query(() => AgentsResponse)
+  async availableAgents(@Ctx() ctx: GraphQLContext) {
+    let logger = ctx.logger.child({ component: "CopilotResolver.availableAgents" });
+
+    logger.debug("Processing");
+    const agents = await ctx._copilotkit.runtime.discoverAgentsFromEndpoints(ctx);
+
+    logger.debug("Event source created, creating response");
+
+    return {
+      agents,
+    };
   }
 
   @Mutation(() => CopilotResponse)

--- a/CopilotKit/packages/runtime/src/graphql/types/agents-response.type.ts
+++ b/CopilotKit/packages/runtime/src/graphql/types/agents-response.type.ts
@@ -1,0 +1,22 @@
+import { Field, InterfaceType, ObjectType } from "type-graphql";
+import { MessageRole } from "./enums";
+import { MessageStatusUnion } from "./message-status.type";
+import { ResponseStatusUnion } from "./response-status.type";
+
+@ObjectType()
+export class Agent {
+  @Field(() => String)
+  id: string;
+
+  @Field(() => String)
+  name: string;
+
+  @Field(() => String)
+  description?: string;
+}
+
+@ObjectType()
+export class AgentsResponse {
+  @Field(() => [Agent])
+  agents: Agent[];
+}

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -72,3 +72,12 @@ An array of LangServer URLs.
 
 </PropertyReference>
 
+<PropertyReference name="discoverAgentsFromEndpoints" type="graphqlContext: GraphQLContext">
+
+
+  <PropertyReference name="graphqlContext" type="GraphQLContext" required>
+  
+  </PropertyReference>
+
+</PropertyReference>
+


### PR DESCRIPTION
We will now show a warning telling the developer that they used an agent we cannot list/find