### PR TITLE
feat(react-ui): add interfaces for full message customization

### DIFF
--- a/CopilotKit/.changeset/tender-horses-begin.md
+++ b/CopilotKit/.changeset/tender-horses-begin.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- feat(react-ui): add interfaces for full message customization
+
+Signed-off-by: Tyler Slaton <tyler@copilotkit.ai>

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -58,6 +58,9 @@ import { RenderTextMessage as DefaultRenderTextMessage } from "./messages/Render
 import { RenderActionExecutionMessage as DefaultRenderActionExecutionMessage } from "./messages/RenderActionExecutionMessage";
 import { RenderResultMessage as DefaultRenderResultMessage } from "./messages/RenderResultMessage";
 import { RenderAgentStateMessage as DefaultRenderAgentStateMessage } from "./messages/RenderAgentStateMessage";
+import { AssistantMessage as DefaultAssistantMessage } from "./messages/AssistantMessage";
+import { UserMessage as DefaultUserMessage } from "./messages/UserMessage";
+import { Markdown as DefaultRenderer } from "./Markdown";
 import { Suggestion } from "./Suggestion";
 import React, { useEffect, useRef, useState } from "react";
 import {
@@ -69,8 +72,15 @@ import {
 import { reloadSuggestions } from "./Suggestion";
 import { CopilotChatSuggestion } from "../../types/suggestions";
 import { Message, Role, TextMessage } from "@copilotkit/runtime-client-gql";
-import { InputProps, MessagesProps, RenderMessageProps, ResponseButtonProps } from "./props";
 import { randomId } from "@copilotkit/shared";
+import {
+  AssistantMessageProps,
+  InputProps,
+  MessagesProps,
+  RenderMessageProps,
+  ResponseButtonProps,
+  UserMessageProps,
+} from "./props";
 
 import { CopilotDevConsole } from "../dev-console";
 import { HintFunction, runAgent, stopAgent } from "@copilotkit/react-core";
@@ -132,6 +142,16 @@ export interface CopilotChatProps {
    * @default true
    */
   showResponseButton?: boolean;
+
+  /**
+   * A custom assistant message component to use instead of the default.
+   */
+  AssistantMessage?: React.ComponentType<AssistantMessageProps>;
+
+  /**
+   * A custom user message component to use instead of the default.
+   */
+  UserMessage?: React.ComponentType<UserMessageProps>;
 
   /**
    * A custom Messages component to use instead of the default.
@@ -245,6 +265,8 @@ export function CopilotChat({
   className,
   icons,
   labels,
+  AssistantMessage = DefaultAssistantMessage,
+  UserMessage = DefaultUserMessage,
 }: CopilotChatProps) {
   const context = useCopilotContext();
 
@@ -274,6 +296,8 @@ export function CopilotChat({
     <WrappedCopilotChat icons={icons} labels={labels} className={className}>
       <CopilotDevConsole />
       <Messages
+        AssistantMessage={AssistantMessage}
+        UserMessage={UserMessage}
         RenderTextMessage={RenderTextMessage}
         RenderActionExecutionMessage={RenderActionExecutionMessage}
         RenderAgentStateMessage={RenderAgentStateMessage}

--- a/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
@@ -11,6 +11,8 @@ export const Messages = ({
   RenderActionExecutionMessage,
   RenderAgentStateMessage,
   RenderResultMessage,
+  AssistantMessage,
+  UserMessage,
 }: MessagesProps) => {
   const context = useChatContext();
   const initialMessages = useMemo(
@@ -49,6 +51,8 @@ export const Messages = ({
               inProgress={inProgress}
               index={index}
               isCurrentMessage={isCurrentMessage}
+              AssistantMessage={AssistantMessage}
+              UserMessage={UserMessage}
             />
           );
         } else if (message.isActionExecutionMessage()) {
@@ -60,6 +64,8 @@ export const Messages = ({
               index={index}
               isCurrentMessage={isCurrentMessage}
               actionResult={actionResults[message.id]}
+              AssistantMessage={AssistantMessage}
+              UserMessage={UserMessage}
             />
           );
         } else if (message.isAgentStateMessage()) {
@@ -70,6 +76,8 @@ export const Messages = ({
               inProgress={inProgress}
               index={index}
               isCurrentMessage={isCurrentMessage}
+              AssistantMessage={AssistantMessage}
+              UserMessage={UserMessage}
             />
           );
         } else if (message.isResultMessage()) {
@@ -80,6 +88,8 @@ export const Messages = ({
               inProgress={inProgress}
               index={index}
               isCurrentMessage={isCurrentMessage}
+              AssistantMessage={AssistantMessage}
+              UserMessage={UserMessage}
             />
           );
         }

--- a/CopilotKit/packages/react-ui/src/components/chat/Modal.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Modal.tsx
@@ -8,6 +8,9 @@ import { Messages as DefaultMessages } from "./Messages";
 import { Input as DefaultInput } from "./Input";
 import { ResponseButton as DefaultResponseButton } from "./Response";
 import { CopilotChat, CopilotChatProps } from "./Chat";
+import { Markdown as DefaultRenderer } from "./Markdown";
+import { AssistantMessage as DefaultAssistantMessage } from "./messages/AssistantMessage";
+import { UserMessage as DefaultUserMessage } from "./messages/UserMessage";
 
 export interface CopilotModalProps extends CopilotChatProps {
   /**
@@ -77,6 +80,8 @@ export const CopilotModal = ({
   Messages = DefaultMessages,
   Input = DefaultInput,
   ResponseButton = DefaultResponseButton,
+  AssistantMessage = DefaultAssistantMessage,
+  UserMessage = DefaultUserMessage,
   className,
   children,
 }: CopilotModalProps) => {
@@ -109,6 +114,8 @@ export const CopilotModal = ({
             Messages={Messages}
             Input={Input}
             ResponseButton={ResponseButton}
+            AssistantMessage={AssistantMessage}
+            UserMessage={UserMessage}
           />
         </Window>
       </div>

--- a/CopilotKit/packages/react-ui/src/components/chat/index.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/index.tsx
@@ -2,4 +2,7 @@ export * from "./props";
 export { CopilotPopup } from "./Popup";
 export { CopilotSidebar } from "./Sidebar";
 export { CopilotChat } from "./Chat";
+export { Markdown } from "./Markdown";
+export { AssistantMessage } from "./messages/AssistantMessage";
+export { UserMessage } from "./messages/UserMessage";
 export { useChatContext } from "./ChatContext";

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
@@ -1,0 +1,20 @@
+import { AssistantMessageProps } from "../props";
+import { useChatContext } from "../ChatContext";
+import { Markdown } from "../Markdown";
+
+export const AssistantMessage = (props: AssistantMessageProps) => {
+  const { icons } = useChatContext();
+  const { message, isLoading, subComponent } = props;
+
+  return (
+    <>
+      {(message || isLoading) && (
+        <div className="copilotKitMessage copilotKitAssistantMessage">
+          {message && <Markdown content={message || ""} />}
+          {isLoading && icons.spinnerIcon}
+        </div>
+      )}
+      <div style={{ marginBottom: "0.5rem" }}>{subComponent}</div>
+    </>
+  );
+};

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderActionExecutionMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderActionExecutionMessage.tsx
@@ -1,12 +1,10 @@
 import { MessageStatusCode } from "@copilotkit/runtime-client-gql";
 import { RenderMessageProps } from "../props";
-import { useChatContext } from "../ChatContext";
 import { RenderFunctionStatus, useCopilotContext } from "@copilotkit/react-core";
 
 export function RenderActionExecutionMessage(props: RenderMessageProps) {
-  const { message, inProgress, index, isCurrentMessage, actionResult } = props;
   const { chatComponentsCache } = useCopilotContext();
-  const { icons } = useChatContext();
+  const { message, inProgress, index, isCurrentMessage, actionResult, AssistantMessage } = props;
 
   if (message.isActionExecutionMessage()) {
     if (
@@ -22,9 +20,14 @@ export function RenderActionExecutionMessage(props: RenderMessageProps) {
         // when render is static, we show it only when in progress
         if (isCurrentMessage && inProgress) {
           return (
-            <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-              {icons.spinnerIcon} <span className="inProgressLabel">{render}</span>
-            </div>
+            <AssistantMessage
+              rawData={message}
+              key={index}
+              data-message-role="assistant"
+              isLoading={false}
+              isGenerating={true}
+              message={render}
+            />
           );
         }
         // Done - silent by default to avoid a series of "done" messages
@@ -57,30 +60,44 @@ export function RenderActionExecutionMessage(props: RenderMessageProps) {
           }
           if (typeof toRender === "string") {
             return (
-              <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-                {isCurrentMessage && inProgress && icons.spinnerIcon} {toRender}
-              </div>
+              <AssistantMessage
+                rawData={message}
+                data-message-role="assistant"
+                key={index}
+                isLoading={false}
+                isGenerating={false}
+                message={toRender}
+              />
             );
           } else {
             return (
-              <div
+              <AssistantMessage
+                rawData={message}
+                data-message-role="action-render"
                 key={index}
-                data-message-type="action-render"
-                className="copilotKitCustomAssistantMessage"
-              >
-                {toRender}
-              </div>
+                isLoading={false}
+                isGenerating={false}
+                subComponent={toRender}
+              />
             );
           }
         } catch (e) {
           console.error(`Error executing render function for action ${message.name}: ${e}`);
           return (
-            <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-              {isCurrentMessage && inProgress && icons.spinnerIcon}
-              <b>❌ Error executing render: {message.name}</b>
-              <br />
-              {e instanceof Error ? e.message : String(e)}
-            </div>
+            <AssistantMessage
+              rawData={message}
+              data-message-role="assistant"
+              key={index}
+              isLoading={false}
+              isGenerating={false}
+              subComponent={
+                <div>
+                  <b>❌ Error executing render: {message.name}</b>
+                  <br />
+                  {e instanceof Error ? e.message : String(e)}
+                </div>
+              }
+            />
           );
         }
       }
@@ -92,9 +109,13 @@ export function RenderActionExecutionMessage(props: RenderMessageProps) {
     } else {
       // In progress
       return (
-        <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-          {icons.spinnerIcon}
-        </div>
+        <AssistantMessage
+          rawData={message}
+          key={index}
+          data-message-role="assistant"
+          isLoading={true}
+          isGenerating={true}
+        />
       );
     }
   }

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderAgentStateMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderAgentStateMessage.tsx
@@ -1,12 +1,9 @@
-import { AgentStateMessage } from "@copilotkit/runtime-client-gql";
 import { RenderMessageProps } from "../props";
-import { useChatContext } from "../ChatContext";
 import { CoagentInChatRenderFunction, useCopilotContext } from "@copilotkit/react-core";
 
 export function RenderAgentStateMessage(props: RenderMessageProps) {
-  const { message, inProgress, index, isCurrentMessage } = props;
   const { chatComponentsCache } = useCopilotContext();
-  const { icons } = useChatContext();
+  const { message, inProgress, index, isCurrentMessage, AssistantMessage } = props;
 
   if (message.isAgentStateMessage()) {
     let render: string | CoagentInChatRenderFunction | undefined;
@@ -24,9 +21,14 @@ export function RenderAgentStateMessage(props: RenderMessageProps) {
         // when render is static, we show it only when in progress
         if (isCurrentMessage && inProgress) {
           return (
-            <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-              {icons.spinnerIcon} <span className="inProgressLabel">{render}</span>
-            </div>
+            <AssistantMessage
+              rawData={message}
+              message={render}
+              data-message-role="assistant"
+              key={index}
+              isLoading={true}
+              isGenerating={true}
+            />
           );
         }
         // Done - silent by default to avoid a series of "done" messages
@@ -53,9 +55,13 @@ export function RenderAgentStateMessage(props: RenderMessageProps) {
 
         if (!toRender && isCurrentMessage && inProgress) {
           return (
-            <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-              {icons.spinnerIcon}
-            </div>
+            <AssistantMessage
+              data-message-role="assistant"
+              key={index}
+              rawData={message}
+              isLoading={true}
+              isGenerating={true}
+            />
           );
         } else if (!toRender) {
           return null;
@@ -63,15 +69,25 @@ export function RenderAgentStateMessage(props: RenderMessageProps) {
 
         if (typeof toRender === "string") {
           return (
-            <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-              {isCurrentMessage && inProgress && icons.spinnerIcon} {toRender}
-            </div>
+            <AssistantMessage
+              rawData={message}
+              message={toRender}
+              isLoading={true}
+              isGenerating={true}
+              data-message-role="assistant"
+              key={index}
+            />
           );
         } else {
           return (
-            <div key={index} className="copilotKitCustomAssistantMessage">
-              {toRender}
-            </div>
+            <AssistantMessage
+              rawData={message}
+              data-message-role="agent-state-render"
+              key={index}
+              isLoading={false}
+              isGenerating={false}
+              subComponent={toRender}
+            />
           );
         }
       }
@@ -83,9 +99,13 @@ export function RenderAgentStateMessage(props: RenderMessageProps) {
     } else {
       // In progress
       return (
-        <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-          {icons.spinnerIcon}
-        </div>
+        <AssistantMessage
+          rawData={message}
+          isLoading={true}
+          isGenerating={true}
+          data-message-role="assistant"
+          key={index}
+        />
       );
     }
   }

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderResultMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderResultMessage.tsx
@@ -1,15 +1,17 @@
-import { ResultMessage } from "@copilotkit/runtime-client-gql";
 import { RenderMessageProps } from "../props";
-import { useChatContext } from "../ChatContext";
 
 export function RenderResultMessage(props: RenderMessageProps) {
-  const { message, inProgress, index, isCurrentMessage } = props;
-  const { icons } = useChatContext();
+  const { message, inProgress, index, isCurrentMessage, AssistantMessage } = props;
+
   if (message.isResultMessage() && inProgress && isCurrentMessage) {
     return (
-      <div key={index} className={`copilotKitMessage copilotKitAssistantMessage`}>
-        {icons.spinnerIcon}
-      </div>
+      <AssistantMessage
+        key={index}
+        data-message-role="assistant"
+        rawData={message}
+        isLoading={true}
+        isGenerating={true}
+      />
     );
   }
 }

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderTextMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderTextMessage.tsx
@@ -1,35 +1,28 @@
-import { TextMessage } from "@copilotkit/runtime-client-gql";
 import { RenderMessageProps } from "../props";
-import { Markdown } from "../Markdown";
-import { useChatContext } from "../ChatContext";
 
 export function RenderTextMessage(props: RenderMessageProps) {
-  const { message, inProgress, index, isCurrentMessage } = props;
-  const { icons } = useChatContext();
+  const { message, inProgress, index, isCurrentMessage, UserMessage, AssistantMessage } = props;
+
   if (message.isTextMessage()) {
     if (message.role === "user") {
       return (
-        <div
+        <UserMessage
           key={index}
           data-message-role="user"
-          className="copilotKitMessage copilotKitUserMessage"
-        >
-          {message.content}
-        </div>
+          message={message.content}
+          rawData={message}
+        />
       );
     } else if (message.role == "assistant") {
       return (
-        <div
+        <AssistantMessage
           key={index}
           data-message-role="assistant"
-          className={`copilotKitMessage copilotKitAssistantMessage`}
-        >
-          {isCurrentMessage && inProgress && !message.content ? (
-            icons.spinnerIcon
-          ) : (
-            <Markdown content={message.content} />
-          )}
-        </div>
+          message={message.content}
+          rawData={message}
+          isLoading={inProgress && isCurrentMessage && !message.content}
+          isGenerating={inProgress && isCurrentMessage && !!message.content}
+        />
       );
     }
   }

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/UserMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/UserMessage.tsx
@@ -1,0 +1,5 @@
+import { UserMessageProps } from "../props";
+
+export const UserMessage = (props: UserMessageProps) => {
+  return <div className="copilotKitMessage copilotKitUserMessage">{props.message}</div>;
+};

--- a/CopilotKit/packages/react-ui/src/components/chat/props.ts
+++ b/CopilotKit/packages/react-ui/src/components/chat/props.ts
@@ -23,10 +23,51 @@ export interface MessagesProps {
   messages: Message[];
   inProgress: boolean;
   children?: React.ReactNode;
+  AssistantMessage: React.ComponentType<AssistantMessageProps>;
+  UserMessage: React.ComponentType<UserMessageProps>;
   RenderTextMessage: React.ComponentType<RenderMessageProps>;
   RenderActionExecutionMessage: React.ComponentType<RenderMessageProps>;
   RenderAgentStateMessage: React.ComponentType<RenderMessageProps>;
   RenderResultMessage: React.ComponentType<RenderMessageProps>;
+}
+
+export interface Renderer {
+  content: string;
+}
+
+export interface UserMessageProps {
+  message?: string;
+  rawData: any;
+}
+
+export interface AssistantMessageProps {
+  /**
+   * The message content from the assistant
+   */
+
+  message?: string;
+
+  /**
+   * The raw data from the assistant's response
+   */
+  rawData: any;
+
+  /**
+   * A component that was decided to render by the LLM.
+   * When working with useCopilotActions and useCoAgentStateRender, this will be
+   * the render component that was specified.
+   */
+  subComponent?: React.JSX.Element;
+
+  /**
+   * Whether a response is loading, this is when the LLM is thinking of a response but hasn't finished yet.
+   */
+  isLoading: boolean;
+
+  /**
+   * Whether a response is generating, this is when the LLM is actively generating and streaming content.
+   */
+  isGenerating: boolean;
 }
 
 export interface RenderMessageProps {
@@ -35,6 +76,8 @@ export interface RenderMessageProps {
   index: number;
   isCurrentMessage: boolean;
   actionResult?: string;
+  AssistantMessage: React.ComponentType<AssistantMessageProps>;
+  UserMessage: React.ComponentType<UserMessageProps>;
 }
 
 export interface InputProps {

--- a/docs/content/docs/reference/components/chat/CopilotChat.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotChat.mdx
@@ -101,6 +101,14 @@ A function that takes in context string and instructions and returns
 Whether to show the response button.
 </PropertyReference>
 
+<PropertyReference name="AssistantMessage" type="React.ComponentType<AssistantMessageProps>"  > 
+A custom assistant message component to use instead of the default.
+</PropertyReference>
+
+<PropertyReference name="UserMessage" type="React.ComponentType<UserMessageProps>"  > 
+A custom user message component to use instead of the default.
+</PropertyReference>
+
 <PropertyReference name="Messages" type="React.ComponentType<MessagesProps>"  > 
 A custom Messages component to use instead of the default.
 </PropertyReference>

--- a/docs/content/docs/reference/components/chat/CopilotPopup.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotPopup.mdx
@@ -102,6 +102,14 @@ A function that takes in context string and instructions and returns
 Whether to show the response button.
 </PropertyReference>
 
+<PropertyReference name="AssistantMessage" type="React.ComponentType<AssistantMessageProps>"  > 
+A custom assistant message component to use instead of the default.
+</PropertyReference>
+
+<PropertyReference name="UserMessage" type="React.ComponentType<UserMessageProps>"  > 
+A custom user message component to use instead of the default.
+</PropertyReference>
+
 <PropertyReference name="Messages" type="React.ComponentType<MessagesProps>"  > 
 A custom Messages component to use instead of the default.
 </PropertyReference>

--- a/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
@@ -104,6 +104,14 @@ A function that takes in context string and instructions and returns
 Whether to show the response button.
 </PropertyReference>
 
+<PropertyReference name="AssistantMessage" type="React.ComponentType<AssistantMessageProps>"  > 
+A custom assistant message component to use instead of the default.
+</PropertyReference>
+
+<PropertyReference name="UserMessage" type="React.ComponentType<UserMessageProps>"  > 
+A custom user message component to use instead of the default.
+</PropertyReference>
+
 <PropertyReference name="Messages" type="React.ComponentType<MessagesProps>"  > 
 A custom Messages component to use instead of the default.
 </PropertyReference>


### PR DESCRIPTION
## What does this PR do?

This PR adds a collection of new interfaces that allow the user to easily add their own custom message components. These interfaces are:
- `AssistantMessage`
- `UserMessage`

These each take their own props that will be used within CopilotKit to communicate state back to the user defined properties.

For example, a user could add their own custom loading bar like so.

```tsx
import { AssistantMessageProps, CopilotSidebar, Markdown } from "@copilotkit/react-ui";

const AssistantMessage = (props: AssistantMessageProps) => {
  const { message, isLoading, isGenerating, component } = props;

  return (
    <div>
      { message && 
        <div className="copilotKitMessage copilotKitAssistantMessage !max-w-full">
          <Markdown content={message || ""} />
        </div>
      }

      {component}

      {(isLoading || isGenerating) && 
        <div className="animate-pulse bg-blue-500 w-full h-2 rounded-full"/>
      }
    </div>
  );
};

<CopilotKit {...copilotKitProps}>
  <CopilotSidebar AssistantMessage={AssistantMessage} />
</CopilotKit>
```

Adding a custom `UserMessage` would look like so.

```tsx
import { UserMessageProps, CopilotSidebar, Markdown } from "@copilotkit/react-ui";

const UserMessage = (props: UserMessageProps) => {
  return (
    <div className="copilotKitMessage copilotKitUserMessage">
      {props.message}
    </div>
  );
};

<CopilotKit {...copilotKitProps}>
  <CopilotSidebar UserMessage={UserMessage} />
</CopilotKit>
```

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation