### PR TITLE
fix(react-ui): check for updates endpoint to point to production

### DIFF
--- a/CopilotKit/.changeset/long-poets-relax.md
+++ b/CopilotKit/.changeset/long-poets-relax.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix(react-ui): check for updates endpoint to point to production

--- a/CopilotKit/packages/react-ui/src/components/dev-console/utils.ts
+++ b/CopilotKit/packages/react-ui/src/components/dev-console/utils.ts
@@ -50,7 +50,7 @@ export async function getPublishedCopilotKitVersion(
   }
 
   try {
-    const response = await fetch("https://api.cloud.stagingcopilotkit.ai/check-for-updates", {
+    const response = await fetch("https://api.cloud.copilotkit.ai/check-for-updates", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
This PR sets the "check for updates" endpoint to point to production.