### PR TITLE
docs: fix docs link in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,6 @@ Our Code of Conduct means that you are responsible for treating everyone on the 
 ## Need Help?
 
 - **Questions**: Use our [Discord support channel](https://discord.com/invite/6dffbvGU3D) for any questions you have.
-- **Resources**: Visit [CopilotKit documentation](https://docs.copilotkit.ai/what-is-copilotkit) for more helpful documentatation info.
+- **Resources**: Visit [CopilotKit documentation](https://docs.copilotkit.ai/) for more helpful documentatation info.
 
 ⭐ Happy coding, and we look forward to your contributions!


### PR DESCRIPTION
fix docs link

## What does this PR do?

fix the documentation link in contributing.md
