### PR TITLE
fix: better error messages

### DIFF
--- a/CopilotKit/.changeset/sixty-lizards-smile.md
+++ b/CopilotKit/.changeset/sixty-lizards-smile.md
@@ -1,0 +1,11 @@
+---
+"@copilotkit/react-core": patch
+"@copilotkit/react-ui": patch
+"@copilotkit/runtime-client-gql": patch
+"@copilotkit/runtime": patch
+"@copilotkit/shared": patch
+---
+
+- fix(errors): add custom error classes to better describe library errors
+- fix(errors): use new errors in error handling
+- chore: add documentation and links to respective errors

--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.4",
     "@types/react": "^18.2.5",
+    "@types/react-dom": "^18.2.4",
     "eslint": "^8.56.0",
     "eslint-config-custom": "workspace:*",
     "jest": "^29.6.4",
@@ -45,13 +46,13 @@
     "ts-jest": "^29.1.1",
     "tsconfig": "workspace:*",
     "tsup": "^6.7.0",
-    "typescript": "^5.2.3",
-    "@types/react-dom": "^18.2.4"
+    "typescript": "^5.2.3"
   },
   "dependencies": {
     "@copilotkit/runtime-client-gql": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "@scarf/scarf": "^1.3.0",
+    "react-markdown": "^8.0.7",
     "untruncate-json": "^0.0.1"
   },
   "keywords": [

--- a/CopilotKit/packages/react-core/src/components/error-boundary/error-utils.tsx
+++ b/CopilotKit/packages/react-core/src/components/error-boundary/error-utils.tsx
@@ -2,8 +2,7 @@ import React, { useCallback } from "react";
 import { GraphQLError } from "@copilotkit/runtime-client-gql";
 import { useToast } from "../toast/toast-provider";
 import { ExclamationMarkIcon } from "../toast/exclamation-mark-icon";
-import { ERROR_NAMES } from "@copilotkit/shared";
-import { CopilotKitError } from "@copilotkit/shared/src";
+import ReactMarkdown from "react-markdown";
 
 interface OriginalError {
   message?: string;
@@ -16,12 +15,6 @@ export function ErrorToast({ errors }: { errors: (Error | GraphQLError)[] }) {
       "extensions" in error ? (error.extensions?.originalError as undefined | OriginalError) : {};
     const message = originalError?.message ?? error.message;
     const code = "extensions" in error ? (error.extensions?.code as string) : null;
-
-    const cpkError =
-      // @ts-expect-error -- name is not one of possible keys
-      "extensions" in error && Object.values(ERROR_NAMES).includes(error.extensions.name)
-        ? error.extensions
-        : null;
 
     return (
       <div
@@ -44,16 +37,7 @@ export function ErrorToast({ errors }: { errors: (Error | GraphQLError)[] }) {
             <span style={{ fontFamily: "monospace", fontWeight: "normal" }}>{code}</span>
           </div>
         )}
-        {cpkError ? (
-          <>
-            <div style={{ marginBottom: 4 }} dangerouslySetInnerHTML={{ __html: message || "" }} />
-            <a href={cpkError.troubleshootingUrl as string} style={{ textDecoration: "underline" }}>
-              Learn More
-            </a>
-          </>
-        ) : (
-          <div>{message}</div>
-        )}
+        <ReactMarkdown>{message}</ReactMarkdown>
       </div>
     );
   });

--- a/CopilotKit/packages/react-ui/src/components/chat/Suggestion.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Suggestion.tsx
@@ -19,6 +19,7 @@ export function Suggestion({ title, message, onClick, partial, className }: Sugg
         onClick(message);
       }}
       className={className || "suggestion"}
+      data-test-id="suggestion"
     >
       {partial && SmallSpinnerIcon}
       <span>{title}</span>

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -28,7 +28,7 @@ const createFetchFn =
       }
       return result;
     } catch (error) {
-      throw new CopilotKitLowLevelError(error as Error);
+      throw new CopilotKitLowLevelError({ error: error as Error, url: args[0] as string });
     }
   };
 

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -316,7 +316,7 @@ please use an LLM adapter instead.`);
             if (response.status === 404) {
               throw new CopilotKitApiDiscoveryError();
             }
-            throw new ResolvedCopilotKitError({ status: response.status });
+            throw new ResolvedCopilotKitError({ status: response.status, isRemoteEndpoint: true });
           }
 
           const data: InfoResponse = await response.json();

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -21,6 +21,7 @@ import {
   randomId,
   CopilotKitError,
   CopilotKitLowLevelError,
+  CopilotKitAgentDiscoveryError,
 } from "@copilotkit/shared";
 import {
   CopilotServiceAdapter,
@@ -304,8 +305,9 @@ please use an LLM adapter instead.`);
           }>;
         }
 
+        const fetchUrl = `${(endpoint as CopilotKitEndpoint).url}/info`;
         try {
-          const response = await fetch(`${(endpoint as CopilotKitEndpoint).url}/info`, {
+          const response = await fetch(fetchUrl, {
             method: "POST",
             headers,
             body: JSON.stringify({ properties: graphqlContext.properties }),
@@ -328,7 +330,7 @@ please use an LLM adapter instead.`);
           if (error instanceof CopilotKitError) {
             throw error;
           }
-          throw new CopilotKitLowLevelError(error as Error);
+          throw new CopilotKitLowLevelError({ error: error as Error, url: fetchUrl });
         }
       },
       Promise.resolve([]),
@@ -351,7 +353,7 @@ please use an LLM adapter instead.`);
     ) as LangGraphAgentAction;
 
     if (!agent) {
-      throw new Error(`Agent ${agentName} not found`);
+      throw new CopilotKitAgentDiscoveryError({ agentName });
     }
 
     const serverSideActionsInput: ActionInput[] = serverSideActions

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -277,28 +277,30 @@ please use an LLM adapter instead.`);
     }
   }
 
-  async discoverAgentsFromEndpoints(graphqlContext: GraphQLContext): Promise<(Agent & { endpoint: EndpointDefinition })[]> {
+  async discoverAgentsFromEndpoints(
+    graphqlContext: GraphQLContext,
+  ): Promise<(Agent & { endpoint: EndpointDefinition })[]> {
     const headers = createHeaders(null, graphqlContext);
     const agents = this.remoteEndpointDefinitions.reduce(
-        async (acc: Promise<Agent[]>, endpoint) => {
-          const agents = await acc;
-          if (endpoint.type === EndpointType.LangGraphPlatform) {
-            const client = new LangGraphClient({
-              apiUrl: endpoint.deploymentUrl,
-              apiKey: endpoint.langsmithApiKey,
-            });
+      async (acc: Promise<Agent[]>, endpoint) => {
+        const agents = await acc;
+        if (endpoint.type === EndpointType.LangGraphPlatform) {
+          const client = new LangGraphClient({
+            apiUrl: endpoint.deploymentUrl,
+            apiKey: endpoint.langsmithApiKey,
+          });
 
-            const data: Array<{ assistant_id: string; graph_id: string }> =
-                await client.assistants.search();
+          const data: Array<{ assistant_id: string; graph_id: string }> =
+            await client.assistants.search();
 
-            const endpointAgents = (data ?? []).map((entry) => ({
-              name: entry.graph_id,
-              id: entry.assistant_id,
-              description: "",
-              endpoint,
-            }));
-            return [...agents, ...endpointAgents];
-          }
+          const endpointAgents = (data ?? []).map((entry) => ({
+            name: entry.graph_id,
+            id: entry.assistant_id,
+            description: "",
+            endpoint,
+          }));
+          return [...agents, ...endpointAgents];
+        }
 
         interface InfoResponse {
           agents?: Array<{

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -88,8 +88,9 @@ async function fetchRemoteInfo({
   logger.debug({ url }, "Fetching actions from url");
   const headers = createHeaders(onBeforeRequest, graphqlContext);
 
+  const fetchUrl = `${url}/info`;
   try {
-    const response = await fetch(`${url}/info`, {
+    const response = await fetch(fetchUrl, {
       method: "POST",
       headers,
       body: JSON.stringify({ properties: graphqlContext.properties, frontendUrl }),
@@ -110,7 +111,7 @@ async function fetchRemoteInfo({
     if (error instanceof CopilotKitError) {
       throw error;
     }
-    throw new CopilotKitLowLevelError(error);
+    throw new CopilotKitLowLevelError({ error, url: fetchUrl });
   }
 }
 

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -101,7 +101,7 @@ async function fetchRemoteInfo({
         { url, status: response.status, body: await response.text() },
         "Failed to fetch actions from url",
       );
-      throw new ResolvedCopilotKitError({ status: response.status });
+      throw new ResolvedCopilotKitError({ status: response.status, isRemoteEndpoint: true });
     }
 
     const json = await response.json();

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -11,6 +11,11 @@ import {
   constructRemoteActions,
   createHeaders,
 } from "./remote-action-constructors";
+import {
+  CopilotKitLowLevelError,
+  ResolvedCopilotKitError,
+  CopilotKitError,
+} from "@copilotkit/shared";
 
 export type EndpointDefinition = CopilotKitEndpoint | LangGraphPlatformEndpoint;
 
@@ -95,18 +100,17 @@ async function fetchRemoteInfo({
         { url, status: response.status, body: await response.text() },
         "Failed to fetch actions from url",
       );
-      return { actions: [], agents: [] };
+      throw new ResolvedCopilotKitError({ status: response.status });
     }
 
     const json = await response.json();
     logger.debug({ json }, "Fetched actions from url");
     return json;
   } catch (error) {
-    logger.error(
-      { error: error.message ? error.message : error + "" },
-      "Failed to fetch actions from url",
-    );
-    return { actions: [], agents: [] };
+    if (error instanceof CopilotKitError) {
+      throw error;
+    }
+    throw new CopilotKitLowLevelError(error);
   }
 }
 

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@segment/analytics-node": "^2.1.2",
     "chalk": "4.1.2",
+    "graphql": "^16.8.1",
     "uuid": "^10.0.0",
     "zod": "^3.23.3",
     "zod-to-json-schema": "^3.23.5"

--- a/CopilotKit/packages/shared/src/utils/errors.ts
+++ b/CopilotKit/packages/shared/src/utils/errors.ts
@@ -1,0 +1,206 @@
+import { GraphQLError } from "graphql";
+
+export const ERROR_NAMES = {
+  COPILOT_ERROR: "CopilotError",
+  COPILOT_API_DISCOVERY_ERROR: "CopilotApiDiscoveryError",
+  COPILOT_KIT_AGENT_DISCOVERY_ERROR: "CopilotKitAgentDiscoveryError",
+  COPILOT_KIT_LOW_LEVEL_ERROR: "CopilotKitLowLevelError",
+  RESOLVED_COPILOT_KIT_ERROR: "ResolvedCopilotKitError",
+} as const;
+
+export enum CopilotKitErrorCode {
+  NETWORK_ERROR = "NETWORK_ERROR",
+  INVALID_REQUEST = "INVALID_REQUEST",
+  SERVER_ERROR = "SERVER_ERROR",
+  NOT_FOUND = "NOT_FOUND",
+  UNKNOWN = "UNKNOWN",
+}
+
+const BASE_URL = "https://docs.copilotkit.ai/coagents/troubleshooting/common-issues";
+export class CopilotKitError extends GraphQLError {
+  code: CopilotKitErrorCode;
+  statusCode: number;
+  troubleshootingUrl?: string;
+
+  private static getErrorDetails(code: CopilotKitErrorCode): {
+    statusCode: number;
+    troubleshootingUrl: string;
+  } {
+    switch (code) {
+      case CopilotKitErrorCode.NETWORK_ERROR:
+        return {
+          statusCode: 503,
+          troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
+        };
+      case CopilotKitErrorCode.INVALID_REQUEST:
+        return {
+          statusCode: 400,
+          troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
+        };
+      case CopilotKitErrorCode.SERVER_ERROR:
+        return {
+          statusCode: 500,
+          troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
+        };
+      case CopilotKitErrorCode.NOT_FOUND:
+        return {
+          statusCode: 500,
+          troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
+        };
+      case CopilotKitErrorCode.UNKNOWN:
+        return {
+          statusCode: 500,
+          troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
+        };
+    }
+  }
+
+  constructor({
+    message = "Unknown error occurred",
+    code,
+    troubleshootingUri,
+  }: {
+    message?: string;
+    code: CopilotKitErrorCode;
+    troubleshootingUri?: string;
+  }) {
+    const name = ERROR_NAMES.COPILOT_ERROR;
+    const { statusCode, troubleshootingUrl } = CopilotKitError.getErrorDetails(code);
+
+    super(message, {
+      extensions: {
+        name,
+        statusCode,
+        troubleshootingUrl,
+      },
+    });
+    this.code = code;
+    this.name = name;
+    this.statusCode = statusCode;
+    this.troubleshootingUrl = troubleshootingUri
+      ? `${BASE_URL}#${troubleshootingUri}`
+      : troubleshootingUrl;
+  }
+}
+
+/**
+ * Error thrown when the CopilotKit API endpoint cannot be discovered or accessed.
+ * This typically occurs when:
+ * - The API endpoint URL is invalid or misconfigured
+ * - The API service is not running at the expected location
+ * - There are network/firewall issues preventing access
+ *
+ * @extends CopilotKitError
+ */
+export class CopilotKitApiDiscoveryError extends CopilotKitError {
+  constructor({ message = "Failed to find CopilotKit API endpoint" }: { message?: string } = {}) {
+    super({ message, code: CopilotKitErrorCode.NOT_FOUND });
+    this.name = ERROR_NAMES.COPILOT_API_DISCOVERY_ERROR;
+  }
+}
+
+/**
+ * Error thrown when a LangGraph agent cannot be found or accessed.
+ * This typically occurs when:
+ * - The specified agent name does not exist in the deployment
+ * - The agent configuration is invalid or missing
+ * - The agent service is not properly deployed or initialized
+ *
+ * @extends CopilotKitError
+ */
+export class CopilotKitAgentDiscoveryError extends CopilotKitError {
+  constructor({ agentName }: { agentName?: string } = {}) {
+    const baseMessage = "Failed to find agent";
+    const configMessage = "Please verify the agent name exists and is properly configured.";
+    const defaultMessage = `${baseMessage}. ${configMessage}`;
+    const finalMessage = agentName
+      ? `${baseMessage} '${agentName}'. ${configMessage}`
+      : defaultMessage;
+    super({ message: finalMessage || finalMessage, code: CopilotKitErrorCode.NOT_FOUND });
+    this.name = ERROR_NAMES.COPILOT_KIT_AGENT_DISCOVERY_ERROR;
+  }
+}
+
+/**
+ * Handles low-level networking errors that occur before a request reaches the server.
+ * These errors arise from issues in the underlying communication infrastructure rather than
+ * application-level logic or server responses. Typically used to handle "fetch failed" errors
+ * where no HTTP status code is available.
+ *
+ * Common scenarios include:
+ * - Connection failures (ECONNREFUSED) when server is down/unreachable
+ * - DNS resolution failures (ENOTFOUND) when domain can't be resolved
+ * - Timeouts (ETIMEDOUT) when request takes too long
+ * - Protocol/transport layer errors like SSL/TLS issues
+ */
+export class CopilotKitLowLevelError extends CopilotKitError {
+  constructor(error: Error) {
+    let errorMessage = "An error occurred while trying to connect to the server.<br/>";
+    let code = CopilotKitErrorCode.NETWORK_ERROR;
+
+    if (error instanceof TypeError && error.message.includes("fetch failed")) {
+      errorMessage = `
+        ${errorMessage} Possible reasons:<br/>
+          - The server might be down or unreachable.<br/>
+          - There might be a network issue (e.g., DNS failure, connection timeout).<br/>
+          - The URL might be incorrect.<br/>
+          - The server is not running on the specified port.<br/>
+      `;
+    } else if ("code" in error && error.code === "ECONNREFUSED") {
+      errorMessage += " Connection was refused. Ensure the server is running and accessible.";
+    } else if ("code" in error && error.code === "ENOTFOUND") {
+      code = CopilotKitErrorCode.NOT_FOUND;
+      errorMessage +=
+        " The server address could not be found. Check the URL or your network configuration.";
+    } else if ("code" in error && error.code === "ETIMEDOUT") {
+      errorMessage +=
+        " The connection timed out. The server might be overloaded or taking too long to respond.";
+    }
+    super({ message: errorMessage, code });
+    this.name = ERROR_NAMES.COPILOT_KIT_LOW_LEVEL_ERROR;
+  }
+}
+
+/**
+ * Generic catch-all error handler for HTTP responses from the CopilotKit API where a status code is available.
+ * Used when we receive an HTTP error status and wish to handle broad range of them
+ *
+ * This differs from CopilotKitLowLevelError in that:
+ * - ResolvedCopilotKitError: Server was reached and returned an HTTP status
+ * - CopilotKitLowLevelError: Error occurred before reaching server (e.g. network failure)
+ *
+ * @param status - The HTTP status code received from the API response
+ * @param message - Optional error message to include
+ * @param code - Optional specific CopilotKitErrorCode to override default behavior
+ *
+ * Default behavior:
+ * - 400 Bad Request: Maps to CopilotKitApiDiscoveryError
+ * - All other status codes: Maps to UNKNOWN error code if no specific code provided
+ */
+export class ResolvedCopilotKitError extends CopilotKitError {
+  constructor({
+    status,
+    message,
+    code,
+  }: {
+    status: number;
+    message?: string;
+    code?: CopilotKitErrorCode;
+  }) {
+    let resolvedCode = code;
+    if (!resolvedCode) {
+      switch (status) {
+        case 400:
+          throw new CopilotKitApiDiscoveryError({ message });
+        case 404:
+          throw new CopilotKitApiDiscoveryError({ message });
+        default:
+          resolvedCode = CopilotKitErrorCode.UNKNOWN;
+          super({ message, code: resolvedCode });
+      }
+    } else {
+      super({ message, code: resolvedCode });
+    }
+    this.name = ERROR_NAMES.RESOLVED_COPILOT_KIT_ERROR;
+  }
+}

--- a/CopilotKit/packages/shared/src/utils/errors.ts
+++ b/CopilotKit/packages/shared/src/utils/errors.ts
@@ -10,9 +10,9 @@ export const ERROR_NAMES = {
 
 export enum CopilotKitErrorCode {
   NETWORK_ERROR = "NETWORK_ERROR",
-  INVALID_REQUEST = "INVALID_REQUEST",
-  SERVER_ERROR = "SERVER_ERROR",
   NOT_FOUND = "NOT_FOUND",
+  AGENT_NOT_FOUND = "AGENT_NOT_FOUND",
+  API_NOT_FOUND = "API_NOT_FOUND",
   UNKNOWN = "UNKNOWN",
 }
 
@@ -25,21 +25,20 @@ export const ERROR_CONFIG = {
     statusCode: 503,
     troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
   },
-  [CopilotKitErrorCode.INVALID_REQUEST]: {
-    statusCode: 400,
-    troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
-  },
-  [CopilotKitErrorCode.SERVER_ERROR]: {
-    statusCode: 500,
-    troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
-  },
   [CopilotKitErrorCode.NOT_FOUND]: {
+    statusCode: 404,
+    troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
+  },
+  [CopilotKitErrorCode.AGENT_NOT_FOUND]: {
     statusCode: 500,
+    troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
+  },
+  [CopilotKitErrorCode.API_NOT_FOUND]: {
+    statusCode: 404,
     troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
   },
   [CopilotKitErrorCode.UNKNOWN]: {
     statusCode: 500,
-    troubleshootingUrl: `${BASE_URL}#my-messages-are-out-of-order`,
   },
 };
 
@@ -80,7 +79,7 @@ export class CopilotKitError extends GraphQLError {
  */
 export class CopilotKitApiDiscoveryError extends CopilotKitError {
   constructor({ message = "Failed to find CopilotKit API endpoint" }: { message?: string } = {}) {
-    const code = CopilotKitErrorCode.NOT_FOUND;
+    const code = CopilotKitErrorCode.API_NOT_FOUND;
     const errorMessage = `${message}.\n\n${getSeeMoreMarkdown(ERROR_CONFIG[code].troubleshootingUrl)}`;
     super({ message: errorMessage, code });
     this.name = ERROR_NAMES.COPILOT_API_DISCOVERY_ERROR;
@@ -98,7 +97,7 @@ export class CopilotKitApiDiscoveryError extends CopilotKitError {
  */
 export class CopilotKitAgentDiscoveryError extends CopilotKitError {
   constructor({ agentName }: { agentName?: string } = {}) {
-    const code = CopilotKitErrorCode.NOT_FOUND;
+    const code = CopilotKitErrorCode.AGENT_NOT_FOUND;
     const baseMessage = "Failed to find agent";
     const configMessage = "Please verify the agent name exists and is properly configured.";
     const finalMessage = agentName

--- a/CopilotKit/packages/shared/src/utils/index.ts
+++ b/CopilotKit/packages/shared/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from "./errors";
 export * from "./json-schema";
 export * from "./random-id";

--- a/CopilotKit/pnpm-lock.yaml
+++ b/CopilotKit/pnpm-lock.yaml
@@ -330,6 +330,9 @@ importers:
       react-dom:
         specifier: ^18 || ^19 || ^19.0.0-rc
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^8.0.7
+        version: 8.0.7(@types/react@18.3.3)(react@18.3.1)
       untruncate-json:
         specifier: ^0.0.1
         version: 0.0.1
@@ -357,7 +360,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.23.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.17.19)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../utilities/tsconfig
@@ -858,7 +861,7 @@ importers:
         version: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.17.19)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.23.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../utilities/tsconfig

--- a/CopilotKit/pnpm-lock.yaml
+++ b/CopilotKit/pnpm-lock.yaml
@@ -357,7 +357,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.17.19)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.23.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../utilities/tsconfig
@@ -828,6 +828,9 @@ importers:
       chalk:
         specifier: 4.1.2
         version: 4.1.2
+      graphql:
+        specifier: ^16.8.1
+        version: 16.9.0
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -855,7 +858,7 @@ importers:
         version: 29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.23.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.17.19)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28(@swc/helpers@0.5.13))(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../utilities/tsconfig
@@ -12271,8 +12274,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -12318,13 +12321,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.5(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-core-module: 2.15.0
@@ -12363,14 +12366,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12385,7 +12388,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -12395,7 +12398,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3

--- a/docs/content/docs/(root)/meta.json
+++ b/docs/content/docs/(root)/meta.json
@@ -8,6 +8,8 @@
     "...guides",
     "---Tutorials---",
     "...tutorials",
+    "---Troubleshooting---",
+    "...troubleshooting",
     "---Other---",
     "(other)/contributing",
     "(other)/telemetry",

--- a/docs/content/docs/(root)/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/(root)/troubleshooting/common-issues.mdx
@@ -1,0 +1,18 @@
+---
+title: Common Issues
+description: Common issues you may encounter when using Copilots.
+---
+import { Accordions, Accordion } from "fumadocs-ui/components/accordion"
+
+Welcome to the CopilotKit Troubleshooting Guide! Here, you can find answers to common issues
+
+<Callout>
+    Have an issue not listed here? Open a ticket on [GitHub](https://github.com/CopilotKit/CopilotKit/issues) or reach out on [Discord](https://discord.com/invite/6dffbvGU3D)
+    and we'll be happy to help.
+
+    We also highly encourage any open source contributors that want to add their own troubleshooting issues to [Github as a pull request](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
+</Callout>
+
+## I am getting a network errors / API not found
+
+[//]: # (Provide some solution to common issues: Making sure that we route to the right runtimeUrl, that "endpoint" in runtime route is right. Some issues regarding using "localhost" instead of 127.0.01 etc)

--- a/docs/content/docs/(root)/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/(root)/troubleshooting/common-issues.mdx
@@ -62,11 +62,8 @@ If you're encountering network or API errors, here's how to troubleshoot:
         - Running on the expected port
         - Accessible from your frontend
         - Not blocked by CORS or firewalls
-        
-        Try accessing the endpoint directly in your browser or with curl:
-        ```bash
-        curl http://127.0.0.1:3000/api/copilotkit
-        ```
+
+        Check the [quickstart](/quickstart) to see how to set it up
     </Accordion>
 </Accordions>
 
@@ -83,7 +80,33 @@ If you're getting a "CopilotKit's Remote Endpoint not found" error, it usually m
         The `/info` endpoint should return agent or action information. Test it directly:
 
         ```bash
-        curl -v -X POST -d '{}' http://localhost:8000/copilotkit/info
+        curl -v -d '{}' http://localhost:8000/copilotkit/info
+        ```
+        The response looks something like this:
+        ```bash
+        * Host localhost:8000 was resolved.
+        * IPv6: ::1
+        * IPv4: 127.0.0.1
+        *   Trying [::1]:8000...
+        * connect to ::1 port 8000 from ::1 port 55049 failed: Connection refused
+        *   Trying 127.0.0.1:8000...
+        * Connected to localhost (127.0.0.1) port 8000
+        > POST /copilotkit/info HTTP/1.1
+        > Host: localhost:8000
+        > User-Agent: curl/8.7.1
+        > Accept: */*
+        > Content-Length: 2
+        > Content-Type: application/x-www-form-urlencoded
+        >
+        * upload completely sent off: 2 bytes
+        < HTTP/1.1 200 OK
+        < date: Thu, 16 Jan 2025 17:45:05 GMT
+        < server: uvicorn
+        < content-length: 214
+        < content-type: application/json
+        <
+        * Connection #0 to host localhost left intact
+        {"actions":[],"agents":[{"name":"my_agent","description":"A helpful agent.","type":"langgraph"},],"sdkVersion":"0.1.32"}%
         ```
 
         You should see a JSON response with your registered agents and actions. If not, check your FastAPI logs for errors.

--- a/docs/content/docs/(root)/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/(root)/troubleshooting/common-issues.mdx
@@ -13,6 +13,79 @@ Welcome to the CopilotKit Troubleshooting Guide! Here, you can find answers to c
     We also highly encourage any open source contributors that want to add their own troubleshooting issues to [Github as a pull request](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
 </Callout>
 
-## I am getting a network errors / API not found
+## I am getting network errors / API not found error
 
-[//]: # (Provide some solution to common issues: Making sure that we route to the right runtimeUrl, that "endpoint" in runtime route is right. Some issues regarding using "localhost" instead of 127.0.01 etc)
+If you're encountering network or API errors, here's how to troubleshoot:
+
+<Accordions>
+    <Accordion title="Check your endpoint configuration">
+        Verify your endpoint configuration in your CopilotKit setup:
+
+        ```tsx
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+        >
+          {/* Your app */}
+        </CopilotKit>
+        ```
+
+        or, if using CopilotCloud
+        ```tsx
+        <CopilotKit
+            publicApiKey="<your-copilot-cloud-public-api-key>"
+        >
+            {/* Your app */}
+        </CopilotKit>
+        ```
+
+        Common issues:
+        - Missing leading slash in endpoint path
+        - Incorrect path relative to your app's base URL, or, if using absolute paths, incorrect full URL
+        - Typos in the endpoint path
+        - If using CopilotCloud, make sure to omit the `runtimeUrl` property and provide a valid API key
+    </Accordion>
+    <Accordion title="localhost vs 127.0.0.1">
+        If you're running locally and getting connection errors, try using `127.0.0.1` instead of `localhost`:
+
+        ```bash
+        # If this doesn't work:
+        http://localhost:3000/api/copilotkit
+
+        # Try this instead:
+        http://127.0.0.1:3000/api/copilotkit
+        ```
+
+        This is often due to local DNS resolution issues in `/etc/hosts` or network configuration.
+    </Accordion>
+    <Accordion title="Verify your backend is running">
+        Make sure your backend server is:
+        - Running on the expected port
+        - Accessible from your frontend
+        - Not blocked by CORS or firewalls
+        
+        Try accessing the endpoint directly in your browser or with curl:
+        ```bash
+        curl http://127.0.0.1:3000/api/copilotkit
+        ```
+    </Accordion>
+</Accordions>
+
+## I am getting "CopilotKit's Remote Endpoint" not found error
+
+If you're getting a "CopilotKit's Remote Endpoint not found" error, it usually means the server serving `/info` endpoint isn't accessible. Here's how to fix it:
+
+<Accordions>
+    <Accordion title="Check your FastAPI setup (if using pytho's FastAPI)">
+        Make sure your FastAPI app has the CopilotKitSDK properly set up.<br/>
+        Refer to [Remote Python Endpoint](/guides/backend-actions/remote-backend-endpoint) to see how to set it up
+    </Accordion>
+    <Accordion title="Test your endpoint">
+        The `/info` endpoint should return agent or action information. Test it directly:
+
+        ```bash
+        curl -v -X POST -d '{}' http://localhost:8000/copilotkit/info
+        ```
+
+        You should see a JSON response with your registered agents and actions. If not, check your FastAPI logs for errors.
+    </Accordion>
+</Accordions>

--- a/docs/content/docs/(root)/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/(root)/troubleshooting/common-issues.mdx
@@ -109,6 +109,7 @@ If you're getting a "CopilotKit's Remote Endpoint not found" error, it usually m
         {"actions":[],"agents":[{"name":"my_agent","description":"A helpful agent.","type":"langgraph"},],"sdkVersion":"0.1.32"}%
         ```
 
-        You should see a JSON response with your registered agents and actions. If not, check your FastAPI logs for errors.
+        As you can see, it's a JSON response with your registered agents and actions, as well as the `200 OK` HTTP response status.
+        If you see a different response, check your FastAPI logs for errors.
     </Accordion>
 </Accordions>

--- a/docs/content/docs/coagents/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/coagents/troubleshooting/common-issues.mdx
@@ -72,10 +72,108 @@ from langchain_openai import AzureOpenAI # [!code --]
 from langchain_openai import AzureChatOpenAI # [!code ++]
 ```
 
-## I am getting a API not found error
-
-[//]: # (Provide some solution to common issues: Making sure that we route to the right runtimeUrl, that "endpoint" in runtime route is right. Some issues regarding using "localhost" instead of 127.0.01 etc)
-
 ## I am getting "agent not found" error
 
-[//]: # (Provide some solution regarding checking agent name, checking langgraph.json for agents and making sure there are no typos or wrong names in agent lock mode or in useCoAgent or in useCoAgentStateRender)
+If you're seeing this error, it means CopilotKit couldn't find the LangGraph agent you're trying to use. Here's how to fix it:
+
+<Accordions>
+    <Accordion title="Verify your agent lock mode configuration">
+        If you're using [agent lock mode](/coagents/advanced/router-mode-agent-lock#agent-lock-mode),
+        check that the agent defined in `langgraph.json` matches what's defined in the CopilotKit provider:
+
+        ```json title="langgraph.json"
+        {
+            "python_version": "3.12",
+            "dockerfile_lines": [],
+            "dependencies": ["."],
+            "graphs": {
+                "my_agent": "./src/agent.py:graph"// In this case, "my_agent" is the agent you're using // [!code highlight]
+            },
+            "env": ".env"
+        }
+        ```
+
+        ```tsx title="layout.tsx"
+        <CopilotKit agent="my_agent"> // [!code highlight]
+            {/* Your application components */}
+        </CopilotKit>
+        ```
+
+        Common issues:
+        - Typos in agent names
+        - Case sensitivity mismatches
+        - Missing entries in `langgraph.json`
+    </Accordion>
+    <Accordion title="Check your agent registration on a LangGraph Platform endpoint">
+        When using LangGraph Platform endpoint, make sure your agents are properly specified and are following the definition in your `langgraph.json`:
+
+        ```json title="langgraph.json"
+        {
+            "python_version": "3.12",
+            "dockerfile_lines": [],
+            "dependencies": ["."],
+            "graphs": {
+                "my_agent": "./src/agent.py:graph"// In this case, "my_agent" is the agent you're using // [!code highlight]
+            },
+            "env": ".env"
+        }
+        ```
+
+        ```typescript title="/copilotkit/api/route.ts"
+        langGraphPlatformEndpoint({
+            deploymentUrl,
+            langsmithApiKey,
+            agents: [
+                {
+                    name: "my_agent",
+                    description: "A helpful agent",
+                },
+            ],
+        })
+        ```
+    </Accordion>
+    <Accordion title="Check your agent name in useCoAgent">
+        Make sure the that the agent defined in `langgraph.json` matches what you use n `useCoAgent` hook:
+
+        ```json title="langgraph.json"
+        {
+            "python_version": "3.12",
+            "dockerfile_lines": [],
+            "dependencies": ["."],
+            "graphs": {
+                "my_agent": "./src/agent.py:graph"// In this case, "my_agent" is the agent you're using // [!code highlight]
+            },
+            "env": ".env"
+        }
+        ```
+
+        ```tsx title="MyComponent.tsx"
+        // Your React component
+        useCoAgent({
+            name: "my_agent", // [!code focus] This must match exactly
+        });
+        ```
+    </Accordion>
+    <Accordion title="Check your agent name in useCoAgentStateRender">
+        Make sure the that the agent defined in `langgraph.json` matches what you use n `useCoAgent` hook:
+
+        ```json title="langgraph.json"
+        {
+            "python_version": "3.12",
+            "dockerfile_lines": [],
+            "dependencies": ["."],
+            "graphs": {
+                "my_agent": "./src/agent.py:graph"// In this case, "my_agent" is the agent you're using // [!code highlight]
+            },
+            "env": ".env"
+        }
+        ```
+
+        ```tsx title="MyComponent.tsx"
+        // Your React component
+        useCoAgentStateRender({
+            name: "my_agent", // [!code focus] This must match exactly
+        });
+        ```
+    </Accordion>
+</Accordions>

--- a/docs/content/docs/coagents/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/coagents/troubleshooting/common-issues.mdx
@@ -71,3 +71,11 @@ issue will be resolved.
 from langchain_openai import AzureOpenAI # [!code --]
 from langchain_openai import AzureChatOpenAI # [!code ++]
 ```
+
+## I am getting a API not found error
+
+[//]: # (Provide some solution to common issues: Making sure that we route to the right runtimeUrl, that "endpoint" in runtime route is right. Some issues regarding using "localhost" instead of 127.0.01 etc)
+
+## I am getting "agent not found" error
+
+[//]: # (Provide some solution regarding checking agent name, checking langgraph.json for agents and making sure there are no typos or wrong names in agent lock mode or in useCoAgent or in useCoAgentStateRender)

--- a/examples/e2e/lib/helpers.ts
+++ b/examples/e2e/lib/helpers.ts
@@ -23,3 +23,15 @@ export async function waitForStepsAndEnsureStreaming(page: Page) {
 export async function waitForResponse(page: Page) {
   await page.waitForSelector("button:has-text('Regenerate response')");
 }
+
+export async function waitForSuggestions(page: Page, numberOfSuggestions: number) {
+  // Wait for the expected number of suggestions to be visible
+  await page.waitForFunction(
+    (expected) => {
+      const suggestions = document.querySelectorAll('[data-test-id="suggestion"]');
+      return suggestions.length === expected && Array.from(suggestions).every(el => el.isConnected);
+    },
+    numberOfSuggestions,
+    { timeout: 10000 }
+  );
+}

--- a/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
+++ b/examples/e2e/tests/coagents-canvas-researcher-demo.spec.ts
@@ -3,6 +3,7 @@ import {
   waitForStepsAndEnsureStreaming,
   waitForResponse,
   sendChatMessage,
+  waitForSuggestions,
 } from "../lib/helpers";
 import {
   getConfigs,
@@ -43,7 +44,7 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               page,
             }) => {
               await page.goto(`${config.url}${variant.queryParams}`);
-
+              await waitForSuggestions(page, 3)
               const researchQuestion = "Lifespan of penguins";
               await page
                 .getByPlaceholder("Enter your research question")


### PR DESCRIPTION
## tl;dr  - This PR introduces new classes for error handling.

## The why
Currently error handling is done "ad-hoc". It means that we're throwing generic errors around, catching and handling. Logging (to console, to a logging solution etc) is also done next to each error.
We do not distinguish between low level errors, server errors or others.
This PR aims to bring a change to that

## The what
This PR introduces the concept of custom made error classes. These classes are made to describe a broad, or a specific error we expect.
Using of custom classes means we're moving error handling from "the outside" (next to where the error happens, e.g in `catch` block) to "the inside", which means inside a class.
When an error class is created, we are able to perform operations, or better describe the issue. Not all these concepts are already part of this PR, but the latter is. A class is able to assign different troubleshooting links to our docs, provide unified messages and in the future, also contain logging.

## The how (to use)

Several classes are introduced here. They all have their documentation set up next to them, but her's a small recap:
- `CopilotKitError`: The class to serve as base for all the rest.
- `CopilotKitApiDiscoveryError`: An error class indicating problems in finding APIs we expect (e.g `/api/copilotkit`)
- `CopilotKitRemoteEndpointDiscoveryError`: An error class indicating problems in finding remote endpoint that user has specified
- `CopilotKitAgentDiscoveryError`: An error class indicating issues in finding agents
- `CopilotKitLowLevelError`: An error class indicating errors contacting a server (usually the `catch` block for a wrapper `fetch` call). Anything from "connection refused" to timeouts and other situations where the actual url was not reachable.
- `ResolvedCopilotKitError`:  A utility error class which will figure out, according to error statuses, which other class it needs to resolve to. So on 404 it will return `CopilotKitApiDiscoveryError` for example.

## Additionals

Since I am introducing several classes, I already went ahead and created the documentation corresponding to some of the issues we expect users to run into (hopefully none!), and these are:
- [The all new Coagents troubleshooting page](https://docs-git-fix-better-error-messages-copilot-kit.vercel.app/troubleshooting/common-issues)
- [An addition to the CoAgents troubleshooting](https://docs-git-fix-better-error-messages-copilot-kit.vercel.app/troubleshooting/common-issues)