### PR TITLE
fix: silence abort controller cancellation throwing an error

### DIFF
--- a/CopilotKit/.changeset/eighty-geese-lay.md
+++ b/CopilotKit/.changeset/eighty-geese-lay.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime-client-gql": patch
+---
+
+- fix: silence abort controller cancellation throwing an error

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -1,4 +1,4 @@
-import { Client, cacheExchange, fetchExchange } from "@urql/core";
+import { Client, cacheExchange, fetchExchange, mapExchange, CombinedError, Operation } from "@urql/core";
 import * as packageJson from "../../package.json";
 
 import {
@@ -89,6 +89,11 @@ export class CopilotRuntimeClient {
       start(controller) {
         source.subscribe(({ data, hasNext, error }) => {
           if (error) {
+            if (error.message.includes('BodyStreamBuffer was aborted') || error.message.includes('signal is aborted without reason')) {
+              // Suppress this specific error
+              console.warn('Abort error suppressed');
+              return;
+            }
             controller.error(error);
             if (handleGQLErrors) {
               handleGQLErrors(error);

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -1,4 +1,11 @@
-import { Client, cacheExchange, fetchExchange, mapExchange, CombinedError, Operation } from "@urql/core";
+import {
+  Client,
+  cacheExchange,
+  fetchExchange,
+  mapExchange,
+  CombinedError,
+  Operation,
+} from "@urql/core";
 import * as packageJson from "../../package.json";
 
 import {
@@ -89,9 +96,12 @@ export class CopilotRuntimeClient {
       start(controller) {
         source.subscribe(({ data, hasNext, error }) => {
           if (error) {
-            if (error.message.includes('BodyStreamBuffer was aborted') || error.message.includes('signal is aborted without reason')) {
+            if (
+              error.message.includes("BodyStreamBuffer was aborted") ||
+              error.message.includes("signal is aborted without reason")
+            ) {
               // Suppress this specific error
-              console.warn('Abort error suppressed');
+              console.warn("Abort error suppressed");
               return;
             }
             controller.error(error);


### PR DESCRIPTION
If someone is quick to type and send before suggestions are shown, we abort fetching suggestions. As a natural behaviour of abort controller, an error it thrown when the fetch is aborted.
This PR will silence these errors