### PR TITLE
Fix/document empty adapter usage

### DIFF
--- a/CopilotKit/.changeset/fuzzy-lobsters-marry.md
+++ b/CopilotKit/.changeset/fuzzy-lobsters-marry.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- chore: add documentation for empty llm adapter
+- fix: throw error when empty adapter is misused

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -13,7 +13,12 @@
  */
 
 import { Action, actionParametersToJsonSchema, Parameter, randomId } from "@copilotkit/shared";
-import { CopilotServiceAdapter, RemoteChain, RemoteChainParameters } from "../../service-adapters";
+import {
+  CopilotServiceAdapter,
+  ExperimentalEmptyAdapter,
+  RemoteChain,
+  RemoteChainParameters,
+} from "../../service-adapters";
 import { MessageInput } from "../../graphql/inputs/message.input";
 import { ActionInput } from "../../graphql/inputs/action.input";
 import { RuntimeEventSource } from "../../service-adapters/events";
@@ -183,6 +188,12 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
     try {
       if (agentSession) {
         return await this.processAgentRequest(request);
+      }
+      if (serviceAdapter instanceof ExperimentalEmptyAdapter) {
+        // TODO: use CPK error here
+        throw new Error(`Invalid adapter configuration: ExperimentalEmptyAdapter is only meant to be used with agent lock mode. 
+For non-agent components like useCopilotChatSuggestions, CopilotTextarea, or CopilotTask, 
+please use an LLM adapter instead.`);
       }
 
       const messages = rawMessages.filter((message) => !message.agentStateMessage);

--- a/docs/components/react/multi-provider-content/utils.ts
+++ b/docs/components/react/multi-provider-content/utils.ts
@@ -11,7 +11,7 @@ export const quickStartProviders: ProvidersConfig = {
         id: "openai",
         title: "OpenAI",
         icon: '/icons/openai.png',
-        endVarName: "OPENAI_API_KEY",
+        envVarName: "OPENAI_API_KEY",
         adapterImport: "OpenAIAdapter",
         adapterSetup: 'const serviceAdapter = new OpenAIAdapter();'
     },
@@ -20,7 +20,7 @@ export const quickStartProviders: ProvidersConfig = {
         title: "Azure OpenAI",
         icon: '/icons/azure.png',
         packageName: "openai",
-        endVarName: "AZURE_OPENAI_API_KEY",
+        envVarName: "AZURE_OPENAI_API_KEY",
         adapterImport: "OpenAIAdapter",
         extraImports: `
             import OpenAI from 'openai';
@@ -37,7 +37,7 @@ export const quickStartProviders: ProvidersConfig = {
         id: "anthropic",
         title: "Anthropic (Claude)",
         icon: '/icons/anthropic.png',
-        endVarName: "ANTHROPIC_API_KEY",
+        envVarName: "ANTHROPIC_API_KEY",
         adapterImport: "AnthropicAdapter",
         adapterSetup: 'const serviceAdapter = new AnthropicAdapter();'
     },
@@ -45,7 +45,7 @@ export const quickStartProviders: ProvidersConfig = {
         id: "groq",
         title: "Groq",
         icon: '/icons/groq.png',
-        endVarName: "GROQ_API_KEY",
+        envVarName: "GROQ_API_KEY",
         adapterImport: "GroqAdapter",
         adapterSetup: 'const serviceAdapter = new GroqAdapter({ model: "<model-name>" });'
     },
@@ -53,7 +53,7 @@ export const quickStartProviders: ProvidersConfig = {
         id: "google",
         title: "Google Generative AI (Gemini)",
         icon: '/icons/google.png',
-        endVarName: "GOOGLE_API_KEY",
+        envVarName: "GOOGLE_API_KEY",
         adapterImport: "GoogleGenerativeAIAdapter",
         adapterSetup: 'const serviceAdapter = new GoogleGenerativeAIAdapter({ model: <optional model choice> });'
     },
@@ -62,7 +62,7 @@ export const quickStartProviders: ProvidersConfig = {
         title: 'LangChain (any model)',
         icon: '/icons/langchain.png',
         packageName: "@langchain/openai",
-        endVarName: "OPENAI_API_KEY",
+        envVarName: "OPENAI_API_KEY",
         adapterImport: "LangChainAdapter",
         extraImports: `
             import { ChatOpenAI } from "@langchain/openai";
@@ -82,7 +82,7 @@ export const quickStartProviders: ProvidersConfig = {
         title: "OpenAI Assistants API",
         icon: '/icons/openai.png',
         packageName: "openai",
-        endVarName: "OPENAI_API_KEY",
+        envVarName: "OPENAI_API_KEY",
         adapterImport: "OpenAIAssistantAdapter",
         extraImports: [
             'import OpenAI from \'openai\';'
@@ -101,5 +101,12 @@ export const quickStartProviders: ProvidersConfig = {
   fileSearchEnabled: true,
 });
         `
+    },
+    "empty": {
+        id: "empty",
+        title: "Experimental Empty Adapter",
+        icon: '/icons/empty.svg',
+        adapterImport: "ExperimentalEmptyAdapter",
+        adapterSetup: 'const serviceAdapter = new ExperimentalEmptyAdapter();'
     },
 };

--- a/docs/public/icons/empty.svg
+++ b/docs/public/icons/empty.svg
@@ -1,0 +1,28 @@
+<svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="100"
+        height="100"
+        viewBox="0 0 100 100"
+        fill="none"
+        stroke="gray"
+        stroke-width="2"
+        stroke-dasharray="4 4"
+>
+    <!-- Dashed rectangle -->
+    <rect x="10" y="10" width="80" height="80" rx="10" />
+
+    <!-- Centered question mark -->
+    <text
+            x="50"
+            y="55"
+            font-family="Arial, sans-serif"
+            font-size="40"
+            fill="gray"
+            text-anchor="middle"
+            alignment-baseline="middle"
+            dominant-baseline="middle"
+            opacity="0.6"
+    >
+        ?
+    </text>
+</svg>

--- a/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
+++ b/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
@@ -17,6 +17,14 @@ import { RiNextjsLine } from "react-icons/ri";
         </Callout>
     </If>
 
+    <If conditions={[{ key: 'id', value: 'empty' }]}>
+        <Callout type="error">
+            Be aware that the empty adapter only works in combination with CoAgents in agent lock mode!
+
+            In addition, bare in mind that `useCopilotChatSuggestions`, `CopilotTextarea` and `CopilotTask` will not work, as these require an LLM.
+        </Callout>
+    </If>
+
     <If conditions={[{ key: 'packageName', value: true }]}>
         Install provider package:
 
@@ -25,12 +33,13 @@ import { RiNextjsLine } from "react-icons/ri";
         ```
     </If>
 
+    <If conditions={[{ key: 'envVarName', value: true }]}>
+        Add your API key to your `.env` file in the root of your project (unless you provide it directly to the client):
 
-    Add your API key to your `.env` file in the root of your project (unless you provide it directly to the client):
-
-    ```plaintext title=".env"
-    {{endVarName}}=your_api_key_here
-    ```
+        ```plaintext title=".env"
+        {{envVarName}}=your_api_key_here
+        ```
+    </If>
 
     <If conditions={[{ key: 'id', value: 'openai' }, { key: 'id', value: 'openai-assistants' }]}>
         <Callout type="warn">


### PR DESCRIPTION
The empty adapter should only be used for CoAgents on agent lock mode.
In this PR, the docs that explain this + an error message when misuse is being made
<img width="661" alt="Screenshot 2025-01-17 at 15 00 06" src="https://github.com/user-attachments/assets/6b33ae05-fac6-4ea8-a590-214a38779864" />
