### PR TITLE
fix: improve UI for error message showing when action render has error

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderActionExecutionMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderActionExecutionMessage.tsx
@@ -91,10 +91,9 @@ export function RenderActionExecutionMessage(props: RenderMessageProps) {
               isLoading={false}
               isGenerating={false}
               subComponent={
-                <div>
-                  <b>❌ Error executing render: {message.name}</b>
-                  <br />
-                  {e instanceof Error ? e.message : String(e)}
+                <div className="copilotKitMessage copilotKitAssistantMessage">
+                  <b>❌ Error executing render function for action {message.name}:</b>
+                  <pre>{e instanceof Error ? e.message : String(e)}</pre>
                 </div>
               }
             />


### PR DESCRIPTION
Small UI improvement for when the `render` method of an action returns an error. This error is shown in the chat and should look more like a chat bubble than what it is today
<img width="225" alt="Screenshot 2025-01-17 at 14 14 12" src="https://github.com/user-attachments/assets/88b8a7c5-7d6d-4c0e-bcc8-445c80ee9e9a" />
