### PR TITLE
fix: rename ExperimentalEmptyAdapter to EmptyAdapter

### DIFF
--- a/CopilotKit/.changeset/mean-peas-repair.md
+++ b/CopilotKit/.changeset/mean-peas-repair.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: rename ExperimentalEmptyAdapter to EmptyAdapter

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -15,7 +15,7 @@
 import { Action, actionParametersToJsonSchema, Parameter, randomId } from "@copilotkit/shared";
 import {
   CopilotServiceAdapter,
-  ExperimentalEmptyAdapter,
+  EmptyAdapter,
   RemoteChain,
   RemoteChainParameters,
 } from "../../service-adapters";
@@ -189,9 +189,9 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
       if (agentSession) {
         return await this.processAgentRequest(request);
       }
-      if (serviceAdapter instanceof ExperimentalEmptyAdapter) {
+      if (serviceAdapter instanceof EmptyAdapter) {
         // TODO: use CPK error here
-        throw new Error(`Invalid adapter configuration: ExperimentalEmptyAdapter is only meant to be used with agent lock mode. 
+        throw new Error(`Invalid adapter configuration: EmptyAdapter is only meant to be used with agent lock mode. 
 For non-agent components like useCopilotChatSuggestions, CopilotTextarea, or CopilotTask, 
 please use an LLM adapter instead.`);
       }

--- a/CopilotKit/packages/runtime/src/service-adapters/empty/empty-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/empty/empty-adapter.ts
@@ -8,21 +8,21 @@
  * ## Example
  *
  * ```ts
- * import { CopilotRuntime, ExperimentalEmptyAdapter } from "@copilotkit/runtime";
+ * import { CopilotRuntime, EmptyAdapter } from "@copilotkit/runtime";
  *
  * const copilotKit = new CopilotRuntime();
  *
- * return new ExperimentalEmptyAdapter();
+ * return new EmptyAdapter();
  * ```
  */
 import {
   CopilotServiceAdapter,
   CopilotRuntimeChatCompletionRequest,
   CopilotRuntimeChatCompletionResponse,
-} from "../../service-adapter";
+} from "../service-adapter";
 import { randomId } from "@copilotkit/shared";
 
-export class ExperimentalEmptyAdapter implements CopilotServiceAdapter {
+export class EmptyAdapter implements CopilotServiceAdapter {
   async process(
     request: CopilotRuntimeChatCompletionRequest,
   ): Promise<CopilotRuntimeChatCompletionResponse> {
@@ -31,3 +31,5 @@ export class ExperimentalEmptyAdapter implements CopilotServiceAdapter {
     };
   }
 }
+
+export const ExperimentalEmptyAdapter = EmptyAdapter;

--- a/CopilotKit/packages/runtime/src/service-adapters/index.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/index.ts
@@ -13,4 +13,4 @@ export * from "./unify/unify-adapter";
 export * from "./groq/groq-adapter";
 export * from "./anthropic/anthropic-adapter";
 export * from "./experimental/ollama/ollama-adapter";
-export * from "./experimental/empty/empty-adapter";
+export * from "./empty/empty-adapter";

--- a/docs/components/react/multi-provider-content/utils.ts
+++ b/docs/components/react/multi-provider-content/utils.ts
@@ -104,9 +104,9 @@ export const quickStartProviders: ProvidersConfig = {
     },
     "empty": {
         id: "empty",
-        title: "Experimental Empty Adapter",
+        title: "Empty Adapter (CoAgents Only)",
         icon: '/icons/empty.svg',
-        adapterImport: "ExperimentalEmptyAdapter",
-        adapterSetup: 'const serviceAdapter = new ExperimentalEmptyAdapter();'
+        adapterImport: "EmptyAdapter",
+        adapterSetup: 'const serviceAdapter = new EmptyAdapter();'
     },
 };


### PR DESCRIPTION
rename ExperimentalEmptyAdapter to EmptyAdapter
backwards compatible