### PR TITLE
feat(runtime): Expose agent state to service adapter

### DIFF
--- a/CopilotKit/packages/runtime/src/service-adapters/service-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/service-adapter.ts
@@ -4,6 +4,8 @@ import { ActionInput } from "../graphql/inputs/action.input";
 import { ForwardedParametersInput } from "../graphql/inputs/forwarded-parameters.input";
 import { ExtensionsInput } from "../graphql/inputs/extensions.input";
 import { ExtensionsResponse } from "../graphql/types/extensions-response.type";
+import { AgentSessionInput } from "../graphql/inputs/agent-session.input";
+import { AgentStateInput } from "../graphql/inputs/agent-state.input";
 
 export interface CopilotKitResponse {
   stream: ReadableStream;
@@ -19,6 +21,8 @@ export interface CopilotRuntimeChatCompletionRequest {
   runId?: string;
   forwardedParameters?: ForwardedParametersInput;
   extensions?: ExtensionsInput;
+  agentSession?: AgentSessionInput;
+  agentStates?: AgentStateInput[];
 }
 
 export interface CopilotRuntimeChatCompletionResponse {

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -63,6 +63,10 @@ A list of remote actions that can be executed.
 An array of LangServer URLs.
 </PropertyReference>
 
+<PropertyReference name="delegateAgentProcessingToServiceAdapter" type="boolean"  > 
+Delegates agent state processing to the service adapter - exposing `agentSession` and `agentStates`.
+</PropertyReference>
+
 <PropertyReference name="processRuntimeRequest" type="request: CopilotRuntimeRequest">
 
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

I introduced the ability to process agent requests through the service adapter, providing greater flexibility to handle requests directly in Node.js. To achieve this:

- **Exposed Agent State and Session:**
I exposed the agent's state and session, allowing the service adapter to access and manipulate these as needed.

- **Disabled Platform-Enforced Request Handling:**
I added functionality to bypass the default request handling enforced by LangGraph’s platform, enabling custom processing via the service adapter instead.

These changes make it possible to fully customize request handling within Node.js while maintaining access to critical agent data.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation