### PR TITLE
feat(use-copilot-chat-suggestions): add available prop

### DIFF
--- a/CopilotKit/packages/react-ui/src/hooks/use-copilot-chat-suggestions.tsx
+++ b/CopilotKit/packages/react-ui/src/hooks/use-copilot-chat-suggestions.tsx
@@ -78,6 +78,13 @@ interface UseCopilotChatSuggestionsConfiguration {
    * @default 1
    */
   maxSuggestions?: number;
+
+  /**
+   * Whether the suggestions are available. Defaults to `enabled`.
+   * @default enabled
+   */
+  available?: "enabled" | "disabled";
+
   /**
    * An optional class name to apply to the suggestions.
    */
@@ -86,6 +93,7 @@ interface UseCopilotChatSuggestionsConfiguration {
 
 export function useCopilotChatSuggestions(
   {
+    available = "enabled",
     instructions,
     className,
     minSuggestions = 1,
@@ -96,6 +104,8 @@ export function useCopilotChatSuggestions(
   const context = useCopilotContext();
 
   useEffect(() => {
+    if (available === "disabled") return;
+
     const id = randomId();
 
     context.addChatSuggestionConfiguration(id, {
@@ -108,5 +118,5 @@ export function useCopilotChatSuggestions(
     return () => {
       context.removeChatSuggestionConfiguration(id);
     };
-  }, [...dependencies, instructions, minSuggestions, maxSuggestions, className]);
+  }, [...dependencies, instructions, minSuggestions, maxSuggestions, className, available]);
 }

--- a/docs/content/docs/reference/hooks/useCopilotChatSuggestions.mdx
+++ b/docs/content/docs/reference/hooks/useCopilotChatSuggestions.mdx
@@ -83,6 +83,10 @@ The minimum number of suggestions to generate. Defaults to `1`.
 The maximum number of suggestions to generate. Defaults to `3`.
 </PropertyReference>
 
+<PropertyReference name="available" type="'enabled' | 'disabled'"  default="enabled"> 
+Whether the suggestions are available. Defaults to `enabled`.
+</PropertyReference>
+
 <PropertyReference name="className" type="string"  > 
 An optional class name to apply to the suggestions.
 </PropertyReference>


### PR DESCRIPTION
## What does this PR do?

Adding a new `available` prop which will allow a user to conditionally enabled or disable a specific chat suggestion.

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation