### PR TITLE
fix(chat): reorder tool execution message flow

### DIFF
--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -64,7 +64,10 @@ An array of LangServer URLs.
 </PropertyReference>
 
 <PropertyReference name="delegateAgentProcessingToServiceAdapter" type="boolean"  > 
-Delegates agent state processing to the service adapter - exposing `agentSession` and `agentStates`.
+Delegates agent state processing to the service adapter.
+ 
+  When enabled, individual agent state requests will not be processed by the agent itself.
+  Instead, all processing will be handled by the service adapter.
 </PropertyReference>
 
 <PropertyReference name="processRuntimeRequest" type="request: CopilotRuntimeRequest">

--- a/sdk-python/copilotkit/integrations/fastapi.py
+++ b/sdk-python/copilotkit/integrations/fastapi.py
@@ -183,6 +183,11 @@ def handle_execute_agent(
             action_results = {}
             
             async for event in events:
+                # Handle string events (like newlines) by yielding them directly
+                if isinstance(event, str):
+                    yield event
+                    continue
+                    
                 if not event.get('generateCopilotResponse'):
                     continue
                     


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The chat UI now displays tool execution messages in a more intuitive order that matches the actual execution flow. Tool results now appear before the assistant's response that uses them, rather than after.

Before:
User -> Action -> Assistant (streaming) -> Result

After:
User -> Action -> Result -> Assistant (streaming)

This improves:
- User experience by showing tool results before responses that use them
- Debugging clarity for tool execution flow
- Alignment with common AI chat interface patterns


## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation