### PR TITLE
fix: allow abort errors to pass further down to handler

### DIFF
--- a/CopilotKit/.changeset/seven-hats-attack.md
+++ b/CopilotKit/.changeset/seven-hats-attack.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime-client-gql": patch
+---
+
+- fix: allow abort errors to pass further down to handler

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -1,6 +1,5 @@
 import { Client, cacheExchange, fetchExchange } from "@urql/core";
 import * as packageJson from "../../package.json";
-
 import {
   AvailableAgentsQuery,
   GenerateCopilotResponseMutation,
@@ -10,8 +9,7 @@ import {
 import { generateCopilotResponseMutation } from "../graphql/definitions/mutations";
 import { getAvailableAgentsQuery, loadAgentStateQuery } from "../graphql/definitions/queries";
 import { OperationResultSource, OperationResult } from "urql";
-import { ResolvedCopilotKitError } from "@copilotkit/shared";
-import { CopilotKitLowLevelError } from "@copilotkit/shared";
+import { ResolvedCopilotKitError, CopilotKitLowLevelError } from "@copilotkit/shared";
 
 const createFetchFn =
   (signal?: AbortSignal) =>

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -1,11 +1,4 @@
-import {
-  Client,
-  cacheExchange,
-  fetchExchange,
-  mapExchange,
-  CombinedError,
-  Operation,
-} from "@urql/core";
+import { Client, cacheExchange, fetchExchange } from "@urql/core";
 import * as packageJson from "../../package.json";
 
 import {
@@ -17,7 +10,8 @@ import {
 import { generateCopilotResponseMutation } from "../graphql/definitions/mutations";
 import { getAvailableAgentsQuery, loadAgentStateQuery } from "../graphql/definitions/queries";
 import { OperationResultSource, OperationResult } from "urql";
-import { CopilotKitLowLevelError, ResolvedCopilotKitError } from "@copilotkit/shared";
+import { ResolvedCopilotKitError } from "@copilotkit/shared";
+import { CopilotKitLowLevelError } from "@copilotkit/shared";
 
 const createFetchFn =
   (signal?: AbortSignal) =>
@@ -29,6 +23,13 @@ const createFetchFn =
       }
       return result;
     } catch (error) {
+      // Let abort error pass through. It will be suppressed later
+      if (
+        (error as Error).message.includes("BodyStreamBuffer was aborted") ||
+        (error as Error).message.includes("signal is aborted without reason")
+      ) {
+        throw error;
+      }
       throw new CopilotKitLowLevelError({ error: error as Error, url: args[0] as string });
     }
   };

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -64,7 +64,10 @@ An array of LangServer URLs.
 </PropertyReference>
 
 <PropertyReference name="delegateAgentProcessingToServiceAdapter" type="boolean"  > 
-Delegates agent state processing to the service adapter - exposing `agentSession` and `agentStates`.
+Delegates agent state processing to the service adapter.
+ 
+  When enabled, individual agent state requests will not be processed by the agent itself.
+  Instead, all processing will be handled by the service adapter.
 </PropertyReference>
 
 <PropertyReference name="processRuntimeRequest" type="request: CopilotRuntimeRequest">


### PR DESCRIPTION
We have several fetch calls, depending on the context and what needs fetching.
They are handling errors with our new error classes, but for abort signal errors, we have a centralized location where we handle this, so I am allowing the error to pass through "as is", so that handler handles it