### PR TITLE
fix: allow empty langsmith api key

### DIFF
--- a/CopilotKit/.changeset/tricky-pots-notice.md
+++ b/CopilotKit/.changeset/tricky-pots-notice.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: allow empty langsmith api key

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -44,7 +44,7 @@ export interface LangGraphPlatformAgent {
 export interface LangGraphPlatformEndpoint
   extends BaseEndpointDefinition<EndpointType.LangGraphPlatform> {
   deploymentUrl: string;
-  langsmithApiKey: string;
+  langsmithApiKey?: string;
   agents: LangGraphPlatformAgent[];
 }
 


### PR DESCRIPTION
LangSmith API key is not required to run langgraph agents. Therefore, making it optional