### PR TITLE
[CPK-1233] pass default headers from properties

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -319,9 +319,14 @@ please use an LLM adapter instead.`,
       async (acc: Promise<Agent[]>, endpoint) => {
         const agents = await acc;
         if (endpoint.type === EndpointType.LangGraphPlatform) {
+          const propertyHeaders = graphqlContext.properties.authorization
+            ? { authorization: `Bearer ${graphqlContext.properties.authorization}` }
+            : null;
+          
           const client = new LangGraphClient({
             apiUrl: endpoint.deploymentUrl,
             apiKey: endpoint.langsmithApiKey,
+            defaultHeaders: { ...propertyHeaders },
           });
 
           const data: Array<{ assistant_id: string; graph_id: string }> =
@@ -392,9 +397,14 @@ please use an LLM adapter instead.`,
     const headers = createHeaders(null, graphqlContext);
 
     if (agentWithEndpoint.endpoint.type === EndpointType.LangGraphPlatform) {
+      const propertyHeaders = graphqlContext.properties.authorization
+        ? { authorization: `Bearer ${graphqlContext.properties.authorization}` }
+        : null;
+      
       const client = new LangGraphClient({
         apiUrl: agentWithEndpoint.endpoint.deploymentUrl,
         apiKey: agentWithEndpoint.endpoint.langsmithApiKey,
+        defaultHeaders: { ...propertyHeaders },
       });
       let state: any = {};
       try {

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -84,13 +84,18 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
     messages,
     actions,
     logger,
+    properties,
   } = args;
 
   let nodeName = initialNodeName;
   let state = initialState;
   const { name, assistantId: initialAssistantId } = agent;
 
-  const client = new Client({ apiUrl: deploymentUrl, apiKey: langsmithApiKey });
+  const defaultHeaders = properties.authorization
+    ? { Authorization: `Bearer ${properties.authorization}` }
+    : undefined;
+
+  const client = new Client({ apiUrl: deploymentUrl, apiKey: langsmithApiKey, ...defaultHeaders });
 
   let threadId = argsInitialThreadId ?? randomUUID();
   if (argsInitialThreadId && argsInitialThreadId.startsWith("ck-")) {

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -1,4 +1,4 @@
-import { Client } from "@langchain/langgraph-sdk";
+import { Client as LangGraphClient } from "@langchain/langgraph-sdk";
 import { createHash } from "node:crypto";
 import { randomUUID, isValidUUID } from "@copilotkit/shared";
 import { parse as parsePartialJson } from "partial-json";
@@ -91,14 +91,14 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
   let state = initialState;
   const { name, assistantId: initialAssistantId } = agent;
 
-  const defaultHeaders = properties.authorization
-    ? { Authorization: `Bearer ${properties.authorization}` }
-    : undefined;
+  const propertyHeaders = properties.authorization
+    ? { authorization: `Bearer ${properties.authorization}` }
+    : null;
 
-  const client = new Client({
+  const client = new LangGraphClient({
     apiUrl: deploymentUrl,
     apiKey: langsmithApiKey,
-    ...(defaultHeaders && { defaultHeaders }),
+    defaultHeaders: { ...propertyHeaders },
   });
 
   let threadId = argsInitialThreadId ?? randomUUID();

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -95,7 +95,11 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
     ? { Authorization: `Bearer ${properties.authorization}` }
     : undefined;
 
-  const client = new Client({ apiUrl: deploymentUrl, apiKey: langsmithApiKey, ...defaultHeaders });
+  const client = new Client({
+    apiUrl: deploymentUrl,
+    apiKey: langsmithApiKey,
+    ...(defaultHeaders && { defaultHeaders }),
+  });
 
   let threadId = argsInitialThreadId ?? randomUUID();
   if (argsInitialThreadId && argsInitialThreadId.startsWith("ck-")) {

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -64,7 +64,10 @@ An array of LangServer URLs.
 </PropertyReference>
 
 <PropertyReference name="delegateAgentProcessingToServiceAdapter" type="boolean"  > 
-Delegates agent state processing to the service adapter - exposing `agentSession` and `agentStates`.
+Delegates agent state processing to the service adapter.
+ 
+  When enabled, individual agent state requests will not be processed by the agent itself.
+  Instead, all processing will be handled by the service adapter.
 </PropertyReference>
 
 <PropertyReference name="processRuntimeRequest" type="request: CopilotRuntimeRequest">


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds the option to pass authorization tokens from the frontend by adding them to the `properties` property of `copilotRuntimeNextJSAppRouterEndpoint` and the `CopilotKit` components in the frontend. The LangGraph Client was previously being constructed without the option to pass auth headers, making it impossible to use the next custom auth workflow with [LangGraph platform](https://langchain-ai.github.io/langgraph/how-tos/auth/custom_auth/)

This is more of a hotfix, since the graphql properties object was the only convenient way to transfer auth headers all the way down the call stack to where the LangGraph Platform Clients were being constructed.

Note: the more consistent way to pass these auth tokens is by accessing the cookies in browser. CopilotKit seems to call `/assistants/search` to check for available agents prior to loading much else of the page. For some reason, this request seems to omit headers included in the NextJS request during initial page load, so retrieving the auth token from cookies is more consistent.

## Related PRs and Issues

- [Original PR from @suhasdeshpande based on our discussion](https://github.com/CopilotKit/CopilotKit/pull/1284)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation