### PR TITLE
chore: add dependencies array to fix langgraph platform deployments

### DIFF
--- a/examples/coagents-ai-researcher/agent/pyproject.toml
+++ b/examples/coagents-ai-researcher/agent/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "tavily-python",
   "python-dotenv",
   "uvicorn",
+  "copilotkit==0.1.34",
 ]
 
 [build-system]

--- a/examples/coagents-qa-native/agent/pyproject.toml
+++ b/examples/coagents-qa-native/agent/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "langchain",
   "openai",
   "langchain-community",
+  "copilotkit==0.1.34"
 ]
 
 [build-system]

--- a/examples/coagents-qa-text/agent/pyproject.toml
+++ b/examples/coagents-qa-text/agent/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "langchain",
   "openai",
   "langchain-community",
+  "copilotkit==0.1.34"
 ]
 
 [build-system]

--- a/examples/coagents-routing/agent/pyproject.toml
+++ b/examples/coagents-routing/agent/pyproject.toml
@@ -8,7 +8,20 @@ license = "MIT"
 [project]
 name = "my_agent"
 version = "0.0.1"
-
+dependencies = [
+    "langgraph",
+    "langchain-openai",
+    "langchain-anthropic",
+    "langchain",
+    "openai",
+    "langchain-community",
+    "copilotkit==0.1.34",
+    "uvicorn",
+    "python-dotenv",
+    "langchain-google-genai",
+    "langchain-core",
+    "langgraph-cli[inmem]==0.1.64"
+]
 
 [build-system]
 requires = ["setuptools >= 61.0"]

--- a/examples/coagents-travel/agent/pyproject.toml
+++ b/examples/coagents-travel/agent/pyproject.toml
@@ -5,6 +5,25 @@ description = ""
 authors = ["Tyler Slaton <tyler@copilotkit.ai>"]
 readme = "README.md"
 
+[project]
+name = "travel"
+version = "0.1.0"
+dependencies = [
+    "langgraph",
+    "langchain_core",
+    "langchain_openai",
+    "langchain-google-genai",
+    "langchain",
+    "openai",
+    "langchain-community",
+    "tavily-python",
+    "python-dotenv",
+    "uvicorn",
+    "copilotkit==0.1.34",
+    "googlemaps",
+    "html2text"
+]
+
 [tool.poetry.dependencies]
 python = "^3.12"
 langchain-openai = "^0.2.1"


### PR DESCRIPTION
These dependencies as an array is what picked up by Langgraph platform when running an agent container, so they should be available