### PR TITLE
fix(runtime-client-gql): call controller.close() after suppressing abort errors

### DIFF
--- a/CopilotKit/.changeset/cool-spoons-cough.md
+++ b/CopilotKit/.changeset/cool-spoons-cough.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/runtime-client-gql": patch
+---
+
+- fix(runtime-client-gql): call controller.close() after suppressing abort errors
+
+Signed-off-by: Tyler Slaton <tyler@copilotkit.ai>

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -98,7 +98,10 @@ export class CopilotRuntimeClient {
               error.message.includes("BodyStreamBuffer was aborted") ||
               error.message.includes("signal is aborted without reason")
             ) {
-              // Suppress this specific error
+              // close the stream if there is no next item
+              if (!hasNext) controller.close();
+
+              //suppress this specific error
               console.warn("Abort error suppressed");
               return;
             }


### PR DESCRIPTION
## What does this PR do?

Fixing an issue where we were not closing the controller on abort error suppression. This would result in "Stop generation" hanging as soon as it was clicked.

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation