### PR TITLE
fix(coagents-qa-native): safely retrieve cpk actions, allowing for LangGraph Studio to execute

### DIFF
--- a/examples/coagents-qa-native/agent/email_agent/agent.py
+++ b/examples/coagents-qa-native/agent/email_agent/agent.py
@@ -34,8 +34,9 @@ async def email_node(state: EmailAgentState, config: RunnableConfig):
 
     instructions = f"You write emails. The email is by the following sender: {sender}, working for: {sender_company}"
 
+    cpk_actions = state.get("copilotkit", {}).get("actions", [])
     email_model = get_model(state).bind_tools(
-        state["copilotkit"]["actions"],
+        cpk_actions,
         tool_choice="EmailTool"
     )
 


### PR DESCRIPTION
## What does this PR do?
Safely retrieve the values CPK actions, this ensures that this will run even outside of a CopilotKit env.

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation