### PR TITLE
fix(docs): address typo and add better 404 page

### DIFF
--- a/docs/app/not-found.tsx
+++ b/docs/app/not-found.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <div className="text-center">
+        <div className="relative w-32 h-32 mx-auto mb-8 animate-bounce">
+          <Image
+            src="/images/copilotkit-logo.svg"
+            alt="CopilotKit Logo"
+            fill
+            priority
+            className="object-contain"
+          />
+        </div>
+        <h1 className="text-4xl font-bold mb-4 bg-gradient-to-r from-blue-600 to-purple-600 text-transparent bg-clip-text">
+          Page Not Found
+        </h1>
+        <p className="text-gray-600 dark:text-gray-300 mb-6 max-w-sm">
+          Oops! The page you're looking for doesn't exist.
+        </p>
+        <Link 
+          href="/" 
+          className="inline-flex items-center px-6 py-3 text-base font-medium text-white bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg hover:opacity-90 transition-opacity"
+        >
+          Go to Documentation
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/docs/content/docs/coagents/quickstart/langgraph.mdx
+++ b/docs/content/docs/coagents/quickstart/langgraph.mdx
@@ -124,8 +124,8 @@ Before you begin, you'll need the following:
             <Step>
                 ### Add a remote endpoint for your LangGraph agent
                 Using Copilot Cloud, you need to connect a remote endpoint that will connect to your LangGraph agent.
-                <Tabs groupId="lg-deployment-type" items={['LangGraph Studio (local)', 'Self hosted (FastAPI)', 'LangGraph Platform']}>
-                    <Tab value="LangGraph Studio (local)">
+                <Tabs groupId="lg-deployment-type" items={['Local (LangGraph Studio)', 'Self hosted (FastAPI)', 'LangGraph Platform']}>
+                    <Tab value="Local (LangGraph Studio)">
                         When running your LangGraph agent locally, you can open a tunnel to it so Copilot Cloud can connect to it.
                         ```bash
                         npx copilotkit@latest dev --port 8000


### PR DESCRIPTION
## What does this PR do?

Fixing a typo that broke smart tabs in the quickstart and adding a better 404 page.

![image](https://github.com/user-attachments/assets/cc07ab9a-2894-4a1d-98d4-552a163af8e7)

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation