### PR TITLE
chore: fix coagents qa native deployment by getting latest corepack

### DIFF
--- a/examples/coagents-qa-native/agent-js/langgraph.json
+++ b/examples/coagents-qa-native/agent-js/langgraph.json
@@ -1,6 +1,6 @@
 {
   "node_version": "20",
-  "dockerfile_lines": [],
+  "dockerfile_lines": ["RUN npm i -g corepack@latest"],
   "dependencies": ["."],
   "graphs": {
     "email_agent": "./src/agent.ts:graph"


### PR DESCRIPTION
chore: fix coagents qa native deployment by getting latest corepack