### PR TITLE
chore: fix coagents deployment by getting latest corepack

### DIFF
--- a/examples/coagents-qa-text/agent-js/langgraph.json
+++ b/examples/coagents-qa-text/agent-js/langgraph.json
@@ -1,6 +1,6 @@
 {
   "node_version": "20",
-  "dockerfile_lines": [],
+  "dockerfile_lines": ["RUN npm i -g corepack@latest"],
   "dependencies": ["."],
   "graphs": {
     "greeting_agent": "./src/agent.ts:graph"

--- a/examples/coagents-research-canvas/agent-js/langgraph.json
+++ b/examples/coagents-research-canvas/agent-js/langgraph.json
@@ -1,6 +1,6 @@
 {
   "node_version": "20",
-  "dockerfile_lines": [],
+  "dockerfile_lines": ["RUN npm i -g corepack@latest"],
   "dependencies": ["."],
   "graphs": {
     "research_agent": "./src/agent.ts:graph"

--- a/examples/coagents-routing/agent-js/langgraph.json
+++ b/examples/coagents-routing/agent-js/langgraph.json
@@ -1,6 +1,6 @@
 {
   "node_version": "20",
-  "dockerfile_lines": [],
+  "dockerfile_lines": ["RUN npm i -g corepack@latest"],
   "dependencies": ["."],
   "graphs": {
     "joke_agent": "./src/joke-agent.ts:jokeGraph",


### PR DESCRIPTION
chore: fix coagents deployment by getting latest corepack