### PR TITLE
chore: publish python sdk v0.1.37

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.36"
+version = "0.1.37"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
publish python sdk v0.1.37