### PR TITLE
fix: use langgraph metadata to get node name

### DIFF
--- a/CopilotKit/.changeset/cyan-vans-begin.md
+++ b/CopilotKit/.changeset/cyan-vans-begin.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: use langgraph metadata to get node name

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -271,7 +271,7 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
       }
 
       const event = chunk.data;
-      const currentNodeName = event.name;
+      const currentNodeName = event.metadata.langgraph_node;
       const eventType = event.event;
       const runId = event.metadata.run_id;
       externalRunId = runId;


### PR DESCRIPTION
There is a more accurate way to get current running node name. Fixes a situation in which wrong node name would result in not executing node interrupt flows properly