### PR TITLE
fix: use warning when version mismatch is not expected to error out

### DIFF
--- a/CopilotKit/.changeset/seven-fishes-hide.md
+++ b/CopilotKit/.changeset/seven-fishes-hide.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-core": patch
+"@copilotkit/runtime-client-gql": patch
+"@copilotkit/shared": patch
+---
+
+- fix: use warning when version mismatch is not expected to error out

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-runtime-client.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-runtime-client.ts
@@ -10,6 +10,7 @@ import { useErrorToast } from "../components/error-boundary/error-utils";
 export const useCopilotRuntimeClient = (options: CopilotRuntimeClientOptions) => {
   const { addGraphQLErrorsToast } = useToast();
   const addErrorToast = useErrorToast();
+  const { addToast } = useToast();
 
   const runtimeClient = useMemo(() => {
     return new CopilotRuntimeClient({
@@ -21,8 +22,12 @@ export const useCopilotRuntimeClient = (options: CopilotRuntimeClientOptions) =>
           addErrorToast([error]);
         }
       },
+      handleGQLWarning: (message: string) => {
+        console.warn(message);
+        addToast({ type: "warning", message });
+      },
     });
-  }, [options, addGraphQLErrorsToast]);
+  }, [options, addGraphQLErrorsToast, addToast]);
 
   return runtimeClient;
 };

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -21,7 +21,7 @@ const createFetchFn =
   (signal?: AbortSignal, handleGQLWarning?: (warning: string) => void) =>
   async (...args: Parameters<typeof fetch>) => {
     // @ts-expect-error -- since this is our own header, TS will not recognize
-    const publicApiKey = args[1]?.headers?.["x-copilotcloud-public-api-key"]
+    const publicApiKey = args[1]?.headers?.["x-copilotcloud-public-api-key"];
     try {
       const result = await fetch(args[0], { ...(args[1] ?? {}), signal });
 

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -12,23 +12,38 @@ import { OperationResultSource, OperationResult } from "urql";
 import {
   ResolvedCopilotKitError,
   CopilotKitLowLevelError,
-  detectPossibleVersionMismatchError,
   CopilotKitError,
+  CopilotKitVersionMismatchError,
+  getPossibleVersionMismatch,
 } from "@copilotkit/shared";
 
 const createFetchFn =
-  (signal?: AbortSignal) =>
+  (signal?: AbortSignal, handleGQLWarning?: (warning: string) => void, publicApiKey?: string) =>
   async (...args: Parameters<typeof fetch>) => {
     try {
       const result = await fetch(args[0], { ...(args[1] ?? {}), signal });
-      await detectPossibleVersionMismatchError({
-        runtimeVersion: result.headers.get("X-CopilotKit-Runtime-Version")!,
-        runtimeClientGqlVersion: packageJson.version,
-      });
+
+      // No mismatch checking if cloud is being used
+      const mismatch = publicApiKey
+        ? null
+        : await getPossibleVersionMismatch({
+            runtimeVersion: result.headers.get("X-CopilotKit-Runtime-Version")!,
+            runtimeClientGqlVersion: packageJson.version,
+          });
       if (result.status !== 200) {
-        // X-CopilotKit-Runtime-Version
-        throw new ResolvedCopilotKitError({ status: result.status });
+        if (result.status >= 400 && result.status <= 500) {
+          if (mismatch) {
+            throw new CopilotKitVersionMismatchError(mismatch);
+          }
+
+          throw new ResolvedCopilotKitError({ status: result.status });
+        }
       }
+
+      if (mismatch && handleGQLWarning) {
+        handleGQLWarning(mismatch.message);
+      }
+
       return result;
     } catch (error) {
       // Let abort error pass through. It will be suppressed later
@@ -51,16 +66,21 @@ export interface CopilotRuntimeClientOptions {
   headers?: Record<string, string>;
   credentials?: RequestCredentials;
   handleGQLErrors?: (error: Error) => void;
+  handleGQLWarning?: (warning: string) => void;
 }
 
 export class CopilotRuntimeClient {
   client: Client;
   public handleGQLErrors?: (error: Error) => void;
+  public handleGQLWarning?: (warning: string) => void;
+  private publicApiKey?: string;
 
   constructor(options: CopilotRuntimeClientOptions) {
     const headers: Record<string, string> = {};
 
     this.handleGQLErrors = options.handleGQLErrors;
+    this.handleGQLWarning = options.handleGQLWarning;
+    this.publicApiKey = options.publicApiKey;
 
     if (options.headers) {
       Object.assign(headers, options.headers);
@@ -92,7 +112,7 @@ export class CopilotRuntimeClient {
     properties?: GenerateCopilotResponseMutationVariables["properties"];
     signal?: AbortSignal;
   }) {
-    const fetchFn = createFetchFn(signal);
+    const fetchFn = createFetchFn(signal, this.handleGQLWarning, this.publicApiKey);
     const result = this.client.mutation<
       GenerateCopilotResponseMutation,
       GenerateCopilotResponseMutationVariables

--- a/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -18,8 +18,10 @@ import {
 } from "@copilotkit/shared";
 
 const createFetchFn =
-  (signal?: AbortSignal, handleGQLWarning?: (warning: string) => void, publicApiKey?: string) =>
+  (signal?: AbortSignal, handleGQLWarning?: (warning: string) => void) =>
   async (...args: Parameters<typeof fetch>) => {
+    // @ts-expect-error -- since this is our own header, TS will not recognize
+    const publicApiKey = args[1]?.headers?.["x-copilotcloud-public-api-key"]
     try {
       const result = await fetch(args[0], { ...(args[1] ?? {}), signal });
 
@@ -73,14 +75,12 @@ export class CopilotRuntimeClient {
   client: Client;
   public handleGQLErrors?: (error: Error) => void;
   public handleGQLWarning?: (warning: string) => void;
-  private publicApiKey?: string;
 
   constructor(options: CopilotRuntimeClientOptions) {
     const headers: Record<string, string> = {};
 
     this.handleGQLErrors = options.handleGQLErrors;
     this.handleGQLWarning = options.handleGQLWarning;
-    this.publicApiKey = options.publicApiKey;
 
     if (options.headers) {
       Object.assign(headers, options.headers);
@@ -112,7 +112,7 @@ export class CopilotRuntimeClient {
     properties?: GenerateCopilotResponseMutationVariables["properties"];
     signal?: AbortSignal;
   }) {
-    const fetchFn = createFetchFn(signal, this.handleGQLWarning, this.publicApiKey);
+    const fetchFn = createFetchFn(signal, this.handleGQLWarning);
     const result = this.client.mutation<
       GenerateCopilotResponseMutation,
       GenerateCopilotResponseMutationVariables

--- a/CopilotKit/packages/shared/src/utils/errors.ts
+++ b/CopilotKit/packages/shared/src/utils/errors.ts
@@ -138,6 +138,12 @@ export class CopilotKitMisuseError extends CopilotKitError {
   }
 }
 
+const getVersionMismatchErrorMessage = ({
+  reactCoreVersion,
+  runtimeVersion,
+  runtimeClientGqlVersion,
+}: VersionMismatchResponse) =>
+  `Version mismatch detected: @copilotkit/runtime@${runtimeVersion ?? ""} is not compatible with @copilotkit/react-core@${reactCoreVersion} and @copilotkit/runtime-client-gql@${runtimeClientGqlVersion}. Please ensure all installed copilotkit packages are on the same version.`;
 /**
  * Error thrown when CPK versions does not match
  *
@@ -150,8 +156,14 @@ export class CopilotKitVersionMismatchError extends CopilotKitError {
     runtimeClientGqlVersion,
   }: VersionMismatchResponse) {
     const code = CopilotKitErrorCode.VERSION_MISMATCH;
-    const message = `Version mismatch detected: @copilotkit/runtime@${runtimeVersion ?? ""} is not compatible with @copilotkit/react-core@${reactCoreVersion} and @copilotkit/runtime-client-gql@${runtimeClientGqlVersion}. Please ensure all installed copilotkit packages are on the same version.`;
-    super({ message, code });
+    super({
+      message: getVersionMismatchErrorMessage({
+        reactCoreVersion,
+        runtimeVersion,
+        runtimeClientGqlVersion,
+      }),
+      code,
+    });
     this.name = ERROR_NAMES.COPILOT_KIT_VERSION_MISMATCH_ERROR;
   }
 }
@@ -343,7 +355,7 @@ interface VersionMismatchResponse {
   reactCoreVersion: string;
 }
 
-export async function detectPossibleVersionMismatchError({
+export async function getPossibleVersionMismatch({
   runtimeVersion,
   runtimeClientGqlVersion,
 }: {
@@ -356,10 +368,17 @@ export async function detectPossibleVersionMismatchError({
     COPILOTKIT_VERSION !== runtimeClientGqlVersion ||
     runtimeVersion !== runtimeClientGqlVersion
   ) {
-    throw new CopilotKitVersionMismatchError({
+    return {
       runtimeVersion,
       runtimeClientGqlVersion,
       reactCoreVersion: COPILOTKIT_VERSION,
-    });
+      message: getVersionMismatchErrorMessage({
+        runtimeVersion,
+        runtimeClientGqlVersion,
+        reactCoreVersion: COPILOTKIT_VERSION,
+      }),
+    };
   }
+
+  return;
 }


### PR DESCRIPTION
If an error occurs, we will check and show a version mismatch error. Otherwise we will just show a warning (on dev only ofc)