### PR TITLE
fix(interrupt): disable input when interrupt is active

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -243,6 +243,11 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
   const runChatCompletion = useAsyncCallback(
     async (previousMessages: Message[]): Promise<Message[]> => {
       setIsLoading(true);
+      const interruptEvent = langGraphInterruptAction?.event
+      // In case an interrupt event exist and valid but has no response yet, we cannot process further messages to an agent
+      if (interruptEvent?.name === MetaEventName.LangGraphInterruptEvent && interruptEvent?.value && !interruptEvent?.response && agentSessionRef.current) {
+        addErrorToast([new Error('A message was sent while interrupt is active. This will cause failure on the agent side')])
+      }
 
       // this message is just a placeholder. It will disappear once the first real message
       // is received

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -243,10 +243,19 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
   const runChatCompletion = useAsyncCallback(
     async (previousMessages: Message[]): Promise<Message[]> => {
       setIsLoading(true);
-      const interruptEvent = langGraphInterruptAction?.event
+      const interruptEvent = langGraphInterruptAction?.event;
       // In case an interrupt event exist and valid but has no response yet, we cannot process further messages to an agent
-      if (interruptEvent?.name === MetaEventName.LangGraphInterruptEvent && interruptEvent?.value && !interruptEvent?.response && agentSessionRef.current) {
-        addErrorToast([new Error('A message was sent while interrupt is active. This will cause failure on the agent side')])
+      if (
+        interruptEvent?.name === MetaEventName.LangGraphInterruptEvent &&
+        interruptEvent?.value &&
+        !interruptEvent?.response &&
+        agentSessionRef.current
+      ) {
+        addErrorToast([
+          new Error(
+            "A message was sent while interrupt is active. This will cause failure on the agent side",
+          ),
+        ]);
       }
 
       // this message is just a placeholder. It will disappear once the first real message

--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -52,7 +52,9 @@ export const Input = ({ inProgress, onSend, isVisible = false }: InputProps) => 
     !inProgress;
 
   const canSend = () => {
-    return !inProgress && text.trim().length > 0 && pushToTalkState === "idle";
+    const interruptEvent = copilotContext.langGraphInterruptAction?.event
+    const interruptInProgress = interruptEvent?.name === 'LangGraphInterruptEvent' && !interruptEvent?.response
+    return !inProgress && text.trim().length > 0 && pushToTalkState === "idle" && !interruptInProgress;
   };
 
   const sendDisabled = !canSend();

--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -52,9 +52,12 @@ export const Input = ({ inProgress, onSend, isVisible = false }: InputProps) => 
     !inProgress;
 
   const canSend = () => {
-    const interruptEvent = copilotContext.langGraphInterruptAction?.event
-    const interruptInProgress = interruptEvent?.name === 'LangGraphInterruptEvent' && !interruptEvent?.response
-    return !inProgress && text.trim().length > 0 && pushToTalkState === "idle" && !interruptInProgress;
+    const interruptEvent = copilotContext.langGraphInterruptAction?.event;
+    const interruptInProgress =
+      interruptEvent?.name === "LangGraphInterruptEvent" && !interruptEvent?.response;
+    return (
+      !inProgress && text.trim().length > 0 && pushToTalkState === "idle" && !interruptInProgress
+    );
   };
 
   const sendDisabled = !canSend();


### PR DESCRIPTION
When using simple interrupt, no messages should be allowed to be sent. This is because the agent is on a full stop and should not invoke the graph without response to the interrupt. Otherwise, unexpected things will happen