### PR TITLE
fix(errors): fix internal usage of error resolver

### DIFF
--- a/CopilotKit/.changeset/chilled-dolphins-jog.md
+++ b/CopilotKit/.changeset/chilled-dolphins-jog.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/shared": patch
+---
+
+- fix(errors): fix internal usage of error resolver

--- a/CopilotKit/packages/shared/src/utils/errors.ts
+++ b/CopilotKit/packages/shared/src/utils/errors.ts
@@ -270,7 +270,8 @@ export class CopilotKitLowLevelError extends CopilotKitError {
     let code = CopilotKitErrorCode.NETWORK_ERROR;
 
     // @ts-expect-error -- code may exist
-    const errorMessage = message ?? resolveLowLevelErrorMessage(error.code as string);
+    const errorCode = error.code as string;
+    const errorMessage = message ?? resolveLowLevelErrorMessage({ errorCode, url });
 
     super({ message: errorMessage, code });
 


### PR DESCRIPTION
For some reason, the following merged PR was gone from main:
https://github.com/CopilotKit/CopilotKit/pull/1367

This brings it back