### PR TITLE
fix: provide the ability to type interrupt event value

### DIFF
--- a/CopilotKit/.changeset/chilly-rats-bow.md
+++ b/CopilotKit/.changeset/chilly-rats-bow.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/react-core": patch
+"@copilotkit/runtime-client-gql": patch
+---
+
+- fix: provide the ability to type interrupt event value

--- a/CopilotKit/packages/react-core/src/hooks/use-langgraph-interrupt.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-langgraph-interrupt.ts
@@ -5,8 +5,8 @@ import { useCopilotChat } from "./use-copilot-chat";
 import { useToast } from "../components/toast/toast-provider";
 import { dataToUUID } from "@copilotkit/shared";
 
-export function useLangGraphInterrupt(
-  action: Omit<LangGraphInterruptRender, "id">,
+export function useLangGraphInterrupt<TEventValue = any>(
+  action: Omit<LangGraphInterruptRender<TEventValue>, "id">,
   dependencies?: any[],
 ) {
   const { setLangGraphInterruptAction, removeLangGraphInterruptAction, langGraphInterruptAction } =

--- a/CopilotKit/packages/react-core/src/types/interrupt-action.ts
+++ b/CopilotKit/packages/react-core/src/types/interrupt-action.ts
@@ -1,13 +1,13 @@
 import { LangGraphInterruptEvent } from "@copilotkit/runtime-client-gql";
 import { Condition } from "@copilotkit/shared";
 
-export interface LangGraphInterruptRender {
+export interface LangGraphInterruptRender<TEventValue = any> {
   id: string;
   /**
    * The handler function to handle the event.
    */
   handler?: (props: {
-    event: LangGraphInterruptEvent;
+    event: LangGraphInterruptEvent<TEventValue>;
     resolve: (resolution: string) => void;
   }) => unknown | Promise<unknown>;
   /**
@@ -15,7 +15,7 @@ export interface LangGraphInterruptRender {
    */
   render?: (props: {
     result: unknown;
-    event: LangGraphInterruptEvent;
+    event: LangGraphInterruptEvent<TEventValue>;
     resolve: (resolution: string) => void;
   }) => string | React.ReactElement;
   /**

--- a/CopilotKit/packages/runtime-client-gql/src/client/types.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/types.ts
@@ -135,9 +135,10 @@ export function langGraphInterruptEvent(
   return { ...eventProps, name: MetaEventName.LangGraphInterruptEvent, type: "MetaEvent" };
 }
 
-type LangGraphInterruptEvent<TValue extends any = any> = GqlLangGraphInterruptEvent & {
+export type LangGraphInterruptEvent<TValue extends any = any> = GqlLangGraphInterruptEvent & {
   value: TValue;
 };
+
 type CopilotKitLangGraphInterruptEvent<TValue extends any = any> =
   GqlCopilotKitLangGraphInterruptEvent & {
     data: GqlCopilotKitLangGraphInterruptEvent["data"] & { value: TValue };

--- a/CopilotKit/packages/runtime-client-gql/src/index.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./client";
 export * from "./graphql/@generated/graphql";
+export type { LangGraphInterruptEvent } from "./client";


### PR DESCRIPTION
This PR adds the ability to set the type of the interrupt event, so developers using `useLangGraphInterrupt` are able to have type safety when using that value