### PR TITLE
chore: release python sdk v0.1.39

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.37"
+version = "0.1.39"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
release python sdk v0.1.39