### PR TITLE
fix: simplify lg interrupt conditions

### DIFF
--- a/CopilotKit/.changeset/sharp-bikes-develop.md
+++ b/CopilotKit/.changeset/sharp-bikes-develop.md
@@ -1,0 +1,8 @@
+---
+"@copilotkit/react-core": patch
+---
+
+- fix: simplify condition options for langgraph interrupts
+- chore: add new enabled to e2e tests
+- fix: refine argument types
+- chore: document hook API reference

--- a/CopilotKit/packages/react-core/src/hooks/use-langgraph-interrupt-render.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-langgraph-interrupt-render.ts
@@ -18,7 +18,8 @@ const InterruptRenderer: React.FC<InterruptProps> = ({ event, result, render, re
 };
 
 export function useLangGraphInterruptRender(): string | React.ReactElement | null {
-  const { langGraphInterruptAction, setLangGraphInterruptAction } = useCopilotContext();
+  const { langGraphInterruptAction, setLangGraphInterruptAction, agentSession } =
+    useCopilotContext();
 
   const responseRef = React.useRef<string>();
   const resolveInterrupt = useCallback(
@@ -39,9 +40,12 @@ export function useLangGraphInterruptRender(): string | React.ReactElement | nul
   )
     return null;
 
-  const { render, handler, event, conditions } = langGraphInterruptAction;
+  const { render, handler, event, enabled } = langGraphInterruptAction;
 
-  const conditionsMet = executeConditions({ conditions, value: event.value });
+  const conditionsMet =
+    !agentSession || !enabled
+      ? true
+      : enabled({ eventValue: event.value, agentMetadata: agentSession });
   if (!conditionsMet) {
     return null;
   }

--- a/CopilotKit/packages/react-core/src/hooks/use-langgraph-interrupt.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-langgraph-interrupt.ts
@@ -35,10 +35,9 @@ export function useLangGraphInterrupt<TEventValue = any>(
 
   useEffect(() => {
     if (!action) return;
-    // console.log(2, { hasAction, isCurrentAction, conditions: action.conditions })
     // An action was already set, with no conditions and it's not the action we're using right now.
     // Show a warning, as this action will not be executed
-    if (hasAction && !isCurrentAction && !action.conditions?.length) {
+    if (hasAction && !isCurrentAction && !action.enabled) {
       addToast({
         type: "warning",
         message: "An action is already registered for the interrupt event",

--- a/CopilotKit/packages/react-core/src/types/interrupt-action.ts
+++ b/CopilotKit/packages/react-core/src/types/interrupt-action.ts
@@ -1,5 +1,5 @@
 import { LangGraphInterruptEvent } from "@copilotkit/runtime-client-gql";
-import { Condition } from "@copilotkit/shared";
+import { AgentSession } from "../context/copilot-context";
 
 export interface LangGraphInterruptRender<TEventValue = any> {
   id: string;
@@ -19,10 +19,10 @@ export interface LangGraphInterruptRender<TEventValue = any> {
     resolve: (resolution: string) => void;
   }) => string | React.ReactElement;
   /**
-   * Conditions to render based on.
+   * Method that returns a boolean, indicating if the interrupt action should run
    * Useful when using multiple interrupts
    */
-  conditions?: Condition[];
+  enabled?: (args: { eventValue: TEventValue; agentMetadata: AgentSession }) => boolean;
 }
 
 export type LangGraphInterruptAction = LangGraphInterruptRender & {

--- a/CopilotKit/packages/react-core/src/types/interrupt-action.ts
+++ b/CopilotKit/packages/react-core/src/types/interrupt-action.ts
@@ -1,23 +1,27 @@
 import { LangGraphInterruptEvent } from "@copilotkit/runtime-client-gql";
 import { AgentSession } from "../context/copilot-context";
 
+export interface LangGraphInterruptRenderHandlerProps<TEventValue = any> {
+  event: LangGraphInterruptEvent<TEventValue>;
+  resolve: (resolution: string) => void;
+}
+
+export interface LangGraphInterruptRenderProps<TEventValue = any> {
+  result: unknown;
+  event: LangGraphInterruptEvent<TEventValue>;
+  resolve: (resolution: string) => void;
+}
+
 export interface LangGraphInterruptRender<TEventValue = any> {
   id: string;
   /**
    * The handler function to handle the event.
    */
-  handler?: (props: {
-    event: LangGraphInterruptEvent<TEventValue>;
-    resolve: (resolution: string) => void;
-  }) => unknown | Promise<unknown>;
+  handler?: (props: LangGraphInterruptRenderHandlerProps<TEventValue>) => any | Promise<any>;
   /**
    * The render function to handle the event.
    */
-  render?: (props: {
-    result: unknown;
-    event: LangGraphInterruptEvent<TEventValue>;
-    resolve: (resolution: string) => void;
-  }) => string | React.ReactElement;
+  render?: (props: LangGraphInterruptRenderProps<TEventValue>) => string | React.ReactElement;
   /**
    * Method that returns a boolean, indicating if the interrupt action should run
    * Useful when using multiple interrupts

--- a/docs/content/docs/reference/hooks/meta.json
+++ b/docs/content/docs/reference/hooks/meta.json
@@ -6,6 +6,7 @@
     "useCopilotChat",
     "useCopilotChatSuggestions",
     "useCoAgent",
-    "useCoAgentStateRender"
+    "useCoAgentStateRender",
+    "useLangGraphInterrupt"
   ]
 }

--- a/docs/content/docs/reference/hooks/useLangGraphInterrupt.mdx
+++ b/docs/content/docs/reference/hooks/useLangGraphInterrupt.mdx
@@ -1,0 +1,65 @@
+---
+title: "useLangGraphInterrupt"
+description: "The useLangGraphInterrupt hook allows setting the generative UI to be displayed on LangGraph's Interrupt event."
+---
+
+<br />
+<video src="/images/coagents/interrupt-flow.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
+
+`useLangGraphInterrupt` is a React hook that you can use in your application to provide
+custom UI to be rendered when using `interrupt` by LangGraph.
+Once an Interrupt event is emitted, that hook would execute, allowing to receive user input with a user experience to your choice.
+
+## Usage
+
+### Simple Usage
+
+```tsx title="app/page.tsx"
+import { useLangGraphInterrupt } from "@copilotkit/react-core"; // [!code highlight]
+// ...
+
+const YourMainContent = () => {
+  // ...
+  // [!code highlight:16]
+  // styles omitted for brevity
+  useLangGraphInterrupt<string>({
+    render: ({ event, resolve }) => (
+      <div>
+        <p>{event.value}</p>
+        <form onSubmit={(e) => {
+          e.preventDefault();
+          resolve((e.target as HTMLFormElement).response.value);
+        }}>
+          <input type="text" name="response" placeholder="Enter your response" />
+          <button type="submit">Submit</button>
+        </form>
+      </div>
+    )
+  });
+  // ...
+
+  return <div>{/* ... */}</div>
+}
+```
+
+## Parameters
+
+<PropertyReference name="action" type="Action" required>
+  The action to perform when an Interrupt event is emitted. Either `handler` or `render` must be defined as arguments
+
+    <PropertyReference name="name" type="string" required>
+      The name of the action.
+    </PropertyReference>
+
+    <PropertyReference name="handler" type="(args: LangGraphInterruptRenderProps<T>) => any | Promise<any>">
+      A handler to programmatically resolve the Interrupt, or perform operations which result will be passed to the `render` method
+    </PropertyReference>
+
+    <PropertyReference name="render" type="(props: LangGraphInterruptRenderProps<T>) => string | React.ReactElement">
+        Render lets you define a custom component or string to render when an Interrupt event is emitted.
+    </PropertyReference>
+</PropertyReference>
+
+<PropertyReference name="dependencies" type="any[]">
+  An optional array of dependencies.
+</PropertyReference>

--- a/examples/coagents-qa-native/ui/app/Mailer.tsx
+++ b/examples/coagents-qa-native/ui/app/Mailer.tsx
@@ -64,7 +64,12 @@ export function Mailer() {
   });
 
   useLangGraphInterrupt({
-    render: ({ event, resolve }) => <InterruptForm event={event} resolve={resolve} />
+    render: ({ event, resolve }) => <InterruptForm event={event} resolve={resolve} />,
+    enabled: ({ eventValue, agentMetadata }) => {
+      return eventValue === "Please provide a sender name which will appear in the email"
+          && agentMetadata.agentName === 'email_agent'
+          && agentMetadata.nodeName === 'email_node';
+    }
   });
 
   return (


### PR DESCRIPTION
Simplifying the conditions to render an interrupt using the hook.
Instead of a "filters" array, we will now use a simple method that returns a boolean.