### PR TITLE
chore: add missing dependency arrays to demos

### DIFF
--- a/examples/coagents-shared-state/agent/pyproject.toml
+++ b/examples/coagents-shared-state/agent/pyproject.toml
@@ -8,6 +8,18 @@ license = "MIT"
 [project]
 name = "translate_agent"
 version = "0.0.1"
+dependencies = [
+    "langchain-openai",
+    "langchain-anthropic",
+    "langchain",
+    "openai",
+    "langchain-community",
+    "copilotkit",
+    "uvicorn",
+    "python-dotenv",
+    "langchain-core",
+    "langgraph-cli"
+]
 
 
 [build-system]

--- a/examples/coagents-starter/agent-py/pyproject.toml
+++ b/examples/coagents-starter/agent-py/pyproject.toml
@@ -8,6 +8,18 @@ license = "MIT"
 [project]
 name = "sample_agent"
 version = "0.0.1"
+dependencies = [
+    "langchain-openai",
+    "langchain-anthropic",
+    "langchain",
+    "openai",
+    "langchain-community",
+    "copilotkit",
+    "uvicorn",
+    "python-dotenv",
+    "langchain-core",
+    "langgraph-cli"
+]
 
 [build-system]
 requires = ["setuptools >= 61.0"]

--- a/examples/coagents-wait-user-input/agent/pyproject.toml
+++ b/examples/coagents-wait-user-input/agent/pyproject.toml
@@ -8,6 +8,18 @@ license = "MIT"
 [project]
 name = "weather_agent"
 version = "0.0.1"
+dependencies = [
+    "langchain-openai",
+    "langchain-anthropic",
+    "langchain",
+    "openai",
+    "langchain-community",
+    "copilotkit",
+    "uvicorn",
+    "python-dotenv",
+    "langchain-core",
+    "langgraph-cli"
+]
 
 [build-system]
 requires = ["setuptools >= 61.0"]


### PR DESCRIPTION
A dependency array is required to make a project deployable on langgraph cloud. Therefore, these were added where needed