### PR TITLE
docs(coagents): add a link to copilot cloud in the coagents quickstart

### DIFF
--- a/docs/content/docs/coagents/quickstart/langgraph.mdx
+++ b/docs/content/docs/coagents/quickstart/langgraph.mdx
@@ -197,8 +197,10 @@ Before you begin, you'll need the following:
                 The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases, 
                 it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
 
+                Since we're using Copilot CLoud, we need to grab our public API key from the [Copilot Cloud dashboard](https://cloud.copilotkit.ai).
+
                 <CloudCopilotKitProvider components={props.components} />
-                
+
                 <Callout type="info">
                     Looking for a way to run multiple LangGraph agents? Check out our [Multi-Agent](/coagents/multi-agent-flows) guide.
                 </Callout>


### PR DESCRIPTION
## What does this PR do?
Adding a link to make sure users know where to get their public API key.

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation