### PR TITLE
fix: use tryMap method to filter out possibly invalid items

### DIFF
--- a/CopilotKit/.changeset/dirty-scissors-wash.md
+++ b/CopilotKit/.changeset/dirty-scissors-wash.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": patch
+"@copilotkit/shared": patch
+---
+
+- fix: use tryMap method to filter out possibly invalid items

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
@@ -18,7 +18,8 @@ import { LangGraphEvent } from "../../agents/langgraph/events";
 import { execute } from "./remote-lg-action";
 import { CopilotKitError, CopilotKitLowLevelError } from "@copilotkit/shared";
 import { CopilotKitApiDiscoveryError, ResolvedCopilotKitError } from "@copilotkit/shared";
-import { parseJson } from "@copilotkit/shared";
+import { parseJson, tryMap } from "@copilotkit/shared";
+import { ActionInput } from "../../graphql/inputs/action.input";
 
 export function constructLGCRemoteAction({
   endpoint,
@@ -77,10 +78,10 @@ export function constructLGCRemoteAction({
           state,
           configurable,
           properties: graphqlContext.properties,
-          actions: actionInputsWithoutAgents.map((action) => ({
+          actions: tryMap(actionInputsWithoutAgents, (action: ActionInput) => ({
             name: action.name,
             description: action.description,
-            parameters: parseJson(action.jsonSchema, "") as string,
+            parameters: JSON.parse(action.jsonSchema),
           })),
           metaEvents,
         });
@@ -222,10 +223,10 @@ export function constructRemoteActions({
                 state,
                 configurable,
                 properties: graphqlContext.properties,
-                actions: actionInputsWithoutAgents.map((action) => ({
+                actions: tryMap(actionInputsWithoutAgents, (action: ActionInput) => ({
                   name: action.name,
                   description: action.description,
-                  parameters: parseJson(action.jsonSchema, {}),
+                  parameters: JSON.parse(action.jsonSchema),
                 })),
                 metaEvents,
               }),

--- a/CopilotKit/packages/runtime/src/service-adapters/conversion.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/conversion.ts
@@ -7,59 +7,51 @@ import {
 } from "../graphql/types/converted";
 import { MessageInput } from "../graphql/inputs/message.input";
 import { plainToInstance } from "class-transformer";
-import { parseJson } from "@copilotkit/shared";
+import { tryMap } from "@copilotkit/shared";
 
 export function convertGqlInputToMessages(inputMessages: MessageInput[]): Message[] {
-  const messages: Message[] = [];
-
-  for (const message of inputMessages) {
+  const messages = tryMap(inputMessages, (message) => {
     if (message.textMessage) {
-      messages.push(
-        plainToInstance(TextMessage, {
-          id: message.id,
-          createdAt: message.createdAt,
-          role: message.textMessage.role,
-          content: message.textMessage.content,
-          parentMessageId: message.textMessage.parentMessageId,
-        }),
-      );
+      return plainToInstance(TextMessage, {
+        id: message.id,
+        createdAt: message.createdAt,
+        role: message.textMessage.role,
+        content: message.textMessage.content,
+        parentMessageId: message.textMessage.parentMessageId,
+      });
     } else if (message.actionExecutionMessage) {
-      messages.push(
-        plainToInstance(ActionExecutionMessage, {
-          id: message.id,
-          createdAt: message.createdAt,
-          name: message.actionExecutionMessage.name,
-          arguments: parseJson(message.actionExecutionMessage.arguments, {}),
-          parentMessageId: message.actionExecutionMessage.parentMessageId,
-        }),
-      );
+      return plainToInstance(ActionExecutionMessage, {
+        id: message.id,
+        createdAt: message.createdAt,
+        name: message.actionExecutionMessage.name,
+        arguments: JSON.parse(message.actionExecutionMessage.arguments),
+        parentMessageId: message.actionExecutionMessage.parentMessageId,
+      });
     } else if (message.resultMessage) {
-      messages.push(
-        plainToInstance(ResultMessage, {
-          id: message.id,
-          createdAt: message.createdAt,
-          actionExecutionId: message.resultMessage.actionExecutionId,
-          actionName: message.resultMessage.actionName,
-          result: message.resultMessage.result,
-        }),
-      );
+      return plainToInstance(ResultMessage, {
+        id: message.id,
+        createdAt: message.createdAt,
+        actionExecutionId: message.resultMessage.actionExecutionId,
+        actionName: message.resultMessage.actionName,
+        result: message.resultMessage.result,
+      });
     } else if (message.agentStateMessage) {
-      messages.push(
-        plainToInstance(AgentStateMessage, {
-          id: message.id,
-          threadId: message.agentStateMessage.threadId,
-          createdAt: message.createdAt,
-          agentName: message.agentStateMessage.agentName,
-          nodeName: message.agentStateMessage.nodeName,
-          runId: message.agentStateMessage.runId,
-          active: message.agentStateMessage.active,
-          role: message.agentStateMessage.role,
-          state: parseJson(message.agentStateMessage.state, {}),
-          running: message.agentStateMessage.running,
-        }),
-      );
+      return plainToInstance(AgentStateMessage, {
+        id: message.id,
+        threadId: message.agentStateMessage.threadId,
+        createdAt: message.createdAt,
+        agentName: message.agentStateMessage.agentName,
+        nodeName: message.agentStateMessage.nodeName,
+        runId: message.agentStateMessage.runId,
+        active: message.agentStateMessage.active,
+        role: message.agentStateMessage.role,
+        state: JSON.parse(message.agentStateMessage.state),
+        running: message.agentStateMessage.running,
+      });
+    } else {
+      return null;
     }
-  }
+  });
 
-  return messages;
+  return messages.filter((m) => m);
 }

--- a/CopilotKit/packages/shared/src/utils/index.ts
+++ b/CopilotKit/packages/shared/src/utils/index.ts
@@ -3,10 +3,36 @@ export * from "./errors";
 export * from "./json-schema";
 export * from "./random-id";
 
+/**
+ * Safely parses a JSON string into an object
+ * @param json The JSON string to parse
+ * @param fallback Optional fallback value to return if parsing fails. If not provided or set to "unset", returns null
+ * @returns The parsed JSON object, or the fallback value (or null) if parsing fails
+ */
 export function parseJson(json: string, fallback: any = "unset") {
   try {
     return JSON.parse(json);
   } catch (e) {
     return fallback === "unset" ? null : fallback;
   }
+}
+
+/**
+ * Maps an array of items to a new array, skipping items that throw errors during mapping
+ * @param items The array to map
+ * @param callback The mapping function to apply to each item
+ * @returns A new array containing only the successfully mapped items
+ */
+export function tryMap<TItem, TMapped>(
+  items: TItem[],
+  callback: (item: TItem, index: number, array: TItem[]) => TMapped,
+): TMapped[] {
+  return items.reduce<TMapped[]>((acc, item, index, array) => {
+    try {
+      acc.push(callback(item, index, array));
+    } catch (error) {
+      console.error(error);
+    }
+    return acc;
+  }, []);
 }


### PR DESCRIPTION
We would like to consider, on some cases, that items which error out on one of their properties (for example) should not be a part of the end result of a mapped list.
Therefore, introducing `tryMap` method and its usage