### PR TITLE
feat: support input and output schema of langgraph

### DIFF
--- a/CopilotKit/.changeset/calm-carpets-peel.md
+++ b/CopilotKit/.changeset/calm-carpets-peel.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": minor
+---
+
+- feat: support input and output schema of langgraph
+- docs: add input output schema docs

--- a/docs/content/docs/coagents/shared-state/meta.json
+++ b/docs/content/docs/coagents/shared-state/meta.json
@@ -2,6 +2,7 @@
     "pages": [
         "in-app-agent-read",
         "in-app-agent-write",
+        "state-filtering",
         "predictive-state-updates"
     ]
 }

--- a/docs/content/docs/coagents/shared-state/meta.json
+++ b/docs/content/docs/coagents/shared-state/meta.json
@@ -2,7 +2,7 @@
     "pages": [
         "in-app-agent-read",
         "in-app-agent-write",
-        "state-filtering",
+        "state-inputs-outputs",
         "predictive-state-updates"
     ]
 }

--- a/docs/content/docs/coagents/shared-state/state-filtering.mdx
+++ b/docs/content/docs/coagents/shared-state/state-filtering.mdx
@@ -1,0 +1,153 @@
+---
+title: Filtering Input and Output State properties
+icon: "lucide/ArrowRightLeft"
+description: Decide which state properties are exposed to the frontend
+---
+
+## What is this?
+
+Not all state properties are relevant for frontend-backend sharing.
+This guide shows how to ensure only the right portion of state is communicated back and forth.
+
+This guide is based on [LangGraph's Input/Output Schema feature](https://langchain-ai.github.io/langgraph/how-tos/input_output_schema/)
+
+## Why?
+
+Depending on your implementation, some properties are meant to be processed internally, while some others are the way for the UI to communicate user input.
+In addition, some state properties contain a lot of information. Syncing them back and forth between the agent and UI can be costly, while it might not have any practical benefit.
+
+## Implementation
+
+<Steps>
+  <Step>
+    ### Define the Agent State
+    LangGraph is stateful. As you transition between nodes, that state is updated and passed to the next node. For this example,
+    let's assume that our agent state looks something like this.
+
+    <Tabs groupId="language" items={["Python", "TypeScript"]}>
+      <Tab value="Python">
+        ```python title="agent-py/sample_agent/agent.py"
+        from copilotkit import CopilotKitState
+        from typing import Literal
+
+        class AgentState(CopilotKitState):
+            question: str
+            answer: str
+            resources: List[str]
+        ```
+      </Tab>
+      <Tab value="TypeScript">
+        ```ts title="agent-js/src/agent.ts"
+        import { Annotation } from "@langchain/langgraph";
+        import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
+
+        export const AgentStateAnnotation = Annotation.Root({
+            question: Annotation<string>,
+            answer: Annotation<string>,
+            resources: Annotation<string[]>,
+            ...CopilotKitStateAnnotation.spec,
+        });
+        export type AgentState = typeof AgentStateAnnotation.State;
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+  <Step>
+    ### Divide state to Input and Output
+    Our example case lists several state properties, which with its own purpose:
+      - The question is being asked by the user, expecting the llm to answer
+      - The answer is what the LLM returns
+      - The resources list will be used by the LLM to answer the question, and should not be communicated to the user, or set by them.
+
+      <Tabs groupId="language" items={["Python", "TypeScript"]}>
+          <Tab value="Python">
+              ```python title="agent-py/sample_agent/agent.py"
+              from copilotkit import CopilotKitState
+              from typing import Literal
+
+              # divide the state into 3
+              class InputState(CopilotKitState):
+                question: str
+
+              class OutputState(CopilotKitState):
+                answer: str
+
+              class OverallState(InputState, OutputState):
+                resources: List[str]
+
+              # ...add the rest of the agent implementation
+
+              # finally, before compiling the graph, we define the 3 state components
+              builder = StateGraph(OverallState, input=InputState, output=OutputState)
+
+              # add all the different nodes and edges and compile the graph
+              builder.add_node(answer_node)
+              builder.add_edge(START, "answer_node")
+              builder.add_edge("answer_node", END)
+              graph = builder.compile()
+              ```
+          </Tab>
+          <Tab value="TypeScript">
+              ```ts title="agent-js/src/agent.ts"
+              import { Annotation } from "@langchain/langgraph";
+              import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
+
+              // Divide the state into 3 different parts
+              export const InputAnnotation = Annotation.Root({
+                question: Annotation<string>,
+                ...CopilotKitStateAnnotation.spec,
+              });
+
+              export const OutputAnnotation = Annotation.Root({
+                answer: Annotation<string>,
+                ...CopilotKitStateAnnotation.spec,
+              });
+
+              export const AgentStateAnnotation = Annotation.Root({
+                resources: Annotation<string[]>,
+                ...InputAnnotation.spec,
+                ...OutputAnnotation.spec,
+              });
+
+              // ...add the rest of the agent implementation
+
+              // finally, before compiling the graph, we define the 3 state components
+              const graph = new StateGraph({
+                  stateSchema: AgentStateAnnotation,
+                  input: InputAnnotation,
+                  output: OutputAnnotation,
+              })
+              // add all the different nodes and edges and compile the graph
+              .addNode("answerNode", answerNode)
+              .addEdge("__start__", "answerNode")
+              .compile();
+              ```
+          </Tab>
+      </Tabs>
+  </Step>
+  <Step>
+    ### Give it a try!
+    Now that we know which state properties our agent emits, we can inspect the state and expect the following to happen:
+    - While we are able to provide a question, we will not receive it back from the agent. If we are using it in our UI, we need to remember the UI is the source of truth for it
+    - Answer will change once it's returned back from the agent
+    - The UI has no access to resources.
+
+    ```tsx
+    import { useCoAgent } from "@copilotkit/react-core";
+
+    type AgentState = {
+      question: string;
+      answer: string;
+    }
+
+    const { state } = useCoAgent<AgentState>({
+      name: "sample_agent",
+      initialState: {
+        question: "How's is the weather in SF?",
+      }
+    });
+
+    console.log(state) // You can expect seeing "answer" change, while the others are not returned from the agent
+    ```
+  </Step>
+</Steps>

--- a/docs/content/docs/coagents/shared-state/state-inputs-outputs.mdx
+++ b/docs/content/docs/coagents/shared-state/state-inputs-outputs.mdx
@@ -1,7 +1,7 @@
 ---
-title: Filtering Input and Output State properties
+title: Agent state inputs and outputs
 icon: "lucide/ArrowRightLeft"
-description: Decide which state properties are exposed to the frontend
+description: Decide which state properties are received and returned to the frontend
 ---
 
 ## What is this?
@@ -11,7 +11,7 @@ This guide shows how to ensure only the right portion of state is communicated b
 
 This guide is based on [LangGraph's Input/Output Schema feature](https://langchain-ai.github.io/langgraph/how-tos/input_output_schema/)
 
-## Why?
+## When should I use this?
 
 Depending on your implementation, some properties are meant to be processed internally, while some others are the way for the UI to communicate user input.
 In addition, some state properties contain a lot of information. Syncing them back and forth between the agent and UI can be costly, while it might not have any practical benefit.
@@ -20,7 +20,7 @@ In addition, some state properties contain a lot of information. Syncing them ba
 
 <Steps>
   <Step>
-    ### Define the Agent State
+    ### Examine our old state
     LangGraph is stateful. As you transition between nodes, that state is updated and passed to the next node. For this example,
     let's assume that our agent state looks something like this.
 

--- a/docs/content/docs/coagents/shared-state/state-inputs-outputs.mdx
+++ b/docs/content/docs/coagents/shared-state/state-inputs-outputs.mdx
@@ -18,39 +18,24 @@ In addition, some state properties contain a lot of information. Syncing them ba
 
 ## Implementation
 
+<Callout>
+    Due to LangGraph support, this feature is currently only available for Python agents
+</Callout>
+
 <Steps>
   <Step>
     ### Examine our old state
     LangGraph is stateful. As you transition between nodes, that state is updated and passed to the next node. For this example,
-    let's assume that our agent state looks something like this.
+    let's assume that the state our agent should be using, can be described like this:
+    ```python title="agent-py/sample_agent/agent.py"
+    from copilotkit import CopilotKitState
+    from typing import Literal
 
-    <Tabs groupId="language" items={["Python", "TypeScript"]}>
-      <Tab value="Python">
-        ```python title="agent-py/sample_agent/agent.py"
-        from copilotkit import CopilotKitState
-        from typing import Literal
-
-        class AgentState(CopilotKitState):
-            question: str
-            answer: str
-            resources: List[str]
-        ```
-      </Tab>
-      <Tab value="TypeScript">
-        ```ts title="agent-js/src/agent.ts"
-        import { Annotation } from "@langchain/langgraph";
-        import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
-
-        export const AgentStateAnnotation = Annotation.Root({
-            question: Annotation<string>,
-            answer: Annotation<string>,
-            resources: Annotation<string[]>,
-            ...CopilotKitStateAnnotation.spec,
-        });
-        export type AgentState = typeof AgentStateAnnotation.State;
-        ```
-      </Tab>
-    </Tabs>
+    class AgentState(CopilotKitState):
+        question: str
+        answer: str
+        resources: List[str]
+    ```
   </Step>
   <Step>
     ### Divide state to Input and Output
@@ -59,71 +44,31 @@ In addition, some state properties contain a lot of information. Syncing them ba
       - The answer is what the LLM returns
       - The resources list will be used by the LLM to answer the question, and should not be communicated to the user, or set by them.
 
-      <Tabs groupId="language" items={["Python", "TypeScript"]}>
-          <Tab value="Python">
-              ```python title="agent-py/sample_agent/agent.py"
-              from copilotkit import CopilotKitState
-              from typing import Literal
+      ```python title="agent-py/sample_agent/agent.py"
+      from copilotkit import CopilotKitState
+      from typing import Literal
 
-              # divide the state into 3
-              class InputState(CopilotKitState):
-                question: str
+      # divide the state into 3
+      class InputState(CopilotKitState):
+        question: str
 
-              class OutputState(CopilotKitState):
-                answer: str
+      class OutputState(CopilotKitState):
+        answer: str
 
-              class OverallState(InputState, OutputState):
-                resources: List[str]
+      class OverallState(InputState, OutputState):
+        resources: List[str]
 
-              # ...add the rest of the agent implementation
+      # ...add the rest of the agent implementation
 
-              # finally, before compiling the graph, we define the 3 state components
-              builder = StateGraph(OverallState, input=InputState, output=OutputState)
+      # finally, before compiling the graph, we define the 3 state components
+      builder = StateGraph(OverallState, input=InputState, output=OutputState)
 
-              # add all the different nodes and edges and compile the graph
-              builder.add_node(answer_node)
-              builder.add_edge(START, "answer_node")
-              builder.add_edge("answer_node", END)
-              graph = builder.compile()
-              ```
-          </Tab>
-          <Tab value="TypeScript">
-              ```ts title="agent-js/src/agent.ts"
-              import { Annotation } from "@langchain/langgraph";
-              import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
-
-              // Divide the state into 3 different parts
-              export const InputAnnotation = Annotation.Root({
-                question: Annotation<string>,
-                ...CopilotKitStateAnnotation.spec,
-              });
-
-              export const OutputAnnotation = Annotation.Root({
-                answer: Annotation<string>,
-                ...CopilotKitStateAnnotation.spec,
-              });
-
-              export const AgentStateAnnotation = Annotation.Root({
-                resources: Annotation<string[]>,
-                ...InputAnnotation.spec,
-                ...OutputAnnotation.spec,
-              });
-
-              // ...add the rest of the agent implementation
-
-              // finally, before compiling the graph, we define the 3 state components
-              const graph = new StateGraph({
-                  stateSchema: AgentStateAnnotation,
-                  input: InputAnnotation,
-                  output: OutputAnnotation,
-              })
-              // add all the different nodes and edges and compile the graph
-              .addNode("answerNode", answerNode)
-              .addEdge("__start__", "answerNode")
-              .compile();
-              ```
-          </Tab>
-      </Tabs>
+      # add all the different nodes and edges and compile the graph
+      builder.add_node(answer_node)
+      builder.add_edge(START, "answer_node")
+      builder.add_edge("answer_node", END)
+      graph = builder.compile()
+      ```
   </Step>
   <Step>
     ### Give it a try!

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -2,7 +2,7 @@
 
 import uuid
 import json
-from typing import Optional, List, Callable, Any, cast, Union, TypedDict
+from typing import Optional, List, Callable, Any, cast, Union, TypedDict, Literal
 from typing_extensions import NotRequired
 
 from langgraph.graph.graph import CompiledGraph
@@ -191,6 +191,7 @@ class LangGraphAgent(Agent):
             active: bool,
             include_messages: bool = False
         ):
+        # First handle messages as before
         if not include_messages:
             state = {
                 k: v for k, v in state.items() if k != "messages"
@@ -200,6 +201,9 @@ class LangGraphAgent(Agent):
                 **state,
                 "messages": langchain_messages_to_copilotkit(state.get("messages", []))
             }
+
+        # Filter by schema keys if available
+        state = self.filter_state_on_schema_keys(state, 'output')
 
         return langchain_dumps({
             "event": "on_copilotkit_state_sync",
@@ -292,6 +296,12 @@ class LangGraphAgent(Agent):
         # Use provided input or fallback to initial_state
         stream_input = resume_input if resume_input else initial_state
 
+        # Get the output and input schema keys the user has allowed for this graph
+        input_keys, output_keys = self.get_schema_keys(config)
+        self.output_schema_keys = output_keys
+        self.input_schema_keys = input_keys
+
+        stream_input = self.filter_state_on_schema_keys(stream_input, 'input')
         async for event in self.graph.astream_events(stream_input, config, version="v2"):
             current_node_name = event.get("name")
             event_type = event.get("event")
@@ -456,6 +466,40 @@ class LangGraphAgent(Agent):
             **super_repr,
             'type': 'langgraph'
         }
+
+    def get_schema_keys(self, config):
+        CONSTANT_KEYS = ['copilotkit', 'messages']
+        try:
+            graph = self.graph.get_graph(config)
+            end_node = graph.nodes["__end__"]
+            start_node = graph.nodes["__start__"]
+            input_schema = start_node.data.schema()
+            output_schema = end_node.data.schema()
+            input_schema_keys = list(input_schema["properties"].keys())
+            output_schema_keys = list(output_schema["properties"].keys())
+
+            # We add "copilotkit" and "messages" as they are always sent and received.
+            for key in CONSTANT_KEYS:
+                if key not in input_schema_keys:
+                    input_schema_keys.append(key)
+                if key not in output_schema_keys:
+                    output_schema_keys.append(key)
+
+            return input_schema_keys, output_schema_keys
+        except Exception:
+            return None
+
+    def filter_state_on_schema_keys(self, state, schema_type: Literal["input", "output"]):
+        try:
+            schema_keys_name = f"{schema_type}_schema_keys"
+            if hasattr(self, schema_keys_name) and getattr(self, schema_keys_name):
+                return {
+                    k: v for k, v in state.items()
+                    if k in getattr(self, schema_keys_name) or k == "messages"
+                }
+        except Exception:
+            return state
+
 
 class _StreamingStateExtractor:
     def __init__(self, emit_intermediate_state: List[dict]):


### PR DESCRIPTION
This PR bring support for [input and output schema by langgraph](https://langchain-ai.github.io/langgraph/how-tos/input_output_schema/).
It does so by breaking down the possible state schema keys of start and end nodes, and only allowing the keys in these schemas in the state emitted.
This is because in general, streaming does not support this feature out of the box (while "invoke" does)