### PR TITLE
fix: rebuild Python with SQLite 3.45.0 for ChromaDB compatibility

### DIFF
--- a/examples/Dockerfile.agent-python
+++ b/examples/Dockerfile.agent-python
@@ -1,47 +1,10 @@
-FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye AS builder
-
-# Install build dependencies and SQLite first
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    wget \
-    libffi-dev \
-    zlib1g-dev \
-    libssl-dev \
-    libbz2-dev \
-    liblzma-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install new SQLite
-WORKDIR /tmp
-RUN wget https://www.sqlite.org/2024/sqlite-autoconf-3450000.tar.gz \
-    && tar xvfz sqlite-autoconf-3450000.tar.gz \
-    && cd sqlite-autoconf-3450000 \
-    && ./configure --prefix=/usr/local \
-    && make \
-    && make install \
-    && cd .. \
-    && rm -rf sqlite-autoconf-3450000*
-
-# Download and build Python with new SQLite
-RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
-    && tar xzf Python-3.12.0.tgz \
-    && cd Python-3.12.0 \
-    && ./configure --enable-optimizations --with-system-sqlite3 --prefix=/usr/local \
-    && make -j$(nproc) \
-    && make install \
-    && cd .. \
-    && rm -rf Python-3.12.0*
-
-# Final stage
-FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
+FROM public.ecr.aws/docker/library/python:3.12-bookworm
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.8.4 /lambda-adapter /opt/extensions/lambda-adapter
-COPY --from=builder /usr/local /usr/local
 
 ARG APP_DIR
 ARG WITH_LOCAL_DEPS
 
 ENV POETRY_VIRTUALENVS_CREATE=false
-ENV LD_LIBRARY_PATH=/usr/local/lib
 
 # Install poetry and configure it
 RUN pip install poetry==1.7.1 && \

--- a/examples/Dockerfile.agent-python
+++ b/examples/Dockerfile.agent-python
@@ -1,23 +1,44 @@
-FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.8.4 /lambda-adapter /opt/extensions/lambda-adapter
-ARG APP_DIR
-ARG WITH_LOCAL_DEPS
+FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye as builder
 
-ENV POETRY_VIRTUALENVS_CREATE=false
-
-# Install system dependencies including newer sqlite3
+# Install build dependencies and SQLite first
 RUN apt-get update && apt-get install -y \
     build-essential \
     wget \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget https://www.sqlite.org/2024/sqlite-autoconf-3450000.tar.gz \
+    libffi-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install new SQLite
+WORKDIR /tmp
+RUN wget https://www.sqlite.org/2024/sqlite-autoconf-3450000.tar.gz \
     && tar xvfz sqlite-autoconf-3450000.tar.gz \
     && cd sqlite-autoconf-3450000 \
-    && ./configure \
+    && ./configure --prefix=/usr/local \
     && make \
     && make install \
     && cd .. \
     && rm -rf sqlite-autoconf-3450000*
+
+# Download and build Python with new SQLite
+RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
+    && tar xzf Python-3.12.0.tgz \
+    && cd Python-3.12.0 \
+    && ./configure --enable-optimizations --with-system-sqlite3 \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf Python-3.12.0*
+
+# Final stage
+FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.8.4 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=builder /usr/local /usr/local
+
+ARG APP_DIR
+ARG WITH_LOCAL_DEPS
+
+ENV POETRY_VIRTUALENVS_CREATE=false
+ENV LD_LIBRARY_PATH=/usr/local/lib
 
 # Install poetry and configure it
 RUN pip install poetry==1.7.1 && \
@@ -26,7 +47,7 @@ RUN pip install poetry==1.7.1 && \
 # Copy only poetry files first
 COPY ${APP_DIR}/pyproject.toml ${APP_DIR}/poetry.lock ./
 
-# Copy SDK and install dependencies in a single layer
+# Copy SDK and install dependencies
 COPY sdk-python/ /opt/sdk-python
 WORKDIR /asset
 RUN poetry install --no-interaction --no-ansi

--- a/examples/Dockerfile.agent-python
+++ b/examples/Dockerfile.agent-python
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye as builder
+FROM public.ecr.aws/docker/library/python:3.12.0-slim-bullseye AS builder
 
 # Install build dependencies and SQLite first
 RUN apt-get update && apt-get install -y \
@@ -6,6 +6,9 @@ RUN apt-get update && apt-get install -y \
     wget \
     libffi-dev \
     zlib1g-dev \
+    libssl-dev \
+    libbz2-dev \
+    liblzma-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install new SQLite
@@ -23,7 +26,7 @@ RUN wget https://www.sqlite.org/2024/sqlite-autoconf-3450000.tar.gz \
 RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
     && tar xzf Python-3.12.0.tgz \
     && cd Python-3.12.0 \
-    && ./configure --enable-optimizations --with-system-sqlite3 \
+    && ./configure --enable-optimizations --with-system-sqlite3 --prefix=/usr/local \
     && make -j$(nproc) \
     && make install \
     && cd .. \


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Add multi-stage build to compile SQLite 3.45.0 from source
- Rebuild Python 3.12 against new SQLite with --with-system-sqlite3
- Set LD_LIBRARY_PATH to ensure proper library loading
- Fix ChromaDB initialization error requiring SQLite >= 3.35.0


## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation