### PR TITLE
fix: use memoization in useCoAgent internal functions

### DIFF
--- a/CopilotKit/.changeset/heavy-owls-relax.md
+++ b/CopilotKit/.changeset/heavy-owls-relax.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+- fix: use memoization in useCoAgent internal functions


### PR DESCRIPTION
This PR internally improves the stability and predictability of functions that depends on state or a bound-to-change variables inside the `useCoAgent` implementation