### PR TITLE
fix(runtime): fix execution of runtime set backend action handlers

### DIFF
--- a/CopilotKit/.changeset/large-flowers-double.md
+++ b/CopilotKit/.changeset/large-flowers-double.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix(runtime): fix execution of runtime set backend action handlers

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -572,7 +572,7 @@ please use an LLM adapter instead.`,
         threadId,
         runId: undefined,
         eventSource,
-        serverSideActions: [],
+        serverSideActions,
         actionInputsWithoutAgents: allAvailableActions,
       };
     } catch (error) {


### PR DESCRIPTION
When setting a backend action in runtime setup (on route.ts for example), and when this action is passed to an agent (as opposed to none CoAgent flow), the action handler would in fact not run.
This PR fixes this issue