### PR TITLE
Revert "fix(runtime): fix execution of runtime set backend action handlers"

### DIFF
--- a/CopilotKit/.changeset/large-flowers-double.md
+++ b/CopilotKit/.changeset/large-flowers-double.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-- fix(runtime): fix execution of runtime set backend action handlers

--- a/CopilotKit/.changeset/thick-schools-pump.md
+++ b/CopilotKit/.changeset/thick-schools-pump.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- Revert "fix(runtime): fix execution of runtime set backend action handlers"

--- a/CopilotKit/packages/runtime/src/agents/langgraph/event-source.ts
+++ b/CopilotKit/packages/runtime/src/agents/langgraph/event-source.ts
@@ -87,20 +87,11 @@ export class RemoteLangGraphEventSource {
             acc.lastMessageId = this.getCurrentMessageId(event) ?? acc.lastMessageId;
             const toolCallChunks = this.getCurrentToolCallChunks(event) ?? [];
             const responseMetadata = this.getResponseMetadata(event);
-            // Check if a given event is a tool call
-            const toolCallCheck = toolCallChunks && toolCallChunks.length > 0;
-            let isToolCallEnd = responseMetadata?.finish_reason === "tool_calls";
 
             acc.isToolCallStart = toolCallChunks.some((chunk: any) => chunk.name && chunk.id);
             acc.isMessageStart = prevMessageId !== acc.lastMessageId && !acc.isToolCallStart;
-
-            // Previous "acc.isToolCall" was set but now it won't pass the check, it means the tool call just ended.
-            if (acc.isToolCall && !toolCallCheck) {
-              isToolCallEnd = true;
-            }
-
-            acc.isToolCall = toolCallCheck;
-            acc.isToolCallEnd = isToolCallEnd;
+            acc.isToolCall = toolCallChunks && toolCallChunks.length > 0;
+            acc.isToolCallEnd = responseMetadata?.finish_reason === "tool_calls";
             acc.isMessageEnd = responseMetadata?.finish_reason === "stop";
             ({ name: acc.lastToolCallName, id: acc.lastToolCallId } = toolCallChunks.find(
               (chunk: any) => chunk.name && chunk.id,
@@ -157,7 +148,7 @@ export class RemoteLangGraphEventSource {
 
         // Tool call ended: emit ActionExecutionEnd
         if (
-          acc.isToolCallEnd &&
+          responseMetadata?.finish_reason === "tool_calls" &&
           this.shouldEmitToolCall(shouldEmitToolCalls, acc.lastToolCallName)
         ) {
           events.push({
@@ -167,7 +158,7 @@ export class RemoteLangGraphEventSource {
         }
 
         // Message ended: emit TextMessageEnd
-        else if (responseMetadata?.finish_reason === "stop" && shouldEmitMessages) {
+        if (responseMetadata?.finish_reason === "stop" && shouldEmitMessages) {
           events.push({
             type: RuntimeEventTypes.TextMessageEnd,
             messageId: acc.lastMessageId,

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -572,7 +572,7 @@ please use an LLM adapter instead.`,
         threadId,
         runId: undefined,
         eventSource,
-        serverSideActions,
+        serverSideActions: [],
         actionInputsWithoutAgents: allAvailableActions,
       };
     } catch (error) {


### PR DESCRIPTION
Reverts CopilotKit/CopilotKit#1412

We aim to remove the runtime set backend action for agents. This is because tools for agents should be set on the agent framework side.