### PR TITLE
fix: disable runtime actions on agent

### DIFF
--- a/CopilotKit/.changeset/chilled-hairs-wait.md
+++ b/CopilotKit/.changeset/chilled-hairs-wait.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: refrain from processing same tool end several times
+- fix: do not register runtime set action when there are remote endpoints

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -153,7 +153,7 @@ export interface CopilotRuntimeConstructorParams<T extends Parameter[] | [] = []
   middleware?: Middleware;
 
   /*
-   * A list of server side actions that can be executed.
+   * A list of server side actions that can be executed. Will be ignored when remoteActions are set
    */
   actions?: ActionsConfiguration<T>;
 
@@ -190,7 +190,13 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
   private delegateAgentProcessingToServiceAdapter: boolean;
 
   constructor(params?: CopilotRuntimeConstructorParams<T>) {
-    this.actions = params?.actions || [];
+    // Do not register actions if endpoints are set
+    if (params?.actions && params?.remoteEndpoints) {
+      console.warn('Actions set in runtime instance will be ignored when remote endpoints are set')
+      this.actions = []
+    } else {
+      this.actions = params?.actions || [];
+    }
 
     for (const chain of params?.langserve || []) {
       const remoteChain = new RemoteChain(chain);

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -192,8 +192,8 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
   constructor(params?: CopilotRuntimeConstructorParams<T>) {
     // Do not register actions if endpoints are set
     if (params?.actions && params?.remoteEndpoints) {
-      console.warn('Actions set in runtime instance will be ignored when remote endpoints are set')
-      this.actions = []
+      console.warn("Actions set in runtime instance will be ignored when remote endpoints are set");
+      this.actions = [];
     } else {
       this.actions = params?.actions || [];
     }

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -48,7 +48,7 @@ Middleware to be used by the runtime.
 </PropertyReference>
 
 <PropertyReference name="actions" type="ActionsConfiguration<T>"  > 
-A list of server side actions that can be executed.
+A list of server side actions that can be executed. Will be ignored when remoteActions are set
 </PropertyReference>
 
 <PropertyReference name="remoteActions" type="CopilotKitEndpoint[]"  > 


### PR DESCRIPTION
Disabling the actions that are set as BE actions when creating a new runtime instance, if there are agents.
This is because agents have their own tools 