### PR TITLE
docs(customize-ui): add sub-components section

### DIFF
--- a/docs/content/docs/(root)/guides/custom-look-and-feel/bring-your-own-components.mdx
+++ b/docs/content/docs/(root)/guides/custom-look-and-feel/bring-your-own-components.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Components
+title: Custom Sub-Components
 icon: "lucide/Puzzle"
 ---
 import { ImageAndCode } from "@/components/react/image-and-code"

--- a/docs/content/docs/(root)/guides/custom-look-and-feel/customize-built-in-ui-components.mdx
+++ b/docs/content/docs/(root)/guides/custom-look-and-feel/customize-built-in-ui-components.mdx
@@ -9,6 +9,9 @@ CopilotKit has a variety of ways to customize colors and structures of the Copil
 - [Custom CSS](#custom-css)
 - [Custom Icons](#custom-icons)
 - [Custom Labels](#custom-labels)
+
+If you want to customize the style as well as the functionality of the Copilot UI, you can also try the following:
+- [Custom Sub-Components](/guides/custom-look-and-feel/bring-your-own-components)
 - [Fully Headless UI](/guides/custom-look-and-feel/headless-ui)
 
 ## CSS Variables (Easiest)


### PR DESCRIPTION
## What does this PR do?
Updating the Custom Components section to be Custom Sub-components instead

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation