### PR TITLE
chore: set post release changeset values

### DIFF
--- a/CopilotKit/.changeset/calm-carpets-peel.md
+++ b/CopilotKit/.changeset/calm-carpets-peel.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/runtime": minor
----
-
-- feat: support input and output schema of langgraph
-- docs: add input output schema docs

--- a/CopilotKit/.changeset/chilled-hairs-wait.md
+++ b/CopilotKit/.changeset/chilled-hairs-wait.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-- fix: refrain from processing same tool end several times
-- fix: do not register runtime set action when there are remote endpoints

--- a/CopilotKit/.changeset/chilly-rats-bow.md
+++ b/CopilotKit/.changeset/chilly-rats-bow.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/react-core": patch
-"@copilotkit/runtime-client-gql": patch
----
-
-- fix: provide the ability to type interrupt event value

--- a/CopilotKit/.changeset/dirty-scissors-wash.md
+++ b/CopilotKit/.changeset/dirty-scissors-wash.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/runtime": patch
-"@copilotkit/shared": patch
----
-
-- fix: use tryMap method to filter out possibly invalid items

--- a/CopilotKit/.changeset/fair-papayas-breathe.md
+++ b/CopilotKit/.changeset/fair-papayas-breathe.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-- fix(coagents): don't fail when LangSmith API key is missing
-- fix(coagents): don't check for langsmithApiKey in resolveEndpointType

--- a/CopilotKit/.changeset/healthy-foxes-serve.md
+++ b/CopilotKit/.changeset/healthy-foxes-serve.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-- fix: add class validator to dependencies

--- a/CopilotKit/.changeset/heavy-owls-relax.md
+++ b/CopilotKit/.changeset/heavy-owls-relax.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/react-core": patch
----
-
-- fix: use memoization in useCoAgent internal functions

--- a/CopilotKit/.changeset/hot-turtles-fold.md
+++ b/CopilotKit/.changeset/hot-turtles-fold.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/react-core": patch
----
-
-- feat(actions): enable restricting actions to frontend only

--- a/CopilotKit/.changeset/large-flowers-double.md
+++ b/CopilotKit/.changeset/large-flowers-double.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-- fix(runtime): fix execution of runtime set backend action handlers

--- a/CopilotKit/.changeset/polite-falcons-melt.md
+++ b/CopilotKit/.changeset/polite-falcons-melt.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/react-core": minor
-"@copilotkit/runtime": minor
----
-
-- feat(configurable): execute langgraph with user config

--- a/CopilotKit/.changeset/pre.json
+++ b/CopilotKit/.changeset/pre.json
@@ -1,37 +1,21 @@
 {
-  "mode": "exit",
+  "mode": "pre",
   "tag": "next",
   "initialVersions": {
     "next-openai": "1.4.6",
     "next-pages-router": "1.4.6",
     "node-express": "1.4.6",
     "node-http": "1.4.6",
-    "@copilotkit/react-core": "1.5.20",
-    "@copilotkit/react-textarea": "1.5.20",
-    "@copilotkit/react-ui": "1.5.20",
-    "@copilotkit/runtime": "1.5.20",
-    "@copilotkit/runtime-client-gql": "1.5.20",
-    "@copilotkit/sdk-js": "1.5.20",
-    "@copilotkit/shared": "1.5.20",
+    "@copilotkit/react-core": "1.6.0",
+    "@copilotkit/react-textarea": "1.6.0",
+    "@copilotkit/react-ui": "1.6.0",
+    "@copilotkit/runtime": "1.6.0",
+    "@copilotkit/runtime-client-gql": "1.6.0",
+    "@copilotkit/sdk-js": "1.6.0",
+    "@copilotkit/shared": "1.6.0",
     "eslint-config-custom": "1.4.6",
     "tailwind-config": "1.4.6",
-    "tsconfig": "1.4.6",
-    "state-machine": "0.1.0"
+    "tsconfig": "1.4.6"
   },
-  "changesets": [
-    "calm-carpets-peel",
-    "chilled-hairs-wait",
-    "chilly-rats-bow",
-    "dirty-scissors-wash",
-    "fair-papayas-breathe",
-    "healthy-foxes-serve",
-    "heavy-owls-relax",
-    "hot-turtles-fold",
-    "large-flowers-double",
-    "polite-falcons-melt",
-    "proud-dingos-poke",
-    "sharp-bikes-develop",
-    "ten-mangos-sort",
-    "tiny-donkeys-speak"
-  ]
+  "changesets": []
 }

--- a/CopilotKit/.changeset/proud-dingos-poke.md
+++ b/CopilotKit/.changeset/proud-dingos-poke.md
@@ -1,7 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-- feat: support latest openai api
-- chore: update all openai dependencies to use latest
-- feat: update adapters using openai API

--- a/CopilotKit/.changeset/sharp-bikes-develop.md
+++ b/CopilotKit/.changeset/sharp-bikes-develop.md
@@ -1,8 +1,0 @@
----
-"@copilotkit/react-core": patch
----
-
-- fix: simplify condition options for langgraph interrupts
-- chore: add new enabled to e2e tests
-- fix: refine argument types
-- chore: document hook API reference

--- a/CopilotKit/.changeset/ten-mangos-sort.md
+++ b/CopilotKit/.changeset/ten-mangos-sort.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/react-core": patch
-"@copilotkit/react-ui": patch
----
-
-- feat: new useCopilotAdditionalInstructions hook and available property on useCopilotReadable

--- a/CopilotKit/.changeset/tiny-donkeys-speak.md
+++ b/CopilotKit/.changeset/tiny-donkeys-speak.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-- handle parsing in fail-safe fashion

--- a/CopilotKit/packages/react-core/CHANGELOG.md
+++ b/CopilotKit/packages/react-core/CHANGELOG.md
@@ -1,5 +1,26 @@
 # ui
 
+## 1.6.0
+
+### Minor Changes
+
+- 7d061d9: - feat(configurable): execute langgraph with user config
+
+### Patch Changes
+
+- d833f4c: - fix: provide the ability to type interrupt event value
+- d800f03: - fix: use memoization in useCoAgent internal functions
+- 85753b3: - feat(actions): enable restricting actions to frontend only
+- b454827: - fix: simplify condition options for langgraph interrupts
+  - chore: add new enabled to e2e tests
+  - fix: refine argument types
+  - chore: document hook API reference
+- c1cc77f: - feat: new useCopilotAdditionalInstructions hook and available property on useCopilotReadable
+- Updated dependencies [d833f4c]
+- Updated dependencies [090203d]
+  - @copilotkit/runtime-client-gql@1.6.0
+  - @copilotkit/shared@1.6.0
+
 ## 1.6.0-next.12
 
 ### Patch Changes

--- a/CopilotKit/packages/react-core/package.json
+++ b/CopilotKit/packages/react-core/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-next.12",
+  "version": "1.6.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/react-textarea/CHANGELOG.md
+++ b/CopilotKit/packages/react-textarea/CHANGELOG.md
@@ -1,5 +1,20 @@
 # ui
 
+## 1.6.0
+
+### Patch Changes
+
+- Updated dependencies [d833f4c]
+- Updated dependencies [090203d]
+- Updated dependencies [d800f03]
+- Updated dependencies [85753b3]
+- Updated dependencies [7d061d9]
+- Updated dependencies [b454827]
+- Updated dependencies [c1cc77f]
+  - @copilotkit/react-core@1.6.0
+  - @copilotkit/runtime-client-gql@1.6.0
+  - @copilotkit/shared@1.6.0
+
 ## 1.6.0-next.12
 
 ### Patch Changes

--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-next.12",
+  "version": "1.6.0",
   "sideEffects": [
     "**/*.css"
   ],

--- a/CopilotKit/packages/react-ui/CHANGELOG.md
+++ b/CopilotKit/packages/react-ui/CHANGELOG.md
@@ -1,5 +1,21 @@
 # ui
 
+## 1.6.0
+
+### Patch Changes
+
+- c1cc77f: - feat: new useCopilotAdditionalInstructions hook and available property on useCopilotReadable
+- Updated dependencies [d833f4c]
+- Updated dependencies [090203d]
+- Updated dependencies [d800f03]
+- Updated dependencies [85753b3]
+- Updated dependencies [7d061d9]
+- Updated dependencies [b454827]
+- Updated dependencies [c1cc77f]
+  - @copilotkit/react-core@1.6.0
+  - @copilotkit/runtime-client-gql@1.6.0
+  - @copilotkit/shared@1.6.0
+
 ## 1.6.0-next.12
 
 ### Patch Changes

--- a/CopilotKit/packages/react-ui/package.json
+++ b/CopilotKit/packages/react-ui/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-next.12",
+  "version": "1.6.0",
   "sideEffects": [
     "**/*.css"
   ],

--- a/CopilotKit/packages/runtime-client-gql/CHANGELOG.md
+++ b/CopilotKit/packages/runtime-client-gql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @copilotkit/runtime-client-gql
 
+## 1.6.0
+
+### Patch Changes
+
+- d833f4c: - fix: provide the ability to type interrupt event value
+- Updated dependencies [090203d]
+  - @copilotkit/shared@1.6.0
+
 ## 1.6.0-next.12
 
 ### Patch Changes

--- a/CopilotKit/packages/runtime-client-gql/package.json
+++ b/CopilotKit/packages/runtime-client-gql/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-next.12",
+  "version": "1.6.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/runtime/CHANGELOG.md
+++ b/CopilotKit/packages/runtime/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @copilotkit/runtime
 
+## 1.6.0
+
+### Minor Changes
+
+- fea916f: - feat: support input and output schema of langgraph
+  - docs: add input output schema docs
+- 7d061d9: - feat(configurable): execute langgraph with user config
+
+### Patch Changes
+
+- 543f703: - fix: refrain from processing same tool end several times
+  - fix: do not register runtime set action when there are remote endpoints
+- 090203d: - fix: use tryMap method to filter out possibly invalid items
+- 1bb9ca2: - fix(coagents): don't fail when LangSmith API key is missing
+  - fix(coagents): don't check for langsmithApiKey in resolveEndpointType
+- 4ddb6d2: - fix: add class validator to dependencies
+- d07f49c: - fix(runtime): fix execution of runtime set backend action handlers
+- 45a3e10: - feat: support latest openai api
+  - chore: update all openai dependencies to use latest
+  - feat: update adapters using openai API
+- 68f7b65: - handle parsing in fail-safe fashion
+- Updated dependencies [090203d]
+  - @copilotkit/shared@1.6.0
+
 ## 1.6.0-next.12
 
 ### Patch Changes

--- a/CopilotKit/packages/runtime/package.json
+++ b/CopilotKit/packages/runtime/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-next.12",
+  "version": "1.6.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/sdk-js/CHANGELOG.md
+++ b/CopilotKit/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @copilotkit/sdk-js
 
+## 1.6.0
+
+### Patch Changes
+
+- Updated dependencies [090203d]
+  - @copilotkit/shared@1.6.0
+
 ## 1.6.0-next.12
 
 ### Patch Changes

--- a/CopilotKit/packages/sdk-js/package.json
+++ b/CopilotKit/packages/sdk-js/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-next.12",
+  "version": "1.6.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/CopilotKit/packages/shared/CHANGELOG.md
+++ b/CopilotKit/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @copilotkit/shared
 
+## 1.6.0
+
+### Patch Changes
+
+- 090203d: - fix: use tryMap method to filter out possibly invalid items
+
 ## 1.6.0-next.12
 
 ## 1.6.0-next.11

--- a/CopilotKit/packages/shared/package.json
+++ b/CopilotKit/packages/shared/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.6.0-next.12",
+  "version": "1.6.0",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Release workflow failed on cleanup/restoration step after releasing a new NPM version. This PR sets everything manually