### PR TITLE
Added dotenv Imports in node-express and node-http

### DIFF
--- a/CopilotKit/examples/node-express/package.json
+++ b/CopilotKit/examples/node-express/package.json
@@ -10,7 +10,8 @@
     "@copilotkit/runtime": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "express": "^4.19.2",
-    "openai": "^4.85.1"
+    "openai": "^4.85.1",
+    "dotenv": "^16.4.7",
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/CopilotKit/examples/node-express/src/index.ts
+++ b/CopilotKit/examples/node-express/src/index.ts
@@ -1,4 +1,6 @@
 import express from "express";
+import * as dotenv from 'dotenv';
+dotenv.config();
 import { CopilotRuntime, OpenAIAdapter, copilotRuntimeNodeHttpEndpoint } from "@copilotkit/runtime";
 import OpenAI from "openai";
 

--- a/CopilotKit/examples/node-http/package.json
+++ b/CopilotKit/examples/node-http/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@copilotkit/runtime": "workspace:*",
     "@copilotkit/shared": "workspace:*",
-    "openai": "^4.85.1"
+    "openai": "^4.85.1",
+     "dotenv": "^16.4.7"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/CopilotKit/examples/node-http/src/index.ts
+++ b/CopilotKit/examples/node-http/src/index.ts
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
 import { CopilotRuntime, OpenAIAdapter, copilotRuntimeNodeHttpEndpoint } from "@copilotkit/runtime";
 import OpenAI from "openai";
+import * as dotenv from 'dotenv';
+dotenv.config();
 
 const openai = new OpenAI();
 const serviceAdapter = new OpenAIAdapter({ openai });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate your spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When the express server and node HTTP server are used as runtime when using environment variables. It fails to get the environment variables from the .env files, so for that, I added the import for the dotenv package, configured it, and added dotenv in the package.json file for both  node-express and  Node-HTTP

# Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation