### PR TITLE
fixes docs generation 

### DIFF
--- a/CopilotKit/scripts/docs/lib/files.ts
+++ b/CopilotKit/scripts/docs/lib/files.ts
@@ -145,20 +145,6 @@ export const REFERENCE_DOCS: ReferenceDocConfiguration[] = [
       "copilotkit_emit_tool_call",
     ],
   },
-  {
-    sourcePath: "../sdk-python/copilotkit/crewai.py",
-    destinationPath: "docs/content/docs/reference/sdk/python/CrewAI.mdx",
-    title: "CrewAI SDK",
-    description:
-      "The CopilotKit CrewAI SDK for Python allows you to build and run CrewAI agents with CopilotKit.",
-    pythonSymbols: [
-      "copilotkit_emit_state",
-      "copilotkit_predict_state",
-      "copilotkit_exit",
-      "copilotkit_emit_message",
-      "copilotkit_emit_tool_call",
-    ],
-  },
 
   /* Agents */
   {

--- a/CopilotKit/scripts/docs/lib/files.ts
+++ b/CopilotKit/scripts/docs/lib/files.ts
@@ -145,6 +145,20 @@ export const REFERENCE_DOCS: ReferenceDocConfiguration[] = [
       "copilotkit_emit_tool_call",
     ],
   },
+  {
+    sourcePath: "../sdk-python/copilotkit/crewai/crewai_sdk.py",
+    destinationPath: "docs/content/docs/reference/sdk/python/CrewAI.mdx",
+    title: "CrewAI SDK",
+    description:
+      "The CopilotKit CrewAI SDK for Python allows you to build and run CrewAI agents with CopilotKit.",
+    pythonSymbols: [
+      "copilotkit_emit_state",
+      "copilotkit_predict_state",
+      "copilotkit_exit",
+      "copilotkit_emit_message",
+      "copilotkit_emit_tool_call",
+    ],
+  },
 
   /* Agents */
   {
@@ -155,7 +169,7 @@ export const REFERENCE_DOCS: ReferenceDocConfiguration[] = [
     pythonSymbols: ["LangGraphAgent", "CopilotKitConfig"],
   },
   {
-    sourcePath: "../sdk-python/copilotkit/crewai_agent.py",
+    sourcePath: "../sdk-python/copilotkit/crewai/crewai_agent.py",
     destinationPath: "docs/content/docs/reference/sdk/python/CrewAIAgent.mdx",
     title: "CrewAIAgent",
     description: "CrewAIAgent lets you define your agent for use with CopilotKit.",

--- a/docs/content/docs/reference/sdk/python/CrewAI.mdx
+++ b/docs/content/docs/reference/sdk/python/CrewAI.mdx
@@ -7,7 +7,7 @@ description: "The CopilotKit CrewAI SDK for Python allows you to build and run C
  /*
   * ATTENTION! DO NOT MODIFY THIS FILE!
   * This page is auto-generated. If you want to make any changes to this page, changes must be made at:
-  * CopilotKit/../sdk-python/copilotkit/crewai.py
+  * CopilotKit/../sdk-python/copilotkit/crewai/crewai_sdk.py
   */
 }
 ## copilotkit_predict_state

--- a/docs/content/docs/reference/sdk/python/CrewAIAgent.mdx
+++ b/docs/content/docs/reference/sdk/python/CrewAIAgent.mdx
@@ -7,7 +7,7 @@ description: "CrewAIAgent lets you define your agent for use with CopilotKit."
  /*
   * ATTENTION! DO NOT MODIFY THIS FILE!
   * This page is auto-generated. If you want to make any changes to this page, changes must be made at:
-  * CopilotKit/../sdk-python/copilotkit/crewai_agent.py
+  * CopilotKit/../sdk-python/copilotkit/crewai/crewai_agent.py
   */
 }
 ## CrewAIAgent
@@ -17,7 +17,7 @@ CrewAIAgent lets you define your agent for use with CopilotKit.
     To install, run:
 
     ```bash
-    pip install copilotkit
+    pip install copilotkit[crewai]
     ```
 
     Every agent must have the `name` and either `crew` or `flow` properties defined. An optional 


### PR DESCRIPTION
## What does this PR do?
- Fix documentation generation for CrewAI SDK and agent files. The docs generator was failing during commits because it was looking for Python files in incorrect locations. This PR:
Updates the path for crewai_agent.py to point to its correct location in the crewai subdirectory
- Adds a configuration entry for crewai_sdk.py to document the CrewAI SDK functions
These changes prevent the "ENOENT: no such file or directory" errors that were occurring during pre-commit hooks when running the documentation generator.

## Related PRs and Issues
N/A

## Checklist

- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation