### PR TITLE
Revert "use `parseJson` util to safely parse"

### DIFF
--- a/CopilotKit/packages/runtime-client-gql/src/client/conversion.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/conversion.ts
@@ -207,7 +207,7 @@ function getPartialArguments(args: string[]) {
   try {
     if (!args.length) return {};
 
-    return parseJson(untruncateJson(args.join("")));
+    return JSON.parse(untruncateJson(args.join("")));
   } catch (e) {
     console.error(e);
     return {};


### PR DESCRIPTION
revert PR that accidentally got into main