### PR TITLE
fix: re-enable runtime actions when remote endpoint is set

### DIFF
--- a/CopilotKit/.changeset/olive-brooms-switch.md
+++ b/CopilotKit/.changeset/olive-brooms-switch.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: re-enable runtime actions when remote endpoint is set

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -15,14 +15,14 @@
 import {
   Action,
   actionParametersToJsonSchema,
-  CopilotKitAgentDiscoveryError,
+  Parameter,
+  ResolvedCopilotKitError,
   CopilotKitApiDiscoveryError,
+  randomId,
   CopilotKitError,
   CopilotKitLowLevelError,
+  CopilotKitAgentDiscoveryError,
   CopilotKitMisuseError,
-  Parameter,
-  randomId,
-  ResolvedCopilotKitError,
 } from "@copilotkit/shared";
 import {
   CopilotServiceAdapter,
@@ -39,13 +39,13 @@ import { Message } from "../../graphql/types/converted";
 import { ForwardedParametersInput } from "../../graphql/inputs/forwarded-parameters.input";
 
 import {
-  CopilotKitEndpoint,
-  EndpointDefinition,
-  EndpointType,
   isRemoteAgentAction,
-  LangGraphPlatformEndpoint,
   RemoteAgentAction,
+  EndpointType,
   setupRemoteActions,
+  EndpointDefinition,
+  CopilotKitEndpoint,
+  LangGraphPlatformEndpoint,
 } from "./remote-actions";
 
 import { GraphQLContext } from "../integrations/shared";
@@ -63,9 +63,9 @@ import { langchainMessagesToCopilotKit } from "./remote-lg-action";
 import { MetaEventInput } from "../../graphql/inputs/meta-event.input";
 import {
   CopilotObservabilityConfig,
-  LLMErrorData,
   LLMRequestData,
   LLMResponseData,
+  LLMErrorData,
 } from "../observability";
 
 interface CopilotRuntimeRequest {

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -220,7 +220,11 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
   private observability?: CopilotObservabilityConfig;
 
   constructor(params?: CopilotRuntimeConstructorParams<T>) {
-    if (params?.actions && params?.remoteEndpoints && params?.remoteEndpoints.some(e => e.type === EndpointType.LangGraphPlatform)) {
+    if (
+      params?.actions &&
+      params?.remoteEndpoints &&
+      params?.remoteEndpoints.some((e) => e.type === EndpointType.LangGraphPlatform)
+    ) {
       console.warn("Actions set in runtime instance will not be available for the agent");
     }
     this.actions = params?.actions || [];


### PR DESCRIPTION
Putting back the runtime actions when remote endpoints are present.
