### PR TITLE
fix(docs): fixed broken links put as reference

### DIFF
--- a/docs/content/docs/(root)/guides/connect-your-data/backend.mdx
+++ b/docs/content/docs/(root)/guides/connect-your-data/backend.mdx
@@ -8,10 +8,10 @@ icon: "lucide/Server"
 CopilotKit allows you to define actions on the backend that can be called by your Copilot. Behind the scenes, this is securely binding
 the action as a tool to your LLM of choice. 
 
-When you ask the LLM decides to retrieve the data, it will do so by securely calling the backend action.
+When you ask the LLM to retrieve the data, it will do so by securely calling the backend action.
 
 <Callout type="info">
-  For more information about backend actions, see the [Backend Action](/docs/guides/backend-actions) guides.
+  For more information about backend actions, see the [Backend Action](/guides/backend-actions) guides.
 </Callout>
 
 ```tsx title="/api/copilotkit/route.ts"

--- a/docs/content/docs/(root)/tutorials/ai-todo-app/step-4-copilot-actions.mdx
+++ b/docs/content/docs/(root)/tutorials/ai-todo-app/step-4-copilot-actions.mdx
@@ -91,7 +91,7 @@ The `useCopilotAction` hook is a powerful hook that allows us to register action
 - `parameters` is an array of parameters that the action takes. It follows the [JSON Schema](https://json-schema.org/) format.
 - `handler` is a function that will be called when the action is triggered. It's even type safe!
 
-You can check out the full reference for the `useCopilotAction` hook [here](https://docs.copilotkit.com/reference/use-copilot-action).
+You can check out the full reference for the `useCopilotAction` hook [here](https://docs.copilotkit.ai/reference/hooks/useCopilotAction).
 
 ## Try it out!
 


### PR DESCRIPTION

## What does this PR do?

This PR introduces minor changes to two links provided in the documentation
1. on connecting your data to backend guide, backend actions link was incorrect
2. on todos app tutorial, for usecopilatactions further reference link was incorrect as well

Finally, a little grammar fix on connecting your data to backend was made as well.

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation