### PR TITLE
docs: add the reference for conditionals of lg interrupt hook

### DIFF
--- a/docs/content/docs/reference/hooks/useLangGraphInterrupt.mdx
+++ b/docs/content/docs/reference/hooks/useLangGraphInterrupt.mdx
@@ -58,6 +58,10 @@ const YourMainContent = () => {
     <PropertyReference name="render" type="(props: LangGraphInterruptRenderProps<T>) => string | React.ReactElement">
         Render lets you define a custom component or string to render when an Interrupt event is emitted.
     </PropertyReference>
+
+    <PropertyReference name="enabled" type="(args: { eventValue: TEventValue; agentMetadata: AgentSession }) => boolean">
+        Method that returns a boolean, indicating if the interrupt action should run. Useful when using multiple interrupts
+    </PropertyReference>
 </PropertyReference>
 
 <PropertyReference name="dependencies" type="any[]">


### PR DESCRIPTION
`useLangGraphInterrupt` takes an `enabled` argument which tells the hook if it should activate the passed action or not. It allows differentiating between multiple instances of this hook.

This PR adds the argument to the reference