### PR TITLE
fix(react-core): export missing action-related types for public API

### DIFF
--- a/CopilotKit/.changeset/fast-books-talk.md
+++ b/CopilotKit/.changeset/fast-books-talk.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+- fix(react-core): export missing action-related types for public API

--- a/CopilotKit/packages/react-core/src/types/index.ts
+++ b/CopilotKit/packages/react-core/src/types/index.ts
@@ -2,7 +2,13 @@ export type { DocumentPointer } from "./document-pointer";
 export type { SystemMessageFunction } from "./system-message";
 export type {
   ActionRenderProps,
+  ActionRenderPropsNoArgs,
+  ActionRenderPropsWait,
+  ActionRenderPropsNoArgsWait,
+  FrontendAction,
+  FrontendActionAvailability,
   RenderFunctionStatus,
   CatchAllActionRenderProps,
+  CatchAllFrontendAction,
 } from "./frontend-action";
 export type { CopilotChatSuggestionConfiguration } from "./chat-suggestion-configuration";


### PR DESCRIPTION

## What does this PR do?

Exports missing action-related types from the react-core package's public API, including `ActionRenderPropsNoArgsWait`, `ActionRenderPropsNoArgs`, `ActionRenderPropsWait`, `FrontendAction`, `FrontendActionAvailability`, and `CatchAllFrontendAction`. This fixes the "Module has no exported member" TypeScript errors when trying to use these types.

## Related PRs and Issues

- N/A

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
