### PR TITLE
docs: enhance input output schema example

### DIFF
--- a/docs/content/docs/coagents/shared-state/state-inputs-outputs.mdx
+++ b/docs/content/docs/coagents/shared-state/state-inputs-outputs.mdx
@@ -58,13 +58,40 @@ In addition, some state properties contain a lot of information. Syncing them ba
       class OverallState(InputState, OutputState):
         resources: List[str]
 
-      # ...add the rest of the agent implementation
+      async def answer_node(state: OverallState, config: RunnableConfig):
+        """
+        Standard chat node, meant to answer general questions.
+        """
+
+        model = ChatOpenAI()
+
+        # add the input question in the system prompt so it's passed to the LLM
+        system_message = SystemMessage(
+          content=f"You are a helpful assistant. Answer the question: {state.get('question')}"
+        )
+
+        response = await model.ainvoke([
+          system_message,
+          *state["messages"],
+        ], config)
+
+        # ...add the rest of the agent implementation
+
+        # extract the answer, which will be assigned to the state soon
+        answer = response.content
+
+        return {
+           "messages": response,
+            # include the answer in the returned state
+           "answer": answer
+        }
+
 
       # finally, before compiling the graph, we define the 3 state components
       builder = StateGraph(OverallState, input=InputState, output=OutputState)
 
       # add all the different nodes and edges and compile the graph
-      builder.add_node(answer_node)
+      builder.add_node("answer_node", answer_node)
       builder.add_edge(START, "answer_node")
       builder.add_edge("answer_node", END)
       graph = builder.compile()


### PR DESCRIPTION
This PR further expends the "input output schema" documentation code example, so it's easier to "reproduce" this and see it working