### PR TITLE
fix: adjust order of colors so app themes prevails OS theme

### DIFF
--- a/CopilotKit/.changeset/twenty-houses-end.md
+++ b/CopilotKit/.changeset/twenty-houses-end.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix: adjust order of colors so app themes prevails OS theme

--- a/CopilotKit/packages/react-ui/src/css/colors.css
+++ b/CopilotKit/packages/react-ui/src/css/colors.css
@@ -1,4 +1,9 @@
-/* Base theme variables (light mode) */
+/* IMPORTANT NOTE:
+THE DARK AND LIGHT COLORS HERE ARE DUPLICATED BECAUSE NO REUSE METHOD POSSIBLE.
+WHEN MAKING ANY CHANGE, MAKE SURE TO INCLUDE IT IN ALL DUPLICATIONS.
+*/
+
+/* BASE LIGHT THEME */
 :root {
   /* Semantic color tokens */
   /* Main brand/action color - used for buttons, interactive elements */
@@ -30,35 +35,7 @@
   --copilot-kit-dev-console-text: black;
 }
 
-/* Dark theme - based on system preference */
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* Main brand/action color - used for buttons, interactive elements */
-    --copilot-kit-primary-color: rgb(255, 255, 255);
-    /* Color that contrasts with primary - used for text on primary elements */
-    --copilot-kit-contrast-color: rgb(28, 28, 28);
-    /* Main page/container background color */
-    --copilot-kit-background-color: rgb(17, 17, 17);
-    /* Input box background color */
-    --copilot-kit-input-background-color: #2c2c2c;
-    /* Secondary background - used for cards, panels, elevated surfaces */
-    --copilot-kit-secondary-color: rgb(28, 28, 28);
-    /* Primary text color for main content */
-    --copilot-kit-secondary-contrast-color: rgb(255, 255, 255);
-    /* Border color for dividers and containers */
-    --copilot-kit-separator-color: rgb(45, 45, 45);
-    /* Muted color for disabled/inactive states */
-    --copilot-kit-muted-color: rgb(45, 45, 45);
-
-    /* Small shadow for subtle elevation */
-    --copilot-kit-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-    /* Medium shadow for cards */
-    --copilot-kit-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
-    /* Large shadow for modals */
-    --copilot-kit-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
-  }
-}
-
+/* BASE DARK THEME */
 .dark,
 html.dark,
 body.dark,
@@ -90,3 +67,65 @@ body[style*="color-scheme: dark"] :root {
   --copilot-kit-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
 }
 
+/* Dark theme - based on system preference - FOLLOWS BASE DARK THEME */
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Main brand/action color - used for buttons, interactive elements */
+    --copilot-kit-primary-color: rgb(255, 255, 255);
+    /* Color that contrasts with primary - used for text on primary elements */
+    --copilot-kit-contrast-color: rgb(28, 28, 28);
+    /* Main page/container background color */
+    --copilot-kit-background-color: rgb(17, 17, 17);
+    /* Input box background color */
+    --copilot-kit-input-background-color: #2c2c2c;
+    /* Secondary background - used for cards, panels, elevated surfaces */
+    --copilot-kit-secondary-color: rgb(28, 28, 28);
+    /* Primary text color for main content */
+    --copilot-kit-secondary-contrast-color: rgb(255, 255, 255);
+    /* Border color for dividers and containers */
+    --copilot-kit-separator-color: rgb(45, 45, 45);
+    /* Muted color for disabled/inactive states */
+    --copilot-kit-muted-color: rgb(45, 45, 45);
+
+    /* Small shadow for subtle elevation */
+    --copilot-kit-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+    /* Medium shadow for cards */
+    --copilot-kit-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
+    /* Large shadow for modals */
+    --copilot-kit-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
+  }
+
+  /* When app has light theme, it should prevail over dark theme of OS - FOLLOWS BASE LIGHT THEME */
+  .light,
+  html.light,
+  body.light,
+  [data-theme="light"],
+  html[style*="color-scheme: light"],
+  body[style*="color-scheme: light"] :root {
+    /* Semantic color tokens */
+    /* Main brand/action color - used for buttons, interactive elements */
+    --copilot-kit-primary-color: rgb(28, 28, 28);
+    /* Color that contrasts with primary - used for text on primary elements */
+    --copilot-kit-contrast-color: rgb(255, 255, 255);
+    /* Main page/container background color */
+    --copilot-kit-background-color: rgb(255 255 255);
+    /* Input box background color */
+    --copilot-kit-input-background-color: #fbfbfb;
+    /* Secondary background - used for cards, panels, elevated surfaces */
+    --copilot-kit-secondary-color: rgb(255 255 255);
+    /* Primary text color for main content */
+    --copilot-kit-secondary-contrast-color: rgb(28, 28, 28);
+    /* Border color for dividers and containers */
+    --copilot-kit-separator-color: rgb(200 200 200);
+    /* Muted color for disabled/inactive states */
+    --copilot-kit-muted-color: rgb(200 200 200);
+
+    /* Shadow tokens */
+    /* Small shadow for subtle elevation */
+    --copilot-kit-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    /* Medium shadow for cards */
+    --copilot-kit-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    /* Large shadow for modals */
+    --copilot-kit-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  }
+}


### PR DESCRIPTION
When using OS dark theme but app system has light theme set up, the embedded copilotkit chat uses dark theme.
This PR makes the app theme prevail the system theme.