### PR TITLE
fix: set text area within the input box to transparent background

### DIFF
--- a/CopilotKit/.changeset/rich-tomatoes-dress.md
+++ b/CopilotKit/.changeset/rich-tomatoes-dress.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix: set text area within the input box to transparent background

--- a/CopilotKit/packages/react-ui/src/css/input.css
+++ b/CopilotKit/packages/react-ui/src/css/input.css
@@ -89,7 +89,7 @@
   font-weight: inherit;
   color: var(--copilot-kit-secondary-contrast-color);
   border: 0px;
-  background-color: var(--copilot-kit-input-background-color);
+  background-color: transparent;
 }
 
 .copilotKitInput > textarea::placeholder {


### PR DESCRIPTION
set text area within the input box to transparent background