### PR TITLE
fix: remove LangGraph persistence in Lambda agent

### DIFF
--- a/examples/Dockerfile.agent-js
+++ b/examples/Dockerfile.agent-js
@@ -30,7 +30,9 @@ COPY ${APP_DIR}/ ./
 # Explicitly install the missing dependency
 RUN pnpm add @langchain/langgraph-checkpoint
 
-RUN mkdir .langgraph_api
+RUN mkdir /tmp/.langgraph_api
+
+ENV LANGGRAPH_API_DIR="/tmp/.langgraph_api"
 
 RUN ls -la
 

--- a/examples/coagents-qa-text/agent-js/src/agent.ts
+++ b/examples/coagents-qa-text/agent-js/src/agent.ts
@@ -12,7 +12,7 @@ import {
 } from "@copilotkit/sdk-js/langgraph";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { getModel } from "./model";
-import { END, MemorySaver, StateGraph } from "@langchain/langgraph";
+import { END, StateGraph } from "@langchain/langgraph";
 
 const ExtractNameTool = tool(() => {}, {
   name: "ExtractNameTool",
@@ -97,9 +97,6 @@ const workflow = new StateGraph(AgentStateAnnotation)
   ])
   .addEdge("greet_node", END);
 
-const memory = new MemorySaver();
-
 export const graph = workflow.compile({
-  checkpointer: memory,
   interruptAfter: ["ask_name_node"],
 });

--- a/examples/coagents-research-canvas/agent-js/src/agent.ts
+++ b/examples/coagents-research-canvas/agent-js/src/agent.ts
@@ -30,9 +30,7 @@ const workflow = new StateGraph(AgentStateAnnotation)
   .addEdge("perform_delete_node", "chat_node")
   .addEdge("search_node", "download");
 
-const memory = new MemorySaver();
 export const graph = workflow.compile({
-  checkpointer: memory,
   interruptAfter: ["delete_node"],
 });
 

--- a/examples/coagents-routing/agent-js/src/agent.ts
+++ b/examples/coagents-routing/agent-js/src/agent.ts
@@ -11,7 +11,7 @@ import {
 } from "@copilotkit/sdk-js/langgraph";
 import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import { getModel } from "./model";
-import { END, MemorySaver, StateGraph } from "@langchain/langgraph";
+import { END, StateGraph } from "@langchain/langgraph";
 import { AgentState, AgentStateAnnotation } from "./state";
 
 const EmailTool = tool(() => {}, {
@@ -80,9 +80,6 @@ const workflow = new StateGraph(AgentStateAnnotation)
   .addEdge("email_node", "send_email_node")
   .addEdge("send_email_node", END);
 
-const memory = new MemorySaver();
-
 export const graph = workflow.compile({
-  checkpointer: memory,
   interruptAfter: ["email_node"],
 });


### PR DESCRIPTION
- Removes MemorySaver from agent.ts since Lambda functions are stateless
- Keeps /tmp/.langgraph_api directory as writable space for temporary files
- Fixes EROFS (read-only filesystem) errors when running in Lambda

The agent doesn't need to persist state between invocations since each Lambda 
execution is independent. This change removes the persistence layer while 
maintaining a writable temporary directory for other potential LangGraph needs.
