### PR TITLE
fix: clarify difference between lgp endpoints to fastapi endpoints

### DIFF
--- a/CopilotKit/.changeset/mean-crabs-enjoy.md
+++ b/CopilotKit/.changeset/mean-crabs-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: clarify difference between lgp endpoints to fastapi endpoints

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -23,7 +23,6 @@ import {
   CopilotKitLowLevelError,
   CopilotKitAgentDiscoveryError,
   CopilotKitMisuseError,
-  CopilotKitRemoteEndpointDiscoveryError,
 } from "@copilotkit/shared";
 import {
   CopilotServiceAdapter,
@@ -502,8 +501,12 @@ please use an LLM adapter instead.`,
               throw new CopilotKitAgentDiscoveryError();
             }
           } catch (e) {
-            throw new CopilotKitRemoteEndpointDiscoveryError({
-              message: `Failed to find or contact remote endpoint at url ${endpoint.deploymentUrl}. Make sure the API is running and that it's indeed a LangGraph platform url.`,
+            throw new CopilotKitMisuseError({
+              message: `
+              Failed to find or contact remote endpoint at url ${endpoint.deploymentUrl}.
+              Make sure the API is running and that it's indeed a LangGraph platform url.
+              
+              See more: https://docs.copilotkit.ai/troubleshooting/common-issues`,
             });
           }
           const endpointAgents = data.map((entry) => ({

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -23,6 +23,7 @@ import {
   CopilotKitLowLevelError,
   CopilotKitAgentDiscoveryError,
   CopilotKitMisuseError,
+  CopilotKitRemoteEndpointDiscoveryError,
 } from "@copilotkit/shared";
 import {
   CopilotServiceAdapter,
@@ -493,11 +494,19 @@ please use an LLM adapter instead.`,
             apiKey: endpoint.langsmithApiKey,
             defaultHeaders: { ...propertyHeaders },
           });
+          let data: Array<{ assistant_id: string; graph_id: string }> | { detail: string } = [];
+          try {
+            data = await client.assistants.search();
 
-          const data: Array<{ assistant_id: string; graph_id: string }> =
-            await client.assistants.search();
-
-          const endpointAgents = (data ?? []).map((entry) => ({
+            if (data && "detail" in data && (data.detail as string).toLowerCase() === "not found") {
+              throw new CopilotKitAgentDiscoveryError();
+            }
+          } catch (e) {
+            throw new CopilotKitRemoteEndpointDiscoveryError({
+              message: `Failed to find or contact remote endpoint at url ${endpoint.deploymentUrl}. Make sure the API is running and that it's indeed a LangGraph platform url.`,
+            });
+          }
+          const endpointAgents = data.map((entry) => ({
             name: entry.graph_id,
             id: entry.assistant_id,
             description: "",

--- a/CopilotKit/packages/shared/src/utils/errors.ts
+++ b/CopilotKit/packages/shared/src/utils/errors.ts
@@ -134,7 +134,7 @@ export class CopilotKitMisuseError extends CopilotKitError {
     code?: CopilotKitErrorCode;
   }) {
     const docsLink =
-      "troubleshootingUrl" in ERROR_CONFIG[code]
+      "troubleshootingUrl" in ERROR_CONFIG[code] && ERROR_CONFIG[code].troubleshootingUrl
         ? getSeeMoreMarkdown(ERROR_CONFIG[code].troubleshootingUrl as string)
         : null;
     const finalMessage = docsLink ? `${message}.\n\n${docsLink}` : message;

--- a/docs/content/docs/coagents/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/coagents/troubleshooting/common-issues.mdx
@@ -202,3 +202,42 @@ If you notice the tunnel creation process spinning indefinitely, your router or 
     </Accordion>
 
 </Accordions>
+
+## I am getting "Failed to find or contact remote endpoint at url, Make sure the API is running and that it's indeed a LangGraph platform url" error
+
+If you're seeing this error, it means the LangGraph platform client cannot connect to your endpoint.
+
+<Accordions>
+    <Accordion title="Verify the endpoint is reachable">
+        Check the logs for the backend API running on the remote endpoint url. Make sure it is up and ready to receive requests
+    </Accordion>
+    <Accordion title="Verify running a LangGraph platform endpoint using LangGraph deployment tools">
+        Verify that the backend API is running using `langgraph dev`, `langgraph up`, on a LangGraph cloud url or equivalent methods supplied by LangGraph
+    </Accordion>
+    <Accordion title="Verify the remote endpoint matches the endpoint definition type">
+        If you are running your remote endpoint using FastAPI, even if it uses LangGraph for the agent, it is not considered a LangGraph platform endpoint.
+        You may need to change your `remoteEndpoints` definition for this endpoint to match the expected format.
+
+        Change the endpoint definition, from:
+        ```
+        new CopilotRuntime({
+          remoteEndpoints: [
+            langGraphPlatformEndpoint({
+            deploymentUrl: "https://your-fastapi-endpoint:port",
+            langsmithApiKey: <langsmith API key>
+            agents: [], // Your previous agents definition
+          ],
+        });
+        ```
+
+        To:
+        ```
+        new CopilotRuntime({
+          remoteEndpoints: [
+            copilotKitEndpoint({ url: "https://your-fastapi-endpoint:port/copilotkit" });
+          ]
+        });
+        ```
+    </Accordion>
+</Accordions>
+


### PR DESCRIPTION
Seeing how "langgraph platform" endpoints concept may confuse some folks, this PR adds more error messages if the endpoint types are misused, as well with an accompanying troubleshooting url