### PR TITLE
fix: handle failure to fetch langgraph schema

### DIFF
--- a/CopilotKit/.changeset/tiny-comics-study.md
+++ b/CopilotKit/.changeset/tiny-comics-study.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: handle failure to fetch langgraph schema


### PR DESCRIPTION
In order to enable input/output schemas of langgraph, we fetch the schema for a given langgraph graph when running it.
The schema returned from this fetching has changed unexpectedly, flagging the fact that lack of schema/faulty schema is not something CPK can recover from. This PR provides recovery 