### PR TITLE
feat: add demo viewer to coagents docs

### DIFF
--- a/docs/content/docs/coagents/meta.json
+++ b/docs/content/docs/coagents/meta.json
@@ -3,6 +3,7 @@
   "root": true,
   "pages": [
     "index",
+    "[lucide/Telescope][Feature Viewer](https://feature-viewer-langgraph.vercel.app/)",
     "---Quickstart---",
     "...quickstart",
     "---Guides---",

--- a/docs/content/docs/crewai-crews/meta.json
+++ b/docs/content/docs/crewai-crews/meta.json
@@ -3,6 +3,7 @@
   "root": true,
   "pages": [
     "index",
+    "[lucide/Telescope][Feature Viewer](https://demo-viewer-five.vercel.app/ )",
     "---Quickstart---",
     "...quickstart",
     "---Guides---",

--- a/docs/content/docs/crewai-flows/meta.json
+++ b/docs/content/docs/crewai-flows/meta.json
@@ -3,6 +3,7 @@
   "root": true,
   "pages": [
     "index",
+    "[lucide/Telescope][Feature Viewer](https://demo-viewer-five.vercel.app/ )",
     "---Quickstart---",
     "...quickstart",
     "---Guides---",


### PR DESCRIPTION
## What does this PR do?
Adding a link to the framework appropriate demo viewer into the docs' sidebar

## Checklist
- [x]  I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation