### PR TITLE
feat: add support for langgraph config schema

### DIFF
--- a/CopilotKit/.changeset/metal-actors-double.md
+++ b/CopilotKit/.changeset/metal-actors-double.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- feat: add support for langgraph config schema

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -210,8 +210,8 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
   const graphSchema = await client.assistants.getSchemas(assistantId);
   const schemaKeys = getSchemaKeys(graphSchema);
   if (configurable) {
-    const filteredConfigurable = schemaKeys.config
-      ? filterObjectBySchemaKeys(configurable, schemaKeys.config)
+    const filteredConfigurable = schemaKeys?.config
+      ? filterObjectBySchemaKeys(configurable, schemaKeys?.config)
       : configurable;
     await client.assistants.update(assistantId, { config: { configurable: filteredConfigurable } });
   }

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -68,7 +68,11 @@ type LangGraphPlatformMessage =
   | LangGraphPlatformResultMessage
   | BaseLangGraphPlatformMessage;
 
-type SchemaKeys = { input: string[] | null; output: string[] | null } | null;
+type SchemaKeys = {
+  input: string[] | null;
+  output: string[] | null;
+  config: string[] | null;
+} | null;
 
 let activeInterruptEvent = false;
 
@@ -202,17 +206,19 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
   }
   const assistantId = retrievedAssistant.assistant_id;
 
-  if (configurable) {
-    await client.assistants.update(assistantId, { config: { configurable } });
-  }
   const graphInfo = await client.assistants.getGraph(assistantId);
   const graphSchema = await client.assistants.getSchemas(assistantId);
   const schemaKeys = getSchemaKeys(graphSchema);
+  if (configurable) {
+    const filteredConfigurable = schemaKeys.config
+      ? filterObjectBySchemaKeys(configurable, schemaKeys.config)
+      : configurable;
+    await client.assistants.update(assistantId, { config: { configurable: filteredConfigurable } });
+  }
+
   // Do not input keys that are not part of the input schema
   if (payload.input && schemaKeys?.input) {
-    payload.input = Object.fromEntries(
-      Object.entries(payload.input).filter(([key]) => schemaKeys.input.includes(key)),
-    );
+    payload.input = filterObjectBySchemaKeys(payload.input, schemaKeys.input);
   }
 
   let streamingStateExtractor = new StreamingStateExtractor([]);
@@ -468,9 +474,7 @@ function getStateSyncEvent({
 
   // Do not emit state keys that are not part of the output schema
   if (schemaKeys?.output) {
-    state = Object.fromEntries(
-      Object.entries(state).filter(([key]) => schemaKeys.output.includes(key)),
-    );
+    state = filterObjectBySchemaKeys(state, schemaKeys.output);
   }
 
   return (
@@ -764,8 +768,12 @@ function copilotkitMessagesToLangChain(messages: Message[]): LangGraphPlatformMe
 
 function getSchemaKeys(graphSchema: GraphSchema): SchemaKeys {
   const CONSTANT_KEYS = ["messages", "copilotkit"];
+  let configSchema = null;
+  if (graphSchema.config_schema.properties) {
+    configSchema = Object.keys(graphSchema.config_schema.properties);
+  }
   if (!graphSchema.input_schema.properties || !graphSchema.output_schema.properties) {
-    return null;
+    return configSchema;
   }
   const inputSchema = Object.keys(graphSchema.input_schema.properties);
   const outputSchema = Object.keys(graphSchema.output_schema.properties);
@@ -773,5 +781,10 @@ function getSchemaKeys(graphSchema: GraphSchema): SchemaKeys {
   return {
     input: inputSchema && inputSchema.length ? [...inputSchema, ...CONSTANT_KEYS] : null,
     output: outputSchema && outputSchema.length ? [...outputSchema, ...CONSTANT_KEYS] : null,
+    config: configSchema,
   };
+}
+
+function filterObjectBySchemaKeys(obj: Record<string, any>, schemaKeys: string[]) {
+  return Object.fromEntries(Object.entries(obj).filter(([key]) => schemaKeys.includes(key)));
 }

--- a/docs/content/docs/coagents/advanced/adding-runtime-configuration.mdx
+++ b/docs/content/docs/coagents/advanced/adding-runtime-configuration.mdx
@@ -69,3 +69,42 @@ Now you can simply pull the values from the provided config argument in any agen
 </Tabs>
 </Step>
 </Steps>
+<Step>
+    ### Optional: Define configurables schema
+    If you'd like, you can define a schema to indicate which configurables you wish to receive.
+    Any item passed to "configurables" which is not included in the schema, will be filtered out.
+
+    You can read more about this (here)[https://langchain-ai.github.io/langgraph/how-tos/configuration/#define-graph]
+    <Tabs groupId="language" items={['Python', 'TypeScript']} default="Python">
+        <Tab value="Python">
+            ```python
+            from typing import TypedDict
+
+            # define which properties will be allowed in the configuration
+            class ConfigSchema(TypedDict):
+              authToken: str
+
+            # ...add all necessary graph nodes
+
+            # when defining the state graph, apply the config schema
+            workflow = StateGraph(AgentState, config_schema=ConfigSchema)
+            ```
+        </Tab>
+        <Tab value="TypeScript">
+            ```typescript
+            import { Annotation } from "@langchain/langgraph";
+
+            // define which properties will be allowed in the configuration
+            export const ConfigSchemaAnnotation = Annotation.Root({
+              authToken: Annotation<string>
+            })
+
+            // ...add all necessary graph nodes
+
+            // when defining the state graph, apply the config schema
+            const workflow = new StateGraph(AgentStateAnnotation, ConfigSchemaAnnotation)
+            ```
+        </Tab>
+    </Tabs>
+</Step>
+</Steps>

--- a/docs/content/docs/coagents/advanced/adding-runtime-configuration.mdx
+++ b/docs/content/docs/coagents/advanced/adding-runtime-configuration.mdx
@@ -68,7 +68,6 @@ Now you can simply pull the values from the provided config argument in any agen
     </Tab>
 </Tabs>
 </Step>
-</Steps>
 <Step>
     ### Optional: Define configurables schema
     If you'd like, you can define a schema to indicate which configurables you wish to receive.

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -480,6 +480,7 @@ class LangGraphAgent(Agent):
 
     def get_schema_keys(self, config):
         CONSTANT_KEYS = ['copilotkit', 'messages']
+        CONSTANT_CONFIG_KEYS = ['checkpoint_id', 'checkpoint_ns', 'thread_id']
         try:
             input_schema = self.graph.get_input_jsonschema(config)
             output_schema = self.graph.get_output_jsonschema(config)
@@ -490,6 +491,10 @@ class LangGraphAgent(Agent):
                 schema_dict = self.graph.config_schema().schema()
                 configurable_schema = schema_dict["$defs"]["Configurable"]
                 config_schema_keys = list(configurable_schema["properties"].keys())
+
+                # If only constant keys are present, it means no schema was passed, we allow everything
+                if set(config_schema_keys) == set(CONSTANT_CONFIG_KEYS):
+                    config_schema_keys = None
             except:
                 config_schema_keys = None
 

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -508,7 +508,7 @@ class LangGraphAgent(Agent):
         try:
             schema_keys_name = f"{schema_type}_schema_keys"
             if hasattr(self, schema_keys_name) and getattr(self, schema_keys_name):
-                filter_by_schema_keys(state, getattr(self, schema_keys_name))
+                return filter_by_schema_keys(state, getattr(self, schema_keys_name))
         except Exception:
             return state
 

--- a/sdk-python/copilotkit/utils.py
+++ b/sdk-python/copilotkit/utils.py
@@ -1,0 +1,8 @@
+def filter_by_schema_keys(obj, schema):
+    try:
+        return {
+            k: v for k, v in obj.items()
+            if k in schema or k == "messages"
+        }
+    except Exception:
+        return obj


### PR DESCRIPTION
This PR adds support to "ConfigurableSchema" - the schema of "configurable" of langgraph.
What this means is that configuration passed that does not adhere to the schema, is being filtered out

See more: https://langchain-ai.github.io/langgraph/how-tos/configuration/#configure-the-graph