### PR TITLE
fix: remove styles corresponding to OS dark theme

### DIFF
--- a/CopilotKit/.changeset/rude-insects-grab.md
+++ b/CopilotKit/.changeset/rude-insects-grab.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix: remove styles corresponding to OS dark theme

--- a/CopilotKit/packages/react-ui/src/css/console.css
+++ b/CopilotKit/packages/react-ui/src/css/console.css
@@ -79,16 +79,6 @@
   background-color: color-mix(in srgb, var(--copilot-kit-dev-console-bg) 85%, black);
 }
 
-@media (prefers-color-scheme: dark) {
-  .copilotKitDevConsole .copilotKitDebugMenuTriggerButton {
-    color: white;
-  }
-
-  .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover {
-    background-color: color-mix(in srgb, var(--copilot-kit-dev-console-bg) 20%, black);
-  }
-}
-
 .dark,
 html.dark,
 body.dark,


### PR DESCRIPTION
We removed the support which follows operation system theme, but this was forgotten. Following.