### PR TITLE
fix: focus on text area when clicking in input box

### DIFF
--- a/CopilotKit/.changeset/stupid-walls-smash.md
+++ b/CopilotKit/.changeset/stupid-walls-smash.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix: focus on text area when clicking in input box

--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -16,9 +16,15 @@ export const Input = ({ inProgress, onSend, isVisible = false, onStop }: InputPr
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleDivClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    // Check if the clicked element is not the textarea itself
-    if (event.target !== event.currentTarget) return;
+    const target = event.target as HTMLElement;
 
+    // If the user clicked a button or inside a button, don't focus the textarea
+    if (target.closest('button')) return;
+
+    // If the user clicked the textarea, do nothing (it's already focused)
+    if (target.tagName === 'TEXTAREA') return;
+
+    // Otherwise, focus the textarea
     textareaRef.current?.focus();
   };
 

--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -19,10 +19,10 @@ export const Input = ({ inProgress, onSend, isVisible = false, onStop }: InputPr
     const target = event.target as HTMLElement;
 
     // If the user clicked a button or inside a button, don't focus the textarea
-    if (target.closest('button')) return;
+    if (target.closest("button")) return;
 
     // If the user clicked the textarea, do nothing (it's already focused)
-    if (target.tagName === 'TEXTAREA') return;
+    if (target.tagName === "TEXTAREA") return;
 
     // Otherwise, focus the textarea
     textareaRef.current?.focus();


### PR DESCRIPTION
The new input has a far bigger box, which can be seen as divided into 2 rows: 1 is the textarea, the 2nd is the buttons.
When this PR is merged, whenever a user clicks on the 2nd row (buttons) but NOT ON A BUTTON, the text area will be focused, thus making the "Hit box" of the text area far larger and easier to target