### PR TITLE
fix: fix duplicate messages on regenerate

### DIFF
--- a/CopilotKit/.changeset/ten-doors-grow.md
+++ b/CopilotKit/.changeset/ten-doors-grow.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-core": patch
+"@copilotkit/react-ui": patch
+"@copilotkit/runtime": patch
+---
+
+- fix: fix duplicate messages on regenerate

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -168,7 +168,7 @@ export type UseChatHelpers = {
    * message isn't from the assistant, it will request the API to generate a
    * new response.
    */
-  reload: () => Promise<void>;
+  reload: (messageId: string) => Promise<void>;
   /**
    * Abort the current request immediately, keep the generated tokens if any.
    */
@@ -725,21 +725,29 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
     [isLoading, messages, setMessages, runChatCompletionAndHandleFunctionCall],
   );
 
-  const reload = useAsyncCallback(async (): Promise<void> => {
-    if (isLoading || messages.length === 0) {
-      return;
-    }
-    let newMessages = [...messages];
-    const lastMessage = messages[messages.length - 1];
+  const reload = useAsyncCallback(
+    async (messageId: string): Promise<void> => {
+      if (isLoading || messages.length === 0) {
+        return;
+      }
 
-    if (lastMessage.isTextMessage() && lastMessage.role === "assistant") {
-      newMessages = newMessages.slice(0, -1);
-    }
+      const index = messages.findIndex((msg) => msg.id === messageId);
+      if (index === -1) {
+        console.warn(`Message with id ${messageId} not found`);
+        return;
+      }
 
-    setMessages(newMessages);
+      let newMessages = messages.slice(0, index); // excludes the message with messageId
+      if (newMessages.length > 0 && newMessages[newMessages.length - 1].isAgentStateMessage()) {
+        newMessages = newMessages.slice(0, newMessages.length - 1); // remove last one too
+      }
 
-    return runChatCompletionAndHandleFunctionCall(newMessages);
-  }, [isLoading, messages, setMessages, runChatCompletionAndHandleFunctionCall]);
+      setMessages(newMessages);
+
+      return runChatCompletionAndHandleFunctionCall(newMessages);
+    },
+    [isLoading, messages, setMessages, runChatCompletionAndHandleFunctionCall],
+  );
 
   const stop = (): void => {
     chatAbortControllerRef.current?.abort("Stop was called");

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
@@ -80,7 +80,7 @@ export interface UseCopilotChatReturn {
   appendMessage: (message: Message, options?: AppendMessageOptions) => Promise<void>;
   setMessages: (messages: Message[]) => void;
   deleteMessage: (messageId: string) => void;
-  reloadMessages: () => Promise<void>;
+  reloadMessages: (messageId: string) => Promise<void>;
   stopGeneration: () => void;
   reset: () => void;
   isLoading: boolean;
@@ -203,9 +203,12 @@ export function useCopilotChat({
   );
 
   const latestReload = useUpdatedRef(reload);
-  const latestReloadFunc = useAsyncCallback(async () => {
-    return await latestReload.current();
-  }, [latestReload]);
+  const latestReloadFunc = useAsyncCallback(
+    async (messageId: string) => {
+      return await latestReload.current(messageId);
+    },
+    [latestReload],
+  );
 
   const latestStop = useUpdatedRef(stop);
   const latestStopFunc = useCallback(() => {

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -118,7 +118,7 @@ export interface CopilotChatProps {
   /**
    * A callback function to regenerate the assistant's response
    */
-  onRegenerate?: () => void;
+  onRegenerate?: (messageId: string) => void;
 
   /**
    * A callback function when the message is copied
@@ -246,7 +246,12 @@ interface OnStopGenerationArguments {
   setCurrentAgentState: (state: any) => void;
 }
 
-export type OnReloadMessagesArguments = OnStopGenerationArguments;
+export type OnReloadMessagesArguments = OnStopGenerationArguments & {
+  /**
+   * The message on which "regenerate" was pressed
+   */
+  messageId: string;
+};
 
 export type OnStopGeneration = (args: OnStopGenerationArguments) => void;
 
@@ -320,12 +325,12 @@ export function CopilotChat({
   const chatContext = React.useContext(ChatContext);
   const isVisible = chatContext ? chatContext.open : true;
 
-  const handleRegenerate = () => {
+  const handleRegenerate = (messageId: string) => {
     if (onRegenerate) {
-      onRegenerate();
+      onRegenerate(messageId);
     }
 
-    reloadMessages();
+    reloadMessages(messageId);
   };
 
   const handleCopy = (message: string) => {
@@ -554,7 +559,7 @@ export const useCopilotChatLogic = (
       defaultStopGeneration();
     }
   }
-  function reloadMessages() {
+  function reloadMessages(messageId: string) {
     if (onReloadMessages) {
       onReloadMessages({
         messages,
@@ -565,9 +570,10 @@ export const useCopilotChatLogic = (
         stopCurrentAgent,
         runCurrentAgent,
         setCurrentAgentState,
+        messageId,
       });
     } else {
-      defaultReloadMessages();
+      defaultReloadMessages(messageId);
     }
   }
 

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderTextMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderTextMessage.tsx
@@ -38,7 +38,7 @@ export function RenderTextMessage({
           isLoading={inProgress && isCurrentMessage && !message.content}
           isGenerating={inProgress && isCurrentMessage && !!message.content}
           isCurrentMessage={isCurrentMessage}
-          onRegenerate={onRegenerate}
+          onRegenerate={() => onRegenerate?.(message.id)}
           onCopy={onCopy}
           onThumbsUp={onThumbsUp}
           onThumbsDown={onThumbsDown}

--- a/CopilotKit/packages/react-ui/src/components/chat/props.ts
+++ b/CopilotKit/packages/react-ui/src/components/chat/props.ts
@@ -33,7 +33,7 @@ export interface MessagesProps {
   /**
    * Callback function to regenerate the assistant's response
    */
-  onRegenerate?: () => void;
+  onRegenerate?: (messageId: string) => void;
 
   /**
    * Callback function when the message is copied
@@ -127,7 +127,7 @@ export interface RenderMessageProps {
   /**
    * Callback function to regenerate the assistant's response
    */
-  onRegenerate?: () => void;
+  onRegenerate?: (messageId: string) => void;
 
   /**
    * Callback function when the message is copied

--- a/docs/content/docs/reference/components/chat/CopilotChat.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotChat.mdx
@@ -82,7 +82,7 @@ A custom stop generation function.
 A custom reload messages function.
 </PropertyReference>
 
-<PropertyReference name="onRegenerate" type="() => void"  > 
+<PropertyReference name="onRegenerate" type="(messageId: string) => void"  > 
 A callback function to regenerate the assistant's response
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/chat/CopilotPopup.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotPopup.mdx
@@ -83,7 +83,7 @@ A custom stop generation function.
 A custom reload messages function.
 </PropertyReference>
 
-<PropertyReference name="onRegenerate" type="() => void"  > 
+<PropertyReference name="onRegenerate" type="(messageId: string) => void"  > 
 A callback function to regenerate the assistant's response
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
@@ -85,7 +85,7 @@ A custom stop generation function.
 A custom reload messages function.
 </PropertyReference>
 
-<PropertyReference name="onRegenerate" type="() => void"  > 
+<PropertyReference name="onRegenerate" type="(messageId: string) => void"  > 
 A callback function to regenerate the assistant's response
 </PropertyReference>
 


### PR DESCRIPTION
Fixes bug in which regeneration of messages on langgraph ends up with the old message, doubled.

It also alters the FE behaviour of the regenerate button: When clicking, all messages after and including the message to be deleted, are removed.