### PR TITLE
feat: enable usage of python 3.13 with cpk

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/CopilotKit/CopilotKit/tree/main/sdk-python"
 keywords = ["copilot", "copilotkit", "langgraph", "langchain", "ai", "langsmith", "langserve"]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.14"
 langgraph = {version = ">=0.2.50"}
 langchain = {version = "^0.3.3"}
 crewai = { version = "0.102.0", optional = true }


### PR DESCRIPTION
Lift off restriction for python 3.12, enabling 3.13