### PR TITLE
feat: Add Model Context Protocol (MCP) support

### DIFF
--- a/CopilotKit/.changeset/moody-countries-clean.md
+++ b/CopilotKit/.changeset/moody-countries-clean.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/react-core": patch
+"@copilotkit/runtime": patch
+---
+
+- feat: Add Model Context Protocol (MCP) support

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -65,13 +65,22 @@ export interface CopilotKitProps {
   children: ReactNode;
 
   /**
-   * Custom properties to be sent with the request
-   * For example:
-   * ```js
-   * {
-   *   'user_id': 'users_id',
-   * }
-   * ```
+   * Custom properties to be sent with the request.
+   * These properties are accessible in the runtime via `graphqlContext.properties`
+   * and can be used for custom logic, including dynamic configuration.
+   *
+   * @example
+   * // Pass arbitrary data, including dynamic MCP endpoint configurations:
+   * const myProps = {
+   *   user_id: 'user123',
+   *   session_theme: 'dark',
+   *   mcpEndpoints: [
+   *     { endpoint: "https://dynamic-mcp.example.com" }
+   *     // ... other request-specific endpoints
+   *   ]
+   * };
+   * // Then use in your component:
+   * // <CopilotKit properties={myProps}> ... </CopilotKit>
    */
   properties?: Record<string, any>;
 
@@ -120,6 +129,10 @@ export interface CopilotKitProps {
    * Allows the CopilotKit runtime to discover and utilize tools hosted
    * on external MCP-compliant servers.
    *
+   * If provided, this configuration will be merged into the `properties` object
+   * sent with each request under the key `mcpEndpoints`.
+   * It provides a strongly-typed way to configure request-specific MCP endpoints.
+   *
    * Each object in the array should contain:
    * - `endpoint`: The URL of the MCP server (required).
    * - `apiKey`: An optional API key if the server requires authentication.
@@ -131,13 +144,14 @@ export interface CopilotKitProps {
    *     { endpoint: "https://my-mcp-server.com/api" },
    *     { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
    *   ]}
+   *   properties={{ user_id: '123' }} // Other properties can still be used
    * >
    *   // ... your components
    * </CopilotKit>
    * ```
    *
-   * Note: This feature relies on a user-provided implementation of `createMCPClient`
-   * in the runtime environment to establish the actual connection.
+   * Note: The runtime still requires a `createMCPClient` function to be provided
+   * during its initialization to handle these endpoints.
    * @experimental
    */
   mcpEndpoints?: Array<{ endpoint: string; apiKey?: string }>;

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -65,22 +65,13 @@ export interface CopilotKitProps {
   children: ReactNode;
 
   /**
-   * Custom properties to be sent with the request.
-   * These properties are accessible in the runtime via `graphqlContext.properties`
-   * and can be used for custom logic, including dynamic configuration.
-   *
-   * @example
-   * // Pass arbitrary data, including dynamic MCP endpoint configurations:
-   * const myProps = {
-   *   user_id: 'user123',
-   *   session_theme: 'dark',
-   *   mcpEndpoints: [
-   *     { endpoint: "https://dynamic-mcp.example.com" }
-   *     // ... other request-specific endpoints
-   *   ]
-   * };
-   * // Then use in your component:
-   * // <CopilotKit properties={myProps}> ... </CopilotKit>
+   * Custom properties to be sent with the request
+   * For example:
+   * ```js
+   * {
+   *   'user_id': 'users_id',
+   * }
+   * ```
    */
   properties?: Record<string, any>;
 
@@ -125,31 +116,17 @@ export interface CopilotKitProps {
   threadId?: string;
 
   /**
-   * Configuration for connecting to Model Context Protocol (MCP) servers.
-   * Allows the CopilotKit runtime to discover and utilize tools hosted
-   * on external MCP-compliant servers.
+   * Config for connecting to Model Context Protocol (MCP) servers.
+   * Enables CopilotKit runtime to access tools on external MCP servers.
    *
-   * If provided, this configuration will be merged into the `properties` object
-   * sent with each request under the key `mcpEndpoints`.
-   * It provides a strongly-typed way to configure request-specific MCP endpoints.
+   * This config merges into the `properties` object with each request as `mcpEndpoints`.
+   * It offers a typed method to set up MCP endpoints for requests.
    *
-   * Each object in the array should contain:
-   * - `endpoint`: The URL of the MCP server (required).
-   * - `apiKey`: An optional API key if the server requires authentication.
+   * Each array item should have:
+   * - `endpoint`: MCP server URL (mandatory).
+   * - `apiKey`: Optional API key for server authentication.
    *
-   * @example
-   * <CopilotKit
-   *   mcpEndpoints={[
-   *     { endpoint: "https://my-mcp-server.com/api" },
-   *     { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
-   *   ]}
-   * >
-   *   // ... your components
-   * </CopilotKit>
-   *
-   * Note: The runtime still requires a `createMCPClient` function to be provided
-   * during its initialization to handle these endpoints.
-   * @experimental
+   * Note: A `createMCPClient` function is still needed during runtime initialization to manage these endpoints.
    */
   mcpEndpoints?: Array<{ endpoint: string; apiKey?: string }>;
 }

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -114,4 +114,31 @@ export interface CopilotKitProps {
    * The thread id to use for the CopilotKit.
    */
   threadId?: string;
+
+  /**
+   * Configuration for connecting to Model Context Protocol (MCP) servers.
+   * Allows the CopilotKit runtime to discover and utilize tools hosted
+   * on external MCP-compliant servers.
+   *
+   * Each object in the array should contain:
+   * - `endpoint`: The URL of the MCP server (required).
+   * - `apiKey`: An optional API key if the server requires authentication.
+   *
+   * @example
+   * ```tsx
+   * <CopilotKit
+   *   mcpEndpoints={[
+   *     { endpoint: "https://my-mcp-server.com/api" },
+   *     { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
+   *   ]}
+   * >
+   *   // ... your components
+   * </CopilotKit>
+   * ```
+   *
+   * Note: This feature relies on a user-provided implementation of `createMCPClient`
+   * in the runtime environment to establish the actual connection.
+   * @experimental
+   */
+  mcpEndpoints?: Array<{ endpoint: string; apiKey?: string }>;
 }

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -138,17 +138,14 @@ export interface CopilotKitProps {
    * - `apiKey`: An optional API key if the server requires authentication.
    *
    * @example
-   * ```tsx
    * <CopilotKit
    *   mcpEndpoints={[
    *     { endpoint: "https://my-mcp-server.com/api" },
    *     { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
    *   ]}
-   *   properties={{ user_id: '123' }} // Other properties can still be used
    * >
    *   // ... your components
    * </CopilotKit>
-   * ```
    *
    * Note: The runtime still requires a `createMCPClient` function to be provided
    * during its initialization to handle these endpoints.

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -219,6 +219,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,
       credentials: props.credentials,
+      mcpEndpoints: props.mcpEndpoints,
     };
   }, [
     props.publicApiKey,
@@ -228,6 +229,8 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     props.textToSpeechUrl,
     props.credentials,
     props.cloudRestrictToTopic,
+    props.mcpEndpoints,
+    props.guardrails_c,
   ]);
 
   const headers = useMemo(() => {

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -79,6 +79,13 @@ export interface CopilotApiConfig {
    * in the case of cross-origin requests.
    */
   credentials?: RequestCredentials;
+
+  /**
+   * Optional configuration for connecting to Model Context Protocol (MCP) servers.
+   * This is typically derived from the CopilotKitProps and used internally.
+   * @experimental
+   */
+  mcpEndpoints?: Array<{ endpoint: string; apiKey?: string }>;
 }
 
 export type InChatRenderFunction<TProps = ActionRenderProps<any> | CatchAllActionRenderProps<any>> =

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -276,6 +276,14 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
 
       const messagesWithContext = [systemMessage, ...(initialMessages || []), ...previousMessages];
 
+      // ----- Add this block: Merge mcpEndpoints into properties -----
+      const finalProperties = { ...(copilotConfig.properties || {}) };
+      if (copilotConfig.mcpEndpoints && copilotConfig.mcpEndpoints.length > 0) {
+        // Prop takes precedence over any potential mcpEndpoints in properties
+        finalProperties.mcpEndpoints = copilotConfig.mcpEndpoints;
+      }
+      // -------------------------------------------------------------
+
       const isAgentRun = agentSessionRef.current !== null;
 
       const stream = runtimeClient.asStream(
@@ -323,7 +331,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
             })),
             forwardedParameters: options.forwardedParameters || {},
           },
-          properties: copilotConfig.properties,
+          properties: finalProperties,
           signal: chatAbortControllerRef.current?.signal,
         }),
       );

--- a/CopilotKit/packages/runtime/src/lib/index.ts
+++ b/CopilotKit/packages/runtime/src/lib/index.ts
@@ -1,4 +1,3 @@
-export * from "./runtime/copilot-runtime";
 export * from "../service-adapters/openai/openai-adapter";
 export * from "../service-adapters/langchain/langchain-adapter";
 export * from "../service-adapters/google/google-genai-adapter";
@@ -7,3 +6,5 @@ export * from "../service-adapters/unify/unify-adapter";
 export * from "../service-adapters/groq/groq-adapter";
 export * from "./integrations";
 export * from "./logger";
+export * from "./runtime/copilot-runtime";
+export * from "./runtime/mcp-tools-utils";

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -230,7 +230,6 @@ export interface CopilotRuntimeConstructorParams<T extends Parameter[] | [] = []
    * (e.g., `@anthropic-ai/sdk`, `ai/experimental`) to establish a connection.
    * Required if `mcpEndpoints` is provided.
    *
-   * @example
    * ```typescript
    * import { Anthropic } from "@anthropic-ai/sdk"; // Or your preferred client
    * // ...
@@ -246,9 +245,6 @@ export interface CopilotRuntimeConstructorParams<T extends Parameter[] | [] = []
    *   }
    * });
    * ```
-   * @param config Connection configuration for the MCP endpoint.
-   * @returns A promise that resolves to an object conforming to the MCPClient interface.
-   * @experimental
    */
   createMCPClient?: CreateMCPClientFunction;
 }

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -227,21 +227,24 @@ export interface CopilotRuntimeConstructorParams<T extends Parameter[] | [] = []
   /**
    * A function that creates an MCP client instance for a given endpoint configuration.
    * This function is responsible for using the appropriate MCP client library
-   * (e.g., `@anthropic-ai/sdk`, `ai/experimental`) to establish a connection.
+   * (e.g., `@copilotkit/runtime`, `ai`) to establish a connection.
    * Required if `mcpEndpoints` is provided.
    *
    * ```typescript
-   * import { Anthropic } from "@anthropic-ai/sdk"; // Or your preferred client
+   * import { experimental_createMCPClient } from "ai"; // Import from vercel ai library
    * // ...
    * const runtime = new CopilotRuntime({
    *   mcpEndpoints: [{ endpoint: "..." }],
    *   async createMCPClient(config) {
-   *     // Your logic to instantiate and return an object conforming to MCPClient
-   *     const client = new Anthropic({ apiKey: config.apiKey }); // Example
-   *     return { // Adapt Anthropic client to MCPClient interface
-   *       async tools() { return client.beta.tools.messages.stream(...); }, // Example mapping
-   *       // close() implementation if needed
-   *     };
+   *     return await experimental_createMCPClient({
+   *       transport: {
+   *         type: "sse",
+   *         url: config.endpoint,
+   *         headers: config.apiKey
+   *           ? { Authorization: `Bearer ${config.apiKey}` }
+   *           : undefined,
+   *       },
+   *     });
    *   }
    * });
    * ```

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -75,7 +75,7 @@ import { MCPClient, MCPEndpointConfig, convertMCPToolsToActions } from "./mcp-to
 type CreateMCPClientFunction = (config: MCPEndpointConfig) => Promise<MCPClient>;
 // --- MCP Imports ---
 
-interface CopilotRuntimeRequest {
+export interface CopilotRuntimeRequest {
   serviceAdapter: CopilotServiceAdapter;
   messages: MessageInput[];
   actions: ActionInput[];

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -1135,8 +1135,6 @@ please use an LLM adapter instead.`,
             console.log(
               `MCP: Fetched and cached ${actionsForEndpoint.length} tools for ${endpointUrl}`,
             );
-            // Optional: Close client immediately if it's stateless and has a close method
-            await client.close?.().catch((err) => console.error("Error closing MCP client:", err));
           } catch (error) {
             console.error(
               `MCP: Failed to fetch tools from endpoint ${endpointUrl}. Skipping. Error:`,

--- a/CopilotKit/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
@@ -1,0 +1,117 @@
+import { Action, Parameter } from "@copilotkit/shared";
+
+/**
+ * Represents a tool provided by an MCP server.
+ */
+export interface MCPTool {
+  description?: string;
+  /** Schema defining parameters, mirroring the MCP structure. */
+  schema?: {
+    parameters?: {
+      properties?: Record<string, any>;
+      required?: string[];
+    };
+  };
+  /** The function to call to execute the tool on the MCP server. */
+  execute(options: { params: any }): Promise<any>;
+}
+
+/**
+ * Defines the contract for *any* MCP client implementation the user might provide.
+ */
+export interface MCPClient {
+  /** A method that returns a map of tool names to MCPTool objects available from the connected MCP server. */
+  tools(): Promise<Record<string, MCPTool>>;
+  /** An optional method for cleanup if the underlying client requires explicit disconnection. */
+  close?(): Promise<void>;
+}
+
+/**
+ * Configuration for connecting to an MCP endpoint.
+ */
+export interface MCPEndpointConfig {
+  endpoint: string;
+  apiKey?: string;
+}
+
+/**
+ * Extracts CopilotKit-compatible parameters from an MCP tool schema.
+ * @param toolSchema The schema object from an MCPTool.
+ * @returns An array of Parameter objects.
+ */
+export function extractParametersFromSchema(toolSchema?: MCPTool["schema"]): Parameter[] {
+  const parameters: Parameter[] = [];
+  const properties = toolSchema?.parameters?.properties;
+  const requiredParams = new Set(toolSchema?.parameters?.required || []);
+
+  if (!properties) {
+    return parameters;
+  }
+
+  for (const paramName in properties) {
+    if (Object.prototype.hasOwnProperty.call(properties, paramName)) {
+      const paramDef = properties[paramName];
+      parameters.push({
+        name: paramName,
+        // Infer type, default to string. MCP schemas might have more complex types.
+        // This might need refinement based on common MCP schema practices.
+        type: paramDef.type || "string",
+        description: paramDef.description,
+        required: requiredParams.has(paramName),
+        // Attributes might not directly map, handle if necessary
+        // attributes: paramDef.attributes || undefined,
+      });
+    }
+  }
+
+  return parameters;
+}
+
+/**
+ * Converts a map of MCPTools into an array of CopilotKit Actions.
+ * @param mcpTools A record mapping tool names to MCPTool objects.
+ * @param mcpEndpoint The endpoint URL from which these tools were fetched.
+ * @returns An array of Action<any> objects.
+ */
+export function convertMCPToolsToActions(
+  mcpTools: Record<string, MCPTool>,
+  mcpEndpoint: string,
+): Action<any>[] {
+  const actions: Action<any>[] = [];
+
+  for (const [toolName, tool] of Object.entries(mcpTools)) {
+    const parameters = extractParametersFromSchema(tool.schema);
+
+    const handler = async (params: any): Promise<any> => {
+      try {
+        const result = await tool.execute({ params });
+        // Ensure the result is a string or stringify it, as required by many LLMs.
+        // This might need adjustment depending on how different LLMs handle tool results.
+        return typeof result === "string" ? result : JSON.stringify(result);
+      } catch (error) {
+        console.error(
+          `Error executing MCP tool '${toolName}' from endpoint ${mcpEndpoint}:`,
+          error,
+        );
+        // Re-throw or format the error for the LLM
+        throw new Error(
+          `Execution failed for MCP tool '${toolName}': ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    };
+
+    actions.push({
+      name: toolName,
+      description: tool.description || `MCP tool: ${toolName} (from ${mcpEndpoint})`,
+      parameters: parameters,
+      handler: handler,
+      // Add metadata for easier identification/debugging
+      _isMCPTool: true,
+      _mcpEndpoint: mcpEndpoint,
+    } as Action<any> & { _isMCPTool: boolean; _mcpEndpoint: string }); // Type assertion for metadata
+  }
+
+  return actions;
+}

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -105,7 +105,6 @@ A function that creates an MCP client instance for a given endpoint configuratio
   (e.g., `@anthropic-ai/sdk`, `ai/experimental`) to establish a connection.
   Required if `mcpEndpoints` is provided.
  
-  @example
   ```typescript
   import { Anthropic } from "@anthropic-ai/sdk"; // Or your preferred client
   // ...
@@ -121,9 +120,6 @@ A function that creates an MCP client instance for a given endpoint configuratio
     }
   });
   ```
-  @param config Connection configuration for the MCP endpoint.
-  @returns A promise that resolves to an object conforming to the MCPClient interface.
-  @experimental
 </PropertyReference>
 
 <PropertyReference name="processRuntimeRequest" type="request: CopilotRuntimeRequest">

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -102,21 +102,24 @@ Configuration for connecting to Model Context Protocol (MCP) servers.
 <PropertyReference name="createMCPClient" type="CreateMCPClientFunction"  > 
 A function that creates an MCP client instance for a given endpoint configuration.
   This function is responsible for using the appropriate MCP client library
-  (e.g., `@anthropic-ai/sdk`, `ai/experimental`) to establish a connection.
+  (e.g., `@copilotkit/runtime`, `ai`) to establish a connection.
   Required if `mcpEndpoints` is provided.
  
   ```typescript
-  import { Anthropic } from "@anthropic-ai/sdk"; // Or your preferred client
+  import { experimental_createMCPClient } from "ai"; // Import from vercel ai library
   // ...
   const runtime = new CopilotRuntime({
     mcpEndpoints: [{ endpoint: "..." }],
     async createMCPClient(config) {
-      // Your logic to instantiate and return an object conforming to MCPClient
-      const client = new Anthropic({ apiKey: config.apiKey }); // Example
-      return { // Adapt Anthropic client to MCPClient interface
-        async tools() { return client.beta.tools.messages.stream(...); }, // Example mapping
-        // close() implementation if needed
-      };
+      return await experimental_createMCPClient({
+        transport: {
+          type: "sse",
+          url: config.endpoint,
+          headers: config.apiKey
+            ? { Authorization: `Bearer ${config.apiKey}` }
+            : undefined,
+        },
+      });
     }
   });
   ```

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -92,8 +92,42 @@ Configuration for LLM request/response logging.
   ```
 </PropertyReference>
 
-<PropertyReference name="processRuntimeRequest" type="request: CopilotRuntimeRequest">
+<PropertyReference name="mcpEndpoints" type="MCPEndpointConfig[]"  > 
+Configuration for connecting to Model Context Protocol (MCP) servers.
+  Allows fetching and using tools defined on external MCP-compliant servers.
+  Requires providing the `createMCPClient` function during instantiation.
+  @experimental
+</PropertyReference>
 
+<PropertyReference name="createMCPClient" type="CreateMCPClientFunction"  > 
+A function that creates an MCP client instance for a given endpoint configuration.
+  This function is responsible for using the appropriate MCP client library
+  (e.g., `@anthropic-ai/sdk`, `ai/experimental`) to establish a connection.
+  Required if `mcpEndpoints` is provided.
+ 
+  @example
+  ```typescript
+  import { Anthropic } from "@anthropic-ai/sdk"; // Or your preferred client
+  // ...
+  const runtime = new CopilotRuntime({
+    mcpEndpoints: [{ endpoint: "..." }],
+    async createMCPClient(config) {
+      // Your logic to instantiate and return an object conforming to MCPClient
+      const client = new Anthropic({ apiKey: config.apiKey }); // Example
+      return { // Adapt Anthropic client to MCPClient interface
+        async tools() { return client.beta.tools.messages.stream(...); }, // Example mapping
+        // close() implementation if needed
+      };
+    }
+  });
+  ```
+  @param config Connection configuration for the MCP endpoint.
+  @returns A promise that resolves to an object conforming to the MCPClient interface.
+  @experimental
+</PropertyReference>
+
+<PropertyReference name="processRuntimeRequest" type="request: CopilotRuntimeRequest">
+// --- MCP Instruction Injection Method ---
 
   <PropertyReference name="request" type="CopilotRuntimeRequest" required>
   

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -4,53 +4,49 @@ description: "The CopilotKit provider component, wrapping your application."
 ---
 
 {
-/\*
-
-- ATTENTION! DO NOT MODIFY THIS FILE!
-- This page is auto-generated. If you want to make any changes to this page, changes must be made at:
-- CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
-  \*/
-  }
-  This component will typically wrap your entire application (or a sub-tree of your application where you want to have a copilot). It provides the copilot context to all other components and hooks.
-
+ /*
+  * ATTENTION! DO NOT MODIFY THIS FILE!
+  * This page is auto-generated. If you want to make any changes to this page, changes must be made at:
+  * CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+  */
+}
+This component will typically wrap your entire application (or a sub-tree of your application where you want to have a copilot). It provides the copilot context to all other components and hooks.
+ 
 ## Example
-
+ 
 You can find more information about self-hosting CopilotKit [here](/guides/self-hosting).
-
+ 
 ```tsx
 import { CopilotKit } from "@copilotkit/react-core";
-
-<CopilotKit runtimeUrl="<your-runtime-url>">// ... your app ...</CopilotKit>;
+ 
+<CopilotKit runtimeUrl="<your-runtime-url>">
+  // ... your app ...
+</CopilotKit>
 ```
 
 ## Properties
 
-<PropertyReference name="publicApiKey" type="string">
-  Your Copilot Cloud API key. Don't have it yet? Go to
-  https://cloud.copilotkit.ai and get one for free.
+<PropertyReference name="publicApiKey" type="string"  > 
+Your Copilot Cloud API key. Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
 </PropertyReference>
 
-<PropertyReference
-  name="guardrails_c"
-  type="{ validTopics?: string[]; invalidTopics?: string[]; }"
->
-  Restrict input to specific topics using guardrails. @remarks This feature is
-  only available when using CopilotKit's hosted cloud service. To use this
-  feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The
-  feature allows restricting chat conversations to specific topics.
+<PropertyReference name="guardrails_c" type="{ validTopics?: string[]; invalidTopics?: string[]; }"  > 
+Restrict input to specific topics using guardrails.
+  @remarks
+ 
+  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 </PropertyReference>
 
-<PropertyReference name="runtimeUrl" type="string">
-  The endpoint for the Copilot Runtime instance. [Click here for more
-  information](/concepts/copilot-runtime).
+<PropertyReference name="runtimeUrl" type="string"  > 
+The endpoint for the Copilot Runtime instance. [Click here for more information](/concepts/copilot-runtime).
 </PropertyReference>
 
-<PropertyReference name="transcribeAudioUrl" type="string">
-  The endpoint for the Copilot transcribe audio service.
+<PropertyReference name="transcribeAudioUrl" type="string"  > 
+The endpoint for the Copilot transcribe audio service.
 </PropertyReference>
 
-<PropertyReference name="textToSpeechUrl" type="string">
-  The endpoint for the Copilot text to speech service.
+<PropertyReference name="textToSpeechUrl" type="string"  > 
+The endpoint for the Copilot text to speech service.
 </PropertyReference>
 
 <PropertyReference name="headers" type="Record<string, string>"  > 
@@ -64,8 +60,8 @@ Additional headers to be sent with the request.
   ```
 </PropertyReference>
 
-<PropertyReference name="children" type="ReactNode" required>
-  The children to be rendered within the CopilotKit.
+<PropertyReference name="children" type="ReactNode" required > 
+The children to be rendered within the CopilotKit.
 </PropertyReference>
 
 <PropertyReference name="properties" type="Record<string, any>"  > 
@@ -74,7 +70,6 @@ Custom properties to be sent with the request.
   and can be used for custom logic, including dynamic configuration.
  
   @example
-  ```js
   // Pass arbitrary data, including dynamic MCP endpoint configurations:
   const myProps = {
     user_id: 'user123',
@@ -86,65 +81,63 @@ Custom properties to be sent with the request.
   };
   // Then use in your component:
   // <CopilotKit properties={myProps}> ... </CopilotKit>
-  ```
 </PropertyReference>
 
-<PropertyReference name="credentials" type="RequestCredentials">
-  Indicates whether the user agent should send or receive cookies from the other
-  domain in the case of cross-origin requests.
+<PropertyReference name="credentials" type="RequestCredentials"  > 
+Indicates whether the user agent should send or receive cookies from the other domain
+  in the case of cross-origin requests.
 </PropertyReference>
 
-<PropertyReference name="showDevConsole" type="boolean | 'auto'">
-  Whether to show the dev console. If set to "auto", the dev console will be
-  show on localhost only.
+<PropertyReference name="showDevConsole" type="boolean | 'auto'"  > 
+Whether to show the dev console.
+ 
+  If set to "auto", the dev console will be show on localhost only.
 </PropertyReference>
 
-<PropertyReference name="agent" type="string">
-  The name of the agent to use.
+<PropertyReference name="agent" type="string"  > 
+The name of the agent to use.
 </PropertyReference>
 
-<PropertyReference
-  name="forwardedParameters"
-  type="Pick<ForwardedParametersInput, 'temperature'>"
->
-  The forwarded parameters to use for the task.
+<PropertyReference name="forwardedParameters" type="Pick<ForwardedParametersInput, 'temperature'>"  > 
+The forwarded parameters to use for the task.
 </PropertyReference>
 
-<PropertyReference
-  name="authConfig_c"
-  type="{ SignInComponent: React.ComponentType<{ onSignInComplete: (authState: AuthState) => void; }>; }"
->
-  The auth config to use for the CopilotKit. @remarks This feature is only
-  available when using CopilotKit's hosted cloud service. To use this feature,
-  sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature
-  allows restricting chat conversations to specific topics.
+<PropertyReference name="authConfig_c" type="{ SignInComponent: React.ComponentType<{ onSignInComplete: (authState: AuthState) => void; }>; }"  > 
+The auth config to use for the CopilotKit.
+  @remarks
+ 
+  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
 </PropertyReference>
 
-<PropertyReference name="threadId" type="string">
-  The thread id to use for the CopilotKit.
+<PropertyReference name="threadId" type="string"  > 
+The thread id to use for the CopilotKit.
 </PropertyReference>
 
-<PropertyReference
-  name="mcpEndpoints"
-  type="Array<{ endpoint: string; apiKey?: string }>"
->
-  Configuration for connecting to Model Context Protocol (MCP) servers. Allows
-  the CopilotKit runtime to discover and utilize tools hosted on external
-  MCP-compliant servers. If provided, this configuration will be merged into the
-  `properties` object sent with each request under the key `mcpEndpoints`. It
-  provides a strongly-typed way to configure request-specific MCP endpoints.
-  Each object in the array should contain: - `endpoint`: The URL of the MCP
-  server (required). - `apiKey`: An optional API key if the server requires
-  authentication. @example ```tsx
+<PropertyReference name="mcpEndpoints" type="Array<{ endpoint: string; apiKey?: string }>"  > 
+Configuration for connecting to Model Context Protocol (MCP) servers.
+  Allows the CopilotKit runtime to discover and utilize tools hosted
+  on external MCP-compliant servers.
+ 
+  If provided, this configuration will be merged into the `properties` object
+  sent with each request under the key `mcpEndpoints`.
+  It provides a strongly-typed way to configure request-specific MCP endpoints.
+ 
+  Each object in the array should contain:
+  - `endpoint`: The URL of the MCP server (required).
+  - `apiKey`: An optional API key if the server requires authentication.
+ 
+  @example
   <CopilotKit
     mcpEndpoints={[
       { endpoint: "https://my-mcp-server.com/api" },
       { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
     ]}
-    properties={{ user_id: "123" }} // Other properties can still be used
   >
     // ... your components
   </CopilotKit>
-  ``` Note: The runtime still requires a `createMCPClient` function to be
-  provided during its initialization to handle these endpoints. @experimental
+ 
+  Note: The runtime still requires a `createMCPClient` function to be provided
+  during its initialization to handle these endpoints.
+  @experimental
 </PropertyReference>
+

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -4,49 +4,53 @@ description: "The CopilotKit provider component, wrapping your application."
 ---
 
 {
- /*
-  * ATTENTION! DO NOT MODIFY THIS FILE!
-  * This page is auto-generated. If you want to make any changes to this page, changes must be made at:
-  * CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
-  */
-}
-This component will typically wrap your entire application (or a sub-tree of your application where you want to have a copilot). It provides the copilot context to all other components and hooks.
- 
+/\*
+
+- ATTENTION! DO NOT MODIFY THIS FILE!
+- This page is auto-generated. If you want to make any changes to this page, changes must be made at:
+- CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+  \*/
+  }
+  This component will typically wrap your entire application (or a sub-tree of your application where you want to have a copilot). It provides the copilot context to all other components and hooks.
+
 ## Example
- 
+
 You can find more information about self-hosting CopilotKit [here](/guides/self-hosting).
- 
+
 ```tsx
 import { CopilotKit } from "@copilotkit/react-core";
- 
-<CopilotKit runtimeUrl="<your-runtime-url>">
-  // ... your app ...
-</CopilotKit>
+
+<CopilotKit runtimeUrl="<your-runtime-url>">// ... your app ...</CopilotKit>;
 ```
 
 ## Properties
 
-<PropertyReference name="publicApiKey" type="string"  > 
-Your Copilot Cloud API key. Don't have it yet? Go to https://cloud.copilotkit.ai and get one for free.
+<PropertyReference name="publicApiKey" type="string">
+  Your Copilot Cloud API key. Don't have it yet? Go to
+  https://cloud.copilotkit.ai and get one for free.
 </PropertyReference>
 
-<PropertyReference name="guardrails_c" type="{ validTopics?: string[]; invalidTopics?: string[]; }"  > 
-Restrict input to specific topics using guardrails.
-  @remarks
- 
-  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+<PropertyReference
+  name="guardrails_c"
+  type="{ validTopics?: string[]; invalidTopics?: string[]; }"
+>
+  Restrict input to specific topics using guardrails. @remarks This feature is
+  only available when using CopilotKit's hosted cloud service. To use this
+  feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The
+  feature allows restricting chat conversations to specific topics.
 </PropertyReference>
 
-<PropertyReference name="runtimeUrl" type="string"  > 
-The endpoint for the Copilot Runtime instance. [Click here for more information](/concepts/copilot-runtime).
+<PropertyReference name="runtimeUrl" type="string">
+  The endpoint for the Copilot Runtime instance. [Click here for more
+  information](/concepts/copilot-runtime).
 </PropertyReference>
 
-<PropertyReference name="transcribeAudioUrl" type="string"  > 
-The endpoint for the Copilot transcribe audio service.
+<PropertyReference name="transcribeAudioUrl" type="string">
+  The endpoint for the Copilot transcribe audio service.
 </PropertyReference>
 
-<PropertyReference name="textToSpeechUrl" type="string"  > 
-The endpoint for the Copilot text to speech service.
+<PropertyReference name="textToSpeechUrl" type="string">
+  The endpoint for the Copilot text to speech service.
 </PropertyReference>
 
 <PropertyReference name="headers" type="Record<string, string>"  > 
@@ -60,8 +64,8 @@ Additional headers to be sent with the request.
   ```
 </PropertyReference>
 
-<PropertyReference name="children" type="ReactNode" required > 
-The children to be rendered within the CopilotKit.
+<PropertyReference name="children" type="ReactNode" required>
+  The children to be rendered within the CopilotKit.
 </PropertyReference>
 
 <PropertyReference name="properties" type="Record<string, any>"  > 
@@ -70,6 +74,7 @@ Custom properties to be sent with the request.
   and can be used for custom logic, including dynamic configuration.
  
   @example
+  ```js
   // Pass arbitrary data, including dynamic MCP endpoint configurations:
   const myProps = {
     user_id: 'user123',
@@ -81,66 +86,65 @@ Custom properties to be sent with the request.
   };
   // Then use in your component:
   // <CopilotKit properties={myProps}> ... </CopilotKit>
+  ```
 </PropertyReference>
 
-<PropertyReference name="credentials" type="RequestCredentials"  > 
-Indicates whether the user agent should send or receive cookies from the other domain
-  in the case of cross-origin requests.
+<PropertyReference name="credentials" type="RequestCredentials">
+  Indicates whether the user agent should send or receive cookies from the other
+  domain in the case of cross-origin requests.
 </PropertyReference>
 
-<PropertyReference name="showDevConsole" type="boolean | 'auto'"  > 
-Whether to show the dev console.
- 
-  If set to "auto", the dev console will be show on localhost only.
+<PropertyReference name="showDevConsole" type="boolean | 'auto'">
+  Whether to show the dev console. If set to "auto", the dev console will be
+  show on localhost only.
 </PropertyReference>
 
-<PropertyReference name="agent" type="string"  > 
-The name of the agent to use.
+<PropertyReference name="agent" type="string">
+  The name of the agent to use.
 </PropertyReference>
 
-<PropertyReference name="forwardedParameters" type="Pick<ForwardedParametersInput, 'temperature'>"  > 
-The forwarded parameters to use for the task.
+<PropertyReference
+  name="forwardedParameters"
+  type="Pick<ForwardedParametersInput, 'temperature'>"
+>
+  The forwarded parameters to use for the task.
 </PropertyReference>
 
-<PropertyReference name="authConfig_c" type="{ SignInComponent: React.ComponentType<{ onSignInComplete: (authState: AuthState) => void; }>; }"  > 
-The auth config to use for the CopilotKit.
-  @remarks
- 
-  This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
+<PropertyReference
+  name="authConfig_c"
+  type="{ SignInComponent: React.ComponentType<{ onSignInComplete: (authState: AuthState) => void; }>; }"
+>
+  The auth config to use for the CopilotKit. @remarks This feature is only
+  available when using CopilotKit's hosted cloud service. To use this feature,
+  sign up at https://cloud.copilotkit.ai to get your publicApiKey. The feature
+  allows restricting chat conversations to specific topics.
 </PropertyReference>
 
-<PropertyReference name="threadId" type="string"  > 
-The thread id to use for the CopilotKit.
+<PropertyReference name="threadId" type="string">
+  The thread id to use for the CopilotKit.
 </PropertyReference>
 
-<PropertyReference name="mcpEndpoints" type="Array<{ endpoint: string; apiKey?: string }>"  > 
-Configuration for connecting to Model Context Protocol (MCP) servers.
-  Allows the CopilotKit runtime to discover and utilize tools hosted
-  on external MCP-compliant servers.
- 
-  If provided, this configuration will be merged into the `properties` object
-  sent with each request under the key `mcpEndpoints`.
-  It provides a strongly-typed way to configure request-specific MCP endpoints.
- 
-  Each object in the array should contain:
-  - `endpoint`: The URL of the MCP server (required).
-  - `apiKey`: An optional API key if the server requires authentication.
- 
-  @example
-  ```tsx
+<PropertyReference
+  name="mcpEndpoints"
+  type="Array<{ endpoint: string; apiKey?: string }>"
+>
+  Configuration for connecting to Model Context Protocol (MCP) servers. Allows
+  the CopilotKit runtime to discover and utilize tools hosted on external
+  MCP-compliant servers. If provided, this configuration will be merged into the
+  `properties` object sent with each request under the key `mcpEndpoints`. It
+  provides a strongly-typed way to configure request-specific MCP endpoints.
+  Each object in the array should contain: - `endpoint`: The URL of the MCP
+  server (required). - `apiKey`: An optional API key if the server requires
+  authentication. @example ```tsx
   <CopilotKit
     mcpEndpoints={[
       { endpoint: "https://my-mcp-server.com/api" },
       { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
     ]}
-    properties={{ user_id: '123' }} // Other properties can still be used
+    properties={{ user_id: "123" }} // Other properties can still be used
   >
     // ... your components
   </CopilotKit>
-  ```
- 
-  Note: The runtime still requires a `createMCPClient` function to be provided
-  during its initialization to handle these endpoints.
-  @experimental
+  ``` Note: The runtime still requires a `createMCPClient` function to be
+  provided during its initialization to handle these endpoints. @experimental
 </PropertyReference>
-

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -65,13 +65,22 @@ The children to be rendered within the CopilotKit.
 </PropertyReference>
 
 <PropertyReference name="properties" type="Record<string, any>"  > 
-Custom properties to be sent with the request
-  For example:
-  ```js
-  {
-    'user_id': 'users_id',
-  }
-  ```
+Custom properties to be sent with the request.
+  These properties are accessible in the runtime via `graphqlContext.properties`
+  and can be used for custom logic, including dynamic configuration.
+ 
+  @example
+  // Pass arbitrary data, including dynamic MCP endpoint configurations:
+  const myProps = {
+    user_id: 'user123',
+    session_theme: 'dark',
+    mcpEndpoints: [
+      { endpoint: "https://dynamic-mcp.example.com" }
+      // ... other request-specific endpoints
+    ]
+  };
+  // Then use in your component:
+  // <CopilotKit properties={myProps}> ... </CopilotKit>
 </PropertyReference>
 
 <PropertyReference name="credentials" type="RequestCredentials"  > 
@@ -109,6 +118,10 @@ Configuration for connecting to Model Context Protocol (MCP) servers.
   Allows the CopilotKit runtime to discover and utilize tools hosted
   on external MCP-compliant servers.
  
+  If provided, this configuration will be merged into the `properties` object
+  sent with each request under the key `mcpEndpoints`.
+  It provides a strongly-typed way to configure request-specific MCP endpoints.
+ 
   Each object in the array should contain:
   - `endpoint`: The URL of the MCP server (required).
   - `apiKey`: An optional API key if the server requires authentication.
@@ -120,13 +133,14 @@ Configuration for connecting to Model Context Protocol (MCP) servers.
       { endpoint: "https://my-mcp-server.com/api" },
       { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
     ]}
+    properties={{ user_id: '123' }} // Other properties can still be used
   >
     // ... your components
   </CopilotKit>
   ```
  
-  Note: This feature relies on a user-provided implementation of `createMCPClient`
-  in the runtime environment to establish the actual connection.
+  Note: The runtime still requires a `createMCPClient` function to be provided
+  during its initialization to handle these endpoints.
   @experimental
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -65,22 +65,13 @@ The children to be rendered within the CopilotKit.
 </PropertyReference>
 
 <PropertyReference name="properties" type="Record<string, any>"  > 
-Custom properties to be sent with the request.
-  These properties are accessible in the runtime via `graphqlContext.properties`
-  and can be used for custom logic, including dynamic configuration.
- 
-  @example
-  // Pass arbitrary data, including dynamic MCP endpoint configurations:
-  const myProps = {
-    user_id: 'user123',
-    session_theme: 'dark',
-    mcpEndpoints: [
-      { endpoint: "https://dynamic-mcp.example.com" }
-      // ... other request-specific endpoints
-    ]
-  };
-  // Then use in your component:
-  // <CopilotKit properties={myProps}> ... </CopilotKit>
+Custom properties to be sent with the request
+  For example:
+  ```js
+  {
+    'user_id': 'users_id',
+  }
+  ```
 </PropertyReference>
 
 <PropertyReference name="credentials" type="RequestCredentials"  > 
@@ -114,30 +105,16 @@ The thread id to use for the CopilotKit.
 </PropertyReference>
 
 <PropertyReference name="mcpEndpoints" type="Array<{ endpoint: string; apiKey?: string }>"  > 
-Configuration for connecting to Model Context Protocol (MCP) servers.
-  Allows the CopilotKit runtime to discover and utilize tools hosted
-  on external MCP-compliant servers.
+Config for connecting to Model Context Protocol (MCP) servers.
+  Enables CopilotKit runtime to access tools on external MCP servers.
  
-  If provided, this configuration will be merged into the `properties` object
-  sent with each request under the key `mcpEndpoints`.
-  It provides a strongly-typed way to configure request-specific MCP endpoints.
+  This config merges into the `properties` object with each request as `mcpEndpoints`.
+  It offers a typed method to set up MCP endpoints for requests.
  
-  Each object in the array should contain:
-  - `endpoint`: The URL of the MCP server (required).
-  - `apiKey`: An optional API key if the server requires authentication.
+  Each array item should have:
+  - `endpoint`: MCP server URL (mandatory).
+  - `apiKey`: Optional API key for server authentication.
  
-  @example
-  <CopilotKit
-    mcpEndpoints={[
-      { endpoint: "https://my-mcp-server.com/api" },
-      { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
-    ]}
-  >
-    // ... your components
-  </CopilotKit>
- 
-  Note: The runtime still requires a `createMCPClient` function to be provided
-  during its initialization to handle these endpoints.
-  @experimental
+  Note: A `createMCPClient` function is still needed during runtime initialization to manage these endpoints.
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -104,3 +104,29 @@ The auth config to use for the CopilotKit.
 The thread id to use for the CopilotKit.
 </PropertyReference>
 
+<PropertyReference name="mcpEndpoints" type="Array<{ endpoint: string; apiKey?: string }>"  > 
+Configuration for connecting to Model Context Protocol (MCP) servers.
+  Allows the CopilotKit runtime to discover and utilize tools hosted
+  on external MCP-compliant servers.
+ 
+  Each object in the array should contain:
+  - `endpoint`: The URL of the MCP server (required).
+  - `apiKey`: An optional API key if the server requires authentication.
+ 
+  @example
+  ```tsx
+  <CopilotKit
+    mcpEndpoints={[
+      { endpoint: "https://my-mcp-server.com/api" },
+      { endpoint: "https://another-mcp.dev", apiKey: "secret-key" },
+    ]}
+  >
+    // ... your components
+  </CopilotKit>
+  ```
+ 
+  Note: This feature relies on a user-provided implementation of `createMCPClient`
+  in the runtime environment to establish the actual connection.
+  @experimental
+</PropertyReference>
+


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Integrates support for discovering and using tools from external servers adhering to the Model Context Protocol.

- Adds `mcpEndpoints` and `createMCPClient` options to `CopilotKit` props and `CopilotRuntime` constructor parameters.
- The `mcpEndpoints` array configures connections to MCP servers.
- The `createMCPClient` function (required when using `mcpEndpoints`) allows users to inject their specific MCP client implementation (e.g., using `@anthropic-ai/sdk`, `ai/experimental`) into the runtime.
- Defines `MCPTool` and `MCPClient` interfaces for abstraction.
- Implements utility functions (`extractParametersFromSchema`, `convertMCPToolsToActions`) to convert MCP tools into standard CopilotKit actions.
- Modifies `CopilotRuntime` to:
    - Lazily initialize MCP clients using the provided `createMCPClient`.
    - Fetch tools from configured endpoints.
    - Convert fetched tools to `Action` objects.
    - Make MCP actions available alongside other server-side actions.
    - Inject a system message describing available MCP tools to the LLM.
- Refactors the initial approach from relying on a global `declare function createMCPClient` to using explicit dependency injection via constructor parameters for improved clarity and type safety.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation