### PR TITLE
fix(crewai): Retrieve and convert messages from stored state

### DIFF
--- a/docs/content/docs/crewai-flows/persistence/loading-message-history.mdx
+++ b/docs/content/docs/crewai-flows/persistence/loading-message-history.mdx
@@ -1,31 +1,32 @@
 ---
-title: Threads
-description: Learn how to load chat messages and threads within the CopilotKit framework.
+title: Threads & Persistence
+description: Learn how to maintain persistent conversations across sessions with CrewAI Flows.
 icon: "lucide/MessagesSquare"
 ---
 
-CrewAI Flows supports threads, a way to group messages together and ultimately maintain a continuous chat history. CopilotKit
-provides a few different ways to interact with this concept.
+# Understanding Thread Persistence
+
+CrewAI Flows supports threads, a way to group messages together and maintain a continuous chat history across sessions. CopilotKit provides mechanisms to ensure conversation state is properly persisted between the frontend and backend.
 
 This guide assumes you have already gone through the [quickstart](/quickstart) guide.
 
-## Loading an Existing Thread
+## Frontend: Setting the ThreadId
 
-To load an existing thread in CopilotKit, you can simply set the `threadId` property on `<CopilotKit>` like so.
+### Loading an Existing Thread
+
+To load an existing thread in CopilotKit, set the `threadId` property on `<CopilotKit>`:
 
 ```tsx
 import { CopilotKit } from "@copilotkit/react-core";
 
 <CopilotKit threadId="37aa68d0-d15b-45ae-afc1-0ba6c3e11353">
-  {" "}
-  // [!code highlight]
   <YourApp />
 </CopilotKit>;
 ```
 
-## Dynamically Switching Threads
+### Dynamically Switching Threads
 
-You can also make the `threadId` dynamic. Once it is set, CopilotKit will load the previous messages for that thread.
+You can make the `threadId` dynamic. Once set, CopilotKit will load previous messages for that thread.
 
 ```tsx
 import { useState } from "react";
@@ -34,40 +35,148 @@ import { CopilotKit } from "@copilotkit/react-core";
 const Page = () => {
   const [threadId, setThreadId] = useState(
     "af2fa5a4-36bd-4e02-9b55-2580ab584f89"
-  ); // [!code highlight]
+  );
   return (
     <CopilotKit threadId={threadId}>
-      {" "}
-      // [!code highlight]
-      <YourApp setThreadId={setThreadId} /> // [!code highlight]
+      <YourApp setThreadId={setThreadId} />
     </CopilotKit>
   );
 };
 
-const YourApp = () => {
+const YourApp = ({ setThreadId }) => {
   return (
     <Button onClick={() => setThreadId("679e8da5-ee9b-41b1-941b-80e0cc73a008")}>
-      {" "}
-      // [!code highlight] Change Thread
+      Change Thread
     </Button>
   );
 };
 ```
 
-## Using setThreadId
+### Using setThreadId
 
-CopilotKit will also return the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook. You can use `setThreadId` to change the `threadId`.
+CopilotKit provides the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook:
 
 ```tsx
 import { useCopilotContext } from "@copilotkit/react-core";
 
 const ChangeThreadButton = () => {
-  const { threadId, setThreadId } = useCopilotContext(); // [!code highlight]
+  const { threadId, setThreadId } = useCopilotContext();
   return (
     <Button onClick={() => setThreadId("d73c22f3-1f8e-4a93-99db-5c986068d64f")}>
-      {" "}
-      // [!code highlight] Change Thread
+      Change Thread
     </Button>
   );
 };
 ```
+
+## Backend: ThreadId with CrewAI Flows
+
+For proper persistence between sessions, the `threadId` from the frontend must be connected to the CrewAI Flow in your backend.
+
+### Understanding Flow State IDs
+
+CrewAI Flows maintain a unique state ID internally which is used for persistence. By default, Flow generates a random UUID for each flow instance. For thread persistence to work correctly, this ID must match the `threadId` from the frontend.
+
+### Initializing Flows with ThreadId
+
+When creating a flow instance, pass the `threadId` to the constructor:
+
+```python
+from sample_agent.agent import SampleAgentFlow
+
+# Create a flow with the threadId from the frontend request
+flow = SampleAgentFlow(thread_id=thread_id)
+```
+
+The flow's constructor should ensure the state ID matches the provided `thread_id`:
+
+```python
+def __init__(self, thread_id=None, **kwargs):
+    # Initialize with standard flow setup
+    super().__init__(**kwargs)
+
+    # Override the state ID with the provided thread_id
+    if thread_id:
+        # Set the ID in the state object
+        if hasattr(self.state, "id"):
+            self.state.id = thread_id
+        elif isinstance(self.state, dict):
+            self.state["id"] = thread_id
+
+        # Also set it in the internal _state property
+        if hasattr(self, "_state"):
+            if hasattr(self._state, "id"):
+                self._state.id = thread_id
+            elif isinstance(self._state, dict):
+                self._state["id"] = thread_id
+```
+
+You can see a complete implementation example in our [sample agent implementation](https://github.com/CopilotKit/CopilotKit/blob/main/examples/coagents-starter-crewai-flows/agent-py/sample_agent/agent.py).
+
+### Implementing Thread Persistence in FastAPI
+
+For FastAPI applications, we recommend implementing a `PersistenceAgent` that ensures thread consistency:
+
+```python
+class PersistenceAgent(CrewAIAgent):
+    """
+    Ensures ThreadID persistence across requests by creating Flow instances
+    with the correct threadId.
+    """
+
+    def execute(self, *, thread_id, **kwargs):
+        # Create a fresh flow instance with the thread_id
+        new_flow = SampleAgentFlow(thread_id=thread_id)
+
+        # Replace self.flow with our new flow
+        self.flow = new_flow
+
+        # Execute using the parent implementation
+        return super().execute(thread_id=thread_id, **kwargs)
+
+    async def get_state(self, *, thread_id: str):
+        # Create a flow with the requested threadId
+        flow = SampleAgentFlow(thread_id=thread_id)
+
+        # Replace self.flow with our new flow
+        self.flow = flow
+
+        # Use the parent's implementation to get the state
+        return await super().get_state(thread_id=thread_id)
+```
+
+## Best Practices for Thread Persistence
+
+1. **Always Create Fresh Flow Instances**: For each request, create a new Flow instance with the correct `threadId` to prevent state contamination.
+
+2. **Use Consistent IDs**: Ensure the Flow's state ID and the frontend `threadId` are identical.
+
+3. **Implement Custom Persistence**: If needed, customize the Flow's persistence layer to handle thread loading/saving based on the provided IDs.
+
+4. **Debug ThreadId Issues**: Add logging to track the `threadId` flow through your application:
+
+```python
+print(f"[DEBUG] Flow created with threadId: {thread_id}")
+print(f"[DEBUG] Current state ID: {getattr(flow.state, 'id', 'unknown')}")
+```
+
+5. **Handle Thread Not Found**: Implement proper handling when a thread doesn't exist in your persistence layer:
+
+```python
+if not result.get("threadExists", False):
+    # Return a new empty state with the requested threadId
+    return {
+        "threadId": thread_id,
+        "threadExists": True,
+        "state": {"id": thread_id, "messages": [], "copilotkit": {"actions": []}},
+        "messages": []
+    }
+```
+
+By following these patterns, you can ensure reliable conversation persistence between your frontend and CrewAI Flow backend.
+
+## Example Implementations
+
+For complete working examples, refer to:
+
+- [Sample Agent Implementation](https://github.com/CopilotKit/CopilotKit/blob/main/examples/coagents-starter-crewai-flows/agent-py/sample_agent/agent.py) - See a full implementation of a Flow with thread persistence

--- a/examples/coagents-starter-crewai-flows/agent-py/sample_agent/agent.py
+++ b/examples/coagents-starter-crewai-flows/agent-py/sample_agent/agent.py
@@ -5,8 +5,14 @@ It defines the workflow graph, state, tools, nodes and edges.
 
 import json
 from typing_extensions import Literal
+from typing import Any, Dict, Optional, Union, List
+from pydantic import BaseModel
 from litellm import completion
 from crewai.flow.flow import Flow, start, router, listen
+from crewai.flow.persistence import persist
+from crewai.flow.persistence.base import FlowPersistence
+import uuid
+import copy
 
 from copilotkit.crewai import copilotkit_stream, CopilotKitState, copilotkit_exit
 
@@ -49,10 +55,280 @@ tool_handlers = {
     # your tool handler here
 }
 
+class InMemoryFlowPersistence(FlowPersistence):
+    def __init__(self):
+        self.storage = {}
+        self.init_db()
+        
+    def init_db(self):
+        # No actual DB initialization needed for in-memory
+        pass
+        
+    def save_state(
+        self,
+        flow_uuid: str,
+        method_name: str,
+        state_data: Union[Dict[str, Any], BaseModel],
+    ) -> None:
+        """Save the current flow state to memory.
+
+        Args:
+            flow_uuid: Unique identifier for the flow instance
+            method_name: Name of the method that just completed
+            state_data: Current state data (either dict or Pydantic model)
+        """
+        print(f"[PERSISTENCE DEBUG] save_state called with flow_uuid: {flow_uuid}")
+        
+        # Convert state_data to dict, handling both Pydantic and dict cases
+        if isinstance(state_data, BaseModel):
+            state_dict = dict(state_data)
+        elif isinstance(state_data, dict):
+            state_dict = state_data
+        else:
+            raise ValueError(
+                f"state_data must be either a Pydantic BaseModel or dict, got {type(state_data)}"
+            )
+        
+        # Check if we have an ID mismatch
+        state_id = None
+        if isinstance(state_dict, dict) and "id" in state_dict:
+            state_id = state_dict["id"]
+        if state_id != flow_uuid:
+            print(f"[PERSISTENCE DEBUG] ID mismatch: flow_uuid={flow_uuid}, state_id={state_id}")
+            # Ensure the ID matches what was passed in
+            state_dict["id"] = flow_uuid
+            print(f"[PERSISTENCE DEBUG] Corrected ID to: {flow_uuid}")
+        
+        # Special handling for proper message serialization
+        if "messages" in state_dict and state_dict["messages"]:
+            print(f"[SAVE DEBUG] Saving {len(state_dict['messages'])} messages to state {flow_uuid}")
+            
+            # Convert any Message objects to a format that's compatible with crewai_flow_messages_to_copilotkit
+            serialized_messages = []
+            for msg in state_dict["messages"]:
+                # Start with a minimal message structure
+                serialized_msg = {}
+                
+                # Handle different message types
+                if hasattr(msg, "model_dump"):
+                    serialized_msg = msg.model_dump()
+                elif hasattr(msg, "dict"):
+                    serialized_msg = msg.dict()
+                elif isinstance(msg, dict):
+                    serialized_msg = msg.copy()
+                else:
+                    # Create a basic compatible message
+                    serialized_msg = {
+                        "content": getattr(msg, "content", str(msg)),
+                        "role": getattr(msg, "role", "assistant"),
+                        "id": getattr(msg, "id", str(uuid.uuid4()))
+                    }
+                
+                # Ensure necessary fields are present for crewai_flow_messages_to_copilotkit
+                # Role and id are the minimum required fields
+                if "role" not in serialized_msg:
+                    serialized_msg["role"] = "assistant"
+                if "id" not in serialized_msg:
+                    serialized_msg["id"] = str(uuid.uuid4())
+                
+                # Handle tool calls - ensure they're in the format expected by crewai_flow_messages_to_copilotkit
+                if "tool_calls" in serialized_msg:
+                    # Check if tool_calls is None and replace with empty list if needed
+                    if serialized_msg["tool_calls"] is None:
+                        serialized_msg["tool_calls"] = []
+                    # Now process if there are any tool calls
+                    elif serialized_msg["tool_calls"]:
+                        for i, tool_call in enumerate(serialized_msg["tool_calls"]):
+                            if isinstance(tool_call, dict):
+                                if "function" not in tool_call:
+                                    tool_call["function"] = {
+                                        "name": tool_call.get("name", f"tool_{i}"),
+                                        "arguments": tool_call.get("arguments", "{}")
+                                    }
+                                elif isinstance(tool_call["function"], dict):
+                                    if "arguments" in tool_call["function"] and not isinstance(tool_call["function"]["arguments"], str):
+                                        tool_call["function"]["arguments"] = json.dumps(tool_call["function"]["arguments"])
+                
+                serialized_messages.append(serialized_msg)
+                
+            # Update the state with properly serialized messages
+            state_dict["messages"] = serialized_messages
+            
+        # Special handling for CopilotKitProperties
+        if "copilotkit" in state_dict:
+            print(f"[SAVE DEBUG] Handling copilotkit property of type {type(state_dict['copilotkit']).__name__}")
+            if hasattr(state_dict["copilotkit"], "model_dump"):
+                state_dict["copilotkit"] = state_dict["copilotkit"].model_dump()
+            elif hasattr(state_dict["copilotkit"], "dict"):
+                state_dict["copilotkit"] = state_dict["copilotkit"].dict()
+            elif not isinstance(state_dict["copilotkit"], dict):
+                # Convert to a basic dict
+                actions = getattr(state_dict["copilotkit"], "actions", [])
+                # Ensure actions is not None
+                if actions is None:
+                    actions = []
+                # Convert actions to dictionaries if needed
+                serialized_actions = []
+                for action in actions:
+                    if hasattr(action, "model_dump"):
+                        serialized_actions.append(action.model_dump())
+                    elif hasattr(action, "dict"):
+                        serialized_actions.append(action.dict())
+                    elif isinstance(action, dict):
+                        serialized_actions.append(action)
+                    else:
+                        serialized_actions.append({"name": str(action)})
+                state_dict["copilotkit"] = {"actions": serialized_actions}
+            
+        # Final serialization test - make sure everything is JSON serializable
+        try:
+            json.dumps(state_dict)
+        except TypeError as e:
+            print(f"[SAVE DEBUG] State contains non-serializable objects: {e}")
+            # If it's not serializable, we'll create a new state dictionary with only serializable content
+            serializable_dict = {}
+            for key, value in state_dict.items():
+                try:
+                    json.dumps({key: value})
+                    serializable_dict[key] = value
+                except TypeError:
+                    print(f"[SAVE DEBUG] Non-serializable field: {key}")
+                    # Convert to string representation
+                    if isinstance(value, (list, tuple)):
+                        serializable_dict[key] = [str(item) for item in value]
+                    else:
+                        serializable_dict[key] = str(value)
+            state_dict = serializable_dict
+            
+        # Important: Make sure the flow_uuid from the method argument is used
+        # to save the state, as this is the threadId from the frontend
+        self.storage[flow_uuid] = state_dict
+        print(f"[STORAGE DEBUG] Storage now has keys: {list(self.storage.keys())}")
+        
+    def load_state(self, flow_uuid: str) -> Optional[Dict[str, Any]]:
+        """Load the state for a given flow UUID.
+
+        Args:
+            flow_uuid: Unique identifier for the flow instance
+
+        Returns:
+            The state as a dictionary, or None if no state exists
+        """
+        print(f"[PERSISTENCE DEBUG] load_state called with flow_uuid: {flow_uuid}")
+        print(f"[PERSISTENCE DEBUG] Available IDs: {list(self.storage.keys())}")
+        
+        # Check if we have the exact ID
+        state = self.storage.get(flow_uuid)
+        
+        # Special handling for frontend's static threadId
+        if not state and flow_uuid == "bcabd353-645c-4954-876d-8803e1bb57de":
+            print(f"[PERSISTENCE DEBUG] Special handling for frontend's static threadId: {flow_uuid}")
+            if len(self.storage) > 0:
+                # Use the first available state as a starting point
+                template_state = next(iter(self.storage.values()))
+                # Clone and set the ID
+                state = copy.deepcopy(template_state)
+                state["id"] = flow_uuid
+                # Save it for future use
+                self.storage[flow_uuid] = state
+                print(f"[PERSISTENCE DEBUG] Created new state for static threadId based on existing state")
+        
+        if not state:
+            print(f"[PERSISTENCE DEBUG] No state found for {flow_uuid}")
+            return None
+        
+        # Debug the structure of the state
+        print(f"[PERSISTENCE DEBUG] Found state for {flow_uuid}")
+        if "messages" in state:
+            print(f"[PERSISTENCE DEBUG] State has {len(state['messages'])} messages")
+        else:
+            print("[PERSISTENCE DEBUG] State has no messages key")
+        
+        # Ensure state ID matches the flow_uuid
+        if "id" in state and state["id"] != flow_uuid:
+            print(f"[PERSISTENCE DEBUG] Loaded state has ID mismatch: state_id={state['id']}, flow_uuid={flow_uuid}")
+            state["id"] = flow_uuid
+            print(f"[PERSISTENCE DEBUG] Corrected ID to: {flow_uuid}")
+        
+        # Special handling for CopilotKitProperties
+        if "copilotkit" in state:
+            if state["copilotkit"] is None:
+                # Replace with empty dict if None
+                state["copilotkit"] = {"actions": []}
+            elif hasattr(state["copilotkit"], "model_dump"):
+                state["copilotkit"] = state["copilotkit"].model_dump()
+            elif hasattr(state["copilotkit"], "dict"):
+                state["copilotkit"] = state["copilotkit"].dict()
+            elif not isinstance(state["copilotkit"], dict):
+                # Convert to a basic dict if it's not already
+                state["copilotkit"] = {"actions": getattr(state["copilotkit"], "actions", [])}
+        
+        # Use more robust serialization
+        try:
+            # Try to dump it directly to JSON
+            return json.loads(json.dumps(state))
+        except TypeError as e:
+            # If that fails, we need to do a more manual conversion
+            print(f"[LOAD DEBUG] JSON serialization failed: {e}")
+            
+            serializable_state = {}
+            # Copy all serializable keys
+            for key, value in state.items():
+                try:
+                    # Test if this value is JSON serializable
+                    json.dumps({key: value})
+                    serializable_state[key] = value
+                except (TypeError, ValueError):
+                    # If not serializable, convert to string representation
+                    print(f"[LOAD DEBUG] Non-serializable field: {key}")
+                    serializable_state[key] = str(value)
+            
+            return serializable_state
+
+# Create an instance
+persistence = InMemoryFlowPersistence()
+
+@persist(persistence=persistence)
 class SampleAgentFlow(Flow[AgentState]):
     """
     This is a sample flow that uses the CopilotKit framework to create a chat agent.
     """
+    
+    def __init__(self, thread_id=None, **kwargs):
+        """Initialize the flow with an optional threadId."""
+        # Log the incoming threadId
+        print(f"[FLOW DEBUG] SampleAgentFlow constructor called with threadId: {thread_id}")
+        
+        # First do the standard initialization
+        super().__init__(**kwargs)
+        
+        # Check what ID was automatically created
+        auto_id = None
+        if hasattr(self, "_state"):
+            if isinstance(self._state, dict) and "id" in self._state:
+                auto_id = self._state["id"]
+            elif hasattr(self._state, "id"):
+                auto_id = getattr(self._state, "id")
+        print(f"[FLOW DEBUG] Auto-generated state ID: {auto_id}")
+        
+        # If thread_id is provided, ensure it's in both the state and directly in flow.state.id
+        if thread_id:
+            print(f"[FLOW DEBUG] Initializing new flow with threadId: {thread_id}")
+            
+            # Set it directly on the state object
+            if isinstance(self.state, dict):
+                self.state["id"] = thread_id
+            elif hasattr(self.state, "id"):
+                setattr(self.state, "id", thread_id)
+                
+            # Also set it on the underlying _state property that Flow uses internally
+            if hasattr(self, "_state"):
+                if isinstance(self._state, dict):
+                    self._state["id"] = thread_id
+                elif hasattr(self._state, "id"):
+                    setattr(self._state, "id", thread_id)
+                    
+            print(f"[FLOW DEBUG] State ID after override: {getattr(self.state, 'id', None)}")
 
     @start()
     @listen("route_follow_up")
@@ -60,6 +336,17 @@ class SampleAgentFlow(Flow[AgentState]):
         """
         This is the entry point for the flow.
         """
+        # Debug logging for threadId handling
+        current_id = getattr(self.state, "id", None)
+        print(f"[STATE DEBUG] Flow started with thread ID: {current_id}")
+        print(f"[STATE DEBUG] State type: {type(self.state).__name__}")
+        print(f"[STATE DEBUG] Messages count: {len(getattr(self.state, 'messages', []))}")
+        
+        # The CopilotKit SDK's execute_flow method automatically sets state['id'] = thread_id
+        # This ensures the Flow's state ID matches the threadId from the frontend
+        print(f"[STATE DEBUG] Using threadId: {current_id} (handled by built-in ThreadId propagation)")
+        
+        # No need for any manual ID manipulation
 
     @router(start_flow)
     async def chat(self):
@@ -145,6 +432,6 @@ class SampleAgentFlow(Flow[AgentState]):
         """
         End the flow.
         """
-        print("MyFlow completed. Observed steps:", self.state.observed_steps)
+        print("SampleAgentFlow completed.")
         # Exit the agent loop
         await copilotkit_exit()

--- a/examples/coagents-starter-crewai-flows/agent-py/sample_agent/demo.py
+++ b/examples/coagents-starter-crewai-flows/agent-py/sample_agent/demo.py
@@ -7,24 +7,108 @@ import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 import uvicorn
 from copilotkit.integrations.fastapi import add_fastapi_endpoint, CopilotKitRemoteEndpoint
 from copilotkit.crewai import CrewAIAgent
 from sample_agent.agent import SampleAgentFlow
+import logging
+import json
+from typing import Dict, Any, List
+import copy
 
 app = FastAPI()
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+# Simple logging middleware
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    # Log the request path only
+    logger.debug(f"[DEBUG] Incoming request: {request.method} {request.url.path}")
+    
+    # Pass the request to the next middleware or endpoint
+    # without attempting to read the body
+    response = await call_next(request)
+    return response
+
+class PersistenceAgent(CrewAIAgent):
+    """
+    A CrewAIAgent subclass that ensures ThreadID persistence across requests.
+    
+    This class solves two specific problems with the Flow framework:
+    
+    1. Thread ID Consistency: Ensures the threadId from the frontend is used 
+       consistently in the Flow's state and persistence layer.
+    
+    2. Flow Instance Isolation: Creates a fresh Flow instance for each request
+       to prevent state sharing between different conversations.
+    
+    Without this class, Flow would generate random UUIDs for its state, causing
+    a mismatch with the frontend's threadId and breaking conversation persistence.
+    """
+    
+    def __init__(self, *, name, description, flow, **kwargs):
+        # Store original flow template for later deep copying
+        self.flow_template = flow
+        super().__init__(name=name, description=description, flow=flow, **kwargs)
+    
+    def execute(self, *, thread_id, **kwargs):
+        logger.info(f"[DEBUG] PersistenceAgent.execute called with thread_id: {thread_id}")
+        
+        # Create a fresh flow instance with the thread_id 
+        # This is simpler than trying to modify an existing flow
+        new_flow = SampleAgentFlow(thread_id=thread_id)
+        logger.info(f"[DEBUG] Created new flow with ID: {getattr(new_flow.state, 'id', 'unknown')}")
+        
+        # Replace self.flow with our new flow instead of passing it as a parameter
+        self.flow = new_flow
+        
+        # No need to pass flow parameter - it will use self.flow
+        return super().execute(thread_id=thread_id, **kwargs)
+        
+    async def get_state(self, *, thread_id: str):
+        """Handle get_state requests by creating a flow instance with the correct threadId."""
+        logger.info(f"[DEBUG] PersistenceAgent.get_state called with thread_id: {thread_id}")
+        
+        # Create a flow with the requested threadId
+        flow = SampleAgentFlow(thread_id=thread_id)
+        logger.info(f"[DEBUG] Created new flow for get_state with ID: {getattr(flow.state, 'id', 'unknown')}")
+        
+        # Replace self.flow with our new flow
+        self.flow = flow
+        
+        # Use the parent's implementation
+        result = await super().get_state(thread_id=thread_id)
+        logger.info(f"[DEBUG] get_state result: threadExists={result.get('threadExists', False)}, " +
+                    f"messages={len(result.get('messages', []))}")
+        
+        # If no existing state, create a default one
+        if not result.get("threadExists", False):
+            logger.info(f"[DEBUG] No state found for {thread_id}, creating empty state")
+            # Return minimally viable empty state
+            return {
+                "threadId": thread_id,
+                "threadExists": True,
+                "state": {"id": thread_id, "messages": [], "copilotkit": {"actions": []}},
+                "messages": []
+            }
+            
+        return result
+
+# Create a CopilotKit endpoint with our custom PersistenceAgent
 sdk = CopilotKitRemoteEndpoint(
     agents=[
-        CrewAIAgent(
+        PersistenceAgent(
             name="sample_agent",
             description="An example agent to use as a starting point for your own agent.",
-            flow=SampleAgentFlow(),
+            flow=SampleAgentFlow(),  # This is just a template, we'll create new instances in execute
         )
     ],
 )
 
+# Register the standard CopilotKit endpoint
 add_fastapi_endpoint(app, sdk, "/copilotkit")
 
 def main():

--- a/examples/coagents-starter-crewai-flows/ui/app/layout.tsx
+++ b/examples/coagents-starter-crewai-flows/ui/app/layout.tsx
@@ -18,6 +18,7 @@ export default function RootLayout({ children }: { children: any }) {
           agent="sample_agent" // lock the agent to the sample_agent since we only have one agent
           runtimeUrl="/api/copilotkit"
           showDevConsole={false}
+          threadId={"bcabd353-645c-4954-876d-8803e1bb57de"}
         >
           {children}
         </CopilotKit>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When resuming a persisted flow, the agent now retrieves messages from the
stored state and converts them to CopilotKit format. This allows for proper
continuation of conversations across sessions.

- Added conversion of stored messages using crewai_flow_messages_to_copilotkit
- Improved error handling with detailed log messages
- Used existing logger from crewai_sdk module

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation