### PR TITLE
fix-vllm-toolcall-streaming-compatibility

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -83,7 +83,7 @@ export async function execute(args: ExecutionArgs): Promise<ReadableStream<Uint8
       try {
         await streamEvents(controller, args);
         controller.close();
-      } catch (err) {}
+      } catch (err) { }
     },
   });
 }
@@ -512,7 +512,7 @@ class StreamingStateExtractor {
     if (event.data.chunk.tool_call_chunks.length > 0) {
       const chunk = event.data.chunk.tool_call_chunks[0];
 
-      if (chunk.name !== null && chunk.name !== undefined) {
+      if (chunk.name !== null && chunk.name !== undefined && chunk.name !== this.currentToolCall) {
         this.currentToolCall = chunk.name;
         this.toolCallBuffer[this.currentToolCall] = chunk.args;
       } else if (this.currentToolCall !== null && this.currentToolCall !== undefined) {


### PR DESCRIPTION

## What does this PR do?

This PR addresses a compatibility issue with vLLM tool call streaming. Each tool call chunk returned by vLLM includes the tool name. The existing code logic incorrectly interprets every chunk with a tool name as a new tool call, causing the `args` to be overwritten instead of accumulated.

The issue stems from the following code:

```typescript
if (chunk.name !== null && chunk.name !== undefined) {
    this.currentToolCall = chunk.name;
    this.toolCallBuffer[this.currentToolCall] = chunk.args;
}
```

This logic resets the `currentToolCall` and overwrites the `toolCallBuffer` for every chunk, preventing proper accumulation of arguments for the same tool call.

### Changes Introduced

This PR modifies the condition to check if the `chunk.name` differs from the current `currentToolCall` before resetting it. The updated code is:

```typescript
if (chunk.name !== null && chunk.name !== undefined && chunk.name !== this.currentToolCall) {
    this.currentToolCall = chunk.name;
    this.toolCallBuffer[this.currentToolCall] = chunk.args;
}
```

This ensures that only when a new tool call is detected (i.e., the tool name changes) will the `currentToolCall` and `toolCallBuffer` be reset, allowing arguments to accumulate correctly for the same tool call across multiple chunks.
