### PR TITLE
Support user-supplied images

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -57,6 +57,7 @@ import { RenderTextMessage as DefaultRenderTextMessage } from "./messages/Render
 import { RenderActionExecutionMessage as DefaultRenderActionExecutionMessage } from "./messages/RenderActionExecutionMessage";
 import { RenderResultMessage as DefaultRenderResultMessage } from "./messages/RenderResultMessage";
 import { RenderAgentStateMessage as DefaultRenderAgentStateMessage } from "./messages/RenderAgentStateMessage";
+import { RenderImageMessage as DefaultRenderImageMessage } from "./messages/RenderImageMessage";
 import { AssistantMessage as DefaultAssistantMessage } from "./messages/AssistantMessage";
 import { UserMessage as DefaultUserMessage } from "./messages/UserMessage";
 import { Suggestion } from "./Suggestion";
@@ -69,7 +70,7 @@ import {
 } from "@copilotkit/react-core";
 import { reloadSuggestions } from "./Suggestion";
 import { CopilotChatSuggestion } from "../../types/suggestions";
-import { Message, Role, TextMessage } from "@copilotkit/runtime-client-gql";
+import { Message, Role, TextMessage, ImageMessage } from "@copilotkit/runtime-client-gql";
 import { randomId } from "@copilotkit/shared";
 import {
   AssistantMessageProps,
@@ -80,6 +81,7 @@ import {
 } from "./props";
 
 import { HintFunction, runAgent, stopAgent } from "@copilotkit/react-core";
+import { ImageUploadQueue } from "./ImageUploadQueue";
 
 /**
  * Props for CopilotChat component.
@@ -146,6 +148,11 @@ export interface CopilotChatProps {
   labels?: CopilotChatLabels;
 
   /**
+   * Enable image uploads (image inputs only supported on Claude models)
+   */
+  imageUploadsEnabled?: boolean;
+
+  /**
    * A function that takes in context string and instructions and returns
    * the system message to include in the chat request.
    * Use this to completely override the system message, when providing
@@ -187,6 +194,11 @@ export interface CopilotChatProps {
    * A custom RenderResultMessage component to use instead of the default.
    */
   RenderResultMessage?: React.ComponentType<RenderMessageProps>;
+
+  /**
+   * A custom RenderImageMessage component to use instead of the default.
+   */
+  RenderImageMessage?: React.ComponentType<RenderMessageProps>;
 
   /**
    * A custom Input component to use instead of the default.
@@ -273,14 +285,18 @@ export function CopilotChat({
   RenderActionExecutionMessage = DefaultRenderActionExecutionMessage,
   RenderAgentStateMessage = DefaultRenderAgentStateMessage,
   RenderResultMessage = DefaultRenderResultMessage,
+  RenderImageMessage = DefaultRenderImageMessage,
   Input = DefaultInput,
   className,
   icons,
   labels,
   AssistantMessage = DefaultAssistantMessage,
   UserMessage = DefaultUserMessage,
+  imageUploadsEnabled,
 }: CopilotChatProps) {
   const { additionalInstructions, setChatInstructions } = useCopilotContext();
+  const [selectedImages, setSelectedImages] = useState<Array<{ contentType: string, bytes: string }>>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!additionalInstructions?.length) {
@@ -322,6 +338,16 @@ export function CopilotChat({
     onReloadMessages,
   );
 
+  // Wrapper for sendMessage to clear selected images
+  const handleSendMessage = async (text: string) => {
+    const message = await sendMessage(text, selectedImages);
+    setSelectedImages([]);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    return message;
+  };
+
   const chatContext = React.useContext(ChatContext);
   const isVisible = chatContext ? chatContext.open : true;
 
@@ -339,6 +365,44 @@ export function CopilotChat({
     }
   };
 
+  const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!event.target.files || event.target.files.length === 0 || isLoading) {
+      return;
+    }
+
+    const files = Array.from(event.target.files).filter(file => file.type.startsWith('image/'));
+    if (files.length === 0) return;
+
+    const fileReadPromises = files.map(file => {
+      return new Promise<{ contentType: string, bytes: string }>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const base64String = (e.target?.result as string)?.split(',')[1] || '';
+          if (base64String) {
+            resolve({
+              contentType: file.type,
+              bytes: base64String
+            });
+          }
+        };
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+    });
+
+    try {
+      const loadedImages = await Promise.all(fileReadPromises);
+      setSelectedImages(prev => [...prev, ...loadedImages]);
+    } catch (error) {
+      // TODO: Show an error message to the user
+      console.error("Error reading files:", error);
+    }
+  };
+
+  const removeSelectedImage = (index: number) => {
+    setSelectedImages(prev => prev.filter((_, i) => i !== index));
+  };
+
   return (
     <WrappedCopilotChat icons={icons} labels={labels} className={className}>
       <Messages
@@ -348,6 +412,7 @@ export function CopilotChat({
         RenderActionExecutionMessage={RenderActionExecutionMessage}
         RenderAgentStateMessage={RenderAgentStateMessage}
         RenderResultMessage={RenderResultMessage}
+        RenderImageMessage={RenderImageMessage}
         messages={visibleMessages}
         inProgress={isLoading}
         onRegenerate={handleRegenerate}
@@ -364,17 +429,38 @@ export function CopilotChat({
                 message={suggestion.message}
                 partial={suggestion.partial}
                 className={suggestion.className}
-                onClick={(message) => sendMessage(message)}
+                onClick={(message) => handleSendMessage(message)}
               />
             ))}
           </div>
         )}
       </Messages>
+
+      {imageUploadsEnabled && (
+        <>
+          {!isLoading && (
+            <ImageUploadQueue
+              images={selectedImages}
+              onRemoveImage={removeSelectedImage}
+            />
+          )}
+          <input
+            type="file"
+            multiple
+            ref={fileInputRef}
+            onChange={handleImageUpload}
+            accept="image/*"
+            style={{ display: 'none' }}
+          />
+        </>
+      )}
+
       <Input
         inProgress={isLoading}
-        onSend={sendMessage}
+        onSend={handleSendMessage}
         isVisible={isVisible}
         onStop={stopGeneration}
+        onUpload={imageUploadsEnabled ? () => fileInputRef.current?.click() : undefined}
       />
     </WrappedCopilotChat>
   );
@@ -467,28 +553,61 @@ export const useCopilotChatLogic = (
     visibleMessages.length == 0,
   ]);
 
-  const sendMessage = async (messageContent: string) => {
+  const sendMessage = async (messageContent: string, imagesToUse?: Array<{ contentType: string, bytes: string }>) => {
+    // Use images passed in the call OR the ones from the state (passed via props)
+    const images = imagesToUse || [];
+
     abortSuggestions();
     setCurrentSuggestions([]);
 
-    const message: Message = new TextMessage({
-      content: messageContent,
-      role: Role.User,
-    });
+    let firstMessage: Message | null = null;
 
-    if (onSubmitMessage) {
-      try {
-        await onSubmitMessage(messageContent);
-      } catch (error) {
-        console.error("Error in onSubmitMessage:", error);
+    // If there's text content, send a text message first
+    if (messageContent.trim().length > 0) {
+      const textMessage = new TextMessage({
+        content: messageContent,
+        role: Role.User,
+      });
+
+      if (onSubmitMessage) {
+        try {
+          // Call onSubmitMessage only with text, as image handling is internal right now
+          await onSubmitMessage(messageContent);
+        } catch (error) {
+          console.error("Error in onSubmitMessage:", error);
+        }
+      }
+
+      await appendMessage(textMessage, { followUp: images.length === 0 });
+
+      if (!firstMessage) {
+        firstMessage = textMessage;
       }
     }
-    // this needs to happen after onSubmitMessage, because it will trigger submission
-    // of the message to the endpoint. Some users depend on performing some actions
-    // before the message is submitted.
-    appendMessage(message);
 
-    return message;
+    // Send image messages
+    if (images.length > 0) {
+      for (let i = 0; i < images.length; i++) {
+        const imageMessage = new ImageMessage({
+          format: images[i].contentType.replace("image/", ""),
+          bytes: images[i].bytes,
+          role: Role.User,
+        });
+        await appendMessage(imageMessage, { followUp: i === images.length - 1 });
+        if (!firstMessage) {
+          firstMessage = imageMessage;
+        }
+      }
+    }
+
+    if (!firstMessage) {
+      // Should not happen if send button is properly disabled, but handle just in case
+      return new TextMessage({ content: "", role: Role.User }); // Return a dummy message
+    }
+
+    // The hook implicitly triggers API call on appendMessage.
+    // We return the first message sent (either text or first image)
+    return firstMessage;
   };
 
   const messages = visibleMessages;

--- a/CopilotKit/packages/react-ui/src/components/chat/ChatContext.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/ChatContext.tsx
@@ -81,6 +81,12 @@ export interface CopilotChatIcons {
    */
 
   thumbsDownIcon?: React.ReactNode;
+
+  /**
+   * The icon to use for the upload button.
+   * @default <UploadIcon />
+   */
+  uploadIcon?: React.ReactNode;
 }
 
 /**
@@ -221,6 +227,7 @@ export const ChatContextProvider = ({
         copyIcon: DefaultIcons.CopyIcon,
         thumbsUpIcon: DefaultIcons.ThumbsUpIcon,
         thumbsDownIcon: DefaultIcons.ThumbsDownIcon,
+        uploadIcon: DefaultIcons.UploadIcon,
       },
       ...icons,
     }),

--- a/CopilotKit/packages/react-ui/src/components/chat/Icons.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Icons.tsx
@@ -207,6 +207,20 @@ export const DownloadIcon = (
   </svg>
 );
 
+export const UploadIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth="1.5"
+    stroke="currentColor"
+    width="24"
+    height="24"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+  </svg>
+);
+
 export const CheckIcon = (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/CopilotKit/packages/react-ui/src/components/chat/ImageUploadQueue.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/ImageUploadQueue.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+interface ImageUploadQueueProps {
+  images: Array<{ contentType: string; bytes: string }>;
+  onRemoveImage: (index: number) => void;
+  className?: string;
+}
+
+export const ImageUploadQueue: React.FC<ImageUploadQueueProps> = ({
+  images,
+  onRemoveImage,
+  className = '',
+}) => {
+  if (images.length === 0) return null;
+
+  return (
+    <div
+      className={`copilotKitImageUploadQueue ${className}`}
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '8px',
+        margin: '8px',
+        padding: '8px'
+      }}
+    >
+      {images.map((image, index) => (
+        <div
+          key={index}
+          className="copilotKitImageUploadQueueItem"
+          style={{
+            position: 'relative',
+            display: 'inline-block',
+            width: '60px',
+            height: '60px',
+            borderRadius: '4px',
+            overflow: 'hidden'
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`data:${image.contentType};base64,${image.bytes}`}
+            alt={`Selected image ${index + 1}`}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover'
+            }}
+          />
+          <button
+            onClick={() => onRemoveImage(index)}
+            className="copilotKitImageUploadQueueRemoveButton"
+            style={{
+              position: 'absolute',
+              top: '2px',
+              right: '2px',
+              background: 'rgba(0,0,0,0.6)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '50%',
+              width: '18px',
+              height: '18px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              fontSize: '10px',
+              padding: 0
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}; 

--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -5,7 +5,7 @@ import AutoResizingTextarea from "./Textarea";
 import { usePushToTalk } from "../../hooks/use-push-to-talk";
 import { useCopilotContext } from "@copilotkit/react-core";
 
-export const Input = ({ inProgress, onSend, isVisible = false, onStop }: InputProps) => {
+export const Input = ({ inProgress, onSend, isVisible = false, onStop, onUpload }: InputProps) => {
   const context = useChatContext();
   const copilotContext = useCopilotContext();
 
@@ -89,7 +89,14 @@ export const Input = ({ inProgress, onSend, isVisible = false, onStop }: InputPr
           }}
         />
         <div className="copilotKitInputControls">
+          {onUpload && (
+            <button onClick={onUpload} className="copilotKitInputControlButton">
+              {context.icons.uploadIcon}
+            </button>
+          )}
+
           <div style={{ flexGrow: 1 }} />
+
           {showPushToTalk && (
             <button
               onClick={() =>

--- a/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
@@ -12,6 +12,7 @@ export const Messages = ({
   RenderActionExecutionMessage,
   RenderAgentStateMessage,
   RenderResultMessage,
+  RenderImageMessage,
   AssistantMessage,
   UserMessage,
   onRegenerate,
@@ -103,6 +104,22 @@ export const Messages = ({
                 isCurrentMessage={isCurrentMessage}
                 AssistantMessage={AssistantMessage}
                 UserMessage={UserMessage}
+              />
+            );
+          } else if (message.isImageMessage && message.isImageMessage()) {
+            return (
+              <RenderImageMessage
+                key={index}
+                message={message}
+                inProgress={inProgress}
+                index={index}
+                isCurrentMessage={isCurrentMessage}
+                AssistantMessage={AssistantMessage}
+                UserMessage={UserMessage}
+                onRegenerate={onRegenerate}
+                onCopy={onCopy}
+                onThumbsUp={onThumbsUp}
+                onThumbsDown={onThumbsDown}
               />
             );
           }

--- a/CopilotKit/packages/react-ui/src/components/chat/index.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/index.tsx
@@ -6,3 +6,4 @@ export { Markdown } from "./Markdown";
 export { AssistantMessage } from "./messages/AssistantMessage";
 export { UserMessage } from "./messages/UserMessage";
 export { useChatContext } from "./ChatContext";
+export { RenderImageMessage } from "./messages/RenderImageMessage";

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderImageMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderImageMessage.tsx
@@ -1,0 +1,64 @@
+import { RenderMessageProps } from "../props";
+import { UserMessage as DefaultUserMessage } from "./UserMessage";
+import { AssistantMessage as DefaultAssistantMessage } from "./AssistantMessage";
+
+export function RenderImageMessage({
+  UserMessage = DefaultUserMessage,
+  AssistantMessage = DefaultAssistantMessage,
+  ...props
+}: RenderMessageProps) {
+  const {
+    message,
+    inProgress,
+    index,
+    isCurrentMessage,
+    onRegenerate,
+    onCopy,
+    onThumbsUp,
+    onThumbsDown,
+  } = props;
+
+  if (message.isImageMessage()) {
+    const imageData = `data:${message.format};base64,${message.bytes}`;
+    const imageComponent = (
+      <div className="copilotKitImage">
+        <img
+          src={imageData}
+          alt="User uploaded image"
+          style={{ maxWidth: '100%', maxHeight: '300px', borderRadius: '8px' }}
+        />
+      </div>
+    );
+
+    if (message.role === "user") {
+      return (
+        <UserMessage
+          key={index}
+          data-message-role="user"
+          message=""
+          rawData={message}
+          subComponent={imageComponent}
+        />
+      );
+    } else if (message.role === "assistant") {
+      return (
+        <AssistantMessage
+          key={index}
+          data-message-role="assistant"
+          message=""
+          rawData={message}
+          subComponent={imageComponent}
+          isLoading={inProgress && isCurrentMessage && !message.bytes}
+          isGenerating={inProgress && isCurrentMessage && !!message.bytes}
+          isCurrentMessage={isCurrentMessage}
+          onRegenerate={() => onRegenerate?.(message.id)}
+          onCopy={onCopy}
+          onThumbsUp={onThumbsUp}
+          onThumbsDown={onThumbsDown}
+        />
+      );
+    }
+  }
+
+  return null;
+} 

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/UserMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/UserMessage.tsx
@@ -1,5 +1,9 @@
 import { UserMessageProps } from "../props";
 
 export const UserMessage = (props: UserMessageProps) => {
-  return <div className="copilotKitMessage copilotKitUserMessage">{props.message}</div>;
+  return (
+    <div className="copilotKitMessage copilotKitUserMessage">
+      {props.subComponent || props.message}
+    </div>
+  );
 };

--- a/CopilotKit/packages/react-ui/src/components/chat/props.ts
+++ b/CopilotKit/packages/react-ui/src/components/chat/props.ts
@@ -29,6 +29,7 @@ export interface MessagesProps {
   RenderActionExecutionMessage: React.ComponentType<RenderMessageProps>;
   RenderAgentStateMessage: React.ComponentType<RenderMessageProps>;
   RenderResultMessage: React.ComponentType<RenderMessageProps>;
+  RenderImageMessage: React.ComponentType<RenderMessageProps>;
 
   /**
    * Callback function to regenerate the assistant's response
@@ -58,6 +59,7 @@ export interface Renderer {
 export interface UserMessageProps {
   message?: string;
   rawData: any;
+  subComponent?: React.JSX.Element;
 }
 
 export interface AssistantMessageProps {
@@ -150,4 +152,5 @@ export interface InputProps {
   onSend: (text: string) => Promise<Message>;
   isVisible?: boolean;
   onStop?: () => void;
+  onUpload?: () => void;
 }

--- a/CopilotKit/packages/runtime-client-gql/src/client/types.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/client/types.ts
@@ -11,10 +11,16 @@ import {
   LangGraphInterruptEvent as GqlLangGraphInterruptEvent,
   MetaEventName,
   CopilotKitLangGraphInterruptEvent as GqlCopilotKitLangGraphInterruptEvent,
+  ImageMessageInput,
 } from "../graphql/@generated/graphql";
 import { parseJson } from "@copilotkit/shared";
 
-type MessageType = "TextMessage" | "ActionExecutionMessage" | "ResultMessage" | "AgentStateMessage";
+type MessageType =
+  | "TextMessage"
+  | "ActionExecutionMessage"
+  | "ResultMessage"
+  | "AgentStateMessage"
+  | "ImageMessage";
 
 export class Message {
   type: MessageType;
@@ -43,6 +49,10 @@ export class Message {
 
   isAgentStateMessage(): this is AgentStateMessage {
     return this.type === "AgentStateMessage";
+  }
+
+  isImageMessage(): this is ImageMessage {
+    return this.type === "ImageMessage";
   }
 }
 
@@ -123,6 +133,20 @@ export class AgentStateMessage extends Message implements Omit<AgentStateMessage
   constructor(props: any) {
     super(props);
     this.type = "AgentStateMessage";
+  }
+}
+
+type ImageMessageConstructorOptions = MessageConstructorOptions & ImageMessageInput;
+
+export class ImageMessage extends Message implements ImageMessageConstructorOptions {
+  format: ImageMessageInput["format"];
+  bytes: ImageMessageInput["bytes"];
+  role: ImageMessageInput["role"];
+  parentMessageId: ImageMessageInput["parentMessageId"];
+
+  constructor(props: ImageMessageConstructorOptions) {
+    super(props);
+    this.type = "ImageMessage";
   }
 }
 

--- a/CopilotKit/packages/runtime-client-gql/src/graphql/definitions/mutations.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/graphql/definitions/mutations.ts
@@ -47,6 +47,12 @@ export const generateCopilotResponseMutation = graphql(/** GraphQL **/ `
           role
           parentMessageId
         }
+        ... on ImageMessageOutput {
+          format
+          bytes
+          role
+          parentMessageId
+        }
         ... on ActionExecutionMessageOutput {
           name
           arguments @stream

--- a/CopilotKit/packages/runtime/src/graphql/inputs/message.input.ts
+++ b/CopilotKit/packages/runtime/src/graphql/inputs/message.input.ts
@@ -17,6 +17,9 @@ export class MessageInput extends BaseMessageInput {
 
   @Field(() => AgentStateMessageInput, { nullable: true })
   agentStateMessage?: AgentStateMessageInput;
+
+  @Field(() => ImageMessageInput, { nullable: true })
+  imageMessage?: ImageMessageInput;
 }
 
 @InputType()
@@ -89,4 +92,19 @@ export class AgentStateMessageInput {
 
   @Field(() => Boolean)
   active: boolean;
+}
+
+@InputType()
+export class ImageMessageInput {
+  @Field(() => String)
+  format: string;
+
+  @Field(() => String)
+  bytes: string;
+
+  @Field(() => String, { nullable: true })
+  parentMessageId?: string;
+
+  @Field(() => MessageRole)
+  role: MessageRole;
 }

--- a/CopilotKit/packages/runtime/src/graphql/types/converted/index.ts
+++ b/CopilotKit/packages/runtime/src/graphql/types/converted/index.ts
@@ -3,6 +3,7 @@ import {
   ResultMessageInput,
   TextMessageInput,
   AgentStateMessageInput,
+  ImageMessageInput,
 } from "../../inputs/message.input";
 import { BaseMessageInput } from "../base";
 import { MessageRole } from "../enums";
@@ -11,7 +12,8 @@ export type MessageType =
   | "TextMessage"
   | "ActionExecutionMessage"
   | "ResultMessage"
-  | "AgentStateMessage";
+  | "AgentStateMessage"
+  | "ImageMessage";
 
 export class Message extends BaseMessageInput {
   type: MessageType;
@@ -30,6 +32,10 @@ export class Message extends BaseMessageInput {
 
   isAgentStateMessage(): this is AgentStateMessage {
     return this.type === "AgentStateMessage";
+  }
+
+  isImageMessage(): this is ImageMessage {
+    return this.type === "ImageMessage";
   }
 }
 
@@ -133,4 +139,12 @@ export class AgentStateMessage extends Message implements Omit<AgentStateMessage
   role: MessageRole;
   state: any;
   running: boolean;
+}
+
+export class ImageMessage extends Message implements ImageMessageInput {
+  type: MessageType = "ImageMessage";
+  format: string;
+  bytes: string;
+  role: MessageRole;
+  parentMessageId?: string;
 }

--- a/CopilotKit/packages/runtime/src/graphql/types/copilot-response.type.ts
+++ b/CopilotKit/packages/runtime/src/graphql/types/copilot-response.type.ts
@@ -15,6 +15,8 @@ import { BaseMetaEvent } from "./meta-events.type";
       return ResultMessageOutput;
     } else if (value.hasOwnProperty("state")) {
       return AgentStateMessageOutput;
+    } else if (value.hasOwnProperty("format") && value.hasOwnProperty("bytes")) {
+      return ImageMessageOutput;
     }
     return undefined;
   },
@@ -97,6 +99,21 @@ export class AgentStateMessageOutput {
 
   @Field(() => Boolean)
   running: boolean;
+}
+
+@ObjectType({ implements: BaseMessageOutput })
+export class ImageMessageOutput {
+  @Field(() => String)
+  format: string;
+
+  @Field(() => String)
+  bytes: string;
+
+  @Field(() => MessageRole)
+  role: MessageRole;
+
+  @Field(() => String, { nullable: true })
+  parentMessageId?: string;
 }
 
 @ObjectType()

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -44,6 +44,7 @@ type BaseLangGraphPlatformMessage = Omit<
   Message,
   | "isResultMessage"
   | "isTextMessage"
+  | "isImageMessage"
   | "isActionExecutionMessage"
   | "isAgentStateMessage"
   | "type"
@@ -740,6 +741,24 @@ function copilotkitMessagesToLangChain(messages: Message[]): LangGraphPlatformMe
         result.push({
           ...message,
           role: MessageRole.assistant,
+        });
+      }
+      continue;
+    }
+
+    // Handle ImageMessage
+    if (message.isImageMessage()) {
+      if (message.role === "user") {
+        result.push({
+          ...message,
+          role: MessageRole.user,
+          content: "",
+        });
+      } else if (message.role === "assistant") {
+        result.push({
+          ...message,
+          role: MessageRole.assistant,
+          content: "",
         });
       }
       continue;

--- a/CopilotKit/packages/runtime/src/service-adapters/conversion.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/conversion.ts
@@ -4,6 +4,7 @@ import {
   ResultMessage,
   TextMessage,
   AgentStateMessage,
+  ImageMessage,
 } from "../graphql/types/converted";
 import { MessageInput } from "../graphql/inputs/message.input";
 import { plainToInstance } from "class-transformer";
@@ -18,6 +19,15 @@ export function convertGqlInputToMessages(inputMessages: MessageInput[]): Messag
         role: message.textMessage.role,
         content: message.textMessage.content,
         parentMessageId: message.textMessage.parentMessageId,
+      });
+    } else if (message.imageMessage) {
+      return plainToInstance(ImageMessage, {
+        id: message.id,
+        createdAt: message.createdAt,
+        role: message.imageMessage.role,
+        bytes: message.imageMessage.bytes,
+        format: message.imageMessage.format,
+        parentMessageId: message.imageMessage.parentMessageId,
       });
     } else if (message.actionExecutionMessage) {
       return plainToInstance(ActionExecutionMessage, {

--- a/docs/content/docs/reference/components/chat/CopilotChat.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotChat.mdx
@@ -106,6 +106,10 @@ Icons can be used to set custom icons for the chat window.
 Labels can be used to set custom labels for the chat window.
 </PropertyReference>
 
+<PropertyReference name="imageUploadsEnabled" type="boolean"  > 
+Enable image uploads (image inputs only supported on Claude models)
+</PropertyReference>
+
 <PropertyReference name="makeSystemMessage" type="SystemMessageFunction"  > 
 A function that takes in context string and instructions and returns
   the system message to include in the chat request.
@@ -139,6 +143,10 @@ A custom RenderAgentStateMessage component to use instead of the default.
 
 <PropertyReference name="RenderResultMessage" type="React.ComponentType<RenderMessageProps>"  > 
 A custom RenderResultMessage component to use instead of the default.
+</PropertyReference>
+
+<PropertyReference name="RenderImageMessage" type="React.ComponentType<RenderMessageProps>"  > 
+A custom RenderImageMessage component to use instead of the default.
 </PropertyReference>
 
 <PropertyReference name="Input" type="React.ComponentType<InputProps>"  > 

--- a/docs/content/docs/reference/components/chat/CopilotPopup.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotPopup.mdx
@@ -107,6 +107,10 @@ Icons can be used to set custom icons for the chat window.
 Labels can be used to set custom labels for the chat window.
 </PropertyReference>
 
+<PropertyReference name="imageUploadsEnabled" type="boolean"  > 
+Enable image uploads (image inputs only supported on Claude models)
+</PropertyReference>
+
 <PropertyReference name="makeSystemMessage" type="SystemMessageFunction"  > 
 A function that takes in context string and instructions and returns
   the system message to include in the chat request.
@@ -140,6 +144,10 @@ A custom RenderAgentStateMessage component to use instead of the default.
 
 <PropertyReference name="RenderResultMessage" type="React.ComponentType<RenderMessageProps>"  > 
 A custom RenderResultMessage component to use instead of the default.
+</PropertyReference>
+
+<PropertyReference name="RenderImageMessage" type="React.ComponentType<RenderMessageProps>"  > 
+A custom RenderImageMessage component to use instead of the default.
 </PropertyReference>
 
 <PropertyReference name="Input" type="React.ComponentType<InputProps>"  > 

--- a/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
@@ -109,6 +109,10 @@ Icons can be used to set custom icons for the chat window.
 Labels can be used to set custom labels for the chat window.
 </PropertyReference>
 
+<PropertyReference name="imageUploadsEnabled" type="boolean"  > 
+Enable image uploads (image inputs only supported on Claude models)
+</PropertyReference>
+
 <PropertyReference name="makeSystemMessage" type="SystemMessageFunction"  > 
 A function that takes in context string and instructions and returns
   the system message to include in the chat request.
@@ -142,6 +146,10 @@ A custom RenderAgentStateMessage component to use instead of the default.
 
 <PropertyReference name="RenderResultMessage" type="React.ComponentType<RenderMessageProps>"  > 
 A custom RenderResultMessage component to use instead of the default.
+</PropertyReference>
+
+<PropertyReference name="RenderImageMessage" type="React.ComponentType<RenderMessageProps>"  > 
+A custom RenderImageMessage component to use instead of the default.
 </PropertyReference>
 
 <PropertyReference name="Input" type="React.ComponentType<InputProps>"  > 


### PR DESCRIPTION
## What does this PR do?

This PR adds support for uploading images from the default chat UI if you pass `imageUploadsEnabled={true}` to `<CopilotChat />`. It updates the graphql definitions to add the new `ImageMessage` type. 

Note: only some models support being passed images.

## Related PRs and Issues

--

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (api reference auto updated)