### PR TITLE
fix: remove caching from preview setup-node to avoid 422 errors

### DIFF
--- a/.github/workflows/preview-envs-deploy.yml
+++ b/.github/workflows/preview-envs-deploy.yml
@@ -109,8 +109,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 21.x
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: (UI) Install app dependencies
         if: matrix.app.type == 'ui'
@@ -240,8 +238,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 21.x
-          cache: "pnpm"
-          cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: Infra install dependencies
         working-directory: infra


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It appears that GitHub’s caching service is now enforcing stricter validation, causing 422 errors on Node jobs. Removing the caching configuration resolves the issue, ensuring that our CI pipeline runs without interruption. We can revisit caching strategies once the underlying issue is addressed.


## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation