### PR TITLE
fix(telemetry): add sampleWeight to support accurate volume estimation in PostHog

### DIFF
--- a/CopilotKit/packages/shared/src/telemetry/telemetry-client.ts
+++ b/CopilotKit/packages/shared/src/telemetry/telemetry-client.ts
@@ -121,6 +121,7 @@ export class TelemetryClient {
     this.setGlobalProperties({
       sampleRate: this.sampleRate,
       sampleRateAdjustmentFactor: 1 - this.sampleRate,
+      sampleWeight: 1 / this.sampleRate,
     });
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

PostHog was underreporting traffic due to sampled telemetry. We now include `sampleWeight = 1 / sampleRate` in global event properties to allow proper scaling using sum(sampleWeight). This eliminates the need for formula-based charts.


## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation