### PR TITLE
feat: expose getAllElements from context, for debugging

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -83,7 +83,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     coAgentStateRenders: {},
   });
 
-  const { addElement, removeElement, printTree } = useTree();
+  const { addElement, removeElement, printTree, getAllElements } = useTree();
   const [isLoading, setIsLoading] = useState(false);
   const [chatInstructions, setChatInstructions] = useState("");
   const [authStates, setAuthStates] = useState<Record<string, AuthState>>({});
@@ -164,6 +164,10 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     },
     [removeElement],
   );
+
+  const getAllContext = useCallback(() => {
+    return getAllElements();
+  }, [getAllElements]);
 
   const getFunctionCallHandler = useCallback(
     (customEntryPoints?: Record<string, FrontendAction<any>>) => {
@@ -392,6 +396,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
         getContextString,
         addContext,
         removeContext,
+        getAllContext,
         getDocumentsContext,
         addDocumentContext,
         removeDocumentContext,

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -5,7 +5,7 @@ import {
   FrontendAction,
 } from "../types/frontend-action";
 import React from "react";
-import { TreeNodeId } from "../hooks/use-tree";
+import { TreeNodeId, Tree } from "../hooks/use-tree";
 import { DocumentPointer } from "../types";
 import { CopilotChatSuggestionConfiguration } from "../types/chat-suggestion-configuration";
 import { CoAgentStateRender, CoAgentStateRenderProps } from "../types/coagent-action";
@@ -113,6 +113,7 @@ export interface AuthState {
 }
 
 export type ActionName = string;
+export type ContextTree = Tree;
 
 export interface CopilotContextParams {
   // function-calling
@@ -134,6 +135,7 @@ export interface CopilotContextParams {
   // text context
   addContext: (context: string, parentId?: string, categories?: string[]) => TreeNodeId;
   removeContext: (id: TreeNodeId) => void;
+  getAllContext: () => Tree;
   getContextString: (documents: DocumentPointer[], categories: string[]) => string;
 
   // document context
@@ -232,6 +234,7 @@ const emptyCopilotContext: CopilotContextParams = {
     returnAndThrowInDebug(""),
   addContext: () => "",
   removeContext: () => {},
+  getAllContext: () => [],
 
   getFunctionCallHandler: () => returnAndThrowInDebug(async () => {}),
 

--- a/CopilotKit/packages/react-core/src/hooks/index.ts
+++ b/CopilotKit/packages/react-core/src/hooks/index.ts
@@ -13,3 +13,4 @@ export { useCopilotAuthenticatedAction_c } from "./use-copilot-authenticated-act
 export { useLangGraphInterrupt } from "./use-langgraph-interrupt";
 export { useLangGraphInterruptRender } from "./use-langgraph-interrupt-render";
 export { useCopilotAdditionalInstructions } from "./use-copilot-additional-instructions";
+export type { Tree, TreeNode } from "./use-tree";

--- a/CopilotKit/packages/react-core/src/hooks/use-tree.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-tree.ts
@@ -18,6 +18,7 @@ export interface UseTreeReturn {
   addElement: (value: string, categories: string[], parentId?: TreeNodeId) => TreeNodeId;
   printTree: (categories: string[]) => string;
   removeElement: (id: TreeNodeId) => void;
+  getAllElements: () => Tree;
 }
 
 const findNode = (nodes: Tree, id: TreeNodeId): TreeNode | undefined => {
@@ -161,6 +162,10 @@ const useTree = (): UseTreeReturn => {
     dispatch({ type: "REMOVE_NODE", id });
   }, []);
 
+  const getAllElements = useCallback(() => {
+    return tree;
+  }, [tree]);
+
   const printTree = useCallback(
     (categories: string[]): string => {
       const categoriesSet = new Set(categories);
@@ -184,7 +189,7 @@ const useTree = (): UseTreeReturn => {
     [tree],
   );
 
-  return { tree, addElement, printTree, removeElement };
+  return { tree, addElement, printTree, removeElement, getAllElements };
 };
 
 export default useTree;


### PR DESCRIPTION
## What does this PR do?

This exposes a new `getAllElements()` function from the copilot provider. This allows an inspection tool to see the entire context (what has been stored via `useCopilotReadable`, etc).

## Related PRs and Issues

- TODO

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation (the methods around this one were not documented so I didn't add any here, but could)