### PR TITLE
Suhas/interface change

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -1,7 +1,6 @@
 import { ForwardedParametersInput } from "@copilotkit/runtime-client-gql";
 import { ReactNode } from "react";
 import { AuthState } from "../../context/copilot-context";
-
 /**
  * Props for CopilotKit.
  */
@@ -114,19 +113,4 @@ export interface CopilotKitProps {
    * The thread id to use for the CopilotKit.
    */
   threadId?: string;
-
-  /**
-   * Config for connecting to Model Context Protocol (MCP) servers.
-   * Enables CopilotKit runtime to access tools on external MCP servers.
-   *
-   * This config merges into the `properties` object with each request as `mcpEndpoints`.
-   * It offers a typed method to set up MCP endpoints for requests.
-   *
-   * Each array item should have:
-   * - `endpoint`: MCP server URL (mandatory).
-   * - `apiKey`: Optional API key for server authentication.
-   *
-   * Note: A `createMCPClient` function is still needed during runtime initialization to manage these endpoints.
-   */
-  mcpEndpoints?: Array<{ endpoint: string; apiKey?: string }>;
 }

--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -219,7 +219,6 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,
       credentials: props.credentials,
-      mcpEndpoints: props.mcpEndpoints,
     };
   }, [
     props.publicApiKey,
@@ -229,7 +228,6 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     props.textToSpeechUrl,
     props.credentials,
     props.cloudRestrictToTopic,
-    props.mcpEndpoints,
     props.guardrails_c,
   ]);
 

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -85,7 +85,7 @@ export interface CopilotApiConfig {
    * This is typically derived from the CopilotKitProps and used internally.
    * @experimental
    */
-  mcpEndpoints?: Array<{ endpoint: string; apiKey?: string }>;
+  mcpServers?: Array<{ endpoint: string; apiKey?: string }>;
 }
 
 export type InChatRenderFunction<TProps = ActionRenderProps<any> | CatchAllActionRenderProps<any>> =

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -278,9 +278,9 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
 
       // ----- Add this block: Merge mcpEndpoints into properties -----
       const finalProperties = { ...(copilotConfig.properties || {}) };
-      if (copilotConfig.mcpEndpoints && copilotConfig.mcpEndpoints.length > 0) {
-        // Prop takes precedence over any potential mcpEndpoints in properties
-        finalProperties.mcpEndpoints = copilotConfig.mcpEndpoints;
+      if (copilotConfig.mcpServers && copilotConfig.mcpServers.length > 0) {
+        // Prop takes precedence over any potential mcpServers in properties
+        finalProperties.mcpServers = copilotConfig.mcpServers;
       }
       // -------------------------------------------------------------
 

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat.ts
@@ -42,7 +42,7 @@
  * } = useCopilotChat();
  * ```
  */
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect, useCallback, useState } from "react";
 import { AgentSession, useCopilotContext } from "../context/copilot-context";
 import { Message, Role, TextMessage } from "@copilotkit/runtime-client-gql";
 import { SystemMessageFunction } from "../types";
@@ -75,6 +75,11 @@ export interface UseCopilotChatOptions {
   makeSystemMessage?: SystemMessageFunction;
 }
 
+export interface MCPServerConfig {
+  endpoint: string;
+  apiKey?: string;
+}
+
 export interface UseCopilotChatReturn {
   visibleMessages: Message[];
   appendMessage: (message: Message, options?: AppendMessageOptions) => Promise<void>;
@@ -85,6 +90,8 @@ export interface UseCopilotChatReturn {
   reset: () => void;
   isLoading: boolean;
   runChatCompletion: () => Promise<Message[]>;
+  mcpServers: MCPServerConfig[];
+  setMcpServers: (mcpServers: MCPServerConfig[]) => void;
 }
 
 export function useCopilotChat({
@@ -117,6 +124,7 @@ export function useCopilotChat({
     setLangGraphInterruptAction,
   } = useCopilotContext();
   const { messages, setMessages } = useCopilotMessagesContext();
+  const [mcpServers, setMcpServers] = useState<MCPServerConfig[]>([]);
 
   // We need to ensure that makeSystemMessageCallback always uses the latest
   // useCopilotReadable data.
@@ -157,10 +165,21 @@ export function useCopilotChat({
     [coAgentStateRenders],
   );
 
+  // Update the copilotApiConfig with mcpServers
+  const updatedCopilotConfig = useCallback(() => {
+    return {
+      ...copilotApiConfig,
+      mcpEndpoints: mcpServers.map((server) => ({
+        endpoint: server.endpoint,
+        apiKey: server.apiKey,
+      })),
+    };
+  }, [copilotApiConfig, mcpServers]);
+
   const { append, reload, stop, runChatCompletion } = useChat({
     ...options,
     actions: Object.values(actions),
-    copilotConfig: copilotApiConfig,
+    copilotConfig: updatedCopilotConfig(),
     initialMessages: options.initialMessages || [],
     onFunctionCall: getFunctionCallHandler(),
     onCoAgentStateRender,
@@ -272,6 +291,8 @@ export function useCopilotChat({
     deleteMessage: latestDeleteFunc,
     runChatCompletion: latestRunChatCompletionFunc,
     isLoading,
+    mcpServers,
+    setMcpServers,
   };
 }
 

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -228,19 +228,19 @@ export interface CopilotRuntimeConstructorParams<T extends Parameter[] | [] = []
    * Requires providing the `createMCPClient` function during instantiation.
    * @experimental
    */
-  mcpEndpoints?: MCPEndpointConfig[];
+  mcpServers?: MCPEndpointConfig[];
 
   /**
    * A function that creates an MCP client instance for a given endpoint configuration.
    * This function is responsible for using the appropriate MCP client library
    * (e.g., `@copilotkit/runtime`, `ai`) to establish a connection.
-   * Required if `mcpEndpoints` is provided.
+   * Required if `mcpServers` is provided.
    *
    * ```typescript
    * import { experimental_createMCPClient } from "ai"; // Import from vercel ai library
    * // ...
    * const runtime = new CopilotRuntime({
-   *   mcpEndpoints: [{ endpoint: "..." }],
+   *   mcpServers: [{ endpoint: "..." }],
    *   async createMCPClient(config) {
    *     return await experimental_createMCPClient({
    *       transport: {
@@ -270,7 +270,7 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
   private availableAgents: Pick<AgentWithEndpoint, "name" | "id">[];
 
   // +++ MCP Properties +++
-  private readonly mcpEndpointsConfig?: MCPEndpointConfig[];
+  private readonly mcpServersConfig?: MCPEndpointConfig[];
   private mcpActionCache = new Map<string, Action<any>[]>();
   // --- MCP Properties ---
 
@@ -303,18 +303,14 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
     this.observability = params?.observability_c;
     this.agents = params?.agents ?? {};
     // +++ MCP Initialization +++
-    this.mcpEndpointsConfig = params?.mcpEndpoints;
+    this.mcpServersConfig = params?.mcpServers;
     this.createMCPClientImpl = params?.createMCPClient;
 
-    // Validate: If mcpEndpoints are provided, createMCPClient must also be provided
-    if (
-      this.mcpEndpointsConfig &&
-      this.mcpEndpointsConfig.length > 0 &&
-      !this.createMCPClientImpl
-    ) {
+    // Validate: If mcpServers are provided, createMCPClient must also be provided
+    if (this.mcpServersConfig && this.mcpServersConfig.length > 0 && !this.createMCPClientImpl) {
       throw new CopilotKitMisuseError({
         message:
-          "MCP Integration Error: `mcpEndpoints` were provided, but the `createMCPClient` function was not passed to the CopilotRuntime constructor. " +
+          "MCP Integration Error: `mcpServers` were provided, but the `createMCPClient` function was not passed to the CopilotRuntime constructor. " +
           "Please provide an implementation for `createMCPClient`.",
       });
     }
@@ -323,7 +319,7 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
     if (
       params?.actions &&
       (params?.remoteEndpoints?.some((e) => e.type === EndpointType.LangGraphPlatform) ||
-        this.mcpEndpointsConfig?.length)
+        this.mcpServersConfig?.length)
     ) {
       console.warn(
         "Local 'actions' defined in CopilotRuntime might not be available to remote agents (LangGraph, MCP). Consider defining actions closer to the agent implementation if needed.",
@@ -1110,9 +1106,10 @@ please use an LLM adapter instead.`,
     const requestSpecificMCPActions: Action<any>[] = [];
     if (this.createMCPClientImpl) {
       // 1. Determine effective MCP endpoints for this request
-      const baseEndpoints = this.mcpEndpointsConfig || [];
-      // Assuming frontend passes config via properties.mcpEndpoints
-      const requestEndpoints = (graphqlContext.properties?.mcpEndpoints ||
+      const baseEndpoints = this.mcpServersConfig || [];
+      // Assuming frontend passes config via properties.mcpServers
+      const requestEndpoints = (graphqlContext.properties?.mcpServers ||
+        graphqlContext.properties?.mcpEndpoints ||
         []) as MCPEndpointConfig[];
 
       // Merge and deduplicate endpoints based on URL

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -96,7 +96,7 @@ Configuration for LLM request/response logging.
   ```
 </PropertyReference>
 
-<PropertyReference name="mcpEndpoints" type="MCPEndpointConfig[]"  > 
+<PropertyReference name="mcpServers" type="MCPEndpointConfig[]"  > 
 Configuration for connecting to Model Context Protocol (MCP) servers.
   Allows fetching and using tools defined on external MCP-compliant servers.
   Requires providing the `createMCPClient` function during instantiation.
@@ -107,13 +107,13 @@ Configuration for connecting to Model Context Protocol (MCP) servers.
 A function that creates an MCP client instance for a given endpoint configuration.
   This function is responsible for using the appropriate MCP client library
   (e.g., `@copilotkit/runtime`, `ai`) to establish a connection.
-  Required if `mcpEndpoints` is provided.
+  Required if `mcpServers` is provided.
  
   ```typescript
   import { experimental_createMCPClient } from "ai"; // Import from vercel ai library
   // ...
   const runtime = new CopilotRuntime({
-    mcpEndpoints: [{ endpoint: "..." }],
+    mcpServers: [{ endpoint: "..." }],
     async createMCPClient(config) {
       return await experimental_createMCPClient({
         transport: {

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -104,17 +104,3 @@ The auth config to use for the CopilotKit.
 The thread id to use for the CopilotKit.
 </PropertyReference>
 
-<PropertyReference name="mcpEndpoints" type="Array<{ endpoint: string; apiKey?: string }>"  > 
-Config for connecting to Model Context Protocol (MCP) servers.
-  Enables CopilotKit runtime to access tools on external MCP servers.
- 
-  This config merges into the `properties` object with each request as `mcpEndpoints`.
-  It offers a typed method to set up MCP endpoints for requests.
- 
-  Each array item should have:
-  - `endpoint`: MCP server URL (mandatory).
-  - `apiKey`: Optional API key for server authentication.
- 
-  Note: A `createMCPClient` function is still needed during runtime initialization to manage these endpoints.
-</PropertyReference>
-


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

refactor: rename mcpEndpoints to mcpServers for naming consistency

This commit renames the `mcpEndpoints` property to `mcpServers` across the codebase for improved naming consistency.

Key changes:
- Remove `mcpEndpoints` from CopilotKitProps in favor of using the hook-based approach 
- Add `mcpServers` to CopilotApiConfig interface with proper typing
- Update the `useCopilotChat` hook to expose `mcpServers` and `setMcpServers`
- Update CopilotRuntime to use `mcpServers` instead of `mcpEndpoints`
- Maintain backward compatibility in runtime by checking for both property names
- Update property merging logic in use-chat.ts to use the new property name

This change improves the API consistency while maintaining the same functionality.
MCP servers should now be managed via the hook:
```tsx
const { mcpServers, setMcpServers } = useCopilotChat();
```
instead of through the component props.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation