### PR TITLE
Fix MCP tool schema structure to match interface requirements

### DIFF
--- a/CopilotKit/.changeset/khaki-candles-compete.md
+++ b/CopilotKit/.changeset/khaki-candles-compete.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- Fix MCP tool schema structure to match interface requirements
+- add utils

--- a/CopilotKit/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
@@ -126,3 +126,63 @@ export function convertMCPToolsToActions(
 
   return actions;
 }
+
+/**
+ * Generate better instructions for using MCP tools
+ * This is used to enhance the system prompt with tool documentation
+ */
+export function generateMcpToolInstructions(toolsMap: Record<string, MCPTool>): string {
+  if (!toolsMap || Object.keys(toolsMap).length === 0) {
+    return "";
+  }
+
+  const toolEntries = Object.entries(toolsMap);
+
+  // Generate documentation for each tool
+  const toolsDoc = toolEntries
+    .map(([name, tool]) => {
+      // Extract schema information if available
+      let paramsDoc = "    No parameters required";
+
+      try {
+        if (tool.schema && typeof tool.schema === "object") {
+          const schema = tool.schema as any;
+
+          // Extract parameters from JSON Schema
+          if (schema.properties) {
+            const requiredParams = schema.required || [];
+
+            // Build parameter documentation from properties
+            const paramsList = Object.entries(schema.properties).map(([paramName, propSchema]) => {
+              const propDetails = propSchema as any;
+              const requiredMark = requiredParams.includes(paramName) ? "*" : "";
+              const typeInfo = propDetails.type || "any";
+              const description = propDetails.description ? ` - ${propDetails.description}` : "";
+
+              return `    - ${paramName}${requiredMark} (${typeInfo})${description}`;
+            });
+
+            if (paramsList.length > 0) {
+              paramsDoc = paramsList.join("\n");
+            }
+          }
+        }
+      } catch (e) {
+        console.error(`Error parsing schema for tool ${name}:`, e);
+      }
+
+      return `- ${name}: ${tool.description || ""}
+${paramsDoc}`;
+    })
+    .join("\n\n");
+
+  return `You have access to the following external tools provided by Model Context Protocol (MCP) servers:
+
+${toolsDoc}
+
+When using these tools:
+1. Only provide valid parameters according to their type requirements
+2. Required parameters are marked with *
+3. Format API calls correctly with the expected parameter structure
+4. Always check tool responses to determine your next action`;
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes a TypeScript error in the MCP tool schema structure by correctly nesting the `properties` and `required` fields inside a `parameters` object to match the expected interface. This resolves the error: "Type '{ properties: any; required: any; } | {}' is not assignable to type '{ parameters?: { properties?: Record<string, any>; required?: string[]; jsonSchema?: Record<string, any>; }; }'".

## Related PRs and Issues

- N/A

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation