### PR TITLE
feat(docs): add CLI as default path in the documentation

### DIFF
--- a/docs/content/docs/coagents/quickstart/langgraph.mdx
+++ b/docs/content/docs/coagents/quickstart/langgraph.mdx
@@ -26,6 +26,9 @@ import SelfHostingRemoteEndpoints from "@/snippets/self-hosting-remote-endpoints
 import { UserIcon, PaintbrushIcon, WrenchIcon, RepeatIcon, ServerIcon } from "lucide-react";
 import { SiLangchain } from "react-icons/si";
 import CopilotUI from "@/snippets/copilot-ui.mdx";
+import { PathIcon } from "lucide-react";
+import { SquareTerminal, SquareChartGantt } from "lucide-react";
+
 
 <video src="/images/coagents/chat-example.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
 
@@ -37,247 +40,319 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <Step>
-        ### Install CopilotKit
-        First, install the latest packages for CopilotKit into your frontend.
-        ```package-install
-        npm install @copilotkit/react-ui @copilotkit/react-core
-        ```
-    </Step>
     <TailoredContent
         className="step"
-        id="agent"
+        id="path"
         header={
             <div>
-                <p className="text-xl font-semibold">Do you already have a LangGraph agent?</p>
+                <p className="text-xl font-semibold">How do you want to get started?</p>
                 <p className="text-base">
-                    You will need a LangGraph agent to get started with CoAgents!
-                </p>
-                <p className="text-base">
-                    Either bring your own or feel free to use our starter repo.
+                    Bootstrap with the new <span className="text-indigo-500 dark:text-indigo-400">CopilotKit CLI (Beta)</span> or code along with us to get started.
                 </p>
             </div>
         }
     >
         <TailoredContentOption
-            id="bring-your-own"
-            title="Bring your own LangGraph agent"
-            description="I already have a LangGraph agent and want to use it with CopilotKit."
-            icon={<SiLangchain />}
-        />
-        <TailoredContentOption
-            id="coagents-starter"
-            title="Use the CoAgents Starter repo"
-            description="I don't have a LangGraph agent yet, but want to get started quickly."
-            icon={<img src="/images/copilotkit-logo.svg" alt="CopilotKit Logo" width={20} height={20} />}
+            id="cli"
+            title="Use the CopilotKit CLI (NextJS only)"
+            description="I have a Next.js application and want to get started quickly."
+            icon={<SquareTerminal />}
         >
             <Step>
-                ### Clone the `coagents-starter` repo and install dependencies:
+                ### Run the CLI
+                Just run this following command in your Next.js application to get started!
 
-                <Tabs groupId="language" items={["Python", "TypeScript"]}>
-                    <Tab value="Python">
+                <Accordions>
+                    <Accordion title="Don't have a Next.js application?">
+                        No problem! Just use `create-next-app` to make one quickly.
                         ```bash
-                        git clone -n --depth=1 --filter=tree:0 https://github.com/CopilotKit/CopilotKit && cd CopilotKit && git sparse-checkout set --no-cone examples/coagents-starter/agent-py && git checkout && cd ..
-                        cd CopilotKit/examples/coagents-starter/agent-py
+                        npx create-next-app@latest
                         ```
-
-                        #### Install dependencies:
-                        ```bash
-                        poetry install
-                        ```
-                    </Tab>
-                    <Tab value="TypeScript">
-                        ```bash
-                        git clone -n --depth=1 --filter=tree:0 https://github.com/CopilotKit/CopilotKit && cd CopilotKit && git sparse-checkout set --no-cone examples/coagents-starter/agent-js && git checkout && cd ..
-                        cd CopilotKit/examples/coagents-starter/agent-js
-                        ```
-
-                        #### Install dependencies:
-                        ```bash
-                        pnpm install
-                        ```
-                    </Tab>
-                </Tabs>
-            </Step>
-            <Step>
-                ### Create a `.env` file
+                    </Accordion>
+                </Accordions>
 
                 ```bash
-                touch .env
+                npx copilotkit@latest init -m LangGraph
                 ```
             </Step>
             <Step>
-                ### Add your API keys
+                ### 🎉 Talk to your agent!
 
-                Then add your **OpenAI API key** and **LangSmith API key** to the `.env` file.
+                Congrats! You've successfully integrated a LangGraph agent chatbot to your application. Depending on the
+                template you chose, you may see some different UI elements. To start, try asking a few questions to your agent.
 
-                ```plaintext title=".env"
-                OPENAI_API_KEY=your_openai_api_key
-                LANGSMITH_API_KEY=your_langsmith_api_key
                 ```
-            </Step>
-        </TailoredContentOption>
-    </TailoredContent>
-    <Step>
-        ### Start your LangGraph Agent
+                Can you tell me a joke?
+                ```
 
-        <LangGraphPlatformDeploymentTabs components={props.components} />
-    </Step>
+                ```
+                Can you help me understand AI?
+                ```
 
-    <TailoredContent 
-        className="step" 
-        id="copilot-hosting" 
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your connection method</p>
-                <p className="text-base">
-                    Now you need to connect your LangGraph agent to CopilotKit.
-                </p>
-            </div>
-        }
-    >
-        <TailoredContentOption
-            id="copilot-cloud"
-            title="Copilot Cloud (Recommended)"
-            description="I want to host my Copilot on Copilot Cloud"
-            icon={<FaCloud />}
-        >
-            <Step>
-                ### Add a remote endpoint for your LangGraph agent
-                Using Copilot Cloud, you need to connect a remote endpoint that will connect to your LangGraph agent.
-                <Tabs groupId="lg-deployment-type" items={['Local (LangGraph Studio)', 'Self hosted (FastAPI)', 'LangGraph Platform']}>
-                    <Tab value="Local (LangGraph Studio)">
-                        When running your LangGraph agent locally, you can open a tunnel to it so Copilot Cloud can connect to it.
-                        First, make sure you're logged in to [Copilot Cloud](https://cloud.copilotkit.ai), and then authenticate the CLI by running:
-                        ```bash
-                        npx copilotkit@latest login
-                        ```
-                        Once authenticated, run:
-                        ```bash
-                        npx copilotkit@latest dev --port 8000
-                        ```
-                    </Tab>
-                    <Tab value="Self hosted (FastAPI)">
-                        **Running your FastAPI server locally**
+                ```
+                What do you think about React?
+                ```
 
-                        If you're running your FastAPI server locally, you can open a tunnel to it so Copilot Cloud can connect to it.
-                        First, make sure you're logged in to [Copilot Cloud](https://cloud.copilotkit.ai), and then authenticate the CLI by running:
-                        ```bash
-                        npx copilotkit@latest login
-                        ```
-                        Once authenticated, run:
-                        ```bash
-                        npx copilotkit@latest dev --port 8000
-                        ```
-
-                        **Running your FastAPI server in production**
-
-                        Head over to [Copilot Cloud](https://cloud.copilotkit.ai) sign up and setup a remote endpoint with the following information:
-                        - OpenAI API key
-                        - LangSmith API key
-                        - Your FastAPI server URL
-                    </Tab>
-                    <Tab value="LangGraph Platform">
-                        Head over to [Copilot Cloud](https://cloud.copilotkit.ai) sign up and setup a remote endpoint to LangGraph Platform with the following information:
-                        - OpenAI API key
-                        - LangSmith API key
-                        - LangGraph agent deployment URL
-                        <Accordions className="mb-4">
-                            <Accordion title="Show me how">
-                                <Frame>
-                                    <img src="/images/copilot-cloud/cpk-cloud-lgp-endpoint.gif" alt="Copilot Cloud Remote Endpoint" />
-                                </Frame>
-                            </Accordion>
-                        </Accordions>
-                    </Tab>
-                </Tabs>
-            </Step>
-            <Step>
-                ### Setup your CopilotKit provider
-                The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases, 
-                it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
-
-                Since we're using Copilot CLoud, we need to grab our public API key from the [Copilot Cloud dashboard](https://cloud.copilotkit.ai).
-
-                <CloudCopilotKitProvider components={props.components} />
-
-                <Callout type="info">
-                    Looking for a way to run multiple LangGraph agents? Check out our [Multi-Agent](/coagents/multi-agent-flows) guide.
-                </Callout>
+                <Accordions className="mb-4">
+                    <Accordion title="Having trouble?">
+                        - Make sure your agent folder contains a `langgraph.json` file.
+                        - In the `langgraph.json` file, reference the path to a `.env` file.
+                        - In the `.env` file, include your `LANGSMITH_API_KEY`.
+                        - Make sure you're in the same folder as your `langgraph.json` file when running the `langgraph dev` command.
+                        - Try changing the host to `0.0.0.0` or `127.0.0.1` instead of `localhost`.
+                    </Accordion>
+                </Accordions>
             </Step>
         </TailoredContentOption>
         <TailoredContentOption
-            id="self-hosted"
-            title="Self-Hosted Copilot Runtime"
-            description="I want to self-host the Copilot Runtime"
-            icon={<ServerIcon />}
+            id="code-along"
+            title="Code along"
+            description="I want to deeply understand what's happening under the hood or don't have a Next.js application."
+            icon={<SquareChartGantt />}
         >
             <Step>
-                ### Install Copilot Runtime
-                Copilot Runtime is a production-ready proxy for your LangGraph agents. In your frontend, go ahead and install it.
-
+                ### Install CopilotKit
+                First, install the latest packages for CopilotKit into your frontend.
                 ```package-install
-                @copilotkit/runtime class-validator
+                npm install @copilotkit/react-ui @copilotkit/react-core
                 ```
             </Step>
+            <TailoredContent
+                className="step"
+                id="agent"
+                header={
+                    <div>
+                        <p className="text-xl font-semibold">Do you already have a LangGraph agent?</p>
+                        <p className="text-base">
+                            You will need a LangGraph agent to get started with CoAgents!
+                        </p>
+                        <p className="text-base">
+                            Either bring your own or feel free to use our starter repo.
+                        </p>
+                    </div>
+                }
+            >
+                <TailoredContentOption
+                    id="bring-your-own"
+                    title="Bring your own LangGraph agent"
+                    description="I already have a LangGraph agent and want to use it with CopilotKit."
+                    icon={<SiLangchain />}
+                />
+                <TailoredContentOption
+                    id="coagents-starter"
+                    title="Use the CoAgents Starter repo"
+                    description="I don't have a LangGraph agent yet, but want to get started quickly."
+                    icon={<img src="/images/copilotkit-logo.svg" alt="CopilotKit Logo" width={20} height={20} />}
+                >
+                    <Step>
+                        ### Clone the `coagents-starter` repo and install dependencies:
+
+                        <Tabs groupId="language" items={["Python", "TypeScript"]}>
+                            <Tab value="Python">
+                                ```bash
+                                git clone -n --depth=1 --filter=tree:0 https://github.com/CopilotKit/CopilotKit && cd CopilotKit && git sparse-checkout set --no-cone examples/coagents-starter/agent-py && git checkout && cd ..
+                                cd CopilotKit/examples/coagents-starter/agent-py
+                                ```
+
+                                #### Install dependencies:
+                                ```bash
+                                poetry install
+                                ```
+                            </Tab>
+                            <Tab value="TypeScript">
+                                ```bash
+                                git clone -n --depth=1 --filter=tree:0 https://github.com/CopilotKit/CopilotKit && cd CopilotKit && git sparse-checkout set --no-cone examples/coagents-starter/agent-js && git checkout && cd ..
+                                cd CopilotKit/examples/coagents-starter/agent-js
+                                ```
+
+                                #### Install dependencies:
+                                ```bash
+                                pnpm install
+                                ```
+                            </Tab>
+                        </Tabs>
+                    </Step>
+                    <Step>
+                        ### Create a `.env` file
+
+                        ```bash
+                        touch .env
+                        ```
+                    </Step>
+                    <Step>
+                        ### Add your API keys
+
+                        Then add your **OpenAI API key** and **LangSmith API key** to the `.env` file.
+
+                        ```plaintext title=".env"
+                        OPENAI_API_KEY=your_openai_api_key
+                        LANGSMITH_API_KEY=your_langsmith_api_key
+                        ```
+                    </Step>
+                </TailoredContentOption>
+            </TailoredContent>
             <Step>
-                ### Setup a Copilot Runtime Endpoint
-                Now we need to setup a Copilot Runtime endpoint and point your frontend to it.
-                <SelfHostingCopilotRuntimeStarter components={props.components}/>
+                ### Start your LangGraph Agent
+
+                <LangGraphPlatformDeploymentTabs components={props.components} />
+            </Step>
+
+            <TailoredContent 
+                className="step" 
+                id="copilot-hosting" 
+                header={
+                    <div>
+                        <p className="text-xl font-semibold">Choose your connection method</p>
+                        <p className="text-base">
+                            Now you need to connect your LangGraph agent to CopilotKit.
+                        </p>
+                    </div>
+                }
+            >
+                <TailoredContentOption
+                    id="copilot-cloud"
+                    title="Copilot Cloud (Recommended)"
+                    description="I want to host my Copilot on Copilot Cloud"
+                    icon={<FaCloud />}
+                >
+                    <Step>
+                        ### Add a remote endpoint for your LangGraph agent
+                        Using Copilot Cloud, you need to connect a remote endpoint that will connect to your LangGraph agent.
+                        <Tabs groupId="lg-deployment-type" items={['Local (LangGraph Studio)', 'Self hosted (FastAPI)', 'LangGraph Platform']}>
+                            <Tab value="Local (LangGraph Studio)">
+                                When running your LangGraph agent locally, you can open a tunnel to it so Copilot Cloud can connect to it.
+                                First, make sure you're logged in to [Copilot Cloud](https://cloud.copilotkit.ai), and then authenticate the CLI by running:
+                                ```bash
+                                npx copilotkit@latest login
+                                ```
+                                Once authenticated, run:
+                                ```bash
+                                npx copilotkit@latest dev --port 8000
+                                ```
+                            </Tab>
+                            <Tab value="Self hosted (FastAPI)">
+                                **Running your FastAPI server locally**
+
+                                If you're running your FastAPI server locally, you can open a tunnel to it so Copilot Cloud can connect to it.
+                                First, make sure you're logged in to [Copilot Cloud](https://cloud.copilotkit.ai), and then authenticate the CLI by running:
+                                ```bash
+                                npx copilotkit@latest login
+                                ```
+                                Once authenticated, run:
+                                ```bash
+                                npx copilotkit@latest dev --port 8000
+                                ```
+
+                                **Running your FastAPI server in production**
+
+                                Head over to [Copilot Cloud](https://cloud.copilotkit.ai) sign up and setup a remote endpoint with the following information:
+                                - OpenAI API key
+                                - LangSmith API key
+                                - Your FastAPI server URL
+                            </Tab>
+                            <Tab value="LangGraph Platform">
+                                Head over to [Copilot Cloud](https://cloud.copilotkit.ai) sign up and setup a remote endpoint to LangGraph Platform with the following information:
+                                - OpenAI API key
+                                - LangSmith API key
+                                - LangGraph agent deployment URL
+                                <Accordions className="mb-4">
+                                    <Accordion title="Show me how">
+                                        <Frame>
+                                            <img src="/images/copilot-cloud/cpk-cloud-lgp-endpoint.gif" alt="Copilot Cloud Remote Endpoint" />
+                                        </Frame>
+                                    </Accordion>
+                                </Accordions>
+                            </Tab>
+                        </Tabs>
+                    </Step>
+                    <Step>
+                        ### Setup your CopilotKit provider
+                        The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases, 
+                        it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
+
+                        Since we're using Copilot CLoud, we need to grab our public API key from the [Copilot Cloud dashboard](https://cloud.copilotkit.ai).
+
+                        <CloudCopilotKitProvider components={props.components} />
+
+                        <Callout type="info">
+                            Looking for a way to run multiple LangGraph agents? Check out our [Multi-Agent](/coagents/multi-agent-flows) guide.
+                        </Callout>
+                    </Step>
+                </TailoredContentOption>
+                <TailoredContentOption
+                    id="self-hosted"
+                    title="Self-Hosted Copilot Runtime"
+                    description="I want to self-host the Copilot Runtime"
+                    icon={<ServerIcon />}
+                >
+                    <Step>
+                        ### Install Copilot Runtime
+                        Copilot Runtime is a production-ready proxy for your LangGraph agents. In your frontend, go ahead and install it.
+
+                        ```package-install
+                        @copilotkit/runtime class-validator
+                        ```
+                    </Step>
+                    <Step>
+                        ### Setup a Copilot Runtime Endpoint
+                        Now we need to setup a Copilot Runtime endpoint and point your frontend to it.
+                        <SelfHostingCopilotRuntimeStarter components={props.components}/>
+                    </Step>
+                    <Step>
+                        ### Add your LangGraph deployment to Copilot Runtime
+                        Now we need to add your LangGraph deployment to Copilot Runtime. This will make it
+                        so your frontend can find your LangGraph agents correctly.
+                        <SelfHostingRemoteEndpoints components={props.components}/>
+                    </Step>
+                    <Step>
+                        ### Configure the CopilotKit Provider
+                        The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases, 
+                        it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
+                        <SelfHostingCopilotRuntimeConfigureCopilotKitProvider components={props.components}/>
+                        <Callout type="info">
+                            Looking for a way to run multiple LangGraph agents? Check out our [Multi-Agent](/coagents/multi-agent-flows) guide.
+                        </Callout>
+                    </Step>
+                </TailoredContentOption>
+            </TailoredContent>
+            <Step>
+                ## Choose a Copilot UI
+
+                You are almost there! Now it's time to setup your Copilot UI.
+
+                <ConnectCopilotUI components={props.components} />
             </Step>
             <Step>
-                ### Add your LangGraph deployment to Copilot Runtime
-                Now we need to add your LangGraph deployment to Copilot Runtime. This will make it
-                so your frontend can find your LangGraph agents correctly.
-                <SelfHostingRemoteEndpoints components={props.components}/>
+                ### 🎉 Talk to your agent!
+
+                Congrats! You've successfully integrated a LangGraph agent chatbot to your application. To start, try asking a few questions to your agent.
+
+                ```
+                Can you tell me a joke?
+                ```
+
+                ```
+                Can you help me understand AI?
+                ```
+
+                ```
+                What do you think about React?
+                ```
+
+                <video src="/images/coagents/chat-example.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
+
+                <Accordions className="mb-4">
+                    <Accordion title="Having trouble?">
+                        - Make sure your agent folder contains a `langgraph.json` file.
+                        - In the `langgraph.json` file, reference the path to a `.env` file.
+                        - In the `.env` file, include your `LANGSMITH_API_KEY`.
+                        - Make sure you're in the same folder as your `langgraph.json` file when running the `langgraph dev` command.
+                        - Try changing the host to `0.0.0.0` or `127.0.0.1` instead of `localhost`.
+                    </Accordion>
+                </Accordions>
             </Step>
-            <Step>
-                ### Configure the CopilotKit Provider
-                The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases, 
-                it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
-                <SelfHostingCopilotRuntimeConfigureCopilotKitProvider components={props.components}/>
-                <Callout type="info">
-                    Looking for a way to run multiple LangGraph agents? Check out our [Multi-Agent](/coagents/multi-agent-flows) guide.
-                </Callout>
-            </Step>
-        </TailoredContentOption>
-    </TailoredContent>
-    <Step>
-        ## Choose a Copilot UI
-
-        You are almost there! Now it's time to setup your Copilot UI.
-
-        <ConnectCopilotUI components={props.components} />
-    </Step>
-    <Step>
-        ### 🎉 Talk to your agent!
-
-        Congrats! You've successfully integrated a LangGraph agent chatbot to your application. To start, try asking a few questions to your agent.
-
-        ```
-        Can you tell me a joke?
-        ```
-
-        ```
-        Can you help me understand AI?
-        ```
-
-        ```
-        What do you think about React?
-        ```
-
-        <video src="/images/coagents/chat-example.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
-
-        <Accordions className="mb-4">
-            <Accordion title="Having trouble?">
-                - Make sure your agent folder contains a `langgraph.json` file.
-                - In the `langgraph.json` file, reference the path to a `.env` file.
-                - In the `.env` file, include your `LANGSMITH_API_KEY`.
-                - Make sure you're in the same folder as your `langgraph.json` file when running the `langgraph dev` command.
-                - Try changing the host to `0.0.0.0` or `127.0.0.1` instead of `localhost`.
-            </Accordion>
-        </Accordions>
-    </Step>
+            </TailoredContentOption>
+        </TailoredContent>
 </Steps>
 
 ---
@@ -294,7 +369,7 @@ can help you build power agent native applications.
     icon={<UserIcon />}
   />
   <Card 
-    title="Utilize the Shared State" 
+    title="Utilize Shared State" 
     description="Learn how to synchronize your agent's state with your UI's state, and vice versa." 
     href="/coagents/shared-state"
     icon={<RepeatIcon />}

--- a/docs/content/docs/crewai-crews/quickstart/crewai.mdx
+++ b/docs/content/docs/crewai-crews/quickstart/crewai.mdx
@@ -48,13 +48,16 @@ Before you begin, you'll need the following:
         id="cli"
         header={
             <div>
-                <p className="text-xl font-semibold">Use the CopilotKit CLI</p>
+                <p className="text-xl font-semibold">How do you want to get started?</p>
+                <p className="text-base">
+                    Bootstrap with the new <span className="text-indigo-500 dark:text-indigo-400">CopilotKit CLI (Beta)</span> or code along with us to get started.
+                </p>
             </div>
         }
     >
         <TailoredContentOption
             id="use-cli"
-            title="Use the CopilotKit CLI"
+            title="Use the CopilotKit CLI (NextJS only)"
             description="I have a Next.js application and want to get started quickly."
             icon={<SquareTerminal />}
         >
@@ -72,7 +75,7 @@ Before you begin, you'll need the following:
                 </Accordions>
 
                 ```bash
-                npx copilotkit@latest init
+                npx copilotkit@latest init -m CrewAI --crew-type Crews
                 ```
             </Step>
 

--- a/docs/content/docs/crewai-flows/quickstart/crewai.mdx
+++ b/docs/content/docs/crewai-flows/quickstart/crewai.mdx
@@ -22,6 +22,7 @@ import SelfHostingCopilotRuntimeConfigureCopilotKitProvider from "@/snippets/coa
 import SelfHostingCopilotRuntimeLangGraphEndpoint from "@/snippets/self-hosting-copilot-runtime-langgraph-endpoint.mdx";
 import SelfHostingCopilotRuntimeStarter from "@/snippets/self-hosting-copilot-runtime-starter.mdx";
 import SelfHostingRemoteEndpoints from "@/snippets/self-hosting-remote-endpoints.mdx";
+import { SquareTerminal, SquareChartGantt } from "lucide-react";
 import {
   UserIcon,
   PaintbrushIcon,
@@ -51,244 +52,306 @@ Before you begin, you'll need the following:
 ## Getting started
 
 <Steps>
-    <Step>
-        ### Install CopilotKit
-        First, install the latest packages for CopilotKit into your frontend.
-        ```package-install
-        npm install @copilotkit/react-ui @copilotkit/react-core
-        ```
-    </Step>
-    <TailoredContent
-        className="step"
-        id="agent"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Do you already have a CrewAI Flow agent?</p>
-                <p className="text-base">
-                    You will need a CrewAI Flow agent to get started!
-                </p>
-                <p className="text-base">
-                    Either bring your own or feel free to use our starter repo.
-                </p>
-            </div>
-        }
+<TailoredContent
+    className="step"
+    id="path"
+    header={
+        <div>
+            <p className="text-xl font-semibold">How do you want to get started?</p>
+            <p className="text-base">
+                Bootstrap with the new <span className="text-indigo-500 dark:text-indigo-400">CopilotKit CLI (Beta)</span> or code along with us to get started.
+            </p>
+        </div>
+    }
+>
+    <TailoredContentOption
+        id="cli"
+        title="Use the CopilotKit CLI (NextJS only)"
+        description="I have a Next.js application and want to get started quickly."
+        icon={<SquareTerminal />}
     >
-        <TailoredContentOption
-            id="bring-your-own"
-            title="Bring your own CrewAI Flow agent"
-            description="I already have a CrewAI Flow agent and want to use it with CopilotKit."
-            icon={<SiCrewai />}
-        />
-        <TailoredContentOption
-            id="coagents-starter"
-            title="Use the CoAgents Starter repo"
-            description="I don't have a CrewAI Flow agent yet, but want to get started quickly."
-            icon={<img src="/images/copilotkit-logo.svg" alt="CopilotKit Logo" width={20} height={20} />}
-        >
-            <Step>
-                ### Clone the `coagents-starter` repo
+        <Step>
+            ### Run the CLI
+            Just run this following command in your Next.js application to get started!
 
-                <Tabs groupId="language" items={["Python"]}>
-                    <Tab value="Python">
-                        ```bash
-                        git clone https://github.com/CopilotKit/CopilotKit
-                        cd CopilotKit/examples/coagents-starter-crewai-flows/agent-py
-                        ```
-                    </Tab>
-                </Tabs>
-            </Step>
-            <Step>
-                ### Create a `.env` file
+            <Accordions>
+                <Accordion title="Don't have a Next.js application?">
+                    No problem! Just use `create-next-app` to make one quickly.
+                    ```bash
+                    npx create-next-app@latest
+                    ```
+                </Accordion>
+            </Accordions>
 
-                ```bash
-                touch .env
-                ```
-            </Step>
-            <Step>
-                ### Add your API keys
+            ```bash
+            npx copilotkit@latest init -m CrewAI --crew-type Flows
+            ```
+        </Step>
+        <Step>
+            ### 🎉 Talk to your agent!
 
-                Then add your **OpenAI API key** to the `.env` file.
+            Congrats! You've successfully integrated a CrewAI Flow agent chatbot to your application. Depending on the
+            template you chose, you may see some different UI elements. To start, try asking a few questions to your agent.
 
-                ```plaintext title=".env"
-                OPENAI_API_KEY=your_openai_api_key
-                ```
-            </Step>
-        </TailoredContentOption>
-    </TailoredContent>
-    <Step>
-        ### Launch your local agent
+            ```
+            Can you tell me a joke?
+            ```
 
-        Start your local CrewAI Flow agent:
+            ```
+            Can you help me understand AI?
+            ```
 
-        ```bash
-        # Install dependencies
-        poetry lock
-        poetry install
-        # Start the server
-        poetry run demo
-        ```
-        This will start a local agent server that you can connect to.
-    </Step>
-
-    <TailoredContent
-        className="step"
-        id="copilot-hosting"
-        header={
-            <div>
-                <p className="text-xl font-semibold">Choose your connection method</p>
-                <p className="text-base">
-                    Now you need to connect your CrewAI Flow to CopilotKit.
-                </p>
-            </div>
-        }
+            ```
+            What do you think about React?
+            ```
+        </Step>
+    </TailoredContentOption>
+    <TailoredContentOption
+        id="code-along"
+        title="Code along"
+        description="I want to deeply understand what's happening under the hood or don't have a Next.js application."
+        icon={<SquareChartGantt />}
     >
-        <TailoredContentOption
-            id="copilot-cloud"
-            title="Copilot Cloud (Recommended)"
-            description="I want to host my Copilot on Copilot Cloud"
-            icon={<FaCloud />}
+        <Step>
+            ### Install CopilotKit
+            First, install the latest packages for CopilotKit into your frontend.
+            ```package-install
+            npm install @copilotkit/react-ui @copilotkit/react-core
+            ```
+        </Step>
+        <TailoredContent
+            className="step"
+            id="agent"
+            header={
+                <div>
+                    <p className="text-xl font-semibold">Do you already have a CrewAI Flow agent?</p>
+                    <p className="text-base">
+                        You will need a CrewAI Flow agent to get started!
+                    </p>
+                    <p className="text-base">
+                        Either bring your own or feel free to use our starter repo.
+                    </p>
+                </div>
+            }
         >
-            <Step>
-                ### Add a remote endpoint for your CrewAI Flow
-                Using Copilot Cloud, you need to connect a remote endpoint that will connect to your CrewAI Flow.
-                <Tabs groupId="lg-deployment-type" items={['Self hosted (FastAPI)', 'CrewAI Enterprise']}>
-                    <Tab value="Self hosted (FastAPI)">
-                        **Running your FastAPI server in production**
+            <TailoredContentOption
+                id="bring-your-own"
+                title="Bring your own CrewAI Flow agent"
+                description="I already have a CrewAI Flow agent and want to use it with CopilotKit."
+                icon={<SiCrewai />}
+            />
+            <TailoredContentOption
+                id="coagents-starter"
+                title="Use the CoAgents Starter repo"
+                description="I don't have a CrewAI Flow agent yet, but want to get started quickly."
+                icon={<img src="/images/copilotkit-logo.svg" alt="CopilotKit Logo" width={20} height={20} />}
+            >
+                <Step>
+                    ### Clone the `coagents-starter` repo
 
-                        Head over to [Copilot Cloud](https://cloud.copilotkit.ai) sign up and setup a remote endpoint with the following information:
-                        - OpenAI API key
-                        - Your FastAPI server URL
+                    <Tabs groupId="language" items={["Python"]}>
+                        <Tab value="Python">
+                            ```bash
+                            git clone https://github.com/CopilotKit/CopilotKit
+                            cd CopilotKit/examples/coagents-starter-crewai-flows/agent-py
+                            ```
+                        </Tab>
+                    </Tabs>
+                </Step>
+                <Step>
+                    ### Create a `.env` file
 
-                        **Running your FastAPI server locally**
+                    ```bash
+                    touch .env
+                    ```
+                </Step>
+                <Step>
+                    ### Add your API keys
 
-                        If you're running your FastAPI server locally, you can open a tunnel to it so Copilot Cloud can connect to it.
+                    Then add your **OpenAI API key** to the `.env` file.
 
-                        ```bash
-                        npx copilotkit@latest dev --port 8000
-                        ```
-                    </Tab>
-                    <Tab value="CrewAI Enterprise">
-                        Coming soon!
-                    </Tab>
-                </Tabs>
-            </Step>
-            <Step>
-                ### Setup your CopilotKit provider
-                The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases,
-                it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
+                    ```plaintext title=".env"
+                    OPENAI_API_KEY=your_openai_api_key
+                    ```
+                </Step>
+            </TailoredContentOption>
+        </TailoredContent>
+        <Step>
+            ### Launch your local agent
 
-                <CloudCopilotKitProvider components={props.components} />
+            Start your local CrewAI Flow agent:
 
-                <Callout type="info">
-                    Looking for a way to run multiple CrewAI Flows? Check out our [Multi-Agent](/crewai-flows/multi-agent-flows) guide.
-                </Callout>
-            </Step>
-        </TailoredContentOption>
-        <TailoredContentOption
-            id="self-hosted"
-            title="Self-Hosted Copilot Runtime"
-            description="I want to self-host the Copilot Runtime"
-            icon={<ServerIcon />}
+            ```bash
+            # Install dependencies
+            poetry lock
+            poetry install
+            # Start the server
+            poetry run demo
+            ```
+            This will start a local agent server that you can connect to.
+        </Step>
+
+        <TailoredContent
+            className="step"
+            id="copilot-hosting"
+            header={
+                <div>
+                    <p className="text-xl font-semibold">Choose your connection method</p>
+                    <p className="text-base">
+                        Now you need to connect your CrewAI Flow to CopilotKit.
+                    </p>
+                </div>
+            }
         >
-            <Step>
-                ### Install Copilot Runtime
-                Copilot Runtime is a production-ready proxy for your CrewAI Flows. In your frontend, go ahead and install it.
+            <TailoredContentOption
+                id="copilot-cloud"
+                title="Copilot Cloud (Recommended)"
+                description="I want to host my Copilot on Copilot Cloud"
+                icon={<FaCloud />}
+            >
+                <Step>
+                    ### Add a remote endpoint for your CrewAI Flow
+                    Using Copilot Cloud, you need to connect a remote endpoint that will connect to your CrewAI Flow.
+                    <Tabs groupId="lg-deployment-type" items={['Self hosted (FastAPI)', 'CrewAI Enterprise']}>
+                        <Tab value="Self hosted (FastAPI)">
+                            **Running your FastAPI server in production**
 
-                ```package-install
-                @copilotkit/runtime
-                ```
-            </Step>
-            <Step>
-                ### Setup a Copilot Runtime Endpoint
-                Now we need to setup a Copilot Runtime endpoint and point your frontend to it.
-                <SelfHostingCopilotRuntimeStarter components={props.components}/>
-            </Step>
-            <Step>
-                ### Add your CrewAI Flow deployment to Copilot Runtime
-                Now we need to add your CrewAI Flow deployment to Copilot Runtime. This will make it
-                so your frontend can find your CrewAI Flows correctly.
-                ```ts
-                import {
-                CopilotRuntime,
-                // ...
-                } from "@copilotkit/runtime";
-                // ...
-                const runtime = new CopilotRuntime({
-                remoteEndpoints: [
-                    // [!code highlight:3]
-                    // Our FastAPI endpoint URL
-                    { url: "http://localhost:8000/copilotkit" },
-                ],
-                });
-                // ...
-                ```
-            </Step>
-            <Step>
-                ### Configure the CopilotKit Provider
-                The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases,
-                it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
-                <SelfHostingCopilotRuntimeConfigureCopilotKitProvider components={props.components}/>
-                <Callout type="info">
-                    Looking for a way to run multiple CrewAI Flows? Check out our [Multi-Agent](/crewai-flows/multi-agent-flows) guide.
-                </Callout>
-            </Step>
-        </TailoredContentOption>
+                            Head over to [Copilot Cloud](https://cloud.copilotkit.ai) sign up and setup a remote endpoint with the following information:
+                            - OpenAI API key
+                            - Your FastAPI server URL
+
+                            **Running your FastAPI server locally**
+
+                            If you're running your FastAPI server locally, you can open a tunnel to it so Copilot Cloud can connect to it.
+
+                            ```bash
+                            npx copilotkit@latest dev --port 8000
+                            ```
+                        </Tab>
+                        <Tab value="CrewAI Enterprise">
+                            Coming soon!
+                        </Tab>
+                    </Tabs>
+                </Step>
+                <Step>
+                    ### Setup your CopilotKit provider
+                    The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases,
+                    it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
+
+                    <CloudCopilotKitProvider components={props.components} />
+
+                    <Callout type="info">
+                        Looking for a way to run multiple CrewAI Flows? Check out our [Multi-Agent](/crewai-flows/multi-agent-flows) guide.
+                    </Callout>
+                </Step>
+            </TailoredContentOption>
+            <TailoredContentOption
+                id="self-hosted"
+                title="Self-Hosted Copilot Runtime"
+                description="I want to self-host the Copilot Runtime"
+                icon={<ServerIcon />}
+            >
+                <Step>
+                    ### Install Copilot Runtime
+                    Copilot Runtime is a production-ready proxy for your CrewAI Flows. In your frontend, go ahead and install it.
+
+                    ```package-install
+                    @copilotkit/runtime
+                    ```
+                </Step>
+                <Step>
+                    ### Setup a Copilot Runtime Endpoint
+                    Now we need to setup a Copilot Runtime endpoint and point your frontend to it.
+                    <SelfHostingCopilotRuntimeStarter components={props.components}/>
+                </Step>
+                <Step>
+                    ### Add your CrewAI Flow deployment to Copilot Runtime
+                    Now we need to add your CrewAI Flow deployment to Copilot Runtime. This will make it
+                    so your frontend can find your CrewAI Flows correctly.
+                    ```ts
+                    import {
+                    CopilotRuntime,
+                    // ...
+                    } from "@copilotkit/runtime";
+                    // ...
+                    const runtime = new CopilotRuntime({
+                    remoteEndpoints: [
+                        // [!code highlight:3]
+                        // Our FastAPI endpoint URL
+                        { url: "http://localhost:8000/copilotkit" },
+                    ],
+                    });
+                    // ...
+                    ```
+                </Step>
+                <Step>
+                    ### Configure the CopilotKit Provider
+                    The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases,
+                    it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
+                    <SelfHostingCopilotRuntimeConfigureCopilotKitProvider components={props.components}/>
+                    <Callout type="info">
+                        Looking for a way to run multiple CrewAI Flows? Check out our [Multi-Agent](/crewai-flows/multi-agent-flows) guide.
+                    </Callout>
+                </Step>
+            </TailoredContentOption>
+        </TailoredContent>
+        <Step>
+            ### Setup the Copilot UI
+            The last step is to use CopilotKit's UI components to render the chat interaction with your agent. In most situations,
+            this is done alongside your core page components, e.g. in your `page.tsx` file.
+
+            ```tsx title="page.tsx"
+            // [!code highlight:3]
+            import "@copilotkit/react-ui/styles.css";
+            import { CopilotPopup } from "@copilotkit/react-ui";
+
+            export function YourApp() {
+            return (
+                <main>
+                <h1>Your main content</h1>
+                // [!code highlight:7]
+                <CopilotPopup
+                    labels={{
+                        title: "Popup Assistant",
+                        initial: "Hi! I'm connected to an agent. How can I help?",
+                    }}
+                />
+                </main>
+            );
+            }
+            ```
+
+            <Callout type="info">
+                Looking for other chat component options? Check out our [Agentic Chat UI](/crewai-flows/agentic-chat-ui) guide.
+            </Callout>
+        </Step>
+        <Step>
+            ### 🎉 Talk to your agent!
+
+            Congrats! You've successfully integrated a CrewAI Flow chatbot to your application. To start, try asking a few questions to your agent.
+
+            ```
+            Can you tell me a joke?
+            ```
+
+            ```
+            Can you help me understand AI?
+            ```
+
+            ```
+            What do you think about React?
+            ```
+
+            <video src="/images/coagents/chat-example.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
+
+            <Accordions className="mb-4">
+                <Accordion title="Having trouble?">
+                    - Try changing the host to `0.0.0.0` or `127.0.0.1` instead of `localhost`.
+                </Accordion>
+            </Accordions>
+        </Step>
+    </TailoredContentOption>
     </TailoredContent>
-    <Step>
-        ### Setup the Copilot UI
-        The last step is to use CopilotKit's UI components to render the chat interaction with your agent. In most situations,
-        this is done alongside your core page components, e.g. in your `page.tsx` file.
-
-        ```tsx title="page.tsx"
-        // [!code highlight:3]
-        import "@copilotkit/react-ui/styles.css";
-        import { CopilotPopup } from "@copilotkit/react-ui";
-
-        export function YourApp() {
-          return (
-            <main>
-              <h1>Your main content</h1>
-              // [!code highlight:7]
-              <CopilotPopup
-                labels={{
-                    title: "Popup Assistant",
-                    initial: "Hi! I'm connected to an agent. How can I help?",
-                }}
-              />
-            </main>
-          );
-        }
-        ```
-
-        <Callout type="info">
-            Looking for other chat component options? Check out our [Agentic Chat UI](/crewai-flows/agentic-chat-ui) guide.
-        </Callout>
-    </Step>
-    <Step>
-        ### 🎉 Talk to your agent!
-
-        Congrats! You've successfully integrated a CrewAI Flow chatbot to your application. To start, try asking a few questions to your agent.
-
-        ```
-        Can you tell me a joke?
-        ```
-
-        ```
-        Can you help me understand AI?
-        ```
-
-        ```
-        What do you think about React?
-        ```
-
-        <video src="/images/coagents/chat-example.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
-
-        <Accordions className="mb-4">
-            <Accordion title="Having trouble?">
-                - Try changing the host to `0.0.0.0` or `127.0.0.1` instead of `localhost`.
-            </Accordion>
-        </Accordions>
-    </Step>
 
 </Steps>
 


### PR DESCRIPTION
## What does this PR do?
The CLI has been tested for a bit, now its time to integrate into the documentation. This adds CLI paths into both LangGraph and Flows.

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation