### PR TITLE
fix: langsmith key hashing

### DIFF
--- a/CopilotKit/.changeset/cuddly-llamas-grin.md
+++ b/CopilotKit/.changeset/cuddly-llamas-grin.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: do not attempt to hash lgc key if it doesnt exist
+- fix: accept null on langsmith api key

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
@@ -53,7 +53,9 @@ export function constructLGCRemoteAction({
         agentExecution: true,
         type: "langgraph-platform",
         agentsAmount: endpoint.agents.length,
-        hashedLgcKey: createHash("sha256").update(endpoint.langsmithApiKey).digest("hex"),
+        hashedLgcKey: endpoint.langsmithApiKey
+          ? createHash("sha256").update(endpoint.langsmithApiKey).digest("hex")
+          : null,
       });
 
       let state = {};

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -47,7 +47,7 @@ export interface LangGraphPlatformAgent {
 export interface LangGraphPlatformEndpoint
   extends BaseEndpointDefinition<EndpointType.LangGraphPlatform> {
   deploymentUrl: string;
-  langsmithApiKey?: string;
+  langsmithApiKey?: string | null;
   agents: LangGraphPlatformAgent[];
 }
 

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -214,9 +214,11 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
     provider?: string;
     langGraphHost?: string;
     langGraphVersion?: string;
-    hashedLgcKey: string;
+    hashedLgcKey?: string | null;
   } = {
-    hashedLgcKey: createHash("sha256").update(langsmithApiKey).digest("hex"),
+    hashedLgcKey: langsmithApiKey
+      ? createHash("sha256").update(langsmithApiKey).digest("hex")
+      : null,
   };
 
   const assistants = await client.assistants.search();


### PR DESCRIPTION
Fixes the error that is shown when attempting to hash langsmith api key that doesn't exist