### PR TITLE
Fix CopilotTextarea #1729

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,21 +45,26 @@ git clone https://github.com/<your-GitHub-username>/CopilotKit
 ## Step 3: Prepare the development environment
 
 ### 1)Install Prerequisites
+
 - Node.js 20.x or later
 - pnpm v9.x installed globally (npm i -g pnpm@^9)
 - Turborepo v2.x installed globally (npm i -g turbo@2)
 
 ### 2)Install Dependencies
+
 To install the dependencies using pnpm
 Go inside project folder and run :
 
 ```jsx
 pnpm install
 ```
+
 ### 3)Build Packages
+
 To make sure everything works, let’s build all packages once:
 
 ```jsx
+cd CopilotKit
 turbo run build
 ```
 
@@ -85,7 +90,7 @@ Now that everything is set up and works as expected, you can get start developin
 ```jsx
 # To start all packages in development mode
 turbo run dev
- 
+
 # Start a specific package in development mode
 turbo run dev --filter="@copilotkit/package-name"
 ```

--- a/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/base-copilot-textarea/base-copilot-textarea.tsx
@@ -92,6 +92,7 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
     const valueOnInitialRender = useMemo(() => props.value ?? "", []);
     const [lastKnownFullEditorText, setLastKnownFullEditorText] = useState(valueOnInitialRender);
     const [cursorMovedSinceLastTextChange, setCursorMovedSinceLastTextChange] = useState(false);
+    const [isUserInputActive, setIsUserInputActive] = useState(false);
 
     // // When the editor text changes, we want to reset the `textEditedSinceLastCursorMovement` state.
     // useEffect(() => {
@@ -128,7 +129,9 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
       hoveringEditorIsDisplayed ||
       // the cursor has moved since the last text change AND we are configured to disable autosuggestions in this case:
       (cursorMovedSinceLastTextChange &&
-        autosuggestionsConfig.temporarilyDisableWhenMovingCursorWithoutChangingText);
+        autosuggestionsConfig.temporarilyDisableWhenMovingCursorWithoutChangingText) ||
+      // not user input and we want to disable non-trusted events (like text insertion from autocomplete plugins):
+      (!isUserInputActive && autosuggestionsConfig.temporarilyDisableNotTrustedEvents);
 
     const {
       currentAutocompleteSuggestion,
@@ -144,7 +147,7 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
       autosuggestionsConfig.disableWhenEmpty,
       shouldDisableAutosuggestions,
     );
-
+    
     const onKeyDownHandlerForHoveringEditor = useCallback(
       (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (
@@ -240,17 +243,18 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
         initialValue={initialValue}
         onChange={(value) => {
           const newEditorState = getTextAroundCollapsedCursor(editor);
-
+          
           const fullEditorText = newEditorState
-            ? newEditorState.textBeforeCursor + newEditorState.textAfterCursor
-            : getFullEditorTextWithNewlines(editor); // we don't double-parse the editor. When `newEditorState` is null, we didn't parse the editor yet.
-
+          ? newEditorState.textBeforeCursor + newEditorState.textAfterCursor
+          : getFullEditorTextWithNewlines(editor);
+          
           setLastKnownFullEditorText((prev) => {
             if (prev !== fullEditorText) {
               setCursorMovedSinceLastTextChange(false);
             }
             return fullEditorText;
           });
+          
           onChangeHandlerForAutocomplete(newEditorState);
 
           props.onValueChange?.(fullEditorText);
@@ -269,6 +273,7 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
           renderElement={renderElementMemoized}
           renderPlaceholder={renderPlaceholderMemoized}
           onKeyDown={(event) => {
+            setIsUserInputActive(true);
             onKeyDownHandlerForHoveringEditor(event); // forward the event for internal use
             onKeyDownHandlerForAutocomplete(event); // forward the event for internal use
             props.onKeyDown?.(event); // forward the event for external use
@@ -282,6 +287,7 @@ const BaseCopilotTextareaWithHoveringContext = React.forwardRef(
             // clear autocompletion on blur
             props.onBlur?.(ev);
             clearAutocompletionsFromEditor(editor);
+            setIsUserInputActive(false);
           }}
           {...propsToForward}
         />

--- a/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
+++ b/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
@@ -18,6 +18,8 @@ import { defaultCopilotContextCategories } from "@copilotkit/react-core";
  *
  * @property {boolean} temporarilyDisableWhenMovingCursorWithoutChangingText - Whether to temporarily disable autosuggestions when the user moves the cursor without changing the text.
  *
+ * @property {boolean} temporarilyDisableNotTrustedEvents - Temporarily disable autosuggestions after change event from non-trusted sources (like text insertion from autocomplete plugins)
+ *
  * @property {(event: React.KeyboardEvent<HTMLDivElement>) => boolean} shouldAcceptAutosuggestionOnKeyPress - A function that determines whether to accept the current autosuggestion based on a key press event. By default, the Tab key is used to accept the autosuggestion. Example code:
  *
  * ```typescript
@@ -63,6 +65,7 @@ export interface BaseAutosuggestionsConfig {
   disableWhenEmpty: boolean;
   disabled: boolean;
   temporarilyDisableWhenMovingCursorWithoutChangingText: boolean;
+  temporarilyDisableNotTrustedEvents: boolean;
   shouldAcceptAutosuggestionOnKeyPress: (event: React.KeyboardEvent<HTMLDivElement>) => boolean;
   shouldAcceptAutosuggestionOnTouch: (event: React.TouchEvent<HTMLDivElement>) => boolean;
   shouldToggleHoveringEditorOnKeyPress: (
@@ -103,6 +106,7 @@ const defaultShouldAcceptAutosuggestionOnTouch = () => false;
  * @property {boolean} disableWhenEmpty - Whether to disable the autosuggestions when the textarea is empty.
  * @property {boolean} disabled - Whether to disable the autosuggestions feature entirely.
  * @property {boolean} temporarilyDisableWhenMovingCursorWithoutChangingText - Whether to temporarily disable the autosuggestions when the cursor is moved without changing the text.
+ * @property {boolean} temporarilyDisableNotTrustedEvents - Temporarily disable the autosuggestions after change event from non-trusted sources (like text insertion from autocomplete plugins)
  * @property {(event: React.KeyboardEvent<HTMLDivElement>) => boolean} shouldToggleHoveringEditorOnKeyPress - A function that determines whether to toggle the hovering editor based on a key press event.
  * @property {(event: React.KeyboardEvent<HTMLDivElement>) => boolean} shouldAcceptAutosuggestionOnKeyPress - A function that determines whether to accept the autosuggestion based on a key press event.
  * @property {() => boolean} defaultShouldAcceptAutosuggestionOnTouch - A function that determines whether to accept the autosuggestion based on a mobile touch event.
@@ -117,6 +121,7 @@ export const defaultBaseAutosuggestionsConfig: Omit<
   disableWhenEmpty: true,
   disabled: false,
   temporarilyDisableWhenMovingCursorWithoutChangingText: true,
+  temporarilyDisableNotTrustedEvents: true,
   shouldToggleHoveringEditorOnKeyPress: defaultShouldToggleHoveringEditorOnKeyPress,
   shouldAcceptAutosuggestionOnKeyPress: defaultShouldAcceptAutosuggestionOnKeyPress,
   shouldAcceptAutosuggestionOnTouch: defaultShouldAcceptAutosuggestionOnTouch,

--- a/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
+++ b/CopilotKit/packages/react-textarea/src/types/base/base-autosuggestions-config.tsx
@@ -79,11 +79,11 @@ const defaultShouldToggleHoveringEditorOnKeyPress = (
   event: React.KeyboardEvent<HTMLDivElement>,
   shortcut: string,
 ) => {
+  const isMac = navigator.userAgent.includes("Mac");  
+  const isMetaKey = isMac ? event.metaKey : event.ctrlKey;
+  
   // if command-k, toggle the hovering editor
-  if (event.key === shortcut && event.metaKey) {
-    return true;
-  }
-  return false;
+  return event.key === shortcut && isMetaKey;
 };
 
 const defaultShouldAcceptAutosuggestionOnKeyPress = (


### PR DESCRIPTION
## What does this PR do?

- Fixes broken CTRL + K behavior on Windows – the handler was only checking for the Meta key, making it Mac-only.

- Improves Grammarly or other autosuggestion extensions compatibility – disables autosuggestions on non-trusted input events to avoid unexpected suggestions.


## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation