### PR TITLE
react-textarea: Fixed useless div in Body

### DIFF
--- a/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Editor, Location, Transforms } from "slate";
-import { useSlate, useSlateSelection } from "slate-react";
+import { useSlate, useSlateSelection, ReactEditor } from "slate-react";
 import { HoveringInsertionPromptBox } from "./text-insertion-prompt-box";
 import { Menu, Portal } from "./hovering-toolbar-components";
 import { useHoveringEditorContext } from "./hovering-editor-provider";
@@ -24,14 +24,16 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
   const editor = useSlate();
   const selection = useSlateSelection();
   const { isDisplayed, setIsDisplayed } = useHoveringEditorContext();
-
+  
   // only render on client
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
     setIsClient(true);
   }, []);
+  
+  const isShown = isClient && isDisplayed && selection;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = ref.current;
     const { selection } = editor;
 
@@ -51,7 +53,7 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
 
     const domRange = domSelection.getRangeAt(0);
     const rect = domRange.getBoundingClientRect();
-
+    
     // We use window = (0,0,0,0) as a signal that the selection is not in the original copilot-textarea,
     // but inside the hovering window.
     //
@@ -59,24 +61,29 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
     if (rect.top === 0 && rect.left === 0 && rect.width === 0 && rect.height === 0) {
       return;
     }
-    const minGapFromEdge = 60;
-    const verticalOffsetFromCorner = 35;
-    const horizontalOffsetFromCorner = 15;
-    let top = rect.top + window.scrollY - el.offsetHeight + verticalOffsetFromCorner;
-    // make sure top is in the viewport and not too close to the edge
-    if (top < minGapFromEdge) {
-      top = rect.bottom + window.scrollY + minGapFromEdge;
-    } else if (top + el.offsetHeight > window.innerHeight - minGapFromEdge) {
-      top = rect.top + window.scrollY - el.offsetHeight - minGapFromEdge;
+    
+    const verticalOffsetFromCorner = 0;
+    const horizontalOffsetFromCorner = 0;
+    
+    // position the toolbar below the selection
+    let top = rect.bottom + window.scrollY + verticalOffsetFromCorner;
+
+    // no space left at bottom, move up
+    if (rect.bottom + el.offsetHeight > window.innerHeight - verticalOffsetFromCorner) {
+      top = rect.top + window.scrollY - el.offsetHeight - verticalOffsetFromCorner;
     }
 
+    // position the toolbar in the center of the selection
     let left =
       rect.left + window.scrollX - el.offsetWidth / 2 + rect.width / 2 + horizontalOffsetFromCorner;
-    // make sure left is in the viewport and not too close to the edge
-    if (left < minGapFromEdge) {
-      left = minGapFromEdge;
-    } else if (left + el.offsetWidth > window.innerWidth - minGapFromEdge) {
-      left = window.innerWidth - el.offsetWidth - minGapFromEdge;
+
+    // no space left at left, move right
+    if (left < horizontalOffsetFromCorner) {
+      left = horizontalOffsetFromCorner;
+    }
+    // no space left at right, move left
+    else if (left + el.offsetWidth > window.innerWidth - horizontalOffsetFromCorner) {
+      left = window.innerWidth - el.offsetWidth - horizontalOffsetFromCorner;
     }
 
     el.style.opacity = "1";
@@ -84,24 +91,44 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
 
     el.style.top = `${top}px`;
     el.style.left = `${left}px`;
-  });
+  }, [isShown]);
 
+  // Close the window when clicking outside or pressing escape
   useEffect(() => {
+    const doc = ref.current?.ownerDocument;
+
+    if (!doc || !isShown) {
+      return;
+    }
+
     const handleClickOutside = (event: MouseEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {
+        // Restore focus to the editor when closing
+        ReactEditor.focus(editor);
         setIsDisplayed(false);
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        ReactEditor.focus(editor);
+        setIsDisplayed(false);
+      }
     };
-  }, [ref, setIsDisplayed]);
 
-  if (!isClient) {
-    return null;
-  }
+    doc.addEventListener("mousedown", handleClickOutside);
+    doc.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      doc.removeEventListener("mousedown", handleClickOutside);
+      doc.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [ref, isShown, editor, setIsDisplayed]);
+
+  // if (!isShown) {
+    // return null;
+  // }
 
   return (
     <Portal>
@@ -114,25 +141,22 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
         }
         data-testid="hovering-toolbar"
       >
-        {isDisplayed && selection && (
-          <HoveringInsertionPromptBox
-            editorState={editorState(editor, selection)}
-            apiConfig={props.apiConfig}
-            closeWindow={() => {
-              setIsDisplayed(false);
-            }}
-            performInsertion={(insertedText) => {
-              // replace the selection with the inserted text
-              Transforms.delete(editor, { at: selection });
-              Transforms.insertText(editor, insertedText, {
-                at: selection,
-              });
-              setIsDisplayed(false);
-            }}
-            contextCategories={props.contextCategories}
-          />
-        )}
-      </Menu>
+      {isShown && (
+        <HoveringInsertionPromptBox
+          editorState={editorState(editor, selection)}
+          apiConfig={props.apiConfig}
+          performInsertion={(insertedText) => {
+            // replace the selection with the inserted text
+            Transforms.delete(editor, { at: selection });
+            Transforms.insertText(editor, insertedText, {
+              at: selection,
+            });
+            setIsDisplayed(false);
+          }}
+          contextCategories={props.contextCategories}
+        />
+      )}
+    </Menu>
     </Portal>
   );
 };

--- a/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/text-insertion-prompt-box/hovering-insertion-prompt-box.tsx
+++ b/CopilotKit/packages/react-textarea/src/components/hovering-toolbar/text-insertion-prompt-box/hovering-insertion-prompt-box.tsx
@@ -8,7 +8,6 @@ export interface Props {
   editorState: EditingEditorState;
   apiConfig: InsertionEditorApiConfig;
   performInsertion: (insertedText: string) => void;
-  closeWindow: () => void;
   contextCategories: string[];
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR primarily fixes the issue where the react-textarea component was injecting **an unnecessary div into the body**.

It also addresses several bugs related to window positioning — the position was being calculated before the content inside the window was rendered, which in some cases caused the window to overlap the content.

This PR can be merged, but I don’t consider the work complete — in my opinion, the component needs a full rewrite.

Here are the main issues still in the code and/or logic:

**HoveringToolbar is bundled into react-textarea by default**
It shouldn’t be. I expect to control this behavior myself and insert the HoveringToolbar wherever I need it. For example, I might want to render a button inside the input that triggers the window, or even trigger the UI with a hotkey from anywhere in the app — not just when a textarea is focused.

**No proper positioning logic**
The window lacks flexibility in how it’s positioned. I generally avoid extra dependencies, but in this case, [Floating UI](https://floating-ui.com/docs/useFloating) would be very helpful. For example, Radix UI uses it under the hood.

**Magic numbers in the code**
Take verticalOffsetFromCorner, for example — it’s not configurable and doesn’t really make sense, so I just zeroed it out. You can achieve the same effect using padding on the root element (which already has 0.5em on all sides).

**Breaks in complex layouts**
The window cannot position itself properly if it’s rendered inside an iframe or if the target element lives inside a custom scroll container.

And that’s not even the full list. Fixing all of this will require a serious rewrite, which would be a breaking change.
I’d be happy to take that on if I get the green light.