### PR TITLE
fix: add headers to runtime client configuration in useCoAgent function

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-coagent.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-coagent.ts
@@ -232,10 +232,14 @@ export function useCoAgent<T = any>(options: UseCoagentOptions<T>): UseCoagentRe
   const { coagentStates, coagentStatesRef, setCoagentStatesWithRef, threadId, copilotApiConfig } =
     context;
   const { appendMessage, runChatCompletion } = useCopilotChat();
+  const headers = {
+    ...(copilotApiConfig.headers || {}),
+  };
 
   const runtimeClient = useCopilotRuntimeClient({
     url: copilotApiConfig.chatApiEndpoint,
     publicApiKey: copilotApiConfig.publicApiKey,
+    headers,
     credentials: copilotApiConfig.credentials,
   });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix issue with authentication headers are not sent the first time coagent is used.

## Related PRs and Issues

- [Bug: sometime copilokit does not send headers to runtime](https://github.com/CopilotKit/CopilotKit/issues/1537)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation