### PR TITLE
Fixed the project name in pyproject.toml file for coagenst-starter-cr…

### DIFF
--- a/examples/coagents-starter-crewai-crews/agent-py/pyproject.toml
+++ b/examples/coagents-starter-crewai-crews/agent-py/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"
 
 [project]
-name = "greeter"
+name = "research"
 version = "0.0.1"
 
 [build-system]


### PR DESCRIPTION
Previously, the project name was set to greeter in the pyproject.toml file, on installing, getting the error. So changed the name to research

"Installing the current project: greeter (0.0.1)
Error: The current project could not be installed: No file/folder found for package greeter
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file."
