### PR TITLE
fix: namespace react-ui dark mode styles

### DIFF
--- a/CopilotKit/.changeset/slimy-pigs-help.md
+++ b/CopilotKit/.changeset/slimy-pigs-help.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix: namespace react-ui dark mode styles

--- a/CopilotKit/packages/react-ui/src/css/colors.css
+++ b/CopilotKit/packages/react-ui/src/css/colors.css
@@ -4,7 +4,7 @@ WHEN MAKING ANY CHANGE, MAKE SURE TO INCLUDE IT IN ALL DUPLICATIONS.
 */
 
 /* BASE LIGHT THEME */
-:root {
+.copilotKitWindow {
   /* Semantic color tokens */
   /* Main brand/action color - used for buttons, interactive elements */
   --copilot-kit-primary-color: rgb(28, 28, 28);
@@ -36,12 +36,13 @@ WHEN MAKING ANY CHANGE, MAKE SURE TO INCLUDE IT IN ALL DUPLICATIONS.
 }
 
 /* BASE DARK THEME */
-.dark,
-html.dark,
-body.dark,
-[data-theme="dark"],
-html[style*="color-scheme: dark"],
-body[style*="color-scheme: dark"] :root {
+.copilotKitWindow.dark,
+.dark .copilotKitWindow,
+html.dark .copilotKitWindow,
+body.dark .copilotKitWindow,
+[data-theme="dark"] .copilotKitWindow,
+html[style*="color-scheme: dark"] .copilotKitWindow,
+body[style*="color-scheme: dark"] .copilotKitWindow {
   /* Main brand/action color - used for buttons, interactive elements */
   --copilot-kit-primary-color: rgb(255, 255, 255);
   /* Color that contrasts with primary - used for text on primary elements */

--- a/CopilotKit/packages/react-ui/src/css/console.css
+++ b/CopilotKit/packages/react-ui/src/css/console.css
@@ -79,21 +79,23 @@
   color: var(--copilot-kit-dev-console-text);
 }
 
-.dark,
-html.dark,
-body.dark,
-[data-theme="dark"],
-html[style*="color-scheme: dark"],
-body[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton {
+.copilotKitWindow.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+.dark .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+html.dark .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+body.dark .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+[data-theme="dark"] .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+html[style*="color-scheme: dark"] .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+body[style*="color-scheme: dark"] .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton {
   color: white;
 }
 
-.dark,
-html.dark,
-body.dark,
-[data-theme="dark"],
-html[style*="color-scheme: dark"],
-body[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover {
+.copilotKitWindow.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+.dark .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+html.dark .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+body.dark .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+[data-theme="dark"] .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+html[style*="color-scheme: dark"] .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+body[style*="color-scheme: dark"] .copilotKitWindow .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover {
   background-color: color-mix(in srgb, var(--copilot-kit-dev-console-bg) 20%, black);
 }
 

--- a/CopilotKit/packages/react-ui/src/css/input.css
+++ b/CopilotKit/packages/react-ui/src/css/input.css
@@ -141,12 +141,13 @@
   margin: 0 !important;
 }
 
-.dark,
-html.dark,
-body.dark,
-[data-theme="dark"],
-html[style*="color-scheme: dark"],
-body[style*="color-scheme: dark"] .poweredBy {
+.copilotKitWindow.dark .poweredBy,
+.dark .copilotKitWindow .poweredBy,
+html.dark .copilotKitWindow .poweredBy,
+body.dark .copilotKitWindow .poweredBy,
+[data-theme="dark"] .copilotKitWindow .poweredBy,
+html[style*="color-scheme: dark"] .copilotKitWindow .poweredBy,
+body[style*="color-scheme: dark"] .copilotKitWindow .poweredBy {
   color: rgb(69, 69, 69) !important;
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

## Summary
- scope color variables and dark mode rules under `.copilotKitWindow`
- prevent CopilotKit CSS from overriding host app styles



## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated theme and dark mode styles to apply only within specific UI components, ensuring color and theme variables are scoped to the relevant window elements rather than the entire page.
	- Adjusted dark mode styling for debug menu trigger buttons and "powered by" labels to be active only inside designated UI windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->