### PR TITLE
fix: synchronously execute renderAndWaitForResponse

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/multi/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/multi/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { CopilotChat } from "@copilotkit/react-ui";
+import "./styles.css";
+import { CopilotKit, useCopilotAction, useCopilotChat } from "@copilotkit/react-core";
+import { useSearchParams } from "next/navigation";
+import { MessageRole, TextMessage } from "@copilotkit/runtime-client-gql";
+
+export default function PanelPage() {
+  const searchParams = useSearchParams();
+  const serviceAdapter = searchParams.get("serviceAdapter") || "openai";
+  const runtimeUrl =
+    searchParams.get("runtimeUrl") || `/api/copilotkit?serviceAdapter=${serviceAdapter}`;
+  const publicApiKey = searchParams.get("publicApiKey");
+  const copilotKitProps: Partial<React.ComponentProps<typeof CopilotKit>> = {
+    runtimeUrl,
+    publicApiKey: publicApiKey || undefined,
+  };
+
+  return (
+    <CopilotKit {...copilotKitProps}>
+      <TravelPlanner />
+    </CopilotKit>
+  );
+}
+
+function TravelPlanner() {
+  const { appendMessage } = useCopilotChat();
+
+  // regular action
+  useCopilotAction({
+    name: "getFlight",
+    followUp: false,
+    render() { return <div>Flight</div>; },
+  });
+  
+  // backend action
+  useCopilotAction({
+    name: "getImageUrl",
+    followUp: true,
+    render() { return <div>Image</div>; },
+  });
+  
+
+  // hitl action 1
+  useCopilotAction({
+    name: "getWeather",
+    renderAndWaitForResponse({ status, respond }) {
+      return (
+        <div className="flex flex-col gap-2 bg-blue-500/50 p-4 border border-blue-500 rounded-md w-1/2">
+          <p>Weather</p>
+          <p>Status: {status}</p>
+          {status !== "complete" && (
+            <button 
+              className="bg-blue-500 text-white p-2 rounded-md" 
+              onClick={() => respond?.("the weather is 70 degrees")}
+            >
+              Continue
+            </button>
+          )}
+        </div>
+      );
+    },
+  });
+
+
+  // hitl action 2
+  useCopilotAction({
+    name: "getHotel",
+    renderAndWaitForResponse({ status, args, respond }) {
+      return (
+        <div className="flex flex-col gap-2 bg-blue-500/50 p-4 border border-blue-500 rounded-md w-1/2">
+          <p>Hotel</p>
+          <p>Status: {status}</p>
+          {status !== "complete" && (
+            <button 
+              className="bg-blue-500 text-white p-2 rounded-md" 
+              onClick={() => respond?.("Marriott")}
+            >
+              Continue
+            </button>
+          )}
+        </div>
+      );
+    },
+  });
+
+
+  // add a message with followUp false
+  useCopilotAction({
+    name: "addMessage",
+    followUp: false,
+    render() {
+      return (
+        <div className="flex flex-col gap-2 bg-blue-500/50 p-4 border border-blue-500 rounded-md w-1/2">
+          <p>Adding a message...</p>
+        </div>
+      );
+    },
+    handler: async () => {
+      appendMessage(
+        new TextMessage({
+          role: MessageRole.Assistant,
+          content: "What is the weather in San Francisco?"
+        }), 
+        {
+          followUp: false,
+        }
+      );
+    },
+  });
+
+  return (
+    <div className="w-screen h-screen flex items-center justify-center">
+      <CopilotChat
+        className="w-4/5 h-4/5 border p-4 rounded-xl border-gray-200"
+        labels={{
+          initial: "Hi you! 👋 Let's book your next vacation. Ask me anything.",
+        }}
+        instructions="You are a travel planner. You help the user plan their vacation. After presenting something, don't summarize, but keep the reply short."
+      />
+      {
+        /* 
+          ----------------------------------------------------------------
+            Buttons for triggering different cases 
+          ----------------------------------------------------------------
+        */ 
+      }
+      <div className="flex flex-col gap-2 px-4">
+        <button 
+          className="bg-blue-500 text-white p-2 rounded-md"
+          onClick={
+            () => appendMessage(new TextMessage({
+              role: MessageRole.User,
+              content: "Get the weather 3 times all at once, you decide everything."
+            }), {
+            })
+          }
+        >
+          Multiple of the same action
+        </button>
+        <button 
+          className="bg-blue-500 text-white p-2 rounded-md"
+          onClick={
+            () => appendMessage(new TextMessage({
+              role: MessageRole.User,
+              content: "Get the weather and the hotel all at once, you decide everything."
+            }), {
+            })
+          }
+        >
+          Multiple different actions
+        </button>
+        <button 
+          className="bg-blue-500 text-white p-2 rounded-md"
+          onClick={
+            () => appendMessage(new TextMessage({
+              role: MessageRole.User,
+              content: "Get the weather, hotel and flight all at once, you decide everything."
+            }), {
+            })
+          }
+        >
+          Multiple HITL actions and non-hitl actions
+        </button>
+        <button 
+          className="bg-blue-500 text-white p-2 rounded-md"
+          onClick={() => appendMessage(new TextMessage({
+            role: MessageRole.User,
+            content: "Add a message"
+          }))}
+        >
+          Add a message
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/CopilotKit/examples/next-openai/src/app/multi/styles.css
+++ b/CopilotKit/examples/next-openai/src/app/multi/styles.css
@@ -1,0 +1,6 @@
+html,
+body {
+  height: 100%;
+  margin: 0;
+  background-color: white;
+}

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef } from "react";
+import { flushSync } from 'react-dom';
 import {
   FunctionCallHandler,
   COPILOT_CLOUD_PUBLIC_API_KEY_HEADER,
@@ -35,7 +36,7 @@ import {
 import { CopilotApiConfig } from "../context";
 import { FrontendAction, processActionsForRuntimeRequest } from "../types/frontend-action";
 import { CoagentState } from "../types/coagent-state";
-import { AgentSession } from "../context/copilot-context";
+import { AgentSession, useCopilotContext } from "../context/copilot-context";
 import { useCopilotRuntimeClient } from "./use-copilot-runtime-client";
 import { useAsyncCallback, useErrorToast } from "../components/error-boundary/error-utils";
 import {
@@ -554,6 +555,55 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
 
         let didExecuteAction = false;
 
+        // ----- Helper function to execute an action and manage its lifecycle -----
+        const executeActionFromMessage = async (
+          currentAction: FrontendAction<any>,
+          actionMessage: ActionExecutionMessage,
+        ) => {
+          const isInterruptAction = interruptMessages.find((m) => m.id === actionMessage.id);
+          // Determine follow-up behavior: use action's specific setting if defined, otherwise default based on interrupt status.
+          followUp = currentAction?.followUp ?? !isInterruptAction;
+
+          // Call _setActivatingMessageId before executing the action for HITL correlation
+          if ((currentAction as any)?._setActivatingMessageId) {
+            (currentAction as any)._setActivatingMessageId(actionMessage.id);
+          }
+
+          const resultMessage = await executeAction({
+            onFunctionCall: onFunctionCall!,
+            message: actionMessage,
+            chatAbortControllerRef,
+            onError: (error: Error) => {
+              addErrorToast([error]);
+              // console.error is kept here as it's a genuine error in action execution
+              console.error(`Failed to execute action ${actionMessage.name}: ${error}`);
+            },
+            setMessages,
+            getFinalMessages: () => finalMessages,
+            isRenderAndWait: (currentAction as any)?._isRenderAndWait || false,
+          });
+          didExecuteAction = true;
+          const messageIndex = finalMessages.findIndex((msg) => msg.id === actionMessage.id);
+          finalMessages.splice(messageIndex + 1, 0, resultMessage);
+
+          // If the executed action was a renderAndWaitForResponse type, update messages immediately
+          // to reflect its completion in the UI, making it interactive promptly.
+          if ((currentAction as any)?._isRenderAndWait) {
+            const messagesForImmediateUpdate = [...finalMessages];
+            flushSync(() => {
+              setMessages(messagesForImmediateUpdate);
+            });
+          }
+
+          // Clear _setActivatingMessageId after the action is done
+          if ((currentAction as any)?._setActivatingMessageId) {
+            (currentAction as any)._setActivatingMessageId(null);
+          }
+
+          return resultMessage;
+        };
+        // ----------------------------------------------------------------------
+
         // execute regular action executions that are specific to the frontend (last actions)
         if (onFunctionCall) {
           // Find consecutive action execution messages at the end
@@ -583,44 +633,33 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
               ? getPairedFeAction(actions, message)
               : null;
 
-            const executeActionFromMessage = async (
-              action: FrontendAction<any>,
-              message: ActionExecutionMessage,
-            ) => {
-              const isInterruptAction = interruptMessages.find((m) => m.id === message.id);
-              followUp = action?.followUp ?? !isInterruptAction;
-              const resultMessage = await executeAction({
-                onFunctionCall,
-                previousMessages,
-                message,
-                chatAbortControllerRef,
-                onError: (error: Error) => {
-                  addErrorToast([error]);
-                  console.error(`Failed to execute action ${message.name}: ${error}`);
-                },
-              });
-              didExecuteAction = true;
-              const messageIndex = finalMessages.findIndex((msg) => msg.id === message.id);
-              finalMessages.splice(messageIndex + 1, 0, resultMessage);
-
-              return resultMessage;
-            };
-
             // execution message which has an action registered with the hook (remote availability):
             // execute that action first, and then the "paired FE action"
             if (action && message.isActionExecutionMessage()) {
-              const resultMessage = await executeActionFromMessage(action, message);
-              const pairedFeAction = getPairedFeAction(actions, resultMessage);
+              // For HITL actions, check if they've already been processed to avoid redundant handler calls.
+              const isRenderAndWaitAction = (action as any)?._isRenderAndWait || false;
+              const alreadyProcessed = isRenderAndWaitAction && finalMessages.some(fm =>
+                fm.isResultMessage() && fm.actionExecutionId === message.id
+              );
 
-              if (pairedFeAction) {
-                const newExecutionMessage = new ActionExecutionMessage({
-                  name: pairedFeAction.name,
-                  arguments: parseJson(resultMessage.result, resultMessage.result),
-                  status: message.status,
-                  createdAt: message.createdAt,
-                  parentMessageId: message.parentMessageId,
-                });
-                await executeActionFromMessage(pairedFeAction, newExecutionMessage);
+              if (alreadyProcessed) {
+                // Skip re-execution if already processed
+              } else {
+                // Call the single, externally defined executeActionFromMessage
+                const resultMessage = await executeActionFromMessage(action, message as ActionExecutionMessage);
+                const pairedFeAction = getPairedFeAction(actions, resultMessage);
+
+                if (pairedFeAction) {
+                  const newExecutionMessage = new ActionExecutionMessage({
+                    name: pairedFeAction.name,
+                    arguments: parseJson(resultMessage.result, resultMessage.result),
+                    status: message.status,
+                    createdAt: message.createdAt,
+                    parentMessageId: message.parentMessageId,
+                  });
+                  // Call the single, externally defined executeActionFromMessage
+                  await executeActionFromMessage(pairedFeAction, newExecutionMessage);
+                }
               }
             } else if (message.isResultMessage() && currentResultMessagePairedFeAction) {
               // Actions which are set up in runtime actions array: Grab the result, executed paired FE action with it as args.
@@ -631,6 +670,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
                 createdAt: message.createdAt,
               });
               finalMessages.push(newExecutionMessage);
+              // Call the single, externally defined executeActionFromMessage
               await executeActionFromMessage(
                 currentResultMessagePairedFeAction,
                 newExecutionMessage,
@@ -641,10 +681,10 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
           setMessages(finalMessages);
         }
 
+        // Conditionally run chat completion again if followUp is not explicitly false
+        // and an action was executed or the last message is a server-side result (for non-agent runs).
         if (
-          // if followUp is not explicitly false
           followUp !== false &&
-          // and we executed an action
           (didExecuteAction ||
             // the last message is a server side result
             (!isAgentRun &&
@@ -854,26 +894,46 @@ function constructFinalMessages(
 
 async function executeAction({
   onFunctionCall,
-  previousMessages,
   message,
   chatAbortControllerRef,
   onError,
+  setMessages,
+  getFinalMessages,
+  isRenderAndWait,
 }: {
   onFunctionCall: FunctionCallHandler;
-  previousMessages: Message[];
   message: ActionExecutionMessage;
   chatAbortControllerRef: React.MutableRefObject<AbortController | null>;
   onError: (error: Error) => void;
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+  getFinalMessages: () => Message[];
+  isRenderAndWait: boolean;
 }) {
   let result: any;
   let error: Error | null = null;
+
+  const currentMessagesForHandler = getFinalMessages();
+
+  // The handler (onFunctionCall) runs its synchronous part here, potentially setting up
+  // renderAndWaitRef.current for HITL actions via useCopilotAction's transformed handler.
+  const handlerReturnedPromise = onFunctionCall({
+    messages: currentMessagesForHandler,
+    name: message.name,
+    args: message.arguments,
+  });
+
+  // For HITL actions, call flushSync immediately after their handler has set up the promise
+  // and before awaiting the promise. This ensures the UI updates to an interactive state.
+  if (isRenderAndWait) {
+    const currentMessagesForRender = getFinalMessages();
+    flushSync(() => {
+      setMessages([...currentMessagesForRender]);
+    });
+  }
+
   try {
     result = await Promise.race([
-      onFunctionCall({
-        messages: previousMessages,
-        name: message.name,
-        args: message.arguments,
-      }),
+      handlerReturnedPromise, // Await the promise returned by the handler
       new Promise((resolve) =>
         chatAbortControllerRef.current?.signal.addEventListener("abort", () =>
           resolve("Operation was aborted by the user"),

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderActionExecutionMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderActionExecutionMessage.tsx
@@ -53,11 +53,12 @@ export function RenderActionExecutionMessage({
 
         try {
           const toRender = render({
-            status: status as any,
+            status: status as any, // Cast to any as RenderFunctionStatus is a union that can be complex to narrow here
             args,
             result: actionResult,
             name: message.name,
-          });
+            messageId: message.id, // Pass messageId for HITL action correlation
+          } as any);
           // No result and complete: stay silent
           if (!toRender && status === "complete") {
             return null;
@@ -86,6 +87,7 @@ export function RenderActionExecutionMessage({
             );
           }
         } catch (e) {
+          // It's useful to log this error for developers to debug their custom render functions
           console.error(`Error executing render function for action ${message.name}: ${e}`);
           return (
             <AssistantMessage


### PR DESCRIPTION
Previously, it was impossible to execute multiple human-in-the-loop (renderAndWaitForResponse) calls in a row. Ultimately this was due to an issue with how CopilotKit was rendering the updates when multiple renderAndWaitForResponse actions appeared on screen due to a reference based approach.

With this change, actions will be executed in a synchronous way appearing almost queue like. This works with any combination of action given much more freedom when asking for user input.

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation