### PR TITLE
fix(docs): link to state machine example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Transform tedious form-filling into natural conversations. The AI assistant asks
 ### 🔄 [State Machine Copilot](https://github.com/CopilotKit/CopilotKit/tree/main/examples/copilot-state-machine)
 Transform complex conversational flows into manageable state machines. This AI-powered car sales application demonstrates how to build sophisticated multi-stage interactions with contextual awareness and state transitions.
 <div>
-  <a href="https://github.com/CopilotKit/CopilotKit/tree/main/examples/state-machine-copilot"><code>GitHub →</code></a>
+  <a href="https://github.com/CopilotKit/CopilotKit/tree/main/examples/copilot-state-machine"><code>GitHub →</code></a>
   <a href="https://state-machine-copilot.vercel.app"><code>Live Demo →</code></a>
 </div>
 


### PR DESCRIPTION
## What does this PR do?

Fix link URL.

## Related PRs and Issues

_No response_

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the GitHub link for the "State Machine Copilot" example to point to the accurate location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->