### PR TITLE
chore: upgrade js sdk version for coagent starter project

### DIFF
--- a/examples/coagents-starter/agent-js/package.json
+++ b/examples/coagents-starter/agent-js/package.json
@@ -15,7 +15,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@copilotkit/sdk-js": "^1.5.13",
+    "@copilotkit/sdk-js": "^1.8.13",
     "@langchain/anthropic": "^0.3.8",
     "@langchain/core": "^0.3.18",
     "@langchain/google-genai": "^0.1.4",

--- a/examples/coagents-starter/agent-js/pnpm-lock.yaml
+++ b/examples/coagents-starter/agent-js/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@copilotkit/sdk-js':
-        specifier: ^1.5.13
+        specifier: ^1.8.13
         version: 1.8.13(@langchain/anthropic@0.3.20(@langchain/core@0.3.56(openai@4.102.0(zod@3.25.17))))(@langchain/google-genai@0.1.12(@langchain/core@0.3.56(openai@4.102.0(zod@3.25.17)))(zod@3.25.17))(openai@4.102.0(zod@3.25.17))(zod-to-json-schema@3.24.5(zod@3.25.17))
       '@langchain/anthropic':
         specifier: ^0.3.8


### PR DESCRIPTION
Use latest JS SDK version in the JS agent of coagents-starter example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of an internal dependency to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->