### PR TITLE
chore: add troubleshooting documentation for "no checkpointer" error

### DIFF
--- a/docs/content/docs/coagents/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/coagents/troubleshooting/common-issues.mdx
@@ -241,6 +241,11 @@ If you're seeing this error, it means the LangGraph platform client cannot conne
     </Accordion>
 </Accordions>
 
+## I am getting a "No checkpointer set" error when using LangGraph with FastAPI
+
+If you're seeing this error, it means you are missing a checkpointer in your compiled graph.
+You can visit the [LangGraph Persistence guide](https://langchain-ai.github.io/langgraph/concepts/persistence/#checkpoints) to undestand what a checkpointer is and how to add it.
+
 ## I see messages being streamed and disappear
 
 LangGraph agents are stateful. As a graph is traversed, the state is saved at the end of each node. CopilotKit uses the agent's state as

--- a/docs/content/docs/coagents/troubleshooting/common-issues.mdx
+++ b/docs/content/docs/coagents/troubleshooting/common-issues.mdx
@@ -243,8 +243,8 @@ If you're seeing this error, it means the LangGraph platform client cannot conne
 
 ## I am getting a "No checkpointer set" error when using LangGraph with FastAPI
 
-If you're seeing this error, it means you are missing a checkpointer in your compiled graph.
-You can visit the [LangGraph Persistence guide](https://langchain-ai.github.io/langgraph/concepts/persistence/#checkpoints) to undestand what a checkpointer is and how to add it.
+If you're encountering this error, it means you are missing a checkpointer in your compiled graph.
+You can visit the [LangGraph Persistence guide](https://langchain-ai.github.io/langgraph/concepts/persistence/#checkpoints) to understand what a checkpointer is and how to add it.
 
 ## I see messages being streamed and disappear
 


### PR DESCRIPTION
Users using FastAPI with LangGraph, getting started with our starter agent, will run into a "no checkpointer set" error. This is because we have removed the checkpointer to support the LangGraph Platform implementation.
Because of this reason, I have added a troubleshooting section to the doc explaining this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a troubleshooting section addressing the "'No checkpointer set' error when using LangGraph with FastAPI," including guidance and a link to the LangGraph Persistence guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->