### PR TITLE
fix: move react-dom to peerDependencies in @copilotkit/react-textarea

### DIFF
--- a/CopilotKit/packages/react-textarea/package.json
+++ b/CopilotKit/packages/react-textarea/package.json
@@ -35,7 +35,8 @@
     "unlink:global": "pnpm unlink --global"
   },
   "peerDependencies": {
-    "react": "^18 || ^19 || ^19.0.0-rc"
+    "react": "^18 || ^19 || ^19.0.0-rc",
+    "react-dom": "^18 || ^19 || ^19.0.0-rc"
   },
   "devDependencies": {
     "@types/jest": "^29.5.4",
@@ -49,6 +50,7 @@
     "postcss": "^8.4.20",
     "postcss-prefix-selector": "^1.16.1",
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "tailwind-config": "workspace:*",
     "tailwindcss": "^3.3.0",
     "ts-jest": "^29.1.1",
@@ -74,7 +76,6 @@
     "lodash.merge": "^4.6.2",
     "lucide-react": "^0.274.0",
     "material-icons": "^1.13.10",
-    "react-dom": "^18.2.0",
     "slate": "^0.94.1",
     "slate-history": "^0.93.0",
     "slate-react": "^0.98.1",

--- a/CopilotKit/pnpm-lock.yaml
+++ b/CopilotKit/pnpm-lock.yaml
@@ -427,9 +427,6 @@ importers:
       material-icons:
         specifier: ^1.13.10
         version: 1.13.12
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
       slate:
         specifier: ^0.94.1
         version: 0.94.1
@@ -476,6 +473,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
       tailwind-config:
         specifier: workspace:*
         version: link:../../utilities/tailwind-config
@@ -13431,7 +13431,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -13483,7 +13483,7 @@ snapshots:
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-core-module: 2.15.0
@@ -13544,7 +13544,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5


### PR DESCRIPTION
## What does this PR do?

This PR resolves dependency conflicts in the `@copilotkit/react-textarea` package by moving `react-dom` from `dependencies` to `peerDependencies`. This change:

- **Moves `react-dom` from dependencies to peerDependencies** to allow consuming applications to provide their own version
- **Adds `react-dom` to devDependencies** to ensure it's available during development and testing
- **Aligns with the existing pattern** used in `@copilotkit/react-core` package
- **Supports React 18 and 19 versions** consistently across the monorepo
- **Resolves version conflicts** that users may encounter when integrating the package

The change follows React library best practices for peer dependencies and maintains backward compatibility.

## Related PRs and Issues

- Addresses dependency conflict issues reported by users
- Aligns with React ecosystem best practices for library packages

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation

## Testing

- [x] Verified that the package builds successfully after changes
- [x] Confirmed that the entire workspace builds without errors
- [x] Ensured TypeScript compilation passes
- [x] Validated that the change follows the same pattern as other packages in the monorepo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package dependencies to align with best practices for compatibility with React and React DOM. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->