### PR TITLE
remove thread from example

### DIFF
--- a/examples/coagents-starter-crewai-flows/ui/app/layout.tsx
+++ b/examples/coagents-starter-crewai-flows/ui/app/layout.tsx
@@ -15,10 +15,9 @@ export default function RootLayout({ children }: { children: any }) {
     <html lang="en">
       <body>
         <CopilotKit
-          agent="sample_agent" // lock the agent to the sample_agent since we only have one agent
+          agent="sample_agent"
           runtimeUrl="/api/copilotkit"
           showDevConsole={false}
-          threadId={"bcabd353-645c-4954-876d-8803e1bb57de"}
         >
           {children}
         </CopilotKit>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the use of the `threadId` property from the main layout component.
  - Cleaned up comments related to component properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->