### PR TITLE
fix: prepare cpk agui wiring for ag-ui langgraph support

### DIFF
--- a/CopilotKit/.changeset/poor-garlics-melt.md
+++ b/CopilotKit/.changeset/poor-garlics-melt.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: prepare cpk agui wiring for ag-ui langgraph support

--- a/CopilotKit/packages/runtime/src/graphql/resolvers/copilot.resolver.ts
+++ b/CopilotKit/packages/runtime/src/graphql/resolvers/copilot.resolver.ts
@@ -53,6 +53,7 @@ import {
 import telemetry from "../../lib/telemetry-client";
 import { randomId } from "@copilotkit/shared";
 import { AgentsResponse } from "../types/agents-response.type";
+import { LangGraphEventTypes } from "../../agents/langgraph/events";
 
 const invokeGuardrails = async ({
   baseUrl,
@@ -263,6 +264,19 @@ export class CopilotResolver {
               return;
             }
             switch (event.name) {
+              // @ts-ignore
+              case LangGraphEventTypes.OnInterrupt:
+                push(
+                  plainToInstance(LangGraphInterruptEvent, {
+                    // @ts-ignore
+                    type: event.type,
+                    // @ts-ignore
+                    name: RuntimeMetaEventName.LangGraphInterruptEvent,
+                    // @ts-ignore
+                    value: event.value,
+                  }),
+                );
+                break;
               case RuntimeMetaEventName.LangGraphInterruptEvent:
                 push(
                   plainToInstance(LangGraphInterruptEvent, {

--- a/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
@@ -14,17 +14,20 @@ import {
 
 import { AbstractAgent } from "@ag-ui/client";
 import { parseJson } from "@copilotkit/shared";
+import { MetaEventInput } from "../../graphql/inputs/meta-event.input";
 
 export function constructAGUIRemoteAction({
   logger,
   messages,
   agentStates,
   agent,
+  metaEvents,
 }: {
   logger: Logger;
   messages: Message[];
   agentStates?: AgentStateInput[];
   agent: AbstractAgent;
+  metaEvents?: MetaEventInput[];
 }) {
   const action = {
     name: agent.agentId,
@@ -66,6 +69,8 @@ export function constructAGUIRemoteAction({
 
       return agent.legacy_to_be_removed_runAgentBridged({
         tools,
+        // @ts-ignore
+        resume: metaEvents[0]?.response,
       }) as Observable<RuntimeEvent>;
     },
   };

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -1130,6 +1130,7 @@ please use an LLM adapter instead.`,
       agentStates,
       frontendUrl: url,
       agents: this.agents,
+      metaEvents: request.metaEvents,
     });
 
     const configuredActions =

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -130,6 +130,7 @@ export async function setupRemoteActions({
   agentStates,
   frontendUrl,
   agents,
+  metaEvents,
 }: {
   remoteEndpointDefinitions: EndpointDefinition[];
   graphqlContext: GraphQLContext;
@@ -137,6 +138,7 @@ export async function setupRemoteActions({
   agentStates?: AgentStateInput[];
   frontendUrl?: string;
   agents: Record<string, AbstractAgent>;
+  metaEvents?: MetaEventInput[];
 }): Promise<Action[]> {
   const logger = graphqlContext.logger.child({ component: "remote-actions.fetchRemoteActions" });
   logger.debug({ remoteEndpointDefinitions }, "Fetching from remote endpoints");
@@ -201,6 +203,7 @@ export async function setupRemoteActions({
         messages,
         agentStates,
         agent: agent,
+        metaEvents,
       }),
     );
   }


### PR DESCRIPTION
As we slowly move towards greater AGUI support and a complete LangGraph AGUI agent, this PR makes small adjustments to how we read and report interrupts when consuming AGUI agents