### PR TITLE
refactor(react-ui): pass full message to onThumbsUp and onThumbsDown handlers

### DIFF
--- a/CopilotKit/examples/next-openai/src/app/page.tsx
+++ b/CopilotKit/examples/next-openai/src/app/page.tsx
@@ -20,7 +20,14 @@ export default function WaterBnb() {
 
   return (
     <CopilotKit {...copilotKitProps}>
-      <CopilotSidebar>
+      <CopilotSidebar
+        onThumbsUp={(message) => {
+          console.log("thumbs up", message);
+        }}
+        onThumbsDown={(message) => {
+          console.log("thumbs down", message);
+        }}
+      >
         <VacationList />
       </CopilotSidebar>
     </CopilotKit>

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -132,12 +132,12 @@ export interface CopilotChatProps {
   /**
    * A callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: string) => void;
+  onThumbsUp?: (message: TextMessage) => void;
 
   /**
    * A callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: string) => void;
+  onThumbsDown?: (message: TextMessage) => void;
 
   /**
    * A list of markdown components to render in assistant message.

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
@@ -2,6 +2,7 @@ import { AssistantMessageProps } from "../props";
 import { useChatContext } from "../ChatContext";
 import { Markdown } from "../Markdown";
 import { useState } from "react";
+import { TextMessage } from "@copilotkit/runtime-client-gql";
 
 export const AssistantMessage = (props: AssistantMessageProps) => {
   const { icons, labels } = useChatContext();
@@ -14,6 +15,7 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
     onThumbsUp,
     onThumbsDown,
     isCurrentMessage,
+    rawData,
     markdownTagRenderers,
   } = props;
   const [copied, setCopied] = useState(false);
@@ -38,14 +40,16 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
   };
 
   const handleThumbsUp = () => {
-    if (onThumbsUp && message) {
-      onThumbsUp(message);
+    const fullMessage = rawData as TextMessage;
+    if (onThumbsUp && fullMessage) {
+      onThumbsUp(fullMessage);
     }
   };
 
   const handleThumbsDown = () => {
-    if (onThumbsDown && message) {
-      onThumbsDown(message);
+    const fullMessage = rawData as TextMessage;
+    if (onThumbsDown && fullMessage) {
+      onThumbsDown(fullMessage);
     }
   };
 

--- a/CopilotKit/packages/react-ui/src/components/chat/props.ts
+++ b/CopilotKit/packages/react-ui/src/components/chat/props.ts
@@ -1,4 +1,4 @@
-import { Message } from "@copilotkit/runtime-client-gql";
+import { Message, TextMessage } from "@copilotkit/runtime-client-gql";
 import { CopilotChatSuggestion } from "../../types/suggestions";
 import { ReactNode } from "react";
 
@@ -50,12 +50,12 @@ export interface MessagesProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: string) => void;
+  onThumbsUp?: (message: TextMessage) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: string) => void;
+  onThumbsDown?: (message: TextMessage) => void;
 
   /**
    * A list of markdown components to render in assistant message.
@@ -121,12 +121,12 @@ export interface AssistantMessageProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: string) => void;
+  onThumbsUp?: (message: TextMessage) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: string) => void;
+  onThumbsDown?: (message: TextMessage) => void;
 
   /**
    * A list of markdown components to render in assistant message.
@@ -157,12 +157,12 @@ export interface RenderMessageProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: string) => void;
+  onThumbsUp?: (message: TextMessage) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: string) => void;
+  onThumbsDown?: (message: TextMessage) => void;
 
   /**
    * A list of markdown components to render in assistant message.

--- a/docs/content/docs/reference/components/chat/CopilotChat.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotChat.mdx
@@ -90,11 +90,11 @@ A callback function to regenerate the assistant's response
 A callback function when the message is copied
 </PropertyReference>
 
-<PropertyReference name="onThumbsUp" type="(message: string) => void"  > 
+<PropertyReference name="onThumbsUp" type="(message: TextMessage) => void"  > 
 A callback function for thumbs up feedback
 </PropertyReference>
 
-<PropertyReference name="onThumbsDown" type="(message: string) => void"  > 
+<PropertyReference name="onThumbsDown" type="(message: TextMessage) => void"  > 
 A callback function for thumbs down feedback
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/chat/CopilotPopup.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotPopup.mdx
@@ -91,11 +91,11 @@ A callback function to regenerate the assistant's response
 A callback function when the message is copied
 </PropertyReference>
 
-<PropertyReference name="onThumbsUp" type="(message: string) => void"  > 
+<PropertyReference name="onThumbsUp" type="(message: TextMessage) => void"  > 
 A callback function for thumbs up feedback
 </PropertyReference>
 
-<PropertyReference name="onThumbsDown" type="(message: string) => void"  > 
+<PropertyReference name="onThumbsDown" type="(message: TextMessage) => void"  > 
 A callback function for thumbs down feedback
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
@@ -93,11 +93,11 @@ A callback function to regenerate the assistant's response
 A callback function when the message is copied
 </PropertyReference>
 
-<PropertyReference name="onThumbsUp" type="(message: string) => void"  > 
+<PropertyReference name="onThumbsUp" type="(message: TextMessage) => void"  > 
 A callback function for thumbs up feedback
 </PropertyReference>
 
-<PropertyReference name="onThumbsDown" type="(message: string) => void"  > 
+<PropertyReference name="onThumbsDown" type="(message: TextMessage) => void"  > 
 A callback function for thumbs down feedback
 </PropertyReference>
 


### PR DESCRIPTION
## What does this PR do?
Previously the handlers would only pass the text content. This wasn't enough for many cases where these handlers being called would reinforce models or analytics given they needed an ID. To be completely sustainable we now pass the entire object through to the handlers for better DevEx.

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Thumbs up and thumbs down feedback actions in chat components now provide richer message details to feedback handlers.

- **Documentation**
  - Updated documentation to reflect that feedback callbacks now receive a detailed message object instead of a simple string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->