### PR TITLE
feat(runtime): make user can use `OpenAIAdapter` to compatible the non openai server.

### DIFF
--- a/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -92,6 +92,11 @@ export interface OpenAIAdapterParams {
    * @default false
    */
   keepSystemRole?: boolean;
+
+  /**
+   * Parameters used to override the openai chat.completions function
+   */
+  overrideOpenAIParam?: object;
 }
 
 export class OpenAIAdapter implements CopilotServiceAdapter {
@@ -100,6 +105,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
   private disableParallelToolCalls: boolean = false;
   private _openai: OpenAI;
   private keepSystemRole: boolean = false;
+  private overrideOpenAIParam: object|undefined;
 
   public get openai(): OpenAI {
     return this._openai;
@@ -112,6 +118,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
     }
     this.disableParallelToolCalls = params?.disableParallelToolCalls || false;
     this.keepSystemRole = params?.keepSystemRole ?? false;
+    this.overrideOpenAIParam = params?.overrideOpenAIParam;
   }
 
   async process(
@@ -179,6 +186,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
         ...(toolChoice && { tool_choice: toolChoice }),
         ...(this.disableParallelToolCalls && { parallel_tool_calls: false }),
         ...(forwardedParameters?.temperature && { temperature: forwardedParameters.temperature }),
+        ...(this.overrideOpenAIParam),
       });
 
       eventSource.stream(async (eventStream$) => {

--- a/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -105,7 +105,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
   private disableParallelToolCalls: boolean = false;
   private _openai: OpenAI;
   private keepSystemRole: boolean = false;
-  private overrideOpenAIParam: object|undefined;
+  private overrideOpenAIParam?: object;
 
   public get openai(): OpenAI {
     return this._openai;

--- a/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -96,7 +96,7 @@ export interface OpenAIAdapterParams {
   /**
    * Parameters used to override the openai chat.completions function
    */
-  overrideOpenAIParam?: object;
+  overrideOpenAIParam?: Record<string, any>;
 }
 
 export class OpenAIAdapter implements CopilotServiceAdapter {

--- a/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -105,7 +105,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
   private disableParallelToolCalls: boolean = false;
   private _openai: OpenAI;
   private keepSystemRole: boolean = false;
-  private overrideOpenAIParam?: object;
+  private overrideOpenAIParam?: Record<string, any>;
 
   public get openai(): OpenAI {
     return this._openai;

--- a/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -94,7 +94,8 @@ export interface OpenAIAdapterParams {
   keepSystemRole?: boolean;
 
   /**
-   * Parameters used to override the openai chat.completions function
+   * Additional parameters to override or extend the OpenAI chat completions API call.
+   * These parameters will be spread into the API request and can override default values.
    */
   overrideOpenAIParam?: Record<string, any>;
 }


### PR DESCRIPTION
## What does this PR do?

Make user can use `OpenAIAdapter` to compatible the non openai server. Such as ollama vllm etc.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for overriding default parameters when interacting with the OpenAI chat completions API, allowing for greater customization of API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->