### PR TITLE
fix: allow custom toolChoice in forwardedParameters in CopilotTask to override default value  

### DIFF
--- a/CopilotKit/packages/react-core/src/lib/copilot-task.ts
+++ b/CopilotKit/packages/react-core/src/lib/copilot-task.ts
@@ -151,8 +151,8 @@ export class CopilotTask<T = any> {
           },
           forwardedParameters: {
             // if forwardedParameters is provided, use it
-            ...(this.forwardedParameters ?? {}),
             toolChoice: "required",
+            ...(this.forwardedParameters ?? {}),
           },
         },
         properties: context.copilotApiConfig.properties,


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where the `toolChoice` parameter passed through `forwardedParameters` in `CopilotTask` is being overwritten by the hardcoded default value `"required"`.

### The Problem
Currently, when passing custom parameters through `CopilotTask`:

```javascript
const task = new CopilotTask({
  forwardedParameters: {
    toolChoice: "function",
    toolChoiceFunctionName: "myTool"
  }
});
```

The `toolChoice` is always overwritten to `"required"` due to incorrect object spread order. This makes it impossible to:
- Force a specific tool with `toolChoice: "function"` and `toolChoiceFunctionName`
- Use automatic tool selection with `toolChoice: "auto"`

### The Solution
This PR swaps the order of object spreading to ensure user-provided parameters take precedence over defaults:

```diff
forwardedParameters: {
-  ...(this.forwardedParameters ?? {}),
   toolChoice: "required",
+  ...(this.forwardedParameters ?? {}),
}
```

Now users can override the default `toolChoice` behavior when needed, which aligns with how other API clients (like OpenAI's Python client) handle this parameter.

## Related PRs and Issues
- Fixes #1973

## Checklist
- [x] I have read the [[Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved code readability with minor formatting adjustments. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->