### PR TITLE
doc: Add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ Stay up to date with our latest releases!
 
 <img width="1685" alt="214 (1)" src="https://github.com/user-attachments/assets/145600ce-c49b-4e25-883e-feee149d6332">
 
+<div align="center">
+  <!-- Keep these links. Translations will automatically update with the README. -->
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=de"><code>Deutsch →</code></a> 
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=es"><code>Español →</code></a> 
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=fr"><code>français →</code></a> 
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=ja"><code>日本語 →</code></a> 
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=ko"><code>한국어 →</code></a> 
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=pt"><code>Português →</code></a> 
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=ru"><code>Русский →</code></a> 
+  <a href="https://www.readme-i18n.com/CopilotKit/CopilotKit?lang=zh"><code>中文 →</code></a>
+</div>
+
 ## 🏆 Featured Examples
 
 ### 📝 [Form-Filling Copilot](https://github.com/CopilotKit/CopilotKit/tree/main/examples/copilot-form-filling)


### PR DESCRIPTION
Allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese. 

This update improves accessibility and project understanding for non-English speakers around the world.

The updated links can be previewed in my forked repository: 
https://github.com/dowithless/CopilotKit/tree/patch-1

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Describe the changes introduced in this PR)

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a centered section with language selection links in the README, allowing users to access translated versions in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->