### PR TITLE
fix(llamaindex): fix broken link and incorrect quickstart

### DIFF
--- a/docs/content/docs/llamaindex/quickstart.mdx
+++ b/docs/content/docs/llamaindex/quickstart.mdx
@@ -75,8 +75,8 @@ Before you begin, you'll need the following:
                 ### Clone the starter template
 
                 ```bash
-                git clone https://github.com/CopilotKit/examples/llamaindex/starter
-                cd starter
+                git clone https://github.com/CopilotKit/CopilotKit
+                cd CopilotKit/examples/llamaindex/starter
                 ```
             </Step>
             <Step>

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -167,6 +167,11 @@ const config = {
         destination: "/ag2/quickstart",
         permanent: true,
       },
+      {
+        source: "/llamaindex/",
+        destination: "/llamaindex",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated quickstart instructions to reflect new repository structure for cloning the starter template.

- **New Features**
  - Added a redirect so that requests to "/llamaindex/" are now automatically redirected to "/llamaindex".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->