### PR TITLE
fix: use latest langgraph agui

### DIFF
--- a/CopilotKit/.changeset/seven-grapes-wonder.md
+++ b/CopilotKit/.changeset/seven-grapes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: use latest langgraph agui

--- a/CopilotKit/packages/runtime/package.json
+++ b/CopilotKit/packages/runtime/package.json
@@ -50,7 +50,7 @@
     "@ag-ui/client": "0.0.28",
     "@ag-ui/core": "0.0.28",
     "@ag-ui/encoder": "0.0.28",
-    "@ag-ui/langgraph": "0.0.3",
+    "@ag-ui/langgraph": "0.0.4",
     "@ag-ui/proto": "0.0.28",
     "@anthropic-ai/sdk": "^0.27.3",
     "@copilotkit/shared": "workspace:*",
@@ -74,7 +74,7 @@
     "pino": "^9.2.0",
     "pino-pretty": "^11.2.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1",
+    "rxjs": "7.8.1",
     "type-graphql": "2.0.0-rc.1",
     "zod": "^3.23.3"
   },

--- a/CopilotKit/pnpm-lock.yaml
+++ b/CopilotKit/pnpm-lock.yaml
@@ -363,7 +363,7 @@ importers:
         version: 18.3.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.23.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.17.19)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../utilities/tsconfig
@@ -484,7 +484,7 @@ importers:
         version: 3.4.6(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@20.14.12)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.17.19)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.3(@babel/core@7.24.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.9))(esbuild@0.23.0)(jest@29.7.0(@types/node@20.14.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@20.14.12)(typescript@5.5.4)))(typescript@5.5.4)
       tsconfig:
         specifier: workspace:*
         version: link:../../utilities/tsconfig
@@ -580,8 +580,8 @@ importers:
         specifier: 0.0.28
         version: 0.0.28
       '@ag-ui/langgraph':
-        specifier: 0.0.3
-        version: 0.0.3(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react@18.3.1)
+        specifier: 0.0.4
+        version: 0.0.4(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react@18.3.1)
       '@ag-ui/proto':
         specifier: 0.0.28
         version: 0.0.28
@@ -652,7 +652,7 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       rxjs:
-        specifier: ^7.8.1
+        specifier: 7.8.1
         version: 7.8.1
       type-graphql:
         specifier: 2.0.0-rc.1
@@ -944,8 +944,8 @@ packages:
   '@ag-ui/encoder@0.0.28':
     resolution: {integrity: sha512-A7N7QE6P70rBQ9k5kcm1xQUAq4K6Dhg7y/hapkL6oJG/zQabRKS5wSePO34wfLtg4KKIPIqiUGqVdy8qk2a3Ng==}
 
-  '@ag-ui/langgraph@0.0.3':
-    resolution: {integrity: sha512-GxKXEtBHZViO5hNL6BTKyneu4lwXrEa3EpxIod5rGg81vT5gamAE0bWAVT532QdveYXQJYrSH5J417cKSFoHdA==}
+  '@ag-ui/langgraph@0.0.4':
+    resolution: {integrity: sha512-ueaHD+yISXZksY3Hqlw/aehX9rxPmlu1Q5X9f2p5vUwH9NP970iyceHHYndv8qNwOYYPWIXGA5wA98CFTEgl2Q==}
 
   '@ag-ui/proto@0.0.28':
     resolution: {integrity: sha512-jgvUT81n4K5TldkrpVxM5eLRNOq5tV5BKNi079NGCDnK1mc2ElORsHcCd6fjAOpUPpfirS8RuQr9MvoMXE42aQ==}
@@ -9376,7 +9376,7 @@ snapshots:
       '@ag-ui/core': 0.0.28
       '@ag-ui/proto': 0.0.28
 
-  '@ag-ui/langgraph@0.0.3(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react@18.3.1)':
+  '@ag-ui/langgraph@0.0.4(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react@18.3.1)':
     dependencies:
       '@ag-ui/client': 0.0.28
       '@langchain/core': 0.3.38(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))


### PR DESCRIPTION
Use latest AGUI langgraph + pin rxjs to fit AGUI version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of a core dependency to improve compatibility.
  - Adjusted dependency versioning for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->