### PR TITLE
fix: enable resolving of langgraph agents when cpk starts

### DIFF
--- a/CopilotKit/.changeset/hip-ghosts-drum.md
+++ b/CopilotKit/.changeset/hip-ghosts-drum.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: enable resolving of langgraph agents when cpk starts

--- a/CopilotKit/packages/runtime/src/graphql/resolvers/state.resolver.ts
+++ b/CopilotKit/packages/runtime/src/graphql/resolvers/state.resolver.ts
@@ -10,9 +10,9 @@ import { CopilotKitAgentDiscoveryError } from "@copilotkit/shared";
 export class StateResolver {
   @Query(() => LoadAgentStateResponse)
   async loadAgentState(@Ctx() ctx: GraphQLContext, @Arg("data") data: LoadAgentStateInput) {
-    const agents = await ctx._copilotkit.runtime.discoverAgentsFromEndpoints(ctx);
-    const agent = agents.find((agent) => agent.name === data.agentName);
-    if (!agent) {
+    const agents = await ctx._copilotkit.runtime.getAllAgents(ctx);
+    const hasAgent = agents.some((agent) => agent.name === data.agentName);
+    if (!hasAgent) {
       throw new CopilotKitAgentDiscoveryError({
         agentName: data.agentName,
         availableAgents: agents.map((a) => ({ name: a.name, id: a.name })),

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -788,6 +788,11 @@ please use an LLM adapter instead.`,
       this.discoverAgentsFromAgui(),
     ]);
 
+    this.availableAgents = [...agentsWithEndpoints, ...aguiAgents].map((a) => ({
+      name: a.name,
+      id: a.id,
+    }));
+
     return [...agentsWithEndpoints, ...aguiAgents];
   }
 
@@ -872,7 +877,6 @@ please use an LLM adapter instead.`,
       },
       Promise.resolve([]),
     );
-    this.availableAgents = ((await agents) ?? []).map((a) => ({ name: a.name, id: a.id }));
 
     return agents;
   }
@@ -908,7 +912,6 @@ please use an LLM adapter instead.`,
       },
       Promise.resolve([]),
     );
-    this.availableAgents = ((await agents) ?? []).map((a) => ({ name: a.name, id: a.id }));
 
     return agents;
   }

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -328,7 +328,9 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
       params?.remoteEndpoints.some((e) => e.type === EndpointType.LangGraphPlatform)
     ) {
       console.warn("Actions set in runtime instance will not be available for the agent");
-      console.warn(`LangGraph Platform remote endpoints are deprecated in favor of the "agents" property`)
+      console.warn(
+        `LangGraph Platform remote endpoints are deprecated in favor of the "agents" property`,
+      );
     }
 
     // TODO: finalize
@@ -924,8 +926,8 @@ please use an LLM adapter instead.`,
     }
 
     if (
-      'endpoint' in agent && (agent.endpoint.type === EndpointType.CopilotKit ||
-        !("type" in agent.endpoint))
+      "endpoint" in agent &&
+      (agent.endpoint.type === EndpointType.CopilotKit || !("type" in agent.endpoint))
     ) {
       const cpkEndpoint = agent.endpoint as CopilotKitEndpoint;
       const fetchUrl = `${cpkEndpoint.url}/agents/state`;
@@ -970,19 +972,19 @@ please use an LLM adapter instead.`,
       : null;
 
     let client: LangGraphClient;
-    if ('endpoint' in agent && agent.endpoint.type === EndpointType.LangGraphPlatform) {
+    if ("endpoint" in agent && agent.endpoint.type === EndpointType.LangGraphPlatform) {
       client = new LangGraphClient({
         apiUrl: agent.endpoint.deploymentUrl,
         apiKey: agent.endpoint.langsmithApiKey,
         defaultHeaders: { ...propertyHeaders },
       });
     } else {
-      const aguiAgent = graphqlContext._copilotkit.runtime.agents[agent.name] as LangGraphAgent
+      const aguiAgent = graphqlContext._copilotkit.runtime.agents[agent.name] as LangGraphAgent;
       if (!aguiAgent) {
-        throw new Error(`Agent: ${agent.name} could not be resolved`)
+        throw new Error(`Agent: ${agent.name} could not be resolved`);
       }
       // @ts-expect-error -- both clients are the same
-      client = aguiAgent.client
+      client = aguiAgent.client;
     }
     let state: any = {};
     try {

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -165,12 +165,26 @@ Optional trace handler for comprehensive debugging and observability.
 
 </PropertyReference>
 
+<PropertyReference name="getAllAgents" type="graphqlContext: GraphQLContext">
+
+
+  <PropertyReference name="graphqlContext" type="GraphQLContext" required>
+  
+  </PropertyReference>
+
+</PropertyReference>
+
 <PropertyReference name="discoverAgentsFromEndpoints" type="graphqlContext: GraphQLContext">
 
 
   <PropertyReference name="graphqlContext" type="GraphQLContext" required>
   
   </PropertyReference>
+
+</PropertyReference>
+
+<PropertyReference name="discoverAgentsFromAgui" type="">
+
 
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/chat/CopilotChat.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotChat.mdx
@@ -175,3 +175,7 @@ A class name to apply to the root element.
 Children to render.
 </PropertyReference>
 
+<PropertyReference name="hideStopButton" type="boolean"  > 
+
+</PropertyReference>
+

--- a/docs/content/docs/reference/components/chat/CopilotPopup.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotPopup.mdx
@@ -176,6 +176,10 @@ A class name to apply to the root element.
 Children to render.
 </PropertyReference>
 
+<PropertyReference name="hideStopButton" type="boolean"  > 
+
+</PropertyReference>
+
 <PropertyReference name="defaultOpen" type="boolean"  default="false"> 
 Whether the chat window should be open by default.
 </PropertyReference>

--- a/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
@@ -178,6 +178,10 @@ A class name to apply to the root element.
 Children to render.
 </PropertyReference>
 
+<PropertyReference name="hideStopButton" type="boolean"  > 
+
+</PropertyReference>
+
 <PropertyReference name="defaultOpen" type="boolean"  default="false"> 
 Whether the chat window should be open by default.
 </PropertyReference>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified support for discovering and managing agents from both remote endpoints and local AGUI agents.
  - Enhanced agent state loading, now compatible with multiple agent sources.

- **Improvements**
  - Improved error handling and extensibility when loading agent states.
  - Added warnings for deprecated remote endpoint usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->