### PR TITLE
fix: add default schema keys for input and output of agui langgraph

### DIFF
--- a/CopilotKit/.changeset/happy-camels-tan.md
+++ b/CopilotKit/.changeset/happy-camels-tan.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: add default schema keys for input and output of agui langgraph

--- a/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
@@ -16,6 +16,7 @@ import {
   LangGraphAgent as AGUILangGraphAgent,
   type LangGraphAgentConfig,
   ProcessedEvents,
+  SchemaKeys,
 } from "@ag-ui/langgraph";
 import { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types.messages";
 
@@ -180,11 +181,22 @@ export class LangGraphAgent extends AGUILangGraphAgent {
       messages,
       tools,
     );
+
     return {
       ...rest,
       copilotkit: {
         actions: returnedTools,
       },
+    };
+  }
+
+  async getSchemaKeys(): Promise<SchemaKeys> {
+    const CONSTANT_KEYS = ["copilotkit"];
+    const schemaKeys = await super.getSchemaKeys();
+    return {
+      config: schemaKeys.config,
+      input: schemaKeys.input ? [...schemaKeys.input, ...CONSTANT_KEYS] : null,
+      output: schemaKeys.output ? [...schemaKeys.output, ...CONSTANT_KEYS] : null,
     };
   }
 }


### PR DESCRIPTION
CPK adds properties to input & output of the LG agent. We should have these working with the new LG AGUI agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced schema key retrieval to include an additional "copilotkit" key in certain categories, improving integration and customization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->