### PR TITLE
docs(agno): fix agno quickstart tutorial

### DIFF
--- a/docs/content/docs/agno/quickstart.mdx
+++ b/docs/content/docs/agno/quickstart.mdx
@@ -216,7 +216,7 @@ Before you begin, you'll need the following:
                 CopilotKit requires a Copilot Runtime endpoint to safely communicate with your agent. This can be served
                 anywhere that Node.js can run, but for this example we'll just use Next.js.
 
-                ```ts title="api/copilotkit/route.ts"
+                ```ts title="app/api/copilotkit/route.ts"
                 import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
@@ -271,7 +271,7 @@ Before you begin, you'll need the following:
                         /* [!code highlight:7] */
                         <CopilotKit 
                           runtimeUrl="/api/copilotkit" 
-                          agentName="agno_agent"
+                          agent="agno_agent"
                         >
                           {children}
                         </CopilotKit>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It resolves the bugs from agno quickstart tutorial described in https://github.com/ag-ui-protocol/ag-ui/issues/113 .

> There are bugs in tutorial at https://docs.copilotkit.ai/agno/quickstart :
a. api/copilotkit/route.ts is actually app/api/copilotkit/route.ts
b. in app/layout.tsx agentName is actually agent (see https://docs.copilotkit.ai/agno/multi-agent-flows#agent-lock-mode)

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated example code snippets to reflect the correct file path and prop name for setting up CopilotKit with an Agno agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->