### PR TITLE
feat(langgraph): new thread metadata

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -65,11 +65,16 @@ export interface CopilotKitProps {
   children: ReactNode;
 
   /**
-   * Custom properties to be sent with the request
+   * Custom properties to be sent with the request.
+   * Can include threadMetadata for thread creation.
    * For example:
    * ```js
    * {
    *   'user_id': 'users_id',
+   *   threadMetadata: {
+   *     'account_id': '123',
+   *     'user_type': 'premium'
+   *   }
    * }
    * ```
    */

--- a/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
@@ -22,12 +22,14 @@ export function constructAGUIRemoteAction({
   agentStates,
   agent,
   metaEvents,
+  threadMetadata,
 }: {
   logger: Logger;
   messages: Message[];
   agentStates?: AgentStateInput[];
   agent: AbstractAgent;
   metaEvents?: MetaEventInput[];
+  threadMetadata?: Record<string, any>;
 }) {
   const action = {
     name: agent.agentId,
@@ -67,9 +69,10 @@ export function constructAGUIRemoteAction({
         };
       });
 
-      const forwardedProps = metaEvents.length
-        ? { command: { resume: metaEvents[0]?.response } }
-        : undefined;
+      const forwardedProps = {
+        ...(metaEvents.length ? { command: { resume: metaEvents[0]?.response } } : {}),
+        ...(threadMetadata ? { threadMetadata } : {}),
+      };
 
       return agent.legacy_to_be_removed_runAgentBridged({
         tools,

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -143,6 +143,8 @@ export async function setupRemoteActions({
   const logger = graphqlContext.logger.child({ component: "remote-actions.fetchRemoteActions" });
   logger.debug({ remoteEndpointDefinitions }, "Fetching from remote endpoints");
 
+  const threadMetadata = graphqlContext.properties.threadMetadata as Record<string, any>;
+
   // Remove duplicates of remoteEndpointDefinitions.url
   const filtered = remoteEndpointDefinitions.filter((value, index, self) => {
     if (value.type === EndpointType.LangGraphPlatform) {
@@ -204,6 +206,7 @@ export async function setupRemoteActions({
         agentStates,
         agent: agent,
         metaEvents,
+        threadMetadata,
       }),
     );
   }

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-lg-action.ts
@@ -185,7 +185,11 @@ async function streamEvents(controller: ReadableStreamDefaultController, args: E
     await client.threads.get(threadId);
   } catch (error) {
     wasInitiatedWithExistingThread = false;
-    await client.threads.create({ threadId });
+    const threadMetadata = properties.threadMetadata as Record<string, any>;
+    await client.threads.create({ 
+      threadId,
+      metadata: threadMetadata 
+    });
   }
 
   let agentState = { values: {} };

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -65,11 +65,16 @@ The children to be rendered within the CopilotKit.
 </PropertyReference>
 
 <PropertyReference name="properties" type="Record<string, any>"  > 
-Custom properties to be sent with the request
+Custom properties to be sent with the request.
+  Can include threadMetadata for thread creation.
   For example:
   ```js
   {
     'user_id': 'users_id',
+    threadMetadata: {
+      'account_id': '123',
+      'user_type': 'premium'
+    }
   }
   ```
 </PropertyReference>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR implements **thread metadata support** in CopilotKit, enabling custom metadata to be attached to threads when they are created.

  ## Key Changes

  - **Added thread metadata prop support** in `CopilotKitProps` with improved documentation and examples
  - **Updated remote actions setup** to extract and forward `threadMetadata` from GraphQL context properties
  - **Enhanced AGUI action forwarding** to pass `threadMetadata` through `forwardedProps`
  -  **(AG-UI) Thread Creation**: Applied as metadata when creating new threads

  ### Use Cases
  - **User tracking**: Attach user IDs, session IDs, or account information
  - **Analytics**: Add metadata for usage tracking and debugging
  - **Customization**: Thread-level configuration and feature flags
  - **Compliance**: Audit trails and data governance metadata

## Related PRs and Issues

- This PR is a companion to this one: 

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation