### PR TITLE
fix: remove agent discovery for agui agents

### DIFF
--- a/CopilotKit/.changeset/hungry-carrots-count.md
+++ b/CopilotKit/.changeset/hungry-carrots-count.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: remove agent discovery for agui agents

--- a/docs/content/docs/reference/classes/CopilotRuntime.mdx
+++ b/docs/content/docs/reference/classes/CopilotRuntime.mdx
@@ -183,11 +183,6 @@ Optional trace handler for comprehensive debugging and observability.
 
 </PropertyReference>
 
-<PropertyReference name="discoverAgentsFromAgui" type="">
-
-
-</PropertyReference>
-
 <PropertyReference name="loadAgentState" type="graphqlContext: GraphQLContext, threadId: string, agentName: string">
 
 


### PR DESCRIPTION
Agent discovery (prematurely contacting agents to make sure they exist) is a "remote endpoints" concept.
For AGUI agents, which should just allow through without it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved agent discovery performance by simplifying how agents are retrieved and combined.
  * Reduced unnecessary network calls and error handling during agent discovery, resulting in a faster and more streamlined experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->