### PR TITLE
fix: reduce checkpointer calls lg events

### DIFF
--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -146,7 +146,6 @@ class LangGraphAgent(Agent):
             agent: Optional[CompiledStateGraph] = None,
             # deprecated - use copilotkit_config instead
             merge_state: Optional[Callable] = None,
-
         ):
         if config is not None:
             logger.warning("Warning: config is deprecated, use langgraph_config instead")
@@ -166,7 +165,7 @@ class LangGraphAgent(Agent):
         )
 
         self.merge_state = None
-
+        self.thread_state = {}
         if copilotkit_config is not None:
             self.merge_state = copilotkit_config.get("merge_state")
         if not self.merge_state and merge_state is not None:
@@ -614,7 +613,10 @@ class LangGraphAgent(Agent):
         config["configurable"] = config.get("configurable", {})
         config["configurable"]["thread_id"] = thread_id
 
-        state = {**(await self.graph.aget_state(config)).values}
+        if self.thread_state.get(thread_id, None) is None:
+            self.thread_state[thread_id] = {**(await self.graph.aget_state(config)).values}
+
+        state = self.thread_state[thread_id]
         if state == {}:
             return {
                 "threadId": thread_id or "",

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.54-alpha.1"
+version = "0.1.54-alpha.3"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Today, we are querying the checkpointer for the latest state on every event. This is too many calls.
This PR introduces a significant reduction of these calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal state handling and caching to optimize performance and synchronization during event streaming.
* **Chores**
  * Updated SDK version to 0.1.54-alpha.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->