### PR TITLE
feat: route all langgraph platform agents to AGUI

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
@@ -3,7 +3,6 @@ import {
   CopilotKitEndpoint,
   RemoteAgentHandlerParams,
   RemoteActionInfoResponse,
-  LangGraphPlatformEndpoint,
 } from "./remote-actions";
 import { GraphQLContext } from "../integrations";
 import { Logger } from "pino";
@@ -14,121 +13,12 @@ import { RuntimeEvent, RuntimeEventSubject } from "../../service-adapters/events
 import telemetry from "../telemetry-client";
 import { RemoteLangGraphEventSource } from "../../agents/langgraph/event-source";
 import { Action } from "@copilotkit/shared";
-import { execute } from "./remote-lg-action";
 import { CopilotKitError, CopilotKitLowLevelError } from "@copilotkit/shared";
 import { writeJsonLineResponseToEventStream } from "../streaming";
 import { CopilotKitApiDiscoveryError, ResolvedCopilotKitError } from "@copilotkit/shared";
 import { parseJson, tryMap } from "@copilotkit/shared";
 import { ActionInput } from "../../graphql/inputs/action.input";
 import { fetchWithRetry } from "./retry-utils";
-
-// Import the utility function from remote-lg-action
-import { isUserConfigurationError } from "./remote-lg-action";
-
-export function constructLGCRemoteAction({
-  endpoint,
-  graphqlContext,
-  logger,
-  messages,
-  agentStates,
-}: {
-  endpoint: LangGraphPlatformEndpoint;
-  graphqlContext: GraphQLContext;
-  logger: Logger;
-  messages: Message[];
-  agentStates?: AgentStateInput[];
-}) {
-  const agents = endpoint.agents.map((agent) => ({
-    name: agent.name,
-    description: agent.description,
-    parameters: [],
-    handler: async (_args: any) => {},
-    remoteAgentHandler: async ({
-      name,
-      actionInputsWithoutAgents,
-      threadId,
-      nodeName,
-      additionalMessages = [],
-      metaEvents,
-    }: RemoteAgentHandlerParams): Promise<Observable<RuntimeEvent>> => {
-      logger.debug({ actionName: agent.name }, "Executing LangGraph Platform agent");
-
-      telemetry.capture("oss.runtime.remote_action_executed", {
-        agentExecution: true,
-        type: "langgraph-platform",
-        agentsAmount: endpoint.agents.length,
-        hashedLgcKey: endpoint.langsmithApiKey
-          ? createHash("sha256").update(endpoint.langsmithApiKey).digest("hex")
-          : null,
-      });
-
-      let state = {};
-      let config = {};
-      if (agentStates) {
-        const jsonState = agentStates.find((state) => state.agentName === name);
-        if (jsonState) {
-          state = parseJson(jsonState.state, {});
-          config = parseJson(jsonState.config, {});
-        }
-      }
-
-      try {
-        const response = await execute({
-          logger: logger.child({ component: "remote-actions.remote-lg-action.streamEvents" }),
-          deploymentUrl: endpoint.deploymentUrl,
-          langsmithApiKey: endpoint.langsmithApiKey,
-          agent,
-          threadId,
-          nodeName,
-          messages: [...messages, ...additionalMessages],
-          state,
-          config,
-          properties: graphqlContext.properties,
-          actions: tryMap(actionInputsWithoutAgents, (action: ActionInput) => ({
-            name: action.name,
-            description: action.description,
-            parameters: JSON.parse(action.jsonSchema),
-          })),
-          metaEvents,
-        });
-
-        const eventSource = new RemoteLangGraphEventSource();
-        writeJsonLineResponseToEventStream(response, eventSource.eventStream$);
-        return eventSource.processLangGraphEvents();
-      } catch (error) {
-        // Preserve structured CopilotKit errors with semantic information
-        if (error instanceof CopilotKitError || error instanceof CopilotKitLowLevelError) {
-          // Distinguish between user errors and system errors for logging
-          if (isUserConfigurationError(error)) {
-            logger.debug(
-              { url: endpoint.deploymentUrl, error: error.message, code: error.code },
-              "User configuration error in LangGraph Platform agent",
-            );
-          } else {
-            logger.error(
-              { url: endpoint.deploymentUrl, error: error.message, type: error.constructor.name },
-              "LangGraph Platform agent error",
-            );
-          }
-          throw error; // Re-throw the structured error to preserve semantic information
-        }
-
-        // For other errors, log and wrap them
-        logger.error(
-          { url: endpoint.deploymentUrl, status: 500, body: error.message },
-          "Failed to execute LangGraph Platform agent",
-        );
-        throw new CopilotKitLowLevelError({
-          error: error instanceof Error ? error : new Error(String(error)),
-          url: endpoint.deploymentUrl,
-          message: "Failed to execute LangGraph Platform agent",
-        });
-      }
-    },
-  }));
-
-  return [...agents];
-}
 
 export enum RemoteAgentType {
   LangGraph = "langgraph",


### PR DESCRIPTION
With this PR, all "remoteEndpoints" agents are now routed to use the new AGUI.
This creates a change in how we run things, while not breaking the API, allowing the old definition to run and helping users avoiding having to migrate manually (although encouraged) 