### PR TITLE
fix(react-ui): RenderTextMessage throwing `Nothing was returned from render` error in React 17

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderTextMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderTextMessage.tsx
@@ -46,6 +46,10 @@ export function RenderTextMessage({
           markdownTagRenderers={markdownTagRenderers}
         />
       );
+    } else {
+      return null;
     }
-  }
+  } else {
+    return null;
+  } 
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It fixes the `Nothing was returned from render` error in React 17 by adding two else statements returning `null` in `RenderTextMessage` component.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in message rendering by ensuring certain invalid messages are not displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->