### PR TITLE
Added a closing brace in CrewAI Flows Documentation

### DIFF
--- a/docs/content/docs/crewai-flows/quickstart.mdx
+++ b/docs/content/docs/crewai-flows/quickstart.mdx
@@ -203,6 +203,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
                   </div>
                 </div>
               );
+            }
 
             // App Component: Main wrapper that provides CopilotKit context
             const CrewAIFlow: React.FC = () => (


### PR DESCRIPTION
Small Fix in the documentation, for a function (const Chat = () => { ), there was no closing brace added that for reference 
https://docs.copilotkit.ai/crewai-flows/quickstart?path=code-along

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a syntax error in the documentation by adding a missing closing brace to the `Chat` component example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->