### PR TITLE
chore: release python sdk version 0.1.53

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.52"
+version = "0.1.53"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"
@@ -11,7 +11,7 @@ keywords = ["copilot", "copilotkit", "langgraph", "langchain", "ai", "langsmith"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-langgraph = {version = ">=0.3.18,<=0.5.0"}
+langgraph = {version = ">=0.3.18,<0.5.0"}
 langchain = {version = ">=0.3.4,<=0.3.26"}
 crewai = { version = "0.118.0", optional = true }
 fastapi = "^0.115.0"


### PR DESCRIPTION
Releasing python 0.1.53 which supports all langgraph versions up to 0.5.0 + includes some fixes which will support the usage of 0.5.0