### PR TITLE
fix: consider empty array content for tool message

### DIFF
--- a/sdk-python/copilotkit/langgraph.py
+++ b/sdk-python/copilotkit/langgraph.py
@@ -133,7 +133,7 @@ def langchain_messages_to_copilotkit(
 
             # Check if content is a list and use the first element
             if isinstance(content, list):
-                content = content[0]
+                content = content[0] if content else ""
 
             # Anthropic models return a dict with a "text" key
             if isinstance(content, dict):


### PR DESCRIPTION
Tool content could possibly be an empty string. We need to consider this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty content lists to prevent errors during message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->