### PR TITLE
feat (react-ui) : add audio format configuration options in push to talk

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -15,6 +15,7 @@ export const Input = ({
   onStop,
   onUpload,
   hideStopButton = false,
+  audioMimeType,
 }: InputProps) => {
   const context = useChatContext();
   const copilotContext = useCopilotContext();
@@ -67,6 +68,7 @@ export const Input = ({
   const { pushToTalkState, setPushToTalkState } = usePushToTalk({
     sendFunction: onSend,
     inProgress,
+   audioMimeType,
   });
 
   const isInProgress = inProgress || pushToTalkState === "transcribing";

--- a/CopilotKit/packages/react-ui/src/components/chat/props.ts
+++ b/CopilotKit/packages/react-ui/src/components/chat/props.ts
@@ -1,6 +1,7 @@
 import { Message, TextMessage } from "@copilotkit/runtime-client-gql";
 import { CopilotChatSuggestion } from "../../types/suggestions";
 import { ReactNode } from "react";
+import { supportedMimeTypes } from "../../hooks/use-push-to-talk";
 
 export interface ButtonProps {}
 
@@ -178,6 +179,7 @@ export interface InputProps {
   onStop?: () => void;
   onUpload?: () => void;
   hideStopButton?: boolean;
+  audioMimeType?: supportedMimeTypes;
 }
 
 export interface RenderSuggestionsListProps {


### PR DESCRIPTION
## What does this PR do?

This PR addresses issue #2049 by implementing the ability to configure media type settings for the `usePushToTalk` hook. This enhancement provides developers with greater flexibility when implementing voice input functionality in their CopilotKit applications.

The implementation allows developers to specify media type configurations such as `audio/wav`.

## Related PRs and Issues

- #2049 

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation