### PR TITLE
fix(sdk-python) converting copilotkit message to langchain messages

### DIFF
--- a/sdk-python/copilotkit/langgraph.py
+++ b/sdk-python/copilotkit/langgraph.py
@@ -487,6 +487,8 @@ def copilotkit_interrupt(
         "__copilotkit_interrupt_value__": interrupt_values,
         "__copilotkit_messages__": [interrupt_message]
     })
+    handler = copilotkit_messages_to_langchain()
+    response = handler(response)
     answer = response[-1].content
 
     return answer, response


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Copilotkit_interrupt for langgraph sdk was not working which was blocking from using the messages window to operate interrupts, I have used the existing handler which converts copilotkitmessages to langchain messages. No changes in doc required because they were written on the assumption that the method returns langchain messages

## Related PRs and Issues
Raised the following issue: https://github.com/CopilotKit/CopilotKit/issues/2109

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation