### PR TITLE
fix(chat): prevent sending messages during IME composition in chat input

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Input.tsx
@@ -26,6 +26,7 @@ export const Input = ({
     copilotContext.copilotApiConfig.transcribeAudioUrl !== undefined;
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [isComposing, setIsComposing] = useState(false);
 
   const handleDivClick = (event: React.MouseEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement;
@@ -103,8 +104,10 @@ export const Input = ({
           maxRows={MAX_NEWLINES}
           value={text}
           onChange={(event) => setText(event.target.value)}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
           onKeyDown={(event) => {
-            if (event.key === "Enter" && !event.shiftKey) {
+            if (event.key === "Enter" && !event.shiftKey && !isComposing) {
               event.preventDefault();
               if (canSend) {
                 send();

--- a/CopilotKit/packages/react-ui/src/components/chat/Textarea.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Textarea.tsx
@@ -6,11 +6,13 @@ interface AutoResizingTextareaProps {
   value: string;
   onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onCompositionStart?: () => void;
+  onCompositionEnd?: () => void;
   autoFocus?: boolean;
 }
 
 const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, AutoResizingTextareaProps>(
-  ({ maxRows = 1, placeholder, value, onChange, onKeyDown, autoFocus }, ref) => {
+  ({ maxRows = 1, placeholder, value, onChange, onKeyDown, onCompositionStart, onCompositionEnd, autoFocus }, ref) => {
     const internalTextareaRef = useRef<HTMLTextAreaElement>(null);
     const [maxHeight, setMaxHeight] = useState<number>(0);
 
@@ -46,6 +48,8 @@ const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, AutoResizingTextare
         value={value}
         onChange={onChange}
         onKeyDown={onKeyDown}
+        onCompositionStart={onCompositionStart}
+        onCompositionEnd={onCompositionEnd}
         placeholder={placeholder}
         style={{
           overflow: "auto",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes an issue where pressing Enter during IME (Input Method Editor) composition in the chat input causes messages to be sent prematurely, before the composition process (i.e., character selection) is complete.

To address this, the PR introduces explicit handling of composition events (`compositionstart`, `compositionend`) within the `AutoResizingTextarea` component. This ensures that messages are only sent after IME composition has fully ended, thereby improving support for languages like Chinese, Japanese, and Korean.

## Testing

- [x] Tested on Chrome and Firefox.
- [x] Verified behavior using Chinese input methods (Pinyin and Bopomofo).
- [x] Confirmed that Enter does **not** send a message during active composition.
- [x] Confirmed that normal English input (non-IME) is **unaffected** — messages are still sent on Enter as expected.

## Related PRs and Issues

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation