### PR TITLE
fix: connect streaming errors to runtime onError handler

### DIFF
--- a/CopilotKit/.changeset/afraid-seahorses-warn.md
+++ b/CopilotKit/.changeset/afraid-seahorses-warn.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: connect streaming errors to runtime onError handler
+- remove request logging

--- a/CopilotKit/.changeset/long-planets-change.md
+++ b/CopilotKit/.changeset/long-planets-change.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: connect streaming errors to runtime onError handler

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -511,32 +511,6 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
     // For storing streamed chunks if progressive logging is enabled
     const streamedChunks: any[] = [];
 
-    // Track request start
-    await this.error(
-      "request",
-      {
-        threadId,
-        runId,
-        source: "runtime",
-        request: {
-          operation: "processRuntimeRequest",
-          method: "POST",
-          url: url,
-          startTime: requestStartTime,
-        },
-        agent: agentSession ? { name: agentSession.agentName } : undefined,
-        messages: {
-          input: rawMessages,
-          messageCount: rawMessages.length,
-        },
-        technical: {
-          environment: process.env.NODE_ENV,
-        },
-      },
-      undefined,
-      publicApiKey,
-    );
-
     try {
       if (
         Object.keys(this.agents).length &&


### PR DESCRIPTION
- Modified RuntimeEventSource to accept error handler and context
- Updated processRuntimeRequest to pass runtime error handler to event source
- Updated processAgentRequest to pass error handler for agent requests
- Streaming errors now properly route to onError handler while preserving original streaming behavior
- Fixes issue where OpenAI authentication errors were not reaching onError handler


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streaming errors by ensuring they are properly routed to the runtime’s error handler, resulting in more reliable error reporting during streaming operations.

* **Chores**
  * Removed request logging functionality for a cleaner runtime experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->