### PR TITLE
fix: do not show error on state loading if thread does not exist

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -975,16 +975,21 @@ please use an LLM adapter instead.`,
     } catch (error) {
       // All errors from agent state loading are user configuration issues
       const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorStatus = error?.response?.status || error?.status;
 
-      // Log user configuration errors at debug level to reduce noise
-      console.debug(`Agent '${agentName}' configuration issue: ${errorMessage}`);
+      if (errorStatus === 404) {
+        state = {};
+      } else {
+        // Log user configuration errors at debug level to reduce noise
+        console.debug(`Agent '${agentName}' configuration issue: ${errorMessage}`);
 
-      // Throw a configuration error - all agent state loading failures are user setup issues
-      throw new ResolvedCopilotKitError({
-        status: 400,
-        message: `Agent '${agentName}' failed to execute: ${errorMessage}`,
-        code: CopilotKitErrorCode.CONFIGURATION_ERROR,
-      });
+        // Throw a configuration error - all agent state loading failures are user setup issues
+        throw new ResolvedCopilotKitError({
+          status: 400,
+          message: `Agent '${agentName}' failed to execute: ${errorMessage}`,
+          code: CopilotKitErrorCode.CONFIGURATION_ERROR,
+        });
+      }
     }
 
     if (Object.keys(state).length === 0) {


### PR DESCRIPTION
Currently in development we show error when loading langgraph agent state for CPK initialization sake.
The thread ID we supply might not exist on the LG side, therefore a 404 error should not show up as an error, as the thread might not exist which is acceptable