### PR TITLE
Fix documentation build

### DIFF
--- a/docs/snippets/langgraph-platform-deployment-tabs.mdx
+++ b/docs/snippets/langgraph-platform-deployment-tabs.mdx
@@ -1,4 +1,5 @@
 import { Tab } from "../components/react/tabs";
+
 <Tabs groupId="lg-deployment-type" items={['Local (LangGraph Studio)', 'Self hosted (FastAPI)', 'LangGraph Platform']}>
   <Tab value="Local (LangGraph Studio)">
     For local development, you can use the [LangGraph CLI](https://langchain-ai.github.io/langgraph/cloud/reference/cli/) to start a development server and LangGraph studio session.


### PR DESCRIPTION
## What does this PR do?

Adds a newline after the import because of course you have to have a newline after an import. 

~~Removes an import that was breaking the build of the docs package.~~

~~I am not sure why this very valid very parseable import is not parsing, but everything builds and seems to work when it is removed, so OK, sure, we can do that. Was introduced this morning.~~

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation snippet to remove an unnecessary import statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->