### PR TITLE
feat(remote-action): add streamSubgraphs support to enhance event str…

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
@@ -63,12 +63,16 @@ export function constructLGCRemoteAction({
       });
 
       let state = {};
-      let config = {};
+      let config: any = {};
+      let streamSubgraphs = false 
       if (agentStates) {
         const jsonState = agentStates.find((state) => state.agentName === name);
         if (jsonState) {
           state = parseJson(jsonState.state, {});
           config = parseJson(jsonState.config, {});
+          if (config.streamSubgraphs !== undefined) {
+            streamSubgraphs = config.streamSubgraphs;
+          }
         }
       }
 
@@ -90,6 +94,7 @@ export function constructLGCRemoteAction({
             parameters: JSON.parse(action.jsonSchema),
           })),
           metaEvents,
+          streamSubgraphs,
         });
 
         const eventSource = new RemoteLangGraphEventSource();


### PR DESCRIPTION
# Add support for LangGraph subgraph stream processing

## What does this PR do?

This PR adds support for streaming subgraph events in LangGraph Platform integration. The changes enable CopilotKit to handle and process subgraph-specific events that start with "events" or "values" prefixes, allowing for more granular control over LangGraph execution flow.

### Key Changes:

1. **Enhanced Event Filtering**: Modified the event filtering logic to accept subgraph events when `streamSubgraphs` is enabled
2. **Subgraph Values Processing**: Added support for processing subgraph-specific values events and merging them with the main state
3. **Improved Metadata Handling**: Enhanced metadata access with optional chaining to prevent runtime errors
4. **Configuration Support**: Added `streamSubgraphs` configuration option to control subgraph event processing

### Technical Details:

- **Event Filtering**: The system now accepts events that start with "events" or "values" when subgraph streaming is enabled
- **State Merging**: Subgraph values are properly merged with the main state using spread operator
- **Backward Compatibility**: All changes are backward compatible and don't affect existing functionality

### Usage:

```typescript
const { state: agentState, setState: setAgentState } = useCoAgent<AgentState>({
  name: 'my-agent',
  config: {
    streamSubgraphs: true, // Enable subgraph streaming
    configurable: {
      // ... other config
    },
  },
});
```

## Related PRs and Issues

- Enhances LangGraph Platform integration capabilities
- Addresses the need for better subgraph event handling in complex LangGraph workflows

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation