### PR TITLE
docs: add LangGraph Platform authentication guide

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -66,17 +66,20 @@ export interface CopilotKitProps {
 
   /**
    * Custom properties to be sent with the request.
-   * Can include threadMetadata for thread creation.
+   * Can include threadMetadata for thread creation and authorization for LangGraph Platform authentication.
    * For example:
    * ```js
    * {
    *   'user_id': 'users_id',
+   *   'authorization': 'your-auth-token', // For LangGraph Platform authentication
    *   threadMetadata: {
    *     'account_id': '123',
    *     'user_type': 'premium'
    *   }
    * }
    * ```
+   *
+   * **Note**: The `authorization` property is automatically forwarded to LangGraph agents. See the [LangGraph Agent Authentication Guide](/coagents/shared-guides/langgraph-platform-authentication) for details.
    */
   properties?: Record<string, any>;
 

--- a/docs/content/docs/coagents/shared-guides/langgraph-platform-authentication.mdx
+++ b/docs/content/docs/coagents/shared-guides/langgraph-platform-authentication.mdx
@@ -1,0 +1,211 @@
+---
+title: "LangGraph Agent Authentication"
+icon: "lucide/Shield"
+description: "Secure your LangGraph agents with user authentication (Platform & Self-hosted)"
+---
+
+## Overview
+
+CopilotKit supports user authentication for LangGraph agents in two deployment modes:
+
+- **LangGraph Platform**: Uses built-in authentication with `@auth.authenticate` decorator
+- **Self-hosted**: Uses dynamic agent configuration to pass authentication context
+
+Both approaches enable your agents to access authenticated user context and implement proper authorization.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Frontend
+    participant CopilotKit
+    participant LangGraphAgent
+    participant Agent
+
+    Frontend->>CopilotKit: authorization: "user-token"
+    CopilotKit->>LangGraphAgent: Forward auth token
+    LangGraphAgent->>Agent: user info via config
+    Agent->>Agent: Access authenticated user context
+```
+
+## Frontend Setup
+
+Pass your authentication token via the `properties` prop:
+
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  properties={{
+    authorization: userToken, // Forwarded as Bearer token
+  }}
+>
+  <YourApp />
+</CopilotKit>
+```
+
+**Note**: For LangGraph Platform, the `authorization` property is forwarded as a Bearer token.
+
+## LangGraph Platform Deployment
+
+**For agents deployed to LangGraph Platform**, authentication works out of the box with the `@auth.authenticate` decorator.
+
+### Setup Authentication Handler
+
+```python
+# auth.py in your LangGraph Platform deployment
+from langgraph_sdk import Auth
+
+auth = Auth()
+
+@auth.authenticate
+async def authenticate(authorization: str | None):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise Auth.exceptions.HTTPException(status_code=401, detail="Unauthorized")
+
+    token = authorization.replace("Bearer ", "")
+    user_info = validate_your_token(token)  # Your validation logic
+
+    return {
+        "identity": user_info["user_id"],
+        "role": user_info.get("role"),
+        "permissions": user_info.get("permissions", [])
+    }
+```
+
+### Access User in Agent
+
+```python
+async def my_agent_node(state: AgentState, config: RunnableConfig):
+    # Access user from LangGraph Platform authentication
+    user_info = config["configuration"]["langgraph_auth_user"]
+    user_id = user_info["identity"]
+    user_role = user_info.get("role")
+
+    # Your agent logic with user context
+    return state
+```
+
+For complete implementation details, see the [LangGraph Platform Authentication documentation](https://langchain-ai.github.io/langgraph/concepts/auth/#authentication).
+
+## Self-hosted Deployment
+
+**For self-hosted agents**, you need to manually configure authentication context through dynamic agent creation.
+
+### Setup Dynamic Agent Configuration
+
+```python
+# demo.py - Configure agent with authentication context
+from copilotkit import CopilotKitRemoteEndpoint, LangGraphAgent
+
+sdk = CopilotKitRemoteEndpoint(
+    agents=lambda context: [
+        LangGraphAgent(
+            name="sample_agent",
+            description="Agent with authentication support",
+            graph=graph,
+            langgraph_config={
+                "configurable": {
+                    "copilotkit_auth": context["properties"].get("authorization")
+                }
+            }
+        )
+    ],
+)
+```
+
+### Access User in Agent
+
+```python
+async def my_agent_node(state: AgentState, config: RunnableConfig):
+    # Handle authentication for self-hosted mode
+    auth_token = config["configurable"].get("copilotkit_auth")
+    if auth_token:
+        user_info = validate_your_token(auth_token)
+        user_id = user_info["user_id"]
+        user_role = user_info.get("role")
+    else:
+        user_id = "anonymous"
+        user_role = None
+
+    # Your agent logic with user context
+    return state
+```
+
+## Universal Authentication Pattern
+
+For agents that work in both environments, use this pattern:
+
+```python
+async def my_agent_node(state: AgentState, config: RunnableConfig):
+    user_id = "anonymous"
+    user_role = None
+
+    # LangGraph Platform mode
+    if "configuration" in config and "langgraph_auth_user" in config["configuration"]:
+        user_info = config["configuration"]["langgraph_auth_user"]
+        user_id = user_info["identity"]
+        user_role = user_info.get("role")
+
+    # Self-hosted mode
+    elif "configurable" in config and "copilotkit_auth" in config["configurable"]:
+        auth_token = config["configurable"]["copilotkit_auth"]
+        if auth_token:
+            user_info = validate_your_token(auth_token)
+            user_id = user_info["user_id"]
+            user_role = user_info.get("role")
+
+    # Your agent logic with user context
+    return state
+```
+
+## Security Notes
+
+### LangGraph Platform
+
+- **Token Validation**: Automatic validation via `@auth.authenticate` handler
+- **Built-in Security**: LangGraph Platform handles token parsing and validation
+- **User Scoping**: Use authorization handlers to scope resources to authenticated users
+
+### Self-hosted
+
+- **Manual Validation**: You must implement token validation in your agent logic
+- **Context Passing**: Authentication context passed through agent configuration
+- **Security Responsibility**: Ensure proper token validation and user scoping
+
+### General Best Practices
+
+- **Permission Checks**: Implement role-based access control in your agents
+- **Token Security**: Use secure token generation and validation
+- **User Scoping**: Always scope data access to authenticated users
+
+For comprehensive authentication patterns, authorization handlers, and security best practices, refer to the [LangGraph Platform Authentication documentation](https://langchain-ai.github.io/langgraph/concepts/auth/#authentication).
+
+## Troubleshooting
+
+### Common Issues
+
+**Token not reaching agent**:
+
+- Ensure you're passing `authorization` in the `properties` prop
+- For self-hosted: Verify dynamic agent configuration is set up correctly
+
+**Invalid token format**:
+
+- CopilotKit automatically adds the `Bearer ` prefix for LangGraph Platform
+- For self-hosted: Handle token format in your validation logic
+
+**User info not available**:
+
+- **LangGraph Platform**: Verify your `@auth.authenticate` handler is properly configured
+- **Self-hosted**: Check that `copilotkit_auth` is properly passed in `langgraph_config`
+
+**Authentication works locally but not in production**:
+
+- Ensure you're using the correct deployment mode (LangGraph Platform vs self-hosted)
+- Verify environment-specific configuration differences
+
+## Next Steps
+
+- [Configure your LangGraph Platform deployment →](/coagents/quickstart/langgraph)
+- [Learn about agent state management →](/coagents/shared-state)
+- [Implement human-in-the-loop workflows →](/coagents/human-in-the-loop)

--- a/docs/content/docs/coagents/shared-guides/meta.json
+++ b/docs/content/docs/coagents/shared-guides/meta.json
@@ -4,6 +4,7 @@
     "---Custom Look and Feel---",
     "...custom-look-and-feel",
     "---Guides---",
+    "langgraph-platform-authentication",
     "copilot-suggestions"
   ]
-} 
+}

--- a/docs/content/docs/direct-to-llm/guides/backend-actions/langgraph-platform-endpoint.mdx
+++ b/docs/content/docs/direct-to-llm/guides/backend-actions/langgraph-platform-endpoint.mdx
@@ -3,17 +3,23 @@ title: "Remote Endpoint (LangGraph Platform)"
 description: "Connect your CopilotKit application to an agent deployed on LangGraph Platform."
 icon: "custom/langchain"
 ---
+
 import FindCopilotRuntimeSnippet from "@/snippets/find-your-copilot-runtime.mdx";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
-import { TailoredContent, TailoredContentOption } from "@/components/react/tailored-content.tsx";
+import {
+  TailoredContent,
+  TailoredContentOption,
+} from "@/components/react/tailored-content.tsx";
 import CopilotCloudConfigureRemoteEndpointLangGraphSnippet from "@/snippets/copilot-cloud-configure-remote-endpoint-langgraph.mdx";
 import CopilotCloudConfigureCopilotkitProviderSnippet from "@/snippets/copilot-cloud-configure-copilotkit-provider.mdx";
 import LangGraphPlatformDeploymentTabs from "@/snippets/langgraph-platform-deployment-tabs.mdx";
 import { FaCloud, FaServer } from "react-icons/fa";
 
 <Callout type="info">
-    This guide assumes you've created a LangGraph agent, and have a `langgraph.json` file set up. If you need a quick introduction, check out [this brief example
-    from the LangGraph docs](https://langchain-ai.github.io/langgraph/) or follow one of our demos.
+  This guide assumes you've created a LangGraph agent, and have a
+  `langgraph.json` file set up. If you need a quick introduction, check out
+  [this brief example from the LangGraph
+  docs](https://langchain-ai.github.io/langgraph/) or follow one of our demos.
 </Callout>
 ## Deploy a Graph to LangGraph Platform
 
@@ -93,7 +99,45 @@ import { FaCloud, FaServer } from "react-icons/fa";
         The graph and interactions can viewed in [LangGraph Studio](smith.langchain.com/studio) and any logs should be available on [LangSmith](smith.langchain.com)
 
     </Step>
+
 </Steps>
+
+---
+
+## Authentication
+
+For production deployments, you'll want to implement proper authentication to ensure users can only access their own data and threads. CopilotKit supports passing user authentication tokens to your LangGraph Platform agents.
+
+<Callout type="info">
+  Learn how to implement secure authentication with your LangGraph agents in our
+  comprehensive [LangGraph Agent Authentication
+  Guide](/coagents/shared-guides/langgraph-platform-authentication).
+</Callout>
+
+### Quick Example
+
+Pass authentication tokens through the `properties` prop:
+
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  properties={{
+    authorization: userToken, // Gets forwarded to LangGraph Platform
+  }}
+>
+  <YourApp />
+</CopilotKit>
+```
+
+Your LangGraph agent can then access the authentication context:
+
+```python
+def authenticate_user(state, config):
+    auth_header = config.get("configurable", {}).get("authorization")
+    user_info = validate_jwt_token(auth_header)
+    # Use user_info to control access and permissions
+    return state
+```
 
 ---
 
@@ -104,3 +148,4 @@ A few things to try if you are running into trouble:
 1. Make sure that you listed your agents according to the graphs mentioned in the `langgraph.json` file
 2. Make sure the agent names are the same between the agent Python implementation, the `langgraph.json` file and the remote endpoint declaration
 3. Make sure the LangGraph Platform deployment has all environment variables listed as you need them to be, according to your agent implementation
+4. **Authentication issues**: If you're having trouble with authentication, check that you're passing the `authorization` token in the `properties` prop and that your agent is properly validating it. See the [authentication guide](/coagents/shared-guides/langgraph-platform-authentication) for details.

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -66,17 +66,20 @@ The children to be rendered within the CopilotKit.
 
 <PropertyReference name="properties" type="Record<string, any>"  > 
 Custom properties to be sent with the request.
-  Can include threadMetadata for thread creation.
+  Can include threadMetadata for thread creation and authorization for LangGraph Platform authentication.
   For example:
   ```js
   {
     'user_id': 'users_id',
+    'authorization': 'your-auth-token', // For LangGraph Platform authentication
     threadMetadata: {
       'account_id': '123',
       'user_type': 'premium'
     }
   }
   ```
+ 
+  Note: The `authorization` property is automatically forwarded to LangGraph agents. See the [LangGraph Agent Authentication Guide](/coagents/shared-guides/langgraph-platform-authentication) for details.
 </PropertyReference>
 
 <PropertyReference name="credentials" type="RequestCredentials"  > 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide on LangGraph agent authentication, covering both platform and self-hosted deployments, including code examples, diagrams, and troubleshooting tips.
  * Updated documentation to clarify how to pass authentication tokens via the `properties` prop for LangGraph Platform agents, with new examples and explanatory notes.
  * Enhanced metadata and formatting for shared guides and related documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->