### PR TITLE
fix(openai): update maxTokens parameter to max_completion_tokens in OpenAIAdapter

### DIFF
--- a/CopilotKit/.changeset/giant-cooks-doubt.md
+++ b/CopilotKit/.changeset/giant-cooks-doubt.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix(openai): update maxTokens parameter to max_completion_tokens in OpenAIAdapter

--- a/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -175,7 +175,9 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
         stream: true,
         messages: openaiMessages,
         ...(tools.length > 0 && { tools }),
-        ...(forwardedParameters?.maxTokens && { max_tokens: forwardedParameters.maxTokens }),
+        ...(forwardedParameters?.maxTokens && {
+          max_completion_tokens: forwardedParameters.maxTokens,
+        }),
         ...(forwardedParameters?.stop && { stop: forwardedParameters.stop }),
         ...(toolChoice && { tool_choice: toolChoice }),
         ...(this.disableParallelToolCalls && { parallel_tool_calls: false }),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes deprecated `max_tokens` 

## Related PRs and Issues

Resolves #2190 

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with OpenAI integration by updating the parameter name for token limits to ensure proper handling of completion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->