### PR TITLE
fix(react-ui): address issue where initial message labels were not vi…

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
@@ -69,7 +69,7 @@ function makeInitialMessages(initial: string | string[] | undefined): Message[] 
   return [
     {
       id: initial,
-      role: "system",
+      role: "assistant",
       content: initial,
     },
   ];

--- a/docs/content/docs/reference/components/chat/CopilotChat.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotChat.mdx
@@ -38,6 +38,23 @@ import "@copilotkit/react-ui/styles.css";
 />
 ```
  
+### With Observability Hooks
+ 
+To monitor user interactions, provide the `observabilityHooks` prop.
+Note: This requires a `publicApiKey` in the `<CopilotKit>` provider.
+ 
+```tsx
+<CopilotKit publicApiKey="YOUR_PUBLIC_API_KEY">
+  <CopilotChat
+    observabilityHooks={{
+      onMessageSent: (message) => {
+        console.log("Message sent:", message);
+      },
+    }}
+  />
+</CopilotKit>
+```
+ 
 ### Look & Feel
  
 By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
@@ -188,5 +205,10 @@ Children to render.
 
 <PropertyReference name="hideStopButton" type="boolean"  > 
 
+</PropertyReference>
+
+<PropertyReference name="observabilityHooks" type="CopilotObservabilityHooks"  > 
+Event hooks for CopilotKit chat events.
+  These hooks only work when publicApiKey is provided.
 </PropertyReference>
 

--- a/docs/content/docs/reference/components/chat/CopilotPopup.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotPopup.mdx
@@ -39,6 +39,26 @@ import "@copilotkit/react-ui/styles.css";
 />
 ```
  
+### With Observability Hooks
+ 
+To monitor user interactions, provide the `observabilityHooks` prop.
+Note: This requires a `publicApiKey` in the `<CopilotKit>` provider.
+ 
+```tsx
+<CopilotKit publicApiKey="YOUR_PUBLIC_API_KEY">
+  <CopilotPopup
+    observabilityHooks={{
+      onChatExpanded: () => {
+        console.log("Popup opened");
+      },
+      onChatMinimized: () => {
+        console.log("Popup closed");
+      },
+    }}
+  />
+</CopilotKit>
+```
+ 
 ### Look & Feel
  
 By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
@@ -189,6 +209,11 @@ Children to render.
 
 <PropertyReference name="hideStopButton" type="boolean"  > 
 
+</PropertyReference>
+
+<PropertyReference name="observabilityHooks" type="CopilotObservabilityHooks"  > 
+Event hooks for CopilotKit chat events.
+  These hooks only work when publicApiKey is provided.
 </PropertyReference>
 
 <PropertyReference name="defaultOpen" type="boolean"  default="false"> 

--- a/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
+++ b/docs/content/docs/reference/components/chat/CopilotSidebar.mdx
@@ -41,6 +41,28 @@ import "@copilotkit/react-ui/styles.css";
 </CopilotSidebar>
 ```
  
+### With Observability Hooks
+ 
+To monitor user interactions, provide the `observabilityHooks` prop.
+Note: This requires a `publicApiKey` in the `<CopilotKit>` provider.
+ 
+```tsx
+<CopilotKit publicApiKey="YOUR_PUBLIC_API_KEY">
+  <CopilotSidebar
+    observabilityHooks={{
+      onChatExpanded: () => {
+        console.log("Sidebar opened");
+      },
+      onChatMinimized: () => {
+        console.log("Sidebar closed");
+      },
+    }}
+  >
+    <YourApp/>
+  </CopilotSidebar>
+</CopilotKit>
+```
+ 
 ### Look & Feel
  
 By default, CopilotKit components do not have any styles. You can import CopilotKit's stylesheet at the root of your project:
@@ -191,6 +213,11 @@ Children to render.
 
 <PropertyReference name="hideStopButton" type="boolean"  > 
 
+</PropertyReference>
+
+<PropertyReference name="observabilityHooks" type="CopilotObservabilityHooks"  > 
+Event hooks for CopilotKit chat events.
+  These hooks only work when publicApiKey is provided.
 </PropertyReference>
 
 <PropertyReference name="defaultOpen" type="boolean"  default="false"> 

--- a/docs/content/docs/reference/hooks/useCopilotChat.mdx
+++ b/docs/content/docs/reference/hooks/useCopilotChat.mdx
@@ -14,13 +14,25 @@ Copilot instance. Use to implement a fully custom UI (headless UI) or to
 programmatically interact with the Copilot instance managed by the default
 UI.
  
+Requires a publicApiKey - Sign up for free at https://cloud.copilotkit.ai/
+to get your API key with generous usage limits.
+ 
 ## Usage
  
 ### Simple Usage
  
 ```tsx
+import { CopilotKit } from "@copilotkit/react-core";
 import { useCopilotChat } from "@copilotkit/react-core";
 import { Role, TextMessage } from "@copilotkit/runtime-client-gql";
+ 
+export function App() {
+  return (
+    <CopilotKit publicApiKey="your-public-api-key">
+      <YourComponent />
+    </CopilotKit>
+  );
+}
  
 export function YourComponent() {
   const { appendMessage } = useCopilotChat();
@@ -40,7 +52,16 @@ export function YourComponent() {
 ### Working with Suggestions
  
 ```tsx
+import { CopilotKit } from "@copilotkit/react-core";
 import { useCopilotChat, useCopilotChatSuggestions } from "@copilotkit/react-core";
+ 
+export function App() {
+  return (
+    <CopilotKit publicApiKey="your-public-api-key">
+      <YourComponent />
+    </CopilotKit>
+  );
+}
  
 export function YourComponent() {
   const {

--- a/examples/e2e/tests/next-openai.spec.ts
+++ b/examples/e2e/tests/next-openai.spec.ts
@@ -276,6 +276,16 @@ Object.entries(groupedConfigs).forEach(([projectName, descriptions]) => {
               ]);
             });
 
+            test(`Initial labels are displayed for variant ${variant.name}`, async ({
+              page,
+            }) => {
+              page.setDefaultTimeout(PAGE_TIMEOUT);
+              await page.goto(`${config.url}multi${variant.queryParams}`);
+              await expect(page.getByText("Hi you! 👋 Let's book your next vacation. Ask me anything.")).toBeVisible({
+                timeout: PAGE_TIMEOUT,
+              });
+            });
+
             test(`Call multiple HITL actions and non-HITL actions with variant ${variant.name}`, async ({
               page,
             }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the role of the initial message in chat to ensure correct labeling when the input is a single string.

* **Tests**
  * Added a test to verify that the initial welcome message is displayed correctly in the chat interface.

* **Documentation**
  * Introduced observability hooks in chat components to monitor user interactions with event callbacks.
  * Updated usage examples to include required API key setup for chat hooks and components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->