### PR TITLE
feat(chat): implement custom error handling in CopilotChat and Modal components

### DIFF
--- a/CopilotKit/.changeset/metal-zebras-return.md
+++ b/CopilotKit/.changeset/metal-zebras-return.md
@@ -1,0 +1,10 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- feat(chat): implement custom error handling in CopilotChat and Modal components
+
+- Added `renderError` prop to `CopilotChat` for inline error rendering.
+- Introduced `triggerChatError` function to manage chat-specific errors and observability hooks.
+- Updated `Modal` to handle observability hooks with public API key checks.
+- Enhanced `CopilotObservabilityHooks` interface to include `onError` for error event handling.

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -974,6 +974,7 @@ export const useCopilotChatLogic = (
       await runAgent(
         generalContext.agentSession.agentName,
         stableContext,
+        messagesContext.messages,
         appendMessage,
         runChatCompletion,
       );

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -85,6 +85,7 @@ import type { SuggestionItem } from "@copilotkit/react-core";
 import {
   CopilotKitError,
   CopilotKitErrorCode,
+  CopilotErrorEvent,
   Message,
   Severity,
   ErrorVisibility,
@@ -281,6 +282,18 @@ export interface CopilotChatProps {
    * These hooks only work when publicApiKey is provided.
    */
   observabilityHooks?: CopilotObservabilityHooks;
+
+  /**
+   * Custom error renderer for chat-specific errors.
+   * When provided, errors will be displayed inline within the chat interface.
+   */
+  renderError?: (error: {
+    message: string;
+    operation?: string;
+    timestamp: number;
+    onDismiss: () => void;
+    onRetry?: () => void;
+  }) => React.ReactNode;
 }
 
 interface OnStopGenerationArguments {
@@ -368,19 +381,28 @@ export function CopilotChat({
   inputFileAccept = "image/*",
   hideStopButton,
   observabilityHooks,
+  renderError,
 }: CopilotChatProps) {
   const { additionalInstructions, setChatInstructions, copilotApiConfig, setBannerError } =
     useCopilotContext();
+
+  // Destructure stable values to avoid object reference changes
+  const { publicApiKey, chatApiEndpoint } = copilotApiConfig;
   const [selectedImages, setSelectedImages] = useState<Array<ImageUpload>>([]);
+  const [chatError, setChatError] = useState<{
+    message: string;
+    operation?: string;
+    timestamp: number;
+  } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Helper function to trigger event hooks only if publicApiKey is provided
   const triggerObservabilityHook = useCallback(
     (hookName: keyof CopilotObservabilityHooks, ...args: any[]) => {
-      if (copilotApiConfig.publicApiKey && observabilityHooks?.[hookName]) {
+      if (publicApiKey && observabilityHooks?.[hookName]) {
         (observabilityHooks[hookName] as any)(...args);
       }
-      if (observabilityHooks?.[hookName] && !copilotApiConfig.publicApiKey) {
+      if (observabilityHooks?.[hookName] && !publicApiKey) {
         setBannerError(
           new CopilotKitError({
             message: "observabilityHooks requires a publicApiKey to function.",
@@ -392,7 +414,58 @@ export function CopilotChat({
         styledConsole.publicApiKeyRequired("observabilityHooks");
       }
     },
-    [copilotApiConfig.publicApiKey, observabilityHooks],
+    [publicApiKey, observabilityHooks, setBannerError],
+  );
+
+  // Helper function to trigger chat error and render error UI
+  const triggerChatError = useCallback(
+    (error: any, operation: string, originalError?: any) => {
+      const errorMessage = error?.message || error?.toString() || "An error occurred";
+
+      // Set chat error state for rendering
+      setChatError({
+        message: errorMessage,
+        operation,
+        timestamp: Date.now(),
+      });
+
+      // Also trigger observability hook if available
+      if (publicApiKey && observabilityHooks?.onError) {
+        const errorEvent: CopilotErrorEvent = {
+          type: "error",
+          timestamp: Date.now(),
+          context: {
+            source: "ui",
+            request: {
+              operation,
+              url: chatApiEndpoint,
+              startTime: Date.now(),
+            },
+            technical: {
+              environment: "browser",
+              userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+              stackTrace: originalError instanceof Error ? originalError.stack : undefined,
+            },
+          },
+          error,
+        };
+        observabilityHooks.onError(errorEvent);
+      }
+
+      // Show banner error if onError hook is used without publicApiKey
+      if (observabilityHooks?.onError && !publicApiKey) {
+        setBannerError(
+          new CopilotKitError({
+            message: "observabilityHooks.onError requires a publicApiKey to function.",
+            code: CopilotKitErrorCode.MISSING_PUBLIC_API_KEY_ERROR,
+            severity: Severity.CRITICAL,
+            visibility: ErrorVisibility.BANNER,
+          }),
+        );
+        styledConsole.publicApiKeyRequired("observabilityHooks.onError");
+      }
+    },
+    [publicApiKey, chatApiEndpoint, observabilityHooks, setBannerError],
   );
 
   // Clipboard paste handler
@@ -436,14 +509,15 @@ export function CopilotChat({
         const loadedImages = (await Promise.all(imagePromises)).filter((img) => img !== null);
         setSelectedImages((prev) => [...prev, ...loadedImages]);
       } catch (error) {
-        // TODO: Show an error message to the user
+        // Trigger chat-level error handler
+        triggerChatError(error, "processClipboardImages", error);
         console.error("Error processing pasted images:", error);
       }
     };
 
     document.addEventListener("paste", handlePaste);
     return () => document.removeEventListener("paste", handlePaste);
-  }, [imageUploadsEnabled]);
+  }, [imageUploadsEnabled, triggerChatError]);
 
   useEffect(() => {
     if (!additionalInstructions?.length) {
@@ -563,7 +637,8 @@ export function CopilotChat({
       const loadedImages = await Promise.all(fileReadPromises);
       setSelectedImages((prev) => [...prev, ...loadedImages]);
     } catch (error) {
-      // TODO: Show an error message to the user
+      // Trigger chat-level error handler
+      triggerChatError(error, "processUploadedImages", error);
       console.error("Error reading files:", error);
     }
   };
@@ -592,6 +667,19 @@ export function CopilotChat({
 
   return (
     <WrappedCopilotChat icons={icons} labels={labels} className={className}>
+      {/* Render error above messages if present */}
+      {chatError &&
+        renderError &&
+        renderError({
+          ...chatError,
+          onDismiss: () => setChatError(null),
+          onRetry: () => {
+            // Clear error and potentially retry based on operation
+            setChatError(null);
+            // TODO: Implement specific retry logic based on operation type
+          },
+        })}
+
       <Messages
         AssistantMessage={AssistantMessage}
         UserMessage={UserMessage}
@@ -886,10 +974,8 @@ export const useCopilotChatLogic = (
       await runAgent(
         generalContext.agentSession.agentName,
         stableContext,
-        messagesContext.messages,
         appendMessage,
         runChatCompletion,
-        hint,
       );
     }
   };

--- a/CopilotKit/packages/react-ui/src/components/chat/props.ts
+++ b/CopilotKit/packages/react-ui/src/components/chat/props.ts
@@ -1,4 +1,4 @@
-import { AIMessage, Message, UserMessage } from "@copilotkit/shared";
+import { AIMessage, Message, UserMessage, CopilotErrorEvent } from "@copilotkit/shared";
 import { CopilotChatSuggestion } from "../../types/suggestions";
 import { ReactNode } from "react";
 import { ImageData } from "@copilotkit/shared";
@@ -47,6 +47,12 @@ export interface CopilotObservabilityHooks {
    * Called when chat generation stops
    */
   onChatStopped?: () => void;
+
+  /**
+   * Called when an error occurs in the chat
+   * This enables chat-specific error handling UX while preserving system-wide error monitoring
+   */
+  onError?: (errorEvent: CopilotErrorEvent) => void;
 }
 
 export interface ButtonProps {}


### PR DESCRIPTION
- Added `renderError` prop to `CopilotChat` for inline error rendering.
- Introduced `triggerChatError` function to manage chat-specific errors and observability hooks.
- Updated `Modal` to handle observability hooks with public API key checks.
- Enhanced `CopilotObservabilityHooks` interface to include `onError` for error event handling.


```tsx
<CopilotKit
  onError={(errorEvent) => monitoring.capture(errorEvent)} // System-wide (unchanged)
>
  <CopilotChat
    observabilityHooks={{
      onError: (errorEvent) => showChatError(errorEvent), // Chat-level (new)
    }}
  />
</CopilotKit>
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable error display in the chat interface, allowing inline rendering of error messages.
  * Introduced an error event callback for enhanced error monitoring, enabling external handling of chat and modal errors.

* **Bug Fixes**
  * Improved error reporting and user feedback when required configuration (such as API keys) is missing.

* **Refactor**
  * Enhanced internal error handling and observability integration for more robust and user-friendly error management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->