### PR TITLE
docs: fixes doc on self-hosting

### DIFF
--- a/docs/content/docs/direct-to-llm/guides/quickstart.mdx
+++ b/docs/content/docs/direct-to-llm/guides/quickstart.mdx
@@ -39,7 +39,7 @@ If you don't have a NextJS application or just want to code-along, you can follo
 <TailoredContentOption
   id="copilot-cloud"
   title="Copilot Cloud (Recommended)"
-  description="Use our hosted backend endpoint to get started quickly (OpenAI only)."
+  description="Use our hosted backend endpoint to get started quickly."
   icon={<FaCloud />}
 >
 

--- a/docs/content/docs/direct-to-llm/guides/quickstart.mdx
+++ b/docs/content/docs/direct-to-llm/guides/quickstart.mdx
@@ -101,7 +101,7 @@ npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime
 </Step>
 
 <Step>
-  ### Step 2: Get Your Copilot Cloud API Key (Optional but Recommended)
+  ### Get Your Copilot Cloud API Key (Optional but Recommended)
 
 {" "}
 

--- a/docs/content/docs/direct-to-llm/guides/quickstart.mdx
+++ b/docs/content/docs/direct-to-llm/guides/quickstart.mdx
@@ -17,6 +17,7 @@ import {
 import { FaCloud, FaServer } from "react-icons/fa";
 
 ## Using the CLI
+
 If you have a **NextJS** application, you can use our CLI to automatically bootstrap your application for use with CopilotKit.
 
 ```bash
@@ -25,14 +26,13 @@ npx copilotkit@latest init
 
 <Accordions>
   <Accordion title="Starting from scratch?">
-    No problem! Just use `create-next-app` to make a new NextJS application quickly.
-    ```bash
-    npx create-next-app@latest
-    ```
+    No problem! Just use `create-next-app` to make a new NextJS application
+    quickly. ```bash npx create-next-app@latest ```
   </Accordion>
 </Accordions>
 
 ## Code-along
+
 If you don't have a NextJS application or just want to code-along, you can follow the steps below.
 
 <TailoredContent id="copilot-hosting">
@@ -61,7 +61,7 @@ Navigate to [Copilot Cloud](https://cloud.copilotkit.ai) and follow the instruct
 <Step>
 ### Setup the CopilotKit Provider
 
-The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases, 
+The [`<CopilotKit>`](/reference/components/CopilotKit) component must wrap the Copilot-aware parts of your application. For most use-cases,
 it's appropriate to wrap the CopilotKit provider around the entire app, e.g. in your layout.tsx.
 
 <CloudCopilotKitProvider components={props.components} />
@@ -92,12 +92,43 @@ First, install the latest packages for CopilotKit.
 ```package-install
 npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime
 ```
+
 </Step>
 <Step>
 ### Set up a Copilot Runtime Endpoint
 
 <SelfHostingCopilotRuntimeCreateEndpoint components={props.components} />
 </Step>
+
+<Step>
+  ### Step 2: Get Your Copilot Cloud API Key (Optional but Recommended)
+
+{" "}
+
+<Callout type="info">
+  While self-hosting, you can still leverage CopilotKit Cloud's enhanced
+  features for production-ready deployments.
+</Callout>
+
+1. Go to [Copilot Cloud](https://cloud.copilotkit.ai) and sign up for free
+2. Get your API key from the dashboard
+3. Add it to your environment variables:
+
+```plaintext title=".env"
+COPILOT_CLOUD_PUBLIC_API_KEY=your_api_key_here
+```
+
+**Why add this?**
+
+- **Free tier available** - Your requests will NOT be logged
+- **Production-ready features** - Enhanced error handling and observability
+- **Developer console** - Better debugging and monitoring (coming soon)
+- **Error observability** - Track and debug issues in production
+
+This enables CopilotKit platform features while still using your self-hosted runtime.
+
+</Step>
+
 <Step>
 ### Configure the CopilotKit Provider
 

--- a/docs/content/docs/direct-to-llm/tutorials/ai-powered-textarea/step-2-setup-copilotkit.mdx
+++ b/docs/content/docs/direct-to-llm/tutorials/ai-powered-textarea/step-2-setup-copilotkit.mdx
@@ -1,9 +1,13 @@
 ---
 title: "Step 2: Setup CopilotKit"
 ---
+
 import SelfHostingCopilotRuntimeCreateEndpoint from "@/snippets/self-hosting-copilot-runtime-create-endpoint.mdx";
 import CopilotCloudConfigureCopilotKitProvider from "@/snippets/copilot-cloud-configure-copilotkit-provider.mdx";
-import { TailoredContent, TailoredContentOption } from "@/components/react/tailored-content";
+import {
+  TailoredContent,
+  TailoredContentOption,
+} from "@/components/react/tailored-content";
 import { FaCloud, FaServer } from "react-icons/fa";
 
 Now that we have our todo list app running, we're ready to integrate CopilotKit. For this tutorial, we will install the following dependencies:
@@ -25,7 +29,7 @@ npm install @copilotkit/react-core @copilotkit/react-textarea
 <TailoredContentOption
   id="copilot-cloud"
   title="Copilot Cloud (Recommended)"
-  description="Use our hosted backend endpoint to get started quickly (OpenAI only)."
+  description="Use our hosted backend endpoint to get started quickly."
   icon={<FaCloud />}
 >
 In order to use CopilotKit, we'll need to configure the CopilotKit provider.
@@ -56,7 +60,9 @@ import "@copilotkit/react-textarea/styles.css"; // [!code highlight]
 
 export default function Home() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit"> // [!code highlight]
+    <CopilotKit runtimeUrl="/api/copilotkit">
+      {" "}
+      // [!code highlight]
       <EmailsProvider>
         <EmailThread />
       </EmailsProvider>
@@ -64,6 +70,7 @@ export default function Home() {
   );
 }
 ```
+
 </Step>
 </Steps>
 </TailoredContentOption>

--- a/docs/content/docs/direct-to-llm/tutorials/ai-todo-app/step-2-setup-copilotkit.mdx
+++ b/docs/content/docs/direct-to-llm/tutorials/ai-todo-app/step-2-setup-copilotkit.mdx
@@ -1,10 +1,14 @@
 ---
 title: "Step 2: Setup CopilotKit"
 ---
+
 import SelfHostingCopilotRuntimeCreateEndpoint from "@/snippets/self-hosting-copilot-runtime-create-endpoint.mdx";
 import CopilotCloudConfigureCopilotKitProvider from "@/snippets/copilot-cloud-configure-copilotkit-provider.mdx";
 import SelfHostingCopilotRuntimeConfigureCopilotKitProvider from "@/snippets/self-hosting-copilot-runtime-configure-copilotkit-provider.mdx";
-import { TailoredContent, TailoredContentOption } from "@/components/react/tailored-content";
+import {
+  TailoredContent,
+  TailoredContentOption,
+} from "@/components/react/tailored-content";
 import { FaCloud, FaServer } from "react-icons/fa";
 
 Now that we have our todo list app running, we're ready to integrate CopilotKit. For this tutorial, we will install the following dependencies:
@@ -26,7 +30,7 @@ npm install @copilotkit/react-core @copilotkit/react-ui
 <TailoredContentOption
   id="copilot-cloud"
   title="Copilot Cloud (Recommended)"
-  description="Use our hosted backend endpoint to get started quickly (OpenAI only)."
+  description="Use our hosted backend endpoint to get started quickly."
   icon={<FaCloud />}
 >
 In order to use CopilotKit, we'll need to configure the `CopilotKit` provider.
@@ -49,7 +53,9 @@ In order to use CopilotKit, we'll need to configure the `CopilotKit` provider.
 
 ### Configure the CopilotKit Provider
 
-<SelfHostingCopilotRuntimeConfigureCopilotKitProvider components={props.components} />
+<SelfHostingCopilotRuntimeConfigureCopilotKitProvider
+  components={props.components}
+/>
 
 </Step>
 </Steps>

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -1874,7 +1874,7 @@ Get started with CopilotKit in under 5 minutes.
 
 Copilot Cloud (Recommended)
 
-Use our hosted backend endpoint to get started quickly (OpenAI only).
+Use our hosted backend endpoint to get started quickly.
 
 Self-hosting
 
@@ -2845,7 +2845,7 @@ Get started with CopilotKit in under 5 minutes.
 
 Copilot Cloud (Recommended)
 
-Use our hosted backend endpoint to get started quickly (OpenAI only).
+Use our hosted backend endpoint to get started quickly.
 
 Self-hosting
 
@@ -4834,7 +4834,7 @@ Get started with CopilotKit in under 5 minutes.
 
 Copilot Cloud (Recommended)
 
-Use our hosted backend endpoint to get started quickly (OpenAI only).
+Use our hosted backend endpoint to get started quickly.
 
 Self-hosting
 
@@ -6741,7 +6741,7 @@ It's not too hard to write your own LLM adapter from scratch -- see the existing
 
 Copilot Cloud (Recommended)
 
-Use our hosted backend endpoint to get started quickly (OpenAI only).
+Use our hosted backend endpoint to get started quickly.
 
 Self-hosting
 
@@ -6814,7 +6814,7 @@ Get started with CopilotKit in under 5 minutes.
 
 Copilot Cloud (Recommended)
 
-Use our hosted backend endpoint to get started quickly (OpenAI only).
+Use our hosted backend endpoint to get started quickly.
 
 Self-hosting
 
@@ -7253,7 +7253,7 @@ Get started with CopilotKit in under 5 minutes.
 
 Copilot Cloud (Recommended)
 
-Use our hosted backend endpoint to get started quickly (OpenAI only).
+Use our hosted backend endpoint to get started quickly.
 
 Self-hosting
 

--- a/docs/snippets/llm-adapters.mdx
+++ b/docs/snippets/llm-adapters.mdx
@@ -1,5 +1,8 @@
-import { Callout } from 'fumadocs-ui/components/callout';
-import { TailoredContent, TailoredContentOption } from "@/components/react/tailored-content.tsx";
+import { Callout } from "fumadocs-ui/components/callout";
+import {
+  TailoredContent,
+  TailoredContentOption,
+} from "@/components/react/tailored-content.tsx";
 import SelfHostingCopilotRuntimeCreateEndpoint from "@/snippets/self-hosting-copilot-runtime-create-endpoint.mdx";
 import { FaCloud, FaServer } from "react-icons/fa";
 import FindYourCopilotRuntime from "@/snippets/find-your-copilot-runtime.mdx";
@@ -16,20 +19,22 @@ Currently, we support the following LLM adapters natively:
 - [Anthropic Adapter](/reference/classes/llm-adapters/AnthropicAdapter)
 
 <Callout type="info">
-  You can use the [LangChain Adapter](/reference/classes/llm-adapters/LangChainAdapter) to use any LLM provider we don't yet natively support!
+  You can use the [LangChain
+  Adapter](/reference/classes/llm-adapters/LangChainAdapter) to use any LLM
+  provider we don't yet natively support!
 </Callout>
-
 
 <Callout type="info">
-  It's not too hard to write your own LLM adapter from scratch -- see the existing adapters for inspiration. And of course, we would love a contribution! ⭐️
+  It's not too hard to write your own LLM adapter from scratch -- see the
+  existing adapters for inspiration. And of course, we would love a
+  contribution! ⭐️
 </Callout>
-
 
 <TailoredContent id="hosting">
   <TailoredContentOption
     id="copilot-cloud"
     title="Copilot Cloud (Recommended)"
-    description="Use our hosted backend endpoint to get started quickly (OpenAI only)."
+    description="Use our hosted backend endpoint to get started quickly."
     icon={<FaCloud />}
   >
   Configure the used LLM adapter [on your Copilot Cloud dashboard](https://cloud.copilotkit.ai/)!
@@ -65,10 +70,5 @@ Currently, we support the following LLM adapters natively:
 
   </Steps>
 
-
-
   </TailoredContentOption>
 </TailoredContent>
-
-
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in the CopilotKit quickstart guide and tutorials.
  * Added an optional step for self-hosted users to obtain and use a Copilot Cloud API key, highlighting its benefits.
  * Simplified descriptions by removing "(OpenAI only)" qualifiers across multiple docs.
  * Enhanced clarity in the CLI usage section and refined import statement formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->