### PR TITLE
fix: throw errors when they happen with agui streams

### DIFF
--- a/CopilotKit/.changeset/new-flowers-wave.md
+++ b/CopilotKit/.changeset/new-flowers-wave.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- fix: throw errors when they happen with agui streams

--- a/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
@@ -1,5 +1,5 @@
 import { Logger } from "pino";
-import { Observable } from "rxjs";
+import { catchError, Observable } from "rxjs";
 import { AgentStateInput } from "../../graphql/inputs/agent-state.input";
 import { Message } from "../../graphql/types/converted";
 import { RuntimeEvent } from "../../service-adapters/events";
@@ -13,7 +13,7 @@ import {
 } from "@ag-ui/client";
 
 import { AbstractAgent } from "@ag-ui/client";
-import { parseJson } from "@copilotkit/shared";
+import { CopilotKitError, CopilotKitErrorCode, parseJson } from "@copilotkit/shared";
 import { MetaEventInput } from "../../graphql/inputs/meta-event.input";
 import { GraphQLContext } from "../integrations/shared";
 
@@ -85,10 +85,17 @@ export function constructAGUIRemoteAction({
         ...graphqlContext.properties,
       };
 
-      return agent.legacy_to_be_removed_runAgentBridged({
+      return (agent.legacy_to_be_removed_runAgentBridged({
         tools,
         forwardedProps,
-      }) as Observable<RuntimeEvent>;
+      }) as Observable<RuntimeEvent>).pipe(
+        catchError(err => {
+          throw new CopilotKitError({
+            message: err.message,
+            code: CopilotKitErrorCode.UNKNOWN,
+          });
+        })
+      );
     },
   };
   return [action];

--- a/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
@@ -85,16 +85,18 @@ export function constructAGUIRemoteAction({
         ...graphqlContext.properties,
       };
 
-      return (agent.legacy_to_be_removed_runAgentBridged({
-        tools,
-        forwardedProps,
-      }) as Observable<RuntimeEvent>).pipe(
-        catchError(err => {
+      return (
+        agent.legacy_to_be_removed_runAgentBridged({
+          tools,
+          forwardedProps,
+        }) as Observable<RuntimeEvent>
+      ).pipe(
+        catchError((err) => {
           throw new CopilotKitError({
             message: err.message,
             code: CopilotKitErrorCode.UNKNOWN,
           });
-        })
+        }),
       );
     },
   };


### PR DESCRIPTION
This PR adds error surfacing as they happen on AGUI streams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for streaming features to ensure errors are reported immediately when they occur. This enhances reliability and user feedback during streaming operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->