### PR TITLE
fix: fix inconsistent tool name of getWeather/get_weather

### DIFF
--- a/examples/coagents-starter/agent-py/sample_agent/agent.py
+++ b/examples/coagents-starter/agent-py/sample_agent/agent.py
@@ -25,7 +25,7 @@ class AgentState(CopilotKitState):
     proverbs: list[str] = []
     # your_custom_agent_state: str = ""
 
-@tool
+@tool("getWeather")
 def get_weather(location: str):
     """
     Get the weather for a given location.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

`examples/coagents-starter/agent-js/src/agent.ts` uses `getWeather`
but
`examples/coagents-starter/agent-py/sample_agent/agent.py` uses `get_weather`

so when using python agent in the starter, WeatherCard will not show.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation