### PR TITLE
fix: address issue where catch-all tool renders don't work

### DIFF
--- a/CopilotKit/.changeset/wise-phones-collect.md
+++ b/CopilotKit/.changeset/wise-phones-collect.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/runtime-client-gql": patch
+---
+
+- fix: address issue where catch-all tool renders don't work
+
+Signed-off-by: Tyler Slaton <tyler@copilotkit.ai>

--- a/CopilotKit/packages/runtime-client-gql/src/message-conversion/agui-to-gql.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/message-conversion/agui-to-gql.ts
@@ -86,8 +86,17 @@ export function aguiToGQL(
         // Preserve render function in actions context
         if ("generativeUI" in message && message.generativeUI && actions) {
           const actionName = toolCall.function.name;
-          if (actions[actionName]) {
-            actions[actionName].render = message.generativeUI;
+          // Check for specific action first, then wild card action
+          const specificAction = Object.values(actions).find(
+            (action: any) => action.name === actionName,
+          );
+          const wildcardAction = Object.values(actions).find((action: any) => action.name === "*");
+
+          // Assign render function to the matching action (specific takes priority)
+          if (specificAction) {
+            specificAction.render = message.generativeUI;
+          } else if (wildcardAction) {
+            wildcardAction.render = message.generativeUI;
           }
         }
         gqlMessages.push(actionExecMsg);


### PR DESCRIPTION
Fixes #2295 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where catch-all (wildcard) tool renders were not functioning correctly, ensuring proper prioritization between specific and wildcard actions.

* **New Features**
  * Added support for wildcard actions, allowing render functions to be assigned when no specific action matches.

* **Tests**
  * Introduced comprehensive new test suites to verify correct behavior of wildcard and specific action handling during message conversions, increasing reliability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->