### PR TITLE
fix: address issue where two $'s would render a math block

### DIFF
--- a/CopilotKit/.changeset/dirty-poems-destroy.md
+++ b/CopilotKit/.changeset/dirty-poems-destroy.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+- fix: address issue where two $'s would render a math block
+
+Signed-off-by: Tyler Slaton <tyler@copilotkit.ai>

--- a/CopilotKit/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Markdown.tsx
@@ -134,7 +134,7 @@ export const Markdown = ({ content, components }: MarkdownProps) => {
     <div className="copilotKitMarkdown">
       <MemoizedReactMarkdown
         components={{ ...defaultComponents, ...components }}
-        remarkPlugins={[remarkGfm, remarkMath]}
+        remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
         rehypePlugins={[rehypeRaw]}
       >
         {content}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where two consecutive dollar signs ($$) incorrectly rendered a math block in chat markdown. Inline math expressions now require proper delimiters for correct display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->