### PR TITLE
fix: disable system message

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -159,6 +159,8 @@ export type UseChatOptions = {
   langGraphInterruptAction: LangGraphInterruptAction | null;
 
   setLangGraphInterruptAction: LangGraphInterruptActionSetter;
+
+  disableSystemMessage?: boolean;
 };
 
 export type UseChatHelpers = {
@@ -222,6 +224,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
     setExtensions,
     langGraphInterruptAction,
     setLangGraphInterruptAction,
+    disableSystemMessage = false,
   } = options;
   const runChatCompletionRef = useRef<(previousMessages: Message[]) => Promise<Message[]>>();
   const addErrorToast = useErrorToast();
@@ -323,7 +326,11 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
 
       const systemMessage = makeSystemMessageCallback();
 
-      const messagesWithContext = [systemMessage, ...(initialMessages || []), ...previousMessages];
+      const messagesWithContext = disableSystemMessage ? [
+        ...(initialMessages || []), ...previousMessages
+      ] : [
+        systemMessage, ...(initialMessages || []), ...previousMessages
+      ];
 
       // ----- Set mcpServers in properties -----
       // Create a copy of properties to avoid modifying the original object

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -41,6 +41,11 @@ export interface UseCopilotChatOptions {
    * A function to generate the system message. Defaults to `defaultSystemMessage`.
    */
   makeSystemMessage?: SystemMessageFunction;
+
+  /**
+   * Disable/remove the system message provided by CopilotKit by default
+   */
+  disableSystemMessage?: boolean;
 }
 
 export interface MCPServerConfig {
@@ -390,6 +395,7 @@ export function useCopilotChat(options: UseCopilotChatOptions = {}): UseCopilotC
     setExtensions,
     langGraphInterruptAction,
     setLangGraphInterruptAction,
+    disableSystemMessage: options.disableSystemMessage,
   });
 
   const latestAppend = useUpdatedRef(append);

--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -226,6 +226,11 @@ export interface CopilotChatProps {
   makeSystemMessage?: SystemMessageFunction;
 
   /**
+   * Disable/remove the system message provided by CopilotKit by default
+   */
+  disableSystemMessage?: boolean;
+
+  /**
    * A custom assistant message component to use instead of the default.
    */
   AssistantMessage?: React.ComponentType<AssistantMessageProps>;
@@ -384,6 +389,7 @@ export function CopilotChat({
   suggestions = "auto",
   onSubmitMessage,
   makeSystemMessage,
+  disableSystemMessage,
   onInProgress,
   onStopGeneration,
   onReloadMessages,
@@ -584,6 +590,7 @@ export function CopilotChat({
   } = useCopilotChatLogic(
     suggestions,
     makeSystemMessage,
+    disableSystemMessage,
     onInProgress,
     onSubmitMessage,
     onStopGeneration,
@@ -789,6 +796,7 @@ export function WrappedCopilotChat({
 export const useCopilotChatLogic = (
   chatSuggestions: ChatSuggestions,
   makeSystemMessage?: SystemMessageFunction,
+  disableSystemMessage?: boolean,
   onInProgress?: (isLoading: boolean) => void,
   onSubmitMessage?: (messageContent: string) => Promise<void> | void,
   onStopGeneration?: OnStopGeneration,
@@ -809,6 +817,7 @@ export const useCopilotChatLogic = (
     isLoadingSuggestions,
   } = useCopilotChat({
     makeSystemMessage,
+    disableSystemMessage,
   });
 
   const generalContext = useCopilotContext();

--- a/examples/coagents-starter/agent-py/.gitignore
+++ b/examples/coagents-starter/agent-py/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.pyc
 .env
 .vercel
+
+# LangGraph API
+.langgraph_api

--- a/examples/coagents-starter/agent-py/sample_agent/agent.py
+++ b/examples/coagents-starter/agent-py/sample_agent/agent.py
@@ -113,10 +113,9 @@ workflow.set_entry_point("chat_node")
 
 # Conditionally use a checkpointer based on the environment
 # Check for multiple indicators that we're running in LangGraph dev/API mode
-is_langgraph_api = (
-    os.environ.get("LANGGRAPH_API", "false").lower() == "true" or
-    os.environ.get("LANGGRAPH_API_DIR") is not None
-)
+is_langgraph_api = os.environ.get("LANGGRAPH_API_DIR") is not None
+if os.environ.get("LANGGRAPH_API", None) is not None:
+    is_langgraph_api = os.environ.get("LANGGRAPH_API", None).lower() == "true"
 
 if is_langgraph_api:
     # When running in LangGraph API/dev, don't use a custom checkpointer

--- a/examples/coagents-starter/agent-py/sample_agent/demo.py
+++ b/examples/coagents-starter/agent-py/sample_agent/demo.py
@@ -6,6 +6,7 @@ through our FastAPI integration. However, you can also host in LangGraph platfor
 import os
 from dotenv import load_dotenv
 load_dotenv() # pylint: disable=wrong-import-position
+# os.environ["LANGGRAPH_API"] = "false"
 
 from fastapi import FastAPI
 import uvicorn


### PR DESCRIPTION
Today a user doesn't have a ton of intuitive or easy options to disable the CopilotKit system prompt. This leads to:
- Initial loss of trust because "wait, I can edit the system prompt from the UI"?
- Confusion because "oh okay, just add system messages not override"
- To "wait, what is going on with this makeSystemMessage hook"

disableSystemPrompt - Makes it so we do not send any SystemMessage as a part of CopilotKit.