### PR TITLE
runtime: Enforce valid tool sequencing for Anthropic and OpenAI

### DIFF
--- a/CopilotKit/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -274,7 +274,9 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
 
       for (const msg of anthropicMessages) {
         if (msg.role === "user" && Array.isArray(msg.content)) {
-          const block = (msg.content as any[]).find((c) => c && c.type === "tool_result" && c.tool_use_id);
+          const block = (msg.content as any[]).find(
+            (c) => c && c.type === "tool_result" && c.tool_use_id,
+          );
           if (block && block.tool_use_id && !toolResultById.has(block.tool_use_id)) {
             toolResultById.set(block.tool_use_id, { ...msg });
           }
@@ -300,7 +302,9 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
 
         // Skip standalone tool_result; it will be inserted right after its tool_use
         if (msg.role === "user" && Array.isArray(msg.content)) {
-          const block = (msg.content as any[]).find((c) => c && c.type === "tool_result" && c.tool_use_id);
+          const block = (msg.content as any[]).find(
+            (c) => c && c.type === "tool_result" && c.tool_use_id,
+          );
           if (block) {
             continue;
           }

--- a/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/CopilotKit/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -178,9 +178,15 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
 
       for (const msg of openaiMessages) {
         const anyMsg = msg as any;
-        if (anyMsg.role === "assistant" && Array.isArray(anyMsg.tool_calls) && anyMsg.tool_calls.length > 0) {
+        if (
+          anyMsg.role === "assistant" &&
+          Array.isArray(anyMsg.tool_calls) &&
+          anyMsg.tool_calls.length > 0
+        ) {
           const toolCalls = anyMsg.tool_calls;
-          const missing = toolCalls.some((tc: any) => !tc?.id || consumed.has(tc.id) || !toolMessageById.has(tc.id));
+          const missing = toolCalls.some(
+            (tc: any) => !tc?.id || consumed.has(tc.id) || !toolMessageById.has(tc.id),
+          );
           if (missing) {
             // Skip assistant tool_calls without complete tool responses to avoid 400
             continue;


### PR DESCRIPTION
## What does this PR do?

Enforce valid tool sequencing for Anthropic and OpenAI tool_use/tool_call with immediate tool_result/tool, filter unmatched/duplicates)

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures assistant tool calls are immediately followed by their matching tool results for Anthropic and OpenAI, preventing invalid request sequences.
  * Skips incomplete or unmatched tool interactions to avoid API errors and reduce failed responses.
  * Applies token limits after messages are reordered, improving which messages are retained in context.
  * Improves reliability of tool-enabled conversations and streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->