### PR TITLE
fix: address issue where catch-all tool renders don't have the name

### DIFF
--- a/CopilotKit/packages/runtime-client-gql/src/message-conversion/gql-to-agui.ts
+++ b/CopilotKit/packages/runtime-client-gql/src/message-conversion/gql-to-agui.ts
@@ -109,17 +109,31 @@ export function gqlActionExecutionMessageToAGUIMessage(
         }
       }
 
-      // Provide the full props structure that the render function expects
-      const renderProps = {
+      // Base props that all actions receive
+      const baseProps = {
         status: props?.status || status,
         args: message.arguments || {},
         result: props?.result || actionResult || undefined,
-        respond: props?.respond || (() => {}),
         messageId: message.id,
-        ...props,
       };
 
-      return originalRender(renderProps);
+      // Add properties based on action type
+      if (action.name === "*") {
+        // Wildcard actions get the tool name; ensure it cannot be overridden by incoming props
+        return originalRender({
+          ...baseProps,
+          ...props,
+          name: message.name,
+        });
+      } else {
+        // Regular actions get respond (defaulting to a no-op if not provided)
+        const respond = props?.respond ?? (() => {});
+        return originalRender({
+          ...baseProps,
+          ...props,
+          respond,
+        });
+      }
     };
   };
 


### PR DESCRIPTION
Fixes #2311 

## Checklist
- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized render prop shapes: wildcard actions now receive the tool name in render props; regular actions no longer include a name. Status, args, and respond behavior remain consistent, improving rendering consistency across message roundtrips.

* **Tests**
  * Added and expanded tests to verify render-prop shapes and GQL ↔ AGUI roundtrip behavior, ensuring args, name presence/absence, status propagation, and generative UI renders are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->