### PR TITLE
adds HTTP Stream client for MCP, deprecate SSE

### DIFF
--- a/registry/registry/quickstarts/mcp-starter/runtime.ts
+++ b/registry/registry/quickstarts/mcp-starter/runtime.ts
@@ -4,14 +4,15 @@ import {
   copilotRuntimeNextJSAppRouterEndpoint,
 } from "@copilotkit/runtime";
 import { NextRequest } from "next/server";
-import { MCPClient } from "@/registry/quickstarts/mcp-starter/utils/mcp-client";
+import { HttpStreamClient } from "@/registry/quickstarts/mcp-starter/utils/http-stream-client";
 
 const serviceAdapter = new OpenAIAdapter();
 const runtime = new CopilotRuntime({
   createMCPClient: async (config) => {
-    const mcpClient = new MCPClient({
+    const mcpClient = new HttpStreamClient({
       serverUrl: config.endpoint,
     });
+
     await mcpClient.connect();
     return mcpClient;
   },

--- a/registry/registry/quickstarts/mcp-starter/utils/http-stream-client.ts
+++ b/registry/registry/quickstarts/mcp-starter/utils/http-stream-client.ts
@@ -1,0 +1,212 @@
+import { MCPTool, MCPClient as MCPClientInterface } from "@copilotkit/runtime";
+
+/**
+ * HTTP Stream Transport client implementation for MCP
+ * Based on the MCP specification version 2025-03-26
+ *
+ * This implementation supports both:
+ * - Pure HTTP Stream Transport (JSON responses)
+ * - Hybrid SSE/HTTP servers (SSE-formatted responses)
+ *
+ * Many current MCP servers use a hybrid approach where they accept
+ * HTTP POST requests but respond with SSE format. This client handles
+ * both response formats automatically.
+ */
+export class HttpStreamClient implements MCPClientInterface {
+  private baseUrl: string;
+  private sessionId: string | null = null;
+  private eventSource: EventSource | null = null;
+  private headers: Record<string, string>;
+  private toolsCache: Record<string, MCPTool> | null = null;
+
+  constructor(options: {
+    serverUrl: string;
+    headers?: Record<string, string>;
+  }) {
+    this.baseUrl = options.serverUrl;
+    this.headers = options.headers || {};
+  }
+
+  async connect(): Promise<void> {
+    // Initialize connection
+    const initRequest = {
+      jsonrpc: "2.0",
+      id: "init-" + Date.now(),
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: {
+          name: "cpk-http-client",
+          version: "1.0.0",
+        },
+      },
+    };
+
+    const response = await fetch(this.baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        ...this.headers,
+      },
+      body: JSON.stringify(initRequest),
+    });
+
+    // Handle SSE response format
+    let responseData;
+    const contentType = response.headers.get("content-type");
+    if (contentType?.includes("text/event-stream")) {
+      // Parse SSE response
+      const text = await response.text();
+      const lines = text.split("\n");
+      const dataLine = lines.find((line) => line.startsWith("data:"));
+      if (dataLine) {
+        responseData = JSON.parse(dataLine.substring(5).trim());
+      }
+    } else {
+      responseData = await response.json();
+    }
+
+    // Store session ID
+    this.sessionId = response.headers.get("Mcp-Session-Id");
+
+    // Open SSE stream for server messages (only if we have a session)
+    if (this.sessionId) {
+      this.openEventStream();
+    }
+
+    console.log(`Connected with session: ${this.sessionId}`);
+  }
+
+  private openEventStream() {
+    if (!this.sessionId) return;
+
+    const url = new URL(this.baseUrl);
+    url.searchParams.append("session", this.sessionId);
+
+    this.eventSource = new EventSource(url.toString());
+
+    this.eventSource.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data);
+        console.log("Received server message:", message);
+      } catch (e) {
+        console.error("Error parsing SSE message:", e);
+      }
+    };
+
+    this.eventSource.onerror = () => {
+      console.error("SSE connection error, reconnecting...");
+      setTimeout(() => this.openEventStream(), 1000);
+    };
+  }
+
+  async tools(): Promise<Record<string, MCPTool>> {
+    if (this.toolsCache) return this.toolsCache;
+
+    const request = {
+      jsonrpc: "2.0",
+      id: "tools-" + Date.now(),
+      method: "tools/list",
+      params: {},
+    };
+
+    const response = await fetch(this.baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": this.sessionId!,
+        ...this.headers,
+      },
+      body: JSON.stringify(request),
+    });
+
+    // Handle SSE response format
+    let result;
+    const contentType = response.headers.get("content-type");
+    if (contentType?.includes("text/event-stream")) {
+      // Parse SSE response
+      const text = await response.text();
+      const lines = text.split("\n");
+      const dataLine = lines.find((line) => line.startsWith("data:"));
+      if (dataLine) {
+        result = JSON.parse(dataLine.substring(5).trim());
+      }
+    } else {
+      result = await response.json();
+    }
+    const toolsMap: Record<string, MCPTool> = {};
+
+    if (result.result?.tools) {
+      for (const tool of result.result.tools) {
+        toolsMap[tool.name] = {
+          description: tool.description,
+          schema: tool.inputSchema,
+          execute: async (args: any) => this.callTool(tool.name, args),
+        };
+      }
+    }
+
+    this.toolsCache = toolsMap;
+    return toolsMap;
+  }
+
+  private async callTool(name: string, args: any): Promise<any> {
+    const request = {
+      jsonrpc: "2.0",
+      id: `tool-${name}-${Date.now()}`,
+      method: "tools/call",
+      params: {
+        name: name,
+        arguments: args,
+      },
+    };
+
+    const response = await fetch(this.baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": this.sessionId!,
+        ...this.headers,
+      },
+      body: JSON.stringify(request),
+    });
+
+    // Handle SSE response format
+    let result;
+    const contentType = response.headers.get("content-type");
+    if (contentType?.includes("text/event-stream")) {
+      // Parse SSE response
+      const text = await response.text();
+      const lines = text.split("\n");
+      const dataLine = lines.find((line) => line.startsWith("data:"));
+      if (dataLine) {
+        result = JSON.parse(dataLine.substring(5).trim());
+      }
+    } else {
+      result = await response.json();
+    }
+    return result.result;
+  }
+
+  async close(): Promise<void> {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+
+    if (this.sessionId) {
+      await fetch(this.baseUrl, {
+        method: "DELETE",
+        headers: {
+          "Mcp-Session-Id": this.sessionId,
+          ...this.headers,
+        },
+      });
+      this.sessionId = null;
+    }
+  }
+}

--- a/registry/registry/quickstarts/mcp-starter/utils/mcp-client.ts
+++ b/registry/registry/quickstarts/mcp-starter/utils/mcp-client.ts
@@ -1,6 +1,8 @@
 import { MCPTool, MCPClient as MCPClientInterface } from "@copilotkit/runtime";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+// TODO: Replace with HttpClientTransport when available in SDK
+// import { HttpClientTransport } from "@modelcontextprotocol/sdk/client/http.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
 export interface McpClientOptions {
@@ -14,6 +16,12 @@ export interface McpClientOptions {
 
 /**
  * McpClient - A Model Context Protocol client implementation
+ * 
+ * @deprecated SSE transport is deprecated. Use HttpStreamClient instead which supports
+ * the new HTTP Stream Transport protocol and is compatible with modern MCP servers.
+ * 
+ * This class uses the deprecated SSE (Server-Sent Events) transport.
+ * Many modern MCP servers (like Composio) no longer support pure SSE connections.
  *
  * This class implements the Model Context Protocol (MCP) client, which allows for
  * standardized communication with MCP servers. It's designed to be compatible with
@@ -49,6 +57,7 @@ export class MCPClient implements MCPClientInterface {
     this.onClose = options.onClose || (() => console.log("Connection closed"));
 
     // Initialize the SSE transport with headers
+    // TODO: Migrate to HttpClientTransport when available
     this.transport = new SSEClientTransport(this.serverUrl, this.headers);
 
     // Initialize the client
@@ -89,7 +98,7 @@ export class MCPClient implements MCPClientInterface {
   }
 
   /**
-   * Connects to the MCP server using SSE
+   * Connects to the MCP server using SSE (will migrate to HTTP Stream when available)
    */
   public async connect(): Promise<void> {
     try {

--- a/registry/registry/quickstarts/mcp-starter/utils/mcp-client.ts
+++ b/registry/registry/quickstarts/mcp-starter/utils/mcp-client.ts
@@ -16,10 +16,10 @@ export interface McpClientOptions {
 
 /**
  * McpClient - A Model Context Protocol client implementation
- * 
+ *
  * @deprecated SSE transport is deprecated. Use HttpStreamClient instead which supports
  * the new HTTP Stream Transport protocol and is compatible with modern MCP servers.
- * 
+ *
  * This class uses the deprecated SSE (Server-Sent Events) transport.
  * Many modern MCP servers (like Composio) no longer support pure SSE connections.
  *


### PR DESCRIPTION
## What does this PR do?

This PR migrates MCP (Model Context Protocol) client implementation from deprecated SSE transport to the new HTTP Stream Transport protocol.

**Changes:**

- Added `HttpStreamClient` that supports both pure HTTP Stream and hybrid SSE/HTTP response formats
- Marked `MCPClient` (SSE-based) as deprecated with clear migration guidance
- Updated runtime configuration to use HTTP Stream client by default
- Configured runtime with Reddit READ-capable MCP server endpoint

**Why this change:**

- SSE transport is deprecated as of MCP spec v2025-03-26
- Many modern MCP servers (like Composio) no longer support pure SSE connections
- HTTP Stream Transport is the recommended approach going forward

## Related PRs and Issues

- MCP SSE Deprecation: https://mcp-framework.com/docs/Transports/sse/
- HTTP Stream Transport docs: https://mcp-framework.com/docs/Transports/http-stream-transport

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added HTTP streaming client for connecting to MCP servers, enabling broader compatibility and more reliable message handling. Supports both HTTP-stream and SSE-style responses transparently.
- Refactor
  - Switched internal transport to HTTP streaming without changing the public API. Improves connection stability, session handling, and tool execution.
- Documentation
  - Added deprecation notice for the legacy SSE transport and notes on future migration to HTTP streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->