### PR TITLE
fix(docs): Guard TailoredContent icon cloning to avoid invalid element

### DIFF
--- a/docs/components/react/tailored-content.tsx
+++ b/docs/components/react/tailored-content.tsx
@@ -80,9 +80,13 @@ export function TailoredContent({ children, className, defaultOptionIndex = 0, i
               tabIndex={0}
             >
               <div className="my-0">
-                {React.cloneElement(option.props.icon as React.ReactElement, {
-                  className: cn(iconCn, selectedIndex === index, "my-0"),
-                })}
+                {React.isValidElement(option.props.icon)
+                  ? React.cloneElement(option.props.icon as React.ReactElement, {
+                      className: cn(iconCn, selectedIndex === index, "my-0"),
+                    })
+                  : (
+                      <span className={cn(iconCn, "my-0")} />
+                    )}
               </div>
               <div>
                 <p className="font-semibold text-lg">{option.props.title}</p>


### PR DESCRIPTION
## What does this PR do?

Guard TailoredContent icon cloning to avoid invalid element (React error #130) on pydantic-ai quickstart

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in TailoredContent: option icons now render safely even when not provided as React elements, preventing runtime errors.
  * When an icon is invalid, a visual placeholder is rendered to preserve spacing and alignment, ensuring consistent layout across options.
  * Behavior for valid icons remains unchanged; URL parameter handling, selected state, and styling are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->