### PR TITLE
[DOCS] Fixed broken links on Styling Copilot UI page

### DIFF
--- a/docs/snippets/shared/guides/custom-look-and-feel/customize-built-in-ui-components.mdx
+++ b/docs/snippets/shared/guides/custom-look-and-feel/customize-built-in-ui-components.mdx
@@ -7,8 +7,8 @@ CopilotKit has a variety of ways to customize colors and structures of the Copil
 - [Custom Labels](#custom-labels)
 
 If you want to customize the style as well as the functionality of the Copilot UI, you can also try the following:
-- [Custom Sub-Components](/guides/custom-look-and-feel/bring-your-own-components)
-- [Fully Headless UI](/guides/custom-look-and-feel/headless-ui)
+- [Custom Sub-Components](/custom-look-and-feel/bring-your-own-components)
+- [Fully Headless UI](/custom-look-and-feel/headless-ui)
 
 ## CSS Variables (Easiest)
 The easiest way to change the colors using in the Copilot UI components is to override CopilotKit CSS variables.


### PR DESCRIPTION
## Fixes broken links on "Styling Copilot UI" page

### Fixed 2 broken link:

from this:
```
- [Custom Sub-Components](/guides/custom-look-and-feel/bring-your-own-components)
- [Fully Headless UI](/guides/custom-look-and-feel/headless-ui)
```

to this
```
- [Custom Sub-Components](/custom-look-and-feel/bring-your-own-components)
- [Fully Headless UI](/custom-look-and-feel/headless-ui)
```

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated two navigation links in the customization guide to point to the correct URLs for “Custom Sub-Components” and “Fully Headless UI.”
  * Improves navigation accuracy and prevents broken or redirected links when exploring options for customizing the built-in UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->