### PR TITLE
feat: send streamSubgraphs forwarded prop to AGUI

### DIFF
--- a/CopilotKit/.changeset/thirty-crabs-press.md
+++ b/CopilotKit/.changeset/thirty-crabs-press.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- feat: send streamSubgraphs forwarded prop to AGUI

--- a/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
@@ -58,7 +58,7 @@ export function constructAGUIRemoteAction({
       });
 
       let state = {};
-      let config = {};
+      let config: Record<string, unknown> = {};
       if (agentStates) {
         const jsonState = agentStates.find((state) => state.agentName === agent.agentId);
         if (jsonState) {
@@ -76,11 +76,14 @@ export function constructAGUIRemoteAction({
         };
       });
 
+      const { streamSubgraphs, ...restConfig } = config;
+
       const forwardedProps = {
-        config,
+        config: restConfig,
         ...(metaEvents?.length ? { command: { resume: metaEvents[0]?.response } } : {}),
         ...(threadMetadata ? { threadMetadata } : {}),
         ...(nodeName ? { nodeName } : {}),
+        ...(streamSubgraphs ? { streamSubgraphs } : {}),
         // Forward properties from the graphql context to the agent, e.g Authorization token
         ...graphqlContext.properties,
       };


### PR DESCRIPTION
In preparation for langgraph subgraphs support in AGUI, this PR send a "forwarded prop" of `streamSubgraphs` which will be sent to and used by AGUI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Runtime now forwards the streamSubgraphs option to AGUI when provided, enabling streaming subgraphs in compatible integrations. No breaking changes.

- Chores
  - Added a changeset entry for a patch release of @copilotkit/runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->