### PR TITLE
fix(react-core): allow maxTokens in forwardedParameters

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -114,7 +114,7 @@ export interface CopilotKitProps {
   /**
    * The forwarded parameters to use for the task.
    */
-  forwardedParameters?: Pick<ForwardedParametersInput, "temperature">;
+  forwardedParameters?: Pick<ForwardedParametersInput, "temperature" | "maxTokens">;
 
   /**
    * The auth config to use for the CopilotKit.

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -201,7 +201,7 @@ export interface CopilotContextParams {
   /**
    * The forwarded parameters to use for the task.
    */
-  forwardedParameters?: Partial<Pick<ForwardedParametersInput, "temperature">>;
+  forwardedParameters?: Partial<Pick<ForwardedParametersInput, "temperature" | "maxTokens">>;
   availableAgents: Agent[];
 
   /**

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -121,7 +121,7 @@ export type UseChatOptions = {
   /**
    * The forwarded parameters.
    */
-  forwardedParameters?: Pick<ForwardedParametersInput, "temperature">;
+  forwardedParameters?: Pick<ForwardedParametersInput, "temperature" | "maxTokens">;
 
   /**
    * The current thread ID.

--- a/docs/content/docs/reference/components/CopilotKit.mdx
+++ b/docs/content/docs/reference/components/CopilotKit.mdx
@@ -106,7 +106,7 @@ Whether to show the dev console.
 The name of the agent to use.
 </PropertyReference>
 
-<PropertyReference name="forwardedParameters" type="Pick<ForwardedParametersInput, 'temperature'>"  > 
+<PropertyReference name="forwardedParameters" type="Pick<ForwardedParametersInput, 'temperature' | 'maxTokens'>"  > 
 The forwarded parameters to use for the task.
 </PropertyReference>
 


### PR DESCRIPTION
## What does this PR do?

This PR updates the type definition of `forwardedParameters` in `CopilotKitProps` to include `maxTokens` in addition to `temperature`.  
Previously, only `temperature` was allowed, which required developers to use `// @ts-ignore` to pass `maxTokens`.  
With this change, `maxTokens` can now be used safely and properly typed.

## Related PRs and Issues

- Fixes [GitHub issue #2354](https://github.com/CopilotKit/CopilotKit/issues/2354)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation