### PR TITLE
fix: enable erasing chat state on new thread creation

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
@@ -282,7 +282,7 @@ export function CopilotMessages({ children }: { children: ReactNode }) {
       const newMessages = result.data?.loadAgentState?.messages;
       if (newMessages === lastLoadedMessages.current) return;
 
-      if (result.data?.loadAgentState?.threadExists) {
+      if (result.data?.loadAgentState) {
         lastLoadedMessages.current = newMessages;
         lastLoadedThreadId.current = threadId;
         lastLoadedAgentName.current = agentSession?.agentName;


### PR DESCRIPTION
When switching threads, we only consider a thread "existing" or valid if it has data. New threads are also valid but they do not have data. This fix enables the "cleanup" of chat when new thread is created and its ID is being passed to CPK