### PR TITLE
docs: update installation instructions to include ddgs alongside duckduckgo-search

### DIFF
--- a/docs/content/docs/agno/generative-ui/tool-based.mdx
+++ b/docs/content/docs/agno/generative-ui/tool-based.mdx
@@ -48,7 +48,7 @@ as this guide uses it as a starting point.
 <Step>
 ### Install the DuckDuckGo search tool
 ```bash
-pip install duckduckgo-search
+pip install ddgs duckduckgo-search
 ```
 
 </Step>


### PR DESCRIPTION
docs: update installation instructions to include ddgs alongside duckduckgo-search

I tested the Agno Generative UI from scratch. Once you follow all the steps in the documentation and start the agent, it gives an error:
"duckduckgo-search" not installed. Please install using "pip install ddgs".
After installing ddgs, it works perfectly fine. So adding ddgs as well
