### PR TITLE
docs: add missing OpenAIChat import in agno quickstart => integrate with existing agent

### DIFF
--- a/docs/content/docs/agno/concepts/copilotkit-stream.mdx
+++ b/docs/content/docs/agno/concepts/copilotkit-stream.mdx
@@ -14,6 +14,7 @@ Message streaming is enabled by default when using your Agno Agents together wit
 ```python
 from agno.app.agui.app import AGUIApp
 from agno.agent.agent import Agent
+from agno.models.openai import OpenAIChat
 
 # Setup your Agno Agent
 agent = Agent(


### PR DESCRIPTION
docs: add missing OpenAIChat import in agno quickstart => integrate with existing agent
`from agno.models.openai import OpenAIChat`
It would otherwise through the error,  "OpenAIChat undefined"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Copilotkit streaming example by adding the missing import required for the agent setup, ensuring the snippet runs as-is when copied.
  * Improved accuracy of the guide without altering application behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->