### PR TITLE
feat: pass copilot readable context to agui agents

### DIFF
--- a/CopilotKit/.changeset/dry-schools-joke.md
+++ b/CopilotKit/.changeset/dry-schools-joke.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/react-core": patch
+"@copilotkit/runtime": patch
+---
+
+- feat: pass copilot readable context to agui agents

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -231,11 +231,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
   const { setBannerError } = useToast();
 
   // Get onError from context since it's not part of copilotConfig
-  const {
-    onError,
-    showDevConsole,
-    getAllContext,
-  } = useCopilotContext();
+  const { onError, showDevConsole, getAllContext } = useCopilotContext();
 
   // Add tracing functionality to use-chat
   const traceUIError = async (error: CopilotKitError, originalError?: any) => {
@@ -363,17 +359,19 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
       // -------------------------------------------------------------
 
       const isAgentRun = agentSessionRef.current !== null;
-      const copilotReadableContext = getAllContext()
+      const copilotReadableContext = getAllContext();
 
-      const context = useMemo(() => (
-        copilotReadableContext.map((contextItem) => {
-          const [description, ...valueParts] = contextItem.value.split(":");
-          return {
-            description: description.trim(),
-            value: valueParts.join(":").trim(),
-          };
-        })
-      ), [copilotReadableContext]);
+      const context = useMemo(
+        () =>
+          copilotReadableContext.map((contextItem) => {
+            const [description, ...valueParts] = contextItem.value.split(":");
+            return {
+              description: description.trim(),
+              value: valueParts.join(":").trim(),
+            };
+          }),
+        [copilotReadableContext],
+      );
 
       const stream = runtimeClient.asStream(
         runtimeClient.generateCopilotResponse({

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -233,6 +233,20 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
   // Get onError from context since it's not part of copilotConfig
   const { onError, showDevConsole, getAllContext } = useCopilotContext();
 
+  const copilotReadableContext = getAllContext();
+
+  const context = useMemo(
+    () =>
+      copilotReadableContext.map((contextItem) => {
+        const [description, ...valueParts] = contextItem.value.split(":");
+        return {
+          description: description.trim(),
+          value: valueParts.join(":").trim(),
+        };
+      }),
+    [copilotReadableContext],
+  );
+
   // Add tracing functionality to use-chat
   const traceUIError = async (error: CopilotKitError, originalError?: any) => {
     try {
@@ -359,19 +373,6 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
       // -------------------------------------------------------------
 
       const isAgentRun = agentSessionRef.current !== null;
-      const copilotReadableContext = getAllContext();
-
-      const context = useMemo(
-        () =>
-          copilotReadableContext.map((contextItem) => {
-            const [description, ...valueParts] = contextItem.value.split(":");
-            return {
-              description: description.trim(),
-              value: valueParts.join(":").trim(),
-            };
-          }),
-        [copilotReadableContext],
-      );
 
       const stream = runtimeClient.asStream(
         runtimeClient.generateCopilotResponse({
@@ -887,6 +888,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
       agentSession,
       setAgentSession,
       disableSystemMessage,
+      context,
     ],
   );
 

--- a/CopilotKit/packages/runtime/package.json
+++ b/CopilotKit/packages/runtime/package.json
@@ -50,7 +50,7 @@
     "@ag-ui/client": "^0.0.37",
     "@ag-ui/core": "^0.0.37",
     "@ag-ui/encoder": "^0.0.37",
-    "@ag-ui/langgraph": "^0.0.12",
+    "@ag-ui/langgraph": "^0.0.13",
     "@ag-ui/proto": "^0.0.37",
     "@anthropic-ai/sdk": "^0.57.0",
     "@copilotkit/shared": "workspace:*",

--- a/CopilotKit/packages/runtime/src/graphql/inputs/copilot-context.input.ts
+++ b/CopilotKit/packages/runtime/src/graphql/inputs/copilot-context.input.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from "type-graphql";
+
+@InputType()
+export class CopilotContextInput {
+  @Field(() => String)
+  description: string;
+
+  @Field(() => String)
+  value: string;
+}

--- a/CopilotKit/packages/runtime/src/graphql/inputs/generate-copilot-response.input.ts
+++ b/CopilotKit/packages/runtime/src/graphql/inputs/generate-copilot-response.input.ts
@@ -8,6 +8,7 @@ import { AgentSessionInput } from "./agent-session.input";
 import { AgentStateInput } from "./agent-state.input";
 import { ExtensionsInput } from "./extensions.input";
 import { MetaEventInput } from "./meta-event.input";
+import { CopilotContextInput } from "./copilot-context.input";
 
 @InputType()
 export class GenerateCopilotResponseMetadataInput {
@@ -52,4 +53,7 @@ export class GenerateCopilotResponseInput {
 
   @Field(() => [MetaEventInput], { nullable: true })
   metaEvents?: MetaEventInput[];
+
+  @Field(() => [CopilotContextInput], { nullable: true })
+  context?: CopilotContextInput[];
 }

--- a/CopilotKit/packages/runtime/src/graphql/resolvers/copilot.resolver.ts
+++ b/CopilotKit/packages/runtime/src/graphql/resolvers/copilot.resolver.ts
@@ -257,6 +257,7 @@ export class CopilotResolver {
         url: data.frontend.url,
         extensions: data.extensions,
         metaEvents: data.metaEvents,
+        context: data.context,
       });
     } catch (error) {
       // Catch structured CopilotKit errors at the main mutation level and re-throw as GraphQL errors

--- a/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/agui-action.ts
@@ -16,6 +16,7 @@ import { AbstractAgent } from "@ag-ui/client";
 import { CopilotKitError, CopilotKitErrorCode, parseJson } from "@copilotkit/shared";
 import { MetaEventInput } from "../../graphql/inputs/meta-event.input";
 import { GraphQLContext } from "../integrations/shared";
+import { CopilotContextInput } from "../../graphql/inputs/copilot-context.input";
 
 export function constructAGUIRemoteAction({
   logger,
@@ -25,6 +26,7 @@ export function constructAGUIRemoteAction({
   metaEvents,
   threadMetadata,
   nodeName,
+  context,
   graphqlContext,
 }: {
   logger: Logger;
@@ -34,6 +36,7 @@ export function constructAGUIRemoteAction({
   metaEvents?: MetaEventInput[];
   threadMetadata?: Record<string, any>;
   nodeName?: string;
+  context?: CopilotContextInput[];
   graphqlContext: GraphQLContext;
 }) {
   const action = {
@@ -92,6 +95,7 @@ export function constructAGUIRemoteAction({
         agent.legacy_to_be_removed_runAgentBridged({
           tools,
           forwardedProps,
+          context,
         }) as Observable<RuntimeEvent>
       ).pipe(
         mergeMap((event) => {

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -90,6 +90,7 @@ type CreateMCPClientFunction = (config: MCPEndpointConfig) => Promise<MCPClient>
 // --- MCP Imports ---
 
 import { generateHelpfulErrorMessage } from "../streaming";
+import { CopilotContextInput } from "../../graphql/inputs/copilot-context.input";
 
 export interface CopilotRuntimeRequest {
   serviceAdapter: CopilotServiceAdapter;
@@ -106,6 +107,7 @@ export interface CopilotRuntimeRequest {
   url?: string;
   extensions?: ExtensionsInput;
   metaEvents?: MetaEventInput[];
+  context?: CopilotContextInput[];
 }
 
 interface CopilotRuntimeResponse {
@@ -484,6 +486,7 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
       agentSession,
       agentStates,
       publicApiKey,
+      context,
     } = request;
 
     const eventSource = new RuntimeEventSource({
@@ -1025,6 +1028,7 @@ please use an LLM adapter instead.`,
       metaEvents,
       publicApiKey,
       forwardedParameters,
+      context,
     } = request;
     const { agentName, nodeName } = agentSession;
 
@@ -1408,6 +1412,7 @@ please use an LLM adapter instead.`,
       agents: this.agents,
       metaEvents: request.metaEvents,
       nodeName: request.agentSession?.nodeName,
+      context: request.context,
     });
 
     const configuredActions =

--- a/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
@@ -180,16 +180,22 @@ export class LangGraphAgent extends AGUILangGraphAgent {
   }
 
   langGraphDefaultMergeState(state: State, messages: LangGraphMessage[], tools: any): State {
-    const { tools: returnedTools, ...rest } = super.langGraphDefaultMergeState(
-      state,
-      messages,
-      tools,
-    );
+    const {
+      tools: returnedTools,
+      "ag-ui": agui,
+      ...rest
+    } = super.langGraphDefaultMergeState(state, messages, tools);
+
+    const combinedTools = {
+      ...returnedTools,
+      ...(agui?.tools ?? []),
+    };
 
     return {
       ...rest,
       copilotkit: {
-        actions: returnedTools,
+        actions: combinedTools,
+        context: agui?.context ?? [],
       },
     };
   }

--- a/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
@@ -25,10 +25,10 @@ import { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types
 import { ThreadState } from "@langchain/langgraph-sdk";
 
 interface CopilotKitStateEnrichment {
-    copilotkit: {
-        actions: StateEnrichment['ag-ui']['tools'];
-        context: StateEnrichment['ag-ui']['context'];
-    }
+  copilotkit: {
+    actions: StateEnrichment["ag-ui"]["tools"];
+    context: StateEnrichment["ag-ui"]["context"];
+  };
 }
 
 export interface PredictStateTool {
@@ -193,10 +193,7 @@ export class LangGraphAgent extends AGUILangGraphAgent {
     input: RunAgentInput,
   ): State<StateEnrichment & CopilotKitStateEnrichment> {
     const aguiMergedState = super.langGraphDefaultMergeState(state, messages, input);
-    const {
-      tools: returnedTools,
-      "ag-ui": agui,
-    } = aguiMergedState
+    const { tools: returnedTools, "ag-ui": agui } = aguiMergedState;
     // tolerate undefined and de-duplicate by stable key (id | name | key)
     const rawCombinedTools = [
       ...((returnedTools as any[]) ?? []),

--- a/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
@@ -179,17 +179,17 @@ export class LangGraphAgent extends AGUILangGraphAgent {
     );
   }
 
-  langGraphDefaultMergeState(state: State, messages: LangGraphMessage[], tools: any): State {
+  langGraphDefaultMergeState(state: State, messages: LangGraphMessage[], input: RunAgentInput): State {
     const {
       tools: returnedTools,
       "ag-ui": agui,
       ...rest
-    } = super.langGraphDefaultMergeState(state, messages, tools);
+    } = super.langGraphDefaultMergeState(state, messages, input);
 
-    const combinedTools = {
+    const combinedTools = [
       ...returnedTools,
       ...(agui?.tools ?? []),
-    };
+    ];
 
     return {
       ...rest,

--- a/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/langgraph/langgraph-agent.ts
@@ -179,17 +179,27 @@ export class LangGraphAgent extends AGUILangGraphAgent {
     );
   }
 
-  langGraphDefaultMergeState(state: State, messages: LangGraphMessage[], input: RunAgentInput): State {
+  langGraphDefaultMergeState(
+    state: State,
+    messages: LangGraphMessage[],
+    input: RunAgentInput,
+  ): State {
     const {
       tools: returnedTools,
       "ag-ui": agui,
       ...rest
     } = super.langGraphDefaultMergeState(state, messages, input);
 
-    const combinedTools = [
-      ...returnedTools,
-      ...(agui?.tools ?? []),
+    // tolerate undefined and de-duplicate by stable key (id | name | key)
+    const rawCombinedTools = [
+      ...((returnedTools as any[]) ?? []),
+      ...((agui?.tools as any[]) ?? []),
     ];
+    const combinedTools = Array.from(
+      new Map(
+        rawCombinedTools.map((t: any) => [t?.id ?? t?.name ?? t?.key ?? JSON.stringify(t), t]),
+      ).values(),
+    );
 
     return {
       ...rest,

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -19,6 +19,7 @@ import {
 import { MetaEventInput } from "../../graphql/inputs/meta-event.input";
 import { AbstractAgent } from "@ag-ui/client";
 import { constructAGUIRemoteAction } from "./agui-action";
+import { CopilotContextInput } from "../../graphql/inputs/copilot-context.input";
 
 export type EndpointDefinition = CopilotKitEndpoint | LangGraphPlatformEndpoint;
 
@@ -132,6 +133,7 @@ export async function setupRemoteActions({
   agents,
   metaEvents,
   nodeName,
+  context,
 }: {
   remoteEndpointDefinitions: EndpointDefinition[];
   graphqlContext: GraphQLContext;
@@ -141,6 +143,7 @@ export async function setupRemoteActions({
   agents: Record<string, AbstractAgent>;
   metaEvents?: MetaEventInput[];
   nodeName?: string;
+  context?: CopilotContextInput[];
 }): Promise<Action[]> {
   const logger = graphqlContext.logger.child({ component: "remote-actions.fetchRemoteActions" });
   logger.debug({ remoteEndpointDefinitions }, "Fetching from remote endpoints");
@@ -211,6 +214,7 @@ export async function setupRemoteActions({
         threadMetadata,
         nodeName,
         graphqlContext,
+        context,
       }),
     );
   }

--- a/CopilotKit/packages/sdk-js/src/langgraph.ts
+++ b/CopilotKit/packages/sdk-js/src/langgraph.ts
@@ -20,6 +20,7 @@ interface OptionsConfig {
 
 export const CopilotKitPropertiesAnnotation = Annotation.Root({
   actions: Annotation<any[]>,
+  context: Annotation<{ description: string; value: string }[]>,
 });
 
 export const CopilotKitStateAnnotation = Annotation.Root({

--- a/CopilotKit/pnpm-lock.yaml
+++ b/CopilotKit/pnpm-lock.yaml
@@ -598,8 +598,8 @@ importers:
         specifier: ^0.0.37
         version: 0.0.37
       '@ag-ui/langgraph':
-        specifier: ^0.0.12
-        version: 0.0.12(@ag-ui/client@0.0.37)(@ag-ui/core@0.0.37)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.13
+        version: 0.0.13(@ag-ui/client@0.0.37)(@ag-ui/core@0.0.37)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
       '@ag-ui/proto':
         specifier: ^0.0.37
         version: 0.0.37
@@ -971,8 +971,8 @@ packages:
   '@ag-ui/encoder@0.0.37':
     resolution: {integrity: sha512-KD5t0ll3n1pn1ZX1xwQ1YxYZrtJjIttLEsUpj8mQgfh8+ZQ1ZSvlPSciKOQkHf7+Sw9eS6kHVDd5nOOLV1N1xw==}
 
-  '@ag-ui/langgraph@0.0.12':
-    resolution: {integrity: sha512-2j7IqIUYh0WAdvCXH65hd5aSHi23EOKVo78BauXa2vZI8Pricpkq9Adr2coZB2cwCbTV37lMn5yVlpDV0iQvOA==}
+  '@ag-ui/langgraph@0.0.13':
+    resolution: {integrity: sha512-/HtqlXHubs96DC6sVpXhjNlV9yKfc+KhtB913kqWAiGm4by4TnJNQVU+JSkEEy04AN3lSBcA5wuszlv3zvl7Ew==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.37'
       '@ag-ui/core': '>=0.0.37'
@@ -10250,7 +10250,7 @@ snapshots:
       '@ag-ui/core': 0.0.37
       '@ag-ui/proto': 0.0.37
 
-  '@ag-ui/langgraph@0.0.12(@ag-ui/client@0.0.37)(@ag-ui/core@0.0.37)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
+  '@ag-ui/langgraph@0.0.13(@ag-ui/client@0.0.37)(@ag-ui/core@0.0.37)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ag-ui/client': 0.0.37
       '@ag-ui/core': 0.0.37

--- a/docs/content/docs/langgraph/agent-app-context.mdx
+++ b/docs/content/docs/langgraph/agent-app-context.mdx
@@ -1,0 +1,198 @@
+---
+title: Shared Context Between the Agent and App
+icon: "lucide/BookA"
+description: Share app specific context with your agent.
+---
+
+One of the most common use cases for CopilotKit is to register app state and context using `useCopilotReadble`.
+This way, you can notify CopilotKit of what is going in your app in real time.
+Some examples might be: the current user, the current page, etc.
+
+This context can then be shared with your LangGraph agent.
+
+## Implementation
+<Callout>
+    Check out the [Frontend Data documentation](https://docs.copilotkit.ai/direct-to-llm/guides/connect-your-data/frontend) to understand what this is and how to use it.
+</Callout>
+
+<Steps>
+    <Step>
+        ### Add the data to the Copilot
+
+        The [`useCopilotReadable` hook](/reference/hooks/useCopilotReadable) is used to add data as context to the Copilot.
+
+        ```tsx title="YourComponent.tsx" showLineNumbers {1, 7-10}
+        "use client" // only necessary if you are using Next.js with the App Router. // [!code highlight]
+        import { useCopilotReadable } from "@copilotkit/react-core"; // [!code highlight]
+        import { useState } from 'react';
+
+        export function YourComponent() {
+            // Create colleagues state with some sample data
+            const [colleagues, setColleagues] = useState([
+                { id: 1, name: "John Doe", role: "Developer" },
+                { id: 2, name: "Jane Smith", role: "Designer" },
+                { id: 3, name: "Bob Wilson", role: "Product Manager" }
+            ]);
+
+            // Define Copilot readable state
+            // [!code highlight:5]
+            useCopilotReadable({
+                description: "The current user's colleagues",
+                value: colleagues,
+            });
+            return (
+                // Your custom UI component
+                <>...</>
+            );
+        }
+        ```
+    </Step>
+
+    <Step>
+        ### Setup your agent state
+        Make sure your agent state inherits from CopilotKit state definition
+
+        <Tabs groupId="language" items={['Python', 'TypeScript']} default="Python">
+            <Tab value="Python">
+                ```python title="agent/sample_agent/agent.py"
+                # ...
+                from copilotkit import CopilotKitState # extends MessagesState
+                # ...
+
+                # This is the state of the agent.
+                # It inherits from the CopilotKitState properties from CopilotKit.
+                class AgentState(CopilotKitState):
+                    # ... Your defined state properties
+                ```
+            </Tab>
+            <Tab value="TypeScript">
+                ```typescript title="agent-js/src/agent.ts"
+                // ...
+                import { Annotation } from "@langchain/langgraph";
+                import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
+                // ...
+
+                // This is the state of the agent.
+                // It inherits from the CopilotKitState properties from CopilotKit.
+                export const AgentStateAnnotation = Annotation.Root({
+                    // ... Your defined state properties
+                    ...CopilotKitStateAnnotation.spec,
+                });
+                export type AgentState = typeof AgentStateAnnotation.State;
+                ```
+            </Tab>
+        </Tabs>
+
+    </Step>
+
+    <Step>
+        ### Consume the data in your LangGraph agent
+        The state of a LangGraph agent is the "hub" for applicative information used by the agent.
+        Naturally, the context from CopilotKit will be injected there.
+
+        <Tabs groupId="language" items={['Python', 'TypeScript']} default="Python">
+            <Tab value="Python">
+                ```python title="agent/sample_agent/agent.py"
+                from langchain_core.messages import SystemMessage
+                from langchain_openai import ChatOpenAI
+                from copilotkit import CopilotKitState
+
+                # add the agent state definition from the previous step
+                class AgentState(CopilotKitState):
+                    # ... Your defined state properties
+
+                def chat_node(state: AgentState, config: RunnableConfig):
+                    # Extract the colleagues from CopilotKit context
+                    colleagues_context_item = next(
+                        (item for item in state["copilotkit"]["context"] if item.get("description") == "The current user's colleagues"),
+                        None
+                    )
+                    colleagues = colleagues_context_item.get("value") if colleagues_context_item else []
+
+                    # Provide the list of colleagues to the LLM
+                    system_message = SystemMessage(
+                        content=f"""You are a helpful assistant that can help emailing colleagues.
+                        The user's colleagues are: {colleagues}"""
+                    )
+
+                    response = ChatOpenAI(model="gpt-4o").invoke(
+                        [system_message, *state["messages"]],
+                        config
+                    )
+
+                    return {
+                        **state,
+                        "messages": response,
+                    }
+                ```
+            </Tab>
+            <Tab value="TypeScript">
+                ```typescript title="agent-js/src/agent.ts"
+                import { SystemMessage } from "@langchain/core/messages";
+                import { ChatOpenAI } from "@langchain/openai";
+
+                // add the agent state definition from the previous step
+                export const AgentStateAnnotation = Annotation.Root({
+                    // ... Your defined state properties
+                    ...CopilotKitStateAnnotation.spec,
+                });
+                export type AgentState = typeof AgentStateAnnotation.State;
+
+                async function chat_node(state: AgentState, config: RunnableConfig) {
+                    // Extract the colleagues from CopilotKit context
+                    const copilotKitContext = state.copilotKit.context
+                    const colleaguesContextItem = copilotKitContext.find(contextItem => contextItem.description === 'The current user\'s colleagues"')
+
+                    // Provide the list of colleagues to the LLM
+                    const systemMessage = new SystemMessage({
+                        content: `
+                          You are a helpful assistant that can help emailing colleagues.
+                          The user's colleagues are: ${colleaguesContextItem.value}
+                        `,
+                    });
+
+                    const response = await new ChatOpenAI({ model: "gpt-4o" }).invoke(
+                        [systemMessage, ...state.messages],
+                        config
+                    );
+
+                    return {
+                        ...state,
+                        messages: response,
+                    };
+                }
+                ```
+            </Tab>
+        </Tabs>
+    </Step>
+
+    <Step>
+        ### Consume the data in your LangGraph agent
+
+        The state of a LangGraph agent is the "hub" for applicative information used by the agent.
+        Naturally, the context from CopilotKit will be injected there.
+
+        ```tsx title="agent.ts"
+        export const colleaguesContactorAgent = new Agent({
+        name: "Colleagues contact Agent",
+        model: openai("gpt-4o"),
+        // Use the injected runtime context
+        // [!code highlight:10]
+        instructions: ({ runtimeContext }) => {
+        // AG-UI context is an array of items, the specific context can be grabbed by filtering
+        const aguiContext = runtimeContext.get('ag-ui')?.context
+        const colleaguesContextItem = aguiContext.find(contextItem => contextItem.description === 'The current user\'s colleagues"')
+        return `
+                You are a helpful assistant that can help emailing colleagues.
+                The user's colleagues are: ${colleaguesContextItem.value}
+              `
+    },
+        // ... Everything else used to configure your agent
+    });
+        ```
+    </Step>
+    <Step>
+        ### Give it a try!
+        Ask your agent a question about the context. It should be able to answer!
+    </Step>
+</Steps>

--- a/docs/content/docs/langgraph/agent-app-context.mdx
+++ b/docs/content/docs/langgraph/agent-app-context.mdx
@@ -167,31 +167,6 @@ This context can then be shared with your LangGraph agent.
     </Step>
 
     <Step>
-        ### Consume the data in your LangGraph agent
-
-        The state of a LangGraph agent is the "hub" for applicative information used by the agent.
-        Naturally, the context from CopilotKit will be injected there.
-
-        ```tsx title="agent.ts"
-        export const colleaguesContactorAgent = new Agent({
-        name: "Colleagues contact Agent",
-        model: openai("gpt-4o"),
-        // Use the injected runtime context
-        // [!code highlight:10]
-        instructions: ({ runtimeContext }) => {
-        // AG-UI context is an array of items, the specific context can be grabbed by filtering
-        const aguiContext = runtimeContext.get('ag-ui')?.context
-        const colleaguesContextItem = aguiContext.find(contextItem => contextItem.description === 'The current user\'s colleagues"')
-        return `
-                You are a helpful assistant that can help emailing colleagues.
-                The user's colleagues are: ${colleaguesContextItem.value}
-              `
-    },
-        // ... Everything else used to configure your agent
-    });
-        ```
-    </Step>
-    <Step>
         ### Give it a try!
         Ask your agent a question about the context. It should be able to answer!
     </Step>

--- a/docs/content/docs/langgraph/meta.json
+++ b/docs/content/docs/langgraph/meta.json
@@ -15,6 +15,7 @@
     "shared-state",
     "frontend-actions",
     "multi-agent-flows",
+    "agent-app-context",
     "auth",
     "persistence",
     "advanced",

--- a/docs/content/docs/mastra/agent-app-context.mdx
+++ b/docs/content/docs/mastra/agent-app-context.mdx
@@ -1,0 +1,81 @@
+---
+title: Shared Context Between the Agent and App
+icon: "lucide/BookA"
+description: Share app specific context with your agent.
+---
+
+One of the most common use cases for CopilotKit is to register app state and context using `useCopilotReadble`.
+This way, you can notify CopilotKit of what is going in your app in real time.
+Some examples might be: the current user, the current page, etc.
+
+This context can then be shared with your Mastra agent.
+
+## Implementation
+<Callout>
+Check out the [Frontend Data documentation](https://docs.copilotkit.ai/direct-to-llm/guides/connect-your-data/frontend) to understand what this is and how to use it.
+</Callout>
+
+<Steps>
+    <Step>
+        ### Add the data to the Copilot
+
+        The [`useCopilotReadable` hook](/reference/hooks/useCopilotReadable) is used to add data as context to the Copilot.
+
+        ```tsx title="YourComponent.tsx" showLineNumbers {1, 7-10}
+        "use client" // only necessary if you are using Next.js with the App Router. // [!code highlight]
+        import { useCopilotReadable } from "@copilotkit/react-core"; // [!code highlight]
+        import { useState } from 'react';
+
+        export function YourComponent() {
+            // Create colleagues state with some sample data
+            const [colleagues, setColleagues] = useState([
+                { id: 1, name: "John Doe", role: "Developer" },
+                { id: 2, name: "Jane Smith", role: "Designer" },
+                { id: 3, name: "Bob Wilson", role: "Product Manager" }
+            ]);
+
+            // Define Copilot readable state
+            // [!code highlight:5]
+            useCopilotReadable({
+                description: "The current user's colleagues",
+                value: colleagues,
+            });
+            return (
+                // Your custom UI component
+                <>...</>
+            );
+        }
+        ```
+    </Step>
+
+    <Step>
+        ### Consume the data in your Mastra agent
+
+        Mastra has `RuntimeContext` class that can be used to set and access the extra context at run time.
+        The context from CopilotKit is automatically injected there, and can be used immediately.
+        You can read more about it [here](https://mastra.ai/en/docs/agents/runtime-context)
+
+        ```tsx title="agent.ts"
+        export const colleaguesContactorAgent = new Agent({
+            name: "Colleagues contact Agent",
+            model: openai("gpt-4o"),
+            // Use the injected runtime context
+            // [!code highlight:10]
+            instructions: ({ runtimeContext }) => {
+              // AG-UI context is an array of items, the specific context can be grabbed by filtering
+              const aguiContext = runtimeContext.get('ag-ui')?.context
+              const colleaguesContextItem = aguiContext.find(contextItem => contextItem.description === 'The current user\'s colleagues"')
+              return `
+                You are a helpful assistant that can help emailing colleagues.
+                The user's colleagues are: ${colleaguesContextItem.value}
+              `
+            },
+            // ... Everything else used to configure your agent
+        });
+        ```
+    </Step>
+    <Step>
+        ### Give it a try!
+        Ask your agent a question about the context. It should be able to answer!
+    </Step>
+</Steps>

--- a/docs/content/docs/mastra/meta.json
+++ b/docs/content/docs/mastra/meta.json
@@ -15,6 +15,7 @@
     "shared-state",
     "frontend-actions",
     "multi-agent-flows",
+    "agent-app-context",
     "---Premium Features---",
     "...premium",
     "---Learn---",

--- a/sdk-python/copilotkit/langgraph.py
+++ b/sdk-python/copilotkit/langgraph.py
@@ -27,10 +27,15 @@ from .logging import get_logger
 
 logger = get_logger(__name__)
 
+class CopilotContextItem(TypedDict):
+    """Copilot context item"""
+    description: str
+    value: Any
 
 class CopilotKitProperties(TypedDict):
     """CopilotKit state"""
     actions: List[Any]
+    context: List[CopilotContextItem]
 
 class CopilotKitState(MessagesState):
     """CopilotKit state"""

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -167,15 +167,16 @@ class LangGraphAGUIAgent(LangGraphAgent):
         async for event_str in super()._handle_single_event(event, state):
             yield event_str
 
-    def langgraph_default_merge_state(self, state: State, messages: List[BaseMessage], tools: Any) -> State:
+    def langgraph_default_merge_state(self, state: State, messages: List[BaseMessage], input: Any) -> State:
         """Override to add CopilotKit actions to the state"""
-        merged_state = super().langgraph_default_merge_state(state, messages, tools)
+        merged_state = super().langgraph_default_merge_state(state, messages, input)
         # Extract tools from the merged state and add them as CopilotKit actions
-        tools_in_state = merged_state.get('tools', [])
-        
+        agui_properties = merged_state.get('ag-ui', {}) or merged_state
+
         return {
             **merged_state,
             'copilotkit': {
-                'actions': tools_in_state,
+                'actions': agui_properties.get('tools', []),
+                'context': agui_properties.get('context', [])
             },
         }

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -14,7 +14,7 @@ python = ">=3.10,<3.13"
 langgraph = {version = ">=0.3.18,<0.7.0"}
 langchain = {version = ">=0.3.4,<=0.3.26"}
 crewai = { version = "0.118.0", optional = true }
-ag-ui-langgraph = { version = "0.0.10", extras = ["fastapi"] }
+ag-ui-langgraph = { version = "0.0.11", extras = ["fastapi"] }
 fastapi = "^0.115.0"
 partialjson = "^0.0.8"
 toml = "^0.10.2"


### PR DESCRIPTION
This PR sends a "context" parameter to AGUI agents, which they can then use.
Each agent implementation would use it differently, but the idea here is to connect `useCopilotReadable` to CoAgents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents, remote actions, and chat requests can now accept and forward structured app context (description/value pairs) for richer, context-aware responses.

* **Documentation**
  * Added guides showing how to register and consume app context in LangGraph and Mastra agents with examples.

* **Chores**
  * Bumped runtime and related SDK/package versions and added a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->