### PR TITLE
Temporarily remove pydantic-ai predictive state from the docs

### DIFF
--- a/docs/content/docs/pydantic-ai/concepts/pydantic-ai.mdx
+++ b/docs/content/docs/pydantic-ai/concepts/pydantic-ai.mdx
@@ -37,7 +37,8 @@ Some additional functionality not mentioned here is:
   [here](/pydantic-ai/human-in-the-loop).
 - **Tool calling**: Tool calling is a fundamental building block for agentic workflows. They allow for greater control over what
   the agent can do and can be used to interact with external systems. CoAgents allow you to easily render in-progress
-  tool calls in the UI so your users know what's happening. Read more about streaming tool calls [here](/pydantic-ai/shared-state/predictive-state-updates).
+  tool calls in the UI so your users know what's happening.
+  {/* Read more about streaming tool calls [here](/pydantic-ai/shared-state/predictive-state-updates). */}
 
 ## Building with Python
 
@@ -53,4 +54,4 @@ Get business support, SLA, private VPC
 Pydantic AI enterprise is a platform for deploying and monitoring Pydantic AI applications. Read more about it on the
 [Pydantic AI website](https://www.pydantic-ai.com/enterprise).
 
-If you want to take the next step to deploy your Pydantic AI application as an CoAgent, check out our [quickstart guide](/pydantic-ai/quickstart/pydantic-ai). 
+If you want to take the next step to deploy your Pydantic AI application as an CoAgent, check out our [quickstart guide](/pydantic-ai/quickstart/pydantic-ai).

--- a/docs/content/docs/pydantic-ai/concepts/state.mdx
+++ b/docs/content/docs/pydantic-ai/concepts/state.mdx
@@ -19,7 +19,7 @@ CoAgents maintain a shared state that seamlessly connects your UI with the agent
 The foundation of this system is built on Pydantic AI's stateful architecture. Pydantic AI Agents maintain their
 internal state throughout execution, which you can access via the `useCoAgentState` hook.
 
-### Understanding Predicted State
+{/* ### Understanding Predicted State
 
 While your agent runs, you can emit state updates using CopilotKit's `emit_intermediate_state` function, ensuring your UI stays synchronized
 with the agent's progress. The emitted state is called the **predicted state** and is used to provide immediate feedback about ongoing
@@ -35,4 +35,4 @@ For example, when your agent is processing a request, the predicted state might 
 shared state updates once the operation is complete.
 
 Want help implementing this into your CoAgent application? Check out our [intermediate state streaming](/pydantic-ai/shared-state/predictive-state-updates)
-documentation. 
+documentation.  */}

--- a/docs/content/docs/pydantic-ai/shared-state/in-app-agent-read.mdx
+++ b/docs/content/docs/pydantic-ai/shared-state/in-app-agent-read.mdx
@@ -146,6 +146,6 @@ function YourMainContent() {
 By default, the Pydantic AI Agent state will only update _between_ Pydantic AI Agent node transitions --
 which means state updates will be discontinuous and delayed.
 
-You likely want to render the agent state as it updates **continuously.**
+{/* You likely want to render the agent state as it updates **continuously.**
 
-See **[emit intermediate state](/pydantic-ai/shared-state/predictive-state-updates).** 
+See **[emit intermediate state](/pydantic-ai/shared-state/predictive-state-updates).**  */}

--- a/docs/content/docs/pydantic-ai/shared-state/in-app-agent-write.mdx
+++ b/docs/content/docs/pydantic-ai/shared-state/in-app-agent-write.mdx
@@ -62,7 +62,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
         def update_language(language: str) -> StateSnapshotEvent:
             """Update the language of the agent."""
             updated_state = {"language": language}
-            
+
             return StateSnapshotEvent(
                 type=EventType.STATE_SNAPSHOT,
                 snapshot=updated_state
@@ -167,6 +167,6 @@ function YourMainContent() {
 By default, the Pydantic AI Agent state will only update _between_ Pydantic AI Agent node transitions --
 which means state updates will be discontinuous and delayed.
 
-You likely want to render the agent state as it updates **continuously.**
+{/* You likely want to render the agent state as it updates **continuously.**
 
-See **[emit intermediate state](/pydantic-ai/shared-state/predictive-state-updates).** 
+See **[emit intermediate state](/pydantic-ai/shared-state/predictive-state-updates).**  */}

--- a/docs/content/docs/pydantic-ai/shared-state/meta.json
+++ b/docs/content/docs/pydantic-ai/shared-state/meta.json
@@ -1,7 +1,6 @@
 {
   "pages": [
     "in-app-agent-read",
-    "in-app-agent-write",
-    "predictive-state-updates"
+    "in-app-agent-write"
   ]
 }


### PR DESCRIPTION
## What does this PR do?

While we figure out the weird bug with predictive state for pydantic-ai in next's production builds (works great in dev! le sigh), remove it from the docs so people aren't trying to use it until we're sure it's working

## Related PRs and Issues

Also see: https://github.com/ag-ui-protocol/ag-ui/pull/359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Simplified wording in the Tool calling section; removed “Read more” link from visible content.
  - Hid the “Understanding Predicted State” section from rendering.
  - In “Intermediately Stream and Render Agent State,” hid guidance lines about continuously rendering and intermediate state.
  - In the in-app agent write guide, hid similar guidance lines and made minor formatting cleanups.
  - Tweaked quickstart link punctuation for clarity.
  - Removed “predictive-state-updates” from the Shared State navigation, leaving only “in-app-agent-read” and “in-app-agent-write.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->