### PR TITLE
chore: remove inaccurate doc item about tool call emittance

### DIFF
--- a/docs/content/docs/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
+++ b/docs/content/docs/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
@@ -27,26 +27,6 @@ tool calls in a more complex example.
 If you have already done that, you can check the following:
 
 <Accordions>
-    <Accordion title="You have not specified the tool call in the `copilotkit_customize_config`">
-        In your LangGraph agent, you have must specify which tool calls will be emitted to the CopilotKit runtime. By default,
-        only streamed messages are emitted. You can fix this by adding the following to the node making the tool call.
-
-        ```python
-        from copilotkit.langgraph import copilotkit_customize_config, copilotkit_emit_message
-        from langgraph_core.runnables import RunnableConfig
-        from langchain.tools import tool
-
-        @tool
-        def say_hello_to(name: str) -> str:
-            return f"Hello, {name}!"
-
-        async def my_node(state: State, config: RunnableConfig) -> State:
-            # ...
-            config = copilotkit_customize_config(config, emit_tool_calls=["say_hello_to"]) # [code highlight]
-            # ...
-            return state
-        ```
-    </Accordion>
     <Accordion title="You're using llm.invoke() instead of llm.ainvoke()">
         <p>
             When you invoke your LangGraph agent, you can invoke it synchronously or asynchronously. If you invoke it synchronously,


### PR DESCRIPTION
The item describing the effect of `emit tool calls` is wrong. Therefore, removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the “My tool calls are not being streamed” section by removing an outdated troubleshooting accordion.
  * Eliminated a redundant code example related to configuring tool call emission.
  * Retained and clarified the guidance comparing synchronous vs. asynchronous invocation to ensure users can still resolve common streaming issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->