### PR TITLE
remove install-sdk from docs where not relevant (and cleanup unused i…

### DIFF
--- a/docs/content/docs/ag2/frontend-actions.mdx
+++ b/docs/content/docs/ag2/frontend-actions.mdx
@@ -3,7 +3,6 @@ title: Frontend Actions
 icon: "lucide/Wrench"
 description: Create frontend actions and use them within your AG2 agent.
 ---
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 
 ## Implementation
 
@@ -59,10 +58,6 @@ Check out the [Frontend Actions overview](/frontend-actions) to understand what 
         Now, we'll need to modify the agent to access these frontend actions. Open up for your agent's folder and continue from there!
     </Step>
     <Step>
-        ### Install the CopilotKit SDK
-        <InstallSDKSnippet components={props.components}/>
-    </Step>
-    <Step>
         ### Inheriting from CopilotKitState
 
         To access the frontend actions provided by CopilotKit, you can inherit from CopilotKitState in your agent's state definition:
@@ -99,4 +94,4 @@ Check out the [Frontend Actions overview](/frontend-actions) to understand what 
         You've now given your agent the ability to directly call any CopilotActions you've defined. These actions will be available as tools to the agent where they can be used as needed.
     </Step>
 
-</Steps> 
+</Steps>

--- a/docs/content/docs/ag2/human-in-the-loop/hitl.mdx
+++ b/docs/content/docs/ag2/human-in-the-loop/hitl.mdx
@@ -5,7 +5,6 @@ icon: lucide/Share2
 ---
 
 import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent.mdx";
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/node-hitl.mp4"
@@ -196,7 +195,7 @@ def create_itinerary(
     """Create a realistic, personalized travel itinerary based on member details."""
     # This function will require human approval before execution
     # because it's generating content that should be reviewed
-    
+
     if not destination or days <= 0:
         return {"error": "Invalid destination or number of days."}
 
@@ -279,14 +278,14 @@ def hitl_workflow(ui: UI, params: dict[str, Any]) -> str:
         recipient="User",
         prompt=INITIAL_MESSAGE,
     )
-    
+
     # Create the travel agent
     with llm_config:
         travel_agent = ConversableAgent(
                 name="travel_agent",
                 system_message=SYSTEM_MESSAGE
             )
-        
+
     # Create the customer agent (human input)
     customer = ConversableAgent(
         name="customer",

--- a/docs/content/docs/crewai-crews/advanced/exit-agent.mdx
+++ b/docs/content/docs/crewai-crews/advanced/exit-agent.mdx
@@ -3,7 +3,6 @@ title: "Exiting the agent loop"
 icon: "lucide/DoorOpen"
 ---
 
-import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
 
 After your agent has finished running a crew, it will automatically exit the agent loop
 

--- a/docs/content/docs/crewai-crews/frontend-actions.mdx
+++ b/docs/content/docs/crewai-crews/frontend-actions.mdx
@@ -3,7 +3,6 @@ title: Frontend Actions
 icon: "lucide/Wrench"
 description: Create frontend actions and use them within your CrewAI Crews agent.
 ---
-import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
 
 ## Implementation
 

--- a/docs/content/docs/crewai-crews/generative-ui/agentic.mdx
+++ b/docs/content/docs/crewai-crews/generative-ui/agentic.mdx
@@ -4,7 +4,6 @@ icon: "lucide/Bot"
 description: Render the state of your agent with custom UI components.
 ---
 
-import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
 <video

--- a/docs/content/docs/crewai-crews/human-in-the-loop/flow.mdx
+++ b/docs/content/docs/crewai-crews/human-in-the-loop/flow.mdx
@@ -4,8 +4,7 @@ description: Learn how to implement Human-in-the-Loop (HITL) using CrewAI Crews.
 icon: lucide/Share2
 ---
 
-import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent.mdx";  
-import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
+import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent.mdx";
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/node-hitl.mp4"
@@ -17,9 +16,9 @@ import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
   muted
 />
 
-<Callout type="info">  
-  Pictured above is the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter-crewai-crews)  
-  with the implementation below applied!  
+<Callout type="info">
+  Pictured above is the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter-crewai-crews)
+  with the implementation below applied!
 </Callout>
 
 ## What is this?
@@ -28,9 +27,9 @@ import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
 
 CopilotKit provides custom UI hooks to capture that input and feed it back into the agent—making it easy to implement Human-in-the-Loop (HITL) workflows.
 
-> **Important**  
+> **Important**
 > To implement HITL with CrewAI, you'll need:
-> - [CrewAI](https://www.crewai.com/) for managing and orchestrating the agents  
+> - [CrewAI](https://www.crewai.com/) for managing and orchestrating the agents
 > - [Copilot Cloud](https://cloud.copilotkit.ai/) to handle UI workflows and communication
 
 ## Why should I use this?
@@ -94,7 +93,7 @@ Crew-based agents are ideal for HITL because they preserve execution state and c
 
     You’ll need to configure your CrewAI Crew to pause and wait for human input before continuing.
 
-    - Follow this CrewAI guide: [Human Input on Execution](https://docs.crewai.com/how-to/human-input-on-execution)  
+    - Follow this CrewAI guide: [Human Input on Execution](https://docs.crewai.com/how-to/human-input-on-execution)
     - Reference this working example: [restaurant-finder-crew with HITL](https://github.com/suhasdeshpande/restaurant-finder-crew/tree/main/src/similar_company_finder_template)
 
     > Reminder: To make this work end-to-end, you must run your crew on [CrewAI](https://www.crewai.com/) and connect it to [Copilot Cloud](https://cloud.copilotkit.ai/). These hosted solutions take care of message passing, HITL state syncing, and UI orchestration.
@@ -103,7 +102,7 @@ Crew-based agents are ideal for HITL because they preserve execution state and c
   <Step>
     ### Try it out!
 
-    Run a test prompt like:  
+    Run a test prompt like:
     **"Research the state of AI in 2025."**
 
     You’ll see your custom UI appear, giving you the chance to approve or cancel the crew’s execution before it continues.

--- a/docs/content/docs/crewai-flows/advanced/disabling-state-streaming.mdx
+++ b/docs/content/docs/crewai-flows/advanced/disabling-state-streaming.mdx
@@ -4,8 +4,6 @@ icon: "lucide/Cog"
 description: "Granularly control what is streamed to the frontend."
 ---
 
-import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
-
 ## What is this?
 
 By default, CopilotKit will stream both your messages and tool calls to the frontend when you use `copilotkit_stream`. You can disable this by choosing when to use `copilotkit_stream` vs calling `completion` directly.

--- a/docs/content/docs/crewai-flows/generative-ui/agentic.mdx
+++ b/docs/content/docs/crewai-flows/generative-ui/agentic.mdx
@@ -4,7 +4,6 @@ icon: "lucide/Bot"
 description: Render the state of your agent with custom UI components.
 ---
 
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
 <video
@@ -45,8 +44,8 @@ is a situation where a user and an agent are working together to solve a problem
   <Step>
     ### Define your agent state
     If you're not familiar with CrewAI, your flows are stateful. As you progress through function, a state object is updated between them. CopilotKit
-    allows you to easily render this state in your application. 
-    
+    allows you to easily render this state in your application.
+
     For the sake of this guide, let's say our state looks like this in our agent.
 
     <Tabs groupId="language" items={['Python']} default="Python">

--- a/docs/content/docs/langgraph/advanced/disabling-state-streaming.mdx
+++ b/docs/content/docs/langgraph/advanced/disabling-state-streaming.mdx
@@ -3,7 +3,6 @@ title: "Disabling state streaming"
 icon: "lucide/Cog"
 description: "Granularly control what is streamed to the frontend."
 ---
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx"
 
 ## What is this?
 By default, CopilotKit will stream both your state and tool calls to the frontend.
@@ -12,7 +11,7 @@ You can disable this by using CopilotKit's custom `RunnableConfig`.
 ## When should I use this?
 
 Occasionally, you'll want to disable streaming temporarily — for example, the LLM may be
-doing something the current user should not see, like emitting tool calls or questions 
+doing something the current user should not see, like emitting tool calls or questions
 pertaining to other employees in an HR system.
 
 ## Implementation
@@ -26,7 +25,7 @@ You can disable all message streaming and tool call streaming by passing `emit_m
         from copilotkit.langgraph import copilotkit_customize_config
 
         async def frontend_actions_node(state: AgentState, config: RunnableConfig):
-            
+
             # 1) Configure CopilotKit not to emit messages
             modifiedConfig = copilotkit_customize_config(
                 config,
@@ -49,7 +48,7 @@ You can disable all message streaming and tool call streaming by passing `emit_m
 
     <Callout type="warn" title="BEWARE!">
         In LangGraph Python, the `config` variable in the surrounding namespace is **implicitly** passed into LangChain LLM calls, even when not explicitly provided.
-        
+
         This is why we create a new variable `modifiedConfig` rather than modifying `config` directly. If we modified `config` itself, it would change the default configuration for all subsequent LLM calls in that namespace.
 
         ```python

--- a/docs/content/docs/langgraph/generative-ui/agentic.mdx
+++ b/docs/content/docs/langgraph/generative-ui/agentic.mdx
@@ -3,7 +3,6 @@ title: Agentic Generative UI
 icon: "lucide/Bot"
 description: Render the state of your agent with custom UI components.
 ---
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx"
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
 <video src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/agentic-generative-ui.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
@@ -34,8 +33,8 @@ is a situation where a user and an agent are working together to solve a problem
   <Step>
     ### Define your agent state
     If you're not familiar with LangGraph, your graphs are stateful. As you progress through nodes, a state object is passed between them. CopilotKit
-    allows you to easily render this state in your application. 
-    
+    allows you to easily render this state in your application.
+
     For the sake of this guide, let's say our state looks like this in our agent.
 
     <Tabs groupId="language" items={['Python', 'TypeScript']} default="Python">
@@ -171,7 +170,7 @@ is a situation where a user and an agent are working together to solve a problem
     };
 
     function YourMainContent() {
-      // ... 
+      // ...
 
       // [!code highlight:14]
       // styles omitted for brevity
@@ -212,7 +211,7 @@ is a situation where a user and an agent are working together to solve a problem
     };
 
     function YourMainContent() {
-      // ... 
+      // ...
 
       // [!code highlight:5]
       const { state } = useCoAgent<AgentState>({

--- a/docs/content/docs/langgraph/shared-state/predictive-state-updates.mdx
+++ b/docs/content/docs/langgraph/shared-state/predictive-state-updates.mdx
@@ -109,7 +109,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                 "Generating recommendations...",
                                 "Formatting final output..."
                             ]
-                            
+
                             for step in steps:
                                 self.state["observed_steps"] = self.state.get("observed_steps", []) + [step]
                                 await copilotkit_emit_state(config, state) # [!code highlight]
@@ -132,7 +132,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                                 "Generating recommendations...",
                                 "Formatting final output..."
                             ];
-                            
+
                             for (const step of steps) {
                                 state.observed_steps = [...(state.observed_steps ?? []), step];
                                 copilotkitEmitState(config, state);
@@ -146,7 +146,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
 
             <TailoredContentOption
                 id="tool-emission"
-                title="Tool-Based Predictive State Updates" 
+                title="Tool-Based Predictive State Updates"
                 description="Configure specific tool calls to automatically emit intermediate state updates."
                 icon={<FaWrench />}
             >
@@ -272,7 +272,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
         type AgentState = {
             observed_steps: string[];
         };
-        
+
         const YourMainContent = () => {
             // Get access to both predicted and final states
             const { state } = useCoAgent<AgentState>({ name: "sample_agent" });

--- a/docs/content/docs/llamaindex/frontend-actions.mdx
+++ b/docs/content/docs/llamaindex/frontend-actions.mdx
@@ -4,8 +4,6 @@ icon: "lucide/Wrench"
 description: Create frontend actions and use them within your LlamaIndex agent.
 ---
 
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
-
 ## Implementation
 
 <Callout>
@@ -59,10 +57,6 @@ Check out the [Frontend Actions overview](/frontend-actions) to understand what 
         Now, we'll need to modify the agent to access these frontend actions. Open up for your agent's folder and continue from there!
     </Step>
     <Step>
-        ### Install the CopilotKit SDK
-        <InstallSDKSnippet components={props.components}/>
-    </Step>
-    <Step>
         ### Accessing Frontend Actions
 
         Since LlamaIndex includes native support for the AG-UI protocol, frontend actions are automatically available to the agent as
@@ -78,4 +72,4 @@ Check out the [Frontend Actions overview](/frontend-actions) to understand what 
         pass control back to the frontend when the `writeEssay` action is found in the model's response.
     </Step>
 
-</Steps> 
+</Steps>

--- a/docs/content/docs/llamaindex/human-in-the-loop/tool-based.mdx
+++ b/docs/content/docs/llamaindex/human-in-the-loop/tool-based.mdx
@@ -5,7 +5,6 @@ icon: lucide/Share2
 ---
 
 import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent.mdx";
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/node-hitl.mp4"
@@ -44,11 +43,6 @@ you can ensure that the agent is always making the right decisions and ultimatel
 
         If you don't already have an agent, you can use the [llamaindex starter](https://github.com/CopilotKit/CopilotKit/tree/main/examples/llamaindex/starter) as a starting point
         as this guide uses it as a starting point.
-    </Step>
-
-    <Step>
-      ### Install the CopilotKit SDK
-      <InstallSDKSnippet components={props.components}/>
     </Step>
 
     <Step>
@@ -135,7 +129,7 @@ you can ensure that the agent is always making the right decisions and ultimatel
     On the agent side, we are already done! LlamaIndex natively supports the AG-UI protocol and will automatically
     pass control back to the frontend when the `writeEssay` action is found in the model's response.
     </Step>
-    
+
     <Step>
         ### Give it a try!
         Try asking your agent to write an essay about the benefits of AI. You'll see that it will generate an essay,

--- a/docs/content/docs/mastra/human-in-the-loop/tool-based.mdx
+++ b/docs/content/docs/mastra/human-in-the-loop/tool-based.mdx
@@ -5,7 +5,6 @@ icon: lucide/Share2
 ---
 
 import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent.mdx";
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/node-hitl.mp4"
@@ -44,7 +43,7 @@ you can ensure that the agent is always making the right decisions and ultimatel
     #### I already have an agent
 
     You can follow the instructions in the [quickstart](/mastra/quickstart) guide.
-    
+
     #### I want to start from scratch
 
     Run the following command to create a brand new project with a pre-configured agent:
@@ -114,4 +113,4 @@ you can ensure that the agent is always making the right decisions and ultimatel
     Try asking your agent to write an essay about the benefits of AI. You'll see that it will generate an essay,
     stream the progress and eventually ask you to review it.
   </Step>
-</Steps> 
+</Steps>

--- a/docs/content/docs/pydantic-ai/frontend-actions.mdx
+++ b/docs/content/docs/pydantic-ai/frontend-actions.mdx
@@ -4,7 +4,6 @@ icon: "lucide/Wrench"
 description: Create frontend actions and use them within your agent.
 ---
 
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/frontend-actions-demo.mp4"
@@ -107,4 +106,4 @@ Without frontend actions, agents are limited to just processing and returning da
         You've now given your agent the ability to directly call any CopilotActions you've defined. These actions will be available as tools to the agent where they can be used as needed.
     </Step>
 
-</Steps> 
+</Steps>

--- a/docs/content/docs/pydantic-ai/generative-ui/agentic.mdx
+++ b/docs/content/docs/pydantic-ai/generative-ui/agentic.mdx
@@ -4,7 +4,6 @@ icon: "lucide/Bot"
 description: Render the state of your agent with custom UI components.
 ---
 
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
 <video
@@ -45,8 +44,8 @@ First, you'll need to make sure you have a running Pydantic AI Agent. If you hav
   <Step>
     ### Define your agent state
     If you're not familiar with Pydantic AI, your flows are stateful. As you progress through function, a state object is updated between them. CopilotKit
-    allows you to easily render this state in your application. 
-    
+    allows you to easily render this state in your application.
+
     For the sake of this guide, let's say our state looks like this in our agent.
 
     <Tabs groupId="language" items={['Python']} default="Python">

--- a/docs/content/docs/pydantic-ai/human-in-the-loop/agent.mdx
+++ b/docs/content/docs/pydantic-ai/human-in-the-loop/agent.mdx
@@ -5,7 +5,6 @@ icon: lucide/Share2
 ---
 
 import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent.mdx";
-import InstallSDKSnippet from "@/snippets/install-sdk.mdx";
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/node-hitl.mp4"
@@ -49,11 +48,6 @@ of everything that has happened during a HITL interaction.
 
         If you don't already have an agent, you can use the [coagent starter](https://github.com/CopilotKit/CopilotKit/tree/main/examples/coagents-starter-pydantic-ai) as a starting point
         as this guide uses it as a starting point.
-    </Step>
-
-    <Step>
-      ### Install the CopilotKit SDK
-      <InstallSDKSnippet components={props.components}/>
     </Step>
 
     <Step>
@@ -142,4 +136,4 @@ Now we'll setup the Pydantic AI agent. The flow is hard to understand without a 
         stream the progress and eventually ask you to review it.
     </Step>
 
-</Steps> 
+</Steps>


### PR DESCRIPTION
## What does this PR do?

There are a number of references in the doc to installing the langgraph sdk where it's not applicable (meaning, in docs for other frameworks). This removes those, and also removes unused imports of the sdk install component in a bunch of files


## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation