### PR TITLE
Feat/upgrade agui lg integration packages

### DIFF
--- a/CopilotKit/.changeset/nine-waves-type.md
+++ b/CopilotKit/.changeset/nine-waves-type.md
@@ -1,0 +1,6 @@
+---
+"@copilotkit/runtime": patch
+---
+
+- feat: use latest agui langgraph package
+- feat: use latest agui fastapi langgraph package and dependencies

--- a/CopilotKit/packages/runtime/package.json
+++ b/CopilotKit/packages/runtime/package.json
@@ -50,7 +50,7 @@
     "@ag-ui/client": "^0.0.38",
     "@ag-ui/core": "^0.0.38",
     "@ag-ui/encoder": "^0.0.38",
-    "@ag-ui/langgraph": "^0.0.15",
+    "@ag-ui/langgraph": "^0.0.16",
     "@ag-ui/proto": "^0.0.38",
     "@anthropic-ai/sdk": "^0.57.0",
     "@copilotkit/shared": "workspace:*",

--- a/CopilotKit/pnpm-lock.yaml
+++ b/CopilotKit/pnpm-lock.yaml
@@ -598,8 +598,8 @@ importers:
         specifier: ^0.0.38
         version: 0.0.38
       '@ag-ui/langgraph':
-        specifier: ^0.0.15
-        version: 0.0.15(@ag-ui/client@0.0.38)(@ag-ui/core@0.0.38)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.16
+        version: 0.0.16(@ag-ui/client@0.0.38)(@ag-ui/core@0.0.38)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)
       '@ag-ui/proto':
         specifier: ^0.0.38
         version: 0.0.38
@@ -974,8 +974,8 @@ packages:
   '@ag-ui/encoder@0.0.38':
     resolution: {integrity: sha512-v07nWtO+cu8HCB4/y/5FONzuRP8BjYLAtTssd5hX26RZh9VgLwu5mWjlF1dmkyLSBNyavf14h3myOA1eA9hjWg==}
 
-  '@ag-ui/langgraph@0.0.15':
-    resolution: {integrity: sha512-0oogAy6y4muw2lk4DGBBCkVCIHP/84hkLeH3iG/mEZXPpLJ+TcucJG3X4gglgZ90+Ya47IbPOoLZ8OUIwZc85Q==}
+  '@ag-ui/langgraph@0.0.16':
+    resolution: {integrity: sha512-qX5DjyOTCE2WmeAMf8NSUXtlzTfquabJQighMRBnIOjoo9SJJcd7UPeHOgRHldpPbgtoPS+nCyaOIO8poi8HyA==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.38'
       '@ag-ui/core': '>=0.0.38'
@@ -10258,7 +10258,7 @@ snapshots:
       '@ag-ui/core': 0.0.38
       '@ag-ui/proto': 0.0.38
 
-  '@ag-ui/langgraph@0.0.15(@ag-ui/client@0.0.38)(@ag-ui/core@0.0.38)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
+  '@ag-ui/langgraph@0.0.16(@ag-ui/client@0.0.38)(@ag-ui/core@0.0.38)(openai@4.85.2(encoding@0.1.13)(ws@8.18.1)(zod@3.23.8))(react-dom@19.1.0(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ag-ui/client': 0.0.38
       '@ag-ui/core': 0.0.38
@@ -17324,7 +17324,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.7.9(debug@4.4.1))
+      retry-axios: 2.6.0(axios@1.7.9)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -20268,7 +20268,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  retry-axios@2.6.0(axios@1.7.9(debug@4.4.1)):
+  retry-axios@2.6.0(axios@1.7.9):
     dependencies:
       axios: 1.7.9(debug@4.4.1)
 

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.64"
+version = "0.1.65"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"
@@ -11,10 +11,10 @@ keywords = ["copilot", "copilotkit", "langgraph", "langchain", "ai", "langsmith"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
-langgraph = {version = ">=0.3.18,<0.7.0"}
-langchain = {version = ">=0.3.4,<=0.3.26"}
+langgraph = {version = ">=0.3.25,<1.1.0"}
+langchain = {version = ">=0.3.0"}
 crewai = { version = "0.118.0", optional = true }
-ag-ui-langgraph = { version = "0.0.13", extras = ["fastapi"] }
+ag-ui-langgraph = { version = "0.0.14", extras = ["fastapi"] }
 fastapi = "^0.115.0"
 partialjson = "^0.0.8"
 toml = "^0.10.2"


### PR DESCRIPTION
Use latest AGUI langgraph to support:
- Fixing duplicated tools passed to agent
- Enabling usage of LangGraph v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies to the latest langgraph release for improved compatibility.
  * Bumped Python SDK version and broadened supported ranges for langgraph and langchain to allow newer versions.
  * Updated ag-ui-langgraph dependency for the Python SDK.
  * Added a changeset entry to document these updates.
  * No feature changes or behavioral differences expected; public APIs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->