### PR TITLE
remove langgraph specific diagram from other frameworks pages

### DIFF
--- a/docs/content/docs/adk/concepts/state.mdx
+++ b/docs/content/docs/adk/concepts/state.mdx
@@ -3,13 +3,6 @@ title: Shared State
 description: CoAgents maintain a shared state across your UI and agent execution.
 ---
 
-<Frame className="mb-10">
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 CoAgents maintain a shared state that seamlessly connects your UI with the agent's execution. This shared state system allows you to:
 
 - Display the agent's current progress and intermediate results

--- a/docs/content/docs/adk/shared-state/index.mdx
+++ b/docs/content/docs/adk/shared-state/index.mdx
@@ -27,13 +27,6 @@ CoAgents maintain a shared state that seamlessly connects your UI with the agent
 - Update the agent's state through UI interactions
 - React to state changes in real-time across your application
 
-<Frame>
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 The foundation of this system is built on ADK's stateful architecture.
 
 ## When should I use this?

--- a/docs/content/docs/agno/concepts/state.mdx
+++ b/docs/content/docs/agno/concepts/state.mdx
@@ -3,13 +3,6 @@ title: Shared State
 description: CoAgents maintain a shared state across your UI and agent execution.
 ---
 
-<Frame className="mb-10">
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 CoAgents maintain a shared state that seamlessly connects your UI with the agent's execution. This shared state system allows you to:
 
 - Display the agent's current progress and intermediate results
@@ -35,4 +28,4 @@ For example, when your agent is processing a request, the predicted state might 
 shared state updates once the operation is complete.
 
 Want help implementing this into your CoAgent application? Check out our [intermediate state streaming](/agno/shared-state/predictive-state-updates)
-documentation. 
+documentation.

--- a/docs/content/docs/crewai-crews/concepts/state.mdx
+++ b/docs/content/docs/crewai-crews/concepts/state.mdx
@@ -3,13 +3,6 @@ title: Shared State
 description: CoAgents maintain a shared state across your UI and agent execution.
 ---
 
-<Frame className="mb-10">
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 CoAgents maintain a shared state that seamlessly connects your UI with the agent's execution. This shared state system allows you to:
 
 - Display the agent's current progress and intermediate results

--- a/docs/content/docs/crewai-crews/shared-state/index.mdx
+++ b/docs/content/docs/crewai-crews/shared-state/index.mdx
@@ -14,13 +14,6 @@ CoAgents maintain a shared state that seamlessly connects your UI with the agent
 - Receive the `outputs` of the crew
 - React to state changes in real-time across your application
 
-<Frame>
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 ## When should I use this?
 
 Shared state is perfect when you want to facilitate collaboration between your agent and the user. Updates to the outputs will be automatically shared by the UI. Similarly, any `inputs` that the user updates in the UI will be automatically reflected in the crews execution.

--- a/docs/content/docs/crewai-flows/concepts/state.mdx
+++ b/docs/content/docs/crewai-flows/concepts/state.mdx
@@ -3,13 +3,6 @@ title: Shared State
 description: CoAgents maintain a shared state across your UI and agent execution.
 ---
 
-<Frame className="mb-10">
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 CoAgents maintain a shared state that seamlessly connects your UI with the agent's execution. This shared state system allows you to:
 
 - Display the agent's current progress and intermediate results

--- a/docs/content/docs/crewai-flows/shared-state/index.mdx
+++ b/docs/content/docs/crewai-flows/shared-state/index.mdx
@@ -14,13 +14,6 @@ CoAgents maintain a shared state that seamlessly connects your UI with the agent
 - Update the agent's state through UI interactions
 - React to state changes in real-time across your application
 
-<Frame>
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 The foundation of this system is built on CrewAI's stateful architecture.
 
 ## When should I use this?

--- a/docs/content/docs/pydantic-ai/concepts/state.mdx
+++ b/docs/content/docs/pydantic-ai/concepts/state.mdx
@@ -3,13 +3,6 @@ title: Shared State
 description: CoAgents maintain a shared state across your UI and agent execution.
 ---
 
-<Frame className="mb-10">
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 CoAgents maintain a shared state that seamlessly connects your UI with the agent's execution. This shared state system allows you to:
 
 - Display the agent's current progress and intermediate results

--- a/docs/content/docs/pydantic-ai/shared-state/index.mdx
+++ b/docs/content/docs/pydantic-ai/shared-state/index.mdx
@@ -27,13 +27,6 @@ CoAgents maintain a shared state that seamlessly connects your UI with the agent
 - Update the agent's state through UI interactions
 - React to state changes in real-time across your application
 
-<Frame>
-  <img
-    src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png"
-    alt="Agentic Copilot State Diagram"
-  />
-</Frame>
-
 The foundation of this system is built on Pydantic AI's stateful architecture.
 
 ## When should I use this?
@@ -41,4 +34,4 @@ The foundation of this system is built on Pydantic AI's stateful architecture.
 State streaming is perfect when you want to facilitate collaboration between your agent and the user. Any state that your Pydantic AI Agent
 persists will be automatically shared by the UI. Similarly, any state that the user updates in the UI will be automatically reflected
 
-This allows for a consistent experience where both the agent and the user are on the same page. 
+This allows for a consistent experience where both the agent and the user are on the same page.


### PR DESCRIPTION
## What does this PR do?

We use a shared state diagram all over the place (see: 
![](https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/coagents-state-diagram.png)
), but it calls out langgraph specifically. Remove this from other frameworks docs pages until it can be made agnostic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the shared state diagram image from multiple “Shared State” and “What is shared state?” pages across product docs (ADK, Agno, CrewAI Crews, CrewAI Flows, Pydantic AI) to streamline presentation.
  * Preserved all surrounding explanatory text; no behavioral or API changes.
  * Fixed minor formatting issues, including a trailing newline and converting an unintended list item into a standard sentence for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->