### PR TITLE
Fix LangChain icons in left bar

### DIFF
--- a/docs/content/docs/adk/concepts/adk.mdx
+++ b/docs/content/docs/adk/concepts/adk.mdx
@@ -1,7 +1,7 @@
 ---
 title: ADK
 description: An agentic framework for building LLM applications that can be used with Copilotkit.
-icon: custom/langchain
+icon: custom/adk
 ---
 
 <Frame>

--- a/docs/content/docs/adk/quickstart.mdx
+++ b/docs/content/docs/adk/quickstart.mdx
@@ -11,15 +11,11 @@ import {
 import { CoAgentsEnterpriseCTA } from "@/components/react/coagents/coagents-enterprise-cta.tsx";
 import { CoAgentsDiagram } from "@/components/react/coagents/coagents-diagram.tsx";
 import { FaPython, FaJs, FaCloud } from "react-icons/fa";
-import SelfHostingCopilotRuntimeCreateEndpoint from "@/snippets/self-hosting-copilot-runtime-create-endpoint.mdx";
-import CopilotCloudConfigureRemoteEndpointLangGraph from "@/snippets/copilot-cloud-configure-remote-endpoint-langgraph.mdx";
 import CopilotKitCloudCopilotKitProvider from "@/snippets/copilot-cloud-configure-copilotkit-provider.mdx";
-import LangGraphPlatformDeploymentTabs from "@/snippets/langgraph-platform-deployment-tabs.mdx";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import FindYourCopilotRuntime from "@/snippets/find-your-copilot-runtime.mdx";
 import CloudCopilotKitProvider from "@/snippets/coagents/cloud-configure-copilotkit-provider.mdx";
 import SelfHostingCopilotRuntimeConfigureCopilotKitProvider from "@/snippets/coagents/self-host-configure-copilotkit-provider.mdx";
-import SelfHostingCopilotRuntimeLangGraphEndpoint from "@/snippets/self-hosting-copilot-runtime-langgraph-endpoint.mdx";
 import SelfHostingCopilotRuntimeStarter from "@/snippets/self-hosting-copilot-runtime-starter.mdx";
 import SelfHostingRemoteEndpoints from "@/snippets/self-hosting-remote-endpoints.mdx";
 import { ADKIcon } from "@/lib/icons/custom-icons";

--- a/docs/content/docs/agno/concepts/your-framework.mdx
+++ b/docs/content/docs/agno/concepts/your-framework.mdx
@@ -1,7 +1,7 @@
 ---
 title: Agno
 description: An agentic framework for building LLM applications that can be used with Copilotkit.
-icon: custom/langchain
+icon: custom/agno
 ---
 
 <Frame>

--- a/docs/content/docs/crewai-crews/concepts/crewai.mdx
+++ b/docs/content/docs/crewai-crews/concepts/crewai.mdx
@@ -1,7 +1,7 @@
 ---
 title: CrewAI
 description: An agentic framework for building LLM applications that can be used with Copilotkit.
-icon: custom/langchain
+icon: custom/crewai
 ---
 
 <Frame>

--- a/docs/content/docs/crewai-flows/concepts/crewai.mdx
+++ b/docs/content/docs/crewai-flows/concepts/crewai.mdx
@@ -1,7 +1,7 @@
 ---
 title: CrewAI
 description: An agentic framework for building LLM applications that can be used with Copilotkit.
-icon: custom/langchain
+icon: custom/crewai
 ---
 
 <Frame>

--- a/docs/content/docs/pydantic-ai/concepts/pydantic-ai.mdx
+++ b/docs/content/docs/pydantic-ai/concepts/pydantic-ai.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pydantic AI
 description: An agentic framework for building LLM applications that can be used with Copilotkit.
-icon: custom/langchain
+icon: custom/pydantic
 ---
 
 <Frame>

--- a/docs/content/docs/pydantic-ai/generative-ui/agentic.mdx
+++ b/docs/content/docs/pydantic-ai/generative-ui/agentic.mdx
@@ -45,8 +45,8 @@ First, you'll need to make sure you have a running Pydantic AI Agent. If you hav
   <Step>
     ### Define your agent state
     If you're not familiar with Pydantic AI, your flows are stateful. As you progress through function, a state object is updated between them. CopilotKit
-    allows you to easily render this state in your application. 
-    
+    allows you to easily render this state in your application.
+
     For the sake of this guide, let's say our state looks like this in our agent.
 
     <Tabs groupId="language" items={['Python']} default="Python">
@@ -103,7 +103,7 @@ First, you'll need to make sure you have a running Pydantic AI Agent. If you hav
     import { useCoAgent } from "@copilotkit/react-core";
     // ...
 
-    // Define the state of the agent, should match the state of the agent in your LangGraph.
+    // Define the state of the agent, should match the state of your Pydantic AI Agent.
     type AgentState = {
       searches: {
         query: string;
@@ -145,7 +145,7 @@ First, you'll need to make sure you have a running Pydantic AI Agent. If you hav
     import { useCoAgent } from "@copilotkit/react-core"; // [!code highlight]
     // ...
 
-    // Define the state of the agent, should match the state of the agent in your LangGraph.
+    // Define the state of the agent, should match the state of your Pydantic AI Agent.
     type AgentState = {
       searches: {
         query: string;

--- a/docs/content/docs/pydantic-ai/quickstart/pydantic-ai.mdx
+++ b/docs/content/docs/pydantic-ai/quickstart/pydantic-ai.mdx
@@ -12,9 +12,7 @@ import { CoAgentsEnterpriseCTA } from "@/components/react/coagents/coagents-ente
 import { CoAgentsDiagram } from "@/components/react/coagents/coagents-diagram.tsx";
 import { FaPython, FaJs, FaCloud } from "react-icons/fa";
 import SelfHostingCopilotRuntimeCreateEndpoint from "@/snippets/self-hosting-copilot-runtime-create-endpoint.mdx";
-import CopilotCloudConfigureRemoteEndpointLangGraph from "@/snippets/copilot-cloud-configure-remote-endpoint-langgraph.mdx";
 import CopilotKitCloudCopilotKitProvider from "@/snippets/copilot-cloud-configure-copilotkit-provider.mdx";
-import LangGraphPlatformDeploymentTabs from "@/snippets/langgraph-platform-deployment-tabs.mdx";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import FindYourCopilotRuntime from "@/snippets/find-your-copilot-runtime.mdx";
 import CloudCopilotKitProvider from "@/snippets/coagents/cloud-configure-copilotkit-provider.mdx";
@@ -143,7 +141,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Create your frontend
                 CopilotKit runs anywhere that React runs. As such, you can such Next.js,
-                Vite, or any other React environment. 
+                Vite, or any other React environment.
 
                 For this example, we'll create a new Next.js app.
 
@@ -173,28 +171,28 @@ Before you begin, you'll need the following:
                 } from "@copilotkit/runtime";
                 import { HttpAgent } from "@ag-ui/client";
                 import { NextRequest } from "next/server";
-                
+
                 // 1. You can use any service adapter here for multi-agent support. We use
                 //    the empty adapter since we're only using one agent.
                 const serviceAdapter = new ExperimentalEmptyAdapter();
-                
+
                 // 2. Create the CopilotRuntime instance and utilize the PydanticAI AG-UI
                 //    integration to setup the connection.
                 const runtime = new CopilotRuntime({
                   agents: {
                     // Our AG-UI endpoint URL
                     "my_agent": new HttpAgent({ url: "http://localhost:8000/" }),
-                  }   
+                  }
                 });
-                
+
                 // 3. Build a Next.js API route that handles the CopilotKit runtime requests.
                 export const POST = async (req: NextRequest) => {
                   const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-                    runtime, 
+                    runtime,
                     serviceAdapter,
                     endpoint: "/api/copilotkit",
                   });
-                
+
                   return handleRequest(req);
                 };
                ```
@@ -202,19 +200,19 @@ Before you begin, you'll need the following:
             <Step>
                 ### Setup the CopilotKit provider
                 The CopilotKit provide component is responsible for managing the session with your current agent. Typically,
-                users will wrap their entire application in the CopilotKit provider.    
+                users will wrap their entire application in the CopilotKit provider.
 
                 ```tsx title="app/layout.tsx"
                 import "./globals.css";
                 import { ReactNode } from "react";
-                import { CopilotKit } from "@copilotkit/react-core"; 
-                
+                import { CopilotKit } from "@copilotkit/react-core";
+
                 export default function RootLayout({ children }: { children: ReactNode }) {
                   return (
                     <html lang="en">
-                      <body> 
+                      <body>
                         {/* This points to the runtime we setup in the previous step */} // [!code highlight:4]
-                        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent"> 
+                        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                           {children}
                         </CopilotKit>
                       </body>
@@ -315,4 +313,4 @@ can help you build power agent native applications.
     href="/pydantic-ai/frontend-actions"
     icon={<WrenchIcon />}
   />
-</Cards> 
+</Cards>


### PR DESCRIPTION

## What does this PR do?

a number of docs pages specific to various frameworks were referencing the LangChain icon in the sidebar for certain pages rather than the relevant icon. This changes that. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated page icons across concept docs (ADK, AGNO, CrewAI, CrewAI Flows, Pydantic AI) for consistent branding.
  - Simplified quickstart guides by removing outdated embedded snippets and references to LangGraph/Copilot Cloud.
  - Clarified wording in Pydantic AI generative UI guide; updated references to “Pydantic AI Agent.”
  - Minor text, formatting, and layout cleanups in examples for readability; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->