### PR TITLE
Update hrefs for guide links in quickstart.mdx

### DIFF
--- a/docs/content/docs/direct-to-llm/guides/quickstart.mdx
+++ b/docs/content/docs/direct-to-llm/guides/quickstart.mdx
@@ -161,19 +161,19 @@ take it further? Learn more about what CopilotKit has to offer!
   <Card
     title="Connecting Your Data"
     description="Learn how to connect CopilotKit to your data, application state and user state."
-    href="/guides/connect-your-data"
+    href="/direct-to-llm/guides/connect-your-data"
     icon={<LinkIcon />}
   />
   <Card
     title="Generative UI"
     description="Learn how to render custom UI components directly in the CopilotKit chat window."
-    href="/guides/generative-ui"
+    href="/direct-to-llm/guides/generative-ui"
     icon={<LinkIcon />}
   />
   <Card
     title="Frontend Actions"
     description="Learn how to allow your copilot to take applications on frontend."
-    href="/guides/frontend-actions"
+    href="/direct-to-llm/guides/frontend-actions"
     icon={<LinkIcon />}
   />
   <Card


### PR DESCRIPTION
Broken links. I notice that you have not been using relative paths to the MDX files, if that is OK you could replace what I put with `./<filename>` since they are in the same dir as `quickstart.mdx`

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes broken links

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guide links in the Direct-to-LLM quickstart to use /direct-to-llm/guides/... across three Cards, ensuring users are directed to the correct section.
  - Improves navigation consistency without altering page content or behavior.

- **Bug Fixes**
  - Corrected outdated/incorrect URLs that could lead to missing or legacy pages, reducing navigation errors and potential 404s.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->