### PR TITLE
docs: hyperlink reference docs in guides and snippets (CPK-4143)

### DIFF
--- a/docs/snippets/component-examples.mdx
+++ b/docs/snippets/component-examples.mdx
@@ -2,7 +2,7 @@
 <Tabs groupId="component" items={["CopilotChat", "CopilotSidebar", "CopilotPopup", "Headless UI"]}>
   <Tab value="CopilotPopup">
 
-    `CopilotPopup` is a convenience wrapper for `CopilotChat` that lives at the same level as your main content in the view hierarchy. It provides **a floating chat interface** that can be toggled on and off.
+    [`CopilotPopup`](/reference/components/chat/CopilotPopup) is a convenience wrapper for [`CopilotChat`](/reference/components/chat/CopilotChat) that lives at the same level as your main content in the view hierarchy. It provides **a floating chat interface** that can be toggled on and off.
 
     <img src="https://cdn.copilotkit.ai/docs/copilotkit/images/popup-example.gif" alt="Popup Example" className="w-full rounded-lg my-4" />
 
@@ -28,7 +28,7 @@
 
   </Tab>
   <Tab value="CopilotSidebar">
-    `CopilotSidebar` is a convenience wrapper for `CopilotChat` that wraps your main content in the view hierarchy. It provides a **collapsible and expandable sidebar** chat interface.
+    [`CopilotSidebar`](/reference/components/chat/CopilotSidebar) is a convenience wrapper for [`CopilotChat`](/reference/components/chat/CopilotChat) that wraps your main content in the view hierarchy. It provides a **collapsible and expandable sidebar** chat interface.
 
     <img src="https://cdn.copilotkit.ai/docs/copilotkit/images/sidebar-example.gif" alt="Popup Example" className="w-full rounded-lg my-4" />
 
@@ -56,13 +56,13 @@
 
   </Tab>
   <Tab value="CopilotChat">
-    `CopilotChat` is a flexible chat interface component that **can be placed anywhere in your app** and can be resized as you desire.
+    [`CopilotChat`](/reference/components/chat/CopilotChat) is a flexible chat interface component that **can be placed anywhere in your app** and can be resized as you desire.
 
     <img src="https://cdn.copilotkit.ai/docs/copilotkit/images/copilotchat-example.gif" alt="Popup Example" className="w-full rounded-lg my-4" />
 
     ```tsx
     // [!code word:CopilotChat]
-    import { CopilotChat } from "@copilotkit/react-ui";
+    import { CopilotChat } from "@copilotkit/react-ui"; // See reference: /reference/components/chat/CopilotChat
 
     export function YourComponent() {
       return (
@@ -81,7 +81,7 @@
   <Tab value="Headless UI">
     The built-in Copilot UI can be customized in many ways -- both through css and by passing in custom sub-components.
 
-    CopilotKit also offers **fully custom headless UI**, through the `useCopilotChat` hook. Everything built with the built-in UI (and more) can be implemented with the headless UI, providing deep customizability.
+    CopilotKit also offers **fully custom headless UI**, through the [`useCopilotChat`](/reference/hooks/useCopilotChat) hook. Everything built with the built-in UI (and more) can be implemented with the headless UI, providing deep customizability.
 
     ```tsx
     import { useCopilotChat } from "@copilotkit/react-core";

--- a/docs/snippets/headless-ui.mdx
+++ b/docs/snippets/headless-ui.mdx
@@ -1,6 +1,6 @@
 The built-in Copilot UI can be customized in many ways -- both through css and by passing in custom sub-components.
 
-CopilotKit also offers **fully custom headless UI**, through the `useCopilotChat` hook. Everything built with the built-in UI (and more) can be implemented with the headless UI, providing deep customizability.
+CopilotKit also offers **fully custom headless UI**, through the [`useCopilotChat`](/reference/hooks/useCopilotChat) hook. Everything built with the built-in UI (and more) can be implemented with the headless UI, providing deep customizability.
 
 ```tsx
 import { useCopilotChat } from "@copilotkit/react-core";

--- a/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
+++ b/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
@@ -25,7 +25,7 @@ If you are not sure yet, simply ignore this note.
         <Callout type="error">
             Be aware that the empty adapter only works in combination with CoAgents in agent lock mode!
 
-            In addition, bare in mind that `useCopilotChatSuggestions`, `CopilotTextarea` and `CopilotTask` will not work, as these require an LLM.
+            In addition, bare in mind that [`useCopilotChatSuggestions`](/reference/hooks/useCopilotChatSuggestions), [`CopilotTextarea`](/reference/components/CopilotTextarea) and [`CopilotTask`](/reference/classes/CopilotTask) will not work, as these require an LLM.
         </Callout>
     </If>
 

--- a/docs/snippets/shared/guides/copilot-suggestions.mdx
+++ b/docs/snippets/shared/guides/copilot-suggestions.mdx
@@ -5,7 +5,7 @@ import UseClientCalloutSnippet from "@/snippets/use-client-callout.mdx";
   change without notice.
 </Callout>
 
-[`useCopilotChatSuggestions`](/reference/hooks/useCopilotChatSuggestions) is a React hook that generates suggestions in the chat window based on real time application state.
+[`useCopilotChatSuggestions`](/reference/hooks/useCopilotChatSuggestions) is a React hook that generates suggestions in the chat window based on real time application state. You can display these suggestions in prebuilt chat components like [`CopilotChat`](/reference/components/chat/CopilotChat) or control them programmatically via [`useCopilotChat`](/reference/hooks/useCopilotChat).
 
 <Frame>
   <img

--- a/docs/snippets/shared/premium/headless-ui.mdx
+++ b/docs/snippets/shared/premium/headless-ui.mdx
@@ -20,7 +20,7 @@ import {
 
 ## Overview
 
-CopilotKit offers *fully headless UI* through the `useCopilotChatHeadless_c` hook. By using this hook, you can build your own chat interfaces
+CopilotKit offers *fully headless UI* through the [`useCopilotChatHeadless_c`](/reference/hooks/useCopilotChatHeadless_c) hook. By using this hook, you can build your own chat interfaces
 from the ground up while still utilizing CopilotKit's core features and ease-of-use.
 
 ## Navigation
@@ -173,7 +173,7 @@ To get there, let's start by building a simple chat interface.
 
 ## Working with Generative UI
 
-You can also render generative UI either via `useCopilotAction` or by reading tools and rendering them directly.
+You can also render generative UI either via [`useCopilotAction`](/reference/hooks/useCopilotAction) or by reading tools and rendering them directly.
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/videos/gen-ui.mp4"
@@ -184,9 +184,9 @@ You can also render generative UI either via `useCopilotAction` or by reading to
   muted
 />
 
-### With `useCopilotAction`
-CopilotKit's standard components utilize `useCopilotAction` to allow tools to be both rendered and called in 
-the frontend. These same interfaces are available to you while using the `useCopilotChatHeadless_c` hook.
+### With [`useCopilotAction`](/reference/hooks/useCopilotAction)
+CopilotKit's standard components utilize [`useCopilotAction`](/reference/hooks/useCopilotAction) to allow tools to be both rendered and called in 
+the frontend. These same interfaces are available to you while using the [`useCopilotChatHeadless_c`](/reference/hooks/useCopilotChatHeadless_c) hook.
 
 ```tsx title="src/app/components/chat.tsx"
 import { useCopilotAction } from "@copilotkit/react-core";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded component examples for CopilotPopup, CopilotSidebar, CopilotChat, and Headless UI with clearer JSX/TSX snippets and direct links to references.
  - Converted plain hook/component mentions to clickable Markdown links across docs (e.g., useCopilotChat, useCopilotAction, useCopilotChatSuggestions, useCopilotChatHeadless_c).
  - Clarified behavior of useCopilotChatSuggestions, noting instruction-driven updates based on monitored state.
  - Updated warning callout to include linked references for related components/hooks.
  - Improved navigability and consistency in premium headless UI docs with comprehensive link updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->