### PR TITLE
more framework cleanup

### DIFF
--- a/docs/content/docs/adk/generative-ui/tool-based.mdx
+++ b/docs/content/docs/adk/generative-ui/tool-based.mdx
@@ -16,12 +16,6 @@ import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent
   autoPlay
   muted
 />
-<Callout>
-  This video demonstrates the [implementation](#implementation) section applied
-  to out [coagents starter
-  project](https://github.com/CopilotKit/CopilotKit/tree/main/examples/coagents-starter).
-</Callout>
-
 ## What is this?
 
 Tools are a way for the LLM to call predefined, typically, deterministic functions. CopilotKit allows you to render these tools in the UI

--- a/docs/content/docs/ag2/human-in-the-loop/hitl.mdx
+++ b/docs/content/docs/ag2/human-in-the-loop/hitl.mdx
@@ -16,9 +16,6 @@ import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent
   muted
 />
 
-<Callout type="info">
-The illustration above is from the [CoAgent Starter](https://github.com/CopilotKit/CopilotKit/tree/main/examples/coagents-starter), included here for demonstration purposes.
-</Callout>
 
 ## What is Human-in-the-Loop?
 

--- a/docs/content/docs/crewai-crews/human-in-the-loop/flow.mdx
+++ b/docs/content/docs/crewai-crews/human-in-the-loop/flow.mdx
@@ -17,7 +17,7 @@ import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent
 />
 
 <Callout type="info">
-  Pictured above is the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter-crewai-crews)
+  Pictured above is the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-crews)
   with the implementation below applied!
 </Callout>
 

--- a/docs/content/docs/crewai-crews/shared-state/in-app-agent-read.mdx
+++ b/docs/content/docs/crewai-crews/shared-state/in-app-agent-read.mdx
@@ -18,7 +18,7 @@ import { ImageZoom } from "fumadocs-ui/components/image-zoom";
 
 <Callout type="info">
   Pictured above is the [coagent
-  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter)
+  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-crews)
   with the [implementation](#implementation) section applied!
 </Callout>
 
@@ -39,7 +39,7 @@ You can use this when you want to provide the user with a way to read the output
     You'll need to run your agent and connect it to CopilotKit before proceeding. If you haven't done so already,
     you can follow the instructions in the [Getting Started](/getting-started) guide.
 
-    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter-crewai-crews) as a starting point
+    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-crews) as a starting point
     as this guide uses it as a starting point.
 
   </Step>

--- a/docs/content/docs/crewai-crews/shared-state/in-app-agent-write.mdx
+++ b/docs/content/docs/crewai-crews/shared-state/in-app-agent-write.mdx
@@ -33,7 +33,7 @@ You can use this when you want to provide the user with a way to update the inpu
 
     You'll need to run your agent and connect it to CopilotKit before proceeding. If you haven't done so already, you can follow the instructions in the [Getting Started](/getting-started) guide.
 
-    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter-crewai-crews) as a starting point
+    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-crews) as a starting point
     as this guide uses it as a starting point.
 
   </Step>

--- a/docs/content/docs/crewai-flows/human-in-the-loop/flow.mdx
+++ b/docs/content/docs/crewai-flows/human-in-the-loop/flow.mdx
@@ -19,7 +19,7 @@ import InstallSDKSnippet from "@/snippets/install-python-sdk-crew.mdx";
 
 <Callout type="info">
   Pictured above is the [coagent
-  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter)
+  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-flows)
   with the implementation below applied!
 </Callout>
 

--- a/docs/content/docs/crewai-flows/shared-state/in-app-agent-read.mdx
+++ b/docs/content/docs/crewai-flows/shared-state/in-app-agent-read.mdx
@@ -18,7 +18,7 @@ import { ImageZoom } from "fumadocs-ui/components/image-zoom";
 
 <Callout type="info">
   Pictured above is the [coagent
-  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter)
+  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-flows)
   with the [implementation](#implementation) section applied!
 </Callout>
 
@@ -40,7 +40,7 @@ state update you can reflect these updates natively in your application.
     You'll need to run your agent and connect it to CopilotKit before proceeding. If you haven't done so already,
     you can follow the instructions in the [Getting Started](/getting-started) guide.
 
-    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter) as a starting point
+    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-flows) as a starting point
     as this guide uses it as a starting point.
 
   </Step>

--- a/docs/content/docs/crewai-flows/shared-state/in-app-agent-write.mdx
+++ b/docs/content/docs/crewai-flows/shared-state/in-app-agent-write.mdx
@@ -35,7 +35,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
     You'll need to run your agent and connect it to CopilotKit before proceeding. If you haven't done so already,
     you can follow the instructions in the [Getting Started](/getting-started) guide.
 
-    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter) as a starting point
+    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagents-starter-crewai-flows) as a starting point
     as this guide uses it as a starting point.
 
   </Step>

--- a/docs/content/docs/mastra/human-in-the-loop/tool-based.mdx
+++ b/docs/content/docs/mastra/human-in-the-loop/tool-based.mdx
@@ -18,7 +18,7 @@ import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent
 
 <Callout type="info">
   Pictured above is the [coagent
-  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter)
+  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/mastra/starter)
   with the implementation below applied!
 </Callout>
 

--- a/docs/content/docs/pydantic-ai/human-in-the-loop/agent.mdx
+++ b/docs/content/docs/pydantic-ai/human-in-the-loop/agent.mdx
@@ -16,12 +16,6 @@ import RunAndConnectAgentSnippet from "@/snippets/coagents/run-and-connect-agent
   muted
 />
 
-<Callout type="info">
-  Pictured above is the [coagent
-  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter)
-  with the implementation below applied!
-</Callout>
-
 ## What is this?
 
 [Flow based agents](https://docs.pydantic-ai.com/concepts/flows) are stateful agents that can be interrupted and resumed

--- a/docs/content/docs/pydantic-ai/shared-state/in-app-agent-read.mdx
+++ b/docs/content/docs/pydantic-ai/shared-state/in-app-agent-read.mdx
@@ -16,12 +16,6 @@ import { ImageZoom } from "fumadocs-ui/components/image-zoom";
   />
 </Frame>
 
-<Callout type="info">
-  Pictured above is the [coagent
-  starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter)
-  with the [implementation](#implementation) section applied!
-</Callout>
-
 ## What is this?
 
 You can easily use the realtime agent state not only in the chat UI, but also in the native application UX.
@@ -40,8 +34,6 @@ state update you can reflect these updates natively in your application.
     You'll need to run your agent and connect it to CopilotKit before proceeding. If you haven't done so already,
     you can follow the instructions in the [Getting Started](/getting-started) guide.
 
-    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter) as a starting point
-    as this guide uses it as a starting point.
 
   </Step>
   <Step>

--- a/docs/content/docs/pydantic-ai/shared-state/in-app-agent-write.mdx
+++ b/docs/content/docs/pydantic-ai/shared-state/in-app-agent-write.mdx
@@ -35,9 +35,6 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
     You'll need to run your agent and connect it to CopilotKit before proceeding. If you haven't done so already,
     you can follow the instructions in the [Getting Started](/getting-started) guide.
 
-    If you don't already have an agent, you can use the [coagent starter](https://github.com/copilotkit/copilotkit/tree/main/examples/coagent-starter) as a starting point
-    as this guide uses it as a starting point.
-
   </Step>
   <Step>
     ### Define the Agent State


### PR DESCRIPTION
Lots of invalid links to the coagents-starter (as coagent-starter) or linking to it for other frameworks (it's lg specific). 

Removed or updated as needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Removed informational Callout notes across multiple guides (ADK Generative UI, AG2 HITL, Pydantic AI).
  - Updated starter links to new repositories: coagents-starter-crewai-crews, coagents-starter-crewai-flows, and mastra/starter.
  - Corrected outdated URLs in CrewAI crews/flows read/write shared-state and flow pages.
  - Streamlined guidance by removing starter recommendations in “When should I use this?” and “Run and Connect” sections.
  - No functional changes; overall content and structure remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->