### PR TITLE
fix: update thread_state with each state update

### DIFF
--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -230,6 +230,7 @@ class LangGraphAgent(Agent):
             agent_name=self.name
         )
         current_graph_state.update(state)
+        self.thread_state[thread_id] = current_graph_state
         lg_interrupt_meta_event = next((ev for ev in (meta_events or []) if ev.get("name") == "LangGraphInterruptEvent"), None)
         has_active_interrupts = active_interrupts is not None and len(active_interrupts) > 0
 
@@ -405,6 +406,7 @@ class LangGraphAgent(Agent):
                     event.get("data", {}).get("output"), dict
                 ):
                     current_graph_state.update(event["data"]["output"])
+                    self.thread_state[thread_id] = current_graph_state
 
                 emit_intermediate_state = metadata.get("copilotkit:emit-intermediate-state")
                 manually_emit_intermediate_state = (
@@ -473,6 +475,7 @@ class LangGraphAgent(Agent):
                     state = updated_state
                     prev_node_name = node_name
                     current_graph_state.update(updated_state)
+                    self.thread_state[thread_id] = current_graph_state
                     yield self._emit_state_sync_event(
                         thread_id=thread_id,
                         run_id=run_id,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates `LangGraphAgent.thread_state` anytime `current_graph_state` is updated. This allows the `thread_state` to be persisted for each `thread_id` as a chat is occurring.

## Related PRs and Issues

- Related to https://github.com/CopilotKit/CopilotKit/issues/2200

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where thread-specific context could be lost between calls, leading to inconsistent behavior. Thread state now persists reliably across interactions.
* **Stability**
  * Improved reliability for multi-threaded use, reducing intermittent context loss and state resets during consecutive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->