### PR TITLE
us gh runners instead of depot until weirdness is figured out

### DIFF
--- a/.github/workflows/dojo-e2e.yml
+++ b/.github/workflows/dojo-e2e.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   e2e:
     name: E2E Tests
-    runs-on: depot-ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout CPK


### PR DESCRIPTION
## What does this PR do?

Experiencing some weirdness with depot runners on e2e right now, switching back to github while we get this sussed out. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the end-to-end testing environment to use a standard CI runner image, improving reliability and consistency of automated checks.
  * No changes to test flow or application behavior; this has no impact on features or performance.
  * No downtime expected and no action required from users or administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->