### PR TITLE
bypass turbo caching

### DIFF
--- a/.github/workflows/dojo-e2e.yml
+++ b/.github/workflows/dojo-e2e.yml
@@ -58,7 +58,11 @@ jobs:
 
     - name: Build cpk
       working-directory: CopilotKit/CopilotKit
-      run: pnpm build
+      run: |
+        unset TURBO_API
+        unset TURBO_TOKEN
+        unset TURBO_TEAM
+        pnpm build
 
     - name: Install ag-ui dependencies
       working-directory: ag-ui/typescript-sdk
@@ -70,7 +74,11 @@ jobs:
 
     - name: Prepare dojo for e2e
       working-directory: ag-ui/typescript-sdk/apps/dojo
-      run: node ./scripts/prep-dojo-everything.js -e2e
+      run: |
+        unset TURBO_API
+        unset TURBO_TOKEN
+        unset TURBO_TEAM
+        node ./scripts/prep-dojo-everything.js
 
     - name: Install e2e dependencies
       working-directory: ag-ui/typescript-sdk/apps/dojo/e2e


### PR DESCRIPTION

## What does this PR do?

Depot.dev automatically configures turbo caching and this is breaking the way we link node modules from cpk for e2e test.
Bypass that by unsetting the relevant env vars in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to sanitize environment variables before build and end-to-end setup for more consistent runs.

* **Tests**
  * Improved reliability of end-to-end test preparation in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->