### PR TITLE
Revert "fix: prevent double action calls on none render copilot actions (#2513)"

### DIFF
--- a/CopilotKit/.changeset/thin-pears-attack.md
+++ b/CopilotKit/.changeset/thin-pears-attack.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/react-core": patch
----
-
-- fix: prevent double action calls on none render copilot actions

--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -766,9 +766,9 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
             // execute that action first, and then the "paired FE action"
             if (action && message.isActionExecutionMessage()) {
               // For HITL actions, check if they've already been processed to avoid redundant handler calls.
-              const pairedFeAction = getPairedFeAction(actions, message);
+              const isRenderAndWaitAction = (action as any)?._isRenderAndWait || false;
               const alreadyProcessed =
-                !pairedFeAction &&
+                isRenderAndWaitAction &&
                 finalMessages.some(
                   (fm) => fm.isResultMessage() && fm.actionExecutionId === message.id,
                 );


### PR DESCRIPTION
This reverts commit b79ed5c99260b113b4c4c3871c05c52fb2cc2800.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved handling of render-and-wait actions to prevent premature or duplicate execution, resulting in more reliable human-in-the-loop flows and more predictable chat/action behavior.

- Chores
  - Removed an obsolete release note entry with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->