### PR TITLE
chore: fix the link to lg interrupt docs

### DIFF
--- a/docs/content/docs/langgraph/human-in-the-loop/node-flow.mdx
+++ b/docs/content/docs/langgraph/human-in-the-loop/node-flow.mdx
@@ -8,7 +8,7 @@ import InstallSDKSnippet from "@/snippets/install-sdk.mdx"
 
 <Callout type="error">
     The usage of node based interrupt is [now discouraged](https://langchain-ai.github.io/langgraph/concepts/v0-human-in-the-loop/) by both LangGraph and CopilotKit.
-    As of LangGraph 0.2.57, the recommended way to set breakpoints is using [the interrupt function](https://https://docs.copilotkit.ai/coagents/human-in-the-loop/interrupt-flow) as it simplifies human-in-the-loop patterns.
+    As of LangGraph 0.2.57, the recommended way to set breakpoints is using [the interrupt function](https://docs.copilotkit.ai/coagents/human-in-the-loop/interrupt-flow) as it simplifies human-in-the-loop patterns.
 </Callout>
 
 <video src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/node-hitl.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected a broken hyperlink in the error callout within the Human-in-the-Loop Node Flow documentation. The URL now correctly points to the CopilotKit docs (removed duplicated protocol), improving navigation and reducing confusion. No other content was modified, and no functional behavior is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->