### PR TITLE
fix: deprecate lg platform remote endpoint

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -339,6 +339,16 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
 
   constructor(params?: CopilotRuntimeConstructorParams<T>) {
     if (
+      params?.remoteEndpoints &&
+      params?.remoteEndpoints.some((e) => e.type === EndpointType.LangGraphPlatform)
+    ) {
+      throw new CopilotKitMisuseError({
+        message:
+          "LangGraph Platform remote endpoints are deprecated in favor of the `agents` property. Refer to https://docs.copilotkit.ai/langgraph for more information.",
+      });
+    }
+
+    if (
       params?.actions &&
       params?.remoteEndpoints &&
       params?.remoteEndpoints.some((e) => e.type === EndpointType.LangGraphPlatform)

--- a/sdk-python/copilotkit/sdk.py
+++ b/sdk-python/copilotkit/sdk.py
@@ -226,6 +226,14 @@ class CopilotKitRemoteEndpoint:
         self.agents = agents or []
         self.actions = actions or []
 
+        if isinstance(agents, list):
+            from .langgraph_agent import LangGraphAgent
+            for agent in agents:
+                if isinstance(agent, LangGraphAgent):
+                    raise ValueError(
+                        "LangGraphAgent should be instantiated using LangGraphAGUIAgent. Refer to https://docs.copilotkit.ai/langgraph for more information.")
+        
+
     def info(
         self,
         *,


### PR DESCRIPTION
It's time to say goodbye.

AG-UI is now the de-facto way to run agents with CopilotKit. With support far ahead of the older agents, it's time to throw an error when these are used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Runtime: Added early validation that rejects deprecated endpoint types. Users now see a clear error with guidance to configure supported agents instead.
  - Python SDK: Added validation preventing construction of a legacy agent type. Errors now direct users to the GUI-enabled agent alternative.
  - These changes enforce deprecations proactively and improve error messaging to guide configuration, with no other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->