### PR TITLE
🚀 feat react-ui: persist visual state for message feedback buttons

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Chat.tsx
@@ -448,6 +448,7 @@ export function CopilotChat({
   const { publicApiKey, chatApiEndpoint } = copilotApiConfig;
   const [selectedImages, setSelectedImages] = useState<Array<ImageUpload>>([]);
   const [chatError, setChatError] = useState<ChatError | null>(null);
+  const [messageFeedback, setMessageFeedback] = useState<Record<string, "thumbsUp" | "thumbsDown">>({});
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Helper function to trigger event hooks only if publicApiKey is provided
@@ -726,6 +727,12 @@ export function CopilotChat({
       onThumbsUp(message);
     }
 
+    // Update feedback state
+    setMessageFeedback((prev) => ({
+      ...prev,
+      [message.id]: "thumbsUp",
+    }));
+
     // Trigger feedback given event
     triggerObservabilityHook("onFeedbackGiven", message.id, "thumbsUp");
   };
@@ -734,6 +741,12 @@ export function CopilotChat({
     if (onThumbsDown) {
       onThumbsDown(message);
     }
+
+    // Update feedback state
+    setMessageFeedback((prev) => ({
+      ...prev,
+      [message.id]: "thumbsDown",
+    }));
 
     // Trigger feedback given event
     triggerObservabilityHook("onFeedbackGiven", message.id, "thumbsDown");
@@ -764,6 +777,7 @@ export function CopilotChat({
         onCopy={handleCopy}
         onThumbsUp={handleThumbsUp}
         onThumbsDown={handleThumbsDown}
+        messageFeedback={messageFeedback}
         markdownTagRenderers={markdownTagRenderers}
         ImageRenderer={ImageRenderer}
         ErrorMessage={ErrorMessage}

--- a/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/Messages.tsx
@@ -17,6 +17,7 @@ export const Messages = ({
   onCopy,
   onThumbsUp,
   onThumbsDown,
+  messageFeedback,
   markdownTagRenderers,
   chatError,
 
@@ -95,6 +96,7 @@ export const Messages = ({
               onCopy={onCopy}
               onThumbsUp={onThumbsUp}
               onThumbsDown={onThumbsDown}
+              messageFeedback={messageFeedback}
               markdownTagRenderers={markdownTagRenderers}
             />
           );

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
@@ -13,6 +13,7 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
     onThumbsUp,
     onThumbsDown,
     isCurrentMessage,
+    feedback,
     markdownTagRenderers,
   } = props;
   const [copied, setCopied] = useState(false);
@@ -36,11 +37,15 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
   };
 
   const handleThumbsUp = () => {
-    if (onThumbsUp && message) onThumbsUp(message);
+    if (onThumbsUp && message) {
+      onThumbsUp(message);
+    }
   };
 
   const handleThumbsDown = () => {
-    if (onThumbsDown && message) onThumbsDown(message);
+    if (onThumbsDown && message) {
+      onThumbsDown(message);
+    }
   };
 
   const LoadingIcon = () => <span>{icons.activityIcon}</span>;
@@ -79,7 +84,9 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
               </button>
               {onThumbsUp && (
                 <button
-                  className="copilotKitMessageControlButton"
+                  className={`copilotKitMessageControlButton ${
+                    feedback === "thumbsUp" ? "active" : ""
+                  }`}
                   onClick={handleThumbsUp}
                   aria-label={labels.thumbsUp}
                   title={labels.thumbsUp}
@@ -89,7 +96,9 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
               )}
               {onThumbsDown && (
                 <button
-                  className="copilotKitMessageControlButton"
+                  className={`copilotKitMessageControlButton ${
+                    feedback === "thumbsDown" ? "active" : ""
+                  }`}
                   onClick={handleThumbsDown}
                   aria-label={labels.thumbsDown}
                   title={labels.thumbsDown}

--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
@@ -18,6 +18,7 @@ export function RenderMessage({
     onCopy,
     onThumbsUp,
     onThumbsDown,
+    messageFeedback,
     markdownTagRenderers,
   } = props;
 
@@ -47,6 +48,7 @@ export function RenderMessage({
           onCopy={onCopy}
           onThumbsUp={onThumbsUp}
           onThumbsDown={onThumbsDown}
+          feedback={messageFeedback?.[message.id] || null}
           markdownTagRenderers={markdownTagRenderers}
           ImageRenderer={ImageRenderer}
         />

--- a/CopilotKit/packages/react-ui/src/components/chat/props.ts
+++ b/CopilotKit/packages/react-ui/src/components/chat/props.ts
@@ -110,6 +110,11 @@ export interface MessagesProps {
   onThumbsDown?: (message: Message) => void;
 
   /**
+   * Map of message IDs to their feedback state
+   */
+  messageFeedback?: Record<string, "thumbsUp" | "thumbsDown">;
+
+  /**
    * A list of markdown components to render in assistant message.
    * Useful when you want to render custom elements in the message (e.g a reference tag element)
    */
@@ -200,6 +205,11 @@ export interface AssistantMessageProps {
   onThumbsDown?: (message: Message) => void;
 
   /**
+   * The feedback state for this message ("thumbsUp" or "thumbsDown")
+   */
+  feedback?: "thumbsUp" | "thumbsDown" | null;
+
+  /**
    * A list of markdown components to render in assistant message.
    * Useful when you want to render custom elements in the message (e.g a reference tag element)
    */
@@ -288,6 +298,11 @@ export interface RenderMessageProps {
    * Callback function for thumbs down feedback
    */
   onThumbsDown?: (message: Message) => void;
+
+  /**
+   * Map of message IDs to their feedback state
+   */
+  messageFeedback?: Record<string, "thumbsUp" | "thumbsDown">;
 
   /**
    * A list of markdown components to render in assistant message.

--- a/CopilotKit/packages/react-ui/src/css/messages.css
+++ b/CopilotKit/packages/react-ui/src/css/messages.css
@@ -121,6 +121,16 @@
   transform: scale(1.05);
 }
 
+.copilotKitMessageControlButton.active {
+  background-color: var(--copilot-kit-primary-color);
+  color: var(--copilot-kit-contrast-color);
+}
+
+.copilotKitMessageControlButton.active:hover {
+  background-color: color-mix(in srgb, var(--copilot-kit-primary-color) 90%, black);
+  color: var(--copilot-kit-contrast-color);
+}
+
 .copilotKitMessageControlButton svg {
   width: 1rem;
   height: 1rem;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Added visual active state persistence for message feedback buttons (thumbs up/down) to provide clear user feedback when feedback has been given on a message.

**Problem**
Previously, when users clicked thumbs up or thumbs down on a message, there was no visual indication that feedback had been recorded. The buttons would trigger callbacks but wouldn't show an active state, leaving users uncertain if their action was registered.

Implemented a feedback state management system that:
Tracks feedback per message using message ID
Applies an active class to the selected button with primary background color
Makes thumbs up/down mutually exclusive (clicking one switches from the other)
Persists during the session (resets on page refresh)
Survives component re-renders caused by new messages being added


## Related PRs and Issues
https://github.com/CopilotKit/CopilotKit/issues/2544

## Checklist

- [✅] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [] If the PR changes or adds functionality, I have updated the relevant documentation