### PR TITLE
fix(render-message): return null for default case

### DIFF
--- a/CopilotKit/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
+++ b/CopilotKit/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
@@ -51,5 +51,7 @@ export function RenderMessage({
           ImageRenderer={ImageRenderer}
         />
       );
+    default:
+      return null;
   }
 }


### PR DESCRIPTION
## What does this PR do?

Added `return null` statement in the default case of the switch statement in `RenderMessage` component to prevent React runtime errors when encountering unexpected message roles.

**Changes:**

- Added `return null` in the default case of the switch statement in `RenderMessage.tsx`.
- This ensures the render function always returns a valid value, JSX or null.

## Related PRs and Issues

- Fixes #2542

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation