### PR TITLE
chore: release python sdk 0.1.66

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.65"
+version = "0.1.66"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"
@@ -14,7 +14,7 @@ python = ">=3.10,<3.13"
 langgraph = {version = ">=0.3.25,<1.1.0"}
 langchain = {version = ">=0.3.0"}
 crewai = { version = "0.118.0", optional = true }
-ag-ui-langgraph = { version = "0.0.14", extras = ["fastapi"] }
+ag-ui-langgraph = { version = "0.0.15", extras = ["fastapi"] }
 fastapi = "^0.115.0"
 partialjson = "^0.0.8"
 toml = "^0.10.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped SDK package version to 0.1.66.
  * Updated dependency ag-ui-langgraph to 0.0.15 (with FastAPI extras).

* **Notes**
  * No functional or API changes; existing integrations continue to work as before.
  * Routine dependency maintenance to keep the SDK current and compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->