### PR TITLE
fix: allow disabling actions in the new action hooks

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-frontend-tool.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-frontend-tool.ts
@@ -2,11 +2,15 @@ import { useCopilotAction } from "./use-copilot-action";
 import { FrontendAction } from "../types/frontend-action";
 import { Parameter } from "@copilotkit/shared";
 
+type UseToolCallArgs<T extends Parameter[] | [] = []> = {
+  available?: "disabled" | undefined;
+} & Pick<
+  FrontendAction<T>,
+  "name" | "description" | "parameters" | "handler" | "followUp" | "render"
+>;
+
 export function useFrontendTool<const T extends Parameter[] | [] = []>(
-  tool: Pick<
-    FrontendAction<T>,
-    "name" | "description" | "parameters" | "handler" | "followUp" | "render"
-  >,
+  tool: UseToolCallArgs<T>,
   dependencies?: any[],
 ) {
   // Use the existing useCopilotAction hook

--- a/CopilotKit/packages/react-core/src/hooks/use-human-in-the-loop.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-human-in-the-loop.ts
@@ -2,10 +2,13 @@ import { useCopilotAction } from "./use-copilot-action";
 import { FrontendAction } from "../types";
 import { Parameter } from "@copilotkit/shared";
 
+type UseToolCallArgs<T extends Parameter[] | [] = []> = {
+  available?: "disabled" | undefined;
+  render: FrontendAction<T>["renderAndWaitForResponse"];
+} & Pick<FrontendAction<T>, "name" | "description" | "parameters">;
+
 export function useHumanInTheLoop<const T extends Parameter[] | [] = []>(
-  tool: Pick<FrontendAction<T>, "name" | "description" | "parameters"> & {
-    render: FrontendAction<T>["renderAndWaitForResponse"];
-  },
+  tool: UseToolCallArgs<T>,
   dependencies?: any[],
 ) {
   const { render, ...toolRest } = tool;
@@ -13,7 +16,7 @@ export function useHumanInTheLoop<const T extends Parameter[] | [] = []>(
   useCopilotAction(
     {
       ...toolRest,
-      available: "remote",
+      available: tool.available ? tool.available : "remote",
       renderAndWaitForResponse: render,
     },
     dependencies,

--- a/CopilotKit/packages/react-core/src/hooks/use-render-tool-call.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-render-tool-call.ts
@@ -1,15 +1,19 @@
 import { useCopilotAction } from "./use-copilot-action";
-import { FrontendAction } from "../types";
+import { FrontendAction, FrontendActionAvailability } from "../types";
 import { Parameter } from "@copilotkit/shared";
 
+type UseToolCallArgs<T extends Parameter[] | [] = []> = {
+  available?: "disabled" | undefined;
+} & Pick<FrontendAction<T>, "name" | "description" | "parameters" | "render">;
+
 export function useRenderToolCall<const T extends Parameter[] | [] = []>(
-  tool: Pick<FrontendAction<T>, "name" | "description" | "parameters" | "render">,
+  tool: UseToolCallArgs<T>,
   dependencies?: any[],
 ) {
   useCopilotAction<T>(
     {
       ...tool,
-      available: "frontend",
+      available: tool.available ? tool.available : "frontend",
     },
     dependencies,
   );


### PR DESCRIPTION
With the creation of the new convenience wrappers around useCopilotAction, the "available" got lost.
We should be able to set "disabled" on it