### PR TITLE
fix: implement initialMessages support in useCopilotChat

### DIFF
--- a/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/CopilotKit/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -421,6 +421,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
   const [runId, setRunId] = useState<string | null>(null);
 
   const chatAbortControllerRef = useRef<AbortController | null>(null);
+  const initialMessagesRef = useRef<any[] | undefined>(undefined);
 
   const showDevConsole = shouldShowDevConsole(props.showDevConsole);
 
@@ -537,6 +538,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
         runId,
         setRunId,
         chatAbortControllerRef,
+        initialMessagesRef,
         availableAgents,
         authConfig_c: props.authConfig_c,
         authStates_c: authStates,

--- a/CopilotKit/packages/react-core/src/context/copilot-context.tsx
+++ b/CopilotKit/packages/react-core/src/context/copilot-context.tsx
@@ -195,6 +195,9 @@ export interface CopilotContextParams {
   // i.e. when using `stop()` from `useChat`
   chatAbortControllerRef: React.MutableRefObject<AbortController | null>;
 
+  // Persistent storage for initialMessages that survives remounts
+  initialMessagesRef: React.MutableRefObject<any[] | undefined>;
+
   // runtime
   runtimeClient: CopilotRuntimeClient;
 
@@ -303,6 +306,7 @@ const emptyCopilotContext: CopilotContextParams = {
   runId: null,
   setRunId: () => {},
   chatAbortControllerRef: { current: null },
+  initialMessagesRef: { current: undefined },
   availableAgents: [],
   extensions: {},
   setExtensions: () => {},

--- a/CopilotKit/packages/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -236,10 +236,19 @@ export function useCopilotChat(options: UseCopilotChatOptions = {}): UseCopilotC
     langGraphInterruptAction,
     setLangGraphInterruptAction,
     chatSuggestionConfiguration,
+    initialMessagesRef,
 
     runtimeClient,
   } = useCopilotContext();
   const { messages, setMessages, suggestions, setSuggestions } = useCopilotMessagesContext();
+
+  // Store initialMessages in context ref (persists across remounts)
+  useEffect(() => {
+    if (options.initialMessages && options.initialMessages.length > 0 && !initialMessagesRef.current) {
+      const converted = aguiToGQL(options.initialMessages);
+      initialMessagesRef.current = converted;
+    }
+  }, []); // Empty dependency array - only run once on mount
 
   // Simple state for MCP servers (keep for interface compatibility)
   const [mcpServers, setLocalMcpServers] = useState<MCPServerConfig[]>([]);
@@ -372,7 +381,7 @@ export function useCopilotChat(options: UseCopilotChatOptions = {}): UseCopilotC
     ...options,
     actions: Object.values(actions),
     copilotConfig: copilotApiConfig,
-    initialMessages: aguiToGQL(options.initialMessages || []),
+    initialMessages: initialMessagesRef.current || [],
     onFunctionCall: getFunctionCallHandler(),
     onCoAgentStateRender,
     messages,

--- a/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -894,7 +894,7 @@ please use an LLM adapter instead.`,
           const data: InfoResponse = await response.json();
           const endpointAgents = (data?.agents ?? []).map((agent) => ({
             name: agent.name,
-            description: agent.description ?? "" ?? "",
+            description: agent.description ?? "",
             id: randomId(), // Required by Agent type
             endpoint,
           }));


### PR DESCRIPTION
## Description

Fixes issue where the `initialMessages` parameter in `useCopilotChat` was completely non-functional - messages never appeared in the UI.

## Changes

- Add `initialMessagesRef` to `CopilotContext` for persistence across remounts
- Store `initialMessages` in ref on first mount in `useCopilotChat`
- Initialize `CopilotMessages` component state from ref
- Prevent agent state from overwriting `initialMessages` with empty array
- Clean up duplicate nullish coalescing in runtime

## Result

The `initialMessages` now display correctly and persist across remounts.

## Test Plan

1. Pass `initialMessages` to `useCopilotChat`:
```tsx
useCopilotChat({
  initialMessages: [
    { role: "user", content: "Hello" },
    { role: "assistant", content: "Hi! How can I help?" }
  ]
})
```
2. Verify messages appear in the UI
3. Trigger a remount (e.g., React Strict Mode) and verify messages persist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initial chat messages now persist across component remounts, retaining preloaded conversations.
* **Bug Fixes**
  * Prevented empty updates from clearing existing messages.
  * Improved error handling during message fetches to avoid partial or invalid states.
  * More reliable initialization of local messages from preloaded data.
* **Refactor**
  * Simplified logic and standardized early-return guards with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->