### PR TITLE
fix(sdk-python): compatibility with langchain v1 (#2633)

### DIFF
--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -8,8 +8,15 @@ from langgraph.graph.state import CompiledStateGraph
 from typing_extensions import NotRequired
 
 from langgraph.types import Command
-from langchain.load.dump import dumps as langchain_dumps
-from langchain.schema import BaseMessage, SystemMessage
+
+try:
+    from langchain.load.dump import dumps as langchain_dumps
+    from langchain.schema import BaseMessage, SystemMessage
+except ImportError:
+    # Langchain >= 1.0.0
+    from langchain_core.load import dumps as langchain_dumps
+    from langchain_core.messages import BaseMessage, SystemMessage
+    
 from langchain_core.runnables import RunnableConfig, ensure_config
 from langchain_core.messages import HumanMessage
 

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -15,7 +15,12 @@ from ag_ui.core import (
 )
 from langgraph.graph.state import CompiledStateGraph
 from langchain_core.runnables import RunnableConfig
-from langchain.schema import BaseMessage
+
+try:
+    from langchain.schema import BaseMessage
+except ImportError:
+    # Langchain >= 1.0.0
+    from langchain_core.messages import BaseMessage
 
 
 class CustomEventNames(Enum):


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Langchain v1 has been streamlined with the removal of many modules from the package. 
- This PR seeks to address some of the module references which are no longer present, whilst maintaining backwards compatibility for langchain < 1.0.0.

## Related PRs and Issues

- https://github.com/CopilotKit/CopilotKit/issues/2633

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved LangChain compatibility to support both legacy versions and LangChain 1.0+, enabling the SDK to work seamlessly across all supported LangChain versions without breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->