### PR TITLE
fix(react-core): include threadId in useChat hook dependencies (#2635)

### DIFF
--- a/CopilotKit/packages/react-core/src/hooks/use-chat.ts
+++ b/CopilotKit/packages/react-core/src/hooks/use-chat.ts
@@ -943,7 +943,7 @@ export function useChat(options: UseChatOptions): UseChatHelpers {
         }
       }, []);
     },
-    [setLangGraphInterruptAction],
+    [setLangGraphInterruptAction, threadId],
   );
 
   const append = useAsyncCallback(


### PR DESCRIPTION
## What does this PR do?

This PR fixs the issue in function `composeAndFlushMetaEventsInput` in `CopilotKit/packages/react-core/src/hooks/use-chat.ts`. The `threadId` parameter is missing from the dependency array of its useCallback hook. This omission prevents the function from being updated when the session changes, leading to incorrect handling of the request input.

## Related PRs and Issues

- 🐛 Bug: resolving langgraph interrupt is not handled correctly after calling setThreadId #2635

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the chat interface wasn't properly responding to conversation thread changes, ensuring smooth transitions between different chat sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->