### PR TITLE
chore: swap all `package-install` blocks for `npm` blocks

### DIFF
--- a/docs/content/docs/adk/quickstart.mdx
+++ b/docs/content/docs/adk/quickstart.mdx
@@ -74,7 +74,7 @@ Before you begin, you'll need the following:
             </Step>
             <Step>
                 ### Install dependencies
-                ```package-install
+                ```npm
                 ```
                 <Callout type="info">
                     This will also install your agent's python dependencies! If you have trouble, try running `npm run install:agent` instead.
@@ -171,7 +171,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install CopilotKit
                 First, install the latest packages for CopilotKit into your frontend.
-                ```package-install
+                ```npm
                 npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime
                 ```
             </Step>

--- a/docs/content/docs/agno/quickstart.mdx
+++ b/docs/content/docs/agno/quickstart.mdx
@@ -205,7 +205,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install CopilotKit packages
 
-                ```package-install
+                ```npm
                 @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/agno
                 ```
             </Step>

--- a/docs/content/docs/crewai-flows/quickstart.mdx
+++ b/docs/content/docs/crewai-flows/quickstart.mdx
@@ -121,7 +121,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
         <Step>
             ### Install CopilotKit
             First, install the latest packages for CopilotKit into your frontend.
-            ```package-install
+            ```npm
             npm install @copilotkit/react-ui @copilotkit/react-core
             ```
         </Step>

--- a/docs/content/docs/direct-to-llm/guides/copilot-textarea.mdx
+++ b/docs/content/docs/direct-to-llm/guides/copilot-textarea.mdx
@@ -23,7 +23,7 @@ suggest changes to the text, for example providing a summary or rephrasing the t
 <Step>
 ### Install `@copilotkit/react-textarea`
     
-```package-install
+```npm
 npm install @copilotkit/react-textarea
 ```
 </Step>

--- a/docs/content/docs/direct-to-llm/guides/quickstart.mdx
+++ b/docs/content/docs/direct-to-llm/guides/quickstart.mdx
@@ -50,7 +50,7 @@ If you don't have a NextJS application or just want to code-along, you can follo
 
 First, install the latest packages for CopilotKit.
 
-```package-install
+```npm
 npm install @copilotkit/react-ui @copilotkit/react-core
 ```
 
@@ -90,7 +90,7 @@ You are almost there! Now it's time to setup your Copilot UI.
 ### Install CopilotKit
 First, install the latest packages for CopilotKit.
 
-```package-install
+```npm
 npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime
 ```
 

--- a/docs/content/docs/direct-to-llm/tutorials/ai-powered-textarea/step-2-setup-copilotkit.mdx
+++ b/docs/content/docs/direct-to-llm/tutorials/ai-powered-textarea/step-2-setup-copilotkit.mdx
@@ -19,7 +19,7 @@ Now that we have our todo list app running, we're ready to integrate CopilotKit.
 
 To install the CopilotKit dependencies, run the following:
 
-```package-install
+```npm
 npm install @copilotkit/react-core @copilotkit/react-textarea
 ```
 

--- a/docs/content/docs/direct-to-llm/tutorials/ai-todo-app/step-2-setup-copilotkit.mdx
+++ b/docs/content/docs/direct-to-llm/tutorials/ai-todo-app/step-2-setup-copilotkit.mdx
@@ -20,7 +20,7 @@ Now that we have our todo list app running, we're ready to integrate CopilotKit.
 
 To install the CopilotKit dependencies, run the following:
 
-```package-install
+```npm
 npm install @copilotkit/react-core @copilotkit/react-ui
 ```
 

--- a/docs/content/docs/langgraph/quickstart.mdx
+++ b/docs/content/docs/langgraph/quickstart.mdx
@@ -96,7 +96,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install dependencies
 
-                ```package-install
+                ```npm
                 ```
             </Step>
             <Step>
@@ -158,7 +158,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install CopilotKit packages
 
-                ```package-install
+                ```npm
                 @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime
                 ```
             </Step>

--- a/docs/content/docs/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
+++ b/docs/content/docs/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
@@ -16,7 +16,7 @@ Now that we have both our application and agent running, let's connect them usin
 <Accordion title="Install command (optional)">
   **The package versions in this tutorial are pinned, so updating the dependencies could break the tutorial.**
 
-  ```package-install
+  ```npm
   @copilotkit/react-core @copilotkit/react-ui
   ```
 </Accordion>

--- a/docs/content/docs/llamaindex/quickstart.mdx
+++ b/docs/content/docs/llamaindex/quickstart.mdx
@@ -194,7 +194,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install CopilotKit packages
 
-                ```package-install
+                ```npm
                 @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/llamaindex
                 ```
             </Step>

--- a/docs/content/docs/mastra/quickstart.mdx
+++ b/docs/content/docs/mastra/quickstart.mdx
@@ -79,7 +79,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install dependencies
 
-                ```package-install
+                ```npm
                 ```
             </Step>
             <Step>
@@ -141,7 +141,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install CopilotKit packages
 
-                ```package-install
+                ```npm
                 @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/mastra @mastra/client-js
                 ```
             </Step>

--- a/docs/content/docs/microsoft-agent-framework/quickstart.mdx
+++ b/docs/content/docs/microsoft-agent-framework/quickstart.mdx
@@ -72,7 +72,7 @@ Before you begin, you'll need the following:
 
                 The starter includes a `postinstall` script that automatically installs both your npm and agent dependencies.
 
-                ```package-install
+                ```npm
                 ```
 
                 <Callout type="info" title="Manual setup">
@@ -324,7 +324,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install CopilotKit packages
 
-                ```package-install
+                ```npm
                 @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/client
                 ```
             </Step>

--- a/docs/content/docs/pydantic-ai/quickstart.mdx
+++ b/docs/content/docs/pydantic-ai/quickstart.mdx
@@ -67,7 +67,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install dependencies
 
-                ```package-install
+                ```npm
                 ```
             </Step>
             <Step>
@@ -182,7 +182,7 @@ Before you begin, you'll need the following:
             <Step>
                 ### Install CopilotKit packages
 
-                ```package-install
+                ```npm
                 @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime @ag-ui/client
                 ```
             </Step>

--- a/docs/snippets/install-sdk.mdx
+++ b/docs/snippets/install-sdk.mdx
@@ -9,7 +9,7 @@ experiences with CopilotKit requires our LangGraph SDK.
     <InstallPythonSDKSnippet components={props.components} />
   </Tab>
   <Tab value="TypeScript" className="p-0 m-0">
-    ```package-install
+    ```npm
     npm install @copilotkit/sdk-js
     ```
   </Tab>

--- a/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
+++ b/docs/snippets/self-hosting-copilot-runtime-create-endpoint.mdx
@@ -32,7 +32,7 @@ If you are not sure yet, simply ignore this note.
     <If conditions={[{ key: 'packageName', value: true }]}>
         ### Install provider package
 
-        ```package-install
+        ```npm
         npm install {{packageName}}
         ```
     </If>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code block formatting across multiple quickstart guides and tutorials to use standard npm syntax highlighting instead of custom package-install formatting. No changes to installation commands or content—only presentational updates affecting how code blocks are displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->