### PR TITLE
fix(langgraph): increase assistant search limit to 1000

### DIFF
--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-action-constructors.ts
@@ -77,6 +77,7 @@ export function constructLGCRemoteAction({
           logger: logger.child({ component: "remote-actions.remote-lg-action.streamEvents" }),
           deploymentUrl: endpoint.deploymentUrl,
           langsmithApiKey: endpoint.langsmithApiKey,
+          assistantSearchLimit: endpoint.assistantSearchLimit,
           agent,
           threadId,
           nodeName,

--- a/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
+++ b/CopilotKit/packages/runtime/src/lib/runtime/remote-actions.ts
@@ -48,6 +48,12 @@ export interface LangGraphPlatformEndpoint
   deploymentUrl: string;
   langsmithApiKey?: string | null;
   agents: LangGraphPlatformAgent[];
+  /**
+   * The maximum number of assistants to search for. Defaults to 1000.
+   * Can also be configured via the COPILOTKIT_LANGGRAPH_ASSISTANT_SEARCH_LIMIT environment variable.
+   * If both are set, this property takes precedence.
+   */
+  assistantSearchLimit?: number;
 }
 
 export type RemoteActionInfoResponse = {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When searching for assistants from the LangGraph API, the number of results was limited to the default of 10 because no `limit` parameter was specified. This prevented the discovery of all available assistants if more than 10 existed.

This PR increases the limit to 1000 (the maximum value allowed by the LangGraph API) to ensure a more comprehensive search and allow for a larger number of assistants to be discovered.

## Related PRs and Issues

- Fixes #2775

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant search is now bounded by a configurable limit (default 1000), adjustable via endpoint setting or environment variable; endpoint setting takes precedence.
* **Bug Fixes**
  * Improves assistant discovery reliability by enforcing the search limit to avoid unbounded queries.
* **Tests**
  * Added tests to verify the endpoint-provided search limit is propagated to execute calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->