### PR TITLE
fix(docs): correct framework name in aws-strands quickstart

### DIFF
--- a/docs/content/docs/aws-strands/quickstart.mdx
+++ b/docs/content/docs/aws-strands/quickstart.mdx
@@ -60,7 +60,7 @@ Before you begin, you'll need the following:
                 ### Run our CLI
 
                 ```bash
-                npx copilotkit@latest create -f strands
+                npx copilotkit@latest create -f aws-strands-py
                 ```
             </Step>
             <Step>


### PR DESCRIPTION
## Summary

- Fix typo in aws-strands quickstart documentation: `strands` → `aws-strands-py`

## Problem

Running `npx copilotkit@latest create -f strands` as documented fails with:

```
Expected --framework=strands to be one of: langgraph-py, langgraph-js, mastra, flows, llamaindex, agno, pydantic-ai, ag2, adk, aws-strands-py, a2a, microsoft-agent-framework-dotnet, microsoft-agent-framework-py
See more help with --help
```

## Solution

Update the CLI command in `docs/content/docs/aws-strands/quickstart.mdx` to use the correct framework name `aws-strands-py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the Quickstart guide to reference the correct starter template identifier for AWS Strands projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->