### PR TITLE
Change req.on 'close' to req.socket.on 'close'

### DIFF
--- a/src/v2.x/packages/runtime/src/endpoints/express-utils.ts
+++ b/src/v2.x/packages/runtime/src/endpoints/express-utils.ts
@@ -66,7 +66,7 @@ export function createFetchRequestFromExpress(req: ExpressRequest): Request {
   }
 
   const controller = new AbortController();
-  req.on("close", () => controller.abort());
+  req.socket.on("close", () => controller.abort());
   init.signal = controller.signal;
 
   try {


### PR DESCRIPTION
Node.js triggers the `req.close` event upon completing the request body parsing, which sets `request.signal.aborted` to true, preventing the result from being returned.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request cancellation to trigger when the underlying socket closes, ensuring more reliable request cleanup on connection termination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->