### PR TITLE
fix: use session storage to fix new tab bug

### DIFF
--- a/docs/app/logo.tsx
+++ b/docs/app/logo.tsx
@@ -21,9 +21,9 @@ export function Logo({
   height = DESKTOP_HEIGHT,
 }: LogoProps) {
   const handleLogoClick = (e: React.MouseEvent) => {
-    // Clear the integration selection from localStorage
-    localStorage.removeItem('selectedIntegration')
-    localStorage.setItem('lastDocsPath', '/')
+    // Clear the integration selection from sessionStorage (tab-specific)
+    sessionStorage.removeItem('selectedIntegration')
+    sessionStorage.setItem('lastDocsPath', '/')
     // Dispatch custom event to notify IntegrationSelector
     window.dispatchEvent(new CustomEvent('clearIntegrationSelection'))
   }

--- a/docs/components/layout/navbar.tsx
+++ b/docs/components/layout/navbar.tsx
@@ -74,9 +74,9 @@ const Navbar = ({ pageTree }: NavbarProps) => {
   const [lastDocsPath, setLastDocsPath] = useState<string | null>(null)
   const pathname = usePathname()
 
-  // Read localStorage on client only to avoid hydration mismatch
+  // Read sessionStorage on client only to avoid hydration mismatch (tab-specific)
   useEffect(() => {
-    setLastDocsPath(localStorage.getItem('lastDocsPath'))
+    setLastDocsPath(sessionStorage.getItem('lastDocsPath'))
   }, [])
 
   // Determine active route based on current path

--- a/docs/components/react/subdocs-menu.tsx
+++ b/docs/components/react/subdocs-menu.tsx
@@ -21,14 +21,16 @@ import {
 import { PiGraph } from "react-icons/pi";
 import { PlugIcon } from "lucide-react";
 
-// localStorage utilities for managing user's connection type preference
+// sessionStorage utilities for managing user's connection type preference
+// Using sessionStorage instead of localStorage so preference is tab-specific
+// and doesn't persist across new tabs or browser sessions
 const STORAGE_KEY = "copilotkit-nav-preference";
 const DEFAULT_URL = "/";
 
 function getStoredNavPreference(): string | null {
   if (typeof window === "undefined") return null;
   try {
-    return localStorage.getItem(STORAGE_KEY);
+    return sessionStorage.getItem(STORAGE_KEY);
   } catch {
     return null;
   }
@@ -37,9 +39,9 @@ function getStoredNavPreference(): string | null {
 function setStoredNavPreference(url: string): void {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(STORAGE_KEY, url);
+    sessionStorage.setItem(STORAGE_KEY, url);
   } catch {
-    // Ignore localStorage errors
+    // Ignore sessionStorage errors
   }
 }
 

--- a/docs/components/ui/integrations-sidebar/integration-selector.tsx
+++ b/docs/components/ui/integrations-sidebar/integration-selector.tsx
@@ -82,9 +82,9 @@ const IntegrationSelector = ({
   const router = useRouter()
   const isClearing = useRef(false)
 
-  // Load persisted selection on mount
+  // Load persisted selection on mount (using sessionStorage for tab-specific state)
   useEffect(() => {
-    const persistedSelection = localStorage.getItem('selectedIntegration')
+    const persistedSelection = sessionStorage.getItem('selectedIntegration')
     if (persistedSelection && persistedSelection !== 'null') {
       setSelectedIntegration(persistedSelection as Integration)
     }
@@ -95,8 +95,8 @@ const IntegrationSelector = ({
     const handleClearSelection = () => {
       // Set flag to prevent pathname effect from re-selecting
       isClearing.current = true
-      // Clear localStorage immediately to prevent race condition
-      localStorage.removeItem('selectedIntegration')
+      // Clear sessionStorage immediately to prevent race condition
+      sessionStorage.removeItem('selectedIntegration')
       flushSync(() => {
         setSelectedIntegration(null)
       })
@@ -111,12 +111,12 @@ const IntegrationSelector = ({
     }
   }, [setSelectedIntegration])
 
-  // Persist selection to localStorage when it changes
+  // Persist selection to sessionStorage when it changes (tab-specific)
   useEffect(() => {
     if (selectedIntegration) {
-      localStorage.setItem('selectedIntegration', selectedIntegration)
+      sessionStorage.setItem('selectedIntegration', selectedIntegration)
     } else {
-      localStorage.removeItem('selectedIntegration')
+      sessionStorage.removeItem('selectedIntegration')
     }
   }, [selectedIntegration])
 
@@ -134,8 +134,8 @@ const IntegrationSelector = ({
     if (selectedIntegration === integrationKey) {
       // Set flag to prevent pathname effect from re-selecting
       isClearing.current = true
-      localStorage.removeItem('selectedIntegration')
-      localStorage.setItem('lastDocsPath', '/')
+      sessionStorage.removeItem('selectedIntegration')
+      sessionStorage.setItem('lastDocsPath', '/')
       flushSync(() => {
         setSelectedIntegration(null)
       })
@@ -180,10 +180,10 @@ const IntegrationSelector = ({
     }
   }, [pathname, selectedIntegration, setSelectedIntegration])
 
-  // Track last visited docs page (not reference)
+  // Track last visited docs page (not reference) - tab-specific
   useEffect(() => {
     if (!pathname.startsWith('/reference')) {
-      localStorage.setItem('lastDocsPath', pathname)
+      sessionStorage.setItem('lastDocsPath', pathname)
     }
   }, [pathname])
 

--- a/docs/components/ui/mobile-sidebar/dropdown.tsx
+++ b/docs/components/ui/mobile-sidebar/dropdown.tsx
@@ -23,9 +23,9 @@ const Dropdown = ({ onSelect }: DropdownProps) => {
   const pathname = usePathname()
   const [lastDocsPath, setLastDocsPath] = useState<string | null>(null)
 
-  // Read localStorage on client only to avoid hydration mismatch
+  // Read sessionStorage on client only to avoid hydration mismatch (tab-specific)
   useEffect(() => {
-    setLastDocsPath(localStorage.getItem('lastDocsPath'))
+    setLastDocsPath(sessionStorage.getItem('lastDocsPath'))
   }, [])
 
   // Get the appropriate href for Documentation link


### PR DESCRIPTION
…elected integration

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes a bug introduced in the sidebar integrations update which caused new tabs to use previously selected integration from other session.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [X ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [X ] If the PR changes or adds functionality, I have updated the relevant documentation
