### PR TITLE
fix: correct script paths in CI workflows

### DIFF
--- a/.github/workflows/publish_custom-pre.yml
+++ b/.github/workflows/publish_custom-pre.yml
@@ -33,6 +33,6 @@ jobs:
         run: pnpm run build
 
       - name: Publish snapshot
-        run: ./scripts/release/publish-snapshot-release.sh
+        run: ./src/v1.x/scripts/release/publish-snapshot-release.sh
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Git Tag
         if: ${{ steps.check-if-published.outputs.published == 'true' && steps.is-in-prerelease-mode.outputs.is_in_prerelease_mode == 'false' }}
         run: |
-          node -p "require('./scripts/release/generate-changelog')('${{ steps.new-version.outputs.version }}')" > changelog.txt
+          node -p "require('./src/v1.x/scripts/release/generate-changelog')('${{ steps.new-version.outputs.version }}')" > changelog.txt
           git tag -a v${{ steps.new-version.outputs.version }} -m "Release ${{ steps.new-version.outputs.version }}"
           git push origin v${{ steps.new-version.outputs.version }}
           git push origin main --force


### PR DESCRIPTION
## What does this PR do?

Fixes CI workflow failures caused by incorrect script paths in GitHub Actions workflows.

The CI was failing with:
```
./scripts/release/publish-snapshot-release.sh: No such file or directory
Error: Process completed with exit code 127
```

This PR corrects the script paths to point to their actual location in `src/v1.x/scripts/release/`.

## Changes

### 1. `publish_custom-pre.yml`
- Fixed path: `./scripts/release/publish-snapshot-release.sh` → `./src/v1.x/scripts/release/publish-snapshot-release.sh`

### 2. `publish_release.yml`
- Fixed path: `./scripts/release/generate-changelog` → `./src/v1.x/scripts/release/generate-changelog`

## Root Cause

The workflows were referencing scripts at `./scripts/release/` but the actual scripts are located at `./src/v1.x/scripts/release/`. There is no `scripts/` directory at the repository root.

## Verification

- ✅ Scripts verified to exist at correct paths
- ✅ YAML syntax validated
- ✅ No other script path references found

## Related PRs and Issues

Fixes the CI error reported in workflow runs.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (N/A - CI fix only)