### PR TITLE
fix(react-core): return array of tool messages

### DIFF
--- a/src/v1.x/packages/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/src/v1.x/packages/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -509,9 +509,9 @@ export function useCopilotChatInternal({
 
       const lazyRendered = lazyToolRendered(message, allMessages);
       if (lazyRendered) {
-        const renderedGenUi = lazyRendered();
-        if (renderedGenUi) {
-          return { ...message, generativeUI: () => renderedGenUi };
+        const renderedGenUiArray = lazyRendered();
+        if (renderedGenUiArray && renderedGenUiArray.length > 0) {
+          return { ...message, generativeUI: () => renderedGenUiArray };
         }
       }
 

--- a/src/v1.x/packages/react-core/src/hooks/use-lazy-tool-renderer.tsx
+++ b/src/v1.x/packages/react-core/src/hooks/use-lazy-tool-renderer.tsx
@@ -1,29 +1,26 @@
 import { useRenderToolCall } from "@copilotkitnext/react";
 import { AIMessage, Message, ToolResult } from "@copilotkit/shared";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 
 export function useLazyToolRenderer(): (
   message?: AIMessage,
   messages?: Message[],
-) => null | (() => ReturnType<ReturnType<typeof useRenderToolCall>> | null) {
+) => null | (() => ReturnType<ReturnType<typeof useRenderToolCall>>[] | null) {
   const renderToolCall = useRenderToolCall();
 
   return useCallback(
     (message?: AIMessage, messages?: Message[]) => {
-      if (!message?.toolCalls?.length) return null;
-
-      const toolCall = message.toolCalls[0];
-      if (!toolCall) return null;
-
-      const toolMessage = messages?.find(
-        (m) => m.role === "tool" && m.toolCallId === toolCall.id,
-      ) as ToolResult;
-
-      return () =>
-        renderToolCall({
-          toolCall,
-          toolMessage,
-        });
+      const { toolCalls } = message || {};
+      const renderToolCalls = () => {
+        if (!toolCalls || toolCalls.length === 0) return [];
+        return toolCalls.map((toolCall) => {
+          const toolMessage = messages?.find(
+            (m) => m.role === "tool" && m.toolCallId === toolCall.id,
+          ) as ToolResult;
+          return renderToolCall({ toolCall, toolMessage });
+        });  // Map over all tool calls
+      };
+      return renderToolCalls;
     },
     [renderToolCall],
   );


### PR DESCRIPTION
## What does this PR do?

Attempt to apply recommended fix to enable all AG-UI tool call events to be intercepted in v1.50 (currently only first tool call message is shown). The fix was based upon the CopilotKit Support Bot's recommendation.

## Related PRs and Issues

- [Bug: 1.50 no longer renders AG-UI tool events correctly](https://github.com/CopilotKit/CopilotKit/issues/2946)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
