### PR TITLE
feat(runtime): forward auth headers on agent.connect()

### DIFF
--- a/src/v2.x/packages/runtime/src/__tests__/handle-connect.test.ts
+++ b/src/v2.x/packages/runtime/src/__tests__/handle-connect.test.ts
@@ -1,0 +1,174 @@
+import { Observable } from "rxjs";
+import { describe, it, expect } from "vitest";
+import { BaseEvent } from "@ag-ui/client";
+import { handleConnectAgent } from "../handlers/handle-connect";
+import { CopilotRuntime } from "../runtime";
+import { AgentRunnerConnectRequest } from "../runner/agent-runner";
+
+describe("handleConnectAgent", () => {
+  const createMockRuntime = (
+    agents: Record<string, unknown> = {},
+    connectHandler?: (request: AgentRunnerConnectRequest) => Observable<BaseEvent>
+  ): CopilotRuntime => {
+    return {
+      agents: Promise.resolve(agents),
+      transcriptionService: undefined,
+      beforeRequestMiddleware: undefined,
+      afterRequestMiddleware: undefined,
+      runner: {
+        run: () =>
+          new Observable<BaseEvent>((subscriber) => {
+            subscriber.complete();
+          }),
+        connect: connectHandler ?? (() =>
+          new Observable<BaseEvent>((subscriber) => {
+            subscriber.complete();
+          })),
+        isRunning: async () => false,
+        stop: async () => false,
+      },
+    } as CopilotRuntime;
+  };
+
+  it("should return 404 when agent does not exist", async () => {
+    const runtime = createMockRuntime({});
+    const request = new Request("https://example.com/agent/nonexistent/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thread-1",
+        runId: "run-1",
+        state: {},
+        messages: [],
+        tools: [],
+        context: [],
+        forwardedProps: {},
+      }),
+    });
+
+    const response = await handleConnectAgent({
+      runtime,
+      request,
+      agentId: "nonexistent-agent",
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+
+    const body = await response.json();
+    expect(body).toEqual({
+      error: "Agent not found",
+      message: "Agent 'nonexistent-agent' does not exist",
+    });
+  });
+
+  it("forwards only authorization and custom x- headers to runner.connect()", async () => {
+    const recordedRequests: AgentRunnerConnectRequest[] = [];
+    let resolveConnect: (() => void) | undefined;
+    const connectInvoked = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+
+    const runtime = createMockRuntime(
+      { "test-agent": { clone: () => ({}) } },
+      (request: AgentRunnerConnectRequest) =>
+        new Observable<BaseEvent>((subscriber) => {
+          recordedRequests.push(request);
+          resolveConnect?.();
+          subscriber.complete();
+        })
+    );
+
+    const requestBody = {
+      threadId: "thread-1",
+      runId: "run-1",
+      state: {},
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    };
+
+    const request = new Request("https://example.com/agent/test-agent/connect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Custom": "custom-value",
+        "X-Another-Header": "another-value",
+        Authorization: "Bearer forwarded-token",
+        Origin: "http://localhost:4200",
+        "User-Agent": "test-agent",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await handleConnectAgent({
+      runtime,
+      request,
+      agentId: "test-agent",
+    });
+
+    expect(response.status).toBe(200);
+    await connectInvoked;
+
+    expect(recordedRequests).toHaveLength(1);
+    expect(recordedRequests[0].threadId).toBe("thread-1");
+    expect(recordedRequests[0].headers).toMatchObject({
+      authorization: "Bearer forwarded-token",
+      "x-custom": "custom-value",
+      "x-another-header": "another-value",
+    });
+    expect(recordedRequests[0].headers).not.toHaveProperty("origin");
+    expect(recordedRequests[0].headers).not.toHaveProperty("content-type");
+    expect(recordedRequests[0].headers).not.toHaveProperty("user-agent");
+  });
+
+  it("passes empty headers object when no forwardable headers present", async () => {
+    const recordedRequests: AgentRunnerConnectRequest[] = [];
+    let resolveConnect: (() => void) | undefined;
+    const connectInvoked = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+
+    const runtime = createMockRuntime(
+      { "test-agent": { clone: () => ({}) } },
+      (request: AgentRunnerConnectRequest) =>
+        new Observable<BaseEvent>((subscriber) => {
+          recordedRequests.push(request);
+          resolveConnect?.();
+          subscriber.complete();
+        })
+    );
+
+    const requestBody = {
+      threadId: "thread-1",
+      runId: "run-1",
+      state: {},
+      messages: [],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    };
+
+    const request = new Request("https://example.com/agent/test-agent/connect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "http://localhost:4200",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await handleConnectAgent({
+      runtime,
+      request,
+      agentId: "test-agent",
+    });
+
+    expect(response.status).toBe(200);
+    await connectInvoked;
+
+    expect(recordedRequests).toHaveLength(1);
+    expect(recordedRequests[0].headers).toEqual({});
+  });
+});

--- a/src/v2.x/packages/runtime/src/__tests__/header-utils.test.ts
+++ b/src/v2.x/packages/runtime/src/__tests__/header-utils.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { shouldForwardHeader, extractForwardableHeaders } from "../handlers/header-utils";
+
+describe("header-utils", () => {
+  describe("shouldForwardHeader", () => {
+    it("forwards authorization header (case-insensitive)", () => {
+      expect(shouldForwardHeader("authorization")).toBe(true);
+      expect(shouldForwardHeader("Authorization")).toBe(true);
+      expect(shouldForwardHeader("AUTHORIZATION")).toBe(true);
+    });
+
+    it("forwards x-* custom headers", () => {
+      expect(shouldForwardHeader("x-custom")).toBe(true);
+      expect(shouldForwardHeader("X-Custom")).toBe(true);
+      expect(shouldForwardHeader("x-request-id")).toBe(true);
+      expect(shouldForwardHeader("X-Forwarded-For")).toBe(true);
+    });
+
+    it("blocks standard headers", () => {
+      expect(shouldForwardHeader("content-type")).toBe(false);
+      expect(shouldForwardHeader("Content-Type")).toBe(false);
+      expect(shouldForwardHeader("origin")).toBe(false);
+      expect(shouldForwardHeader("user-agent")).toBe(false);
+      expect(shouldForwardHeader("accept")).toBe(false);
+      expect(shouldForwardHeader("cookie")).toBe(false);
+      expect(shouldForwardHeader("host")).toBe(false);
+    });
+  });
+
+  describe("extractForwardableHeaders", () => {
+    it("extracts only forwardable headers from request", () => {
+      const request = new Request("https://example.com", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Custom": "custom-value",
+          "X-Request-ID": "req-123",
+          Authorization: "Bearer token",
+          Origin: "http://localhost",
+        },
+      });
+
+      const result = extractForwardableHeaders(request);
+
+      expect(result).toEqual({
+        "x-custom": "custom-value",
+        "x-request-id": "req-123",
+        authorization: "Bearer token",
+      });
+    });
+
+    it("returns empty object when no forwardable headers present", () => {
+      const request = new Request("https://example.com", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "http://localhost",
+        },
+      });
+
+      const result = extractForwardableHeaders(request);
+
+      expect(result).toEqual({});
+    });
+
+    it("preserves header values exactly", () => {
+      const request = new Request("https://example.com", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+          "X-Complex-Value": "value with spaces and special=chars&more",
+        },
+      });
+
+      const result = extractForwardableHeaders(request);
+
+      expect(result.authorization).toBe("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+      expect(result["x-complex-value"]).toBe("value with spaces and special=chars&more");
+    });
+  });
+});

--- a/src/v2.x/packages/runtime/src/handlers/handle-connect.ts
+++ b/src/v2.x/packages/runtime/src/handlers/handle-connect.ts
@@ -1,6 +1,7 @@
 import { RunAgentInput, RunAgentInputSchema } from "@ag-ui/client";
 import { EventEncoder } from "@ag-ui/encoder";
 import { CopilotRuntime } from "../runtime";
+import { extractForwardableHeaders } from "./header-utils";
 
 interface ConnectAgentParameters {
   request: Request;
@@ -50,9 +51,12 @@ export async function handleConnectAgent({
         );
       }
 
+      const forwardableHeaders = extractForwardableHeaders(request);
+
       runtime.runner
         .connect({
           threadId: input.threadId,
+          headers: forwardableHeaders,
         })
         .subscribe({
           next: async (event) => {

--- a/src/v2.x/packages/runtime/src/handlers/handle-run.ts
+++ b/src/v2.x/packages/runtime/src/handlers/handle-run.ts
@@ -6,6 +6,7 @@ import {
 } from "@ag-ui/client";
 import { EventEncoder } from "@ag-ui/encoder";
 import { CopilotRuntime } from "../runtime";
+import { extractForwardableHeaders } from "./header-utils";
 
 interface RunAgentParameters {
   request: Request;
@@ -39,21 +40,10 @@ export async function handleRunAgent({
     const agent = registeredAgent.clone() as AbstractAgent;
 
     if (agent && "headers" in agent) {
-      const shouldForward = (headerName: string) => {
-        const lower = headerName.toLowerCase();
-        return lower === "authorization" || lower.startsWith("x-");
-      };
-
-      const forwardableHeaders: Record<string, string> = {};
-      request.headers.forEach((value, key) => {
-        if (shouldForward(key)) {
-          forwardableHeaders[key] = value;
-        }
-      });
-
-      agent.headers = { 
-        ...agent.headers as Record<string, string>, 
-        ...forwardableHeaders 
+      const forwardableHeaders = extractForwardableHeaders(request);
+      agent.headers = {
+        ...agent.headers as Record<string, string>,
+        ...forwardableHeaders
       };
     }
 

--- a/src/v2.x/packages/runtime/src/handlers/header-utils.ts
+++ b/src/v2.x/packages/runtime/src/handlers/header-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Determines if a header should be forwarded based on the allowlist.
+ * Forwards: authorization header and all x-* custom headers.
+ */
+export function shouldForwardHeader(headerName: string): boolean {
+  const lower = headerName.toLowerCase();
+  return lower === "authorization" || lower.startsWith("x-");
+}
+
+/**
+ * Extracts headers that should be forwarded from a Request object.
+ * Forwards only authorization and x-* headers.
+ */
+export function extractForwardableHeaders(request: Request): Record<string, string> {
+  const forwardableHeaders: Record<string, string> = {};
+  request.headers.forEach((value, key) => {
+    if (shouldForwardHeader(key)) {
+      forwardableHeaders[key] = value;
+    }
+  });
+  return forwardableHeaders;
+}

--- a/src/v2.x/packages/runtime/src/runner/agent-runner.ts
+++ b/src/v2.x/packages/runtime/src/runner/agent-runner.ts
@@ -9,6 +9,7 @@ export interface AgentRunnerRunRequest {
 
 export interface AgentRunnerConnectRequest {
   threadId: string;
+  headers?: Record<string, string>;
 }
 
 export interface AgentRunnerIsRunningRequest {


### PR DESCRIPTION
Add support for forwarding authorization and x-* headers to the AgentRunner.connect() method, matching the existing behavior in handleRunAgent().

- Add optional `headers` field to AgentRunnerConnectRequest interface
- Extract header forwarding logic into reusable header-utils module
- Update handleConnectAgent to extract and forward allowlisted headers
- Refactor handleRunAgent to use shared extractForwardableHeaders utility
- Add tests for header forwarding in connect and header utils

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Describe the changes introduced in this PR)

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
