### PR TITLE
fix(sdk-js): correct langgraph types export

### DIFF
--- a/.changeset/fix-sdk-js-langgraph-types.md
+++ b/.changeset/fix-sdk-js-langgraph-types.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/sdk-js": patch
+---
+
+fix: point langgraph types export to dist/langgraph/index.d.ts

--- a/src/v1.x/packages/sdk-js/package.json
+++ b/src/v1.x/packages/sdk-js/package.json
@@ -25,7 +25,7 @@
       "import": "./dist/langchain.mjs"
     },
     "./langgraph": {
-      "types": "./dist/langgraph.d.ts",
+      "types": "./dist/langgraph/index.d.ts",
       "require": "./dist/langgraph.js",
       "import": "./dist/langgraph.mjs"
     }


### PR DESCRIPTION
## Summary
- fix sdk-js langgraph types export to point at dist/langgraph/index.d.ts
- add changeset for patch release

## Context
The current export map in @copilotkit/sdk-js 1.51.x points `./langgraph` types to `dist/langgraph.d.ts`, but the build outputs `dist/langgraph/index.d.ts`. This breaks TS resolution for `@copilotkit/sdk-js/langgraph`.

Closes #3053.
