### PR TITLE
fix: disable welcome screen in tests to fix failures

### DIFF
--- a/src/v2.x/packages/react/src/__tests__/utils/test-helpers.tsx
+++ b/src/v2.x/packages/react/src/__tests__/utils/test-helpers.tsx
@@ -162,7 +162,7 @@ export function renderWithCopilotKit({
       >
         {children || (
           <div style={{ height: 400 }}>
-            <CopilotChat />
+            <CopilotChat welcomeScreen={false} />
           </div>
         )}
       </CopilotChatConfigurationProvider>

--- a/src/v2.x/packages/react/src/hooks/__tests__/use-frontend-tool.e2e.test.tsx
+++ b/src/v2.x/packages/react/src/hooks/__tests__/use-frontend-tool.e2e.test.tsx
@@ -135,7 +135,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <DynamicToolComponent />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -238,7 +238,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <StreamingTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -366,7 +366,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <NoFollowUpTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -441,7 +441,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <ContinueFollowUpTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -530,7 +530,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <ToolRegistrar />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -626,7 +626,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
             </button>
             {showTool && <ToggleableToolComponent />}
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         );
@@ -726,7 +726,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
               Activate Override
             </button>
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         );
@@ -848,7 +848,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <IntegratedToolComponent />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -966,7 +966,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <ExecutingStateTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -1385,7 +1385,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
             <ParentTool />
             <ChildTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -1481,7 +1481,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <AvailabilityTestTool onRegistered={onRegistered} />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -1569,7 +1569,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <IdempotentTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -1743,7 +1743,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <ErrorTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -1837,7 +1837,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <AsyncErrorTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -1928,7 +1928,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
           <>
             <WildcardTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -2048,7 +2048,7 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
             <SpecificTool />
             <WildcardTool />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),

--- a/src/v2.x/packages/react/src/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
+++ b/src/v2.x/packages/react/src/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
@@ -69,7 +69,7 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
           <>
             <HITLComponent />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -181,7 +181,7 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
           <>
             <InteractiveHITLComponent />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -280,7 +280,7 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
           <>
             <MultipleHITLComponent />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -388,7 +388,7 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
           <>
             <DualHookComponent />
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         ),
@@ -490,7 +490,7 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
             </button>
             {enabled && <DynamicHITLComponent />}
             <div style={{ height: 400 }}>
-              <CopilotChat />
+              <CopilotChat welcomeScreen={false} />
             </div>
           </>
         );
@@ -690,7 +690,7 @@ describe("HITL Thread Reconnection Bug", () => {
         <>
           <HITLComponent />
           <div style={{ height: 400 }}>
-            <CopilotChat />
+            <CopilotChat welcomeScreen={false} />
           </div>
         </>
       ),
@@ -742,7 +742,7 @@ describe("HITL Thread Reconnection Bug", () => {
         <>
           <HITLComponent />
           <div style={{ height: 400 }}>
-            <CopilotChat />
+            <CopilotChat welcomeScreen={false} />
           </div>
         </>
       ),
@@ -797,7 +797,7 @@ describe("HITL Thread Reconnection Bug", () => {
         <>
           <HITLComponent />
           <div style={{ height: 400 }}>
-            <CopilotChat />
+            <CopilotChat welcomeScreen={false} />
           </div>
         </>
       ),
@@ -894,7 +894,7 @@ describe("HITL Thread Reconnection Bug", () => {
         <>
           <MultiToolComponent />
           <div style={{ height: 400 }}>
-            <CopilotChat />
+            <CopilotChat welcomeScreen={false} />
           </div>
         </>
       ),
@@ -1000,7 +1000,7 @@ describe("HITL Thread Reconnection Bug", () => {
         <>
           <ToggleableHITL />
           <div style={{ height: 400 }}>
-            <CopilotChat />
+            <CopilotChat welcomeScreen={false} />
           </div>
         </>
       ),
@@ -1090,7 +1090,7 @@ describe("HITL Thread Reconnection Bug", () => {
         <>
           <RemountableHITL />
           <div style={{ height: 400 }}>
-            <CopilotChat />
+            <CopilotChat welcomeScreen={false} />
           </div>
         </>
       ),


### PR DESCRIPTION
## Summary
- Fixes test failures introduced by the welcome screen feature (c56fe61)
- The welcome screen shows a different UI when `messages.length === 0`, which broke tests expecting the normal chat layout
- Pass `welcomeScreen={false}` to `CopilotChat` in test helpers and test files

## Test plan
- [x] All 361 React package tests pass