### PR TITLE
fix: center welcome screen when parent uses flex sizing

### DIFF
--- a/src/v2.x/packages/react/src/components/chat/CopilotChatView.tsx
+++ b/src/v2.x/packages/react/src/components/chat/CopilotChatView.tsx
@@ -190,7 +190,7 @@ export function CopilotChatView({
     );
 
     return (
-      <div className={twMerge("relative h-full", className)} {...props}>
+      <div className={twMerge("relative h-full flex flex-col", className)} {...props}>
         {BoundWelcomeScreen}
       </div>
     );
@@ -480,7 +480,7 @@ export namespace CopilotChatView {
     return (
       <div
         className={cn(
-          "h-full flex flex-col items-center justify-center px-4",
+          "flex-1 flex flex-col items-center justify-center px-4",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- Fixed welcome screen not being vertically centered when parent container uses `flex: 1` instead of explicit height
- Changed the welcome screen wrapper to be a flex container (`flex flex-col`)
- Changed WelcomeScreen component to use `flex-1` instead of `h-full` for proper flex-based sizing