### PR TITLE
chore: show full build output in turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
-      "outputLogs": "errors-only"
+      "outputLogs": "full"
     },
     "@copilotkit/runtime#generate-graphql-schema": {
       "cache": false,


### PR DESCRIPTION
## Summary
- Changed `outputLogs` from `"errors-only"` to `"full"` for the `build` task in `turbo.json`
- Build output was previously completely silent on success, making it hard to observe progress