### PR TITLE
feat: improve CI by running build only once

### DIFF
--- a/.github/workflows/e2e_dojo.yml
+++ b/.github/workflows/e2e_dojo.yml
@@ -91,12 +91,12 @@ jobs:
             test_path: tests/a2aMiddlewareTests
             services: ["dojo", "a2a-middleware"]
             wait_on: http://localhost:9999,tcp:localhost:8011,tcp:localhost:8012,tcp:localhost:8013,tcp:localhost:8014
-            needs_python: false
+            needs_python: true
           - suite: adk-middleware
             test_path: tests/adkMiddlewareTests
             services: ["dojo", "adk-middleware"]
             wait_on: http://localhost:9999,tcp:localhost:8010
-            needs_python: false
+            needs_python: true
           - suite: agno
             test_path: tests/agnoTests
             services: ["dojo", "agno"]
@@ -151,12 +151,12 @@ jobs:
             test_path: tests/serverStarterTests
             services: ["dojo", "server-starter"]
             wait_on: http://localhost:9999,tcp:localhost:8000
-            needs_python: false
+            needs_python: true
           - suite: server-starter-all
             test_path: tests/serverStarterAllFeaturesTests
             services: ["dojo", "server-starter-all"]
             wait_on: http://localhost:9999,tcp:localhost:8001
-            needs_python: false
+            needs_python: true
           - suite: aws-strands
             test_path: tests/awsStrandsTests
             services: ["dojo", "aws-strands"]


### PR DESCRIPTION
 

## What does this PR do?

## Speed up e2e dojo workflow

### Problem

Every matrix job (15 total) in the `e2e_dojo` workflow repeats the full setup: checkout, install, and `pnpm build` of CopilotKit. The build step is the most expensive (~5 min) and produces identical output across all jobs. Additionally, 4 TypeScript-only suites unnecessarily install Python tooling (Poetry, uv).

### Changes

**1. Split into `build` + `dojo` jobs**

- New `build` job runs once: checks out CPK, installs deps, runs `pnpm build`, and uploads `packages/*/dist/` as an artifact (~35MB)
- The `dojo` matrix job (`needs: build`) downloads the artifact instead of rebuilding — eliminating 14 redundant builds

**2. Conditional Python setup via `needs_python` matrix flag**

- Each matrix entry now has a `needs_python` field
- The 3 Python steps (cache Python deps, install Poetry, install uv) are gated with `if: ${{ matrix.needs_python }}`
- 4 suites skip Python entirely: `langgraph-typescript`, `mastra`, `mastra-agent-local`, `middleware-starter`

### Impact

| Metric | Before | After |
|---|---|---|
| Redundant CPK builds | 15 | 1 |
| Unnecessary Python setups | 4 of 15 jobs | 0 |
| Est. billable minutes | ~240 min | ~160 min (~33% reduction) |
 

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
