### PR TITLE
fix: typing of useCopilotReadable

### DIFF
--- a/src/v1.x/packages/react-core/src/hooks/use-copilot-readable.ts
+++ b/src/v1.x/packages/react-core/src/hooks/use-copilot-readable.ts
@@ -67,7 +67,7 @@ import { useEffect, useRef } from "react";
 /**
  * Options for the useCopilotReadable hook.
  */
-export interface UseCopilotReadableOptions {
+export interface UseCopilotReadableOptions<T> {
   /**
    * The description of the information to be added to the Copilot context.
    */
@@ -75,7 +75,7 @@ export interface UseCopilotReadableOptions {
   /**
    * The value to be added to the Copilot context. Object values are automatically stringified.
    */
-  value: any;
+  value: T;
   /**
    * The ID of the parent context, if any.
    */
@@ -95,15 +95,14 @@ export interface UseCopilotReadableOptions {
    * A custom conversion function to use to serialize the value to a string. If not provided, the value
    * will be serialized using `JSON.stringify`.
    */
-  convert?: (description: string, value: any) => string;
+  convert?: (value: T) => string;
 }
 
 /**
  * Adds the given information to the Copilot context to make it readable by Copilot.
  */
-export function useCopilotReadable(
-  { description, value, convert, available }: UseCopilotReadableOptions,
-  dependencies?: any[],
+export function useCopilotReadable<T,>(
+  { description, value, convert, available }: UseCopilotReadableOptions<T>
 ): string | undefined {
   const { copilotkit } = useCopilotKit();
   const ctxIdRef = useRef<string | undefined>(undefined);


### PR DESCRIPTION
## What does this PR do?

Fix typing issue in useCopilotReadable hook.

There is an issue in typing of the **convert** props. We pass in this method only value. 

It is is a type of 
```ts 
(value: any) => void
``` 
and not 
```ts 
convert?: (value: T) => string;
````

I also change typing:

- Remove useless dependencies props.
- Make hook generic.

That maybe imply a breaking change.


## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
