### PR TITLE
fix: propagate agent error messages into RUN_ERROR events

### DIFF
--- a/src/v2.x/packages/runtime/src/runner/in-memory.ts
+++ b/src/v2.x/packages/runtime/src/runner/in-memory.ts
@@ -230,9 +230,12 @@ export class InMemoryAgentRunner extends AgentRunner {
         store.isRunning = false;
         runSubject.complete();
         nextSubject.complete();
-      } catch {
+      } catch (error) {
+        const interruptionMessage =
+          error instanceof Error ? error.message : String(error);
         const appendedEvents = finalizeRunEvents(currentRunEvents, {
           stopRequested: store.stopRequested,
+          interruptionMessage,
         });
         for (const event of appendedEvents) {
           runSubject.next(event);


### PR DESCRIPTION
## Summary
- When a remote ag-ui agent connection fails (e.g. HTTP 401, connection refused), the catch block in `InMemoryAgentRunner.run()` was discarding the error, causing users to see a generic "Run ended without emitting a terminal event" message
- Now the actual error message (including HTTP status and response body) is forwarded through `finalizeRunEvents` into the `RUN_ERROR` event so users see what actually went wrong

## Test plan
- [x] Added two new tests in `in-memory-runner.test.ts` covering HTTP errors (401) and generic connection errors
- [x] All 7 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)