### PR TITLE
fix(runtime): remove dead GraphQL schema building from runtime init

### DIFF
--- a/packages/v1/runtime/src/lib/integrations/shared.ts
+++ b/packages/v1/runtime/src/lib/integrations/shared.ts
@@ -1,16 +1,12 @@
 import { YogaInitialContext } from "graphql-yoga";
 import { buildSchemaSync } from "type-graphql";
 import { CopilotResolver } from "../../graphql/resolvers/copilot.resolver";
-import { useDeferStream } from "@graphql-yoga/plugin-defer-stream";
 import { CopilotRuntime } from "../runtime/copilot-runtime";
 import { CopilotServiceAdapter } from "../../service-adapters";
 import { CopilotCloudOptions } from "../cloud";
 import { LogLevel, createLogger } from "../../lib/logger";
-import { createYoga } from "graphql-yoga";
 import telemetry from "../telemetry-client";
 import { StateResolver } from "../../graphql/resolvers/state.resolver";
-import * as packageJson from "../../../package.json";
-import { CopilotKitError, CopilotKitErrorCode } from "@copilotkit/shared";
 
 /**
  * CORS configuration for CopilotKit endpoints.
@@ -31,13 +27,6 @@ export interface CopilotEndpointCorsConfig {
 }
 
 const logger = createLogger();
-
-export const addCustomHeaderPlugin = {
-  onResponse({ response }) {
-    // Set your custom header; adjust the header name and value as needed
-    response.headers.set("X-CopilotKit-Runtime-Version", packageJson.version);
-  },
-};
 
 type AnyPrimitive = string | boolean | number | null;
 export type CopilotRequestContextProperties = Record<
@@ -66,24 +55,6 @@ export interface CreateCopilotRuntimeServerOptions {
   cors?: CopilotEndpointCorsConfig;
 }
 
-export async function createContext(
-  initialContext: YogaInitialContext,
-  copilotKitContext: CreateCopilotRuntimeServerOptions,
-  contextLogger: typeof logger,
-  properties: CopilotRequestContextProperties = {},
-): Promise<Partial<GraphQLContext>> {
-  logger.debug({ copilotKitContext }, "Creating GraphQL context");
-  const ctx: GraphQLContext = {
-    ...initialContext,
-    _copilotkit: {
-      ...copilotKitContext,
-    },
-    properties: { ...properties },
-    logger: contextLogger,
-  };
-  return ctx;
-}
-
 export function buildSchema(
   options: {
     emitSchemaFile?: string;
@@ -100,12 +71,6 @@ export function buildSchema(
 
 export type CommonConfig = {
   logging: typeof logger;
-  schema: ReturnType<typeof buildSchema>;
-  plugins: Parameters<typeof createYoga>[0]["plugins"];
-  context: (ctx: YogaInitialContext) => Promise<Partial<GraphQLContext>>;
-  maskedErrors: {
-    maskError: (error: any, message: string, isDev?: boolean) => any;
-  };
 };
 
 export function getCommonConfig(
@@ -119,8 +84,6 @@ export function getCommonConfig(
     level: logLevel,
     component: "getCommonConfig",
   });
-
-  const contextLogger = createLogger({ level: logLevel });
 
   if (options.cloud) {
     telemetry.setCloudConfiguration({
@@ -143,50 +106,7 @@ export function getCommonConfig(
     },
   });
 
-  // User error codes that should not be logged as server errors
-  const userErrorCodes = [
-    CopilotKitErrorCode.AGENT_NOT_FOUND,
-    CopilotKitErrorCode.API_NOT_FOUND,
-    CopilotKitErrorCode.REMOTE_ENDPOINT_NOT_FOUND,
-    CopilotKitErrorCode.CONFIGURATION_ERROR,
-    CopilotKitErrorCode.MISSING_PUBLIC_API_KEY_ERROR,
-  ];
-
   return {
-    logging: createLogger({ component: "Yoga GraphQL", level: logLevel }),
-    schema: buildSchema(),
-    plugins: [useDeferStream(), addCustomHeaderPlugin],
-    context: (ctx: YogaInitialContext): Promise<Partial<GraphQLContext>> =>
-      createContext(ctx, options, contextLogger, options.properties),
-    // Suppress logging for user configuration errors
-    maskedErrors: {
-      maskError: (error: any, message: string, isDev?: boolean) => {
-        // Check if this is a user configuration error (could be wrapped in GraphQLError)
-        const originalError = error.originalError || error;
-        const extensions = error.extensions;
-        const errorCode = extensions?.code;
-
-        // Suppress logging for user errors based on error code
-        if (errorCode && userErrorCodes.includes(errorCode)) {
-          // Log user configuration errors at debug level instead
-          console.debug("User configuration error:", error.message);
-          return error;
-        }
-
-        // Check if the original error is a user error
-        if (
-          originalError instanceof CopilotKitError &&
-          userErrorCodes.includes(originalError.code)
-        ) {
-          // Log user configuration errors at debug level instead
-          console.debug("User configuration error:", error.message);
-          return error;
-        }
-
-        // For application errors, log normally and mask if needed
-        console.error("Application error:", error);
-        return error;
-      },
-    },
+    logging: createLogger({ component: "CopilotKit Runtime", level: logLevel }),
   };
 }


### PR DESCRIPTION
`getCommonConfig()` was calling `buildSchema()` at startup, but the resulting schema was never used — all integrations only read `.logging` from the config. The actual request handling uses v2's Hono-based runtime. Under Vercel's server minification, class names got mangled (e.g. `Boolean` -> `B$`), causing GraphQL name validation errors on deploy.
