### PR TITLE
fix(sdk-python): loosen FastAPI version ceiling from ^0.115.0 to >=0.115.0,<1.0.0

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -15,7 +15,7 @@ langgraph = {version = ">=0.3.25,<1.1.0"}
 langchain = {version = ">=0.3.0"}
 crewai = { version = "0.118.0", optional = true }
 ag-ui-langgraph = { version = ">=0.0.24", extras = ["fastapi"] }
-fastapi = "^0.115.0"
+fastapi = ">=0.115.0,<1.0.0"
 partialjson = "^0.0.8"
 toml = "^0.10.2"
 


### PR DESCRIPTION
## Problem

The Poetry caret constraint `^0.115.0` in `sdk-python/pyproject.toml` resolves to `>=0.115.0,<0.116.0` for 0.x versions (per [PEP 440 / Poetry docs](https://python-poetry.org/docs/dependency-specification/#caret-requirements)). This blocks installation alongside any FastAPI release since **0.116.0 (June 2025)**.

Current stable FastAPI is **0.129.0** — 14 minor versions ahead of the ceiling.

## Impact

- Cannot `pip install copilotkit` in any project using FastAPI >=0.116.0
- Multiple users blocked (see #2771 comments)
- Our production project has **~90 tests bypassed** with `COPILOTKIT_AVAILABLE = False` guards because of this

## Fix

```diff
- fastapi = "^0.115.0"
+ fastapi = ">=0.115.0,<1.0.0"
```

This allows all current and future 0.x FastAPI releases while still capping at the upcoming 1.0 major version boundary, which may introduce breaking changes.

## Testing

- The SDK uses standard FastAPI features (routing, dependency injection, middleware) that have been stable across all 0.11x–0.12x releases
- No FastAPI APIs used by the SDK were deprecated or removed in 0.116.0–0.129.0
- `ag-ui-langgraph` (also in deps) uses `>=0.115.0` without an upper bound, so this change aligns the two constraints

## Note on `ag-ui-langgraph`

`ag-ui-langgraph[fastapi]` also depends on FastAPI. Its constraint is already `>=0.115.0` (no ceiling), so this change to `copilotkit` is the only fix needed.

Fixes #2771