### PR TITLE
fix: guard against undefined return from sendFunction in push-to-talk

### DIFF
--- a/packages/v1/react-ui/src/hooks/use-push-to-talk.tsx
+++ b/packages/v1/react-ui/src/hooks/use-push-to-talk.tsx
@@ -155,7 +155,9 @@ export const usePushToTalk = ({
           recordedChunks.current = [];
           setPushToTalkState("idle");
           const message = await sendFunction(transcription);
-          setStartReadingFromMessageId(message.id);
+          if (message) {
+            setStartReadingFromMessageId(message.id);
+          }
         });
       }
     }


### PR DESCRIPTION
sendFunction (wrapping sendMessage) returns Promise<void>, so accessing .id on the result throws a TypeError. Add a null check to skip setting startReadingFromMessageId when the return value is undefined.

Fixes #3042, fixes #3011

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Describe the changes introduced in this PR)

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
