### PR TITLE
ci: support workflow_dispatch for social copy generator

### DIFF
--- a/.github/workflows/social_copy-generator.yml
+++ b/.github/workflows/social_copy-generator.yml
@@ -195,8 +195,7 @@ jobs:
             - If the changes are internal/minor, still generate copy but note it's a maintenance/improvement update
           allowed_tools: "Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),View,GlobTool,GrepTool"
           max_turns: "10"
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Update comment with results
         if: steps.verify.outputs.should_run == 'true' && success()


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger with `pr_number` input so the social copy generator can be run on **any existing PR** (open or merged) via Actions → Run workflow
- Add duplicate comment detection to skip posting if a social-copy-generator comment already exists
- Add GitHub API diff fallback (`gh pr diff`) for merged PRs where the branch may have been deleted and `git merge-base` fails

## How to use on an existing PR
1. Go to **Actions** → **social / copy-generator** → **Run workflow**
2. Enter the PR number
3. The bot posts the checkbox comment on that PR
4. Check the checkbox to generate

## Test plan
- [ ] Run workflow_dispatch with an existing open PR number → verify comment appears
- [ ] Run workflow_dispatch with a merged PR number → verify comment appears
- [ ] Check checkbox on merged PR → verify generation works
- [ ] Run workflow_dispatch twice on same PR → verify no duplicate comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)