### PR TITLE
fix(anthropic): validate tool_use input is object before sending to API

### DIFF
--- a/.changeset/fix-anthropic-tool-input.md
+++ b/.changeset/fix-anthropic-tool-input.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix(anthropic): validate tool_use input is object before sending to API

--- a/packages/v1/runtime/src/service-adapters/anthropic/utils.ts
+++ b/packages/v1/runtime/src/service-adapters/anthropic/utils.ts
@@ -134,13 +134,22 @@ export function convertMessageToAnthropicMessage(
       ],
     };
   } else if (message.isActionExecutionMessage()) {
+    // Anthropic requires tool_use input to be a valid object (dict).
+    // If the LLM returned non-object arguments (e.g. empty string, array, null),
+    // fall back to an empty object to avoid 400 errors.
+    const input =
+      message.arguments &&
+      typeof message.arguments === "object" &&
+      !Array.isArray(message.arguments)
+        ? message.arguments
+        : {};
     return {
       role: "assistant",
       content: [
         {
           id: message.id,
           type: "tool_use",
-          input: message.arguments,
+          input,
           name: message.name,
         },
       ],

--- a/packages/v1/runtime/tests/service-adapters/anthropic/utils-tool-input-validation.test.ts
+++ b/packages/v1/runtime/tests/service-adapters/anthropic/utils-tool-input-validation.test.ts
@@ -1,0 +1,90 @@
+import { convertMessageToAnthropicMessage } from "../../../src/service-adapters/anthropic/utils";
+
+/**
+ * Tests for tool_use input validation in convertMessageToAnthropicMessage.
+ *
+ * Anthropic requires tool_use.input to be a valid dictionary (object).
+ * When an LLM returns non-object arguments (empty string, array, null, etc.),
+ * the converter must fall back to {} to avoid HTTP 400 errors.
+ *
+ * See: https://github.com/CopilotKit/CopilotKit/issues/3300
+ */
+
+function makeActionExecutionMessage(overrides: {
+  id?: string;
+  name?: string;
+  arguments?: any;
+}) {
+  return {
+    id: overrides.id ?? "tool-1",
+    name: overrides.name ?? "myTool",
+    arguments: overrides.arguments ?? {},
+    isTextMessage: () => false,
+    isImageMessage: () => false,
+    isActionExecutionMessage: () => true,
+    isResultMessage: () => false,
+    isAgentStateMessage: () => false,
+  } as any;
+}
+
+describe("convertMessageToAnthropicMessage – tool_use input validation", () => {
+  it("passes through valid object arguments", () => {
+    const msg = makeActionExecutionMessage({
+      arguments: { key: "value" },
+    });
+    const result = convertMessageToAnthropicMessage(msg);
+    expect(result.role).toBe("assistant");
+    const content = (result as any).content[0];
+    expect(content.type).toBe("tool_use");
+    expect(content.input).toEqual({ key: "value" });
+  });
+
+  it("falls back to {} when arguments is an empty string", () => {
+    const msg = makeActionExecutionMessage({ arguments: "" });
+    const result = convertMessageToAnthropicMessage(msg);
+    const content = (result as any).content[0];
+    expect(content.input).toEqual({});
+  });
+
+  it("falls back to {} when arguments is a non-empty string", () => {
+    const msg = makeActionExecutionMessage({ arguments: "some string" });
+    const result = convertMessageToAnthropicMessage(msg);
+    const content = (result as any).content[0];
+    expect(content.input).toEqual({});
+  });
+
+  it("falls back to {} when arguments is null", () => {
+    const msg = makeActionExecutionMessage({ arguments: null });
+    const result = convertMessageToAnthropicMessage(msg);
+    const content = (result as any).content[0];
+    expect(content.input).toEqual({});
+  });
+
+  it("falls back to {} when arguments is undefined", () => {
+    const msg = makeActionExecutionMessage({ arguments: undefined });
+    const result = convertMessageToAnthropicMessage(msg);
+    const content = (result as any).content[0];
+    expect(content.input).toEqual({});
+  });
+
+  it("falls back to {} when arguments is an array", () => {
+    const msg = makeActionExecutionMessage({ arguments: [1, 2, 3] });
+    const result = convertMessageToAnthropicMessage(msg);
+    const content = (result as any).content[0];
+    expect(content.input).toEqual({});
+  });
+
+  it("falls back to {} when arguments is a number", () => {
+    const msg = makeActionExecutionMessage({ arguments: 42 });
+    const result = convertMessageToAnthropicMessage(msg);
+    const content = (result as any).content[0];
+    expect(content.input).toEqual({});
+  });
+
+  it("passes through an empty object {}", () => {
+    const msg = makeActionExecutionMessage({ arguments: {} });
+    const result = convertMessageToAnthropicMessage(msg);
+    const content = (result as any).content[0];
+    expect(content.input).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

When an LLM returns non-object tool call arguments (e.g., an empty string `""`), the Anthropic adapter forwards them as-is to the API, causing HTTP 400:

```
messages.X.content.0.tool_use.input: Input should be a valid dictionary
```

## Root Cause

In `convertMessageToAnthropicMessage()` (`utils.ts`), `message.arguments` is passed directly as `tool_use.input` without validating that it's a plain object. When the LLM hallucinates non-object arguments (empty string, array, null, etc.), Anthropic rejects the request.

## Fix

Added a type check before passing `input` to ensure it's always a plain object (`Record<string, any>`). Falls back to `{}` for any non-object value.

## Tests

Added 8 test cases covering:
- Valid object arguments (pass-through)
- Empty string, non-empty string → `{}`
- `null`, `undefined` → `{}`
- Array, number → `{}`
- Empty object `{}` (pass-through)

All existing tests pass.

Fixes #3300

Signed-off-by: sxu75374 <imshuaixu@gmail.com>