### PR TITLE
fix(react): prevent Enter from sending message during IME composition

### DIFF
--- a/.changeset/fix-ime-composition-enter.md
+++ b/.changeset/fix-ime-composition-enter.md
@@ -1,0 +1,5 @@
+---
+"@copilotkitnext/react": patch
+---
+
+Fix IME composition handling in CopilotChat input: pressing Enter to commit CJK characters no longer sends the message prematurely.

--- a/packages/v2/react/src/components/chat/CopilotChatInput.tsx
+++ b/packages/v2/react/src/components/chat/CopilotChatInput.tsx
@@ -167,6 +167,8 @@ export function CopilotChatInput({
   const audioRecorderRef =
     useRef<React.ElementRef<typeof CopilotChatAudioRecorder>>(null);
   const slashMenuRef = useRef<HTMLDivElement>(null);
+  const isComposingRef = useRef(false);
+  const compositionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const config = useCopilotChatConfiguration();
   const labels = config?.labels ?? CopilotChatDefaultLabels;
 
@@ -178,6 +180,14 @@ export function CopilotChatInput({
     paddingLeft: 0,
     paddingRight: 0,
   });
+
+  useEffect(() => {
+    return () => {
+      if (compositionTimeoutRef.current !== null) {
+        clearTimeout(compositionTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const commandItems = useMemo(() => {
     const entries: ToolsMenuItem[] = [];
@@ -377,6 +387,20 @@ export function CopilotChatInput({
     [clearInputValue],
   );
 
+  const handleCompositionStart = () => {
+    isComposingRef.current = true;
+  };
+
+  const handleCompositionEnd = () => {
+    // Firefox fires compositionend BEFORE the final keydown (Enter).
+    // Deferring the reset ensures handleKeyDown still sees isComposing=true
+    // for that Enter event, preventing premature message send.
+    compositionTimeoutRef.current = setTimeout(() => {
+      isComposingRef.current = false;
+      compositionTimeoutRef.current = null;
+    }, 0);
+  };
+
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (commandQuery !== null && mode === "input") {
       if (e.key === "ArrowDown") {
@@ -409,7 +433,7 @@ export function CopilotChatInput({
         return;
       }
 
-      if (e.key === "Enter") {
+      if (e.key === "Enter" && !isComposingRef.current && !e.nativeEvent.isComposing) {
         const selected =
           slashHighlightIndex >= 0
             ? filteredCommands[slashHighlightIndex]
@@ -428,7 +452,7 @@ export function CopilotChatInput({
       }
     }
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !isComposingRef.current && !e.nativeEvent.isComposing) {
       e.preventDefault();
       if (isProcessing) {
         onStop?.();
@@ -464,6 +488,8 @@ export function CopilotChatInput({
     value: resolvedValue,
     onChange: handleChange,
     onKeyDown: handleKeyDown,
+    onCompositionStart: handleCompositionStart,
+    onCompositionEnd: handleCompositionEnd,
     autoFocus: autoFocus,
     className: twMerge(
       "cpk:w-full cpk:py-3",

--- a/packages/v2/react/src/components/chat/__tests__/CopilotChatInput.test.tsx
+++ b/packages/v2/react/src/components/chat/__tests__/CopilotChatInput.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   waitFor,
   within,
+  act,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
@@ -959,6 +960,127 @@ describe("CopilotChatInput", () => {
       // It's up to the parent to manage the value
       expect((input as HTMLTextAreaElement).value).toBe("test message");
       expect(mockOnSubmitMessage).toHaveBeenCalledWith("test message");
+    });
+  });
+
+  describe("IME composition handling", () => {
+    it("does not send message when Enter is pressed during IME composition", () => {
+      const mockOnChange = vi.fn();
+      renderWithProvider(
+        <CopilotChatInput
+          value="test"
+          onChange={mockOnChange}
+          onSubmitMessage={mockOnSubmitMessage}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText("Type a message...");
+      fireEvent.compositionStart(input);
+      fireEvent.keyDown(input, { key: "Enter", shiftKey: false });
+
+      expect(mockOnSubmitMessage).not.toHaveBeenCalled();
+    });
+
+    it("sends message normally after IME composition ends", async () => {
+      const mockOnChange = vi.fn();
+      renderWithProvider(
+        <CopilotChatInput
+          value="你好"
+          onChange={mockOnChange}
+          onSubmitMessage={mockOnSubmitMessage}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText("Type a message...");
+      fireEvent.compositionStart(input);
+      fireEvent.compositionEnd(input);
+
+      // Wait for setTimeout(0) in compositionEnd handler to flush
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      fireEvent.keyDown(input, { key: "Enter", shiftKey: false });
+
+      expect(mockOnSubmitMessage).toHaveBeenCalledWith("你好");
+    });
+
+    it("does not select slash command when Enter is pressed during IME composition", async () => {
+      const handleCommand = vi.fn();
+
+      renderWithProvider(
+        <CopilotChatInput
+          onSubmitMessage={mockOnSubmitMessage}
+          toolsMenu={[{ label: "Say hi", action: handleCommand }]}
+        />,
+      );
+
+      const textarea = screen.getByRole("textbox");
+      fireEvent.change(textarea, { target: { value: "/" } });
+
+      await screen.findByTestId("copilot-slash-menu");
+
+      fireEvent.compositionStart(textarea);
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      expect(handleCommand).not.toHaveBeenCalled();
+      expect(mockOnSubmitMessage).not.toHaveBeenCalled();
+    });
+
+    it("allows send button click during IME composition", () => {
+      const mockOnChange = vi.fn();
+      const { container } = renderWithProvider(
+        <CopilotChatInput
+          value="composed"
+          onChange={mockOnChange}
+          onSubmitMessage={mockOnSubmitMessage}
+        />,
+      );
+
+      const input = screen.getByPlaceholderText("Type a message...");
+      fireEvent.compositionStart(input);
+
+      const sendButton = getSendButton(container);
+      fireEvent.click(sendButton!);
+
+      expect(mockOnSubmitMessage).toHaveBeenCalledWith("composed");
+    });
+
+    it("handles Firefox compositionend-before-keydown timing correctly", () => {
+      vi.useFakeTimers();
+
+      try {
+        const mockOnChange = vi.fn();
+        renderWithProvider(
+          <CopilotChatInput
+            value="你好"
+            onChange={mockOnChange}
+            onSubmitMessage={mockOnSubmitMessage}
+          />,
+        );
+
+        const input = screen.getByPlaceholderText("Type a message...");
+
+        // Simulate Firefox event order: compositionend fires BEFORE keydown
+        fireEvent.compositionStart(input);
+        fireEvent.compositionEnd(input);
+
+        // In Firefox, keydown fires immediately after compositionend
+        // but setTimeout(0) in compositionEnd handler hasn't flushed yet
+        fireEvent.keyDown(input, { key: "Enter", shiftKey: false });
+
+        // Message should NOT be sent because isComposingRef is still true
+        expect(mockOnSubmitMessage).not.toHaveBeenCalled();
+
+        // Now flush the setTimeout(0) that resets isComposingRef
+        vi.runAllTimers();
+
+        // After timer flush, Enter should work normally
+        fireEvent.keyDown(input, { key: "Enter", shiftKey: false });
+        expect(mockOnSubmitMessage).toHaveBeenCalledWith("你好");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #3318

CopilotChatInput (v2) does not handle IME composition events. When typing Chinese/Japanese/Korean characters, pressing Enter to commit the composition sends the message prematurely instead of finalizing the characters.

## Changes
- Added `isComposingRef` to track IME composition state
- Added `onCompositionStart`/`onCompositionEnd` handlers on the textarea
- Guarded both the slash command Enter and message send Enter with composition checks
- Handles Firefox timing edge case (compositionend fires before keydown) via `setTimeout(0)`
- Added `e.nativeEvent.isComposing` as defense-in-depth browser fallback

## Prior Art
- v1 React implementation already handles this correctly (`packages/v1/react-ui/src/components/chat/Input.tsx`)
- Angular v2 example also handles this (`examples/v2/angular/demo/.../custom-chat-input.component.ts`)

## Test Plan
- [x] Added unit tests for IME composition scenarios (5 new tests)
- [x] Verified Enter during composition does NOT send message
- [x] Verified Enter after composition ends sends message normally
- [x] Verified slash command not triggered during composition
- [x] Verified send button still works during composition
- [x] Verified Firefox compositionend-before-keydown timing handled correctly
- [x] All 43 tests passing
