### PR TITLE
fix(openai): force Chat Completions API in OpenAIAdapter.getLanguageModel()

### DIFF
--- a/packages/v1/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/packages/v1/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -136,7 +136,12 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
       headers: options.defaultHeaders,
       fetch: options.fetch,
     });
-    return provider(this.model);
+    // Use .chat() explicitly to force the Chat Completions API.
+    // The default provider(model) auto-selects the Responses API for newer
+    // models, which breaks OpenAI-compatible providers (e.g. OpenRouter)
+    // that expose /responses as a separate, incompatible endpoint.
+    // See: https://github.com/CopilotKit/CopilotKit/issues/3317
+    return provider.chat(this.model);
   }
 
   private ensureOpenAI(): OpenAI {

--- a/packages/v1/runtime/tests/service-adapters/openai/openai-adapter-language-model.test.ts
+++ b/packages/v1/runtime/tests/service-adapters/openai/openai-adapter-language-model.test.ts
@@ -36,10 +36,14 @@ type _exhaustive =
       };
 const _check: _exhaustive = true;
 
-const { mockProviderFn, mockCreateOpenAI } = vi.hoisted(() => {
-  const mockProviderFn = vi.fn().mockReturnValue({ modelId: "test-model" });
+const { mockProviderFn, mockChatFn, mockCreateOpenAI } = vi.hoisted(() => {
+  const mockChatFn = vi.fn().mockReturnValue({ modelId: "test-model" });
+  const mockProviderFn = Object.assign(
+    vi.fn().mockReturnValue({ modelId: "test-model" }),
+    { chat: mockChatFn },
+  );
   const mockCreateOpenAI = vi.fn().mockReturnValue(mockProviderFn);
-  return { mockProviderFn, mockCreateOpenAI };
+  return { mockProviderFn, mockChatFn, mockCreateOpenAI };
 });
 
 vi.mock("@ai-sdk/openai", async (importOriginal) => {
@@ -105,7 +109,9 @@ describe("OpenAIAdapter.getLanguageModel()", () => {
     expect(settings.headers).toEqual({ "api-key": "azure-key" });
     expect(settings.fetch).toBe(customFetch);
 
-    expect(mockProviderFn).toHaveBeenCalledWith("gpt-4o");
+    // Must use .chat() to force Chat Completions API (#3317)
+    expect(mockChatFn).toHaveBeenCalledWith("gpt-4o");
+    expect(mockProviderFn).not.toHaveBeenCalled();
   });
 
   it("works with default OpenAI config (no custom options)", () => {
@@ -118,5 +124,20 @@ describe("OpenAIAdapter.getLanguageModel()", () => {
     expect(settings.apiKey).toBe("sk-test");
     expect(settings.organization).toBeUndefined();
     expect(settings.project).toBeUndefined();
+  });
+
+  it("uses .chat() to avoid Responses API for OpenAI-compatible providers (#3317)", () => {
+    const openai = new OpenAI({
+      apiKey: "or-key",
+      baseURL: "https://openrouter.ai/api/v1",
+    });
+    const adapter = new OpenAIAdapter({ openai, model: "google/gemini-2.5-flash-lite" });
+    adapter.getLanguageModel();
+
+    // provider.chat() must be called instead of provider() to prevent
+    // the AI SDK from auto-selecting the Responses API, which breaks
+    // OpenAI-compatible providers like OpenRouter.
+    expect(mockChatFn).toHaveBeenCalledWith("google/gemini-2.5-flash-lite");
+    expect(mockProviderFn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

When using CopilotKit with OpenAI-compatible providers (e.g. OpenRouter), the second conversation request fails because `@ai-sdk/openai` auto-detects the Responses API and routes subsequent requests to `/responses` instead of `/chat/completions`.

## Root Cause

`OpenAIAdapter.getLanguageModel()` calls `provider(this.model)` which lets the AI SDK auto-select the API. For non-OpenAI providers like OpenRouter, `/responses` is a separate, incompatible endpoint.

## Fix

Use `provider.chat(this.model)` instead of `provider(this.model)` to explicitly force the Chat Completions API. This aligns `getLanguageModel()` with `process()` which already uses `openai.beta.chat.completions.stream()` (Chat Completions).

## Changes

- `openai-adapter.ts`: 1 line change + comment
- `openai-adapter-language-model.test.ts`: Updated mock to support `.chat()`, updated assertions, added OpenRouter-specific test case

## Testing

- Updated existing tests to verify `.chat()` is called
- Added dedicated test for OpenRouter base URL scenario

Fixes #3317