### PR TITLE
fix: add .next dist to nx.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -29,7 +29,8 @@
         "{projectRoot}/.env*"
       ],
       "outputs": [
-        "{projectRoot}/dist/**"
+        "{projectRoot}/dist/**",
+        "{projectRoot}/.next/**"
       ],
       "cache": true
     },


### PR DESCRIPTION
This was causing issues with next-built apps since the cache would refresh but not include the builds correctly.