### PR TITLE
fix: update build process and add outputs for snapshot caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -77,6 +77,9 @@
       "dependsOn": [
         "^build"
       ],
+      "outputs": [
+        "{projectRoot}/__snapshots__/**"
+      ],
       "cache": true
     },
     "graphql-codegen": {

--- a/packages/v1/runtime/package.json
+++ b/packages/v1/runtime/package.json
@@ -36,7 +36,7 @@
   "types": "./dist/index.d.cts",
   "license": "MIT",
   "scripts": {
-    "build": "pnpm run generate-graphql-schema && tsdown",
+    "build": "tsdown",
     "dev": "tsdown --watch",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -127,6 +127,16 @@
     },
     "openai": {
       "optional": true
+    }
+  },
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": [
+          "generate-graphql-schema",
+          "^build"
+        ]
+      }
     }
   },
   "keywords": [


### PR DESCRIPTION
 
## What does this PR do?

Splits the graphql generation into a separate step that's cached for nx cloud resolution

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
