### PR TITLE
Move link-cpk after prep-dojo to fix dojo E2E build failures

### DIFF
--- a/.github/workflows/e2e_dojo.yml
+++ b/.github/workflows/e2e_dojo.yml
@@ -187,16 +187,16 @@ jobs:
         working-directory: ag-ui
         run: pnpm install --frozen-lockfile
 
-      - name: Link cpk into ag-ui
-        working-directory: CopilotKit
-        run: node ../ag-ui/apps/dojo/scripts/link-cpk.js ${{ github.workspace }}/CopilotKit/packages
-
       - name: Prepare dojo for e2e
         working-directory: ag-ui/apps/dojo
         env:
           NODE_OPTIONS: --max-old-space-size=8192
         if: ${{ join(matrix.services, ',') != '' }}
         run: node ./scripts/prep-dojo-everything.js --only ${{ join(matrix.services, ',') }}
+
+      - name: Link cpk into ag-ui
+        working-directory: CopilotKit
+        run: node ../ag-ui/apps/dojo/scripts/link-cpk.js ${{ github.workspace }}/CopilotKit/packages
 
       - name: Install e2e dependencies
         working-directory: ag-ui/apps/dojo/e2e


### PR DESCRIPTION
## Summary
- Swaps the order of "Link cpk into ag-ui" and "Prepare dojo for e2e" steps in the dojo E2E workflow
- `prep-dojo-everything.js` runs `pnpm install --no-frozen-lockfile` for the dojo target, which resolves `@copilotkit/*` from the npm registry — overwriting the symlinks that `link-cpk.js` just created
- By running prep-dojo first, then link-cpk, the local CopilotKit build outputs correctly replace the registry packages

## Test plan
- [ ] Dojo E2E workflow passes on this PR (the workflow change triggers itself via `paths: .github/workflows/e2e_dojo.yml`)
- [ ] Verify `demo-viewer:build` no longer fails with "Module not found: Can't resolve '@copilotkit/react-core'"