### PR TITLE
fix: only run sync-lockfile hook when package.json changes

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,7 @@ pre-commit:
   commands:
     sync-lockfile:
       tags: lockfile
+      glob: "**/package.json"
       run: pnpm i --lockfile-only
       stage_fixed: true
     lint-fix:


### PR DESCRIPTION
## Summary
- Adds a `glob: "**/package.json"` filter to the `sync-lockfile` lefthook pre-commit command
- Previously `pnpm i --lockfile-only` ran on every commit, even code-only changes, causing unnecessary lockfile diffs that frequently conflicted with main
- Now the hook only triggers when a `package.json` file is actually staged

## Test plan
- [ ] Commit a code-only change (no package.json edits) and verify the `sync-lockfile` hook is skipped
- [ ] Commit a change that includes a package.json edit and verify the hook runs and stages lockfile updates