### PR TITLE
fix: replace @copilotkitnext with @copilotkit packages in big-hornets-shake changeset

### DIFF
--- a/.changeset/big-hornets-shake.md
+++ b/.changeset/big-hornets-shake.md
@@ -1,6 +1,5 @@
 ---
 "@copilotkit/runtime": patch
-"@copilotkit/docs": patch
 ---
 
 feat(runtime): expose messages in afterRequestMiddleware


### PR DESCRIPTION
The `big-hornets-shake` changeset was using `@copilotkitnext/*` package names instead of `@copilotkit/*`, which caused the release workflow to fail due to mixing ignored and non-ignored packages.

Fixes: https://github.com/CopilotKit/CopilotKit/actions/runs/22644986711