### PR TITLE
Fix CopilotTextarea CMD/CTRL+K toolbar overflowing viewport

### DIFF
--- a/packages/v1/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
+++ b/packages/v1/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
@@ -12,6 +12,7 @@ import {
 import { useHoveringEditorContext } from "./hovering-editor-provider";
 import { Menu, Portal } from "./hovering-toolbar-components";
 import { HoveringInsertionPromptBox } from "./text-insertion-prompt-box";
+import { calculateToolbarViewportPosition } from "./positioning";
 
 export interface HoveringToolbarProps {
   apiConfig: InsertionEditorApiConfig;
@@ -20,6 +21,7 @@ export interface HoveringToolbarProps {
 }
 
 export const HoveringToolbar = (props: HoveringToolbarProps) => {
+  const VIEWPORT_PADDING_PX = 6;
   const ref = useRef<HTMLDivElement>(null);
   const editor = useSlate();
   const selection = useSlateSelection();
@@ -67,47 +69,23 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
       return;
     }
 
-    const verticalOffsetFromCorner = 0;
-    const horizontalOffsetFromCorner = 0;
-
-    // position the toolbar below the selection
-    let top = rect.bottom + window.scrollY + verticalOffsetFromCorner;
-
-    // no space left at bottom, move up
-    if (
-      rect.bottom + el.offsetHeight >
-      window.innerHeight - verticalOffsetFromCorner
-    ) {
-      top =
-        rect.top + window.scrollY - el.offsetHeight - verticalOffsetFromCorner;
-    }
-
-    // position the toolbar in the center of the selection
-    let left =
-      rect.left +
-      window.scrollX -
-      el.offsetWidth / 2 +
-      rect.width / 2 +
-      horizontalOffsetFromCorner;
-
-    // no space left at left, move right
-    if (left < horizontalOffsetFromCorner) {
-      left = horizontalOffsetFromCorner;
-    }
-    // no space left at right, move left
-    else if (
-      left + el.offsetWidth >
-      window.innerWidth - horizontalOffsetFromCorner
-    ) {
-      left = window.innerWidth - el.offsetWidth - horizontalOffsetFromCorner;
-    }
+    const { top, left } = calculateToolbarViewportPosition({
+      rect,
+      toolbarWidth: el.offsetWidth,
+      toolbarHeight: el.offsetHeight,
+      scrollX: window.scrollX,
+      scrollY: window.scrollY,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      viewportPadding: VIEWPORT_PADDING_PX,
+    });
 
     el.style.opacity = "1";
     el.style.position = "absolute";
 
     el.style.top = `${top}px`;
     el.style.left = `${left}px`;
-  }, [isShown]);
+  }, [editor, isShown, selection]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/packages/v1/react-textarea/src/components/hovering-toolbar/positioning.test.ts
+++ b/packages/v1/react-textarea/src/components/hovering-toolbar/positioning.test.ts
@@ -1,0 +1,93 @@
+import { calculateToolbarViewportPosition } from "./positioning";
+
+describe("calculateToolbarViewportPosition", () => {
+  it("centers the toolbar below the selection when there is space", () => {
+    const position = calculateToolbarViewportPosition({
+      rect: { top: 100, left: 200, bottom: 120, width: 40 },
+      toolbarWidth: 120,
+      toolbarHeight: 50,
+      scrollX: 0,
+      scrollY: 0,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      viewportPadding: 6,
+    });
+
+    expect(position).toEqual({ top: 120, left: 160 });
+  });
+
+  it("keeps the toolbar inside the left viewport boundary", () => {
+    const position = calculateToolbarViewportPosition({
+      rect: { top: 100, left: 0, bottom: 120, width: 20 },
+      toolbarWidth: 120,
+      toolbarHeight: 50,
+      scrollX: 50,
+      scrollY: 0,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      viewportPadding: 6,
+    });
+
+    expect(position.left).toBe(56);
+  });
+
+  it("keeps the toolbar inside the right viewport boundary when scrolled", () => {
+    const position = calculateToolbarViewportPosition({
+      rect: { top: 100, left: 760, bottom: 120, width: 40 },
+      toolbarWidth: 220,
+      toolbarHeight: 50,
+      scrollX: 120,
+      scrollY: 0,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      viewportPadding: 6,
+    });
+
+    expect(position.left).toBe(694);
+  });
+
+  it("flips above the selection when the toolbar would overflow at the bottom", () => {
+    const position = calculateToolbarViewportPosition({
+      rect: { top: 560, left: 200, bottom: 580, width: 40 },
+      toolbarWidth: 140,
+      toolbarHeight: 80,
+      scrollX: 0,
+      scrollY: 0,
+      viewportWidth: 800,
+      viewportHeight: 600,
+      viewportPadding: 6,
+    });
+
+    expect(position.top).toBe(480);
+  });
+
+  it("clamps to top padding when flipping above would overflow top", () => {
+    const position = calculateToolbarViewportPosition({
+      rect: { top: 20, left: 200, bottom: 40, width: 40 },
+      toolbarWidth: 140,
+      toolbarHeight: 80,
+      scrollX: 0,
+      scrollY: 0,
+      viewportWidth: 800,
+      viewportHeight: 100,
+      viewportPadding: 6,
+    });
+
+    expect(position.top).toBe(6);
+  });
+
+  it("handles toolbar wider than viewport by pinning to viewport padding", () => {
+    const position = calculateToolbarViewportPosition({
+      rect: { top: 50, left: 80, bottom: 70, width: 20 },
+      toolbarWidth: 500,
+      toolbarHeight: 60,
+      scrollX: 0,
+      scrollY: 0,
+      viewportWidth: 320,
+      viewportHeight: 600,
+      viewportPadding: 6,
+    });
+
+    expect(position.left).toBe(6);
+  });
+});

--- a/packages/v1/react-textarea/src/components/hovering-toolbar/positioning.ts
+++ b/packages/v1/react-textarea/src/components/hovering-toolbar/positioning.ts
@@ -1,0 +1,58 @@
+export interface SelectionRect {
+  top: number;
+  left: number;
+  bottom: number;
+  width: number;
+}
+
+export interface ToolbarViewportPositionInput {
+  rect: SelectionRect;
+  toolbarWidth: number;
+  toolbarHeight: number;
+  scrollX: number;
+  scrollY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  viewportPadding: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+export function calculateToolbarViewportPosition(
+  input: ToolbarViewportPositionInput,
+): { top: number; left: number } {
+  const {
+    rect,
+    toolbarWidth,
+    toolbarHeight,
+    scrollX,
+    scrollY,
+    viewportWidth,
+    viewportHeight,
+    viewportPadding,
+  } = input;
+
+  const minLeft = scrollX + viewportPadding;
+  const maxLeft = scrollX + viewportWidth - toolbarWidth - viewportPadding;
+  const centeredLeft = scrollX + rect.left + rect.width / 2 - toolbarWidth / 2;
+  const left = clamp(centeredLeft, minLeft, maxLeft);
+
+  // Prefer to render below selection, then flip above if there's no room.
+  let top = scrollY + rect.bottom;
+  const wouldOverflowBottom =
+    rect.bottom + toolbarHeight + viewportPadding > viewportHeight;
+  if (wouldOverflowBottom) {
+    top = scrollY + rect.top - toolbarHeight;
+  }
+
+  const minTop = scrollY + viewportPadding;
+  const maxTop = scrollY + viewportHeight - toolbarHeight - viewportPadding;
+  top = clamp(top, minTop, maxTop);
+
+  return { top, left };
+}


### PR DESCRIPTION
## Summary
This fixes #479 by making the hovering toolbar positioning viewport-safe with explicit padding and proper scroll-aware clamping.

### What changed
- extracted toolbar placement math into a pure utility (`positioning.ts`)
- added viewport clamping with 6px padding on all sides
- corrected right-edge clamping for scrolled pages by using viewport bounds plus scrollX
- added top clamping when flipping above would still overflow

### Tests
- added focused unit tests for positioning behavior:
  - centers below selection when there is room
  - clamps on left and right boundaries
  - flips above on bottom overflow
  - clamps top overflow
  - handles toolbar wider than viewport

## Validation
- `pnpm -C packages/v1/react-textarea test`
