### PR TITLE
Fix CopilotSidebar children not stretching to 100% height

### DIFF
--- a/packages/v1/react-ui/src/components/chat/Modal.tsx
+++ b/packages/v1/react-ui/src/components/chat/Modal.tsx
@@ -140,7 +140,7 @@ const CopilotModalInner = ({
 
   return (
     <>
-      {memoizedChildren}
+      <div className="copilotKitModalChildrenWrapper">{memoizedChildren}</div>
       <div className={className}>
         <Button></Button>
         <Window

--- a/packages/v1/react-ui/src/css/sidebar.css
+++ b/packages/v1/react-ui/src/css/sidebar.css
@@ -25,6 +25,19 @@
   overflow: visible;
   margin-right: 0px;
   transition: margin-right 0.3s ease;
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: 100%;
+}
+
+.copilotKitSidebarContentWrapper > .copilotKitModalChildrenWrapper {
+  min-height: 100%;
+  height: 100%;
+}
+
+.copilotKitSidebarContentWrapper > .copilotKitModalChildrenWrapper > * {
+  min-height: 100%;
+  height: 100%;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
Fixes #261 by making `CopilotSidebar` children reliably stretch to full height when users apply `height: 100%` in app layouts.

## What changed
- wrapped modal children in a stable container: `copilotKitModalChildrenWrapper`
- updated sidebar CSS to provide a full-height ancestor chain:
  - `copilotKitSidebarContentWrapper` now has `height: 100%` and viewport-backed min-height
  - `copilotKitModalChildrenWrapper` and its immediate children inherit full height in sidebar mode

This preserves existing sidebar behavior while making full-height page layouts predictable.

## Validation
- `pnpm -C packages/v1/react-ui test`
