### PR TITLE
Fix sidebar CSS override precedence in Chrome

### DIFF
--- a/packages/react-ui/src/css/header.css
+++ b/packages/react-ui/src/css/header.css
@@ -14,7 +14,7 @@
   z-index: 2;
 }
 
-.copilotKitSidebar .copilotKitHeader {
+:where(.copilotKitSidebar) .copilotKitHeader {
   border-radius: 0;
 }
 

--- a/packages/react-ui/src/css/input.css
+++ b/packages/react-ui/src/css/input.css
@@ -19,7 +19,7 @@
   border-bottom-right-radius: 0.75rem;
 }
 
-.copilotKitSidebar .copilotKitInputContainer {
+:where(.copilotKitSidebar) .copilotKitInputContainer {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }

--- a/packages/react-ui/src/css/window.css
+++ b/packages/react-ui/src/css/window.css
@@ -16,7 +16,7 @@
   pointer-events: none;
 }
 
-.copilotKitSidebar .copilotKitWindow {
+:where(.copilotKitSidebar) .copilotKitWindow {
   border-radius: 0;
   opacity: 1;
   transform: translateX(100%);
@@ -28,7 +28,7 @@
   pointer-events: auto;
 }
 
-.copilotKitSidebar .copilotKitWindow.open {
+:where(.copilotKitSidebar) .copilotKitWindow.open {
   transform: translateX(0);
 }
 
@@ -54,7 +54,7 @@
     max-height: calc(100% - 6rem);
   }
 
-  .copilotKitSidebar .copilotKitWindow {
+  :where(.copilotKitSidebar) .copilotKitWindow {
     bottom: 0;
     right: 0;
     top: auto;


### PR DESCRIPTION
## Summary
Fixes #263 by lowering selector specificity for sidebar-scoped UI styles so user overrides are more reliable across browsers (especially Chrome).

## What changed
Replaced high-specificity selectors like:
- `.copilotKitSidebar .copilotKitWindow`
- `.copilotKitSidebar .copilotKitHeader`
- `.copilotKitSidebar .copilotKitInputContainer`

with specificity-reduced equivalents using `:where(...)`, for example:
- `:where(.copilotKitSidebar) .copilotKitWindow`

This keeps behavior unchanged while making downstream CSS customizations easier to override.

## Validation
- `pnpm -C packages/v1/react-ui test`
