### PR TITLE
docs: add dedicated Dev Console troubleshooting guide

### DIFF
--- a/docs/content/docs/(root)/troubleshooting/dev-console.mdx
+++ b/docs/content/docs/(root)/troubleshooting/dev-console.mdx
@@ -1,0 +1,9 @@
+---
+title: "Using the Dev Console"
+description: "Enable and use the CopilotKit Dev Console to debug actions, readables, and messages."
+icon: "lucide/Bug"
+---
+
+import DevConsoleTroubleshooting from "@/snippets/shared/troubleshooting/dev-console.mdx";
+
+<DevConsoleTroubleshooting components={props.components} />

--- a/docs/content/docs/(root)/troubleshooting/meta.json
+++ b/docs/content/docs/(root)/troubleshooting/meta.json
@@ -1,6 +1,7 @@
 {
   "pages": [
     "migrate-to-v2",
+    "dev-console",
     "error-debugging",
     "observability-connectors",
     "common-issues",

--- a/docs/content/docs/integrations/langgraph/coagent-troubleshooting/dev-console.mdx
+++ b/docs/content/docs/integrations/langgraph/coagent-troubleshooting/dev-console.mdx
@@ -1,0 +1,9 @@
+---
+title: "Using the Dev Console"
+description: "Enable and use the CopilotKit Dev Console to debug actions, readables, and messages."
+icon: "lucide/Bug"
+---
+
+import DevConsoleTroubleshooting from "@/snippets/shared/troubleshooting/dev-console.mdx";
+
+<DevConsoleTroubleshooting components={props.components} />

--- a/docs/content/docs/integrations/langgraph/coagent-troubleshooting/meta.json
+++ b/docs/content/docs/integrations/langgraph/coagent-troubleshooting/meta.json
@@ -1,7 +1,4 @@
 {
   "title": "Troubleshooting",
-  "pages": [
-    "error-debugging",
-    "common-coagent-issues"
-  ]
+  "pages": ["error-debugging", "dev-console", "common-coagent-issues"]
 }

--- a/docs/snippets/shared/troubleshooting/dev-console.mdx
+++ b/docs/snippets/shared/troubleshooting/dev-console.mdx
@@ -1,0 +1,56 @@
+# Using the CopilotKit Dev Console
+
+The Dev Console is the fastest way to debug CopilotKit behavior in local development. It helps you inspect how actions, readables, and messages are flowing through your app.
+
+## Enable the Dev Console
+
+Set `showDevConsole` on your provider while developing:
+
+```tsx
+import { CopilotKit } from "@copilotkit/react-core";
+
+export function App() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      showDevConsole={process.env.NODE_ENV === "development"}
+    >
+      {/* Your app */}
+    </CopilotKit>
+  );
+}
+```
+
+<Callout type="warning">
+  Keep `showDevConsole={false}` in production to avoid exposing internal
+  debugging details.
+</Callout>
+
+## Where to Find It
+
+When enabled, the Dev Console appears in the chat header and exposes a `Debug` menu.
+
+<Frame description="CopilotKit Dev Console">
+  <img
+    src="https://cdn.copilotkit.ai/docs/copilotkit/images/contributing/copilotkit-dev-console.png"
+    className="w-auto max-w-[560px]"
+  />
+</Frame>
+
+## How to Use It for Troubleshooting
+
+Use the `Debug` menu while reproducing your issue:
+
+- **Log Actions**: validate action names, schemas, and arguments.
+- **Log Readables**: inspect the readable state available to the assistant.
+- **Log Messages**: verify message ordering and payload content.
+- **Check for Updates**: confirm your local package versions are current.
+
+## Recommended Debugging Workflow
+
+1. Reproduce the issue in development.
+2. Open the `Debug` menu and run one of the log actions.
+3. Inspect browser console output to confirm expected state and payloads.
+4. Fix mismatches in action registration, readable data shape, or message flow.
+
+If needed, pair this workflow with the [Error Debugging](/troubleshooting/error-debugging) guide.


### PR DESCRIPTION
## Summary
- add a dedicated Dev Console troubleshooting page with setup, debugging workflow, and visual reference
- add the page to the global troubleshooting section
- add the same page to LangGraph CoAgent troubleshooting

## Details
This adds concrete guidance for debugging actions, readables, and messages with the Debug menu (Log Actions, Log Readables, Log Messages) and includes an in-doc visual of the Dev Console.

## Verification
- pnpm exec prettier --check docs/snippets/shared/troubleshooting/dev-console.mdx docs/content/docs/(root)/troubleshooting/dev-console.mdx docs/content/docs/(root)/troubleshooting/meta.json docs/content/docs/integrations/langgraph/coagent-troubleshooting/dev-console.mdx docs/content/docs/integrations/langgraph/coagent-troubleshooting/meta.json

Closes #1170