### PR TITLE
docs: update legacy LangChain links to current docs

### DIFF
--- a/docs/content/docs/integrations/langgraph/auth.mdx
+++ b/docs/content/docs/integrations/langgraph/auth.mdx
@@ -85,7 +85,7 @@ async def my_agent_node(state: AgentState, config: RunnableConfig):
     return state
 ```
 
-For complete implementation details, see the [LangGraph Platform Authentication documentation](https://docs.langchain.com/langsmith/auth#authentication).
+For complete implementation details, see the [LangGraph Platform Authentication documentation](https://docs.smith.langchain.com/langgraph_platform/authentication).
 
 ## Self-hosted Deployment
 
@@ -178,7 +178,7 @@ async def my_agent_node(state: AgentState, config: RunnableConfig):
 - **Token Security**: Use secure token generation and validation
 - **User Scoping**: Always scope data access to authenticated users
 
-For comprehensive authentication patterns, authorization handlers, and security best practices, refer to the [LangGraph Platform Authentication documentation](https://docs.langchain.com/langsmith/auth#authentication).
+For comprehensive authentication patterns, authorization handlers, and security best practices, refer to the [LangGraph Platform Authentication documentation](https://docs.smith.langchain.com/langgraph_platform/authentication).
 
 ## Troubleshooting
 

--- a/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent.mdx
+++ b/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent.mdx
@@ -2,14 +2,15 @@
 title: "Step 2: LangGraph Agent"
 ---
 
-Before we start integrating the LangGraph agent, let's understand how it works. 
+Before we start integrating the LangGraph agent, let's understand how it works.
 
-For the sake of this tutorial we won't be building the LangGraph together from scratch. 
+For the sake of this tutorial we won't be building the LangGraph together from scratch.
 Instead, we'll be using the LangGraph constructed in the `agent/` directory.
 
 <Callout>
-If you're interested in a step-by-step guide for building a LangGraph agent, you can checkout the 
-[LangGraph quickstart guide](https://docs.langchain.com/oss/python/langgraph/quickstart).
+  If you're interested in a step-by-step guide for building a LangGraph agent,
+  you can checkout the [LangGraph quickstart
+  guide](https://docs.langchain.com/oss/python/langgraph/quickstart).
 </Callout>
 
 Let's walk through the LangGraph agent to understand how it works before we integrate it into the application.
@@ -19,15 +20,16 @@ Let's walk through the LangGraph agent to understand how it works before we inte
 ### Install LangGraph Studio
 
 LangGraph Studio is a tool for visualizing and debugging LangGraph workflows. It is not required for using CopilotKit but it is highly recommended
-for understanding how LangGraph works. 
+for understanding how LangGraph works.
 
-To install LangGraph Studio, checkout the [setup guide](https://studio.langchain.com/).
+To install LangGraph Studio, checkout the [setup guide](https://docs.smith.langchain.com/langgraph_cloud/quick_start).
 
 </Step>
 <Step>
 ### Retreive API keys
 
 For this application, we'll need two API keys:
+
 - OpenAI API key: You can get an API key from the OpenAI console [here](https://platform.openai.com/api-keys).
 - Google Maps API key: This can be retrieved from the Google Cloud Console [here](https://developers.google.com/maps/documentation/places/web-service/get-api-key#creating-api-keys).
 
@@ -64,7 +66,6 @@ The agent will take some time to load as things get setup but once finished it w
 
 ![LangGraph Studio](https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/tutorials/ai-travel-app/lgs-overview.png)
 
-
 </Step>
 <Step>
 
@@ -84,7 +85,7 @@ As we're building this agent into an agentic experience, we'll want to understan
 You can submit a message to the agent by adding a message to the `messages` state variable and then clicking "Submit".
 
 You'll see the agent respond in the chat and direct appropriately through the various nodes. In this case, you should notice that the
-agent calls the `search_node` and, once it has received a response, will add a new trip based on its findings to the state via the 
+agent calls the `search_node` and, once it has received a response, will add a new trip based on its findings to the state via the
 `trips_node`.
 
 </Step>
@@ -105,7 +106,7 @@ Make sure to remove the `interrupt_after` option before proceeding, this will br
 <Step>
 ### Leave LangGraph Studio running
 
-In order to create an agentic copilot, you'll need to have your LangGraph agent running somewhere. In our case, LangGraph studio is 
+In order to create an agentic copilot, you'll need to have your LangGraph agent running somewhere. In our case, LangGraph studio is
 running this locally for us. We can see this by looking at the URL at the bottom left of the application.
 
 ![LangGraph Studio URL](https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/tutorials/ai-travel-app/lgs-url.png)

--- a/docs/snippets/langgraph-platform-deployment-tabs.mdx
+++ b/docs/snippets/langgraph-platform-deployment-tabs.mdx
@@ -2,7 +2,7 @@ import { Tab } from "../components/react/tabs";
 
 <Tabs groupId="lg-deployment-type" items={['Local (LangGraph Studio)', 'Self hosted (FastAPI)', 'LangGraph Platform']}>
   <Tab value="Local (LangGraph Studio)">
-    For local development, you can use the [LangGraph CLI](https://docs.langchain.com/langsmith/cli) to start a development server and LangGraph studio session.
+    For local development, you can use the [LangGraph CLI](https://docs.smith.langchain.com/langgraph_cloud/quick_start) to start a development server and LangGraph studio session.
 
     <Callout type="info">
       You will need a [LangSmith account](https://smith.langchain.com) to use this method.
@@ -103,7 +103,7 @@ import { Tab } from "../components/react/tabs";
   </Tab>
 
   <Tab value="LangGraph Platform">
-    For production, you can deploy to LangGraph Platform by following the official [LangGraph Platform deployment guide](https://docs.langchain.com/langsmith/cloud).
+    For production, you can deploy to LangGraph Platform by following the official [LangGraph Platform deployment guide](https://docs.smith.langchain.com/langgraph_platform/deployment).
 
     Come back with that URL and a LangSmith API key before proceeding.
 

--- a/examples/v1/travel/README.md
+++ b/examples/v1/travel/README.md
@@ -12,7 +12,7 @@ Plan your next trip with an AI-powered travel planner. This demo showcases a tra
   <a href="https://nextjs.org" target="_blank">
     <img src="https://img.shields.io/badge/Built%20with-Next.js%2014-black" alt="Built with Next.js"/>
   </a>
-  <a href="https://www.langchain.com/langgraph" target="_blank">
+  <a href="https://langchain-ai.github.io/langgraph/" target="_blank">
     <img src="https://img.shields.io/badge/Powered%20by-LangGraph-blue" alt="Powered by LangGraph"/>
   </a>
   <a href="https://leafletjs.com/" target="_blank">

--- a/examples/v2/interrupts-langraph/README.md
+++ b/examples/v2/interrupts-langraph/README.md
@@ -1,6 +1,6 @@
 # CopilotKit <> LangGraph Starter
 
-This is a starter template for building AI agents using [LangGraph](https://www.langchain.com/langgraph) and [CopilotKit](https://copilotkit.ai). It provides a modern Next.js application with an integrated LangGraph agent to be built on top of.
+This is a starter template for building AI agents using [LangGraph](https://langchain-ai.github.io/langgraph/) and [CopilotKit](https://copilotkit.ai). It provides a modern Next.js application with an integrated LangGraph agent to be built on top of.
 
 This project is organized as a monorepo using [Turborepo](https://turbo.build) and [pnpm workspaces](https://pnpm.io/workspaces).
 


### PR DESCRIPTION
## Summary
- replace legacy LangChain docs URLs with current LangGraph/LangSmith documentation links
- update affected troubleshooting snippets and LangGraph tutorial/auth pages
- update example READMEs to point to the current LangGraph docs domain

## Updated files
- docs/snippets/langgraph-platform-deployment-tabs.mdx
- docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent.mdx
- docs/content/docs/integrations/langgraph/auth.mdx
- examples/v1/travel/README.md
- examples/v2/interrupts-langraph/README.md

## Verification
- confirmed replacement URLs return HTTP 200
- pnpm exec prettier --check docs/snippets/langgraph-platform-deployment-tabs.mdx docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent.mdx docs/content/docs/integrations/langgraph/auth.mdx examples/v1/travel/README.md examples/v2/interrupts-langraph/README.md

Closes #3190