### PR TITLE
[docs] Clarify useAgent initial state and LangGraph tool runtime state

### DIFF
--- a/docs/content/docs/integrations/langgraph/shared-state/state-inputs-outputs.mdx
+++ b/docs/content/docs/integrations/langgraph/shared-state/state-inputs-outputs.mdx
@@ -49,6 +49,7 @@ In addition, some state properties contain a lot of information. Syncing them ba
         ```
         </Tab>
     </Tabs>
+
   </Step>
   <Step>
     ### Divide state to Input and Output
@@ -188,6 +189,7 @@ In addition, some state properties contain a lot of information. Syncing them ba
             ```
           </Tab>
       </Tabs>
+
   </Step>
   <Step>
     ### Give it a try!
@@ -207,5 +209,76 @@ In addition, some state properties contain a lot of information. Syncing them ba
 
     console.log(answer) // You can expect seeing "answer" change, while the others are not returned from the agent
     ```
+
   </Step>
 </Steps>
+
+## Common Pitfall: Missing Keys in `runtime.state`
+
+If your tool runtime does not include a custom key (for example
+`mem0_user_id`), the key is usually not part of the graph's input schema or was
+not set before the run started.
+
+### 1. Include the key in your input state schema
+
+```python title="agent.py"
+from typing import List
+from copilotkit import CopilotKitState
+
+class InputState(CopilotKitState):
+  question: str
+  mem0_user_id: str
+
+class OutputState(CopilotKitState):
+  answer: str
+
+class OverallState(InputState, OutputState):
+  resources: List[str]
+```
+
+### 2. Set the key on the frontend before running the agent
+
+```tsx title="ui/app/page.tsx"
+import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
+import { randomUUID } from "@copilotkit/shared/v2";
+
+function AskWithMemory() {
+  const { agent } = useAgent({ agentId: "sample_agent" });
+  const { copilotkit } = useCopilotKit();
+
+  const ask = async (question: string, userId: string) => {
+    agent.setState({
+      ...agent.state,
+      mem0_user_id: userId,
+    });
+
+    agent.addMessage({
+      id: randomUUID(),
+      role: "user",
+      content: question,
+    });
+
+    await copilotkit.runAgent({ agent });
+  };
+
+  return (
+    <button onClick={() => ask("What should I do today?", "user_123")}>
+      Ask
+    </button>
+  );
+}
+```
+
+### 3. Read it in your tool runtime
+
+```python title="tools.py"
+from langchain_core.tools import tool
+from langgraph.prebuilt import ToolRuntime
+
+@tool
+def add_memory(content: str, runtime: ToolRuntime) -> str:
+  state = runtime.state or {}
+  user_id = state.get("mem0_user_id", "default")
+  # your memory write implementation here
+  return f"Saved memory for {user_id}"
+```

--- a/docs/content/docs/reference/v2/hooks/useAgent.mdx
+++ b/docs/content/docs/reference/v2/hooks/useAgent.mdx
@@ -14,7 +14,7 @@ description: "React hook for accessing AG-UI agent instances"
 ```tsx
 import { useAgent } from "@copilotkit/react-core/v2";
 
-function useAgent(options?: UseAgentProps): { agent: AbstractAgent }
+function useAgent(options?: UseAgentProps): { agent: AbstractAgent };
 ```
 
 ## Parameters
@@ -22,9 +22,10 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent }
 <PropertyReference name="options" type="UseAgentProps">
   Configuration object for the hook.
 
-  <PropertyReference name="agentId" type="string" default='"default"'>
-    ID of the agent to retrieve. Must match an agent configured in `CopilotKitProvider`.
-  </PropertyReference>
+<PropertyReference name="agentId" type="string" default='"default"'>
+  ID of the agent to retrieve. Must match an agent configured in
+  `CopilotKitProvider`.
+</PropertyReference>
 
   <PropertyReference name="updates" type="UseAgentUpdate[]" default="[OnMessagesChanged, OnStateChanged, OnRunStatusChanged]">
     Controls which agent changes trigger component re-renders. Options:
@@ -33,6 +34,7 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent }
     - `UseAgentUpdate.OnRunStatusChanged` - Re-render when execution status changes
 
     Pass an empty array `[]` to prevent automatic re-renders.
+
   </PropertyReference>
 </PropertyReference>
 
@@ -176,6 +178,43 @@ function StateController() {
 }
 ```
 
+### Initialize State Before the First Run
+
+Use this pattern when your backend tools rely on state keys (for example
+`mem0_user_id`) and you want those values available in the first run.
+
+```tsx
+import { useEffect, useRef } from "react";
+import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
+
+function BootstrapAgentState() {
+  const { agent } = useAgent({ agentId: "memory-agent" });
+  const { copilotkit } = useCopilotKit();
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    agent.setState({
+      ...agent.state,
+      mem0_user_id: "user_123",
+      todos: [],
+    });
+
+    void copilotkit.runAgent({ agent });
+  }, [agent, copilotkit]);
+
+  return null;
+}
+```
+
+<Callout type="info">
+  If a tool runtime is missing custom keys, make sure those keys are part of
+  your LangGraph input state schema and that you set them before running the
+  agent.
+</Callout>
+
 ### Event Subscription
 
 ```tsx
@@ -224,7 +263,7 @@ import { useAgent, UseAgentUpdate } from "@copilotkit/react-core/v2";
 // Only re-render when messages change
 function MessageCount() {
   const { agent } = useAgent({
-    updates: [UseAgentUpdate.OnMessagesChanged]
+    updates: [UseAgentUpdate.OnMessagesChanged],
   });
 
   return <div>Messages: {agent.messages.length}</div>;


### PR DESCRIPTION
## Summary
- add a new "Initialize State Before the First Run" section to the `useAgent` v2 reference docs
- document a concrete bootstrap pattern (`agent.setState` + `copilotkit.runAgent`) for state keys required by tools
- add a LangGraph shared-state troubleshooting section for missing keys in `runtime.state`
- include an end-to-end schema + frontend + tool runtime example centered on `mem0_user_id`

## Why
Issue #3273 asks how to initialize v2 agent state and reliably access that state during tool execution. The docs now explicitly connect schema design, frontend state initialization, and runtime tool access in one place.

## Validation
- `pnpm prettier --check docs/content/docs/reference/v2/hooks/useAgent.mdx docs/content/docs/integrations/langgraph/shared-state/state-inputs-outputs.mdx`
- repository pre-commit hooks passed (test, check:packages, lint --fix, format)

Closes #3273
