### PR TITLE
[docs] Document structured input pattern for CopilotSidebar state

### DIFF
--- a/docs/content/docs/reference/v2/components/CopilotSidebar.mdx
+++ b/docs/content/docs/reference/v2/components/CopilotSidebar.mdx
@@ -21,7 +21,9 @@ import "@copilotkit/react-core/v2/styles.css";
 ### Own Props
 
 <PropertyReference name="header" type="SlotValue<typeof CopilotModalHeader>">
-  Slot override for the sidebar header. Accepts a replacement component, a `className` string merged into the default, or a partial props object. The default header displays a title and a close button.
+  Slot override for the sidebar header. Accepts a replacement component, a
+  `className` string merged into the default, or a partial props object. The
+  default header displays a title and a close button.
 </PropertyReference>
 
 <PropertyReference name="defaultOpen" type="boolean" default="false">
@@ -29,7 +31,8 @@ import "@copilotkit/react-core/v2/styles.css";
 </PropertyReference>
 
 <PropertyReference name="width" type="number | string">
-  Width of the sidebar panel. Accepts a number (pixels) or a CSS string (e.g. `"400px"`, `"30vw"`).
+  Width of the sidebar panel. Accepts a number (pixels) or a CSS string (e.g.
+  `"400px"`, `"30vw"`).
 </PropertyReference>
 
 ### Inherited CopilotChat Props
@@ -37,7 +40,8 @@ import "@copilotkit/react-core/v2/styles.css";
 `CopilotSidebar` accepts all props from [`CopilotChatProps`](/reference/v2/components/CopilotChat) **except** `chatView`, which is set internally to `CopilotSidebarView`. This includes:
 
 <PropertyReference name="agentId" type="string">
-  ID of the agent to use. Must match an agent configured in `CopilotKitProvider`.
+  ID of the agent to use. Must match an agent configured in
+  `CopilotKitProvider`.
 </PropertyReference>
 
 <PropertyReference name="threadId" type="string">
@@ -52,11 +56,17 @@ import "@copilotkit/react-core/v2/styles.css";
   Whether the chat scrolls to the bottom automatically when new messages arrive.
 </PropertyReference>
 
-<PropertyReference name="inputProps" type="Partial<Omit<CopilotChatInputProps, 'children'>>">
+<PropertyReference
+  name="inputProps"
+  type="Partial<Omit<CopilotChatInputProps, 'children'>>"
+>
   Additional props forwarded to the inner `CopilotChatInput` component.
 </PropertyReference>
 
-<PropertyReference name="welcomeScreen" type='SlotValue<React.FC<WelcomeScreenProps>> | boolean'>
+<PropertyReference
+  name="welcomeScreen"
+  type="SlotValue<React.FC<WelcomeScreenProps>> | boolean"
+>
   Controls the welcome screen shown when no messages exist.
 </PropertyReference>
 
@@ -66,11 +76,11 @@ All `CopilotChatView` slot props (`messageView`, `input`, `scrollView`, `inputCo
 
 All slot props follow the same override pattern used across CopilotKit v2 components. Each slot accepts one of three value types:
 
-| Value | Behavior |
-|-------|----------|
-| **Component** | Replaces the default component entirely. Receives the same props the default would. |
-| **`className` string** | Merged into the default component's class list via `twMerge`. |
-| **Partial props object** | Spread into the default component as additional or overriding props. |
+| Value                    | Behavior                                                                            |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| **Component**            | Replaces the default component entirely. Receives the same props the default would. |
+| **`className` string**   | Merged into the default component's class list via `twMerge`.                       |
+| **Partial props object** | Spread into the default component as additional or overriding props.                |
 
 ## Usage
 
@@ -97,13 +107,7 @@ import { CopilotSidebar } from "@copilotkit/react-core/v2";
 import "@copilotkit/react-core/v2/styles.css";
 
 function App() {
-  return (
-    <CopilotSidebar
-      agentId="my-agent"
-      defaultOpen={true}
-      width={500}
-    />
-  );
+  return <CopilotSidebar agentId="my-agent" defaultOpen={true} width={500} />;
 }
 ```
 
@@ -115,10 +119,74 @@ import "@copilotkit/react-core/v2/styles.css";
 
 function App() {
   return (
-    <CopilotSidebar
-      agentId="my-agent"
-      header="bg-indigo-700 text-white"
-    />
+    <CopilotSidebar agentId="my-agent" header="bg-indigo-700 text-white" />
+  );
+}
+```
+
+### Send Structured Input (e.g. `email_input`) to Agent State
+
+`CopilotSidebar` does not have a dedicated prop for arbitrary agent-state keys.
+Use `useAgent()` to write structured values, then run the agent.
+
+```tsx
+import { useState } from "react";
+import { CopilotKit } from "@copilotkit/react-core";
+import {
+  CopilotSidebar,
+  useAgent,
+  useCopilotKit,
+} from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+
+type EmailInput = {
+  to: string[];
+  subject: string;
+  body: string;
+};
+
+type AgentState = {
+  email_input?: EmailInput;
+};
+
+function EmailAssistantWorkspace() {
+  const { agent } = useAgent({ agentId: "email_agent" });
+  const { copilotkit } = useCopilotKit();
+
+  const [emailInput, setEmailInput] = useState<EmailInput>({
+    to: ["team@example.com"],
+    subject: "Weekly update",
+    body: "Draft your update here...",
+  });
+
+  const runWithStructuredInput = async () => {
+    agent.setState({
+      ...((agent.state ?? {}) as AgentState),
+      email_input: emailInput,
+    });
+
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: "Review this draft and improve tone and clarity.",
+    });
+
+    await copilotkit.runAgent({ agent });
+  };
+
+  return (
+    <div>
+      <button onClick={runWithStructuredInput}>Send Draft to Agent</button>
+      <CopilotSidebar agentId="email_agent" defaultOpen />
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit">
+      <EmailAssistantWorkspace />
+    </CopilotKit>
   );
 }
 ```
@@ -136,3 +204,4 @@ function App() {
 - [`CopilotChat`](/reference/v2/components/CopilotChat) -- the base chat component used internally
 - [`CopilotPopup`](/reference/v2/components/CopilotPopup) -- popup variant
 - [`CopilotChatView`](/reference/v2/components/CopilotChatView) -- the layout component used internally
+- [`Shared State`](/shared-state) -- two-way state sync patterns for UI + agent


### PR DESCRIPTION
## Summary
- add a dedicated `CopilotSidebar` v2 example for sending structured input to agent state
- explicitly clarify that `CopilotSidebar` has no direct prop for arbitrary state keys (such as `email_input`)
- document the recommended pattern: `useAgent().setState(...)` + add user message + `copilotkit.runAgent(...)`
- include a concrete `email_input` object example and link to shared-state docs

## Why
Issue #3091 asks how to assign structured data (e.g. `email_input`) when using `CopilotSidebar`. This PR adds a direct answer in the sidebar reference docs with a copy/paste-ready implementation.

## Validation
- `pnpm prettier --check docs/content/docs/reference/v2/components/CopilotSidebar.mdx`
- repository pre-commit hooks passed (test, check:packages, lint --fix, format)

Closes #3091
