### PR TITLE
ci: add stable NX_CI_EXECUTION_ID across all PR workflows

### DIFF
--- a/.github/workflows/e2e_dojo.yml
+++ b/.github/workflows/e2e_dojo.yml
@@ -22,6 +22,10 @@ on:
         default: "main"
         type: string
 
+env:
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "E2E Dojo"
+
 jobs:
   dojo:
     name: ${{ matrix.suite }}

--- a/.github/workflows/e2e_examples.yml
+++ b/.github/workflows/e2e_examples.yml
@@ -20,6 +20,10 @@ on:
         default: "main"
         type: string
 
+env:
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "E2E Examples"
+
 jobs:
   examples:
     name: ${{ matrix.example }}

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -4,6 +4,11 @@ on: [push, pull_request]
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "Publish Commit"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/static_commitlint.yml
+++ b/.github/workflows/static_commitlint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "Commitlint"
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/static_danger.yml
+++ b/.github/workflows/static_danger.yml
@@ -6,6 +6,10 @@ on:
       - "sdk-python/copilotkit/langgraph_agent.py"
       - "packages/v1/sdk-js/src/langgraph.ts"
 
+env:
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "Danger"
+
 jobs:
   danger:
     runs-on: ubuntu-latest

--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -22,6 +22,8 @@ on:
 
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "Static Quality"
 
 jobs:
   prettier:

--- a/.github/workflows/test_unit-v1.yml
+++ b/.github/workflows/test_unit-v1.yml
@@ -27,6 +27,8 @@ on:
         type: string
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "Unit Tests V1"
 
 jobs:
   v1:

--- a/.github/workflows/test_unit-v2.yml
+++ b/.github/workflows/test_unit-v2.yml
@@ -23,6 +23,8 @@ on:
         type: string
 env:
   NODE_OPTIONS: "--max-old-space-size=4096"
+  NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
+  NX_CI_EXECUTION_ENV: "Unit Tests V2"
 
 jobs:
   v2:


### PR DESCRIPTION
## Summary

- Adds `NX_CI_EXECUTION_ID` (`head_ref-sha-run_attempt`) to all 8 PR-triggered CI workflows so parallel runs are grouped into a single Nx Cloud CI Pipeline Execution (CIPE)
- Adds `NX_CI_EXECUTION_ENV` per workflow to create labeled tab sections in the CIPE page (e.g. "E2E Dojo", "Unit Tests V1", "Static Quality")
- Fixes the issue where each parallel workflow got a different execution ID, resulting in fragmented Nx Cloud views

## Details

Previously, each workflow used the default `NX_CI_EXECUTION_ID` (based on `GITHUB_RUN_ID`), which is unique per workflow. Since all PR workflows run in parallel with different run IDs, Nx Cloud treated them as separate pipeline executions.

The fix sets a stable ID using `${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}` which is:
- **Consistent** across all workflows triggered by the same PR push
- **Unique per retry** thanks to `run_attempt`

References:
- [NX_CI_EXECUTION_ID docs](https://nx.dev/docs/reference/environment-variables#nx-ci-execution-id)
- [NX_CI_EXECUTION_ENV docs](https://nx.dev/docs/reference/environment-variables#nx-ci-execution-env)

## Workflows updated

| Workflow | `NX_CI_EXECUTION_ENV` |
|---|---|
| `e2e_dojo.yml` | E2E Dojo |
| `e2e_examples.yml` | E2E Examples |
| `static_commitlint.yml` | Commitlint |
| `static_danger.yml` | Danger |
| `static_quality.yml` | Static Quality |
| `test_unit-v1.yml` | Unit Tests V1 |
| `test_unit-v2.yml` | Unit Tests V2 |
| `publish-commit.yml` | Publish Commit |

## Test plan

- [ ] Open a PR and verify all workflows show up under a single CIPE in Nx Cloud
- [ ] Verify each workflow appears as a separate tab with its label
- [ ] Re-run a failed workflow and confirm it creates a new execution (different `run_attempt`)