### PR TITLE
feat(react-core): export CopilotKit from v2 subpath

### DIFF
--- a/packages/v1/react-core/src/v2/index.ts
+++ b/packages/v1/react-core/src/v2/index.ts
@@ -2,3 +2,6 @@ import "./index.css";
 
 export * from "@copilotkitnext/core";
 export * from "@copilotkitnext/react";
+
+export { CopilotKit } from "../components/copilot-provider/copilotkit";
+export type { CopilotKitProps } from "../components/copilot-provider/copilotkit-props";


### PR DESCRIPTION
## Summary
- Re-exports `CopilotKit` component and `CopilotKitProps` type from `@copilotkit/react-core/v2`
- Users can now import the full-featured provider (with compatibility layer) from the v2 subpath:
  ```tsx
  import { CopilotKit } from "@copilotkit/react-core/v2"
  ```
- No breaking changes — existing imports continue to work

## Test plan
- [x] `nx run @copilotkit/react-core:build` passes
- [x] Verified `CopilotKit` and `CopilotKitProps` appear in built `dist/v2/index.d.mts`