### PR TITLE
fix(runtime): add messages-tuple stream mode for LangGraph Platform streaming

### DIFF
--- a/packages/v1/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/v1/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -1,4 +1,4 @@
-import { map } from "rxjs";
+import { map, Subscriber } from "rxjs";
 import { LangGraphEventTypes } from "../../../../agents/langgraph/events";
 import { RawEvent } from "@ag-ui/core";
 import {
@@ -11,7 +11,11 @@ import {
   StateEnrichment,
 } from "@ag-ui/langgraph";
 import { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types.messages";
-import { ThreadState } from "@langchain/langgraph-sdk";
+import { ThreadState, StreamMode } from "@langchain/langgraph-sdk";
+
+// Extract the RunAgentExtendedInput type from the parent class method signature
+// since it's not exported from @ag-ui/langgraph
+type RunAgentExtendedInput = Parameters<AGUILangGraphAgent["runAgentStream"]>[0];
 
 interface CopilotKitStateEnrichment {
   copilotkit: {
@@ -32,8 +36,171 @@ import {
 export { CustomEventNames };
 
 export class LangGraphAgent extends AGUILangGraphAgent {
+  /**
+   * Tracks whether the "events" stream mode is producing on_chat_model_stream events.
+   * When true, messages-tuple events are skipped to avoid duplicate streaming.
+   */
+  private _eventsStreamActive = false;
+
+  /**
+   * Tracks the current in-progress message or tool call from messages-tuple events.
+   */
+  private _messagesTupleTracker: { messageId?: string; toolCallId?: string } = {};
+
   constructor(config: LangGraphAgentConfig) {
     super(config);
+  }
+
+  /**
+   * Override to add "messages-tuple" to default stream modes as a fallback for
+   * LangGraph Platform deployments where "events" mode doesn't emit streaming data
+   * (e.g., graphs built with create_agent from langchain).
+   */
+  async runAgentStream(input: RunAgentExtendedInput, subscriber: Subscriber<ProcessedEvents>) {
+    // Reset per-run state
+    this._eventsStreamActive = false;
+    this._messagesTupleTracker = {};
+
+    // Add "messages-tuple" as fallback for deployments where "events" mode
+    // doesn't emit data (e.g., create_agent on LangGraph Platform)
+    if (!input.forwardedProps?.streamMode) {
+      (input as any).forwardedProps = {
+        ...input.forwardedProps,
+        streamMode: ["events", "values", "updates", "messages-tuple"],
+      };
+    }
+    return super.runAgentStream(input, subscriber);
+  }
+
+  /**
+   * Override to fix a filter mismatch: the "messages-tuple" stream mode produces SSE
+   * events with event type "messages", but the parent's filter checks
+   * streamModes.includes(event.event). We add "messages" to the filter list so these
+   * events pass through to handleSingleEvent.
+   */
+  async handleStreamEvents(
+    stream: Awaited<ReturnType<typeof this.prepareStream>>,
+    threadId: string,
+    subscriber: Subscriber<ProcessedEvents>,
+    input: RunAgentExtendedInput,
+    streamModes: StreamMode | StreamMode[],
+  ) {
+    const modes: StreamMode[] = Array.isArray(streamModes) ? [...streamModes] : [streamModes];
+    if (modes.includes("messages-tuple" as StreamMode) && !modes.includes("messages" as StreamMode)) {
+      modes.push("messages" as StreamMode);
+    }
+    return super.handleStreamEvents(stream, threadId, subscriber, input, modes);
+  }
+
+  /**
+   * Override to detect and route messages-tuple data. The parent calls
+   * handleSingleEvent(event.data) where event.data for "messages" events is a
+   * [AIMessageChunk, metadata] tuple (an array), not an object with an .event property.
+   */
+  handleSingleEvent(event: any) {
+    // Detect messages-tuple data: it arrives as an array [AIMessageChunk, metadata]
+    // Regular events-mode data has event.event (like "on_chat_model_stream")
+    if (Array.isArray(event)) {
+      if (!this._eventsStreamActive) {
+        this.handleMessagesTupleEvent(event);
+      }
+      return;
+    }
+
+    // Track if events-mode streaming is producing data
+    if (event.event === "on_chat_model_stream") {
+      this._eventsStreamActive = true;
+    }
+
+    super.handleSingleEvent(event);
+  }
+
+  /**
+   * Process [AIMessageChunk, metadata] tuples from messages-tuple stream mode
+   * and convert them into AG-UI text message and tool call events.
+   */
+  private handleMessagesTupleEvent(data: any[]) {
+    const chunk = data[0];
+
+    // Skip non-AI chunks (e.g., tool result messages, human messages)
+    if (chunk.type && chunk.type !== "AIMessageChunk") return;
+
+    const content =
+      typeof chunk.content === "string"
+        ? chunk.content
+        : Array.isArray(chunk.content)
+          ? chunk.content.find((c: any) => c.type === "text")?.text
+          : null;
+    const toolCallChunks = chunk.tool_call_chunks;
+    const isFinished = chunk.response_metadata?.finish_reason === "stop";
+
+    // Handle tool call chunks
+    if (toolCallChunks?.length > 0) {
+      const tc = toolCallChunks[0];
+      if (tc.name) {
+        // End any text message in progress
+        if (this._messagesTupleTracker.messageId && !this._messagesTupleTracker.toolCallId) {
+          this.dispatchEvent({
+            type: EventType.TEXT_MESSAGE_END,
+            messageId: this._messagesTupleTracker.messageId,
+          });
+        }
+        // Start new tool call
+        this.dispatchEvent({
+          type: EventType.TOOL_CALL_START,
+          toolCallId: tc.id || chunk.id,
+          toolCallName: tc.name,
+          parentMessageId: chunk.id,
+        });
+        this._messagesTupleTracker = { messageId: chunk.id, toolCallId: tc.id || chunk.id };
+        this.activeRun!.hasFunctionStreaming = true;
+      } else if (tc.args && this._messagesTupleTracker.toolCallId) {
+        // Stream tool call args
+        this.dispatchEvent({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: this._messagesTupleTracker.toolCallId,
+          delta: tc.args,
+        });
+      }
+      return;
+    }
+
+    // Handle finish
+    if (isFinished) {
+      if (this._messagesTupleTracker.toolCallId) {
+        this.dispatchEvent({
+          type: EventType.TOOL_CALL_END,
+          toolCallId: this._messagesTupleTracker.toolCallId,
+        });
+      } else if (this._messagesTupleTracker.messageId) {
+        this.dispatchEvent({
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: this._messagesTupleTracker.messageId,
+        });
+      }
+      this._messagesTupleTracker = {};
+      return;
+    }
+
+    // Skip empty initialization chunks
+    if (!content && !toolCallChunks?.length) return;
+
+    // Handle text content streaming
+    if (content) {
+      if (!this._messagesTupleTracker.messageId) {
+        this.dispatchEvent({
+          type: EventType.TEXT_MESSAGE_START,
+          role: "assistant",
+          messageId: chunk.id,
+        });
+        this._messagesTupleTracker = { messageId: chunk.id };
+      }
+      this.dispatchEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: this._messagesTupleTracker.messageId,
+        delta: content,
+      });
+    }
   }
 
   dispatchEvent(event: ProcessedEvents) {


### PR DESCRIPTION
## Summary
Supersedes #3201 — rebased onto current main and modernized for the current architecture.

- Fixes streaming not working when connecting to LangGraph Platform deployments (e.g., graphs built with `create_agent` from `langchain`)
- The `events` stream mode produces no `on_chat_model_stream` data on LangGraph Platform for these graphs, causing all content to arrive as a single `MessagesSnapshot` at the end
- Adds `messages-tuple` as a fallback stream mode and converts `[AIMessageChunk, metadata]` tuples into AG-UI text/tool-call events
- Includes dedup logic so when `events` mode works (local dev), `messages-tuple` events are skipped — no regressions

### How it works

Three method overrides in the CopilotKit `LangGraphAgent` wrapper:

1. **`runAgentStream`** — adds `messages-tuple` to the default stream modes (`["events", "values", "updates", "messages-tuple"]`)
2. **`handleStreamEvents`** — fixes a filter mismatch where `messages-tuple` mode produces SSE events with type `"messages"` (not `"messages-tuple"`), which the parent's `streamModes.includes()` check silently drops
3. **`handleSingleEvent`** — detects `[AIMessageChunk, metadata]` array tuples (vs regular event objects with `.event` property) and routes them to a new `handleMessagesTupleEvent` method
4. **`handleMessagesTupleEvent`** — converts chunk data into AG-UI `TEXT_MESSAGE_*` and `TOOL_CALL_*` events with proper start/content/end lifecycle

When `events` mode IS producing `on_chat_model_stream` data (normal local dev), `_eventsStreamActive` is set to `true` and messages-tuple events are automatically skipped to avoid duplicates.

### Concern: tight coupling to parent class internals

This fix works entirely through method overrides on `AGUILangGraphAgent` from `@ag-ui/langgraph`, which means it's tightly coupled to the parent class's internal method signatures and streaming pipeline. If the parent class refactors `runAgentStream`, `handleStreamEvents`, or `handleSingleEvent`, these overrides could silently break.

Ideally, the `messages-tuple` stream mode handling (including the `"messages"` filter fix) would live in `@ag-ui/langgraph` itself, since the mismatch between `messages-tuple` as a stream mode and `"messages"` as the SSE event type is a bug/gap in the parent class. This PR is a pragmatic workaround in the CopilotKit wrapper, but a proper upstream fix in ag-ui would be cleaner and less fragile.

## Test plan
- [ ] Build passes (`nx run @copilotkit/runtime:build`)
- [ ] Local LangGraph dev server: streaming still works via `events` mode (no regressions)
- [ ] LangSmith-hosted deployment: token-by-token streaming now works via `messages-tuple` fallback
- [ ] Tool calls stream correctly through `messages-tuple` mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)