### PR TITLE
fix: raise commitlint header-max-length from 100 to 120

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,5 +2,9 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'subject-case': [0],
+    // GitHub merge commits append " (#NNNN)" which eats 8+ chars.
+    // With scoped conventional prefixes like "fix(runtime): ...",
+    // 100 chars is too tight. 120 gives enough room.
+    'header-max-length': [2, 'always', 120],
   },
 };


### PR DESCRIPTION
## Summary

GitHub's merge commit format appends ` (#NNNN)` to the commit header (8+ chars). Combined with scoped conventional prefixes like `fix(runtime):`, the default 100-char `header-max-length` is too tight — e.g. PR #3270's merge commit was 102 chars and failed commitlint.

Raises the limit to 120.

## Test plan
- [x] `npx commitlint --last` passes locally