### PR TITLE
fix(react-ui): return message from handleSendMessage for voice commands

### DIFF
--- a/packages/v1/react-ui/src/components/chat/Chat.tsx
+++ b/packages/v1/react-ui/src/components/chat/Chat.tsx
@@ -599,7 +599,7 @@ export function CopilotChat({
   }, [isLoading, triggerObservabilityHook]);
 
   // Wrapper for sendMessage to clear selected images
-  const handleSendMessage = (text: string) => {
+  const handleSendMessage = (text: string): Promise<Message> => {
     const images = selectedImages;
     setSelectedImages([]);
     if (fileInputRef.current) {
@@ -610,11 +610,13 @@ export function CopilotChat({
     triggerObservabilityHook("onMessageSent", text);
 
     // TODO: send images?
-    return sendMessage({
+    const message: Message = {
       id: randomUUID(),
       content: text,
       role: "user",
-    });
+    };
+    void sendMessage(message);
+    return Promise.resolve(message);
   };
 
   const chatContext = React.useContext(ChatContext);
@@ -781,7 +783,6 @@ export function CopilotChat({
       <Input
         inProgress={isLoading}
         chatReady={Boolean(agent)}
-        // @ts-ignore
         onSend={handleSendMessage}
         isVisible={isVisible}
         onStop={stopGeneration}


### PR DESCRIPTION
Fixes #3042

## What does this PR do?

This PR fixes a bug where the `usePushToTalk` hook threw a `TypeError: Cannot read properties of undefined (reading 'id')` error after a voice command was processed and the agent responded.

### Root Cause
The `usePushToTalk` hook expected `sendFunction` (passed as `onSend`) to return a `Message` object with an `id` property. However, `handleSendMessage` was returning the result of `sendMessage()`, which returns `Promise<void>` instead of `Promise<Message>`.

### The Fix
Modified `handleSendMessage` in `Chat.tsx` to:
1. Create the message object with a known `id` before sending
2. Send the message via `sendMessage()`
3. Return the message wrapped in `Promise.resolve()` to satisfy the expected `Promise<Message>` return type

This ensures that when `usePushToTalk` awaits `sendFunction(transcription)`, it receives a valid `Message` object with an `id` property that can be used to track assistant responses for audio playback.

## Related PRs and Issues

- Issue #3042

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

### Files Changed
```
 packages/v1/react-ui/src/components/chat/Chat.tsx | 9 +++++----
 1 file changed, 5 insertions(+), 4 deletions(-)
```