### PR TITLE
fix(react): add types condition to package.json exports map

### DIFF
--- a/packages/v2/react/package.json
+++ b/packages/v2/react/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.cts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
Fixes #3324

## What does this PR do?

Adds the missing `"types"` condition to the `@copilotkitnext/react` package.json exports map. When using `moduleResolution: "bundler"` (or `node16`/`nodenext`) in tsconfig.json, TypeScript strictly follows the exports map and ignores the top-level `"types"` field. This fix enables proper type resolution for consumers using modern TypeScript module resolution settings.

## Related PRs and Issues

- Issue #3324

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

```diff
 packages/v2/react/package.json | 1 +
 1 file changed, 1 insertion(+)
```