### PR TITLE
fix(core): persist runId after HITL resolve

### DIFF
--- a/packages/v2/core/src/core/run-handler.ts
+++ b/packages/v2/core/src/core/run-handler.ts
@@ -15,6 +15,7 @@ import type { FrontendTool } from "../types";
 export interface CopilotKitCoreRunAgentParams {
   agent: AbstractAgent;
   forwardedProps?: Record<string, unknown>;
+  runId?: string;
 }
 
 export interface CopilotKitCoreConnectAgentParams {
@@ -212,6 +213,7 @@ export class RunHandler {
   async runAgent({
     agent,
     forwardedProps,
+    runId,
   }: CopilotKitCoreRunAgentParams): Promise<RunAgentResult> {
     // Agent ID is guaranteed to be set by validateAndAssignAgentId
     if (agent.agentId) {
@@ -244,10 +246,11 @@ export class RunHandler {
           },
           tools: this.buildFrontendTools(agent.agentId),
           context: Object.values(this._internal.context),
+          runId,
         },
         this.createAgentErrorSubscriber(agent),
       );
-      return this.processAgentResult({ runAgentResult, agent });
+      return this.processAgentResult({ runAgentResult, agent, runId });
     } catch (error) {
       const runError =
         error instanceof Error ? error : new Error(String(error));
@@ -270,9 +273,11 @@ export class RunHandler {
   private async processAgentResult({
     runAgentResult,
     agent,
+    runId,
   }: {
     runAgentResult: RunAgentResult;
     agent: AbstractAgent;
+    runId?: string;
   }): Promise<RunAgentResult> {
     const { newMessages } = runAgentResult;
     // Agent ID is guaranteed to be set by validateAndAssignAgentId
@@ -333,7 +338,7 @@ export class RunHandler {
       // complete and write fresh values into the context store before runAgent
       // reads it. The base implementation is a no-op; React overrides this.
       await this._internal.waitForPendingFrameworkUpdates();
-      return await this.runAgent({ agent });
+      return await this.runAgent({ agent, runId });
     }
 
     void this._internal.suggestionEngine.reloadSuggestions(agentId);


### PR DESCRIPTION
## Summary

Fixes #3456

When a frontend tool using `renderAndWaitForResponse` (Human-in-the-Loop) completes and triggers a follow-up run, the `runId` was changing. This caused issues with external observability tools like Langfuse that track runs by their ID.

## Changes

- Add optional `runId` to `CopilotKitCoreRunAgentParams` interface
- Pass `runId` through `runAgent` to `agent.runAgent()` parameters
- Accept and forward `runId` in `processAgentResult` for follow-up runs

## Technical Details

The issue was in the `RunHandler.processAgentResult` method. When a HITL frontend tool completed execution and `needsFollowUp` was set to `true`, the code called `this.runAgent({ agent })` without passing the existing `runId`. This caused `AbstractAgent.runAgent` to generate a new `runId` via `prepareRunAgentInput`, breaking continuity for the same logical run.

The fix ensures that when `runAgent` is called for a follow-up after tool execution, the original `runId` is passed through to maintain continuity.