### PR TITLE
chore: replace custom enforce-git-hooks.js with block-no-verify package

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/enforce-git-hooks.js"
+            "command": "npx --yes block-no-verify@1.1.2"
           }
         ]
       }


### PR DESCRIPTION
Closes #3479

This PR replaces the custom .claude/hooks/enforce-git-hooks.js script with the community-maintained block-no-verify package (version 1.1.2).

The existing hook script manually implements no-verify detection logic. The block-no-verify package (https://github.com/tupe12334/block-no-verify) provides the same protection and is maintained upstream, removing the burden of keeping a custom script in sync as new bypass patterns emerge.

The change updates .claude/settings.json: the command field changes from node .claude/hooks/enforce-git-hooks.js to npx --yes block-no-verify@1.1.2. The custom hook script file can be removed in a follow-up.

Related issue: https://github.com/CopilotKit/CopilotKit/issues/3479

Checklist:
- I have read the Contribution Guide
- This change does not add or modify user-facing functionality (tooling/config only)