### PR TITLE
feat: port streaming markdown parser and renderer from Hashbrown

### DIFF
--- a/packages/v2/core/LICENSE-THIRD-PARTY
+++ b/packages/v2/core/LICENSE-THIRD-PARTY
@@ -1,0 +1,4 @@
+This package contains code derived from Hashbrown
+(https://github.com/liveloveapp/hashbrown)
+Copyright (c) 2025 LiveLoveApp
+Licensed under the MIT License

--- a/packages/v2/core/src/index.ts
+++ b/packages/v2/core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./intelligence-agent";
 export * from "./utils/micro-redux";
 export * from "./utils/phoenix-observable";
 export * from "./threads";
+export * from "./streaming-markdown";

--- a/packages/v2/core/src/streaming-markdown/__tests__/block-parser.spec.ts
+++ b/packages/v2/core/src/streaming-markdown/__tests__/block-parser.spec.ts
@@ -1,0 +1,386 @@
+// Derived from hashbrown/packages/core/src/magic-text/block-parser.spec.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+import { describe, it, expect } from "vitest";
+import {
+  createBlockParserState,
+  parseBlockChunk,
+  finalizeBlocks,
+  Block,
+  HeadingBlock,
+  ParagraphBlock,
+  CodeFenceBlock,
+  BlockquoteBlock,
+  OrderedListBlock,
+  UnorderedListBlock,
+  TableBlock,
+  ThematicBreakBlock,
+} from "../block-parser";
+
+/** Helper: parse a complete markdown string into blocks. */
+function parseBlocks(markdown: string): Block[] {
+  let state = createBlockParserState();
+  state = parseBlockChunk(state, markdown);
+  state = finalizeBlocks(state);
+  return state.blocks;
+}
+
+describe("block-parser", () => {
+  describe("headings", () => {
+    it("parses h1 through h6", () => {
+      const blocks = parseBlocks(
+        "# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n",
+      );
+      expect(blocks).toHaveLength(6);
+      for (let i = 0; i < 6; i++) {
+        expect(blocks[i].type).toBe("heading");
+        expect((blocks[i] as HeadingBlock).level).toBe(i + 1);
+      }
+      expect((blocks[0] as HeadingBlock).content).toBe("H1");
+      expect((blocks[5] as HeadingBlock).content).toBe("H6");
+    });
+
+    it("parses heading with inline formatting", () => {
+      const blocks = parseBlocks("# **Bold** heading\n");
+      expect(blocks).toHaveLength(1);
+      const h = blocks[0] as HeadingBlock;
+      expect(h.type).toBe("heading");
+      expect(h.level).toBe(1);
+      expect(h.inline).toHaveLength(2);
+      expect(h.inline[0]).toEqual({
+        type: "bold",
+        children: [{ type: "text", content: "Bold" }],
+      });
+    });
+  });
+
+  describe("paragraphs", () => {
+    it("parses a simple paragraph", () => {
+      const blocks = parseBlocks("Hello world\n");
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].type).toBe("paragraph");
+      expect((blocks[0] as ParagraphBlock).content).toBe("Hello world");
+    });
+
+    it("merges consecutive lines into one paragraph", () => {
+      const blocks = parseBlocks("Line one\nLine two\n");
+      expect(blocks).toHaveLength(1);
+      expect((blocks[0] as ParagraphBlock).content).toBe("Line one\nLine two");
+    });
+
+    it("separates paragraphs by blank lines", () => {
+      const blocks = parseBlocks("Para one\n\nPara two\n");
+      expect(blocks).toHaveLength(2);
+      expect((blocks[0] as ParagraphBlock).content).toBe("Para one");
+      expect((blocks[1] as ParagraphBlock).content).toBe("Para two");
+    });
+  });
+
+  describe("code fences", () => {
+    it("parses a backtick code fence", () => {
+      const blocks = parseBlocks('```javascript\nconsole.log("hi");\n```\n');
+      expect(blocks).toHaveLength(1);
+      const cf = blocks[0] as CodeFenceBlock;
+      expect(cf.type).toBe("code_fence");
+      expect(cf.language).toBe("javascript");
+      expect(cf.content).toBe('console.log("hi");');
+      expect(cf.closed).toBe(true);
+    });
+
+    it("parses a tilde code fence", () => {
+      const blocks = parseBlocks("~~~python\nprint('hi')\n~~~\n");
+      expect(blocks).toHaveLength(1);
+      const cf = blocks[0] as CodeFenceBlock;
+      expect(cf.type).toBe("code_fence");
+      expect(cf.language).toBe("python");
+      expect(cf.content).toBe("print('hi')");
+      expect(cf.closed).toBe(true);
+    });
+
+    it("handles code fence without language", () => {
+      const blocks = parseBlocks("```\nsome code\n```\n");
+      const cf = blocks[0] as CodeFenceBlock;
+      expect(cf.language).toBe("");
+      expect(cf.content).toBe("some code");
+    });
+
+    it("preserves markdown-like content inside code fences", () => {
+      const blocks = parseBlocks(
+        "```\n# Not a heading\n**Not bold**\n```\n",
+      );
+      const cf = blocks[0] as CodeFenceBlock;
+      expect(cf.content).toBe("# Not a heading\n**Not bold**");
+    });
+
+    it("handles unclosed code fence via finalize", () => {
+      const blocks = parseBlocks("```js\nunclosed code");
+      const cf = blocks[0] as CodeFenceBlock;
+      expect(cf.type).toBe("code_fence");
+      expect(cf.content).toBe("unclosed code");
+      expect(cf.closed).toBe(false);
+    });
+
+    it("handles longer fence markers (4+ backticks)", () => {
+      const blocks = parseBlocks("````\n```\nnested\n```\n````\n");
+      expect(blocks).toHaveLength(1);
+      const cf = blocks[0] as CodeFenceBlock;
+      expect(cf.content).toBe("```\nnested\n```");
+      expect(cf.closed).toBe(true);
+    });
+  });
+
+  describe("blockquotes", () => {
+    it("parses a simple blockquote", () => {
+      const blocks = parseBlocks("> This is a quote\n");
+      expect(blocks).toHaveLength(1);
+      const bq = blocks[0] as BlockquoteBlock;
+      expect(bq.type).toBe("blockquote");
+      expect(bq.children).toHaveLength(1);
+      expect((bq.children[0] as ParagraphBlock).content).toBe(
+        "This is a quote",
+      );
+    });
+
+    it("merges consecutive blockquote lines", () => {
+      const blocks = parseBlocks("> Line one\n> Line two\n");
+      expect(blocks).toHaveLength(1);
+      const bq = blocks[0] as BlockquoteBlock;
+      expect(bq.children).toHaveLength(1);
+      expect((bq.children[0] as ParagraphBlock).content).toBe(
+        "Line one\nLine two",
+      );
+    });
+
+    it("handles nested blockquotes", () => {
+      const blocks = parseBlocks("> > Nested quote\n");
+      expect(blocks).toHaveLength(1);
+      const outer = blocks[0] as BlockquoteBlock;
+      expect(outer.children).toHaveLength(1);
+      const inner = outer.children[0] as BlockquoteBlock;
+      expect(inner.type).toBe("blockquote");
+      expect((inner.children[0] as ParagraphBlock).content).toBe(
+        "Nested quote",
+      );
+    });
+  });
+
+  describe("ordered lists", () => {
+    it("parses an ordered list", () => {
+      const blocks = parseBlocks("1. First\n2. Second\n3. Third\n");
+      expect(blocks).toHaveLength(1);
+      const list = blocks[0] as OrderedListBlock;
+      expect(list.type).toBe("ordered_list");
+      expect(list.start).toBe(1);
+      expect(list.items).toHaveLength(3);
+      expect(list.items[0].content).toBe("First");
+      expect(list.items[2].content).toBe("Third");
+    });
+
+    it("handles non-1 start numbers", () => {
+      const blocks = parseBlocks("5. Fifth item\n6. Sixth item\n");
+      const list = blocks[0] as OrderedListBlock;
+      expect(list.start).toBe(5);
+    });
+
+    it("parses list items with inline formatting", () => {
+      const blocks = parseBlocks("1. **Bold** item\n");
+      const list = blocks[0] as OrderedListBlock;
+      expect(list.items[0].inline[0]).toEqual({
+        type: "bold",
+        children: [{ type: "text", content: "Bold" }],
+      });
+    });
+  });
+
+  describe("unordered lists", () => {
+    it("parses an unordered list with dashes", () => {
+      const blocks = parseBlocks("- First\n- Second\n");
+      expect(blocks).toHaveLength(1);
+      const list = blocks[0] as UnorderedListBlock;
+      expect(list.type).toBe("unordered_list");
+      expect(list.items).toHaveLength(2);
+    });
+
+    it("parses an unordered list with asterisks", () => {
+      const blocks = parseBlocks("* Alpha\n* Beta\n");
+      const list = blocks[0] as UnorderedListBlock;
+      expect(list.type).toBe("unordered_list");
+      expect(list.items).toHaveLength(2);
+      expect(list.items[0].content).toBe("Alpha");
+    });
+
+    it("parses an unordered list with plus signs", () => {
+      const blocks = parseBlocks("+ One\n+ Two\n");
+      const list = blocks[0] as UnorderedListBlock;
+      expect(list.type).toBe("unordered_list");
+      expect(list.items).toHaveLength(2);
+    });
+  });
+
+  describe("tables", () => {
+    it("parses a simple table", () => {
+      const blocks = parseBlocks(
+        "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |\n",
+      );
+      expect(blocks).toHaveLength(1);
+      const table = blocks[0] as TableBlock;
+      expect(table.type).toBe("table");
+      expect(table.headers).toHaveLength(2);
+      expect(table.headers[0].content).toBe("Name");
+      expect(table.headers[1].content).toBe("Age");
+      expect(table.rows).toHaveLength(2);
+      expect(table.rows[0][0].content).toBe("Alice");
+      expect(table.rows[0][1].content).toBe("30");
+      expect(table.rows[1][0].content).toBe("Bob");
+      expect(table.rows[1][1].content).toBe("25");
+    });
+
+    it("parses table with alignment", () => {
+      const blocks = parseBlocks(
+        "| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |\n",
+      );
+      const table = blocks[0] as TableBlock;
+      expect(table.alignments).toEqual(["left", "center", "right"]);
+    });
+
+    it("parses table with inline formatting in cells", () => {
+      const blocks = parseBlocks(
+        "| Header |\n| --- |\n| **bold** cell |\n",
+      );
+      const table = blocks[0] as TableBlock;
+      expect(table.rows[0][0].inline[0]).toEqual({
+        type: "bold",
+        children: [{ type: "text", content: "bold" }],
+      });
+    });
+
+    it("pads missing cells to match header count", () => {
+      const blocks = parseBlocks(
+        "| A | B | C |\n| --- | --- | --- |\n| only-one |\n",
+      );
+      const table = blocks[0] as TableBlock;
+      expect(table.rows[0]).toHaveLength(3);
+      expect(table.rows[0][0].content).toBe("only-one");
+      expect(table.rows[0][1].content).toBe("");
+      expect(table.rows[0][2].content).toBe("");
+    });
+
+    it("trims excess cells to match header count", () => {
+      const blocks = parseBlocks(
+        "| A | B |\n| --- | --- |\n| x | y | z | w |\n",
+      );
+      const table = blocks[0] as TableBlock;
+      expect(table.rows[0]).toHaveLength(2);
+    });
+
+    it("handles multi-column table with mixed alignment", () => {
+      const md = [
+        "| ID | Name | Score | Grade |",
+        "| ---: | :--- | :---: | --- |",
+        "| 1 | Alice | 95 | A |",
+        "| 2 | Bob | 87 | B |",
+        "| 3 | Charlie | 92 | A |",
+        "",
+      ].join("\n");
+      const blocks = parseBlocks(md);
+      const table = blocks[0] as TableBlock;
+      expect(table.type).toBe("table");
+      expect(table.headers).toHaveLength(4);
+      expect(table.alignments).toEqual(["right", "left", "center", "none"]);
+      expect(table.rows).toHaveLength(3);
+      expect(table.rows[2][1].content).toBe("Charlie");
+    });
+  });
+
+  describe("thematic breaks", () => {
+    it("parses --- as thematic break", () => {
+      const blocks = parseBlocks("Text above\n\n---\n\nText below\n");
+      expect(blocks).toHaveLength(3);
+      expect(blocks[1].type).toBe("thematic_break");
+    });
+
+    it("parses *** as thematic break", () => {
+      const blocks = parseBlocks("***\n");
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].type).toBe("thematic_break");
+    });
+
+    it("parses ___ as thematic break", () => {
+      const blocks = parseBlocks("___\n");
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].type).toBe("thematic_break");
+    });
+  });
+
+  describe("stable block IDs", () => {
+    it("assigns unique IDs to each block", () => {
+      const blocks = parseBlocks("# Heading\n\nParagraph\n\n---\n");
+      const ids = blocks.map((b) => b.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("preserves block IDs across chunks", () => {
+      let state = createBlockParserState();
+      state = parseBlockChunk(state, "# Hello\n\n");
+      const firstBlocks = finalizeBlocks(state).blocks;
+      const headingId = firstBlocks[0].id;
+
+      state = parseBlockChunk(state, "More text\n");
+      const secondBlocks = finalizeBlocks(state).blocks;
+      // The heading should still have the same ID
+      expect(secondBlocks[0].id).toBe(headingId);
+    });
+
+    it("table block reuses paragraph ID when upgraded", () => {
+      let state = createBlockParserState();
+      // First chunk: header row (parsed as paragraph initially)
+      state = parseBlockChunk(state, "| A | B |\n");
+      const intermediateBlocks = finalizeBlocks(state).blocks;
+      const paragraphId = intermediateBlocks[0].id;
+
+      // Second chunk: separator (upgrades paragraph to table)
+      state = parseBlockChunk(state, "| --- | --- |\n");
+      const tableBlocks = finalizeBlocks(state).blocks;
+      // The table should reuse the paragraph's ID
+      expect(tableBlocks[0].id).toBe(paragraphId);
+      expect(tableBlocks[0].type).toBe("table");
+    });
+  });
+
+  describe("mixed content", () => {
+    it("parses a document with multiple block types", () => {
+      const md = [
+        "# Title",
+        "",
+        "A paragraph with **bold** text.",
+        "",
+        "```python",
+        "print('hello')",
+        "```",
+        "",
+        "- Item one",
+        "- Item two",
+        "",
+        "> A quote",
+        "",
+        "---",
+        "",
+        "| Col1 | Col2 |",
+        "| --- | --- |",
+        "| a | b |",
+        "",
+      ].join("\n");
+
+      const blocks = parseBlocks(md);
+
+      expect(blocks[0].type).toBe("heading");
+      expect(blocks[1].type).toBe("paragraph");
+      expect(blocks[2].type).toBe("code_fence");
+      expect(blocks[3].type).toBe("unordered_list");
+      expect(blocks[4].type).toBe("blockquote");
+      expect(blocks[5].type).toBe("thematic_break");
+      expect(blocks[6].type).toBe("table");
+    });
+  });
+});

--- a/packages/v2/core/src/streaming-markdown/__tests__/citations.spec.ts
+++ b/packages/v2/core/src/streaming-markdown/__tests__/citations.spec.ts
@@ -1,0 +1,113 @@
+// Derived from hashbrown/packages/core/src/magic-text/citations.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+import { describe, it, expect } from "vitest";
+import { extractCitations, Citation } from "../citations";
+
+describe("extractCitations", () => {
+  describe("no citations", () => {
+    it("should return an empty array for text with no citations", () => {
+      expect(extractCitations("Hello world")).toEqual([]);
+    });
+
+    it("should not match regular bracket expressions", () => {
+      expect(extractCitations("array[0] and map[key]")).toEqual([]);
+    });
+  });
+
+  describe("single citation", () => {
+    it("should extract a single numeric footnote citation", () => {
+      const result = extractCitations("Some text [^1] more text");
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual<Citation>({
+        label: "1",
+        raw: "[^1]",
+        start: 10,
+        end: 14,
+      });
+    });
+
+    it("should extract a citation with a text label", () => {
+      const result = extractCitations("Reference [^note] here");
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual<Citation>({
+        label: "note",
+        raw: "[^note]",
+        start: 10,
+        end: 17,
+      });
+    });
+  });
+
+  describe("multiple citations", () => {
+    it("should extract multiple citations from text", () => {
+      const result = extractCitations("First [^1] and second [^2] end");
+      expect(result).toHaveLength(2);
+      expect(result[0].label).toBe("1");
+      expect(result[0].start).toBe(6);
+      expect(result[0].end).toBe(10);
+      expect(result[1].label).toBe("2");
+      expect(result[1].start).toBe(22);
+      expect(result[1].end).toBe(26);
+    });
+
+    it("should handle citations at the start and end of text", () => {
+      const result = extractCitations("[^a] middle [^b]");
+      expect(result).toHaveLength(2);
+      expect(result[0].label).toBe("a");
+      expect(result[1].label).toBe("b");
+    });
+  });
+
+  describe("footnote-style citations", () => {
+    it("should extract footnote references like [^1]", () => {
+      const result = extractCitations("See [^1] for details.");
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual<Citation>({
+        label: "1",
+        raw: "[^1]",
+        start: 4,
+        end: 8,
+      });
+    });
+
+    it("should handle multi-digit footnote references", () => {
+      const result = extractCitations("See [^42].");
+      expect(result).toHaveLength(1);
+      expect(result[0].label).toBe("42");
+    });
+
+    it("should handle mixed alphanumeric labels", () => {
+      const result = extractCitations("[^ref1] and [^ref2]");
+      expect(result).toHaveLength(2);
+      expect(result[0].label).toBe("ref1");
+      expect(result[1].label).toBe("ref2");
+    });
+  });
+
+  describe("empty input", () => {
+    it("should return an empty array for an empty string", () => {
+      expect(extractCitations("")).toEqual([]);
+    });
+  });
+
+  describe("global regex lastIndex reset", () => {
+    it("should produce consistent results across sequential calls", () => {
+      const text = "Citation [^1] here";
+      const first = extractCitations(text);
+      const second = extractCitations(text);
+
+      expect(first).toEqual(second);
+      expect(first).toHaveLength(1);
+      expect(first[0].label).toBe("1");
+    });
+
+    it("should work correctly after a call with no matches", () => {
+      extractCitations("no citations here");
+      const result = extractCitations("has [^1] citation");
+      expect(result).toHaveLength(1);
+      expect(result[0].label).toBe("1");
+    });
+  });
+});

--- a/packages/v2/core/src/streaming-markdown/__tests__/inline-parser.spec.ts
+++ b/packages/v2/core/src/streaming-markdown/__tests__/inline-parser.spec.ts
@@ -1,0 +1,232 @@
+// Derived from hashbrown/packages/core/src/magic-text/inline-parser.spec.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+import { describe, it, expect } from "vitest";
+import { parseInline, inlineToPlainText, InlineSegment } from "../inline-parser";
+
+describe("inline-parser", () => {
+  describe("plain text", () => {
+    it("parses plain text", () => {
+      const result = parseInline("Hello world");
+      expect(result).toEqual([{ type: "text", content: "Hello world" }]);
+    });
+
+    it("handles empty string", () => {
+      const result = parseInline("");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("bold", () => {
+    it("parses **bold** with asterisks", () => {
+      const result = parseInline("This is **bold** text");
+      expect(result).toEqual([
+        { type: "text", content: "This is " },
+        {
+          type: "bold",
+          children: [{ type: "text", content: "bold" }],
+        },
+        { type: "text", content: " text" },
+      ]);
+    });
+
+    it("parses __bold__ with underscores", () => {
+      const result = parseInline("This is __bold__ text");
+      expect(result).toEqual([
+        { type: "text", content: "This is " },
+        {
+          type: "bold",
+          children: [{ type: "text", content: "bold" }],
+        },
+        { type: "text", content: " text" },
+      ]);
+    });
+
+    it("does not parse ** with only whitespace content", () => {
+      const result = parseInline("This ** is ** not bold");
+      expect(result).toEqual([
+        { type: "text", content: "This ** is ** not bold" },
+      ]);
+    });
+  });
+
+  describe("italic", () => {
+    it("parses *italic* with asterisks", () => {
+      const result = parseInline("This is *italic* text");
+      expect(result).toEqual([
+        { type: "text", content: "This is " },
+        {
+          type: "italic",
+          children: [{ type: "text", content: "italic" }],
+        },
+        { type: "text", content: " text" },
+      ]);
+    });
+
+    it("parses _italic_ with underscores", () => {
+      const result = parseInline("This is _italic_ text");
+      expect(result).toEqual([
+        { type: "text", content: "This is " },
+        {
+          type: "italic",
+          children: [{ type: "text", content: "italic" }],
+        },
+        { type: "text", content: " text" },
+      ]);
+    });
+
+    it("does not parse _ inside words", () => {
+      const result = parseInline("some_variable_name");
+      expect(result).toEqual([
+        { type: "text", content: "some_variable_name" },
+      ]);
+    });
+  });
+
+  describe("inline code", () => {
+    it("parses `code` with single backticks", () => {
+      const result = parseInline("Use `code` here");
+      expect(result).toEqual([
+        { type: "text", content: "Use " },
+        { type: "code", content: "code" },
+        { type: "text", content: " here" },
+      ]);
+    });
+
+    it("parses ``code with backticks`` with double backticks", () => {
+      const result = parseInline("Use ``code ` here`` ok");
+      expect(result).toEqual([
+        { type: "text", content: "Use " },
+        { type: "code", content: "code ` here" },
+        { type: "text", content: " ok" },
+      ]);
+    });
+
+    it("does not parse inline formatting inside code", () => {
+      const result = parseInline("Use `**not bold**` here");
+      expect(result).toEqual([
+        { type: "text", content: "Use " },
+        { type: "code", content: "**not bold**" },
+        { type: "text", content: " here" },
+      ]);
+    });
+  });
+
+  describe("strikethrough", () => {
+    it("parses ~~strikethrough~~", () => {
+      const result = parseInline("This is ~~deleted~~ text");
+      expect(result).toEqual([
+        { type: "text", content: "This is " },
+        {
+          type: "strikethrough",
+          children: [{ type: "text", content: "deleted" }],
+        },
+        { type: "text", content: " text" },
+      ]);
+    });
+  });
+
+  describe("links", () => {
+    it("parses [text](url) links", () => {
+      const result = parseInline("Visit [our site](https://example.com)");
+      expect(result).toEqual([
+        { type: "text", content: "Visit " },
+        {
+          type: "link",
+          href: "https://example.com",
+          children: [{ type: "text", content: "our site" }],
+        },
+      ]);
+    });
+
+    it("parses links with inline formatting in text", () => {
+      const result = parseInline("[**bold link**](url)");
+      expect(result).toEqual([
+        {
+          type: "link",
+          href: "url",
+          children: [
+            {
+              type: "bold",
+              children: [{ type: "text", content: "bold link" }],
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("images", () => {
+    it("parses ![alt](src) images", () => {
+      const result = parseInline("An image: ![alt text](image.png)");
+      expect(result).toEqual([
+        { type: "text", content: "An image: " },
+        { type: "image", alt: "alt text", src: "image.png" },
+      ]);
+    });
+  });
+
+  describe("nested formatting", () => {
+    it("parses bold inside italic", () => {
+      const result = parseInline("*This is **bold inside italic***");
+      expect(result).toEqual([
+        {
+          type: "italic",
+          children: [
+            { type: "text", content: "This is " },
+            {
+              type: "bold",
+              children: [{ type: "text", content: "bold inside italic" }],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("parses code inside bold", () => {
+      const result = parseInline("**Use `code` here**");
+      expect(result).toEqual([
+        {
+          type: "bold",
+          children: [
+            { type: "text", content: "Use " },
+            { type: "code", content: "code" },
+            { type: "text", content: " here" },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("escape sequences", () => {
+    it("handles escaped asterisks", () => {
+      const result = parseInline("This is \\*not italic\\*");
+      expect(result).toEqual([
+        { type: "text", content: "This is *not italic*" },
+      ]);
+    });
+
+    it("handles escaped backticks", () => {
+      const result = parseInline("Use \\`not code\\`");
+      expect(result).toEqual([
+        { type: "text", content: "Use `not code`" },
+      ]);
+    });
+  });
+
+  describe("inlineToPlainText", () => {
+    it("extracts plain text from segments", () => {
+      const segments: InlineSegment[] = [
+        { type: "text", content: "Hello " },
+        {
+          type: "bold",
+          children: [{ type: "text", content: "world" }],
+        },
+        { type: "text", content: " and " },
+        { type: "code", content: "code" },
+      ];
+      expect(inlineToPlainText(segments)).toBe("Hello world and code");
+    });
+  });
+});

--- a/packages/v2/core/src/streaming-markdown/__tests__/integration.spec.ts
+++ b/packages/v2/core/src/streaming-markdown/__tests__/integration.spec.ts
@@ -1,0 +1,344 @@
+// Derived from hashbrown/packages/core/src/magic-text/magic-text.integration.spec.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+import { describe, it, expect } from "vitest";
+import {
+  createMagicTextParserState,
+  parseMagicTextChunk,
+  finalizeMagicText,
+  MagicTextParserState,
+} from "../state";
+import {
+  Block,
+  HeadingBlock,
+  ParagraphBlock,
+  CodeFenceBlock,
+  TableBlock,
+  UnorderedListBlock,
+  OrderedListBlock,
+  BlockquoteBlock,
+} from "../block-parser";
+
+/** Helper: parse a full string incrementally, one character at a time. */
+function parseCharByChar(text: string): Block[] {
+  let state = createMagicTextParserState();
+  for (const ch of text) {
+    state = parseMagicTextChunk(state, ch);
+  }
+  state = finalizeMagicText(state);
+  return state.blocks;
+}
+
+/** Helper: parse a full string in a single chunk. */
+function parseSingleChunk(text: string): Block[] {
+  let state = createMagicTextParserState();
+  state = parseMagicTextChunk(state, text);
+  state = finalizeMagicText(state);
+  return state.blocks;
+}
+
+/** Helper: parse in variably-sized chunks. */
+function parseInChunks(text: string, chunkSizes: number[]): Block[] {
+  let state = createMagicTextParserState();
+  let offset = 0;
+  for (const size of chunkSizes) {
+    const chunk = text.substring(offset, offset + size);
+    if (chunk.length === 0) break;
+    state = parseMagicTextChunk(state, chunk);
+    offset += size;
+  }
+  if (offset < text.length) {
+    state = parseMagicTextChunk(state, text.substring(offset));
+  }
+  state = finalizeMagicText(state);
+  return state.blocks;
+}
+
+describe("streaming markdown integration", () => {
+  describe("incremental consistency", () => {
+    it("produces the same heading from char-by-char and single-chunk parsing", () => {
+      const md = "# Hello World\n";
+      const single = parseSingleChunk(md);
+      const charByChar = parseCharByChar(md);
+
+      expect(single).toHaveLength(1);
+      expect(charByChar).toHaveLength(1);
+      expect((single[0] as HeadingBlock).content).toBe("Hello World");
+      expect((charByChar[0] as HeadingBlock).content).toBe("Hello World");
+    });
+
+    it("produces the same paragraph from different chunk sizes", () => {
+      const md = "Hello world, this is a test.\n";
+      const single = parseSingleChunk(md);
+      const chunked = parseInChunks(md, [5, 10, 5, 20]);
+
+      expect(single).toHaveLength(1);
+      expect(chunked).toHaveLength(1);
+      expect((single[0] as ParagraphBlock).content).toBe(
+        (chunked[0] as ParagraphBlock).content,
+      );
+    });
+
+    it("produces the same code fence from different chunk sizes", () => {
+      const md = '```javascript\nconsole.log("hello");\n```\n';
+      const single = parseSingleChunk(md);
+      const charByChar = parseCharByChar(md);
+
+      expect(single).toHaveLength(1);
+      expect(charByChar).toHaveLength(1);
+
+      const singleFence = single[0] as CodeFenceBlock;
+      const charFence = charByChar[0] as CodeFenceBlock;
+      expect(singleFence.language).toBe(charFence.language);
+      expect(singleFence.content).toBe(charFence.content);
+      expect(singleFence.closed).toBe(charFence.closed);
+    });
+  });
+
+  describe("streaming partial states", () => {
+    it("shows partial heading content during streaming", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "# Hel");
+      // The heading line is buffered because there's no newline yet
+      // When we view the blocks, finalization should flush it
+      expect(state.blocks).toHaveLength(1);
+      const heading = state.blocks[0] as HeadingBlock;
+      expect(heading.content).toBe("Hel");
+
+      state = parseMagicTextChunk(state, "lo World\n");
+      expect(state.blocks).toHaveLength(1);
+      expect((state.blocks[0] as HeadingBlock).content).toBe("Hello World");
+    });
+
+    it("shows code fence content growing during streaming", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "```js\n");
+      expect(state.blocks).toHaveLength(1);
+      expect((state.blocks[0] as CodeFenceBlock).language).toBe("js");
+      expect((state.blocks[0] as CodeFenceBlock).content).toBe("");
+
+      state = parseMagicTextChunk(state, "const x = 1;\n");
+      expect((state.blocks[0] as CodeFenceBlock).content).toBe("const x = 1;");
+
+      state = parseMagicTextChunk(state, "const y = 2;\n");
+      expect((state.blocks[0] as CodeFenceBlock).content).toBe(
+        "const x = 1;\nconst y = 2;",
+      );
+    });
+
+    it("block IDs are stable as content grows", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "# Title\n\n");
+      const titleId = state.blocks[0].id;
+
+      state = parseMagicTextChunk(state, "Some text\n");
+      expect(state.blocks[0].id).toBe(titleId);
+      expect(state.blocks[0].type).toBe("heading");
+    });
+  });
+
+  describe("table streaming (regression tests)", () => {
+    it("streams a simple table correctly", () => {
+      let state = createMagicTextParserState();
+
+      // Stream header row
+      state = parseMagicTextChunk(state, "| Name | Age |\n");
+      // At this point, the header is parsed as a paragraph
+      expect(state.blocks).toHaveLength(1);
+
+      // Stream separator
+      state = parseMagicTextChunk(state, "| --- | --- |\n");
+      // Now it should be a table
+      expect(state.blocks).toHaveLength(1);
+      expect(state.blocks[0].type).toBe("table");
+
+      // Stream data rows
+      state = parseMagicTextChunk(state, "| Alice | 30 |\n");
+      const table = state.blocks[0] as TableBlock;
+      expect(table.rows).toHaveLength(1);
+      expect(table.rows[0][0].content).toBe("Alice");
+
+      state = parseMagicTextChunk(state, "| Bob | 25 |\n");
+      const table2 = state.blocks[0] as TableBlock;
+      expect(table2.rows).toHaveLength(2);
+    });
+
+    it("handles table streamed one character at a time", () => {
+      const md =
+        "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |\n";
+      const blocks = parseCharByChar(md);
+
+      expect(blocks).toHaveLength(1);
+      const table = blocks[0] as TableBlock;
+      expect(table.type).toBe("table");
+      expect(table.headers).toHaveLength(2);
+      expect(table.headers[0].content).toBe("Name");
+      expect(table.headers[1].content).toBe("Age");
+      expect(table.rows).toHaveLength(2);
+      expect(table.rows[0][0].content).toBe("Alice");
+      expect(table.rows[0][1].content).toBe("30");
+      expect(table.rows[1][0].content).toBe("Bob");
+      expect(table.rows[1][1].content).toBe("25");
+    });
+
+    it("handles table with alignment streamed char by char", () => {
+      const md = [
+        "| Left | Center | Right |",
+        "| :--- | :---: | ---: |",
+        "| a | b | c |",
+        "",
+      ].join("\n");
+
+      const blocks = parseCharByChar(md);
+      expect(blocks).toHaveLength(1);
+      const table = blocks[0] as TableBlock;
+      expect(table.alignments).toEqual(["left", "center", "right"]);
+      expect(table.rows[0][0].content).toBe("a");
+    });
+
+    it("handles table with inline formatting in cells streamed char by char", () => {
+      const md = [
+        "| Feature | Status |",
+        "| --- | --- |",
+        "| **Bold** feature | *Active* |",
+        "| `code` item | ~~removed~~ |",
+        "",
+      ].join("\n");
+
+      const blocks = parseCharByChar(md);
+      const table = blocks[0] as TableBlock;
+      expect(table.type).toBe("table");
+      expect(table.rows).toHaveLength(2);
+
+      // Check inline formatting in first row
+      expect(table.rows[0][0].inline[0]).toEqual({
+        type: "bold",
+        children: [{ type: "text", content: "Bold" }],
+      });
+      expect(table.rows[0][0].inline[1]).toEqual({
+        type: "text",
+        content: " feature",
+      });
+    });
+
+    it("handles table followed by other blocks", () => {
+      const md = [
+        "| A | B |",
+        "| --- | --- |",
+        "| 1 | 2 |",
+        "",
+        "A paragraph after the table.",
+        "",
+      ].join("\n");
+
+      const blocks = parseSingleChunk(md);
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].type).toBe("table");
+      expect(blocks[1].type).toBe("paragraph");
+    });
+
+    it("handles table preceded by other blocks", () => {
+      const md = [
+        "# Title",
+        "",
+        "| A | B |",
+        "| --- | --- |",
+        "| 1 | 2 |",
+        "",
+      ].join("\n");
+
+      const blocks = parseSingleChunk(md);
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0].type).toBe("heading");
+      expect(blocks[1].type).toBe("table");
+    });
+  });
+
+  describe("complex streaming scenarios", () => {
+    it("handles multi-block document streamed in realistic chunks", () => {
+      const chunks = [
+        "# Getting Started\n\nInstall the package",
+        " with:\n\n```bash\nnpm install ",
+        "my-package\n```\n\n## Features\n\n",
+        "- Fast\n- Reliable\n- Easy to use\n",
+      ];
+
+      let state = createMagicTextParserState();
+      for (const chunk of chunks) {
+        state = parseMagicTextChunk(state, chunk);
+      }
+      state = finalizeMagicText(state);
+
+      const blocks = state.blocks;
+      expect(blocks[0].type).toBe("heading");
+      expect((blocks[0] as HeadingBlock).level).toBe(1);
+      expect(blocks[1].type).toBe("paragraph");
+      expect(blocks[2].type).toBe("code_fence");
+      expect((blocks[2] as CodeFenceBlock).content).toBe(
+        "npm install my-package",
+      );
+      expect(blocks[3].type).toBe("heading");
+      expect((blocks[3] as HeadingBlock).level).toBe(2);
+      expect(blocks[4].type).toBe("unordered_list");
+      expect((blocks[4] as UnorderedListBlock).items).toHaveLength(3);
+    });
+
+    it("handles blockquote with multiple lines streamed", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "> First line\n");
+      state = parseMagicTextChunk(state, "> Second line\n");
+      state = finalizeMagicText(state);
+
+      const bq = state.blocks[0] as BlockquoteBlock;
+      expect(bq.type).toBe("blockquote");
+      expect(bq.children).toHaveLength(1);
+      expect((bq.children[0] as ParagraphBlock).content).toBe(
+        "First line\nSecond line",
+      );
+    });
+
+    it("handles ordered list items arriving in separate chunks", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "1. First\n");
+      state = parseMagicTextChunk(state, "2. Second\n");
+      state = parseMagicTextChunk(state, "3. Third\n");
+      state = finalizeMagicText(state);
+
+      const list = state.blocks[0] as OrderedListBlock;
+      expect(list.type).toBe("ordered_list");
+      expect(list.items).toHaveLength(3);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty input", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "");
+      state = finalizeMagicText(state);
+      expect(state.blocks).toHaveLength(0);
+    });
+
+    it("handles whitespace-only input", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "   \n  \n");
+      state = finalizeMagicText(state);
+      expect(state.blocks).toHaveLength(0);
+    });
+
+    it("handles newline-only input", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "\n\n\n");
+      state = finalizeMagicText(state);
+      expect(state.blocks).toHaveLength(0);
+    });
+
+    it("tracks consumed character count", () => {
+      let state = createMagicTextParserState();
+      state = parseMagicTextChunk(state, "Hello");
+      expect(state.consumed).toBe(5);
+      state = parseMagicTextChunk(state, " World");
+      expect(state.consumed).toBe(11);
+    });
+  });
+});

--- a/packages/v2/core/src/streaming-markdown/__tests__/segments.spec.ts
+++ b/packages/v2/core/src/streaming-markdown/__tests__/segments.spec.ts
@@ -1,0 +1,77 @@
+// Derived from hashbrown/packages/core/src/magic-text/segments.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { segmentText } from "../segments";
+
+describe("segmentText", () => {
+  describe("basic strings", () => {
+    it("should segment a simple ASCII string into individual characters", () => {
+      expect(segmentText("abc")).toEqual(["a", "b", "c"]);
+    });
+
+    it("should handle a single character", () => {
+      expect(segmentText("x")).toEqual(["x"]);
+    });
+
+    it("should handle multi-word text", () => {
+      expect(segmentText("hello world")).toEqual([
+        "h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d",
+      ]);
+    });
+  });
+
+  describe("empty input", () => {
+    it("should return an empty array for an empty string", () => {
+      expect(segmentText("")).toEqual([]);
+    });
+  });
+
+  describe("unicode and emoji handling", () => {
+    it("should keep a simple emoji as a single segment", () => {
+      const result = segmentText("\u{1F600}");
+      expect(result).toEqual(["\u{1F600}"]);
+    });
+
+    it("should handle a string with mixed ASCII and emoji", () => {
+      const result = segmentText("hi\u{1F44B}");
+      expect(result).toEqual(["h", "i", "\u{1F44B}"]);
+    });
+
+    it("should handle multi-codepoint emoji (family ZWJ sequence)", () => {
+      // The family emoji is a ZWJ sequence: man + ZWJ + woman + ZWJ + girl
+      const family = "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}";
+      const result = segmentText(family);
+      // Intl.Segmenter should treat the ZWJ sequence as one grapheme cluster
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(family);
+    });
+
+    it("should handle flag emoji (regional indicators)", () => {
+      // US flag: regional indicator U + regional indicator S
+      const flag = "\u{1F1FA}\u{1F1F8}";
+      const result = segmentText(flag);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(flag);
+    });
+  });
+
+  describe("Intl.Segmenter fallback", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should fall back to Array.from when Intl.Segmenter is unavailable", () => {
+      vi.stubGlobal("Intl", { ...Intl, Segmenter: undefined });
+      expect(segmentText("abc")).toEqual(["a", "b", "c"]);
+    });
+
+    it("should handle basic emoji with Array.from fallback", () => {
+      vi.stubGlobal("Intl", { ...Intl, Segmenter: undefined });
+      // Array.from splits by code points, so a simple emoji is still one entry
+      const result = segmentText("\u{1F600}");
+      expect(result).toEqual(["\u{1F600}"]);
+    });
+  });
+});

--- a/packages/v2/core/src/streaming-markdown/block-parser.ts
+++ b/packages/v2/core/src/streaming-markdown/block-parser.ts
@@ -1,0 +1,696 @@
+// Derived from hashbrown/packages/core/src/magic-text/block-parser.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * Block-level parser for streaming markdown.
+ *
+ * Parses markdown text into a tree of blocks: headings, paragraphs,
+ * lists (ordered/unordered), blockquotes, code fences, tables, and
+ * thematic breaks.
+ *
+ * Each block receives a stable numeric ID on creation, which persists
+ * across incremental parsing chunks. This is critical for React key
+ * stability during streaming rendering.
+ */
+
+import { parseInline, InlineSegment } from "./inline-parser";
+
+// ─── Block types ────────────────────────────────────────────────
+
+export type Block =
+  | HeadingBlock
+  | ParagraphBlock
+  | CodeFenceBlock
+  | BlockquoteBlock
+  | OrderedListBlock
+  | UnorderedListBlock
+  | TableBlock
+  | ThematicBreakBlock;
+
+export interface HeadingBlock {
+  type: "heading";
+  id: number;
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  content: string;
+  inline: InlineSegment[];
+}
+
+export interface ParagraphBlock {
+  type: "paragraph";
+  id: number;
+  content: string;
+  inline: InlineSegment[];
+}
+
+export interface CodeFenceBlock {
+  type: "code_fence";
+  id: number;
+  language: string;
+  content: string;
+  closed: boolean;
+}
+
+export interface BlockquoteBlock {
+  type: "blockquote";
+  id: number;
+  children: Block[];
+}
+
+export interface ListItemBlock {
+  id: number;
+  content: string;
+  inline: InlineSegment[];
+  children: Block[];
+}
+
+export interface OrderedListBlock {
+  type: "ordered_list";
+  id: number;
+  start: number;
+  items: ListItemBlock[];
+}
+
+export interface UnorderedListBlock {
+  type: "unordered_list";
+  id: number;
+  items: ListItemBlock[];
+}
+
+export interface TableBlock {
+  type: "table";
+  id: number;
+  headers: TableCell[];
+  alignments: TableAlignment[];
+  rows: TableCell[][];
+}
+
+export interface TableCell {
+  content: string;
+  inline: InlineSegment[];
+}
+
+export type TableAlignment = "left" | "center" | "right" | "none";
+
+export interface ThematicBreakBlock {
+  type: "thematic_break";
+  id: number;
+}
+
+// ─── Parser state ──────────────────────────────────────────────
+
+export interface BlockParserState {
+  blocks: Block[];
+  /** Monotonically increasing block ID counter */
+  nextId: number;
+  /** Buffered text that hasn't yet been committed to a block */
+  buffer: string;
+  /** Whether we're currently inside a code fence */
+  inCodeFence: boolean;
+  /** The fence marker (e.g. "```" or "~~~") for matching the closing fence */
+  codeFenceMarker: string;
+  /** The indent of the opening fence */
+  codeFenceIndent: number;
+  /** ID of the current code fence block (when inside one) */
+  codeFenceBlockId: number;
+  /** Whether we're accumulating table rows */
+  inTable: boolean;
+  /** ID of the current table block */
+  tableBlockId: number;
+  /** Whether the last processed line was blank (for paragraph separation) */
+  lastLineWasBlank: boolean;
+}
+
+export function createBlockParserState(): BlockParserState {
+  return {
+    blocks: [],
+    nextId: 1,
+    buffer: "",
+    inCodeFence: false,
+    codeFenceMarker: "",
+    codeFenceIndent: 0,
+    codeFenceBlockId: -1,
+    inTable: false,
+    tableBlockId: -1,
+    lastLineWasBlank: true, // Start true so first paragraph is always new
+  };
+}
+
+// ─── Line-level regexes ────────────────────────────────────────
+
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const CODE_FENCE_OPEN_RE = /^(\s*)((`{3,})(.*?)|(~{3,})(.*?))$/;
+const ORDERED_LIST_RE = /^(\s*)(\d+)[.)]\s+(.*)$/;
+const UNORDERED_LIST_RE = /^(\s*)[-*+]\s+(.*)$/;
+const BLOCKQUOTE_RE = /^>\s?(.*)$/;
+const THEMATIC_BREAK_RE = /^(\*{3,}|-{3,}|_{3,})\s*$/;
+const TABLE_ROW_RE = /^\|(.+)\|?\s*$/;
+// Matches GFM table separator rows like | --- | --- | or |:---:|---:|
+// Also handles single-column tables like | --- |
+const TABLE_SEPARATOR_RE =
+  /^\|[\s:]*-{3,}[\s:]*(\|[\s:]*-{3,}[\s:]*)*\|?\s*$/;
+
+// ─── Core parsing ──────────────────────────────────────────────
+
+/**
+ * Feed a chunk of text into the block parser. Returns a new state
+ * with the block tree updated. The state is immutable — each call
+ * returns a fresh object.
+ */
+export function parseBlockChunk(
+  state: BlockParserState,
+  chunk: string,
+): BlockParserState {
+  // Combine any leftover buffer with new chunk
+  const text = state.buffer + chunk;
+
+  // Clone state for mutation
+  const s: BlockParserState = {
+    ...state,
+    blocks: state.blocks.map(cloneBlock),
+    buffer: "",
+  };
+
+  // Split into lines, keeping the last (potentially incomplete) line in buffer
+  const lines = text.split("\n");
+  // The last element might be a partial line; buffer it unless it ends with \n
+  if (!text.endsWith("\n")) {
+    s.buffer = lines.pop()!;
+  } else {
+    // Text ended with newline, so last split is empty string
+    lines.pop();
+  }
+
+  for (const line of lines) {
+    processLine(s, line);
+  }
+
+  return s;
+}
+
+/**
+ * Finalize the parser state — flush any remaining buffer as a block.
+ */
+export function finalizeBlocks(state: BlockParserState): BlockParserState {
+  const s: BlockParserState = {
+    ...state,
+    blocks: state.blocks.map(cloneBlock),
+    buffer: state.buffer, // Preserve buffer for finalization processing
+  };
+
+  // If we're in a code fence, append any remaining buffer to its content
+  if (s.inCodeFence && s.buffer.length > 0) {
+    const block = findBlockById(s.blocks, s.codeFenceBlockId) as
+      | CodeFenceBlock
+      | undefined;
+    if (block) {
+      if (block.content.length > 0) {
+        block.content += "\n" + s.buffer;
+      } else {
+        block.content = s.buffer;
+      }
+    }
+    s.buffer = "";
+    return s;
+  }
+
+  // If there's buffered text, flush it
+  if (s.buffer.length > 0) {
+    processLine(s, s.buffer);
+    s.buffer = "";
+  }
+
+  // Close any open table
+  if (s.inTable) {
+    s.inTable = false;
+    s.tableBlockId = -1;
+  }
+
+  return s;
+}
+
+// ─── Line processing ───────────────────────────────────────────
+
+function processLine(s: BlockParserState, line: string): void {
+  // Inside a code fence — check for closing fence or append content
+  if (s.inCodeFence) {
+    if (isClosingFence(line, s.codeFenceMarker, s.codeFenceIndent)) {
+      const block = findBlockById(s.blocks, s.codeFenceBlockId) as
+        | CodeFenceBlock
+        | undefined;
+      if (block) {
+        block.closed = true;
+      }
+      s.inCodeFence = false;
+      s.codeFenceMarker = "";
+      s.codeFenceIndent = 0;
+      s.codeFenceBlockId = -1;
+      return;
+    }
+
+    const block = findBlockById(s.blocks, s.codeFenceBlockId) as
+      | CodeFenceBlock
+      | undefined;
+    if (block) {
+      if (block.content.length > 0) {
+        block.content += "\n" + line;
+      } else {
+        block.content = line;
+      }
+    }
+    return;
+  }
+
+  // Remember whether previous line was blank (for paragraph separation)
+  // then reset the flag — blank line handler will set it back if needed
+  const prevLineWasBlank = s.lastLineWasBlank;
+  s.lastLineWasBlank = false;
+
+  // Thematic break
+  if (THEMATIC_BREAK_RE.test(line)) {
+    closeTable(s);
+    const id = s.nextId++;
+    s.blocks.push({ type: "thematic_break", id });
+    return;
+  }
+
+  // Code fence opening
+  const fenceMatch = CODE_FENCE_OPEN_RE.exec(line);
+  if (fenceMatch) {
+    closeTable(s);
+    const indent = fenceMatch[1]?.length ?? 0;
+    // fenceMatch[3] is backtick fence, fenceMatch[5] is tilde fence
+    const marker = fenceMatch[3] || fenceMatch[5] || "";
+    const language = (fenceMatch[4] || fenceMatch[6] || "").trim();
+    const id = s.nextId++;
+    s.blocks.push({
+      type: "code_fence",
+      id,
+      language,
+      content: "",
+      closed: false,
+    });
+    s.inCodeFence = true;
+    s.codeFenceMarker = marker;
+    s.codeFenceIndent = indent;
+    s.codeFenceBlockId = id;
+    return;
+  }
+
+  // Heading
+  const headingMatch = HEADING_RE.exec(line);
+  if (headingMatch) {
+    closeTable(s);
+    const level = headingMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6;
+    const content = headingMatch[2];
+    const id = s.nextId++;
+    s.blocks.push({
+      type: "heading",
+      id,
+      level,
+      content,
+      inline: parseInline(content),
+    });
+    return;
+  }
+
+  // Blockquote
+  const blockquoteMatch = BLOCKQUOTE_RE.exec(line);
+  if (blockquoteMatch) {
+    closeTable(s);
+    const innerContent = blockquoteMatch[1];
+    const lastBlock = s.blocks[s.blocks.length - 1];
+
+    if (lastBlock && lastBlock.type === "blockquote") {
+      // Append to existing blockquote by parsing inner as a mini-block
+      appendToBlockquote(s, lastBlock, innerContent);
+    } else {
+      const id = s.nextId++;
+      const bq: BlockquoteBlock = { type: "blockquote", id, children: [] };
+      s.blocks.push(bq);
+      appendToBlockquote(s, bq, innerContent);
+    }
+    return;
+  }
+
+  // Table detection — a line starting with | and containing |
+  if (TABLE_ROW_RE.test(line)) {
+    if (s.inTable) {
+      // Continuing an existing table
+      appendTableRow(s, line);
+      return;
+    }
+
+    // Check if the previous block is a paragraph that looks like a table header.
+    // This handles the case where the header row was parsed as a paragraph
+    // before we saw the separator.
+    const lastBlock = s.blocks[s.blocks.length - 1];
+    if (
+      lastBlock &&
+      lastBlock.type === "paragraph" &&
+      TABLE_ROW_RE.test(lastBlock.content)
+    ) {
+      // This line could be a separator — check
+      if (TABLE_SEPARATOR_RE.test(line)) {
+        // Convert the paragraph to a table header
+        const headerContent = lastBlock.content;
+        const headers = parseTableCells(headerContent);
+        const alignments = parseTableAlignments(line);
+        const id = lastBlock.id; // Reuse the paragraph's ID for stability
+        const table: TableBlock = {
+          type: "table",
+          id,
+          headers,
+          alignments,
+          rows: [],
+        };
+        // Replace the paragraph with the table
+        const idx = s.blocks.indexOf(lastBlock);
+        s.blocks[idx] = table;
+        s.inTable = true;
+        s.tableBlockId = id;
+        return;
+      }
+    }
+
+    // Otherwise start treating it as a potential table header (paragraph for now)
+    // It might become a table if the next line is a separator
+    const id = s.nextId++;
+    s.blocks.push({
+      type: "paragraph",
+      id,
+      content: line,
+      inline: parseInline(line),
+    });
+    return;
+  }
+
+  // If we were in a table and got a non-table line, close the table
+  if (s.inTable && !TABLE_ROW_RE.test(line)) {
+    closeTable(s);
+  }
+
+  // Ordered list
+  const orderedMatch = ORDERED_LIST_RE.exec(line);
+  if (orderedMatch) {
+    closeTable(s);
+    const startNum = parseInt(orderedMatch[2], 10);
+    const content = orderedMatch[3];
+    const lastBlock = s.blocks[s.blocks.length - 1];
+
+    if (lastBlock && lastBlock.type === "ordered_list") {
+      const itemId = s.nextId++;
+      lastBlock.items.push({
+        id: itemId,
+        content,
+        inline: parseInline(content),
+        children: [],
+      });
+    } else {
+      const id = s.nextId++;
+      const itemId = s.nextId++;
+      s.blocks.push({
+        type: "ordered_list",
+        id,
+        start: startNum,
+        items: [
+          {
+            id: itemId,
+            content,
+            inline: parseInline(content),
+            children: [],
+          },
+        ],
+      });
+    }
+    return;
+  }
+
+  // Unordered list
+  const unorderedMatch = UNORDERED_LIST_RE.exec(line);
+  if (unorderedMatch) {
+    closeTable(s);
+    const content = unorderedMatch[2];
+    const lastBlock = s.blocks[s.blocks.length - 1];
+
+    if (lastBlock && lastBlock.type === "unordered_list") {
+      const itemId = s.nextId++;
+      lastBlock.items.push({
+        id: itemId,
+        content,
+        inline: parseInline(content),
+        children: [],
+      });
+    } else {
+      const id = s.nextId++;
+      const itemId = s.nextId++;
+      s.blocks.push({
+        type: "unordered_list",
+        id,
+        items: [
+          {
+            id: itemId,
+            content,
+            inline: parseInline(content),
+            children: [],
+          },
+        ],
+      });
+    }
+    return;
+  }
+
+  // Empty line — acts as a block separator
+  if (line.trim() === "") {
+    closeTable(s);
+    s.lastLineWasBlank = true;
+    return;
+  }
+
+  // Default: paragraph
+  const lastBlock = s.blocks[s.blocks.length - 1];
+  if (lastBlock && lastBlock.type === "paragraph" && !prevLineWasBlank) {
+    // Append to the existing paragraph (soft line break)
+    lastBlock.content += "\n" + line;
+    lastBlock.inline = parseInline(lastBlock.content);
+  } else {
+    const id = s.nextId++;
+    s.blocks.push({
+      type: "paragraph",
+      id,
+      content: line,
+      inline: parseInline(line),
+    });
+  }
+  s.lastLineWasBlank = false;
+}
+
+// ─── Table helpers ─────────────────────────────────────────────
+
+function parseTableCells(line: string): TableCell[] {
+  // Remove leading/trailing pipe and split
+  let content = line.trim();
+  if (content.startsWith("|")) content = content.substring(1);
+  if (content.endsWith("|")) content = content.substring(0, content.length - 1);
+
+  return content.split("|").map((cell) => {
+    const trimmed = cell.trim();
+    return {
+      content: trimmed,
+      inline: parseInline(trimmed),
+    };
+  });
+}
+
+function parseTableAlignments(line: string): TableAlignment[] {
+  let content = line.trim();
+  if (content.startsWith("|")) content = content.substring(1);
+  if (content.endsWith("|")) content = content.substring(0, content.length - 1);
+
+  return content.split("|").map((cell) => {
+    const trimmed = cell.trim();
+    const leftColon = trimmed.startsWith(":");
+    const rightColon = trimmed.endsWith(":");
+
+    if (leftColon && rightColon) return "center";
+    if (rightColon) return "right";
+    if (leftColon) return "left";
+    return "none";
+  });
+}
+
+function appendTableRow(s: BlockParserState, line: string): void {
+  const table = findBlockById(s.blocks, s.tableBlockId) as
+    | TableBlock
+    | undefined;
+  if (!table) return;
+
+  // Check if this is a separator line (can happen with multi-separator tables)
+  if (TABLE_SEPARATOR_RE.test(line)) {
+    return; // Skip duplicate separator lines
+  }
+
+  const cells = parseTableCells(line);
+
+  // Pad or trim cells to match header count
+  const headerCount = table.headers.length;
+  while (cells.length < headerCount) {
+    cells.push({ content: "", inline: [] });
+  }
+  if (cells.length > headerCount) {
+    cells.length = headerCount;
+  }
+
+  table.rows.push(cells);
+}
+
+function closeTable(s: BlockParserState): void {
+  if (s.inTable) {
+    s.inTable = false;
+    s.tableBlockId = -1;
+  }
+}
+
+// ─── Code fence helpers ────────────────────────────────────────
+
+function isClosingFence(
+  line: string,
+  openMarker: string,
+  openIndent: number,
+): boolean {
+  const trimmedLine = line.trimStart();
+  const lineIndent = line.length - trimmedLine.length;
+
+  // Closing fence indent must not exceed opening indent + 3
+  if (lineIndent > openIndent + 3) return false;
+
+  const fenceChar = openMarker[0]; // ` or ~
+  const openLength = openMarker.length;
+
+  // Count consecutive fence chars
+  let count = 0;
+  for (let i = 0; i < trimmedLine.length; i++) {
+    if (trimmedLine[i] === fenceChar) {
+      count++;
+    } else {
+      break;
+    }
+  }
+
+  // Closing fence must be at least as long as the opening fence
+  if (count < openLength) return false;
+
+  // Nothing after the closing fence except whitespace
+  const afterFence = trimmedLine.substring(count).trim();
+  return afterFence === "";
+}
+
+// ─── Blockquote helpers ────────────────────────────────────────
+
+function appendToBlockquote(
+  s: BlockParserState,
+  bq: BlockquoteBlock,
+  content: string,
+): void {
+  // Check if the content itself is a blockquote (nested)
+  const nestedMatch = BLOCKQUOTE_RE.exec(content);
+  if (nestedMatch) {
+    const lastChild = bq.children[bq.children.length - 1];
+    if (lastChild && lastChild.type === "blockquote") {
+      appendToBlockquote(s, lastChild, nestedMatch[1]);
+    } else {
+      const nestedBq: BlockquoteBlock = {
+        type: "blockquote",
+        id: s.nextId++,
+        children: [],
+      };
+      bq.children.push(nestedBq);
+      appendToBlockquote(s, nestedBq, nestedMatch[1]);
+    }
+    return;
+  }
+
+  // Check if content is a heading
+  const headingMatch = HEADING_RE.exec(content);
+  if (headingMatch) {
+    const level = headingMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6;
+    const headingContent = headingMatch[2];
+    bq.children.push({
+      type: "heading",
+      id: s.nextId++,
+      level,
+      content: headingContent,
+      inline: parseInline(headingContent),
+    });
+    return;
+  }
+
+  // Otherwise treat as paragraph
+  const lastChild = bq.children[bq.children.length - 1];
+  if (lastChild && lastChild.type === "paragraph") {
+    lastChild.content += "\n" + content;
+    lastChild.inline = parseInline(lastChild.content);
+  } else {
+    bq.children.push({
+      type: "paragraph",
+      id: s.nextId++,
+      content,
+      inline: parseInline(content),
+    });
+  }
+}
+
+// ─── Utilities ─────────────────────────────────────────────────
+
+function findBlockById(blocks: Block[], id: number): Block | undefined {
+  for (const block of blocks) {
+    if (block.id === id) return block;
+    if (block.type === "blockquote") {
+      const found = findBlockById(block.children, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function cloneBlock(block: Block): Block {
+  switch (block.type) {
+    case "heading":
+      return { ...block, inline: [...block.inline] };
+    case "paragraph":
+      return { ...block, inline: [...block.inline] };
+    case "code_fence":
+      return { ...block };
+    case "thematic_break":
+      return { ...block };
+    case "blockquote":
+      return { ...block, children: block.children.map(cloneBlock) };
+    case "ordered_list":
+      return {
+        ...block,
+        items: block.items.map((item) => ({
+          ...item,
+          inline: [...item.inline],
+          children: item.children.map(cloneBlock),
+        })),
+      };
+    case "unordered_list":
+      return {
+        ...block,
+        items: block.items.map((item) => ({
+          ...item,
+          inline: [...item.inline],
+          children: item.children.map(cloneBlock),
+        })),
+      };
+    case "table":
+      return {
+        ...block,
+        headers: block.headers.map((h) => ({ ...h, inline: [...h.inline] })),
+        alignments: [...block.alignments],
+        rows: block.rows.map((row) =>
+          row.map((cell) => ({ ...cell, inline: [...cell.inline] })),
+        ),
+      };
+  }
+}

--- a/packages/v2/core/src/streaming-markdown/citations.ts
+++ b/packages/v2/core/src/streaming-markdown/citations.ts
@@ -1,0 +1,42 @@
+// Derived from hashbrown/packages/core/src/magic-text/citations.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * Citation extraction for streaming markdown.
+ *
+ * Extracts citation references like [^1], [^note], etc.
+ */
+
+export interface Citation {
+  /** The citation label, e.g. "1" or "note" */
+  label: string;
+  /** The full matched text, e.g. "[^1]" */
+  raw: string;
+  /** Start index in the original text */
+  start: number;
+  /** End index in the original text */
+  end: number;
+}
+
+const CITATION_REGEX = /\[\^([^\]]+)\]/g;
+
+/**
+ * Extract all citation references from a text string.
+ */
+export function extractCitations(text: string): Citation[] {
+  const citations: Citation[] = [];
+  let match: RegExpExecArray | null;
+
+  CITATION_REGEX.lastIndex = 0;
+  while ((match = CITATION_REGEX.exec(text)) !== null) {
+    citations.push({
+      label: match[1],
+      raw: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  return citations;
+}

--- a/packages/v2/core/src/streaming-markdown/index.ts
+++ b/packages/v2/core/src/streaming-markdown/index.ts
@@ -1,0 +1,65 @@
+// Derived from hashbrown/packages/core/src/magic-text/index.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * Streaming Markdown Parser
+ *
+ * A proper streaming state-machine parser for markdown, replacing the
+ * regex-based completePartialMarkdown() heuristic. Supports headings,
+ * paragraphs, lists, blockquotes, code fences, tables (GFM), and
+ * inline formatting (bold, italic, code, links, images, strikethrough).
+ *
+ * Key properties:
+ * - Stable block IDs across chunks (critical for React key stability)
+ * - Incremental: streaming chunks produce the same result as the whole string
+ * - GFM table support (the known completePartialMarkdown bug is fixed)
+ */
+
+// State machine (main API)
+export {
+  createMagicTextParserState,
+  parseMagicTextChunk,
+  finalizeMagicText,
+  type MagicTextParserState,
+} from "./state";
+
+// Block types and parser
+export {
+  type Block,
+  type HeadingBlock,
+  type ParagraphBlock,
+  type CodeFenceBlock,
+  type BlockquoteBlock,
+  type OrderedListBlock,
+  type UnorderedListBlock,
+  type TableBlock,
+  type TableCell,
+  type TableAlignment,
+  type ThematicBreakBlock,
+  type ListItemBlock,
+  type BlockParserState,
+  createBlockParserState,
+  parseBlockChunk,
+  finalizeBlocks,
+} from "./block-parser";
+
+// Inline types and parser
+export {
+  type InlineSegment,
+  type TextSegment,
+  type BoldSegment,
+  type ItalicSegment,
+  type CodeSegment,
+  type StrikethroughSegment,
+  type LinkSegment,
+  type ImageSegment,
+  parseInline,
+  inlineToPlainText,
+} from "./inline-parser";
+
+// Segmentation
+export { segmentText } from "./segments";
+
+// Citations
+export { type Citation, extractCitations } from "./citations";

--- a/packages/v2/core/src/streaming-markdown/inline-parser.ts
+++ b/packages/v2/core/src/streaming-markdown/inline-parser.ts
@@ -1,0 +1,438 @@
+// Derived from hashbrown/packages/core/src/magic-text/inline-parser.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * Inline formatting parser for streaming markdown.
+ *
+ * Parses bold, italic, code, links, images, and strikethrough
+ * from a line of text into an array of inline segments.
+ */
+
+export type InlineSegment =
+  | TextSegment
+  | BoldSegment
+  | ItalicSegment
+  | CodeSegment
+  | StrikethroughSegment
+  | LinkSegment
+  | ImageSegment;
+
+export interface TextSegment {
+  type: "text";
+  content: string;
+}
+
+export interface BoldSegment {
+  type: "bold";
+  children: InlineSegment[];
+}
+
+export interface ItalicSegment {
+  type: "italic";
+  children: InlineSegment[];
+}
+
+export interface CodeSegment {
+  type: "code";
+  content: string;
+}
+
+export interface StrikethroughSegment {
+  type: "strikethrough";
+  children: InlineSegment[];
+}
+
+export interface LinkSegment {
+  type: "link";
+  href: string;
+  children: InlineSegment[];
+}
+
+export interface ImageSegment {
+  type: "image";
+  src: string;
+  alt: string;
+}
+
+/**
+ * Parse inline markdown formatting from a string.
+ *
+ * Handles: **bold**, *italic*, __bold__, _italic_, `code`,
+ * ~~strikethrough~~, [links](url), ![images](url)
+ */
+export function parseInline(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+  let i = 0;
+  let currentText = "";
+
+  function flushText() {
+    if (currentText.length > 0) {
+      segments.push({ type: "text", content: currentText });
+      currentText = "";
+    }
+  }
+
+  while (i < text.length) {
+    // Escape sequences
+    if (text[i] === "\\" && i + 1 < text.length) {
+      currentText += text[i + 1];
+      i += 2;
+      continue;
+    }
+
+    // Inline code (backtick)
+    if (text[i] === "`") {
+      const codeResult = tryParseInlineCode(text, i);
+      if (codeResult) {
+        flushText();
+        segments.push(codeResult.segment);
+        i = codeResult.end;
+        continue;
+      }
+    }
+
+    // Image: ![alt](src)
+    if (text[i] === "!" && text[i + 1] === "[") {
+      const imageResult = tryParseImage(text, i);
+      if (imageResult) {
+        flushText();
+        segments.push(imageResult.segment);
+        i = imageResult.end;
+        continue;
+      }
+    }
+
+    // Link: [text](url)
+    if (text[i] === "[") {
+      const linkResult = tryParseLink(text, i);
+      if (linkResult) {
+        flushText();
+        segments.push(linkResult.segment);
+        i = linkResult.end;
+        continue;
+      }
+    }
+
+    // Strikethrough: ~~text~~
+    if (text[i] === "~" && text[i + 1] === "~") {
+      const strikeResult = tryParseDelimited(text, i, "~~", "strikethrough");
+      if (strikeResult) {
+        flushText();
+        segments.push(strikeResult.segment);
+        i = strikeResult.end;
+        continue;
+      }
+    }
+
+    // Bold: **text** or __text__
+    if (
+      (text[i] === "*" && text[i + 1] === "*") ||
+      (text[i] === "_" && text[i + 1] === "_")
+    ) {
+      const delimiter = text.substring(i, i + 2);
+      const boldResult = tryParseDelimited(text, i, delimiter, "bold");
+      if (boldResult) {
+        flushText();
+        segments.push(boldResult.segment);
+        i = boldResult.end;
+        continue;
+      }
+      // If bold parsing failed, emit both characters as text and skip
+      // to avoid the italic parser misinterpreting the second char
+      currentText += text[i];
+      currentText += text[i + 1];
+      i += 2;
+      continue;
+    }
+
+    // Italic: *text* or _text_
+    if (text[i] === "*" || text[i] === "_") {
+      const delimiter = text[i];
+      // Don't parse _ in the middle of a word
+      if (
+        delimiter === "_" &&
+        i > 0 &&
+        isWordChar(text[i - 1]) &&
+        i + 1 < text.length &&
+        isWordChar(text[i + 1])
+      ) {
+        currentText += text[i];
+        i++;
+        continue;
+      }
+      const italicResult = tryParseDelimited(text, i, delimiter, "italic");
+      if (italicResult) {
+        flushText();
+        segments.push(italicResult.segment);
+        i = italicResult.end;
+        continue;
+      }
+    }
+
+    currentText += text[i];
+    i++;
+  }
+
+  flushText();
+  return segments;
+}
+
+function isWordChar(ch: string): boolean {
+  return /\w/.test(ch);
+}
+
+interface ParseResult<T> {
+  segment: T;
+  end: number;
+}
+
+function tryParseInlineCode(
+  text: string,
+  start: number,
+): ParseResult<CodeSegment> | null {
+  // Count opening backticks
+  let backtickCount = 0;
+  let i = start;
+  while (i < text.length && text[i] === "`") {
+    backtickCount++;
+    i++;
+  }
+
+  // Find matching closing backticks
+  const closingPattern = "`".repeat(backtickCount);
+  const closingIndex = text.indexOf(closingPattern, i);
+  if (closingIndex === -1) return null;
+
+  // Ensure we have exactly the right number of backticks at the close
+  // (not more)
+  if (
+    backtickCount > 1 &&
+    closingIndex + backtickCount < text.length &&
+    text[closingIndex + backtickCount] === "`"
+  ) {
+    return null;
+  }
+
+  let content = text.substring(i, closingIndex);
+  // Strip one leading and one trailing space if both are present
+  // (standard markdown behavior for code spans)
+  if (
+    content.length >= 2 &&
+    content[0] === " " &&
+    content[content.length - 1] === " "
+  ) {
+    content = content.substring(1, content.length - 1);
+  }
+
+  return {
+    segment: { type: "code", content },
+    end: closingIndex + backtickCount,
+  };
+}
+
+function tryParseImage(
+  text: string,
+  start: number,
+): ParseResult<ImageSegment> | null {
+  // Must start with ![
+  if (text[start] !== "!" || text[start + 1] !== "[") return null;
+
+  const closeBracket = findClosingBracket(text, start + 1);
+  if (closeBracket === -1) return null;
+
+  const alt = text.substring(start + 2, closeBracket);
+
+  // Must be followed by (
+  if (text[closeBracket + 1] !== "(") return null;
+
+  const closeParen = findClosingParen(text, closeBracket + 1);
+  if (closeParen === -1) return null;
+
+  const src = text.substring(closeBracket + 2, closeParen).trim();
+
+  return {
+    segment: { type: "image", alt, src },
+    end: closeParen + 1,
+  };
+}
+
+function tryParseLink(
+  text: string,
+  start: number,
+): ParseResult<LinkSegment> | null {
+  const closeBracket = findClosingBracket(text, start);
+  if (closeBracket === -1) return null;
+
+  // Must be followed by (
+  if (text[closeBracket + 1] !== "(") return null;
+
+  const closeParen = findClosingParen(text, closeBracket + 1);
+  if (closeParen === -1) return null;
+
+  const linkText = text.substring(start + 1, closeBracket);
+  const href = text.substring(closeBracket + 2, closeParen).trim();
+  const children = parseInline(linkText);
+
+  return {
+    segment: { type: "link", href, children },
+    end: closeParen + 1,
+  };
+}
+
+function tryParseDelimited(
+  text: string,
+  start: number,
+  delimiter: string,
+  type: "bold" | "italic" | "strikethrough",
+): ParseResult<BoldSegment | ItalicSegment | StrikethroughSegment> | null {
+  const delimLen = delimiter.length;
+  const afterOpen = start + delimLen;
+
+  // Must have content after delimiter
+  if (afterOpen >= text.length) return null;
+  // Content must not start with whitespace
+  if (text[afterOpen] === " ") return null;
+
+  const delimChar = delimiter[0];
+
+  // Search for closing delimiter
+  let i = afterOpen;
+  while (i < text.length) {
+    // Escape character
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i += 2;
+      continue;
+    }
+
+    // For single-char delimiters (* or _), when we encounter a double
+    // delimiter (**), try to skip over the matched ** pair to handle
+    // nested bold-inside-italic correctly (e.g. *text **bold** text*)
+    if (delimLen === 1 && text[i] === delimChar && text[i + 1] === delimChar) {
+      // This is a double-delimiter opening. Find its matching close.
+      const doubleDelim = delimiter + delimiter;
+      const closeIdx = findMatchingClose(text, i + 2, doubleDelim);
+      if (closeIdx !== -1) {
+        // Skip over the entire **...**  block
+        i = closeIdx + 2;
+        continue;
+      }
+      // If no matching close, fall through
+    }
+
+    if (text.substring(i, i + delimLen) === delimiter) {
+      // For single-char delimiters, ensure this isn't part of a double
+      if (delimLen === 1 && text[i + 1] === delimChar) {
+        // This is the start of a ** or __, skip it
+        i += 2;
+        continue;
+      }
+
+      // Content must not end with whitespace
+      if (text[i - 1] === " ") {
+        i++;
+        continue;
+      }
+
+      const innerText = text.substring(afterOpen, i);
+      if (innerText.length === 0) {
+        i++;
+        continue;
+      }
+
+      const children = parseInline(innerText);
+
+      return {
+        segment: { type, children } as
+          | BoldSegment
+          | ItalicSegment
+          | StrikethroughSegment,
+        end: i + delimLen,
+      };
+    }
+
+    i++;
+  }
+
+  return null;
+}
+
+/**
+ * Find matching closing delimiter for a double-char delimiter sequence.
+ * Returns the index of the first char of the closing delimiter, or -1.
+ */
+function findMatchingClose(
+  text: string,
+  start: number,
+  delimiter: string,
+): number {
+  const delimLen = delimiter.length;
+  let i = start;
+  while (i < text.length) {
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i += 2;
+      continue;
+    }
+    if (text.substring(i, i + delimLen) === delimiter) {
+      return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+function findClosingBracket(text: string, start: number): number {
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i++;
+      continue;
+    }
+    if (text[i] === "[") depth++;
+    if (text[i] === "]") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function findClosingParen(text: string, start: number): number {
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i++;
+      continue;
+    }
+    if (text[i] === "(") depth++;
+    if (text[i] === ")") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Get the plain text content from inline segments (strips formatting).
+ */
+export function inlineToPlainText(segments: InlineSegment[]): string {
+  return segments
+    .map((seg) => {
+      switch (seg.type) {
+        case "text":
+          return seg.content;
+        case "code":
+          return seg.content;
+        case "bold":
+        case "italic":
+        case "strikethrough":
+          return inlineToPlainText(seg.children);
+        case "link":
+          return inlineToPlainText(seg.children);
+        case "image":
+          return seg.alt;
+      }
+    })
+    .join("");
+}

--- a/packages/v2/core/src/streaming-markdown/segments.ts
+++ b/packages/v2/core/src/streaming-markdown/segments.ts
@@ -1,0 +1,32 @@
+// Derived from hashbrown/packages/core/src/magic-text/segments.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * Intl.Segmenter-based text segmentation for streaming markdown.
+ *
+ * Uses grapheme-cluster segmentation to correctly handle multi-byte
+ * characters, emoji, and other complex Unicode sequences.
+ */
+
+let _segmenter: Intl.Segmenter | null = null;
+
+function getSegmenter(): Intl.Segmenter {
+  if (!_segmenter) {
+    _segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  }
+  return _segmenter;
+}
+
+/**
+ * Segment text into an array of grapheme clusters.
+ * Falls back to Array.from if Intl.Segmenter is not available.
+ */
+export function segmentText(text: string): string[] {
+  if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
+    const segmenter = getSegmenter();
+    return Array.from(segmenter.segment(text), (s) => s.segment);
+  }
+  // Fallback for environments without Intl.Segmenter
+  return Array.from(text);
+}

--- a/packages/v2/core/src/streaming-markdown/state.ts
+++ b/packages/v2/core/src/streaming-markdown/state.ts
@@ -1,0 +1,98 @@
+// Derived from hashbrown/packages/core/src/magic-text/state.ts
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * Streaming markdown parser state machine.
+ *
+ * Pure functional API:
+ *   createMagicTextParserState()   → initial state
+ *   parseMagicTextChunk(state, chunk) → new state with updated block tree
+ *   finalizeMagicText(state)       → final state (flushes buffers)
+ *
+ * Same pattern as the JSON streaming parser — immutable state,
+ * incremental processing, stable block IDs for React key stability.
+ */
+
+import {
+  Block,
+  BlockParserState,
+  createBlockParserState,
+  parseBlockChunk,
+  finalizeBlocks,
+} from "./block-parser";
+
+// ─── Public types ──────────────────────────────────────────────
+
+export interface MagicTextParserState {
+  /** The current block tree — the parsed markdown structure */
+  blocks: Block[];
+  /** Internal block parser state (opaque to consumers) */
+  _blockState: BlockParserState;
+  /** Total characters consumed so far */
+  consumed: number;
+}
+
+// ─── Public API ────────────────────────────────────────────────
+
+/**
+ * Create an initial parser state.
+ */
+export function createMagicTextParserState(): MagicTextParserState {
+  const blockState = createBlockParserState();
+  return {
+    blocks: [],
+    _blockState: blockState,
+    consumed: 0,
+  };
+}
+
+/**
+ * Feed a chunk of text into the parser. Returns a new state with
+ * the block tree updated.
+ *
+ * This is the core incremental parsing function. Feed chunks as they
+ * arrive from the stream — the parser handles partial lines, buffering,
+ * and all state transitions.
+ *
+ * @param state - The current parser state
+ * @param chunk - A string chunk to parse (can be any length)
+ * @returns A new parser state with updated blocks
+ */
+export function parseMagicTextChunk(
+  state: MagicTextParserState,
+  chunk: string,
+): MagicTextParserState {
+  const newBlockState = parseBlockChunk(state._blockState, chunk);
+
+  // To get the current "view" of blocks for rendering, we finalize
+  // a copy of the state (which flushes the buffer into blocks)
+  // but keep the real un-finalized state for continued parsing.
+  const viewState = finalizeBlocks(newBlockState);
+
+  return {
+    blocks: viewState.blocks,
+    _blockState: newBlockState,
+    consumed: state.consumed + chunk.length,
+  };
+}
+
+/**
+ * Finalize the parser — flush any remaining buffered text and close
+ * any open structures.
+ *
+ * Call this when the stream is complete to get the final block tree.
+ *
+ * @param state - The current parser state
+ * @returns The final parser state with all blocks resolved
+ */
+export function finalizeMagicText(
+  state: MagicTextParserState,
+): MagicTextParserState {
+  const finalState = finalizeBlocks(state._blockState);
+  return {
+    blocks: finalState.blocks,
+    _blockState: finalState,
+    consumed: state.consumed,
+  };
+}

--- a/packages/v2/core/src/utils/markdown.ts
+++ b/packages/v2/core/src/utils/markdown.ts
@@ -1,3 +1,31 @@
+/**
+ * @deprecated Use the streaming markdown parser instead:
+ *   import { createMagicTextParserState, parseMagicTextChunk, finalizeMagicText }
+ *     from './streaming-markdown';
+ *
+ * DEPRECATION PLAN (CPK-7073):
+ *
+ * This regex-based heuristic is replaced by a proper streaming state-machine
+ * parser in `../streaming-markdown/`. The new parser correctly handles tables
+ * (a known bug here), produces a block tree with stable IDs for React key
+ * stability, and supports incremental parsing.
+ *
+ * Current consumers:
+ *   1. packages/v2/angular/.../copilot-chat-assistant-message-renderer.ts
+ *      — uses completePartialMarkdown to pre-process markdown before
+ *        feeding to `marked`. Migration: adopt the streaming parser with
+ *        an Angular equivalent of useMagicTextParser, or use the block
+ *        tree directly for rendering.
+ *   2. packages/v2/react/src/lib/__tests__/completePartialMarkdown.test.ts
+ *      — test suite for this function. Will be removed when this function
+ *        is removed.
+ *
+ * Migration timeline:
+ *   - Walk milestone: migrate Angular consumer to new parser
+ *   - Post-Walk: remove this function and its test suite
+ *
+ * DO NOT add new consumers of this function.
+ */
 export function completePartialMarkdown(input: string): string {
   let s = input;
 

--- a/packages/v2/react/LICENSE-THIRD-PARTY
+++ b/packages/v2/react/LICENSE-THIRD-PARTY
@@ -1,0 +1,4 @@
+This package contains code derived from Hashbrown
+(https://github.com/liveloveapp/hashbrown)
+Copyright (c) 2025 LiveLoveApp
+Licensed under the MIT License

--- a/packages/v2/react/src/index.ts
+++ b/packages/v2/react/src/index.ts
@@ -12,6 +12,7 @@ export * from "./hooks";
 export * from "./providers";
 export * from "./types";
 export * from "./lib/react-core";
+export * from "./streaming-markdown";
 export { createA2UIMessageRenderer } from "./a2ui/A2UIMessageRenderer";
 export type { A2UIMessageRendererOptions } from "./a2ui/A2UIMessageRenderer";
 export type { Theme as A2UITheme } from "@copilotkit/a2ui-renderer";

--- a/packages/v2/react/src/streaming-markdown/__tests__/renderer.spec.tsx
+++ b/packages/v2/react/src/streaming-markdown/__tests__/renderer.spec.tsx
@@ -1,0 +1,322 @@
+// Derived from hashbrown/packages/react/src/magic-text-renderer.tsx
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MagicTextRenderer } from "../renderer";
+import type { Block } from "@copilotkitnext/core";
+
+describe("MagicTextRenderer", () => {
+  describe("headings", () => {
+    it("renders h1 through h6", () => {
+      const blocks: Block[] = [
+        { type: "heading", id: 1, level: 1, content: "H1", inline: [{ type: "text", content: "H1" }] },
+        { type: "heading", id: 2, level: 2, content: "H2", inline: [{ type: "text", content: "H2" }] },
+        { type: "heading", id: 3, level: 3, content: "H3", inline: [{ type: "text", content: "H3" }] },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      expect(container.querySelector("h1")?.textContent).toBe("H1");
+      expect(container.querySelector("h2")?.textContent).toBe("H2");
+      expect(container.querySelector("h3")?.textContent).toBe("H3");
+    });
+  });
+
+  describe("paragraphs", () => {
+    it("renders a paragraph", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 1,
+          content: "Hello world",
+          inline: [{ type: "text", content: "Hello world" }],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      expect(container.querySelector("p")?.textContent).toBe("Hello world");
+    });
+
+    it("renders a paragraph with bold text", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 1,
+          content: "Hello **world**",
+          inline: [
+            { type: "text", content: "Hello " },
+            {
+              type: "bold",
+              children: [{ type: "text", content: "world" }],
+            },
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      expect(container.querySelector("strong")?.textContent).toBe("world");
+    });
+  });
+
+  describe("code fences", () => {
+    it("renders a code fence with language class", () => {
+      const blocks: Block[] = [
+        {
+          type: "code_fence",
+          id: 1,
+          language: "javascript",
+          content: 'console.log("hi");',
+          closed: true,
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const pre = container.querySelector("pre");
+      const code = pre?.querySelector("code");
+      expect(code?.textContent).toBe('console.log("hi");');
+      expect(code?.className).toBe("language-javascript");
+    });
+
+    it("renders a code fence without language", () => {
+      const blocks: Block[] = [
+        {
+          type: "code_fence",
+          id: 1,
+          language: "",
+          content: "plain code",
+          closed: true,
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const code = container.querySelector("code");
+      expect(code?.textContent).toBe("plain code");
+      expect(code?.className).toBe("");
+    });
+  });
+
+  describe("lists", () => {
+    it("renders an unordered list", () => {
+      const blocks: Block[] = [
+        {
+          type: "unordered_list",
+          id: 1,
+          items: [
+            { id: 10, content: "Item A", inline: [{ type: "text", content: "Item A" }], children: [] },
+            { id: 11, content: "Item B", inline: [{ type: "text", content: "Item B" }], children: [] },
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const ul = container.querySelector("ul");
+      expect(ul).not.toBeNull();
+      const items = ul?.querySelectorAll("li");
+      expect(items).toHaveLength(2);
+      expect(items?.[0].textContent).toBe("Item A");
+      expect(items?.[1].textContent).toBe("Item B");
+    });
+
+    it("renders an ordered list with custom start", () => {
+      const blocks: Block[] = [
+        {
+          type: "ordered_list",
+          id: 1,
+          start: 3,
+          items: [
+            { id: 10, content: "Third", inline: [{ type: "text", content: "Third" }], children: [] },
+            { id: 11, content: "Fourth", inline: [{ type: "text", content: "Fourth" }], children: [] },
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const ol = container.querySelector("ol");
+      expect(ol?.getAttribute("start")).toBe("3");
+    });
+  });
+
+  describe("blockquotes", () => {
+    it("renders a blockquote with nested paragraph", () => {
+      const blocks: Block[] = [
+        {
+          type: "blockquote",
+          id: 1,
+          children: [
+            {
+              type: "paragraph",
+              id: 2,
+              content: "A quote",
+              inline: [{ type: "text", content: "A quote" }],
+            },
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const bq = container.querySelector("blockquote");
+      expect(bq?.querySelector("p")?.textContent).toBe("A quote");
+    });
+  });
+
+  describe("tables", () => {
+    it("renders a table with headers, alignment, and rows", () => {
+      const blocks: Block[] = [
+        {
+          type: "table",
+          id: 1,
+          headers: [
+            { content: "Name", inline: [{ type: "text", content: "Name" }] },
+            { content: "Age", inline: [{ type: "text", content: "Age" }] },
+          ],
+          alignments: ["left", "right"],
+          rows: [
+            [
+              { content: "Alice", inline: [{ type: "text", content: "Alice" }] },
+              { content: "30", inline: [{ type: "text", content: "30" }] },
+            ],
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const table = container.querySelector("table");
+      expect(table).not.toBeNull();
+
+      const ths = table?.querySelectorAll("th");
+      expect(ths).toHaveLength(2);
+      expect(ths?.[0].textContent).toBe("Name");
+      expect(ths?.[0].style.textAlign).toBe("left");
+      expect(ths?.[1].textContent).toBe("Age");
+      expect(ths?.[1].style.textAlign).toBe("right");
+
+      const tds = table?.querySelectorAll("td");
+      expect(tds).toHaveLength(2);
+      expect(tds?.[0].textContent).toBe("Alice");
+      expect(tds?.[1].textContent).toBe("30");
+    });
+  });
+
+  describe("thematic breaks", () => {
+    it("renders an hr element", () => {
+      const blocks: Block[] = [{ type: "thematic_break", id: 1 }];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      expect(container.querySelector("hr")).not.toBeNull();
+    });
+  });
+
+  describe("inline formatting", () => {
+    it("renders italic text", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 1,
+          content: "*italic*",
+          inline: [
+            {
+              type: "italic",
+              children: [{ type: "text", content: "italic" }],
+            },
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      expect(container.querySelector("em")?.textContent).toBe("italic");
+    });
+
+    it("renders inline code", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 1,
+          content: "`code`",
+          inline: [{ type: "code", content: "code" }],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      expect(container.querySelector("code")?.textContent).toBe("code");
+    });
+
+    it("renders strikethrough", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 1,
+          content: "~~deleted~~",
+          inline: [
+            {
+              type: "strikethrough",
+              children: [{ type: "text", content: "deleted" }],
+            },
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      expect(container.querySelector("del")?.textContent).toBe("deleted");
+    });
+
+    it("renders links", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 1,
+          content: "[click](url)",
+          inline: [
+            {
+              type: "link",
+              href: "https://example.com",
+              children: [{ type: "text", content: "click" }],
+            },
+          ],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const a = container.querySelector("a");
+      expect(a?.textContent).toBe("click");
+      expect(a?.getAttribute("href")).toBe("https://example.com");
+    });
+
+    it("renders images", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 1,
+          content: "![alt](src)",
+          inline: [{ type: "image", alt: "photo", src: "photo.png" }],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const img = container.querySelector("img");
+      expect(img?.getAttribute("alt")).toBe("photo");
+      expect(img?.getAttribute("src")).toBe("photo.png");
+    });
+  });
+
+  describe("stable keys", () => {
+    it("uses block IDs as keys for stable rendering", () => {
+      const blocks: Block[] = [
+        {
+          type: "paragraph",
+          id: 42,
+          content: "First",
+          inline: [{ type: "text", content: "First" }],
+        },
+        {
+          type: "paragraph",
+          id: 43,
+          content: "Second",
+          inline: [{ type: "text", content: "Second" }],
+        },
+      ];
+      const { container } = render(<MagicTextRenderer blocks={blocks} />);
+      const paragraphs = container.querySelectorAll("p");
+      expect(paragraphs).toHaveLength(2);
+      // Keys are internal to React, but we can verify the elements render
+      expect(paragraphs[0].textContent).toBe("First");
+      expect(paragraphs[1].textContent).toBe("Second");
+    });
+  });
+
+  describe("className prop", () => {
+    it("applies className to the wrapper div", () => {
+      const blocks: Block[] = [];
+      const { container } = render(
+        <MagicTextRenderer blocks={blocks} className="my-class" />,
+      );
+      expect(container.firstElementChild?.className).toBe("my-class");
+    });
+  });
+});

--- a/packages/v2/react/src/streaming-markdown/__tests__/use-magic-text-parser.spec.tsx
+++ b/packages/v2/react/src/streaming-markdown/__tests__/use-magic-text-parser.spec.tsx
@@ -1,0 +1,163 @@
+// Derived from hashbrown/packages/react/src/hooks/use-magic-text-parser.tsx
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMagicTextParser } from "../use-magic-text-parser";
+import type { HeadingBlock, ParagraphBlock, CodeFenceBlock, TableBlock } from "@copilotkitnext/core";
+
+describe("useMagicTextParser", () => {
+  it("starts with empty blocks", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+    expect(result.current.blocks).toHaveLength(0);
+    expect(result.current.consumed).toBe(0);
+  });
+
+  it("parses a heading via feed()", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feed("# Hello\n");
+    });
+
+    expect(result.current.blocks).toHaveLength(1);
+    const heading = result.current.blocks[0] as HeadingBlock;
+    expect(heading.type).toBe("heading");
+    expect(heading.content).toBe("Hello");
+  });
+
+  it("accumulates blocks across multiple feed() calls", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feed("# Title\n\n");
+    });
+
+    act(() => {
+      result.current.feed("Some text\n");
+    });
+
+    expect(result.current.blocks.length).toBeGreaterThanOrEqual(2);
+    expect(result.current.blocks[0].type).toBe("heading");
+    expect(result.current.blocks[1].type).toBe("paragraph");
+  });
+
+  it("handles partial content via streaming feed()", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feed("# Hel");
+    });
+
+    // Even partial content should show up (via internal finalization for view)
+    expect(result.current.blocks).toHaveLength(1);
+    const heading = result.current.blocks[0] as HeadingBlock;
+    expect(heading.content).toBe("Hel");
+
+    act(() => {
+      result.current.feed("lo World\n");
+    });
+
+    expect(result.current.blocks).toHaveLength(1);
+    expect((result.current.blocks[0] as HeadingBlock).content).toBe(
+      "Hello World",
+    );
+  });
+
+  it("feedFullText only parses new content", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feedFullText("# Hello\n");
+    });
+
+    expect(result.current.blocks).toHaveLength(1);
+    expect(result.current.consumed).toBe(8); // "# Hello\n" = 8 chars
+
+    act(() => {
+      result.current.feedFullText("# Hello\nWorld\n");
+    });
+
+    // Should have parsed only the new "World\n" part
+    expect(result.current.consumed).toBe(14); // "# Hello\nWorld\n" = 14 chars
+  });
+
+  it("finalize() flushes remaining buffer", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feed("Hello world");
+    });
+
+    // Content is visible due to internal view finalization
+    expect(result.current.blocks).toHaveLength(1);
+
+    act(() => {
+      result.current.finalize();
+    });
+
+    expect(result.current.blocks).toHaveLength(1);
+    expect((result.current.blocks[0] as ParagraphBlock).content).toBe(
+      "Hello world",
+    );
+  });
+
+  it("reset() clears all state", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feed("# Hello\n");
+    });
+
+    expect(result.current.blocks).toHaveLength(1);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.blocks).toHaveLength(0);
+    expect(result.current.consumed).toBe(0);
+  });
+
+  it("handles table streaming", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feed("| A | B |\n");
+    });
+
+    act(() => {
+      result.current.feed("| --- | --- |\n");
+    });
+
+    expect(result.current.blocks[0].type).toBe("table");
+
+    act(() => {
+      result.current.feed("| 1 | 2 |\n");
+    });
+
+    const table = result.current.blocks[0] as TableBlock;
+    expect(table.rows).toHaveLength(1);
+    expect(table.rows[0][0].content).toBe("1");
+  });
+
+  it("handles code fence streaming", () => {
+    const { result } = renderHook(() => useMagicTextParser());
+
+    act(() => {
+      result.current.feed("```js\n");
+    });
+
+    expect(result.current.blocks[0].type).toBe("code_fence");
+    expect((result.current.blocks[0] as CodeFenceBlock).language).toBe("js");
+
+    act(() => {
+      result.current.feed("const x = 1;\n```\n");
+    });
+
+    const fence = result.current.blocks[0] as CodeFenceBlock;
+    expect(fence.content).toBe("const x = 1;");
+    expect(fence.closed).toBe(true);
+  });
+});

--- a/packages/v2/react/src/streaming-markdown/index.ts
+++ b/packages/v2/react/src/streaming-markdown/index.ts
@@ -1,0 +1,4 @@
+export { MagicTextRenderer } from "./renderer";
+export type { MagicTextRendererProps } from "./renderer";
+export { useMagicTextParser } from "./use-magic-text-parser";
+export type { UseMagicTextParserResult } from "./use-magic-text-parser";

--- a/packages/v2/react/src/streaming-markdown/renderer.tsx
+++ b/packages/v2/react/src/streaming-markdown/renderer.tsx
@@ -1,0 +1,280 @@
+// Derived from hashbrown/packages/react/src/magic-text-renderer.tsx
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * React renderer for the streaming markdown block tree.
+ *
+ * Walks the block tree produced by the streaming markdown parser and
+ * renders React elements with stable keys (using block IDs). This
+ * ensures minimal DOM churn during streaming.
+ */
+
+import React from "react";
+import type {
+  Block,
+  HeadingBlock,
+  ParagraphBlock,
+  CodeFenceBlock,
+  BlockquoteBlock,
+  OrderedListBlock,
+  UnorderedListBlock,
+  TableBlock,
+  ThematicBreakBlock,
+  ListItemBlock,
+  InlineSegment,
+  TextSegment,
+  BoldSegment,
+  ItalicSegment,
+  CodeSegment,
+  StrikethroughSegment,
+  LinkSegment,
+  ImageSegment,
+  TableAlignment,
+} from "@copilotkitnext/core";
+
+// ─── Public API ────────────────────────────────────────────────
+
+export interface MagicTextRendererProps {
+  /** The block tree from the parser */
+  blocks: Block[];
+  /** Optional className for the wrapper */
+  className?: string;
+}
+
+/**
+ * Render a streaming markdown block tree into React elements.
+ *
+ * Each block is keyed by its stable ID, so React can efficiently
+ * update the DOM as new blocks stream in.
+ */
+export function MagicTextRenderer({
+  blocks,
+  className,
+}: MagicTextRendererProps): React.ReactElement {
+  return React.createElement(
+    "div",
+    { className },
+    blocks.map((block) => renderBlock(block)),
+  );
+}
+
+// ─── Block renderers ───────────────────────────────────────────
+
+function renderBlock(block: Block): React.ReactElement {
+  switch (block.type) {
+    case "heading":
+      return renderHeading(block);
+    case "paragraph":
+      return renderParagraph(block);
+    case "code_fence":
+      return renderCodeFence(block);
+    case "blockquote":
+      return renderBlockquote(block);
+    case "ordered_list":
+      return renderOrderedList(block);
+    case "unordered_list":
+      return renderUnorderedList(block);
+    case "table":
+      return renderTable(block);
+    case "thematic_break":
+      return renderThematicBreak(block);
+  }
+}
+
+function renderHeading(block: HeadingBlock): React.ReactElement {
+  const tag = `h${block.level}` as keyof JSX.IntrinsicElements;
+  return React.createElement(
+    tag,
+    { key: `block-${block.id}` },
+    renderInlineSegments(block.inline, block.id),
+  );
+}
+
+function renderParagraph(block: ParagraphBlock): React.ReactElement {
+  return React.createElement(
+    "p",
+    { key: `block-${block.id}` },
+    renderInlineSegments(block.inline, block.id),
+  );
+}
+
+function renderCodeFence(block: CodeFenceBlock): React.ReactElement {
+  const codeElement = React.createElement(
+    "code",
+    block.language
+      ? { className: `language-${block.language}` }
+      : undefined,
+    block.content,
+  );
+  return React.createElement("pre", { key: `block-${block.id}` }, codeElement);
+}
+
+function renderBlockquote(block: BlockquoteBlock): React.ReactElement {
+  return React.createElement(
+    "blockquote",
+    { key: `block-${block.id}` },
+    block.children.map((child) => renderBlock(child)),
+  );
+}
+
+function renderOrderedList(block: OrderedListBlock): React.ReactElement {
+  return React.createElement(
+    "ol",
+    {
+      key: `block-${block.id}`,
+      start: block.start !== 1 ? block.start : undefined,
+    },
+    block.items.map((item) => renderListItem(item)),
+  );
+}
+
+function renderUnorderedList(block: UnorderedListBlock): React.ReactElement {
+  return React.createElement(
+    "ul",
+    { key: `block-${block.id}` },
+    block.items.map((item) => renderListItem(item)),
+  );
+}
+
+function renderListItem(item: ListItemBlock): React.ReactElement {
+  const children: React.ReactNode[] = renderInlineSegments(
+    item.inline,
+    item.id,
+  );
+  if (item.children.length > 0) {
+    children.push(
+      ...item.children.map((child) => renderBlock(child)),
+    );
+  }
+  return React.createElement("li", { key: `item-${item.id}` }, children);
+}
+
+function renderTable(block: TableBlock): React.ReactElement {
+  const headerCells = block.headers.map((header, i) =>
+    React.createElement(
+      "th",
+      {
+        key: `th-${block.id}-${i}`,
+        style: getAlignmentStyle(block.alignments[i]),
+      },
+      renderInlineSegments(header.inline, block.id * 1000 + i),
+    ),
+  );
+
+  const thead = React.createElement(
+    "thead",
+    null,
+    React.createElement("tr", null, headerCells),
+  );
+
+  const rows = block.rows.map((row, rowIdx) => {
+    const cells = row.map((cell, cellIdx) =>
+      React.createElement(
+        "td",
+        {
+          key: `td-${block.id}-${rowIdx}-${cellIdx}`,
+          style: getAlignmentStyle(block.alignments[cellIdx]),
+        },
+        renderInlineSegments(
+          cell.inline,
+          block.id * 1000000 + rowIdx * 1000 + cellIdx,
+        ),
+      ),
+    );
+    return React.createElement("tr", { key: `tr-${block.id}-${rowIdx}` }, cells);
+  });
+
+  const tbody =
+    rows.length > 0 ? React.createElement("tbody", null, rows) : null;
+
+  return React.createElement(
+    "table",
+    { key: `block-${block.id}` },
+    thead,
+    tbody,
+  );
+}
+
+function renderThematicBreak(block: ThematicBreakBlock): React.ReactElement {
+  return React.createElement("hr", { key: `block-${block.id}` });
+}
+
+// ─── Inline renderers ──────────────────────────────────────────
+
+function renderInlineSegments(
+  segments: InlineSegment[],
+  parentId: number,
+): React.ReactNode[] {
+  return segments.map((seg, i) => renderInlineSegment(seg, `${parentId}-${i}`));
+}
+
+function renderInlineSegment(
+  segment: InlineSegment,
+  keyPrefix: string,
+): React.ReactNode {
+  switch (segment.type) {
+    case "text":
+      return (segment as TextSegment).content;
+    case "bold":
+      return React.createElement(
+        "strong",
+        { key: `bold-${keyPrefix}` },
+        renderInlineChildren((segment as BoldSegment).children, keyPrefix),
+      );
+    case "italic":
+      return React.createElement(
+        "em",
+        { key: `italic-${keyPrefix}` },
+        renderInlineChildren((segment as ItalicSegment).children, keyPrefix),
+      );
+    case "code":
+      return React.createElement(
+        "code",
+        { key: `code-${keyPrefix}` },
+        (segment as CodeSegment).content,
+      );
+    case "strikethrough":
+      return React.createElement(
+        "del",
+        { key: `del-${keyPrefix}` },
+        renderInlineChildren(
+          (segment as StrikethroughSegment).children,
+          keyPrefix,
+        ),
+      );
+    case "link":
+      return React.createElement(
+        "a",
+        {
+          key: `link-${keyPrefix}`,
+          href: (segment as LinkSegment).href,
+        },
+        renderInlineChildren((segment as LinkSegment).children, keyPrefix),
+      );
+    case "image":
+      return React.createElement("img", {
+        key: `img-${keyPrefix}`,
+        src: (segment as ImageSegment).src,
+        alt: (segment as ImageSegment).alt,
+      });
+  }
+}
+
+function renderInlineChildren(
+  children: InlineSegment[],
+  keyPrefix: string,
+): React.ReactNode[] {
+  return children.map((child, i) =>
+    renderInlineSegment(child, `${keyPrefix}-${i}`),
+  );
+}
+
+// ─── Helpers ───────────────────────────────────────────────────
+
+function getAlignmentStyle(
+  alignment: TableAlignment | undefined,
+): React.CSSProperties | undefined {
+  if (!alignment || alignment === "none") return undefined;
+  return { textAlign: alignment };
+}

--- a/packages/v2/react/src/streaming-markdown/use-magic-text-parser.tsx
+++ b/packages/v2/react/src/streaming-markdown/use-magic-text-parser.tsx
@@ -1,0 +1,102 @@
+// Derived from hashbrown/packages/react/src/hooks/use-magic-text-parser.tsx
+// Original: https://github.com/liveloveapp/hashbrown
+// License: MIT (see LICENSE-THIRD-PARTY)
+
+/**
+ * React hook for managing streaming markdown parser state.
+ *
+ * Provides a simple API: { blocks, feed(chunk), reset() }
+ *
+ * Handles prefix-only incremental parsing — when new text arrives,
+ * only the new portion is fed to the parser, making it efficient
+ * for streaming use cases.
+ */
+
+import { useState, useCallback, useRef, useMemo } from "react";
+import type { Block, MagicTextParserState } from "@copilotkitnext/core";
+import {
+  createMagicTextParserState,
+  parseMagicTextChunk,
+  finalizeMagicText,
+} from "@copilotkitnext/core";
+
+export interface UseMagicTextParserResult {
+  /** The current block tree — ready for rendering */
+  blocks: Block[];
+  /**
+   * Feed a chunk of text to the parser.
+   * Call this as streaming chunks arrive.
+   */
+  feed: (chunk: string) => void;
+  /**
+   * Feed the full text so far (prefix-mode).
+   * The hook tracks how much has already been parsed and only
+   * feeds the new suffix to the parser.
+   */
+  feedFullText: (fullText: string) => void;
+  /**
+   * Finalize the parser — call when the stream is complete.
+   */
+  finalize: () => void;
+  /** Reset the parser to its initial state. */
+  reset: () => void;
+  /** Total characters consumed */
+  consumed: number;
+}
+
+/**
+ * Hook for managing streaming markdown parser state.
+ *
+ * @example
+ * ```tsx
+ * const { blocks, feed, finalize, reset } = useMagicTextParser();
+ *
+ * // As streaming chunks arrive:
+ * feed(chunk);
+ *
+ * // When stream completes:
+ * finalize();
+ *
+ * // Render:
+ * <MagicTextRenderer blocks={blocks} />
+ * ```
+ */
+export function useMagicTextParser(): UseMagicTextParserResult {
+  const [state, setState] = useState<MagicTextParserState>(() =>
+    createMagicTextParserState(),
+  );
+
+  // Track the last known full-text length for prefix-mode parsing
+  const lastLengthRef = useRef(0);
+
+  const feed = useCallback((chunk: string) => {
+    setState((prev) => parseMagicTextChunk(prev, chunk));
+  }, []);
+
+  const feedFullText = useCallback((fullText: string) => {
+    const prevLength = lastLengthRef.current;
+    if (fullText.length > prevLength) {
+      const newChunk = fullText.substring(prevLength);
+      lastLengthRef.current = fullText.length;
+      setState((prev) => parseMagicTextChunk(prev, newChunk));
+    }
+  }, []);
+
+  const finalize = useCallback(() => {
+    setState((prev) => finalizeMagicText(prev));
+  }, []);
+
+  const reset = useCallback(() => {
+    lastLengthRef.current = 0;
+    setState(createMagicTextParserState());
+  }, []);
+
+  return useMemo(() => ({
+    blocks: state.blocks,
+    feed,
+    feedFullText,
+    finalize,
+    reset,
+    consumed: state.consumed,
+  }), [state, feed, feedFullText, finalize, reset]);
+}


### PR DESCRIPTION
Port Hashbrown's streaming markdown parser into CopilotKit v2:

- Block parser: headings, paragraphs, lists, blockquotes, code fences, tables, thematic breaks with stable block IDs
- Inline parser: bold, italic, code, strikethrough, links, images
- Intl.Segmenter-based text segmentation with fallback
- Citation extraction
- React MagicTextRenderer component with stable keys
- useMagicTextParser hook (standalone, no CopilotKit runtime dependency)
- Fix known table streaming bug
- Add deprecation plan for completePartialMarkdown()
- MIT attribution on all ported files

