### PR TITLE
fix(runtime): isStreamConsumed false positive in async frameworks (Next.js pages router + bodyParser:false)

### DIFF
--- a/.changeset/fix-stream-consumed-async-false-positive.md
+++ b/.changeset/fix-stream-consumed-async-false-positive.md
@@ -2,4 +2,4 @@
 "@copilotkit/runtime": patch
 ---
 
-fix(runtime): isStreamConsumed false positive in async frameworks — req.complete and _readableState.ended become true after the HTTP parser receives bytes, not after app code reads the stream. In async pipelines like Next.js pages router, this caused bodyParser:false requests to silently send an empty body to Hono. Now relies only on req.readableEnded, which correctly signals app-level stream consumption.
+fix(runtime): isStreamConsumed false positive in async frameworks — req.complete and \_readableState.ended become true after the HTTP parser receives bytes, not after app code reads the stream. In async pipelines like Next.js pages router, this caused bodyParser:false requests to silently send an empty body to Hono. Now relies only on req.readableEnded, which correctly signals app-level stream consumption.

--- a/.changeset/fix-stream-consumed-async-false-positive.md
+++ b/.changeset/fix-stream-consumed-async-false-positive.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix(runtime): isStreamConsumed false positive in async frameworks — req.complete and _readableState.ended become true after the HTTP parser receives bytes, not after app code reads the stream. In async pipelines like Next.js pages router, this caused bodyParser:false requests to silently send an empty body to Hono. Now relies only on req.readableEnded, which correctly signals app-level stream consumption.

--- a/packages/v1/runtime/src/lib/integrations/node-http/__tests__/request-handler.test.ts
+++ b/packages/v1/runtime/src/lib/integrations/node-http/__tests__/request-handler.test.ts
@@ -20,29 +20,14 @@ describe("isStreamConsumed", () => {
   });
 
   it("returns false after an async tick with data in buffer (async framework scenario)", async () => {
-    // This is the regression test for Next.js pages router + bodyParser:false.
-    //
-    // The Node.js HTTP parser sets req.complete and _readableState.ended
-    // synchronously when all bytes arrive. In async frameworks (Next.js pages
-    // router, etc.) at least one event loop tick passes before the handler
-    // runs, so by then complete=true and ended=true — but the data is still
-    // unread in _readableState.buffer.
-    //
-    // The old implementation checked req.complete and _readableState.ended,
-    // which caused a false positive here, skipping the streaming path and
-    // sending an empty body to Hono.
     const stream = makeStream();
 
-    // Simulate HTTP parser pushing bytes and signaling end-of-message
     stream.push('{"foo":"bar"}');
-    stream.push(null); // sets _readableState.ended = true
-    (stream as any).complete = true; // mirrors req.complete = true
+    stream.push(null);
+    (stream as any).complete = true;
 
-    // Yield to the event loop (mirrors async routing in Next.js)
     await new Promise((r) => setImmediate(r));
 
-    // Data is still in the buffer — stream is NOT consumed
-    expect(stream.readableEnded).toBe(false);
     expect(isStreamConsumed(stream)).toBe(false);
   });
 
@@ -54,7 +39,6 @@ describe("isStreamConsumed", () => {
 
     await drainStream(stream);
 
-    expect(stream.readableEnded).toBe(true);
     expect(isStreamConsumed(stream)).toBe(true);
   });
 
@@ -62,11 +46,6 @@ describe("isStreamConsumed", () => {
     const stream = makeStream();
     stream.push('{"foo":"bar"}');
 
-    expect(isStreamConsumed(stream)).toBe(false);
-  });
-
-  it("returns false on an empty stream that has not been ended", () => {
-    const stream = makeStream();
     expect(isStreamConsumed(stream)).toBe(false);
   });
 });

--- a/packages/v1/runtime/src/lib/integrations/node-http/__tests__/request-handler.test.ts
+++ b/packages/v1/runtime/src/lib/integrations/node-http/__tests__/request-handler.test.ts
@@ -1,0 +1,72 @@
+import { Readable } from "node:stream";
+import { describe, it, expect } from "vitest";
+import { isStreamConsumed, type IncomingWithBody } from "../request-handler";
+
+function makeStream(): IncomingWithBody {
+  return new Readable({ read() {} }) as unknown as IncomingWithBody;
+}
+
+function drainStream(stream: Readable): Promise<void> {
+  return new Promise((resolve) => {
+    stream.resume();
+    stream.on("end", resolve);
+  });
+}
+
+describe("isStreamConsumed", () => {
+  it("returns false for a fresh, unread stream", () => {
+    const stream = makeStream();
+    expect(isStreamConsumed(stream)).toBe(false);
+  });
+
+  it("returns false after an async tick with data in buffer (async framework scenario)", async () => {
+    // This is the regression test for Next.js pages router + bodyParser:false.
+    //
+    // The Node.js HTTP parser sets req.complete and _readableState.ended
+    // synchronously when all bytes arrive. In async frameworks (Next.js pages
+    // router, etc.) at least one event loop tick passes before the handler
+    // runs, so by then complete=true and ended=true — but the data is still
+    // unread in _readableState.buffer.
+    //
+    // The old implementation checked req.complete and _readableState.ended,
+    // which caused a false positive here, skipping the streaming path and
+    // sending an empty body to Hono.
+    const stream = makeStream();
+
+    // Simulate HTTP parser pushing bytes and signaling end-of-message
+    stream.push('{"foo":"bar"}');
+    stream.push(null); // sets _readableState.ended = true
+    (stream as any).complete = true; // mirrors req.complete = true
+
+    // Yield to the event loop (mirrors async routing in Next.js)
+    await new Promise((r) => setImmediate(r));
+
+    // Data is still in the buffer — stream is NOT consumed
+    expect(stream.readableEnded).toBe(false);
+    expect(isStreamConsumed(stream)).toBe(false);
+  });
+
+  it("returns true after the stream is fully drained by application code", async () => {
+    const stream = makeStream();
+
+    stream.push('{"foo":"bar"}');
+    stream.push(null);
+
+    await drainStream(stream);
+
+    expect(stream.readableEnded).toBe(true);
+    expect(isStreamConsumed(stream)).toBe(true);
+  });
+
+  it("returns false when stream has data but has not been read yet", () => {
+    const stream = makeStream();
+    stream.push('{"foo":"bar"}');
+
+    expect(isStreamConsumed(stream)).toBe(false);
+  });
+
+  it("returns false on an empty stream that has not been ended", () => {
+    const stream = makeStream();
+    expect(isStreamConsumed(stream)).toBe(false);
+  });
+});

--- a/packages/v1/runtime/src/lib/integrations/node-http/request-handler.ts
+++ b/packages/v1/runtime/src/lib/integrations/node-http/request-handler.ts
@@ -84,14 +84,17 @@ export function toHeaders(rawHeaders: IncomingMessage["headers"]): Headers {
 }
 
 export function isStreamConsumed(req: IncomingWithBody): boolean {
+  // req.complete and _readableState.ended become true after the HTTP parser
+  // receives all bytes at the network layer. This happens before the handler
+  // runs in async frameworks (Next.js pages router, etc.) even when no
+  // application code has read the stream — so they are false positives here.
+  //
+  // req.readableEnded (===_readableState.endEmitted) only becomes true after
+  // application code has fully drained the stream and the 'end' event fires,
+  // making it the only reliable signal that the body is actually consumed.
   const readableState = (req as any)._readableState;
 
-  return Boolean(
-    req.readableEnded ||
-    req.complete ||
-    readableState?.ended ||
-    readableState?.endEmitted,
-  );
+  return Boolean(req.readableEnded || readableState?.endEmitted);
 }
 
 export function synthesizeBodyFromParsedBody(

--- a/packages/v1/runtime/src/lib/integrations/node-http/request-handler.ts
+++ b/packages/v1/runtime/src/lib/integrations/node-http/request-handler.ts
@@ -84,14 +84,6 @@ export function toHeaders(rawHeaders: IncomingMessage["headers"]): Headers {
 }
 
 export function isStreamConsumed(req: IncomingWithBody): boolean {
-  // req.complete and _readableState.ended become true after the HTTP parser
-  // receives all bytes at the network layer. This happens before the handler
-  // runs in async frameworks (Next.js pages router, etc.) even when no
-  // application code has read the stream — so they are false positives here.
-  //
-  // req.readableEnded only becomes true after application code has fully
-  // drained the stream and the 'end' event fires, making it the only reliable
-  // signal that the body is actually consumed.
   return Boolean(req.readableEnded);
 }
 

--- a/packages/v1/runtime/src/lib/integrations/node-http/request-handler.ts
+++ b/packages/v1/runtime/src/lib/integrations/node-http/request-handler.ts
@@ -89,12 +89,10 @@ export function isStreamConsumed(req: IncomingWithBody): boolean {
   // runs in async frameworks (Next.js pages router, etc.) even when no
   // application code has read the stream — so they are false positives here.
   //
-  // req.readableEnded (===_readableState.endEmitted) only becomes true after
-  // application code has fully drained the stream and the 'end' event fires,
-  // making it the only reliable signal that the body is actually consumed.
-  const readableState = (req as any)._readableState;
-
-  return Boolean(req.readableEnded || readableState?.endEmitted);
+  // req.readableEnded only becomes true after application code has fully
+  // drained the stream and the 'end' event fires, making it the only reliable
+  // signal that the body is actually consumed.
+  return Boolean(req.readableEnded);
 }
 
 export function synthesizeBodyFromParsedBody(


### PR DESCRIPTION
## Problem

`isStreamConsumed()` in the node-http integration returns a false positive in async request pipelines — specifically **Next.js pages router with `bodyParser: false`**.

This caused the handler to silently skip the streaming path and forward an **empty body** to Hono, producing request failures for any user running CopilotKit behind the Next.js pages router without body parsing.

## Root Cause

`isStreamConsumed` previously checked four flags:

```ts
req.readableEnded ||
req.complete ||
readableState?.ended ||
readableState?.endEmitted
```

`req.complete` and `_readableState.ended` are set by the Node.js **HTTP parser** when all network bytes are received at the socket level — **not** when application code reads the stream. In frameworks that `await` before dispatching to the route handler (Next.js pages router performs async routing, component loading, etc.), the event loop ticks after the socket `data` callback completes. By that point, both flags are already `true` — even though the body is still sitting unread in `_readableState.buffer`.

The result: with `bodyParser: false`, `isStreamConsumed()` returned `true`, `req.body` was `undefined` (body parser never ran), and the code fell through to:

```
"Request stream consumed with no available body; sending empty payload."
```

...forwarding an empty body to Hono, finally the, `400 Invalid JSON payload` was sent to the client, making the agent completely  the agent was completely unreachable.

## Fix

Rely only on `req.readableEnded` (`=== _readableState.endEmitted`), which only becomes `true` after application code has fully drained the stream and the Node.js `end` event fires. This is the only reliable flag that distinguishes *"HTTP layer received bytes"* from *"application code consumed the stream"*.

## Verification

Reproduced and fixed with live Node.js HTTP experiments:

| Scenario | Before | After |
|---|---|---|
| `bodyParser:false` + async routing (Next.js) | `true` ❌ false positive → empty payload | `false` ✅ streaming path taken |
| `bodyParser:true` (middleware consumed stream) | `true` ✅ synthesis path | `true` ✅ synthesis path |
| `bodyParser:false` + sync handler (plain Node) | `false` ✅ | `false` ✅ |

## Files Changed

`packages/v1/runtime/src/lib/integrations/node-http/request-handler.ts`

Made with [Cursor](https://cursor.com)