### PR TITLE
fix(sdk-python): add missing import re in copilotkit_lg_middleware

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -15,6 +15,7 @@ Example:
 """
 
 import json
+import re
 from typing import Any, Callable, Awaitable, ClassVar, List
 
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.82"
+version = "0.1.83"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- `re` module was used in `_fix_messages_for_bedrock` (`re.compile(...)`) but never imported, causing a `NameError` at runtime whenever the middleware is invoked
- This was introduced in #3488 and shipped in `0.1.82`
- The alpha `0.1.82a1` happened to have the import (built from the PR branch before squash), but the final merged commit lost it
- Bumps version to `0.1.83`

## Test Plan

- [ ] Verify `from copilotkit import CopilotKitMiddleware` and invoking an agent no longer raises `NameError: name 're' is not defined`
- [ ] Confirm follow-up messages after frontend tool calls work correctly on Bedrock Converse API

🤖 Generated with [Claude Code](https://claude.com/claude-code)