### PR TITLE
fix: Add console.error logging when observability hooks are skipped due to not having a license key

### DIFF
--- a/packages/v1/react-core/src/components/copilot-provider/copilot-messages.tsx
+++ b/packages/v1/react-core/src/components/copilot-provider/copilot-messages.tsx
@@ -138,8 +138,15 @@ export function CopilotMessages({ children }: { children: ReactNode }) {
   // Helper function to trace UI errors (similar to useCopilotRuntimeClient)
   const traceUIError = useCallback(
     async (error: CopilotKitError, originalError?: any) => {
-      // Just check if onError and publicApiKey are defined
-      if (!onError || !copilotApiConfig.publicApiKey) return;
+      if (!onError) return;
+
+      if (!copilotApiConfig.publicApiKey) {
+        console.error(
+          "[CopilotKit] onError handler is configured but publicApiKey is not set. " +
+            "Skipping error tracing. Provide a publicApiKey to enable this feature.",
+        );
+        return;
+      }
 
       try {
         const traceEvent = {

--- a/packages/v1/runtime/src/lib/observability.ts
+++ b/packages/v1/runtime/src/lib/observability.ts
@@ -94,6 +94,13 @@ function setupProgressiveLogging(
   },
   publicApiKey?: string,
 ): void {
+  if (this.observability?.enabled && this.observability.progressive && !publicApiKey) {
+    console.error(
+      "[CopilotKit] Observability progressive logging is enabled but publicApiKey is not set. " +
+        "Skipping progressive logging. Provide a publicApiKey to enable this feature.",
+    );
+  }
+
   if (
     this.observability?.enabled &&
     this.observability.progressive &&
@@ -157,6 +164,13 @@ async function logObservabilityError(
   errorData: LLMErrorData,
   publicApiKey?: string,
 ): Promise<void> {
+  if (this.observability?.enabled && !publicApiKey) {
+    console.error(
+      "[CopilotKit] Observability error logging is enabled but publicApiKey is not set. " +
+        "Skipping error hook. Provide a publicApiKey to enable this feature.",
+    );
+  }
+
   if (this.observability?.enabled && publicApiKey) {
     try {
       await this.observability.hooks.handleError(errorData);


### PR DESCRIPTION
## What does this PR do?

Previously, observability hooks in the runtime and the onError handler in copilot-messages silently returned when publicApiKey was not set. This made it hard to diagnose why observability features weren't working. Now these code paths log a clear error message indicating which feature is being skipped and that a publicApiKey is needed.

## Rationale

I've seen dozens of questions on discord all around "onError doesn't work" or "why didn't
this hook work", etc.  CopilotKit keeps those from working without a key, so let's be
explicit about why functionality isn't working instead of causing support questions and
frustrated people.


- [X] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [N/A] If the PR changes or adds functionality, I have updated the relevant documentation
