### PR TITLE
fix: forward `defaultOpen` prop through `CopilotChat` to configuration provider

### DIFF
--- a/packages/v2/react/src/components/chat/CopilotChat.tsx
+++ b/packages/v2/react/src/components/chat/CopilotChat.tsx
@@ -36,6 +36,13 @@ export type CopilotChatProps = Omit<
   labels?: Partial<CopilotChatLabels>;
   chatView?: SlotValue<typeof CopilotChatView>;
   /**
+   * Whether the chat modal (sidebar/popup) should be open by default.
+   * Forwarded to the inner CopilotChatConfigurationProvider so nested
+   * view components respect the caller's preference instead of
+   * defaulting to `true`.
+   */
+  isModalDefaultOpen?: boolean;
+  /**
    * Error handler scoped to this chat's agent. Fires in addition to the
    * provider-level onError (does not suppress it). Receives only errors
    * whose context.agentId matches this chat's agent.
@@ -51,6 +58,7 @@ export function CopilotChat({
   threadId,
   labels,
   chatView,
+  isModalDefaultOpen,
   onError,
   ...props
 }: CopilotChatProps) {
@@ -378,6 +386,7 @@ export function CopilotChat({
       agentId={resolvedAgentId}
       threadId={resolvedThreadId}
       labels={labels}
+      isModalDefaultOpen={isModalDefaultOpen}
     >
       {transcriptionError && (
         <div

--- a/packages/v2/react/src/components/chat/CopilotPopup.tsx
+++ b/packages/v2/react/src/components/chat/CopilotPopup.tsx
@@ -55,6 +55,7 @@ export function CopilotPopup({
       welcomeScreen={CopilotPopupView.WelcomeScreen}
       {...chatProps}
       chatView={PopupViewOverride}
+      isModalDefaultOpen={defaultOpen}
     />
   );
 }

--- a/packages/v2/react/src/components/chat/CopilotSidebar.tsx
+++ b/packages/v2/react/src/components/chat/CopilotSidebar.tsx
@@ -50,6 +50,7 @@ export function CopilotSidebar({
       welcomeScreen={CopilotSidebarView.WelcomeScreen}
       {...chatProps}
       chatView={SidebarViewOverride}
+      isModalDefaultOpen={defaultOpen}
     />
   );
 }


### PR DESCRIPTION
## Problem

Fixes #3475

`CopilotSidebar` and `CopilotPopup` accept a `defaultOpen` prop, but it is silently ignored. The sidebar/popup always opens regardless of `defaultOpen={false}`.

### Root Cause

`CopilotChat` wraps its children in `CopilotChatConfigurationProvider` but does not forward `isModalDefaultOpen`. The provider defaults `isModalOpen` to `true` when no prop is given:

```ts
const resolvedDefaultOpen = isModalDefaultOpen ?? true;
```

When `CopilotSidebarView` creates its own nested provider with `isModalDefaultOpen: defaultOpen` (correctly `false`), the inner provider resolves:

```ts
const resolvedIsModalOpen = parentConfig?.isModalOpen ?? internalModalOpen;
```

The parent's `true` takes precedence, so the inner `false` is never used.

## Solution

1. **Add `isModalDefaultOpen` prop to `CopilotChatProps`** — allows callers to control the default modal state
2. **Forward the prop** to `CopilotChatConfigurationProvider` in `CopilotChat`'s render
3. **Pass `defaultOpen` as `isModalDefaultOpen`** from both `CopilotSidebar` and `CopilotPopup`

### Files changed

- `packages/v2/react/src/components/chat/CopilotChat.tsx` — add prop + forward to provider
- `packages/v2/react/src/components/chat/CopilotSidebar.tsx` — pass `defaultOpen` through
- `packages/v2/react/src/components/chat/CopilotPopup.tsx` — pass `defaultOpen` through

### Before

```tsx
<CopilotSidebar defaultOpen={false} />  // ❌ sidebar opens anyway
<CopilotPopup defaultOpen={false} />    // ❌ popup opens anyway
```

### After

```tsx
<CopilotSidebar defaultOpen={false} />  // ✅ sidebar starts closed
<CopilotPopup defaultOpen={false} />    // ✅ popup starts closed
```