### PR TITLE
fix(react): return null instead of throwing in useRenderCustomMessages when agent is absent

### DIFF
--- a/packages/v2/react/src/hooks/use-render-custom-messages.tsx
+++ b/packages/v2/react/src/hooks/use-render-custom-messages.tsx
@@ -40,7 +40,13 @@ export function useRenderCustomMessages() {
     const runId = resolvedRunId ?? `missing-run-id:${message.id}`;
     const agent = copilotkit.getAgent(agentId);
     if (!agent) {
-      throw new Error("Agent not found");
+      // Agent may not be registered yet while the runtime is connecting,
+      // in an error state, or during React re-renders before the /info
+      // sync completes.  Return null to skip custom rendering for this
+      // cycle — the component will re-render once the agent is available.
+      // This matches the defensive pattern used by useRenderActivityMessage
+      // and SuggestionEngine.reloadSuggestions.
+      return null;
     }
 
     const messagesIdsInRun = resolvedRunId


### PR DESCRIPTION
## Summary

- Replace hard `throw new Error("Agent not found")` with `return null` in `useRenderCustomMessages` when `copilotkit.getAgent(agentId)` returns `undefined`
- Fixes #3497

## Problem

After upgrading from 1.53.0 to 1.54.0, the React tree crashes immediately with:

```
Error: Agent not found
    at use-render-custom-messages.tsx:43:13
```

The crash occurs because:

1. The v1 `CopilotKit` wrapper always injects `CoAgentStateRenderBridge` into `renderCustomMessages`, so the inner render function always executes for every message.
2. `useRenderCustomMessages` calls `copilotkit.getAgent(agentId)` and hard-throws if it returns `undefined`.
3. During runtime connecting/error states (or before the `/info` sync completes), agents are not yet in the registry, so `getAgent()` returns `undefined`.
4. The `useSingleEndpoint` default changed to `true` in 1.54.0, which can cause the `/info` fetch to fail, leaving the runtime in permanent error state with no agents registered.

## Fix

Replace the throw with `return null` — the same defensive pattern already used by:

- **`useRenderActivityMessage`** (line 54): passes `getAgent()` result through without throwing
- **`SuggestionEngine.reloadSuggestions`**: does `if (!agent) return;`
- **The hook's own early-return** (line 33-35): `if (!customMessageRenderers.length) return null;`

The component will re-render once the agent is available (the `CopilotKitProvider` forces re-renders on `onAgentsChanged` and `onRuntimeStatusChanged` events).

## Changed file

- `packages/v2/react/src/hooks/use-render-custom-messages.tsx` — 1 line changed (throw → return null) + comment explaining why

## Test plan

- [x] Verified the fix matches the existing defensive patterns in the codebase
- [ ] Upgrade from 1.53.0 to patched 1.54.x with a self-hosted Express runtime using `LangGraphHttpAgent` agents
- [ ] Confirm no crash on initial page load while the runtime is connecting
- [ ] Confirm custom message renderers (including `CoAgentStateRenderBridge`) work normally after the agent registers
- [ ] Confirm chat works end-to-end after the runtime connection establishes