### PR TITLE
feat(agent): add MiniMax as built-in LLM provider

### DIFF
--- a/docs/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/docs/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -4,7 +4,7 @@ icon: "lucide/Cpu"
 description: "Choose and configure models for your Built-in Agent."
 ---
 
-The Built-in Agent uses the [Vercel AI SDK](https://sdk.vercel.ai) under the hood, giving you access to models from OpenAI, Anthropic, and Google — plus the ability to use any custom AI SDK model.
+The Built-in Agent uses the [Vercel AI SDK](https://sdk.vercel.ai) under the hood, giving you access to models from OpenAI, Anthropic, Google, and MiniMax — plus the ability to use any custom AI SDK model.
 
 ## Supported Models
 
@@ -62,6 +62,19 @@ const agent = new BuiltInAgent({
 });
 ```
 
+### MiniMax
+
+| Model | Specifier |
+|-------|-----------|
+| MiniMax-M2.7 | `minimax:MiniMax-M2.7` |
+| MiniMax-M2.7-highspeed | `minimax:MiniMax-M2.7-highspeed` |
+
+```typescript
+const agent = new BuiltInAgent({
+  model: "minimax:MiniMax-M2.7",
+});
+```
+
 ## Environment Variables
 
 Set the API key for your chosen provider:
@@ -75,6 +88,9 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 # Google
 GOOGLE_API_KEY=...
+
+# MiniMax
+MINIMAX_API_KEY=...
 ```
 
 Alternatively, pass the API key directly in your configuration:
@@ -126,5 +142,6 @@ Under the hood, the Built-in Agent resolves model strings to AI SDK provider ins
 - `"openai:gpt-4.1"` → `@ai-sdk/openai` → `openai("gpt-4.1")`
 - `"anthropic:claude-sonnet-4.5"` → `@ai-sdk/anthropic` → `anthropic("claude-sonnet-4.5")`
 - `"google:gemini-2.5-pro"` → `@ai-sdk/google` → `google("gemini-2.5-pro")`
+- `"minimax:MiniMax-M2.7"` → `@ai-sdk/openai` (compatible mode) → `minimax("MiniMax-M2.7")`
 
 Both `"provider:model"` and `"provider/model"` separators are supported and work identically.

--- a/packages/v2/agent/src/__tests__/minimax-integration.test.ts
+++ b/packages/v2/agent/src/__tests__/minimax-integration.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { BasicAgent, resolveModel } from "../index";
+import { EventType, type RunAgentInput } from "@ag-ui/client";
+import { streamText } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  mockStreamTextResponse,
+  textDelta,
+  finish,
+  toolCallStreamingStart,
+  toolCallDelta,
+  toolCall,
+  toolResult,
+  collectEvents,
+} from "./test-helpers";
+import { z } from "zod";
+
+// Mock the ai module
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+  tool: vi.fn((config) => config),
+}));
+
+// Mock the SDK clients
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => (modelId: string) => ({
+    modelId,
+    provider: "openai",
+  })),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({
+    modelId,
+    provider: "anthropic",
+  })),
+}));
+
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: vi.fn(() => (modelId: string) => ({
+    modelId,
+    provider: "google",
+  })),
+}));
+
+describe("MiniMax Integration", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.MINIMAX_API_KEY = "test-minimax-key";
+    process.env.OPENAI_API_KEY = "test-openai-key";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should handle MiniMax agent with tool calls", async () => {
+    const agent = new BasicAgent({
+      model: "minimax/MiniMax-M2.7",
+    });
+
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([
+        toolCallStreamingStart("call1", "searchTool"),
+        toolCallDelta("call1", '{"query":"test"}'),
+        toolCall("call1", "searchTool", { query: "test" }),
+        toolResult("call1", "searchTool", { results: ["item1"] }),
+        textDelta("Found results."),
+        finish(),
+      ]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread1",
+      runId: "run1",
+      messages: [{ id: "1", role: "user", content: "Search for test" }],
+      tools: [],
+      context: [],
+      state: {},
+    };
+
+    const events = await collectEvents(agent["run"](input));
+
+    const eventTypes = events.map((e: any) => e.type);
+    expect(eventTypes).toContain(EventType.RUN_STARTED);
+    expect(eventTypes).toContain(EventType.TOOL_CALL_START);
+    expect(eventTypes).toContain(EventType.TOOL_CALL_END);
+    expect(eventTypes).toContain(EventType.TEXT_MESSAGE_CHUNK);
+    expect(eventTypes).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("should handle multi-turn conversation with MiniMax", async () => {
+    const agent = new BasicAgent({
+      model: "minimax/MiniMax-M2.7",
+      prompt: "You are a helpful assistant powered by MiniMax.",
+    });
+
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([
+        textDelta("I understand your question."),
+        textDelta(" Here is my answer."),
+        finish(),
+      ]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread1",
+      runId: "run1",
+      messages: [
+        { id: "1", role: "user", content: "Hello" },
+        { id: "2", role: "assistant", content: "Hi there!" },
+        { id: "3", role: "user", content: "What can you do?" },
+      ],
+      tools: [],
+      context: [{ description: "User preference", value: "concise answers" }],
+      state: { conversationCount: 2 },
+    };
+
+    const events = await collectEvents(agent["run"](input));
+
+    // Verify model was resolved with MiniMax config
+    expect(createOpenAI).toHaveBeenCalledWith({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: "test-minimax-key",
+      compatibility: "compatible",
+    });
+
+    // Verify messages include system prompt, context, and state
+    const callArgs = vi.mocked(streamText).mock.calls[0][0];
+    const systemMessage = callArgs.messages[0];
+    expect(systemMessage.role).toBe("system");
+    expect(systemMessage.content).toContain(
+      "You are a helpful assistant powered by MiniMax.",
+    );
+    expect(systemMessage.content).toContain("User preference");
+    expect(systemMessage.content).toContain("conversationCount");
+
+    // Verify text events
+    const textEvents = events.filter(
+      (e: any) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+    );
+    expect(textEvents).toHaveLength(2);
+  });
+
+  it("should work alongside other providers without interference", async () => {
+    // Resolve MiniMax model
+    const minimaxModel = resolveModel("minimax/MiniMax-M2.7");
+    expect(createOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: "https://api.minimax.io/v1",
+        compatibility: "compatible",
+      }),
+    );
+
+    vi.clearAllMocks();
+
+    // Resolve OpenAI model - should not use MiniMax config
+    const openaiModel = resolveModel("openai/gpt-4o");
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: "test-openai-key",
+    });
+  });
+});

--- a/packages/v2/agent/src/__tests__/minimax-provider.test.ts
+++ b/packages/v2/agent/src/__tests__/minimax-provider.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { BasicAgent, resolveModel } from "../index";
+import { EventType, type RunAgentInput } from "@ag-ui/client";
+import { streamText } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+import {
+  mockStreamTextResponse,
+  textDelta,
+  finish,
+  collectEvents,
+} from "./test-helpers";
+
+// Mock the ai module
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+  tool: vi.fn((config) => config),
+}));
+
+// Mock the SDK clients
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => (modelId: string) => ({
+    modelId,
+    provider: "openai",
+  })),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({
+    modelId,
+    provider: "anthropic",
+  })),
+}));
+
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: vi.fn(() => (modelId: string) => ({
+    modelId,
+    provider: "google",
+  })),
+}));
+
+describe("MiniMax Provider", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.MINIMAX_API_KEY = "test-minimax-key";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("resolveModel", () => {
+    it("should resolve minimax/MiniMax-M2.7 model string", () => {
+      const model = resolveModel("minimax/MiniMax-M2.7");
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.minimax.io/v1",
+        apiKey: "test-minimax-key",
+        compatibility: "compatible",
+      });
+      expect(model).toMatchObject({ modelId: "MiniMax-M2.7" });
+    });
+
+    it("should resolve minimax/MiniMax-M2.7-highspeed model string", () => {
+      const model = resolveModel("minimax/MiniMax-M2.7-highspeed");
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.minimax.io/v1",
+        apiKey: "test-minimax-key",
+        compatibility: "compatible",
+      });
+      expect(model).toMatchObject({ modelId: "MiniMax-M2.7-highspeed" });
+    });
+
+    it("should resolve minimax:MiniMax-M2.7 colon format", () => {
+      const model = resolveModel("minimax:MiniMax-M2.7");
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.minimax.io/v1",
+        apiKey: "test-minimax-key",
+        compatibility: "compatible",
+      });
+      expect(model).toMatchObject({ modelId: "MiniMax-M2.7" });
+    });
+
+    it("should use explicit apiKey over env var", () => {
+      const model = resolveModel("minimax/MiniMax-M2.7", "explicit-key");
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.minimax.io/v1",
+        apiKey: "explicit-key",
+        compatibility: "compatible",
+      });
+    });
+
+    it("should fall back to MINIMAX_API_KEY env var", () => {
+      process.env.MINIMAX_API_KEY = "env-minimax-key";
+      const model = resolveModel("minimax/MiniMax-M2.7");
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.minimax.io/v1",
+        apiKey: "env-minimax-key",
+        compatibility: "compatible",
+      });
+    });
+
+    it("should be case-insensitive for provider name", () => {
+      const model = resolveModel("MINIMAX/MiniMax-M2.7");
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.minimax.io/v1",
+        apiKey: "test-minimax-key",
+        compatibility: "compatible",
+      });
+    });
+
+    it("should include minimax in unknown provider error", () => {
+      expect(() => resolveModel("unknown/model")).toThrow(
+        /minimax/,
+      );
+    });
+  });
+
+  describe("BasicAgent with MiniMax", () => {
+    it("should create agent with MiniMax M2.7 model", async () => {
+      const agent = new BasicAgent({
+        model: "minimax/MiniMax-M2.7",
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          textDelta("Hello from MiniMax"),
+          finish(),
+        ]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+      };
+
+      const events = await collectEvents(agent["run"](input));
+
+      expect(events[0]).toMatchObject({
+        type: EventType.RUN_STARTED,
+        threadId: "thread1",
+        runId: "run1",
+      });
+
+      const textEvents = events.filter(
+        (e: any) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+      );
+      expect(textEvents).toHaveLength(1);
+      expect(textEvents[0]).toMatchObject({
+        type: EventType.TEXT_MESSAGE_CHUNK,
+        delta: "Hello from MiniMax",
+      });
+
+      expect(events[events.length - 1]).toMatchObject({
+        type: EventType.RUN_FINISHED,
+      });
+    });
+
+    it("should create agent with MiniMax M2.7-highspeed model", async () => {
+      const agent = new BasicAgent({
+        model: "minimax/MiniMax-M2.7-highspeed",
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          textDelta("Fast response"),
+          finish(),
+        ]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+      };
+
+      const events = await collectEvents(agent["run"](input));
+
+      const textEvents = events.filter(
+        (e: any) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+      );
+      expect(textEvents).toHaveLength(1);
+      expect(textEvents[0]).toMatchObject({
+        delta: "Fast response",
+      });
+    });
+
+    it("should pass temperature to MiniMax agent", async () => {
+      const agent = new BasicAgent({
+        model: "minimax/MiniMax-M2.7",
+        temperature: 0.7,
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([finish()]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+      };
+
+      await collectEvents(agent["run"](input));
+
+      const callArgs = vi.mocked(streamText).mock.calls[0][0];
+      expect(callArgs.temperature).toBe(0.7);
+    });
+
+    it("should pass prompt to MiniMax agent", async () => {
+      const agent = new BasicAgent({
+        model: "minimax/MiniMax-M2.7",
+        prompt: "You are a helpful MiniMax-powered assistant.",
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([finish()]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [{ id: "1", role: "user", content: "Hello" }],
+        tools: [],
+        context: [],
+        state: {},
+      };
+
+      await collectEvents(agent["run"](input));
+
+      const callArgs = vi.mocked(streamText).mock.calls[0][0];
+      expect(callArgs.messages[0]).toMatchObject({
+        role: "system",
+        content: "You are a helpful MiniMax-powered assistant.",
+      });
+    });
+  });
+});

--- a/packages/v2/agent/src/index.ts
+++ b/packages/v2/agent/src/index.ts
@@ -103,6 +103,9 @@ export type BuiltInAgentModel =
   | "google/gemini-2.5-pro"
   | "google/gemini-2.5-flash"
   | "google/gemini-2.5-flash-lite"
+  // MiniMax models
+  | "minimax/MiniMax-M2.7"
+  | "minimax/MiniMax-M2.7-highspeed"
   // Allow any LanguageModel instance
   | (string & {});
 
@@ -221,6 +224,16 @@ export function resolveModel(
       return google(model);
     }
 
+    case "minimax": {
+      // Use OpenAI-compatible mode for MiniMax API
+      const minimax = createOpenAI({
+        baseURL: "https://api.minimax.io/v1",
+        apiKey: apiKey || process.env.MINIMAX_API_KEY!,
+        compatibility: "compatible",
+      });
+      return minimax(model);
+    }
+
     case "vertex": {
       const vertex = createVertex();
       return vertex(model);
@@ -228,7 +241,7 @@ export function resolveModel(
 
     default:
       throw new Error(
-        `Unknown provider "${provider}" in "${spec}". Supported: openai, anthropic, google (gemini).`,
+        `Unknown provider "${provider}" in "${spec}". Supported: openai, anthropic, google (gemini), minimax.`,
       );
   }
 }


### PR DESCRIPTION
## Summary

Adds [MiniMax AI](https://www.minimax.io) as a first-class LLM provider in the Built-in Agent, alongside OpenAI, Anthropic, and Google.

- **Zero new dependencies** — reuses `@ai-sdk/openai` in `compatible` mode with MiniMax's OpenAI-compatible endpoint (`https://api.minimax.io/v1`)
- Adds `minimax` case to `resolveModel()` with `MINIMAX_API_KEY` env var support
- Registers `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` in the `BuiltInAgentModel` type
- Updates model-selection docs with MiniMax table, code examples, and env var reference
- 11 unit tests + 3 integration tests (all passing)

### Usage

```typescript
const agent = new BuiltInAgent({
  model: "minimax/MiniMax-M2.7",
});
```

Or the highspeed variant:

```typescript
const agent = new BuiltInAgent({
  model: "minimax/MiniMax-M2.7-highspeed",
});
```

## Files Changed

| File | Change |
|------|--------|
| `packages/v2/agent/src/index.ts` | Add `minimax` case to `resolveModel()`, update `BuiltInAgentModel` type |
| `packages/v2/agent/src/__tests__/minimax-provider.test.ts` | 11 unit tests for model resolution and BasicAgent |
| `packages/v2/agent/src/__tests__/minimax-integration.test.ts` | 3 integration tests (tool calls, multi-turn, cross-provider) |
| `docs/.../model-selection.mdx` | MiniMax section with model table, env var, and how-it-works |

## Test Plan

- [x] All 11 unit tests pass (`resolveModel` with various formats, env var fallback, case insensitivity)
- [x] All 3 integration tests pass (tool calls, multi-turn conversation, cross-provider isolation)
- [x] All 32 existing `basic-agent.test.ts` tests pass unchanged
- [ ] Manual verification with `MINIMAX_API_KEY` set

## About MiniMax

[MiniMax](https://www.minimax.io) is an AI company offering high-performance language models. MiniMax-M2.7 supports 1M token context with function calling, streaming, and JSON mode via an OpenAI-compatible API.