### PR TITLE
feat: rename tenantId to organizationId in intelligence 

### DIFF
--- a/packages/v2/core/src/__tests__/threads.test.ts
+++ b/packages/v2/core/src/__tests__/threads.test.ts
@@ -36,7 +36,7 @@ const flushEffects = async (): Promise<void> => {
 const sampleThreads: ThreadRecord[] = [
   {
     id: "thread-1",
-    tenantId: "tenant-1",
+    organizationId: "org-1",
     agentId: "agent-1",
     createdById: "user-1",
     name: "Older Thread",
@@ -46,7 +46,7 @@ const sampleThreads: ThreadRecord[] = [
   },
   {
     id: "thread-2",
-    tenantId: "tenant-1",
+    organizationId: "org-1",
     agentId: "agent-1",
     createdById: "user-1",
     name: "Newest Thread",
@@ -161,7 +161,7 @@ describe("thread store", () => {
       operation: "renamed",
       threadId: "thread-1",
       userId: "user-1",
-      tenantId: "tenant-1",
+      organizationId: "org-1",
       occurredAt: "2026-01-03T00:00:00Z",
       thread: {
         ...sampleThreads[0],
@@ -215,7 +215,7 @@ describe("thread store", () => {
       operation: "deleted",
       threadId: "thread-2",
       userId: "user-2",
-      tenantId: "tenant-1",
+      organizationId: "org-1",
       occurredAt: "2026-01-03T00:00:00Z",
       deleted: { id: "thread-2" },
     });

--- a/packages/v2/core/src/threads.ts
+++ b/packages/v2/core/src/threads.ts
@@ -44,7 +44,7 @@ const REQUEST_TIMEOUT_MS = 15_000;
 
 interface ThreadRecord {
   id: string;
-  tenantId: string;
+  organizationId: string;
   agentId: string;
   createdById: string;
   name: string | null;
@@ -68,7 +68,7 @@ type ThreadMetadataEvent =
       operation: "created" | "renamed" | "archived" | "unarchived" | "updated";
       threadId: string;
       userId: string;
-      tenantId: string;
+      organizationId: string;
       occurredAt: string;
       thread: ThreadRecord;
     }
@@ -76,7 +76,7 @@ type ThreadMetadataEvent =
       operation: "deleted";
       threadId: string;
       userId: string;
-      tenantId: string;
+      organizationId: string;
       occurredAt: string;
       deleted: {
         id: string;

--- a/packages/v2/react/src/hooks/__tests__/use-threads.test.tsx
+++ b/packages/v2/react/src/hooks/__tests__/use-threads.test.tsx
@@ -170,7 +170,7 @@ const defaultInput = { userId: "user-1", agentId: "agent-1" };
 const sampleThreads = [
   {
     id: "t-1",
-    tenantId: "tenant-1",
+    organizationId: "org-1",
     agentId: "agent-1",
     createdById: "user-1",
     name: "Thread One",
@@ -180,7 +180,7 @@ const sampleThreads = [
   },
   {
     id: "t-2",
-    tenantId: "tenant-1",
+    organizationId: "org-1",
     agentId: "agent-1",
     createdById: "user-1",
     name: "Thread Two",
@@ -273,7 +273,7 @@ describe("useThreads", () => {
         operation: "updated",
         threadId: "t-1",
         userId: "user-1",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         occurredAt: "2026-01-03T00:00:00Z",
         thread: {
           ...sampleThreads[0],
@@ -306,7 +306,7 @@ describe("useThreads", () => {
         operation: "deleted",
         threadId: "t-2",
         userId: "user-2",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         occurredAt: "2026-01-03T00:00:00Z",
         deleted: { id: "t-2" },
       });

--- a/packages/v2/runtime/src/intelligence-platform/__tests__/client.test.ts
+++ b/packages/v2/runtime/src/intelligence-platform/__tests__/client.test.ts
@@ -35,7 +35,7 @@ describe("CopilotKitIntelligence", () => {
       apiUrl: "https://api.example.com",
       wsUrl: "wss://ws.example.com/socket",
       apiKey: "test-key",
-      tenantId: "tenant-1",
+      organizationId: "org-1",
     });
   });
 
@@ -44,7 +44,7 @@ describe("CopilotKitIntelligence", () => {
       apiUrl: "https://api.example.com/",
       wsUrl: "wss://ws.example.com/socket",
       apiKey: "k",
-      tenantId: "tenant-1",
+      organizationId: "org-1",
     });
     fetchMock.mockReturnValue(jsonResponse({ threads: [], joinCode: "" }));
     await c.listThreads({ userId: "u", agentId: "a" });
@@ -58,7 +58,7 @@ describe("CopilotKitIntelligence", () => {
       apiUrl: "https://api.example.com",
       wsUrl: "wss://ws.example.com",
       apiKey: "k",
-      tenantId: "tenant-1",
+      organizationId: "org-1",
     });
 
     expect(c.ɵgetRunnerWsUrl()).toBe("wss://ws.example.com/runner");
@@ -71,7 +71,7 @@ describe("CopilotKitIntelligence", () => {
     const headers = fetchMock.mock.calls[0][1].headers;
     expect(headers.Authorization).toBe("Bearer test-key");
     expect(headers["Content-Type"]).toBe("application/json");
-    expect(headers["X-Tenant-Id"]).toBe("tenant-1");
+    expect(headers["X-Organization-Id"]).toBe("org-1");
   });
 
   it("throws on non-ok response", async () => {
@@ -175,7 +175,7 @@ describe("CopilotKitIntelligence", () => {
         apiUrl: "https://api.example.com",
         wsUrl: "wss://ws.example.com/socket",
         apiKey: "test-key",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         onThreadUpdated,
       });
       const thread = { id: "t-1", name: "Renamed" };
@@ -225,7 +225,7 @@ describe("CopilotKitIntelligence", () => {
         apiUrl: "https://api.example.com",
         wsUrl: "wss://ws.example.com/socket",
         apiKey: "test-key",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         onThreadCreated,
       });
       const thread = { id: "t-1", name: null };
@@ -312,7 +312,7 @@ describe("CopilotKitIntelligence", () => {
         apiUrl: "https://api.example.com",
         wsUrl: "wss://ws.example.com/socket",
         apiKey: "test-key",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         onThreadUpdated,
       });
       const thread = { id: "t-1", name: "Archived", archived: true };
@@ -353,7 +353,7 @@ describe("CopilotKitIntelligence", () => {
         apiUrl: "https://api.example.com",
         wsUrl: "wss://ws.example.com/socket",
         apiKey: "test-key",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         onThreadDeleted,
       });
       fetchMock.mockReturnValue(jsonResponse(undefined));
@@ -376,7 +376,7 @@ describe("CopilotKitIntelligence", () => {
         apiUrl: "https://api.example.com",
         wsUrl: "wss://ws.example.com/socket",
         apiKey: "test-key",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         onThreadDeleted: () => {
           throw new Error("callback exploded");
         },
@@ -489,7 +489,7 @@ describe("CopilotKitIntelligence", () => {
         apiUrl: "https://api.example.com",
         wsUrl: "wss://ws.example.com/socket",
         apiKey: "test-key",
-        tenantId: "tenant-1",
+        organizationId: "org-1",
         onThreadUpdated: configCb,
       });
       client.onThreadUpdated(runtimeCb);

--- a/packages/v2/runtime/src/intelligence-platform/client.ts
+++ b/packages/v2/runtime/src/intelligence-platform/client.ts
@@ -42,7 +42,7 @@ export class PlatformRequestError extends Error {
  *   apiUrl: "https://api.copilotkit.ai",
  *   wsUrl: "wss://api.copilotkit.ai",
  *   apiKey: process.env.COPILOTKIT_API_KEY!,
- *   tenantId: process.env.COPILOTKIT_TENANT_ID!,
+ *   organizationId: process.env.COPILOTKIT_ORGANIZATION_ID!,
  * });
  *
  * const runtime = new CopilotRuntime({
@@ -66,8 +66,8 @@ export interface CopilotKitIntelligenceConfig {
   wsUrl: string;
   /** API key for authenticating with the intelligence platform */
   apiKey: string;
-  /** Tenant identifier used for self-hosted Intelligence instances */
-  tenantId: string;
+  /** Organization identifier used for self-hosted Intelligence instances */
+  organizationId: string;
   /**
    * Initial listener invoked after a thread is created.
    * Prefer {@link CopilotKitIntelligence.onThreadCreated} for multiple listeners.
@@ -111,8 +111,8 @@ export interface ThreadSummary {
   agentId?: string;
   /** The user who created this thread. */
   createdById?: string;
-  /** The tenant this thread belongs to. */
-  tenantId?: string;
+  /** The organization this thread belongs to. */
+  organizationId?: string;
 }
 
 /** Response from listing threads for a user/agent pair. */
@@ -223,7 +223,7 @@ export class CopilotKitIntelligence {
   #runnerWsUrl: string;
   #clientWsUrl: string;
   #apiKey: string;
-  #tenantId: string;
+  #organizationId: string;
   #threadCreatedListeners = new Set<(thread: ThreadSummary) => void>();
   #threadUpdatedListeners = new Set<(thread: ThreadSummary) => void>();
   #threadDeletedListeners = new Set<(params: ThreadDeletedPayload) => void>();
@@ -235,7 +235,7 @@ export class CopilotKitIntelligence {
     this.#runnerWsUrl = deriveRunnerWsUrl(intelligenceWsUrl);
     this.#clientWsUrl = deriveClientWsUrl(intelligenceWsUrl);
     this.#apiKey = config.apiKey;
-    this.#tenantId = config.tenantId;
+    this.#organizationId = config.organizationId;
 
     if (config.onThreadCreated) {
       this.onThreadCreated(config.onThreadCreated);
@@ -320,8 +320,8 @@ export class CopilotKitIntelligence {
     return this.#clientWsUrl;
   }
 
-  ɵgetTenantId(): string {
-    return this.#tenantId;
+  ɵgetOrganizationId(): string {
+    return this.#organizationId;
   }
 
   ɵgetRunnerAuthToken(): string {
@@ -334,7 +334,7 @@ export class CopilotKitIntelligence {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.#apiKey}`,
       "Content-Type": "application/json",
-      "X-Tenant-Id": this.#tenantId,
+      "X-Organization-Id": this.#organizationId,
     };
 
     const response = await fetch(url, {


### PR DESCRIPTION
To match intelligence structure. THis should be removed entirely soon 