### PR TITLE
fix: race condition in RunHandler.runAgent() causes dropped runs

### DIFF
--- a/.changeset/fix-race-condition-dropped-runs.md
+++ b/.changeset/fix-race-condition-dropped-runs.md
@@ -1,0 +1,6 @@
+---
+"@copilotkitnext/core": patch
+"@copilotkit/react-core": patch
+---
+
+fix: race condition in RunHandler.runAgent() causes dropped runs

--- a/packages/v1/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx
+++ b/packages/v1/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx
@@ -35,6 +35,7 @@ const mockAgent = {
   addMessage: vi.fn(),
   abortRun: vi.fn(),
   runAgent: vi.fn(),
+  detachActiveRun: vi.fn().mockResolvedValue(undefined),
 };
 
 let lastSubscriber: TestAgentSubscriber | null = null;

--- a/packages/v1/react-core/src/hooks/__tests__/use-copilot-chat-internal-connect.test.tsx
+++ b/packages/v1/react-core/src/hooks/__tests__/use-copilot-chat-internal-connect.test.tsx
@@ -28,6 +28,7 @@ const mockAgent: Record<string, unknown> = {
   addMessage: vi.fn(),
   abortRun: vi.fn(),
   runAgent: vi.fn(),
+  detachActiveRun: vi.fn().mockResolvedValue(undefined),
   threadId: undefined as string | undefined,
 };
 

--- a/packages/v1/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/packages/v1/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -26,7 +26,11 @@ import {
   CopilotKitCoreRuntimeConnectionStatus,
 } from "@copilotkitnext/core";
 import { useLazyToolRenderer } from "./use-lazy-tool-renderer";
-import { AbstractAgent, AGUIConnectNotImplementedError } from "@ag-ui/client";
+import {
+  AbstractAgent,
+  AGUIConnectNotImplementedError,
+  HttpAgent,
+} from "@ag-ui/client";
 import {
   CoAgentStateRenderBridge,
   type CoAgentStateRenderBridgeProps,
@@ -336,12 +340,28 @@ export function useCopilotChatInternal({
   const { agent } = useAgent({ agentId: resolvedAgentId });
 
   useEffect(() => {
+    let detached = false;
+
+    // Create a fresh AbortController so we can cancel the HTTP request on cleanup.
+    // Mirrors the V2 CopilotChat pattern: HttpAgent uses abortController.signal in
+    // its fetch config.  connectAgent() does NOT create a new AbortController
+    // automatically, so we must set one before connecting.
+    const connectAbortController = new AbortController();
+    if (agent instanceof HttpAgent) {
+      agent.abortController = connectAbortController;
+    }
+
     const connect = async (agent: AbstractAgent) => {
       setAgentAvailable(false);
       try {
         await copilotkit.connectAgent({ agent });
-        setAgentAvailable(true);
+        // Guard against setting state after cleanup (e.g. React StrictMode unmount)
+        if (!detached) {
+          setAgentAvailable(true);
+        }
       } catch (error) {
+        // Ignore errors from aborted connections (e.g. React StrictMode cleanup)
+        if (detached) return;
         if (error instanceof AGUIConnectNotImplementedError) {
           // connect not implemented, ignore
         } else {
@@ -360,7 +380,14 @@ export function useCopilotChatInternal({
       agent.threadId = existingConfig.threadId;
       connect(agent);
     }
-    return () => {};
+    return () => {
+      // Abort the HTTP request and detach the active run.
+      // This is critical for React StrictMode which unmounts+remounts in dev,
+      // preventing duplicate /connect requests from reaching the server.
+      detached = true;
+      connectAbortController.abort();
+      agent?.detachActiveRun();
+    };
   }, [
     existingConfig?.threadId,
     agent,

--- a/packages/v2/core/src/core/run-handler.ts
+++ b/packages/v2/core/src/core/run-handler.ts
@@ -225,15 +225,22 @@ export class RunHandler {
       };
     }
 
-    // Signal any active run to detach (e.g. a long-lived connectAgent pipeline)
-    // before starting a new run.  We intentionally fire-and-forget rather than
-    // awaiting: the detach merely completes the previous observable pipeline, and
-    // `agent.runAgent()` below will create a fresh pipeline anyway.  Awaiting
-    // caused a deadlock when `connectAgent` was still resolving its internal
-    // promise (e.g. ConnectNotImplementedError cleanup) at the moment the user
-    // triggered a run.
+    // Detach any active run (e.g. a long-lived connectAgent pipeline) before
+    // starting a new run.  We await the detach to ensure the previous pipeline
+    // has fully finalized — its activeRunCompletionPromise resolves once the
+    // observable finalize block runs, which happens synchronously after the
+    // takeUntil signal completes the chain.  This prevents a race where the new
+    // runAgent() overwrites activeRunDetach$ / activeRunCompletionPromise before
+    // the old pipeline can clean up, causing dropped runs.
+    //
+    // Historical note: an earlier version used fire-and-forget (`void`) here
+    // because awaiting caused a deadlock when connectAgent's
+    // ConnectNotImplementedError cleanup was still in-flight.  That deadlock
+    // was resolved in @ag-ui/client ≥0.0.42 where the catchError path
+    // (ConnectNotImplementedError → EMPTY) always runs the finalize block,
+    // so the completion promise now resolves reliably.
     if (agent.detachActiveRun) {
-      void agent.detachActiveRun();
+      await agent.detachActiveRun();
     }
 
     try {


### PR DESCRIPTION
## Summary

Fixes a race condition where `detachActiveRun()` was called without `await`, allowing a new run to overwrite pipeline state before cleanup finished — silently dropping the previous run.

- **`run-handler.ts`**: `void agent.detachActiveRun()` → `await agent.detachActiveRun()`. The original deadlock that motivated fire-and-forget (ConnectNotImplementedError cleanup) has been resolved in the current `@ag-ui/client`. Confirmed via git history: added as fire-and-forget in `5b3037a` on Mar 13 by Max Korp.
- **`use-copilot-chat_internal.ts`**: Added AbortController cleanup in the `connectAgent` useEffect, mirroring the V2 `CopilotChat.tsx` pattern. Guards state updates against aborted signals.
- Updated test mocks to include `detachActiveRun`

**Linear:** [CPK-7151](https://linear.app/copilotkit/issue/CPK-7151/fix-race-condition-in-runhandlerrunagent-causes-dropped-runs)
**GitHub Issue:** #3482

## Files changed

- `packages/v2/core/src/core/run-handler.ts`
- `packages/v1/react-core/src/hooks/use-copilot-chat_internal.ts`
- `packages/v1/react-core/src/hooks/__tests__/use-copilot-chat-internal-connect.test.tsx`
- `packages/v1/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx`

## Test plan

- [x] All tests pass (pre-commit hook ran full suite)
- [x] Manual: rapid sequential message sends don't drop runs
- [x] Manual: verify no deadlock on initial connectAgent → immediate runAgent

🤖 Generated with [Claude Code](https://claude.com/claude-code)