### PR TITLE
fix(v2): pass message instead of click event to toolbar callbacks

### DIFF
--- a/packages/v2/react/src/components/chat/CopilotChatAssistantMessage.tsx
+++ b/packages/v2/react/src/components/chat/CopilotChatAssistantMessage.tsx
@@ -100,7 +100,7 @@ export function CopilotChatAssistantMessage({
     thumbsUpButton,
     CopilotChatAssistantMessage.ThumbsUpButton,
     {
-      onClick: onThumbsUp,
+      onClick: () => onThumbsUp?.(message),
     },
   );
 
@@ -108,7 +108,7 @@ export function CopilotChatAssistantMessage({
     thumbsDownButton,
     CopilotChatAssistantMessage.ThumbsDownButton,
     {
-      onClick: onThumbsDown,
+      onClick: () => onThumbsDown?.(message),
     },
   );
 
@@ -116,7 +116,7 @@ export function CopilotChatAssistantMessage({
     readAloudButton,
     CopilotChatAssistantMessage.ReadAloudButton,
     {
-      onClick: onReadAloud,
+      onClick: () => onReadAloud?.(message),
     },
   );
 
@@ -124,7 +124,7 @@ export function CopilotChatAssistantMessage({
     regenerateButton,
     CopilotChatAssistantMessage.RegenerateButton,
     {
-      onClick: onRegenerate,
+      onClick: () => onRegenerate?.(message),
     },
   );
 


### PR DESCRIPTION
## Summary

`onThumbsUp`, `onThumbsDown`, `onReadAloud`, and `onRegenerate` callbacks in `CopilotChatAssistantMessage` receive a `SyntheticEvent` instead of the `AssistantMessage` object.

## Root Cause

The callbacks are passed directly as `onClick` handlers to `renderSlot()`:
```tsx
{ onClick: onThumbsUp }  // receives click event, not message
```

## Fix

Wrap each in an arrow function that passes the `message` prop:
```tsx
{ onClick: () => onThumbsUp?.(message) }
```

Applied to all four toolbar callbacks (thumbsUp, thumbsDown, readAloud, regenerate).

Fixes #3457