### PR TITLE
chore: disable nx cloud remote cache

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -138,6 +138,5 @@
     }
   },
   "parallel": 14,
-  "defaultBase": "main",
-  "nxCloudId": "69a1ceae0efc94d36e7f9044"
+  "defaultBase": "main"
 }


### PR DESCRIPTION
## Summary

- Removes `nxCloudId` from `nx.json` to disable the Nx Cloud remote cache
- The remote cache was serving stale green results for tasks whose local code had broken tests, making failures invisible during development

## Test plan

- [x] Ran `npx nx run-many -t test --skip-nx-cache` — all 20 projects pass with no cache involved

🤖 Generated with [Claude Code](https://claude.com/claude-code)