### PR TITLE
fix(runtime): preserve agent-owned connect semantics for sse

### DIFF
--- a/.changeset/agent-connect-semantics.md
+++ b/.changeset/agent-connect-semantics.md
@@ -1,0 +1,5 @@
+---
+"@copilotkitnext/runtime": patch
+---
+
+fix: preserve agent-owned connect semantics for the sse runtime path

--- a/packages/v2/runtime/src/__tests__/handle-connect.test.ts
+++ b/packages/v2/runtime/src/__tests__/handle-connect.test.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 import { describe, it, expect, vi } from "vitest";
-import { BaseEvent } from "@ag-ui/client";
+import { BaseEvent, HttpAgent, type AbstractAgent } from "@ag-ui/client";
 import { handleConnectAgent } from "../handlers/handle-connect";
 import { CopilotRuntime } from "../runtime";
 import { AgentRunnerConnectRequest } from "../runner/agent-runner";
@@ -185,6 +185,89 @@ describe("handleConnectAgent", () => {
 
     expect(recordedRequests).toHaveLength(1);
     expect(recordedRequests[0].headers).toEqual({});
+  });
+
+  it("configures and seeds the cloned agent before delegating connect", async () => {
+    class RecordingHttpAgent extends HttpAgent {
+      constructor(initialHeaders: Record<string, string>) {
+        super({ url: "https://runtime.example/connect" });
+        this.headers = initialHeaders;
+      }
+
+      clone(): AbstractAgent {
+        return new RecordingHttpAgent({ ...(this.headers ?? {}) });
+      }
+    }
+
+    const recordedRequests: AgentRunnerConnectRequest[] = [];
+    let resolveConnect: (() => void) | undefined;
+    const connectInvoked = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+
+    const registeredAgent = new RecordingHttpAgent({
+      authorization: "Bearer base-token",
+    });
+
+    const runtime = {
+      agents: Promise.resolve({ "test-agent": registeredAgent }),
+      transcriptionService: undefined,
+      beforeRequestMiddleware: undefined,
+      afterRequestMiddleware: undefined,
+      runner: {
+        run: () =>
+          new Observable<BaseEvent>((subscriber) => {
+            subscriber.complete();
+          }),
+        connect: (request: AgentRunnerConnectRequest) =>
+          new Observable<BaseEvent>((subscriber) => {
+            recordedRequests.push(request);
+            resolveConnect?.();
+            subscriber.complete();
+          }),
+        isRunning: async () => false,
+        stop: async () => false,
+      },
+    } as CopilotRuntime;
+
+    const input = {
+      threadId: "thread-configured",
+      runId: "run-configured",
+      state: { cycle: 3 },
+      messages: [{ id: "m-1", role: "user", content: "hello" }],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    };
+
+    const response = await handleConnectAgent({
+      runtime,
+      request: new Request("https://example.com/agent/test-agent/connect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer forwarded-token",
+          "X-Connect": "enabled",
+        },
+        body: JSON.stringify(input),
+      }),
+      agentId: "test-agent",
+    });
+
+    expect(response.status).toBe(200);
+    await connectInvoked;
+
+    expect(recordedRequests).toHaveLength(1);
+    expect(recordedRequests[0].threadId).toBe("thread-configured");
+    expect(recordedRequests[0].agent).toBeInstanceOf(RecordingHttpAgent);
+    expect((recordedRequests[0].agent as HttpAgent).headers).toMatchObject({
+      authorization: "Bearer forwarded-token",
+      "x-connect": "enabled",
+    });
+    expect(recordedRequests[0].agent?.threadId).toBe("thread-configured");
+    expect(recordedRequests[0].agent?.state).toEqual({ cycle: 3 });
+    expect(recordedRequests[0].agent?.messages).toEqual(input.messages);
+    expect(recordedRequests[0].input).toMatchObject(input);
   });
 
   describe("IntelligenceAgentRunner connect planning path", () => {

--- a/packages/v2/runtime/src/handlers/handle-connect.ts
+++ b/packages/v2/runtime/src/handlers/handle-connect.ts
@@ -6,6 +6,7 @@ import {
   parseConnectRequest,
   RunAgentParameters as ConnectAgentParameters,
   cloneAgentForRequest,
+  configureAgentForRequest,
 } from "./shared/agent-utils";
 
 export async function handleConnectAgent({
@@ -34,10 +35,20 @@ export async function handleConnectAgent({
       return agent;
     }
 
+    configureAgentForRequest({ runtime, request, agentId, agent });
+
     const connectRequest = await parseConnectRequest(request);
     if (connectRequest instanceof Response) {
       return connectRequest;
     }
+
+    if (typeof agent.setMessages === "function") {
+      agent.setMessages(connectRequest.input.messages);
+    }
+    if (typeof agent.setState === "function") {
+      agent.setState(connectRequest.input.state);
+    }
+    agent.threadId = connectRequest.input.threadId;
 
     if (isIntelligenceRuntime(runtime)) {
       return handleIntelligenceConnect({
@@ -51,6 +62,8 @@ export async function handleConnectAgent({
     return handleSseConnect({
       runtime,
       request,
+      agent,
+      input: connectRequest.input,
       threadId: connectRequest.input.threadId,
     });
   } catch (error) {

--- a/packages/v2/runtime/src/handlers/sse/connect.ts
+++ b/packages/v2/runtime/src/handlers/sse/connect.ts
@@ -1,3 +1,4 @@
+import { AbstractAgent, RunAgentInput } from "@ag-ui/client";
 import { CopilotRuntimeLike } from "../../runtime";
 import { createSseEventResponse } from "../shared/sse-response";
 import { extractForwardableHeaders } from "../header-utils";
@@ -5,12 +6,16 @@ import { extractForwardableHeaders } from "../header-utils";
 interface HandleSseConnectParams {
   runtime: CopilotRuntimeLike;
   request: Request;
+  agent: AbstractAgent;
+  input: RunAgentInput;
   threadId: string;
 }
 
 export function handleSseConnect({
   runtime,
   request,
+  agent,
+  input,
   threadId,
 }: HandleSseConnectParams): Response {
   return createSseEventResponse({
@@ -18,6 +23,8 @@ export function handleSseConnect({
     observableFactory: () =>
       runtime.runner.connect({
         threadId,
+        agent,
+        input,
         headers: extractForwardableHeaders(request),
       }),
   });

--- a/packages/v2/runtime/src/runner/__tests__/in-memory-runner.e2e.test.ts
+++ b/packages/v2/runtime/src/runner/__tests__/in-memory-runner.e2e.test.ts
@@ -142,6 +142,32 @@ class RunnerConnectAgent extends AbstractAgent {
   }
 }
 
+class AgentOwnedConnectAgent extends AbstractAgent {
+  public readonly connectInputs: RunAgentInput[] = [];
+
+  constructor(
+    private readonly eventsFactory: (input: RunAgentInput) => BaseEvent[],
+    threadId: string,
+  ) {
+    super({ threadId });
+  }
+
+  async runAgent(): Promise<void> {
+    throw new Error("not used");
+  }
+
+  protected run(): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+
+  protected connect(
+    input: RunAgentInput,
+  ): ReturnType<AbstractAgent["connect"]> {
+    this.connectInputs.push(input);
+    return from(this.eventsFactory(input));
+  }
+}
+
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;
@@ -354,6 +380,67 @@ describe("InMemoryAgentRunner e2e", () => {
   });
 
   describe("Fresh Agent Connection After Prior Runs", () => {
+    it("preserves agent-owned connect semantics when an agent and input are provided", async () => {
+      const runner = new InMemoryAgentRunner();
+      const threadId = "thread-agent-connect";
+      const input = createRunInput({
+        threadId,
+        runId: "run-agent-connect",
+        messages: [{ id: "user-1", role: "user", content: "hello" }],
+      });
+
+      const connectAgent = new AgentOwnedConnectAgent(
+        (connectInput) => [
+          {
+            type: EventType.RUN_STARTED,
+            threadId: connectInput.threadId,
+            runId: connectInput.runId,
+          } satisfies RunStartedEvent,
+          ...createTextMessageEvents({
+            messageId: "assistant-connect",
+            content: "from-agent-connect",
+          }),
+          {
+            type: EventType.RUN_FINISHED,
+            threadId: connectInput.threadId,
+            runId: connectInput.runId,
+          } satisfies RunFinishedEvent,
+        ],
+        threadId,
+      );
+
+      const events = await collectEvents(
+        runner.connect({
+          threadId,
+          agent: connectAgent,
+          input,
+        }),
+      );
+
+      expect(connectAgent.connectInputs).toHaveLength(1);
+      expect(connectAgent.connectInputs[0]).toMatchObject({
+        threadId,
+        runId: "run-agent-connect",
+        messages: input.messages,
+        state: {},
+      });
+      expect(events.map((event) => event.type)).toEqual([
+        EventType.RUN_STARTED,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_FINISHED,
+      ]);
+      expect(
+        (
+          events[2] as Extract<
+            BaseEvent,
+            { type: EventType.TEXT_MESSAGE_CONTENT }
+          >
+        ).delta,
+      ).toBe("from-agent-connect");
+    });
+
     it("hydrates a brand-new agent via connect()", async () => {
       const runner = new InMemoryAgentRunner();
       const threadId = "thread-new-agent-connection";

--- a/packages/v2/runtime/src/runner/agent-runner.ts
+++ b/packages/v2/runtime/src/runner/agent-runner.ts
@@ -16,6 +16,8 @@ export interface AgentRunnerRunRequest {
 
 export interface AgentRunnerConnectRequest {
   threadId: string;
+  agent?: AbstractAgent;
+  input?: RunAgentInput;
   headers?: Record<string, string>;
   joinCode?: string;
 }

--- a/packages/v2/runtime/src/runner/in-memory.ts
+++ b/packages/v2/runtime/src/runner/in-memory.ts
@@ -10,7 +10,6 @@ import {
   AbstractAgent,
   BaseEvent,
   EventType,
-  MessagesSnapshotEvent,
   RunStartedEvent,
   compactEvents,
 } from "@ag-ui/client";
@@ -292,6 +291,51 @@ export class InMemoryAgentRunner extends AgentRunner {
   }
 
   connect(request: AgentRunnerConnectRequest): Observable<BaseEvent> {
+    if (request.agent && request.input) {
+      if (typeof request.agent.setMessages === "function") {
+        request.agent.setMessages(request.input.messages);
+      }
+      if (typeof request.agent.setState === "function") {
+        request.agent.setState(request.input.state);
+      }
+      request.agent.threadId = request.input.threadId;
+
+      return new Observable<BaseEvent>((subscriber) => {
+        void request
+          .agent!.connectAgent(
+            {
+              runId: request.input!.runId,
+              tools: request.input!.tools,
+              context: request.input!.context,
+              forwardedProps: request.input!.forwardedProps,
+            },
+            {
+              onEvent: ({ event }) => {
+                if (!subscriber.closed) {
+                  subscriber.next(event);
+                }
+              },
+            },
+          )
+          .then(() => {
+            if (!subscriber.closed) {
+              subscriber.complete();
+            }
+          })
+          .catch((error: unknown) => {
+            if (!subscriber.closed) {
+              subscriber.error(
+                error instanceof Error ? error : new Error(String(error)),
+              );
+            }
+          });
+
+        return () => {
+          void request.agent?.detachActiveRun();
+        };
+      });
+    }
+
     const store = GLOBAL_STORE.get(request.threadId);
     const connectionSubject = new ReplaySubject<BaseEvent>(Infinity);
 


### PR DESCRIPTION
## Summary
- align the v2 SSE connect path with the run path by configuring and seeding the cloned agent before connect
- pass agent and parsed connect input through the SSE handler into the in-memory runner
- preserve agent-owned connect semantics in `InMemoryAgentRunner.connect` when runtime supplies an agent and connect input
- add regression coverage for handler configuration/seeding and agent-owned connect delegation

## Testing
- `pnpm nx run @copilotkitnext/runtime:test --output-style=stream`
- `pnpm nx run @copilotkit/runtime-client-gql:test --output-style=stream`

## Related
- Related to #3532
- Scope note: this PR fixes the SSE/in-memory runtime path. Intelligence-mode connect still follows its existing platform-managed path and likely needs a separate design decision if full symmetry is desired there.
