### PR TITLE
feat(runtime): Support configuring Threads lock TTL, prefix and heartbeat

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/runtime.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/runtime.test.ts
@@ -120,4 +120,113 @@ describe("runtime construction", () => {
         .identifyUser,
     ).toBeUndefined();
   });
+
+  it("defaults lockTtlSeconds to 20 and lockHeartbeatIntervalSeconds to 15", () => {
+    const sdk = createMockIntelligence();
+
+    const runtime = new CopilotIntelligenceRuntime({
+      agents,
+      intelligence: sdk,
+      identifyUser,
+    });
+
+    expect(runtime.lockTtlSeconds).toBe(20);
+    expect(runtime.lockHeartbeatIntervalSeconds).toBe(15);
+  });
+
+  it("clamps lockTtlSeconds to a maximum of 3600 (1 hour)", () => {
+    const sdk = createMockIntelligence();
+
+    const runtime = new CopilotIntelligenceRuntime({
+      agents,
+      intelligence: sdk,
+      identifyUser,
+      lockTtlSeconds: 7200,
+    });
+
+    expect(runtime.lockTtlSeconds).toBe(3600);
+  });
+
+  it("clamps lockHeartbeatIntervalSeconds to a maximum of 3000 (50 minutes)", () => {
+    const sdk = createMockIntelligence();
+
+    const runtime = new CopilotIntelligenceRuntime({
+      agents,
+      intelligence: sdk,
+      identifyUser,
+      lockHeartbeatIntervalSeconds: 5000,
+    });
+
+    expect(runtime.lockHeartbeatIntervalSeconds).toBe(3000);
+  });
+
+  it("uses provided values when they are within allowed range", () => {
+    const sdk = createMockIntelligence();
+
+    const runtime = new CopilotIntelligenceRuntime({
+      agents,
+      intelligence: sdk,
+      identifyUser,
+      lockTtlSeconds: 30,
+    });
+
+    expect(runtime.lockTtlSeconds).toBe(30);
+    expect(runtime.lockHeartbeatIntervalSeconds).toBe(15);
+  });
+
+  it("stores lock config on CopilotIntelligenceRuntime", () => {
+    const sdk = createMockIntelligence();
+
+    const runtime = new CopilotIntelligenceRuntime({
+      agents,
+      intelligence: sdk,
+      identifyUser,
+      lockTtlSeconds: 30,
+      lockKeyPrefix: "custom",
+      lockHeartbeatIntervalSeconds: 10,
+    });
+
+    expect(runtime.lockTtlSeconds).toBe(30);
+    expect(runtime.lockKeyPrefix).toBe("custom");
+    expect(runtime.lockHeartbeatIntervalSeconds).toBe(10);
+  });
+
+  it("forwards lock config through the CopilotRuntime intelligence shim", () => {
+    const sdk = createMockIntelligence();
+
+    const runtime = new CopilotRuntime({
+      agents,
+      intelligence: sdk,
+      identifyUser,
+      lockTtlSeconds: 60,
+      lockKeyPrefix: "agent",
+      lockHeartbeatIntervalSeconds: 20,
+    });
+
+    expect(
+      (runtime as CopilotRuntime & { lockTtlSeconds?: number }).lockTtlSeconds,
+    ).toBe(60);
+    expect(
+      (runtime as CopilotRuntime & { lockKeyPrefix?: string }).lockKeyPrefix,
+    ).toBe("agent");
+    expect(
+      (runtime as CopilotRuntime & { lockHeartbeatIntervalSeconds?: number })
+        .lockHeartbeatIntervalSeconds,
+    ).toBe(20);
+  });
+
+  it("exposes lock config as undefined for SSE runtimes", () => {
+    const runtime = new CopilotRuntime({ agents });
+
+    expect(
+      (runtime as CopilotRuntime & { lockTtlSeconds?: number }).lockTtlSeconds,
+    ).toBeUndefined();
+    expect(
+      (runtime as CopilotRuntime & { lockKeyPrefix?: string }).lockKeyPrefix,
+    ).toBeUndefined();
+    expect(
+      (runtime as CopilotRuntime & { lockHeartbeatIntervalSeconds?: number })
+        .lockHeartbeatIntervalSeconds,
+    ).toBeUndefined();
+  });
 });

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -82,6 +82,16 @@ export interface CopilotIntelligenceRuntimeOptions extends BaseCopilotRuntimeOpt
   identifyUser: IdentifyUserCallback;
   /** Auto-generate short names for newly created threads. */
   generateThreadNames?: boolean;
+  /** Max delay (ms) for WebSocket reconnect backoff. @default 10_000 */
+  maxReconnectMs?: number;
+  /** Max delay (ms) for channel rejoin backoff. @default 30_000 */
+  maxRejoinMs?: number;
+  /** Lock TTL in seconds. Clamped to a maximum of 3600 (1 hour). @default 20 */
+  lockTtlSeconds?: number;
+  /** Custom Redis key prefix for the thread lock. */
+  lockKeyPrefix?: string;
+  /** Interval in seconds at which the runtime renews the thread lock. Clamped to a maximum of 3000 (50 minutes). @default 15 */
+  lockHeartbeatIntervalSeconds?: number;
 }
 
 export type CopilotRuntimeOptions =
@@ -111,6 +121,9 @@ export interface CopilotIntelligenceRuntimeLike extends CopilotRuntimeLike {
   intelligence: CopilotKitIntelligence;
   identifyUser: IdentifyUserCallback;
   generateThreadNames: boolean;
+  lockTtlSeconds: number;
+  lockKeyPrefix?: string;
+  lockHeartbeatIntervalSeconds: number;
   mode: RUNTIME_MODE_INTELLIGENCE;
 }
 
@@ -166,7 +179,15 @@ export class CopilotIntelligenceRuntime
   readonly intelligence: CopilotKitIntelligence;
   readonly identifyUser: IdentifyUserCallback;
   readonly generateThreadNames: boolean;
+  readonly lockTtlSeconds: number;
+  readonly lockKeyPrefix?: string;
+  readonly lockHeartbeatIntervalSeconds: number;
   readonly mode = RUNTIME_MODE_INTELLIGENCE;
+
+  /** Maximum allowed lock TTL in seconds (1 hour). */
+  static readonly MAX_LOCK_TTL_SECONDS = 3_600;
+  /** Maximum allowed heartbeat interval in seconds (50 minutes). */
+  static readonly MAX_HEARTBEAT_INTERVAL_SECONDS = 3_000;
 
   constructor(options: CopilotIntelligenceRuntimeOptions) {
     super(
@@ -174,12 +195,23 @@ export class CopilotIntelligenceRuntime
       new IntelligenceAgentRunner({
         url: options.intelligence.ɵgetRunnerWsUrl(),
         authToken: options.intelligence.ɵgetRunnerAuthToken(),
+        maxReconnectMs: options.maxReconnectMs,
+        maxRejoinMs: options.maxRejoinMs,
       }),
     );
     this.intelligence = options.intelligence;
     this.identifyUser = options.identifyUser;
     this.generateThreadNames = options.generateThreadNames ?? true;
     this.licenseChecker = createLicenseChecker(options.licenseToken);
+    this.lockTtlSeconds = Math.min(
+      options.lockTtlSeconds ?? 20,
+      CopilotIntelligenceRuntime.MAX_LOCK_TTL_SECONDS,
+    );
+    this.lockKeyPrefix = options.lockKeyPrefix;
+    this.lockHeartbeatIntervalSeconds = Math.min(
+      options.lockHeartbeatIntervalSeconds ?? 15,
+      CopilotIntelligenceRuntime.MAX_HEARTBEAT_INTERVAL_SECONDS,
+    );
   }
 }
 
@@ -249,6 +281,24 @@ export class CopilotRuntime implements CopilotRuntimeLike {
   get identifyUser(): IdentifyUserCallback | undefined {
     return isIntelligenceRuntime(this.delegate)
       ? this.delegate.identifyUser
+      : undefined;
+  }
+
+  get lockTtlSeconds(): number | undefined {
+    return isIntelligenceRuntime(this.delegate)
+      ? this.delegate.lockTtlSeconds
+      : undefined;
+  }
+
+  get lockKeyPrefix(): string | undefined {
+    return isIntelligenceRuntime(this.delegate)
+      ? this.delegate.lockKeyPrefix
+      : undefined;
+  }
+
+  get lockHeartbeatIntervalSeconds(): number | undefined {
+    return isIntelligenceRuntime(this.delegate)
+      ? this.delegate.lockHeartbeatIntervalSeconds
       : undefined;
   }
 

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
@@ -73,6 +73,10 @@ export async function handleIntelligenceRun({
       threadId: input.threadId,
       runId: input.runId,
       userId,
+      ...(runtime.lockKeyPrefix !== undefined
+        ? { lockKeyPrefix: runtime.lockKeyPrefix }
+        : {}),
+      ttlSeconds: runtime.lockTtlSeconds,
     });
     joinToken = lockResult.joinToken;
     joinCode = lockResult.joinCode;
@@ -121,6 +125,30 @@ export async function handleIntelligenceRun({
 
   telemetry.capture("oss.runtime.agent_execution_stream_started", {});
 
+  // Start heartbeat timer to renew the thread lock.
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  heartbeatTimer = setInterval(() => {
+    runtime.intelligence
+      .ɵrenewThreadLock({
+        threadId: input.threadId,
+        runId: input.runId,
+        ttlSeconds: runtime.lockTtlSeconds,
+        ...(runtime.lockKeyPrefix !== undefined
+          ? { lockKeyPrefix: runtime.lockKeyPrefix }
+          : {}),
+      })
+      .catch((err) => {
+        logger.error("Failed to renew thread lock:", err);
+      });
+  }, runtime.lockHeartbeatIntervalSeconds * 1_000);
+
+  const clearHeartbeat = () => {
+    if (heartbeatTimer !== undefined) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
+  };
+
   runtime.runner
     .run({
       threadId: input.threadId,
@@ -133,12 +161,14 @@ export async function handleIntelligenceRun({
     })
     .subscribe({
       error: (error) => {
+        clearHeartbeat();
         telemetry.capture("oss.runtime.agent_execution_stream_errored", {
           error: error instanceof Error ? error.message : String(error),
         });
         logger.error("Error running agent:", error);
       },
       complete: () => {
+        clearHeartbeat();
         telemetry.capture("oss.runtime.agent_execution_stream_ended", {});
       },
     });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -157,6 +157,8 @@ export interface ThreadConnectionResponse {
   joinToken: string;
   /** Optional join code that can be shared with other clients to join the same channel. */
   joinCode?: string;
+  /** Lock metadata echoed back by the platform. */
+  lock?: ThreadLockInfo;
 }
 
 export interface SubscribeToThreadsRequest {
@@ -213,6 +215,28 @@ export interface AcquireThreadLockRequest {
   threadId: string;
   runId: string;
   userId: string;
+  /** Custom Redis key prefix for the lock (default: "thread"). */
+  lockKeyPrefix?: string;
+  /** Lock TTL in seconds. When set, the lock auto-expires after this duration. */
+  ttlSeconds?: number;
+}
+
+export interface RenewThreadLockRequest {
+  threadId: string;
+  runId: string;
+  /** New TTL to set on the lock in seconds. */
+  ttlSeconds: number;
+  /** Must match the prefix used when acquiring. */
+  lockKeyPrefix?: string;
+}
+
+export interface RenewThreadLockResponse {
+  ttlSeconds: number;
+}
+
+export interface ThreadLockInfo {
+  key: string;
+  ttlSeconds: number | null;
 }
 
 interface ThreadEnvelope {
@@ -596,7 +620,32 @@ export class CopilotKitIntelligence {
     return this.#request<ThreadConnectionResponse>(
       "POST",
       `/api/threads/${encodeURIComponent(params.threadId)}/lock`,
-      { runId: params.runId, userId: params.userId },
+      {
+        runId: params.runId,
+        userId: params.userId,
+        ...(params.lockKeyPrefix !== undefined
+          ? { lockKeyPrefix: params.lockKeyPrefix }
+          : {}),
+        ...(params.ttlSeconds !== undefined
+          ? { ttlSeconds: params.ttlSeconds }
+          : {}),
+      },
+    );
+  }
+
+  async ɵrenewThreadLock(
+    params: RenewThreadLockRequest,
+  ): Promise<RenewThreadLockResponse> {
+    return this.#request<RenewThreadLockResponse>(
+      "PATCH",
+      `/api/threads/${encodeURIComponent(params.threadId)}/lock`,
+      {
+        runId: params.runId,
+        ttlSeconds: params.ttlSeconds,
+        ...(params.lockKeyPrefix !== undefined
+          ? { lockKeyPrefix: params.lockKeyPrefix }
+          : {}),
+      },
     );
   }
 

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -26,6 +26,10 @@ export interface IntelligenceAgentRunnerOptions {
   url: string;
   /** Optional Phoenix socket auth token used during websocket connect. */
   authToken?: string;
+  /** Max delay (ms) for WebSocket reconnect backoff. @default 10_000 */
+  maxReconnectMs?: number;
+  /** Max delay (ms) for channel rejoin backoff. @default 30_000 */
+  maxRejoinMs?: number;
 }
 
 interface ThreadState {
@@ -59,10 +63,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
    *  - Each run gets its own independent retry budget.
    *
    * reconnectAfterMs — delay before Phoenix reconnects the WebSocket
-   *   after an unclean close. 100ms base, doubling up to a 10s cap.
+   *   after an unclean close. 100ms base, doubling up to maxReconnectMs (default 10s).
    *
    * rejoinAfterMs — delay before Phoenix re-joins a channel that
-   *   entered the "errored" state. 1s base, doubling up to 30s cap.
+   *   entered the "errored" state. 1s base, doubling up to maxRejoinMs (default 30s).
    *
    * These are set explicitly because Phoenix's default schedule is a
    * fixed stepped array (not exponential), and any code that calls
@@ -73,8 +77,14 @@ export class IntelligenceAgentRunner extends AgentRunner {
   private createSocket(): Socket {
     const socket = new Socket(this.options.url, {
       ...(this.options.authToken ? { authToken: this.options.authToken } : {}),
-      reconnectAfterMs: phoenixExponentialBackoff(100, 10_000),
-      rejoinAfterMs: phoenixExponentialBackoff(1_000, 30_000),
+      reconnectAfterMs: phoenixExponentialBackoff(
+        100,
+        this.options.maxReconnectMs ?? 10_000,
+      ),
+      rejoinAfterMs: phoenixExponentialBackoff(
+        1_000,
+        this.options.maxRejoinMs ?? 30_000,
+      ),
     });
     socket.connect();
     return socket;


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds thread lock TTL and prefix configurability to the Intelligence runtime configuration, and plumbs those values through the 'acquire lock' API call.

Since setting a TTL will cause the lock to expire, also added is a heartbeat interval that is required if TTL is configured. 

When set, the runtime will call the heartbeat endpoint for the lock every 'interval' seconds to keep the lock alive.

## Related PRs and Issues

- ENT-82

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
