### PR TITLE
fix(runtime): keep browser bundles free of LangChain/AWS imports

### DIFF
--- a/.changeset/odd-bears-relax.md
+++ b/.changeset/odd-bears-relax.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+Add a browser-safe runtime entry so browser bundles stop pulling LangChain-backed adapters and their AWS SDK transitive imports.

--- a/.changeset/odd-bears-relax.md
+++ b/.changeset/odd-bears-relax.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-Add a browser-safe runtime entry so browser bundles stop pulling LangChain-backed adapters and their AWS SDK transitive imports.

--- a/.changeset/young-donkeys-bake.md
+++ b/.changeset/young-donkeys-bake.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix runtime browser bundles to avoid pulling in LangChain and AWS browser-incompatible dependencies

--- a/packages/v1/runtime/package.json
+++ b/packages/v1/runtime/package.json
@@ -11,6 +11,8 @@
   },
   "version": "1.54.1-next.6",
   "sideEffects": [
+    "./dist/browser.mjs",
+    "./dist/browser.cjs",
     "./dist/index.mjs",
     "./dist/index.cjs",
     "./dist/v2/index.mjs",
@@ -20,8 +22,22 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
+      "browser": {
+        "import": {
+          "types": "./dist/browser.d.mts",
+          "default": "./dist/browser.mjs"
+        },
+        "require": {
+          "types": "./dist/browser.d.cts",
+          "default": "./dist/browser.cjs"
+        }
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./browser": {
+      "import": "./dist/browser.mjs",
+      "require": "./dist/browser.cjs"
     },
     "./langgraph": {
       "import": "./dist/langgraph.mjs",

--- a/packages/v1/runtime/src/browser-stubs.ts
+++ b/packages/v1/runtime/src/browser-stubs.ts
@@ -1,0 +1,26 @@
+const browserOnlyError = (name: string) =>
+  new Error(
+    `${name} is not available in browser bundles. Import it from a server-side runtime entry instead.`,
+  );
+
+export class LangChainAdapter {
+  constructor() {
+    throw browserOnlyError("LangChainAdapter");
+  }
+}
+
+export class GoogleGenerativeAIAdapter extends LangChainAdapter {}
+
+export class BedrockAdapter extends LangChainAdapter {}
+
+export class ExperimentalOllamaAdapter {
+  constructor() {
+    throw browserOnlyError("ExperimentalOllamaAdapter");
+  }
+}
+
+export class RemoteChain {
+  constructor() {
+    throw browserOnlyError("RemoteChain");
+  }
+}

--- a/packages/v1/runtime/src/browser.test.ts
+++ b/packages/v1/runtime/src/browser.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  BedrockAdapter,
+  ExperimentalOllamaAdapter,
+  GoogleGenerativeAIAdapter,
+  LangChainAdapter,
+  RemoteChain,
+} from "./browser-stubs";
+
+describe("browser entry", () => {
+  it("keeps LangChain-backed adapters out of browser bundles", () => {
+    expect(() => new LangChainAdapter()).toThrow(
+      /not available in browser bundles/i,
+    );
+    expect(() => new GoogleGenerativeAIAdapter()).toThrow(
+      /not available in browser bundles/i,
+    );
+    expect(() => new BedrockAdapter()).toThrow(
+      /not available in browser bundles/i,
+    );
+    expect(() => new ExperimentalOllamaAdapter()).toThrow(
+      /not available in browser bundles/i,
+    );
+    expect(() => new RemoteChain()).toThrow(/not available in browser bundles/i);
+  });
+});

--- a/packages/v1/runtime/src/browser.ts
+++ b/packages/v1/runtime/src/browser.ts
@@ -1,0 +1,27 @@
+export * from "./langgraph";
+export * from "./lib/runtime/copilot-runtime";
+export * from "./lib/runtime/mcp-tools-utils";
+export * from "./lib/integrations";
+export * from "./lib/logger";
+export * from "./utils";
+export * from "./service-adapters/shared";
+export * from "./service-adapters/openai/openai-adapter";
+export * from "./service-adapters/openai/openai-assistant-adapter";
+export * from "./service-adapters/anthropic/anthropic-adapter";
+export * from "./service-adapters/groq/groq-adapter";
+export * from "./service-adapters/unify/unify-adapter";
+export * from "./service-adapters/empty/empty-adapter";
+
+export type {
+  CopilotRuntimeChatCompletionRequest,
+  CopilotRuntimeChatCompletionResponse,
+  CopilotServiceAdapter,
+} from "./service-adapters/service-adapter";
+export type { RemoteChainParameters } from "./service-adapters/langchain/langserve";
+export {
+  BedrockAdapter,
+  ExperimentalOllamaAdapter,
+  GoogleGenerativeAIAdapter,
+  LangChainAdapter,
+  RemoteChain,
+} from "./browser-stubs";

--- a/packages/v1/runtime/tsdown.config.ts
+++ b/packages/v1/runtime/tsdown.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/v2/index.ts", "src/langgraph.ts"],
+  entry: [
+    "src/index.ts",
+    "src/browser.ts",
+    "src/v2/index.ts",
+    "src/langgraph.ts",
+  ],
   format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
This adds a browser-safe runtime entry so Vite/browser builds no longer pull in LangChain-backed adapters and their AWS SDK transitive dependencies.

Validation:
- pnpm -C packages/v1/runtime build
- pnpm -C packages/v1/runtime exec vitest run src/browser.test.ts
- pnpm -C packages/v1/runtime publint .
- rg -n "@langchain/core|@langchain/aws|@langchain/community|langchain/runnables/remote|@aws-sdk" packages/v1/runtime/dist/browser.mjs packages/v1/runtime/dist/browser.cjs