### PR TITLE
fix: travel example e2e test hanging on slow CDN

### DIFF
--- a/examples/e2e/tests/v1.x/travel.spec.ts
+++ b/examples/e2e/tests/v1.x/travel.spec.ts
@@ -6,7 +6,12 @@ test.describe("travel", () => {
   test.skip(EXAMPLE !== "travel", `EXAMPLE=${EXAMPLE}`);
 
   test("loads", async ({ page }) => {
-    await page.goto("/?copilotOpen=false");
+    // Use domcontentloaded because the travel layout loads external CDN
+    // resources (leaflet CSS/JS from unpkg) that are render-blocking.
+    // The default "load" waitUntil hangs when unpkg is slow in CI.
+    await page.goto("/?copilotOpen=false", {
+      waitUntil: "domcontentloaded",
+    });
     await expect(page).toHaveTitle(/CopilotKit Travel/i);
   });
 });


### PR DESCRIPTION
This would result in a flakey test suite.