### PR TITLE
fix(release): manually re-enter pre-mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "exit",
+  "mode": "pre",
   "tag": "next",
   "initialVersions": {
     "@copilotkit-examples/chat-with-your-data": "0.1.0",


### PR DESCRIPTION
Our CI broke and we got into an exit mode with a bunch of changesets.