### PR TITLE
fix(web-inspector): prevent flaky test from timer firing after jsdom teardown

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -5,7 +5,7 @@ import {
   type CopilotKitCoreSubscriber,
 } from "@copilotkit/core";
 import type { AbstractAgent, AgentSubscriber } from "@ag-ui/client";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 type MockAgentController = {
   emit: (key: keyof AgentSubscriber, payload: unknown) => void;
@@ -115,6 +115,10 @@ describe("WebInspectorElement", () => {
     const mockClipboard = { writeText: vi.fn().mockResolvedValue(undefined) };
     (navigator as unknown as { clipboard: typeof mockClipboard }).clipboard =
       mockClipboard;
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
   });
 
   it("records agent events and syncs state/messages/tools", async () => {


### PR DESCRIPTION
## Summary

- Added `vi.clearAllTimers()` in `afterEach` in `packages/web-inspector/src/__tests__/web-inspector.spec.ts`
- Prevents a leaked `setTimeout` from firing after jsdom tears down, which caused intermittent test failures

## Test plan

- [x] Run `nx test web-inspector` multiple times to confirm no flaky failures
- [x] Verify the `afterEach` cleanup does not affect other test assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)