### PR TITLE
ci: auto-merge showcase-only PRs from Demo team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @arielweinberger @mme @ataibarkai @ranst91 @tylerslaton @suhasdeshpande
+
+# Showcases — demo team owns these alongside core dev
+examples/showcases/ @CopilotKit/demo @arielweinberger @mme @ataibarkai @ranst91 @tylerslaton @suhasdeshpande

--- a/.github/workflows/auto_merge_showcases.yml
+++ b/.github/workflows/auto_merge_showcases.yml
@@ -1,0 +1,87 @@
+name: Auto-merge showcase PRs
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/showcases/**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check author is on Demo team
+        id: check-team
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org: 'CopilotKit',
+                team_slug: 'demo',
+                username: context.actor,
+              });
+              core.setOutput('is_demo', 'true');
+            } catch {
+              core.info(`${context.actor} is not a member of CopilotKit/demo`);
+              core.setOutput('is_demo', 'false');
+            }
+
+      - name: Check PR only touches showcases
+        if: steps.check-team.outputs.is_demo == 'true'
+        id: check-files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const allShowcases = files.every(f =>
+              f.filename.startsWith('examples/showcases/')
+            );
+
+            if (!allShowcases) {
+              const outside = files
+                .filter(f => !f.filename.startsWith('examples/showcases/'))
+                .map(f => f.filename);
+              core.info(`Files outside showcases: ${outside.join(', ')}`);
+            }
+
+            core.setOutput('only_showcases', allShowcases.toString());
+
+      - name: Approve PR
+        if: steps.check-team.outputs.is_demo == 'true' && steps.check-files.outputs.only_showcases == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE',
+              body: 'Auto-approved: showcase-only changes from CopilotKit/demo team member.',
+            });
+
+      - name: Enable auto-merge
+        if: steps.check-team.outputs.is_demo == 'true' && steps.check-files.outputs.only_showcases == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.graphql(`
+              mutation($prId: ID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $prId,
+                  mergeMethod: MERGE
+                }) {
+                  clientMutationId
+                }
+              }
+            `, { prId: context.payload.pull_request.node_id });


### PR DESCRIPTION
## Summary

- Adds `@CopilotKit/demo` as CODEOWNER for `examples/showcases/` alongside the existing dev team
- Adds a workflow that auto-approves and merges PRs from any Demo team member when changes are **isolated to** `examples/showcases/`
- PRs touching anything outside showcases sit for normal review, regardless of author

## How it works

1. PR touches `examples/showcases/**` → workflow triggers
2. Checks if PR author is a member of `CopilotKit/demo` team
3. Verifies **every file** in the PR is under `examples/showcases/`
4. Both pass → auto-approve + enable auto-merge
5. Either fails → PR sits for normal review

## Demo team members

`maxkorp` `uliyahoo` `NathanTarbert` `Anmol-Baranwal` `GeneralJerel` `eli-berman8`

## Prerequisites

- "Allow auto-merge" is already enabled on the repo ✓
- `GITHUB_TOKEN` needs permission to query team membership (org-level read)

## Test plan

- [ ] Demo team member opens showcase-only PR → auto-approved and merged
- [ ] Demo team member opens PR touching files outside showcases → normal review
- [ ] Non-demo contributor opens showcase PR → normal review