### PR TITLE
ci: re-enable Nx Cloud and improve CI reporting

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -31,4 +31,5 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - run: npx pkg-pr-new publish  --pnpm --packageManager pnpm "./packages/*"
+      - name: Publish preview packages (skipped in fork)
+        run: echo "Skipping pkg-pr-new publish (fork — no access)"

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -31,5 +31,4 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Publish preview packages (skipped in fork)
-        run: echo "Skipping pkg-pr-new publish (fork — no access)"
+      - run: npx pkg-pr-new publish  --pnpm --packageManager pnpm "./packages/*"

--- a/.github/workflows/static_commitlint.yml
+++ b/.github/workflows/static_commitlint.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
-        run: npx commitlint --last --verbose
+        run: pnpm exec nx-cloud record -- npx commitlint --last --verbose
 
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: pnpm exec nx-cloud record -- npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/static_danger.yml
+++ b/.github/workflows/static_danger.yml
@@ -34,6 +34,6 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Danger
-        run: pnpm exec danger ci
+        run: pnpm exec nx-cloud record -- pnpm exec danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -48,8 +50,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run Prettier check
-        run: pnpm run check-prettier
+      - name: Run Prettier check (affected files only)
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npx nx format:check --base=origin/${{ github.base_ref }} --head=HEAD
+          else
+            npx nx format:check --base=HEAD~1 --head=HEAD
+          fi
 
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -50,13 +50,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - uses: nrwl/nx-set-shas@v4
+
       - name: Run Prettier check (affected files only)
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            npx nx format:check --base=origin/${{ github.base_ref }} --head=HEAD
-          else
-            npx nx format:check --base=HEAD~1 --head=HEAD
-          fi
+        run: pnpm exec nx-cloud record -- nx format:check
 
   eslint:
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Match the scope of the original `prettier --check "**/*.{ts,tsx,md}"` command.
+# nx format:check runs prettier on all supported files by default,
+# so we explicitly ignore everything else to avoid false positives
+# from pre-existing unformatted files (mdx, json, css, etc.).
+*.mdx
+*.json
+*.css
+*.html
+*.js
+*.mjs
+*.mts
+*.yaml
+*.yml

--- a/nx.json
+++ b/nx.json
@@ -95,6 +95,5 @@
   },
   "parallel": 14,
   "defaultBase": "main",
-  "nxCloudId": "69c7bf9782147299c6e8d6f0",
-  "nxCloudUrl": "https://staging.nx.app"
+  "nxCloudId": "69a1ceae0efc94d36e7f9044"
 }

--- a/nx.json
+++ b/nx.json
@@ -94,5 +94,7 @@
     }
   },
   "parallel": 14,
-  "defaultBase": "main"
+  "defaultBase": "main",
+  "nxCloudId": "69c7bf9782147299c6e8d6f0",
+  "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
WIP based on a convo with @AlemTuzlak 

## Summary

- **Re-enables Nx Cloud** by restoring the `nxCloudId` that was removed in b3520c17e
- **Switches prettier check to `nx format:check`** which only checks affected files (via `nrwl/nx-set-shas`), avoiding false failures from pre-existing unformatted files outside the PR scope
- **Adds `.prettierignore`** to scope `nx format:check` to `*.{ts,tsx,md}` files only, matching the original `prettier --check` command
- **Wraps static checks with `nx-cloud record`** (commitlint, danger, prettier) so they appear in the Nx Cloud CI Pipeline Execution view alongside build/test/lint