### PR TITLE
fix(docs): expand sidebar link clickable area to full item width

### DIFF
--- a/docs/components/ui/sidebar/page.tsx
+++ b/docs/components/ui/sidebar/page.tsx
@@ -70,13 +70,13 @@ const Page = ({ node, onNavigate, minimal }: PageProps) => {
   return (
     <li
       className={cn(
-        "flex justify-start items-center px-3 h-10 text-sm opacity-60 transition-all duration-300 shrink-0 hover:opacity-100 hover:bg-white dark:hover:bg-white/10 rounded-lg",
+        "flex h-10 text-sm opacity-60 transition-all duration-300 shrink-0 hover:opacity-100 hover:bg-white dark:hover:bg-white/10 rounded-lg",
         isActive && "opacity-100 bg-white dark:bg-white/10",
       )}
     >
       <Link
         href={normalizedUrl}
-        className="text-foreground dark:text-white"
+        className="flex items-center w-full h-full px-3 text-foreground dark:text-white"
         onClick={onNavigate}
       >
         {node.name}


### PR DESCRIPTION
## Summary

- Fixed docs sidebar page items where clicking to the right of the text (but still within the item area) did not trigger navigation
- The `<Link>` element only spanned the width of its text content — moved `px-3` padding and `flex items-center` into the `<Link>` and added `w-full h-full` so it fills the entire `<li>` container
- Matches the pattern already used in `integration-link.tsx` which correctly uses `w-full h-full` on its Link

## Test plan

- [ ] Open docs site and navigate using sidebar
- [ ] Click on the right side of a sidebar item (not on the text itself) — should now navigate correctly
- [ ] Verify active state styling still works
- [ ] Verify hover effects still appear on the full item area