### PR TITLE
Fix changeset referencing non-existent package

### DIFF
--- a/.changeset/fix-thread-shared-state.md
+++ b/.changeset/fix-thread-shared-state.md
@@ -1,5 +1,5 @@
 ---
-"@copilotkitnext/react": patch
+"@copilotkit/react-core": patch
 ---
 
 Fix multiple CopilotChat components with different threadIds sharing message state. The useAgent hook now creates per-thread agent clones when threadId is provided, ensuring each chat instance maintains isolated messages and state.


### PR DESCRIPTION
## Summary

- Fixes the `fix-thread-shared-state` changeset which references `@copilotkitnext/react` — a package that doesn't exist in the workspace
- The actual changes from PR #3525 were to `packages/react-core` (`@copilotkit/react-core`), not a `@copilotkitnext` package
- This is blocking the publish/release CI workflow on main: https://github.com/CopilotKit/CopilotKit/actions/runs/23870780644

## Change

`@copilotkitnext/react` → `@copilotkit/react-core` in `.changeset/fix-thread-shared-state.md`

## Test plan

- [x] The changeset now references a package that exists in the workspace
- [ ] Re-run the publish/release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)