### PR TITLE
fix(docs): fix broken links and add followUp to useFrontendTool v2 reference  

### DIFF
--- a/docs/content/docs/integrations/ag2/readables.mdx
+++ b/docs/content/docs/integrations/ag2/readables.mdx
@@ -19,7 +19,7 @@ This context can then be shared with your AG2 backend.
 
 ## Implementation
 <Callout>
-    Check out the [Frontend Data documentation](https://docs.copilotkit.ai/direct-to-llm/guides/connect-your-data/frontend) to understand what this is and how to use it.
+    Check out the [Frontend Data documentation](/built-in-agent/agent-app-context) to understand what this is and how to use it.
 </Callout>
 
 <Callout type="info">

--- a/docs/content/docs/integrations/built-in-agent/index.mdx
+++ b/docs/content/docs/integrations/built-in-agent/index.mdx
@@ -34,4 +34,4 @@ If you need more control over your agent loop, consider using an [agent framewor
 
 ## Getting Started
 
-Head to the [Quickstart](/built-in-agent/quickstart) to set up a working Built-in Agent in minutes.
+Head to the [Quickstart](./quickstart) to set up a working Built-in Agent in minutes.

--- a/docs/content/docs/integrations/langgraph/agent-app-context.mdx
+++ b/docs/content/docs/integrations/langgraph/agent-app-context.mdx
@@ -19,7 +19,7 @@ This context can then be shared with your LangChain agent.
 
 ## Implementation
 <Callout>
-    Check out the [Frontend Data documentation](https://docs.copilotkit.ai/direct-to-llm/guides/connect-your-data/frontend) to understand what this is and how to use it.
+    Check out the [Frontend Data documentation](/built-in-agent/agent-app-context) to understand what this is and how to use it.
 </Callout>
 
 <TailoredContent

--- a/docs/content/docs/integrations/langgraph/multi-agent-flows.mdx
+++ b/docs/content/docs/integrations/langgraph/multi-agent-flows.mdx
@@ -43,7 +43,7 @@ Be advised that when using this mode, you'll have to "exit the workflow" explici
 You can find more information about it in the ["Exiting the agent loop" section](https://docs.copilotkit.ai/langgraph/advanced/exit-agent).
 
 <Callout type="warn">
-    Router mode requires that you set up an LLM adapter. See how in ["Set up a copilot runtime"](https://docs.copilotkit.ai/direct-to-llm/guides/quickstart?copilot-hosting=self-hosted#set-up-a-copilot-runtime-endpoint) section of the docs.
+    Router mode requires that you set up an LLM adapter. See how in ["Set up a copilot runtime"](/built-in-agent/copilot-runtime) section of the docs.
 </Callout>
 
 ### Agent Lock Mode

--- a/docs/content/docs/integrations/microsoft-agent-framework/agent-app-context.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/agent-app-context.mdx
@@ -13,7 +13,7 @@ This context can then be shared with your AG-UI server and agent logic.
 
 ## Implementation
 <Callout>
-    Check out the [Frontend Data documentation](https://docs.copilotkit.ai/direct-to-llm/guides/connect-your-data/frontend) to understand what this is and how to use it.
+    Check out the [Frontend Data documentation](/built-in-agent/agent-app-context) to understand what this is and how to use it.
 </Callout>
 
 <Steps>

--- a/docs/content/docs/integrations/pydantic-ai/multi-agent-flows.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/multi-agent-flows.mdx
@@ -40,7 +40,7 @@ In router mode, CopilotKit acts as a central hub, dynamically selecting and _rou
 In this mode, CopilotKit will intelligently route requests to the most appropriate agent or action based on the context and user input.
 
 <Callout type="warn">
-    Router mode requires that you set up an LLM adapter. See how in ["Set up a copilot runtime"](https://docs.copilotkit.ai/direct-to-llm/guides/quickstart?copilot-hosting=self-hosted#set-up-a-copilot-runtime-endpoint) section of the docs.
+    Router mode requires that you set up an LLM adapter. See how in ["Set up a copilot runtime"](/built-in-agent/copilot-runtime) section of the docs.
 </Callout>
 
 ### Agent Lock Mode

--- a/docs/content/docs/reference/v2/hooks/useFrontendTool.mdx
+++ b/docs/content/docs/reference/v2/hooks/useFrontendTool.mdx
@@ -55,6 +55,10 @@ function useFrontendTool<T extends Record<string, unknown>>(
   <PropertyReference name="available" type='"enabled" | "disabled" | "remote"' default='"enabled"'>
     Controls tool availability. Set to `"disabled"` to temporarily prevent the agent from calling the tool, or `"remote"` to indicate the tool is handled server-side.
   </PropertyReference>
+
+  <PropertyReference name="followUp" type="boolean" default="true">
+    When `false`, the agent won't generate a follow-up chat message after the tool's component renders. Use this when the rendered component is the complete response.
+  </PropertyReference>
 </PropertyReference>
 
 <PropertyReference name="deps" type="ReadonlyArray<unknown>">


### PR DESCRIPTION
## Summary                                                                                                                                                                                        
  - Fixed double-path link `/built-in-agent/built-in-agent/quickstart` in built-in-agent overview page
  - Updated stale `direct-to-llm/guides/...` links across langgraph, ag2, microsoft-agent-framework, pydantic-ai pages pointing to correct current URLs                                             
  - Added missing `followUp` property to `useFrontendTool` v2 reference docs (`packages/core/src/types.ts`) 

## Test plan                                                                                                                                                                                      
  - [ ] `/built-in-agent` → click Quickstart → lands on `/built-in-agent/quickstart`                                                                                                                
  - [ ] `/langgraph/agent-app-context` → "Frontend Data documentation" callout links to `/built-in-agent/agent-app-context`                                                                         
  - [ ] `/ag2/readables` → same callout → same destination                                                                                                                                          
  - [ ] `/microsoft-agent-framework/agent-app-context` → same callout → same destination                                                                                                            
  - [ ] `/langgraph/multi-agent-flows` → "Set up a copilot runtime" warning callout links to `/built-in-agent/copilot-runtime`                                                                      
  - [ ] `/pydantic-ai/multi-agent-flows` → same callout → same destination                                                                                                                          
  - [ ] `/reference/v2/hooks/useFrontendTool` → `followUp` visible under Parameters (`packages/core/src/types.ts`)  
