### PR TITLE
updated with-mcp-use README to not have stale references

### DIFF
--- a/examples/showcases/open-mcp-client/README.md
+++ b/examples/showcases/open-mcp-client/README.md
@@ -1,8 +1,6 @@
 # Open MCP Client Builder
 
-**Production go-live:** [`docs/TRACKER.md`](docs/TRACKER.md) · **Stakeholder / product handoff** (shipped scope, CopilotKit open questions): [`docs/HANDOFF.md`](docs/HANDOFF.md)
-
-This monorepo demonstrates **MCP Apps** with **CopilotKit**: the **MCP App builder** web UI (`apps/web`) drives a **Mastra** agent (`/api/mastra-agent`) that can provision **E2B** sandboxes running the **`mcp-use-server`** template (`apps/mcp-use-server`). An optional local sample is the [Three.js MCP example](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/threejs-server) in **`apps/threejs-server`** (used for sidebar defaults when running everything locally).
+This monorepo demonstrates how to render and create **MCP Apps** with **CopilotKit**: the **MCP App builder** web UI (`apps/web`) drives a **Mastra** agent (`/api/mastra-agent`) that can provision **E2B** sandboxes running the **`mcp-use-server`** template (`apps/mcp-use-server`). An optional local sample is the [Three.js MCP example](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/threejs-server) in **`apps/threejs-server`** (used for sidebar defaults when running everything locally).
 
 https://github.com/user-attachments/assets/4bb35806-5e42-43c0-a8fe-01c0d1e5b8b3
 
@@ -16,7 +14,7 @@ https://github.com/user-attachments/assets/4bb35806-5e42-43c0-a8fe-01c0d1e5b8b3
 
 ## Getting started
 
-From the **repository root** (`with-mcp-apps`):
+From the **repository root**:
 
 ```powershell
 pnpm i
@@ -76,8 +74,6 @@ Requirements: **`E2B_API_KEY`** in `.env` (or environment). The CLI prints a **`
 
 ## Agent and UI
 
-The app title is **MCP App builder** (subtitle **Powered by CopilotKit**), logo **`apps/web/app/image.png`**, agent route **`/api/mastra-agent`**. Header CTAs use **`NEXT_PUBLIC_HEADER_*`** (and **`NEXT_PUBLIC_GITHUB_REPO_URL`** for the secondary link; code default points at **this demo repo**). Chat starters: **`NEXT_PUBLIC_CHAT_STARTER_PROMPTS`** (JSON) or **three** built-in bounded demos — tic tac toe, tip calculator, dice roller (**[`docs/HANDOFF.md`](docs/HANDOFF.md)**). Reference CopilotKit route: **`apps/web/app/api/copilotkit/route.ts`**.
-
 **Starter prompts** use **`useCopilotChatSuggestions`** (`ChatSuggestions.tsx`) with v2 **`CopilotChat`**.
 
 **Post-provision test chips:** frontend action **`show_mcp_test_prompts`** (`McpTestPromptsAction.tsx`) — JSON string of `{ label, message }[]` for clickable chips (**`appendMessage`**).
@@ -86,17 +82,11 @@ The app title is **MCP App builder** (subtitle **Powered by CopilotKit**), logo 
 
 **Debug agent traffic:** set **`MASTRA_AGENT_DEBUG=1`** in `.env` for verbose **`/api/mastra-agent`** logs (see `.env.example`).
 
-### Duplicate React keys (Mastra agent) — RCA and fix
-
-Mastra can reuse the same `messageId` for tool-call parents and text events; CopilotKit then collides keys. **`mastra-agent/route.ts`** remaps ids when collisions are detected — see **`docs/HANDOFF.md`** / inline comments.
-
 ## Dynamic MCP UI (sidebar)
 
 - **MCP servers:** add/remove by URL (+ optional `serverId`); list is sent as **`x-mcp-servers`**. Built-in default: **Excalidraw** (`https://mcp.excalidraw.com`). Override via **`NEXT_PUBLIC_DEFAULT_MCP_SERVERS`** / **`DEFAULT_MCP_SERVERS`**.
 - **Tools:** compact list; open a tool for **detail + preview** in a **modal** (not a third mobile tab).
 - **Chat:** CopilotKit v2 chat with suggestions.
-
-More: **[`docs/DYNAMIC_MCP.md`](docs/DYNAMIC_MCP.md)**.
 
 ### Mobile layout
 
@@ -119,28 +109,17 @@ More: **[`docs/DYNAMIC_MCP.md`](docs/DYNAMIC_MCP.md)**.
 3. Set secret env vars in the dashboard: at least **`OPENAI_API_KEY`**; for sandboxes add **`E2B_API_KEY`** + **`E2B_TEMPLATE`**.
 4. Deploy. The Blueprint configures build/start commands, `NODE_VERSION`, and `HOSTNAME` automatically.
 
-Render runs a long-lived Node.js process (not serverless), so there are no per-function timeout limits. See **[`docs/DEPLOY-RENDER.md`](docs/DEPLOY-RENDER.md)** for full setup, env var tables, and troubleshooting.
+Render runs a long-lived Node.js process (not serverless), so there are no per-function timeout limits.
 
 ### Agent tool pattern (sidebar preview)
 
 Widget tools should include **`_meta["ui/previewData"]`** for offline sidebar preview (example: **`apps/mcp-use-server/tools/product-search.ts`**).
-
-## Documentation
-
-**In this repo**
-
-- **[`docs/TRACKER.md`](docs/TRACKER.md)** — **production go-live checklist**
-- **[`docs/HANDOFF.md`](docs/HANDOFF.md)** — shipped scope, CopilotKit open questions
-- **[`docs/DEPLOY-RENDER.md`](docs/DEPLOY-RENDER.md)** — Render deployment guide
-- **[`docs/DYNAMIC_MCP.md`](docs/DYNAMIC_MCP.md)** — dynamic MCP patterns
-- **[`docs/PLAN.md`](docs/PLAN.md)** / **[`docs/E2B-IMPLEMENTATION.md`](docs/E2B-IMPLEMENTATION.md)** — roadmap and E2B design
 
 **UI entry:** `apps/web/app/page.tsx` (theme, layout, CopilotKit wiring).
 
 **External**
 
 - [CopilotKit](https://docs.copilotkit.ai)
-- [Next.js](https://nextjs.org/docs)
 - [MCP Apps / UI](https://mcpui.dev/guide/introduction)
 
 ## Contributing


### PR DESCRIPTION
Removed redundant text and improved clarity in the README. Removed stale and internal references

## What does this PR do?

Fixed the Readme references for the open mcp app example, it was referencing stale docs folder which does not exist.

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ *] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
