### PR TITLE
fix: preserve whitespace in code blocks for CopilotKit v2

### DIFF
--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -177,7 +177,7 @@
 }
 
 [data-copilotkit] div[data-streamdown="code-block"] > pre {
-  @apply cpk:mt-0 cpk:mb-0;
+  @apply cpk:mt-0 cpk:mb-0 cpk:whitespace-pre;
 }
 
 /* Minimal scrollbar for WebKit browsers (Chrome, Safari, Edge) */


### PR DESCRIPTION
## Problem

Closes #3330

Code blocks rendered inside `CopilotChatAssistantMessage` (v2) lose their newlines. The root cause is that the Tailwind Typography (`cpk:prose`) styles override the default `white-space` behavior on `<pre>` elements. The existing CSS rule in `packages/react-core/src/v2/styles/globals.css` targets the correct selector (`div[data-streamdown="code-block"] > pre`) but only resets margins, leaving `white-space` unset.

## What changed

Added `cpk:whitespace-pre` to the `[data-copilotkit] div[data-streamdown="code-block"] > pre` rule in `packages/react-core/src/v2/styles/globals.css`.

```diff
 [data-copilotkit] div[data-streamdown="code-block"] > pre {
-  @apply cpk:mt-0 cpk:mb-0;
+  @apply cpk:mt-0 cpk:mb-0 cpk:whitespace-pre;
 }
```

## How to test

1. Run the v2 Storybook: `pnpm storybook:react`
2. Open the `CopilotChatAssistantMessage` story that tests all markdown features
3. Verify that code blocks now render with preserved newlines