### PR TITLE
docs(mastra): add interrupt-based HITL docs for suspend/resume support

### DIFF
--- a/docs/content/docs/integrations/mastra/human-in-the-loop/index.mdx
+++ b/docs/content/docs/integrations/mastra/human-in-the-loop/index.mdx
@@ -1,0 +1,54 @@
+---
+title: Human-in-the-Loop
+description: Learn how to implement Human-in-the-Loop (HITL) using Mastra Agents.
+icon: lucide/User
+---
+
+import { CTACards } from "@/components/react/cta-cards";
+
+<video
+  src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/human-in-the-loop-example.mp4"
+  className="rounded-lg shadow-xl"
+  loop
+  playsInline
+  controls
+  autoPlay
+  muted
+/>
+
+## What is Human-in-the-Loop (HITL)?
+
+Human-in-the-loop (HITL) allows agents to request human input or approval during execution, making AI systems more reliable and trustworthy. This pattern is essential when building AI applications that need to handle complex decisions or actions that require human judgment.
+
+## When should I use this?
+
+HITL combines the efficiency of AI with human judgment, creating a system that's both powerful and reliable. The key advantages include:
+
+- **Quality Control**: Human oversight at critical decision points
+- **Edge Cases**: Graceful handling of low-confidence situations
+- **Expert Input**: Leverage human expertise when needed
+- **Reliability**: More robust system for real-world use
+
+## How can I use this?
+
+Mastra supports two approaches to HITL, each suited for different use cases.
+
+<CTACards
+  columns={2}
+  cards={[
+    {
+      iconKey: "circlePause",
+      title: "Interrupt-based",
+      description:
+        "Use Mastra's native suspend/resume to pause tool execution and collect user input via useInterrupt.",
+      href: "/mastra/human-in-the-loop/interrupt-flow",
+    },
+    {
+      iconKey: "share2",
+      title: "Tool-based",
+      description:
+        "Register frontend tools with useHumanInTheLoop that render UI and wait for user responses.",
+      href: "/mastra/human-in-the-loop/tool-based",
+    },
+  ]}
+/>

--- a/docs/content/docs/integrations/mastra/human-in-the-loop/interrupt-flow.mdx
+++ b/docs/content/docs/integrations/mastra/human-in-the-loop/interrupt-flow.mdx
@@ -1,0 +1,267 @@
+---
+title: Interrupts
+icon: "lucide/CirclePause"
+description: Learn how to implement Human-in-the-Loop (HITL) using Mastra's native tool suspension.
+---
+
+import RunAndConnect from "@/snippets/integrations/mastra/run-and-connect.mdx"
+
+## What is this?
+
+Mastra's [tool suspension](https://mastra.ai/docs/agents/agent-approval) provides a native way to implement Human-in-the-Loop workflows.
+Tools can call `suspend()` to pause execution mid-tool and send a payload to the frontend. CopilotKit's `useInterrupt` hook
+captures the suspension, renders custom UI, and sends the user's response back to resume the tool.
+
+## When should I use this?
+
+Interrupt-based HITL is ideal when a tool needs to pause its own execution to collect user input before continuing. Common use cases include:
+
+- **Approvals** — confirm before performing destructive or irreversible actions
+- **Disambiguation** — ask the user to clarify ambiguous inputs
+- **Progressive disclosure** — collect additional details only when needed at runtime
+
+<Callout type="info">
+  If you want to render a standalone frontend tool that collects user input without suspending tool execution, see the [tool-based approach](/mastra/human-in-the-loop/tool-based).
+</Callout>
+
+## Implementation
+
+<Steps>
+<Step>
+  ### Run and connect your agent
+  <RunAndConnect components={props.components} />
+</Step>
+
+<Step>
+  ### Define a tool with `suspend()`
+
+  Create a Mastra tool that uses `suspend()` to pause execution and ask for user confirmation.
+  The `suspendSchema` defines what gets sent to the frontend, and the `resumeSchema` defines what the frontend sends back.
+
+  ```typescript title="src/mastra/tools/index.ts"
+  import { createTool } from "@mastra/core/tools";
+  import { z } from "zod";
+
+  export const confirmActionTool = createTool({
+    id: "confirm-action",
+    description: "Ask the user to confirm before performing a critical action",
+    inputSchema: z.object({
+      action: z.string().describe("Description of the action to confirm"),
+    }),
+    outputSchema: z.object({ confirmed: z.boolean() }),
+    suspendSchema: z.object({ action: z.string() }), // [!code highlight]
+    resumeSchema: z.object({ confirmed: z.boolean() }), // [!code highlight]
+    execute: async (inputData, context) => {
+      const { resumeData, suspend } = context?.agent ?? {};
+
+      // [!code highlight:4]
+      // First execution: pause and ask for confirmation
+      if (!resumeData) {
+        return suspend?.({ action: inputData.action });
+      }
+
+      // Resumed: the user has responded
+      return { confirmed: resumeData.confirmed };
+    },
+  });
+  ```
+</Step>
+
+<Step>
+  ### Add the tool to your agent
+
+  ```typescript title="src/mastra/agents/index.ts"
+  import { Agent } from "@mastra/core/agent";
+  import { openai } from "@ai-sdk/openai";
+  import { confirmActionTool } from "@/mastra/tools"; // [!code highlight]
+
+  export const myAgent = new Agent({
+    id: "my-agent",
+    name: "My Agent",
+    tools: { confirmActionTool }, // [!code highlight]
+    model: openai("gpt-4o"),
+    instructions:
+      "You are a helpful assistant. When performing critical actions, " +
+      "always use the confirm-action tool to get user approval first.",
+  });
+  ```
+</Step>
+
+<Step>
+  ### Handle the interrupt in your frontend
+
+  Use the `useInterrupt` hook to render UI when the agent suspends a tool.
+  The `event.value.suspendPayload` contains the data from the tool's `suspend()` call.
+  Call `resolve()` with the user's response to resume execution.
+
+  ```tsx title="ui/app/page.tsx"
+  import { useInterrupt } from "@copilotkit/react-core/v2"; // [!code highlight]
+  // ...
+
+  function YourMainContent() {
+    // ...
+
+    // [!code highlight:16]
+    useInterrupt({
+      render: ({ event, resolve }) => {
+        const { action } = event.value.suspendPayload;
+        return (
+          <div>
+            <p>{action}</p>
+            <button onClick={() => resolve({ confirmed: true })}>
+              Approve
+            </button>
+            <button onClick={() => resolve({ confirmed: false })}>
+              Reject
+            </button>
+          </div>
+        );
+      },
+    });
+
+    // ...
+    return <div>{/* ... */}</div>;
+  }
+  ```
+</Step>
+
+<Step>
+  ### Give it a try!
+
+  Try asking your agent to do something that requires confirmation.
+
+  ```
+  Can you delete all inactive user accounts?
+  ```
+
+  The agent will call the `confirm-action` tool, which suspends execution and shows an approval UI.
+  After you approve or reject, the tool resumes with your response and the agent continues.
+</Step>
+</Steps>
+
+## Advanced usage
+
+### Handle multiple interrupt types
+
+When your agent has multiple tools that use `suspend()`, use the `enabled` property to route each
+interrupt to the correct handler. The `eventValue.toolName` field identifies which tool triggered the suspension.
+
+<Steps>
+<Step>
+  ### Define multiple suspending tools
+
+  ```typescript title="src/mastra/tools/index.ts"
+  import { createTool } from "@mastra/core/tools";
+  import { z } from "zod";
+
+  export const confirmActionTool = createTool({
+    id: "confirm-action",
+    description: "Ask the user to confirm an action",
+    inputSchema: z.object({ action: z.string() }),
+    outputSchema: z.object({ confirmed: z.boolean() }),
+    suspendSchema: z.object({ action: z.string() }),
+    resumeSchema: z.object({ confirmed: z.boolean() }),
+    execute: async (inputData, context) => {
+      const { resumeData, suspend } = context?.agent ?? {};
+      if (!resumeData) return suspend?.({ action: inputData.action });
+      return { confirmed: resumeData.confirmed };
+    },
+  });
+
+  export const askQuestionTool = createTool({
+    id: "ask-question",
+    description: "Ask the user a free-form question",
+    inputSchema: z.object({ question: z.string() }),
+    outputSchema: z.object({ answer: z.string() }),
+    suspendSchema: z.object({ question: z.string() }),
+    resumeSchema: z.object({ answer: z.string() }),
+    execute: async (inputData, context) => {
+      const { resumeData, suspend } = context?.agent ?? {};
+      if (!resumeData) return suspend?.({ question: inputData.question });
+      return { answer: resumeData.answer };
+    },
+  });
+  ```
+</Step>
+
+<Step>
+  ### Route interrupts with `enabled`
+
+  ```tsx title="ui/app/page.tsx"
+  import { useInterrupt } from "@copilotkit/react-core/v2";
+
+  function YourMainContent() {
+    // ...
+
+    // [!code highlight:10]
+    useInterrupt({
+      enabled: ({ eventValue }) => eventValue.toolName === "confirm-action",
+      render: ({ event, resolve }) => (
+        <div>
+          <p>{event.value.suspendPayload.action}</p>
+          <button onClick={() => resolve({ confirmed: true })}>Approve</button>
+          <button onClick={() => resolve({ confirmed: false })}>Reject</button>
+        </div>
+      ),
+    });
+
+    // [!code highlight:14]
+    useInterrupt({
+      enabled: ({ eventValue }) => eventValue.toolName === "ask-question",
+      render: ({ event, resolve }) => (
+        <div>
+          <p>{event.value.suspendPayload.question}</p>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              resolve({ answer: (e.target as HTMLFormElement).response.value });
+            }}
+          >
+            <input type="text" name="response" placeholder="Your answer" />
+            <button type="submit">Submit</button>
+          </form>
+        </div>
+      ),
+    });
+
+    // ...
+    return <div>{/* ... */}</div>;
+  }
+  ```
+</Step>
+</Steps>
+
+### Preprocessing with `handler`
+
+Use the `handler` property to transform interrupt data or resolve interrupts programmatically before rendering UI.
+The return value of `handler` is passed to `render` as the `result` argument.
+
+```tsx title="ui/app/page.tsx"
+import { useInterrupt } from "@copilotkit/react-core/v2";
+
+function YourMainContent() {
+  const [user] = useState({ role: "admin" });
+
+  useInterrupt({
+    // [!code highlight:10]
+    handler: async ({ event, resolve }) => {
+      // Auto-approve for admins
+      if (user.role === "admin") {
+        resolve({ confirmed: true });
+        return;
+      }
+      return { action: event.value.suspendPayload.action };
+    },
+    render: ({ result, resolve }) => (
+      <div>
+        <p>{result.action}</p>
+        <button onClick={() => resolve({ confirmed: true })}>Approve</button>
+        <button onClick={() => resolve({ confirmed: false })}>Reject</button>
+      </div>
+    ),
+  });
+
+  // ...
+  return <div>{/* ... */}</div>;
+}
+```

--- a/docs/content/docs/integrations/mastra/human-in-the-loop/meta.json
+++ b/docs/content/docs/integrations/mastra/human-in-the-loop/meta.json
@@ -1,0 +1,3 @@
+{
+  "pages": ["interrupt-flow", "tool-based"]
+}

--- a/docs/content/docs/integrations/mastra/human-in-the-loop/tool-based.mdx
+++ b/docs/content/docs/integrations/mastra/human-in-the-loop/tool-based.mdx
@@ -1,14 +1,14 @@
 ---
-title: Human-in-the-Loop
-description: Learn how to implement Human-in-the-Loop (HITL) using Mastra Agents.
-icon: lucide/Pause
+title: Tool-based
+description: Implement HITL with Mastra using frontend tools that render UI and collect user input.
+icon: lucide/Share2
 ---
 
 import { IframeSwitcher } from "@/components/content"
 import RunAndConnect from "@/snippets/integrations/mastra/run-and-connect.mdx"
 
 <IframeSwitcher
-  id="human-in-the-loop-example"
+  id="human-in-the-loop-tool-based-example"
   exampleUrl="https://feature-viewer.copilotkit.ai/mastra/feature/human_in_the_loop?sidebar=false&chatDefaultOpen=false"
   codeUrl="https://feature-viewer.copilotkit.ai/mastra/feature/human_in_the_loop?view=code&sidebar=false&codeLayout=tabs"
   exampleLabel="Demo"
@@ -18,10 +18,11 @@ import RunAndConnect from "@/snippets/integrations/mastra/run-and-connect.mdx"
 
 ## What is this?
 
-CopilotKit lets you to add custom UI to take user input and then pass it back to the agent upon completion.
+CopilotKit lets you add custom UI to take user input and then pass it back to the agent upon completion.
+This approach uses `useHumanInTheLoop` to register a frontend tool that renders a UI component and waits for the user's response.
 
-<Callout type="warning">
-Calling `suspend()` or `resume()` inside of a workflow is not currently supported in this integration.
+<Callout type="info">
+  Looking for an approach where tools can pause mid-execution and wait for user input? See the [interrupt-based approach](/mastra/human-in-the-loop/interrupt-flow).
 </Callout>
 
 ## Why should I use this?

--- a/docs/content/docs/integrations/mastra/meta.json
+++ b/docs/content/docs/integrations/mastra/meta.json
@@ -10,6 +10,8 @@
     "...generative-ui",
     "---App Control---",
     "frontend-tools", "shared-state", "agent-app-context",
+    "---Mastra---",
+    "...human-in-the-loop",
     "---Backend---",
     "copilot-runtime", "ag-ui",
     "---Premium Features---",


### PR DESCRIPTION
## Summary
- Restructures Mastra Human-in-the-Loop docs from a single page into a subfolder with two approaches
- Adds new **interrupt-flow.mdx** documenting Mastra's native `suspend()`/`resume` → `useInterrupt` flow (basic + advanced usage with `enabled` routing and `handler` preprocessing)
- Extracts existing tool-based content into **tool-based.mdx** and removes the "suspend/resume not supported" warning
- Adds **index.mdx** landing page with CTACards linking both approaches
- Updates Mastra `meta.json` to add a "Mastra" nav section with the HITL pages

Companion docs for ag-ui-protocol/ag-ui#1359 and CopilotKit/CopilotKit#3505.

## Test plan
- [ ] Verify docs build locally (`nx run docs:build`)
- [ ] Verify navigation: Mastra sidebar shows "Interrupts" and "Tool-based" under "Mastra" section
- [ ] Verify root HITL hub (`/human-in-the-loop`) still links to Mastra via IntegrationGrid
- [ ] Verify cross-links between interrupt-flow and tool-based pages work
- [ ] Verify CTACards on the index landing page link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)