### PR TITLE
fix(docs): update GPT model version from gpt-5.2-mini to gpt-5.4-mini

### DIFF
--- a/docs/content/docs/integrations/ag2/auth.mdx
+++ b/docs/content/docs/integrations/ag2/auth.mdx
@@ -71,7 +71,7 @@ from autogen.ag_ui import AGUIStream, RunAgentInput
 agent = ConversableAgent(
     name="assistant",
     system_message="You are a helpful assistant.",
-    llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+    llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
 )
 
 stream = AGUIStream(agent)
@@ -139,7 +139,7 @@ from autogen.ag_ui import AGUIStream, RunAgentInput
 agent = ConversableAgent(
     name="assistant",
     system_message="You are a helpful assistant.",
-    llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+    llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
 )
 
 stream = AGUIStream(agent)

--- a/docs/content/docs/integrations/ag2/frontend-tools.mdx
+++ b/docs/content/docs/integrations/ag2/frontend-tools.mdx
@@ -99,7 +99,7 @@ Without frontend actions, agents are limited to just processing and returning da
                 agent = ConversableAgent(
                     name="assistant",
                     system_message="You are a helpful assistant.",
-                    llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+                    llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
                 )
 
                 stream = AGUIStream(agent)

--- a/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
@@ -65,7 +65,7 @@ is a situation where a user and an agent are working together to solve a problem
             "You are a helpful assistant for storing searches. "
             "Use `add_search` once per query, then call `run_searches`."
         ),
-        llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+        llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
     )
 
 

--- a/docs/content/docs/integrations/ag2/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/integrations/ag2/generative-ui/tool-rendering.mdx
@@ -42,7 +42,7 @@ Start your AG2 backend with a `/chat` endpoint and connect CopilotKit to that en
         agent = ConversableAgent(
             name="assistant",
             system_message="You are a helpful assistant.",
-            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
         )
 
         @agent.register_for_llm(

--- a/docs/content/docs/integrations/ag2/human-in-the-loop.mdx
+++ b/docs/content/docs/integrations/ag2/human-in-the-loop.mdx
@@ -115,7 +115,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
                 "When you need the user to choose, call the frontend tool `offerOptions`. "
                 "After it returns, call `store_user_choice` with the selected value."
             ),
-            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
         )
 
         @agent.register_for_llm(description="Store the latest user choice in shared state.")

--- a/docs/content/docs/integrations/ag2/readables.mdx
+++ b/docs/content/docs/integrations/ag2/readables.mdx
@@ -116,7 +116,7 @@ This context can then be shared with your AG2 backend.
                                 "You are a helpful assistant that can help emailing colleagues. "
                                 "Call `get_colleagues` before suggesting recipients."
                             ),
-                            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+                            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
                         )
 
                         @agent.register_for_llm(description="Return the current user's colleagues from CopilotKit readables.")
@@ -201,7 +201,7 @@ This context can then be shared with your AG2 backend.
                         agent = ConversableAgent(
                             name="assistant",
                             system_message="You are a helpful assistant.",
-                            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+                            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
                         )
 
                         @agent.register_for_llm(description="Read colleagues from CopilotKit readable context.")

--- a/docs/content/docs/integrations/ag2/shared-state/read.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/read.mdx
@@ -63,7 +63,7 @@ state updates, you can reflect these updates natively in your application.
             "You are a helpful assistant for tracking language. "
             "Always respond in the current language."
         ),
-        llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+        llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
     )
 
     @agent.register_for_llm(description="Update the language in shared state.")

--- a/docs/content/docs/integrations/ag2/shared-state/write.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/write.mdx
@@ -62,7 +62,7 @@ You can use this when you want to keep your interface and backend agent state sy
             "You are a helpful assistant for tracking language. "
             "Always respond in the current language."
         ),
-        llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+        llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
     )
 
     @agent.register_for_llm(description="Update the language in shared state.")

--- a/docs/content/docs/integrations/agent-spec/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/integrations/agent-spec/generative-ui/tool-rendering.mdx
@@ -65,7 +65,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
 
         llm = OpenAiCompatibleConfig(
             name="my_llm",
-            model_id="gpt-5.2-mini",
+            model_id="gpt-5.4-mini",
             url="https://api.openai.com/v1",
         )
         weather_tool = ServerTool( # ServerTool are backend tools in Agent Spec

--- a/docs/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/docs/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -20,7 +20,7 @@ Specify a model using the `"provider:model"` format (or `"provider/model"` — b
 | GPT-4.1 Mini | `openai:gpt-4.1-mini` |
 | GPT-4.1 Nano | `openai:gpt-4.1-nano` |
 | GPT-4o | `openai:gpt-5.2` |
-| GPT-4o Mini | `openai:gpt-5.2-mini` |
+| GPT-5.4 mini | `openai:gpt-5.4-mini` |
 | o3 | `openai:o3` |
 | o3-mini | `openai:o3-mini` |
 | o4-mini | `openai:o4-mini` |

--- a/docs/content/docs/integrations/mastra/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/integrations/mastra/generative-ui/tool-rendering.mdx
@@ -68,7 +68,7 @@ export const weatherAgent = new Agent({
   name: "Weather Agent",
   instructions:
     "You are a helpful assistant that provides current weather information. When asked about the weather, use the weather information tool to fetch the data.",
-  model: openai("gpt-5.2-mini"),
+  model: openai("gpt-5.4-mini"),
   tools: {
     weatherInfo,
   },

--- a/docs/content/docs/integrations/microsoft-agent-framework/auth.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/auth.mdx
@@ -68,7 +68,7 @@ Configure authentication in your AG-UI server:
         new System.ClientModel.ApiKeyCredential(githubToken),
         new OpenAIClientOptions { Endpoint = new Uri("https://models.inference.ai.azure.com") }
     );
-    var agent = openAI.GetChatClient("gpt-5.2-mini")
+    var agent = openAI.GetChatClient("gpt-5.4-mini")
         .CreateAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
 
     app.MapAGUI("/", agent).RequireAuthorization();
@@ -115,7 +115,7 @@ Configure authentication in your AG-UI server:
     # Build a chat client (same pattern as the Quickstart)
     def _build_chat_client() -> ChatClientProtocol:
         if bool(os.getenv("AZURE_OPENAI_ENDPOINT")):
-            deployment_name = os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.2-mini")
+            deployment_name = os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.4-mini")
             return AzureOpenAIChatClient(
                 credential=DefaultAzureCredential(),
                 deployment_name=deployment_name,
@@ -123,7 +123,7 @@ Configure authentication in your AG-UI server:
             )
         if bool(os.getenv("OPENAI_API_KEY")):
             return OpenAIChatClient(
-                model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.2-mini"),
+                model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.4-mini"),
                 api_key=os.getenv("OPENAI_API_KEY"),
             )
         raise RuntimeError("Set AZURE_OPENAI_* or OPENAI_API_KEY in agent/.env")

--- a/docs/content/docs/integrations/microsoft-agent-framework/frontend-tools.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/frontend-tools.mdx
@@ -124,12 +124,12 @@ Use frontend tools when you need your agent to interact with client-side primiti
                 if bool(os.getenv("AZURE_OPENAI_ENDPOINT")):
                     return AzureOpenAIChatClient(
                         credential=DefaultAzureCredential(),
-                        deployment_name=os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.2-mini"),
+                        deployment_name=os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.4-mini"),
                         endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
                     )
                 if bool(os.getenv("OPENAI_API_KEY")):
                     return OpenAIChatClient(
-                        model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.2-mini"),
+                        model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.4-mini"),
                         api_key=os.getenv("OPENAI_API_KEY"),
                     )
                 raise RuntimeError("Set AZURE_OPENAI_* or OPENAI_API_KEY in agent/.env")

--- a/docs/content/docs/integrations/microsoft-agent-framework/human-in-the-loop.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/human-in-the-loop.mdx
@@ -132,12 +132,12 @@ Use frontend tools when you need your agent to interact with client-side primiti
                 if bool(os.getenv("AZURE_OPENAI_ENDPOINT")):
                     return AzureOpenAIChatClient(
                         credential=DefaultAzureCredential(),
-                        deployment_name=os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.2-mini"),
+                        deployment_name=os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.4-mini"),
                         endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
                     )
                 if bool(os.getenv("OPENAI_API_KEY")):
                     return OpenAIChatClient(
-                        model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.2-mini"),
+                        model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.4-mini"),
                         api_key=os.getenv("OPENAI_API_KEY"),
                     )
                 raise RuntimeError("Set AZURE_OPENAI_* or OPENAI_API_KEY in agent/.env")

--- a/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -129,12 +129,12 @@ Before you begin, you'll need the following:
 
                         ```bash title="agent/.env (OpenAI)"
                         OPENAI_API_KEY=sk-...your-openai-key-here...
-                        OPENAI_CHAT_MODEL_ID=gpt-5.2-mini
+                        OPENAI_CHAT_MODEL_ID=gpt-5.4-mini
                         ```
 
                         ```bash title="agent/.env (Azure OpenAI)"
                         AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
-                        AZURE_OPENAI_CHAT_DEPLOYMENT_NAME=gpt-5.2-mini
+                        AZURE_OPENAI_CHAT_DEPLOYMENT_NAME=gpt-5.4-mini
                         # If you are not relying on az login:
                         # AZURE_OPENAI_API_KEY=...
                         ```
@@ -214,7 +214,7 @@ Before you begin, you'll need the following:
                                 Endpoint = new Uri("https://models.inference.ai.azure.com")
                             });
 
-                        var chatClient = openAI.GetChatClient("gpt-5.2-mini").AsIChatClient();
+                        var chatClient = openAI.GetChatClient("gpt-5.4-mini").AsIChatClient();
                         var agent = new ChatClientAgent(
                             chatClient,
                             name: "MyAgent",
@@ -257,7 +257,7 @@ Before you begin, you'll need the following:
 
                         def _build_chat_client() -> ChatClientProtocol:
                             if bool(os.getenv("AZURE_OPENAI_ENDPOINT")):
-                                deployment_name = os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.2-mini")
+                                deployment_name = os.getenv("AZURE_OPENAI_CHAT_DEPLOYMENT_NAME", "gpt-5.4-mini")
                                 return AzureOpenAIChatClient(
                                     credential=DefaultAzureCredential(),
                                     deployment_name=deployment_name,
@@ -266,7 +266,7 @@ Before you begin, you'll need the following:
 
                             if bool(os.getenv("OPENAI_API_KEY")):
                                 return OpenAIChatClient(
-                                    model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.2-mini"),
+                                    model_id=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-5.4-mini"),
                                     api_key=os.getenv("OPENAI_API_KEY"),
                                 )
 
@@ -297,10 +297,10 @@ Before you begin, you'll need the following:
                         ```bash
                         # OpenAI (agent/.env)
                         OPENAI_API_KEY=sk-...your-openai-key-here...
-                        OPENAI_CHAT_MODEL_ID=gpt-5.2-mini
+                        OPENAI_CHAT_MODEL_ID=gpt-5.4-mini
                         # or Azure OpenAI (agent/.env)
                         AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
-                        AZURE_OPENAI_CHAT_DEPLOYMENT_NAME=gpt-5.2-mini
+                        AZURE_OPENAI_CHAT_DEPLOYMENT_NAME=gpt-5.4-mini
                         # (optional) AZURE_OPENAI_API_KEY=...
 
                         # Run the agent

--- a/docs/content/docs/integrations/pydantic-ai/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/generative-ui/state-rendering.mdx
@@ -57,7 +57,7 @@ is a situation where a user and an agent are working together to solve a problem
         searches: list[Search] = Field(default_factory=list)
 
 
-    agent = Agent("openai:gpt-5.2-mini", deps_type=StateDeps[AgentState])
+    agent = Agent("openai:gpt-5.4-mini", deps_type=StateDeps[AgentState])
 
 
     @agent.tool

--- a/docs/content/docs/integrations/pydantic-ai/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/generative-ui/tool-rendering.mdx
@@ -47,7 +47,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
         ```python title="agent.py"
         from pydantic_ai import Agent
 
-        agent = Agent("openai:gpt-5.2-mini")
+        agent = Agent("openai:gpt-5.4-mini")
 
 
         @agent.tool_plain

--- a/docs/content/docs/integrations/pydantic-ai/human-in-the-loop.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/human-in-the-loop.mdx
@@ -98,7 +98,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
         ```python title="agent.py"
         from pydantic_ai import Agent
 
-        agent = Agent('openai:gpt-5.2-mini')
+        agent = Agent('openai:gpt-5.4-mini')
         app = agent.to_ag_ui()
         ```
 

--- a/docs/content/docs/integrations/pydantic-ai/human-in-the-loop/agent.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/human-in-the-loop/agent.mdx
@@ -111,7 +111,7 @@ Now we'll setup the Pydantic AI agent. The flow is hard to understand without a 
         ```python title="agent/sample_agent/agent.py"
         from pydantic_ai import Agent
 
-        agent = Agent('openai:gpt-5.2-mini')
+        agent = Agent('openai:gpt-5.4-mini')
 
         @agent.tool_plain
         async def write_essay(topic: str) -> str:

--- a/docs/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
@@ -54,7 +54,7 @@ state updates, you can reflect these updates natively in your application.
         language: str = "english"
 
 
-    agent = Agent("openai:gpt-5.2-mini", deps_type=StateDeps[AgentState])
+    agent = Agent("openai:gpt-5.4-mini", deps_type=StateDeps[AgentState])
 
 
     @agent.instructions()

--- a/docs/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
@@ -53,7 +53,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
         language: str = "english"
 
 
-    agent = Agent("openai:gpt-5.2-mini", deps_type=StateDeps[AgentState])
+    agent = Agent("openai:gpt-5.4-mini", deps_type=StateDeps[AgentState])
 
 
     @agent.instructions()

--- a/docs/content/docs/integrations/pydantic-ai/shared-state/predictive-state-updates.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/shared-state/predictive-state-updates.mdx
@@ -66,7 +66,7 @@ included in the function's final returned state. Otherwise, they will be overwri
             observed_steps: list[str] = []
 
 
-        agent = Agent('openai:gpt-5.2-mini', deps_type=StateDeps[AgentState])
+        agent = Agent('openai:gpt-5.4-mini', deps_type=StateDeps[AgentState])
         app = agent.to_ag_ui(deps=StateDeps(AgentState()))
 
 


### PR DESCRIPTION
## What
Updated the GPT model specifier from `gpt-mini-5.2` to `gpt-mini-5.4` in the docs.

## Why
`gpt-mini-5.2` does not exist as a valid OpenAI model. A developer following
this doc and copy-pasting the specifier would get a runtime error immediately,
making the example non-functional out of the box.

## Fix
Replaced `gpt-mini-5.2` with `gpt-mini-5.4` which is the correct and valid
model identifier.

## Verified
Confirmed `gpt-mini-5.4` is a valid OpenAI model identifier.