### PR TITLE
fix(docs): replace dots with hyphens in Anthropic model identifiers

### DIFF
--- a/docs/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/docs/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -35,12 +35,12 @@ const agent = new BuiltInAgent({
 
 | Model | Specifier |
 |-------|-----------|
-| Claude Sonnet 4.5 | `anthropic:claude-sonnet-4.5` |
+| Claude Sonnet 4.5 | `anthropic:claude-sonnet-4-5` |
 | Claude Sonnet 4 | `anthropic:claude-sonnet-4` |
-| Claude 3.7 Sonnet | `anthropic:claude-3.7-sonnet` |
-| Claude Opus 4.1 | `anthropic:claude-opus-4.1` |
+| Claude 3.7 Sonnet | `anthropic:claude-3-7-sonnet` |
+| Claude Opus 4.1 | `anthropic:claude-opus-4-1` |
 | Claude Opus 4 | `anthropic:claude-opus-4` |
-| Claude 3.5 Haiku | `anthropic:claude-3.5-haiku` |
+| Claude 3.5 Haiku | `anthropic:claude-3-5-haiku` |
 
 ```typescript
 const agent = new BuiltInAgent({


### PR DESCRIPTION
## What
Updated all Anthropic model specifiers in the docs to use hyphens instead
of dots in version numbers.

## Why
Model identifiers with dots (e.g. `anthropic:claude-sonnet-4.5`) are invalid
and will fail at runtime. The correct format uses hyphens
(e.g. `anthropic:claude-sonnet-4-5`), consistent with how Anthropic
formats its model IDs.

## Fix
Replaced dots with hyphens in the version portion of the following specifiers:

| Before | After |
|--------|-------|
| `anthropic:claude-sonnet-4.5` | `anthropic:claude-sonnet-4-5` |
| `anthropic:claude-3.7-sonnet` | `anthropic:claude-3-7-sonnet` |
| `anthropic:claude-opus-4.1`   | `anthropic:claude-opus-4-1`   |
| `anthropic:claude-3.5-haiku`  | `anthropic:claude-3-5-haiku`  |

Models with whole number versions (`claude-sonnet-4`, `claude-opus-4`)
were already correct and left unchanged.

## Verified
All 6 models confirmed as live and valid against Anthropic's official
models overview at platform.claude.com/docs/en/about-claude/models/overview.
The hyphenated format matches Anthropic's official API IDs
(e.g. `claude-sonnet-4-5-20250929`, `claude-opus-4-1-20250805`).