### PR TITLE
Fix/docs ag2 context variable import

### DIFF
--- a/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
@@ -35,7 +35,7 @@ is a situation where a user and an agent are working together to solve a problem
     from fastapi import FastAPI, Header
     from fastapi.responses import StreamingResponse
     from pydantic import BaseModel, Field
-    from autogen import ContextVariables, ConversableAgent, LLMConfig
+    from autogen import ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
     from autogen.agentchat import ContextVariables
 

--- a/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
@@ -37,6 +37,7 @@ is a situation where a user and an agent are working together to solve a problem
     from pydantic import BaseModel, Field
     from autogen import ContextVariables, ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
+    from autogen.agentchat import ContextVariables
 
 
     class Search(BaseModel):

--- a/docs/content/docs/integrations/ag2/readables.mdx
+++ b/docs/content/docs/integrations/ag2/readables.mdx
@@ -99,7 +99,7 @@ This context can then be shared with your AG2 backend.
                         ```python title="agent.py"
                         from fastapi import FastAPI, Header
                         from fastapi.responses import StreamingResponse
-                        from autogen import ContextVariables, ConversableAgent, LLMConfig
+                        from autogen import ConversableAgent, LLMConfig
                         from autogen.ag_ui import AGUIStream, RunAgentInput
                         from autogen.agentchat import ContextVariables
 

--- a/docs/content/docs/integrations/ag2/readables.mdx
+++ b/docs/content/docs/integrations/ag2/readables.mdx
@@ -101,6 +101,7 @@ This context can then be shared with your AG2 backend.
                         from fastapi.responses import StreamingResponse
                         from autogen import ContextVariables, ConversableAgent, LLMConfig
                         from autogen.ag_ui import AGUIStream, RunAgentInput
+                        from autogen.agentchat import ContextVariables
 
                         def get_readable(context: ContextVariables, description: str):
                             copilot = context.get("copilotkit", {})

--- a/docs/content/docs/integrations/ag2/shared-state/read.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/read.mdx
@@ -49,6 +49,7 @@ state updates, you can reflect these updates natively in your application.
     from fastapi.responses import StreamingResponse
     from autogen import ContextVariables, ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
+    from autogen.agentchat import ContextVariables
 
     def read_state(context: ContextVariables) -> dict:
         return context.get("agent_state", {"language": "english"})

--- a/docs/content/docs/integrations/ag2/shared-state/read.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/read.mdx
@@ -47,7 +47,7 @@ state updates, you can reflect these updates natively in your application.
     from ag_ui.core import EventType, StateSnapshotEvent
     from fastapi import FastAPI, Header
     from fastapi.responses import StreamingResponse
-    from autogen import ContextVariables, ConversableAgent, LLMConfig
+    from autogen import ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
     from autogen.agentchat import ContextVariables
 

--- a/docs/content/docs/integrations/ag2/shared-state/write.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/write.mdx
@@ -48,6 +48,7 @@ You can use this when you want to keep your interface and backend agent state sy
     from fastapi.responses import StreamingResponse
     from autogen import ContextVariables, ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
+    from autogen.agentchat import ContextVariables
 
     def read_state(context: ContextVariables) -> dict:
         return context.get("agent_state", {"language": "english"})

--- a/docs/content/docs/integrations/ag2/shared-state/write.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/write.mdx
@@ -46,7 +46,7 @@ You can use this when you want to keep your interface and backend agent state sy
     from ag_ui.core import EventType, StateSnapshotEvent
     from fastapi import FastAPI, Header
     from fastapi.responses import StreamingResponse
-    from autogen import ContextVariables, ConversableAgent, LLMConfig
+    from autogen import ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
     from autogen.agentchat import ContextVariables
 


### PR DESCRIPTION
docs(ag2): update imports for ContextVariables to match latest AutoGen

- Updated documentation to reflect the new location of `ContextVariables` in AutoGen.
- Replaced the outdated import:
      from autogen import ContextVariables
  with:
      from autogen.agentchat import ContextVariables
- Other imports (`ConversableAgent`, `LLMConfig`, `AGUIStream`, `RunAgentInput`) remain unchanged.
- Ensures the ag2 module documentation is accurate for users following examples and tutorials.
- No functional code changes; this PR is strictly a documentation update.