### PR TITLE
docs(pydantic-quickstart): pin Starlette version in installation inst…

### DIFF
--- a/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -134,7 +134,7 @@ Before you begin, you'll need the following:
                 Add Pydantic AI with AG-UI support and uvicorn to your project:
 
                 ```bash
-                uv add 'pydantic-ai-slim[ag-ui]' 'pydantic-ai-slim[openai]' uvicorn
+                uv add 'pydantic-ai-slim[ag-ui]' 'pydantic-ai-slim[openai]' uvicorn starlette==0.45.3
                 ```
             </Step>
             <Step>


### PR DESCRIPTION
**What**
Updated the installation command in the Pydantic quickstart documentation to pin a compatible Starlette version.

**Why**
The original command:
    uv add 'pydantic-ai-slim[ag-ui]' 'pydantic-ai-slim[openai]' uvicorn
installs Starlette 1.0.0, which is incompatible with the current setup. 
A developer following the documentation would encounter runtime issues if the Starlette version is not pinned.

**Fix**
Replaced the installation command with:
    uv add 'pydantic-ai-slim[ag-ui]' 'pydantic-ai-slim[openai]' uvicorn starlette==0.45.3
This ensures Starlette 0.45.3 is installed, which is compatible with the rest of the environment.

**Verified**
Confirmed that running the updated installation command installs Starlette 0.45.3 and the examples work without runtime errors.