### PR TITLE
docs: add global CSS import to Prebuilt Components examples

### DIFF
--- a/docs/content/docs/integrations/adk/quickstart.mdx
+++ b/docs/content/docs/integrations/adk/quickstart.mdx
@@ -270,6 +270,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
+                import './globals.css';
 
                 // ...
 

--- a/docs/content/docs/integrations/agno/quickstart.mdx
+++ b/docs/content/docs/integrations/agno/quickstart.mdx
@@ -235,6 +235,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
+                import './globals.css'; 
 
                 // ...
 

--- a/docs/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/docs/content/docs/integrations/aws-strands/quickstart.mdx
@@ -251,6 +251,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
+                import './globals.css'; 
 
                 // ...
 

--- a/docs/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/docs/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -104,7 +104,7 @@ Before you begin, you'll need the following:
         ```tsx title="app/layout.tsx"
         import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
         import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
-
+        import './globals.css'; 
         // ...
 
         export default function RootLayout({ children }: {children: React.ReactNode}) {

--- a/docs/content/docs/integrations/langgraph/quickstart.mdx
+++ b/docs/content/docs/integrations/langgraph/quickstart.mdx
@@ -407,6 +407,7 @@ Before you begin, you'll need the following:
               // [!code highlight:2]
               import { CopilotKit } from "@copilotkit/react-core";
               import "@copilotkit/react-ui/v2/styles.css";
+              import './globals.css'; 
 
               // ...
 

--- a/docs/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/docs/content/docs/integrations/llamaindex/quickstart.mdx
@@ -278,6 +278,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
+                import './globals.css'; 
 
                 // ...
 

--- a/docs/content/docs/integrations/mastra/quickstart.mdx
+++ b/docs/content/docs/integrations/mastra/quickstart.mdx
@@ -238,6 +238,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
+                import './globals.css'; 
 
                 // ...
 

--- a/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -380,6 +380,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
+                import './globals.css'; 
 
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (

--- a/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/docs/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -228,6 +228,7 @@ Before you begin, you'll need the following:
                 ```tsx title="app/layout.tsx"
                 import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
+                import './globals.css'; 
 
                 // ...
 


### PR DESCRIPTION
**What**  
Fixed the Prebuilt Components page examples across all frameworks by adding a global CSS import.

**Why**  
The Customization section at the end of the Prebuilt Components page allows changing text, background, and other styles.  
However, the code snippets do not work on their own because `globals.css` (containing base/global styles) was not imported in `layout.tsx`. Developers copying the examples would not see any style changes.

**Fix**  
Added the following line to `layout.tsx` in the quickstart of all frameworks:
```ts
import './globals.css';