### PR TITLE
docs: remove deprecated CLI instructions from Crew AI Flows quickstart

### DIFF
--- a/docs/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/docs/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -60,6 +60,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
         </div>
     }
 >
+    {/* 
     <TailoredContentOption
         id="cli"
         title="Use the CopilotKit CLI (NextJS only)"
@@ -102,6 +103,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
             ```
         </Step>
     </TailoredContentOption>
+    */}
     <TailoredContentOption
         id="code-along"
         title="Code along"


### PR DESCRIPTION
**What**  
Removed the deprecated CLI method from the Crew AI Flows quickstart documentation.

**Why**  
The CLI method no longer works and shows a deprecation warning when used.  
Keeping it in the documentation would mislead developers and cause errors.

**Fix**  
Deleted references to the CLI method and instructions from the quickstart docs.

**Verified**  
Confirmed that the documentation now only includes supported methods for Crew AI Flows and no deprecated CLI instructions remain.