### PR TITLE
docs: add missing default export in CopilotChat example

### DIFF
--- a/docs/content/docs/integrations/langgraph/prebuilt-components.mdx
+++ b/docs/content/docs/integrations/langgraph/prebuilt-components.mdx
@@ -38,7 +38,7 @@ A flexible chat component that can be placed anywhere in your app and sized as n
 // [!code word:CopilotChat]
 import { CopilotChat } from "@copilotkit/react-core/v2";
 
-export function YourComponent() {
+export default function YourComponent() {
   return (
     <CopilotChat
       labels={{

--- a/docs/snippets/shared/basics/prebuilt-components.mdx
+++ b/docs/snippets/shared/basics/prebuilt-components.mdx
@@ -31,7 +31,7 @@ A flexible chat component that can be placed anywhere in your app and sized as n
 // [!code word:CopilotChat]
 import { CopilotChat } from "@copilotkit/react-core/v2";
 
-export function YourComponent() {
+export default function YourComponent() {
   return (
     <CopilotChat
       labels={{


### PR DESCRIPTION
**What**  
Fixed the CopilotChat example in the Prebuilt Components section by adding a default export.

**Why**  
The example used:
```ts
export function YourComponent()