### PR TITLE
docs: fix Strands agent state initialization in multiple guides

### DIFF
--- a/docs/content/docs/integrations/aws-strands/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/aws-strands/generative-ui/state-rendering.mdx
@@ -40,6 +40,7 @@ is a situation where a user and an agent are working together to solve a problem
 
     ```python title="agent/main.py"
     import json
+    import os
     from ag_ui_strands import StrandsAgent, StrandsAgentConfig, ToolBehavior, create_strands_app
     from strands import Agent, tool
     from strands.models.openai import OpenAIModel
@@ -86,6 +87,11 @@ is a situation where a user and an agent are working together to solve a problem
         system_prompt="You are a helpful assistant for storing searches. Use the add_search tool to add searches.",
         tools=[add_search],
     )
+
+    # Patch the state object to add the _state attribute
+    # that ag-ui-strands expects
+    if not hasattr(strands_agent.state, '_state'):
+      strands_agent.state._state = strands_agent.state
 
     agui_agent = StrandsAgent(
         agent=strands_agent,

--- a/docs/content/docs/integrations/aws-strands/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/integrations/aws-strands/generative-ui/tool-rendering.mdx
@@ -78,6 +78,11 @@ agent = Agent(
     tools=[get_weather],  # [!code highlight]
 )
 
+# Patch the state object to add the _state attribute
+# that ag-ui-strands expects
+if not hasattr(agent.state, '_state'):
+   agent.state._state = agent.state
+
 # Wrap with AG-UI integration
 agui_agent = StrandsAgent(
     agent=agent,

--- a/docs/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/docs/content/docs/integrations/aws-strands/quickstart.mdx
@@ -173,6 +173,12 @@ Before you begin, you'll need the following:
                     system_prompt="You are a helpful AI assistant.",
                 )
 
+                # Patch the state object to add the _state attribute
+                # that ag-ui-strands expects
+                if not hasattr(agent.state, '_state'):
+                    agent.state._state = agent.state
+
+
                 # Wrap with AG-UI integration
                 agui_agent = StrandsAgent(
                     agent=agent,

--- a/docs/content/docs/integrations/aws-strands/shared-state/in-app-agent-read.mdx
+++ b/docs/content/docs/integrations/aws-strands/shared-state/in-app-agent-read.mdx
@@ -67,6 +67,11 @@ state updates, you can reflect these updates natively in your application.
 
     config = StrandsAgentConfig(state_context_builder=language_prompt)
 
+    # Patch the state object to add the _state attribute
+    # that ag-ui-strands expects
+    if not hasattr(strands_agent.state, '_state'):
+      strands_agent.state._state = strands_agent.state
+
     # Wrap with AG-UI integration
     agui_agent = StrandsAgent(
         agent=strands_agent,

--- a/docs/content/docs/integrations/aws-strands/shared-state/in-app-agent-write.mdx
+++ b/docs/content/docs/integrations/aws-strands/shared-state/in-app-agent-write.mdx
@@ -66,6 +66,12 @@ You can use this when you want to provide user input or control to your agent's 
 
     config = StrandsAgentConfig(state_context_builder=language_prompt)
 
+    # Patch the state object to add the _state attribute
+    # that ag-ui-strands expects
+    if not hasattr(strands_agent.state, '_state'):
+      strands_agent.state._state = strands_agent.state
+
+    
     # Wrap with AG-UI integration
     agui_agent = StrandsAgent(
         agent=strands_agent,


### PR DESCRIPTION
## What
Added a missing state patch across multiple AWS Strands documentation pages
to fix a runtime error when wrapping agents with `StrandsAgent`.

## Why
Without this patch, all Strands integration examples fail immediately with:

    AttributeError: 'JSONSerializableDict' object has no attribute '_state'

## Pages Fixed

| Page | Section |
|------|---------|
| Quickstart > Use an Existing Agent | Section 4 - Expose your agent via AG-UI |
| Generative UI > Tool Rendering | Section 2 - Give your agent a tool to call |
| Generative UI > State Rendering | Section 2 - Setup your AWS Strands agent with state |
| Shared State > Reading agent state | Section 2 - Setup your agent with state |
| Shared State > Writing agent state | Section 2 - Setup your agent with state |

## Fix
Added the following patch before every `StrandsAgent` initialization:

    if not hasattr(agent.state, '_state'):
        agent.state._state = agent.state

Also added missing `import os` in Generative UI > State Rendering.

## Verified
All affected sections run without errors after applying the patch.