### PR TITLE
fix(react-core): clear controlled CopilotChatInput on send

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -455,10 +455,7 @@ export function CopilotChatInput({
 
     onSubmitMessage(trimmed);
 
-    if (!isControlled) {
-      setInternalValue("");
-      onChange?.("");
-    }
+    clearInputValue();
 
     if (inputRef.current) {
       inputRef.current.focus();

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
@@ -854,6 +854,25 @@ describe("CopilotChatInput", () => {
       expect(mockOnSubmitMessage).toHaveBeenCalledWith("test message");
     });
 
+    it("calls onChange with empty string after sending to clear the input", () => {
+      const mockOnChange = vi.fn();
+      const mockOnSubmitMessage = vi.fn();
+
+      const { container } = renderWithProvider(
+        <CopilotChatInput
+          value="test message"
+          onChange={mockOnChange}
+          onSubmitMessage={mockOnSubmitMessage}
+        />,
+      );
+
+      const sendButton = getSendButton(container);
+      fireEvent.click(sendButton!);
+
+      expect(mockOnSubmitMessage).toHaveBeenCalledWith("test message");
+      expect(mockOnChange).toHaveBeenCalledWith("");
+    });
+
     it("trims whitespace when submitting", () => {
       const mockOnChange = vi.fn();
       const mockOnSubmitMessage = vi.fn();


### PR DESCRIPTION
## What does this PR do?

Fixes #3593 — when `CopilotChatInput` is used as a controlled component (with `value` + `onChange` props), sending a message never calls `onChange("")`, so the parent component is never notified to clear the input.

The `send()` function had inline clearing logic that only ran in uncontrolled mode:

```ts
if (!isControlled) {
  setInternalValue("");
  onChange?.("");
}
```

The component already has a `clearInputValue()` helper that handles both modes correctly — it calls `setInternalValue("")` for uncontrolled, and always calls `onChange("")` when the prop exists. This PR replaces the inline logic with `clearInputValue()`.

The existing test "does not clear input after submission when controlled" still passes because it checks the DOM textarea value, which stays unchanged since the test parent doesn't re-render with a new `value` prop — this is correct React controlled component behavior.

## Related PRs and Issues

- Fixes #3593

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation