### PR TITLE
docs(adk): fix workflow-execution snippet to run the agent

### DIFF
--- a/docs/content/docs/integrations/adk/shared-state/workflow-execution.mdx
+++ b/docs/content/docs/integrations/adk/shared-state/workflow-execution.mdx
@@ -128,36 +128,84 @@ In addition, some state properties contain a lot of information. Syncing them ba
     ```tsx title="ui/app/page.tsx"
     "use client";
 
-    import { useAgent } from "@copilotkit/react-core/v2";
+    import { useState } from "react";
+    import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
 
-    // Only define the types for state you'll interact with
+    // Define the agent state type, should match the actual state of your agent
     type AgentState = {
       question: string;
       answer: string;
-      // Note: 'resources' is intentionally omitted - it's internal to the agent
     }
 
-    function YourMainContent() {
+    /* Example usage in a pseudo React component */
+    function YourMainContent() { // [!code highlight]
+      const [inputQuestion, setInputQuestion] = useState("What's the capital of France?");
+      const [isLoading, setIsLoading] = useState(false);
+
       const { agent } = useAgent({
         agentId: "my_agent",
-        initialState: {
-          question: "How's the weather in SF?",
-          answer: "",
-        }
       });
+      const { copilotkit } = useCopilotKit();
 
-      const askQuestion = (newQuestion: string) => {
-        agent.setState({ ...agent.state, question: newQuestion });
+      const askQuestion = async (newQuestion: string) => {
+        setIsLoading(true);
+
+        // Update the state with the new question
+        agent.setState({ ...agent.state, question: newQuestion, answer: "" });
+
+        try {
+          // Add a message and trigger the agent to run
+          agent.addMessage({
+            id: crypto.randomUUID(),
+            role: "user",
+            content: newQuestion,
+          });
+          await copilotkit.runAgent({ agent });
+        } catch (error) {
+          console.error("Error running agent:", error);
+        } finally {
+          setIsLoading(false);
+        }
       };
 
       return (
-        <div>
+        <div style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
           <h1>Q&A Assistant</h1>
-          <p><strong>Question:</strong> {agent.state?.question}</p>
-          <p><strong>Answer:</strong> {agent.state?.answer || "Waiting for response..."}</p>
-          <button onClick={() => askQuestion("What's the capital of France?")}>
-            Ask New Question
-          </button>
+          
+          <div style={{ marginBottom: "1rem" }}>
+            <input
+              type="text"
+              value={inputQuestion}
+              onChange={(e) => setInputQuestion(e.target.value)}
+              placeholder="Enter your question..."
+              style={{ 
+                padding: "0.5rem", 
+                width: "300px", 
+                marginRight: "0.5rem",
+                borderRadius: "4px",
+                border: "1px solid #ccc"
+              }}
+            />
+            <button 
+              onClick={() => askQuestion(inputQuestion)}
+              disabled={isLoading || !inputQuestion.trim()}
+              style={{
+                padding: "0.5rem 1rem",
+                borderRadius: "4px",
+                border: "none",
+                backgroundColor: isLoading ? "#ccc" : "#0070f3",
+                color: "white",
+                cursor: isLoading ? "not-allowed" : "pointer"
+              }}
+            >
+              {isLoading ? "Thinking..." : "Ask Question"}
+            </button>
+          </div>
+
+          <div style={{ marginTop: "1.5rem" }}>
+            <p><strong>Question:</strong> {agent.state?.question || "(none yet)"}</p>
+            <p><strong>Answer:</strong> {agent.state?.answer || (isLoading ? "Thinking..." : "Waiting for question...")}</p>
+          </div>
         </div>
       );
     }

--- a/showcase/shell/src/content/docs/integrations/adk/shared-state/workflow-execution.mdx
+++ b/showcase/shell/src/content/docs/integrations/adk/shared-state/workflow-execution.mdx
@@ -129,35 +129,84 @@ In addition, some state properties contain a lot of information. Syncing them ba
     ```tsx title="ui/app/page.tsx"
     "use client";
 
+    import { useState } from "react";
+    import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
 
-    // Only define the types for state you'll interact with
+    // Define the agent state type, should match the actual state of your agent
     type AgentState = {
       question: string;
       answer: string;
-      // Note: 'resources' is intentionally omitted - it's internal to the agent
     }
 
-    function YourMainContent() {
+    /* Example usage in a pseudo React component */
+    function YourMainContent() { // [!code highlight]
+      const [inputQuestion, setInputQuestion] = useState("What's the capital of France?");
+      const [isLoading, setIsLoading] = useState(false);
+
       const { agent } = useAgent({
         agentId: "my_agent",
-        initialState: {
-          question: "How's the weather in SF?",
-          answer: "",
-        }
       });
+      const { copilotkit } = useCopilotKit();
 
-      const askQuestion = (newQuestion: string) => {
-        agent.setState({ ...agent.state, question: newQuestion });
+      const askQuestion = async (newQuestion: string) => {
+        setIsLoading(true);
+
+        // Update the state with the new question
+        agent.setState({ ...agent.state, question: newQuestion, answer: "" });
+
+        try {
+          // Add a message and trigger the agent to run
+          agent.addMessage({
+            id: crypto.randomUUID(),
+            role: "user",
+            content: newQuestion,
+          });
+          await copilotkit.runAgent({ agent });
+        } catch (error) {
+          console.error("Error running agent:", error);
+        } finally {
+          setIsLoading(false);
+        }
       };
 
       return (
-        <div>
+        <div style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
           <h1>Q&A Assistant</h1>
-          <p><strong>Question:</strong> {agent.state?.question}</p>
-          <p><strong>Answer:</strong> {agent.state?.answer || "Waiting for response..."}</p>
-          <button onClick={() => askQuestion("What's the capital of France?")}>
-            Ask New Question
-          </button>
+          
+          <div style={{ marginBottom: "1rem" }}>
+            <input
+              type="text"
+              value={inputQuestion}
+              onChange={(e) => setInputQuestion(e.target.value)}
+              placeholder="Enter your question..."
+              style={{ 
+                padding: "0.5rem", 
+                width: "300px", 
+                marginRight: "0.5rem",
+                borderRadius: "4px",
+                border: "1px solid #ccc"
+              }}
+            />
+            <button 
+              onClick={() => askQuestion(inputQuestion)}
+              disabled={isLoading || !inputQuestion.trim()}
+              style={{
+                padding: "0.5rem 1rem",
+                borderRadius: "4px",
+                border: "none",
+                backgroundColor: isLoading ? "#ccc" : "#0070f3",
+                color: "white",
+                cursor: isLoading ? "not-allowed" : "pointer"
+              }}
+            >
+              {isLoading ? "Thinking..." : "Ask Question"}
+            </button>
+          </div>
+
+          <div style={{ marginTop: "1.5rem" }}>
+            <p><strong>Question:</strong> {agent.state?.question || "(none yet)"}</p>
+            <p><strong>Answer:</strong> {agent.state?.answer || (isLoading ? "Thinking..." : "Waiting for question...")}</p>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
# Summary
Updates the ADK **Workflow execution** shared-state example so the UI actually runs the agent (same pattern as LlamaIndex): \`setState\` → \`addMessage\` → \`await copilotkit.runAgent({ agent })\`, with matching input/button UI and error handling.
## Changes
- \`docs/content/docs/integrations/adk/shared-state/workflow-execution.mdx\`
- \`showcase/shell/src/content/docs/integrations/adk/shared-state/workflow-execution.mdx\`
## Why
The prior snippet only called \`agent.setState()\`, so the backend never ran and \`answer\` did not update reliably.
