### PR TITLE
Docs/built in agent tool rendering server tools link

### DIFF
--- a/docs/snippets/shared/generative-ui/tool-rendering.mdx
+++ b/docs/snippets/shared/generative-ui/tool-rendering.mdx
@@ -27,7 +27,16 @@ Rendering tools in the UI is useful when you want to provide the user with feedb
 Use the `useRenderTool` hook to render tool calls in the UI. The name must match the name of the tool defined in your agent.
 
 <Callout type="info" title="Important">
-  In order to render a tool call in the UI, the name must match the name of the tool.
+  In order to render a tool call in the UI, the name must match the name of the
+  tool.{" "}
+  <a
+    href="https://docs.copilotkit.ai/built-in-agent/server-tools"
+    target="_blank"
+    rel="noreferrer"
+  >
+    Learn more
+  </a>
+  .
 </Callout>
 
 ```tsx title="app/page.tsx"

--- a/docs/snippets/shared/generative-ui/tool-rendering.mdx
+++ b/docs/snippets/shared/generative-ui/tool-rendering.mdx
@@ -27,16 +27,7 @@ Rendering tools in the UI is useful when you want to provide the user with feedb
 Use the `useRenderTool` hook to render tool calls in the UI. The name must match the name of the tool defined in your agent.
 
 <Callout type="info" title="Important">
-  In order to render a tool call in the UI, the name must match the name of the
-  tool.{" "}
-  <a
-    href="https://docs.copilotkit.ai/built-in-agent/server-tools"
-    target="_blank"
-    rel="noreferrer"
-  >
-    Learn more
-  </a>
-  .
+In order to render a tool call in the UI, the name must match the name of the tool. [Learn more](/built-in-agent/server-tools).
 </Callout>
 
 ```tsx title="app/page.tsx"

--- a/showcase/shell/src/content/snippets/shared/generative-ui/tool-rendering.mdx
+++ b/showcase/shell/src/content/snippets/shared/generative-ui/tool-rendering.mdx
@@ -34,16 +34,7 @@ Rendering tools in the UI is useful when you want to provide the user with feedb
 Use the `useRenderTool` hook to render tool calls in the UI. The name must match the name of the tool defined in your agent.
 
 <Callout type="info" title="Important">
-  In order to render a tool call in the UI, the name must match the name of the
-  tool.{" "}
-  <a
-    href="https://docs.copilotkit.ai/built-in-agent/server-tools"
-    target="_blank"
-    rel="noreferrer"
-  >
-    Learn more
-  </a>
-  .
+In order to render a tool call in the UI, the name must match the name of the tool. [Learn more](/built-in-agent/server-tools).
 </Callout>
 
 ```tsx title="app/page.tsx"

--- a/showcase/shell/src/content/snippets/shared/generative-ui/tool-rendering.mdx
+++ b/showcase/shell/src/content/snippets/shared/generative-ui/tool-rendering.mdx
@@ -35,7 +35,15 @@ Use the `useRenderTool` hook to render tool calls in the UI. The name must match
 
 <Callout type="info" title="Important">
   In order to render a tool call in the UI, the name must match the name of the
-  tool.
+  tool.{" "}
+  <a
+    href="https://docs.copilotkit.ai/built-in-agent/server-tools"
+    target="_blank"
+    rel="noreferrer"
+  >
+    Learn more
+  </a>
+  .
 </Callout>
 
 ```tsx title="app/page.tsx"


### PR DESCRIPTION
### Summary
The shared Tool rendering snippet’s **Important** callout now includes a **Learn more** link to the Built-in Agent [Server tools](https://docs.copilotkit.ai/built-in-agent/server-tools) page, using a relative path (`/built-in-agent/server-tools`) consistent with other Built-in Agent docs.

### Why
Tool UI only matters after tools exist on the server. The link points readers to where tools are defined and registered so they are less likely to assume `useRenderTool` alone is enough.

### Changes
- `docs/snippets/shared/generative-ui/tool-rendering.mdx`
- `showcase/shell/src/content/snippets/shared/generative-ui/tool-rendering.mdx`

