### PR TITLE
Fix/showcase docs ag2 context variable import

### DIFF
--- a/docs/content/docs/integrations/ag2/human-in-the-loop.mdx
+++ b/docs/content/docs/integrations/ag2/human-in-the-loop.mdx
@@ -106,8 +106,9 @@ Use frontend tools when you need your agent to interact with client-side primiti
         from ag_ui.core import EventType, StateSnapshotEvent
         from fastapi import FastAPI, Header
         from fastapi.responses import StreamingResponse
-        from autogen import ContextVariables, ConversableAgent, LLMConfig
+        from autogen import ConversableAgent, LLMConfig
         from autogen.ag_ui import AGUIStream, RunAgentInput
+        from autogen.agentchat import ContextVariables
 
         agent = ConversableAgent(
             name="assistant",

--- a/showcase/shell/src/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
+++ b/showcase/shell/src/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
@@ -41,8 +41,9 @@ is a situation where a user and an agent are working together to solve a problem
     from fastapi import FastAPI, Header
     from fastapi.responses import StreamingResponse
     from pydantic import BaseModel, Field
-    from autogen import ContextVariables, ConversableAgent, LLMConfig
+    from autogen import ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
+    from autogen.agentchat import ContextVariables
 
 
     class Search(BaseModel):

--- a/showcase/shell/src/content/docs/integrations/ag2/human-in-the-loop.mdx
+++ b/showcase/shell/src/content/docs/integrations/ag2/human-in-the-loop.mdx
@@ -113,8 +113,9 @@ Use frontend tools when you need your agent to interact with client-side primiti
         from ag_ui.core import EventType, StateSnapshotEvent
         from fastapi import FastAPI, Header
         from fastapi.responses import StreamingResponse
-        from autogen import ContextVariables, ConversableAgent, LLMConfig
+        from autogen import ConversableAgent, LLMConfig
         from autogen.ag_ui import AGUIStream, RunAgentInput
+        from autogen.agentchat import ContextVariables
 
         agent = ConversableAgent(
             name="assistant",

--- a/showcase/shell/src/content/docs/integrations/ag2/readables.mdx
+++ b/showcase/shell/src/content/docs/integrations/ag2/readables.mdx
@@ -104,8 +104,9 @@ This context can then be shared with your AG2 backend.
                         ```python title="agent.py"
                         from fastapi import FastAPI, Header
                         from fastapi.responses import StreamingResponse
-                        from autogen import ContextVariables, ConversableAgent, LLMConfig
+                        from autogen import ConversableAgent, LLMConfig
                         from autogen.ag_ui import AGUIStream, RunAgentInput
+                        from autogen.agentchat import ContextVariables
 
                         def get_readable(context: ContextVariables, description: str):
                             copilot = context.get("copilotkit", {})
@@ -198,8 +199,9 @@ This context can then be shared with your AG2 backend.
                         ```python title="agent.py"
                         from fastapi import FastAPI, Header
                         from fastapi.responses import StreamingResponse
-                        from autogen import ContextVariables, ConversableAgent, LLMConfig
+                        from autogen import ConversableAgent, LLMConfig
                         from autogen.ag_ui import AGUIStream, RunAgentInput
+                        from autogen.agentchat import ContextVariables
 
                         agent = ConversableAgent(
                             name="assistant",

--- a/showcase/shell/src/content/docs/integrations/ag2/shared-state/read.mdx
+++ b/showcase/shell/src/content/docs/integrations/ag2/shared-state/read.mdx
@@ -54,8 +54,9 @@ state updates, you can reflect these updates natively in your application.
     from ag_ui.core import EventType, StateSnapshotEvent
     from fastapi import FastAPI, Header
     from fastapi.responses import StreamingResponse
-    from autogen import ContextVariables, ConversableAgent, LLMConfig
+    from autogen import ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
+    from autogen.agentchat import ContextVariables
 
     def read_state(context: ContextVariables) -> dict:
         return context.get("agent_state", {"language": "english"})

--- a/showcase/shell/src/content/docs/integrations/ag2/shared-state/write.mdx
+++ b/showcase/shell/src/content/docs/integrations/ag2/shared-state/write.mdx
@@ -53,8 +53,9 @@ You can use this when you want to keep your interface and backend agent state sy
     from ag_ui.core import EventType, StateSnapshotEvent
     from fastapi import FastAPI, Header
     from fastapi.responses import StreamingResponse
-    from autogen import ContextVariables, ConversableAgent, LLMConfig
+    from autogen import ConversableAgent, LLMConfig
     from autogen.ag_ui import AGUIStream, RunAgentInput
+    from autogen.agentchat import ContextVariables
 
     def read_state(context: ContextVariables) -> dict:
         return context.get("agent_state", {"language": "english"})


### PR DESCRIPTION
docs(ag2): update imports for ContextVariables to match latest AutoGen

- Updated documentation to reflect the new location of `ContextVariables` in AutoGen.
- Replaced the outdated import:
      from autogen import ContextVariables
  with:
      from autogen.agentchat import ContextVariables
- Other imports (`ConversableAgent`, `LLMConfig`, `AGUIStream`, `RunAgentInput`) remain unchanged.
- Ensures the ag2 module documentation is accurate for users following examples and tutorials.
- No functional code changes; this PR is strictly a documentation update.