### PR TITLE
fix: respect Retry-After header on 429 responses

### DIFF
--- a/packages/runtime/src/lib/runtime/retry-utils.ts
+++ b/packages/runtime/src/lib/runtime/retry-utils.ts
@@ -1,5 +1,32 @@
 import { Logger } from "pino";
 
+// Maximum Retry-After value (in seconds) we're willing to wait.
+// Beyond this, the 429 likely indicates quota exhaustion, not a transient spike.
+const MAX_RETRY_AFTER_SECONDS = 60;
+
+// Parse the Retry-After header value into seconds.
+// Handles both numeric seconds ("120") and HTTP-date format
+// ("Wed, 21 Oct 2015 07:28:00 GMT").
+// Returns null if the value cannot be parsed.
+export function parseRetryAfter(value: string): number | null {
+  const trimmed = value.trim();
+
+  // Numeric seconds
+  const asNumber = Number(trimmed);
+  if (!Number.isNaN(asNumber) && asNumber >= 0) {
+    return asNumber;
+  }
+
+  // HTTP-date format
+  const date = new Date(trimmed);
+  if (!Number.isNaN(date.getTime())) {
+    const diffMs = date.getTime() - Date.now();
+    return Math.max(0, Math.ceil(diffMs / 1000));
+  }
+
+  return null;
+}
+
 // Retry configuration for network requests
 export const RETRY_CONFIG = {
   maxRetries: 3,
@@ -61,6 +88,45 @@ export async function fetchWithRetry(
   for (let attempt = 0; attempt <= RETRY_CONFIG.maxRetries; attempt++) {
     try {
       const response = await fetch(url, options);
+
+      // Handle 429 responses with Retry-After awareness
+      if (response.status === 429) {
+        const retryAfterHeader = response.headers.get("Retry-After");
+        const retryAfterSeconds =
+          retryAfterHeader != null
+            ? parseRetryAfter(retryAfterHeader)
+            : null;
+
+        // If Retry-After exceeds our threshold, this is likely quota
+        // exhaustion — surface the error immediately instead of wasting retries.
+        if (
+          retryAfterSeconds != null &&
+          retryAfterSeconds > MAX_RETRY_AFTER_SECONDS
+        ) {
+          throw new Error(
+            `Rate-limited by ${url} with Retry-After: ${retryAfterSeconds}s ` +
+              `(exceeds ${MAX_RETRY_AFTER_SECONDS}s threshold). ` +
+              `This likely indicates quota exhaustion — not retrying.`,
+          );
+        }
+
+        // For short Retry-After values, honor the header as the delay
+        if (
+          retryAfterSeconds != null &&
+          retryAfterSeconds > 0 &&
+          attempt < RETRY_CONFIG.maxRetries
+        ) {
+          const delay = retryAfterSeconds * 1000;
+          logger?.warn(
+            `Request to ${url} rate-limited (429) with Retry-After: ${retryAfterSeconds}s. ` +
+              `Retrying attempt ${attempt + 1}/${RETRY_CONFIG.maxRetries + 1} in ${delay}ms.`,
+          );
+          await sleep(delay);
+          continue;
+        }
+
+        // No Retry-After header (or zero value) — fall through to standard backoff
+      }
 
       // If response is retryable, treat as error and retry
       if (


### PR DESCRIPTION
## Summary
- Adds `parseRetryAfter()` helper that handles both numeric seconds and HTTP-date formats
- When 429 response includes `Retry-After > 60s`, throws immediately with descriptive error (quota exhaustion) instead of wasting retries
- When `Retry-After <= 60s`, uses the header value as delay instead of `calculateDelay()`
- No behavioral change for non-429 retryable status codes (502, 503, 504)

## Relates to
Relates to #3637

## Changes
- `packages/runtime/src/lib/runtime/retry-utils.ts` — added `parseRetryAfter()`, `MAX_RETRY_AFTER_SECONDS` constant, and 429-specific handler in `fetchWithRetry`

## Test plan
- [ ] 429 with `Retry-After: 5` — retries after 5 seconds
- [ ] 429 with `Retry-After: 3600` — throws immediately with quota exhaustion message
- [ ] 429 without `Retry-After` — falls back to existing exponential backoff
- [ ] 502/503/504 — unchanged behavior (exponential backoff)