### PR TITLE
fix: validate slot prop types and warn on invalid objects

### DIFF
--- a/packages/react-core/src/v2/lib/slots.tsx
+++ b/packages/react-core/src/v2/lib/slots.tsx
@@ -125,6 +125,22 @@ function renderSlotElement(
 
   // If slot is a plain object (not a React element), treat it as props override
   if (slot && typeof slot === "object" && !React.isValidElement(slot)) {
+    const slotKeys = Object.keys(slot);
+    const defaultPropKeys = Object.keys(props);
+    const recognizedKeys = new Set([...defaultPropKeys, "className", "style", "children", "id"]);
+    const hasValidKeys =
+      slotKeys.length === 0 || slotKeys.some((key) => recognizedKeys.has(key));
+
+    if (!hasValidKeys) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          `[CopilotKit] Slot received a plain object with unrecognized keys: [${slotKeys.join(", ")}]. ` +
+            `Expected a React element, component, string, or partial props object. Falling back to defaults.`,
+        );
+      }
+      return React.createElement(DefaultComponent, props);
+    }
+
     return React.createElement(DefaultComponent, {
       ...props,
       ...slot,


### PR DESCRIPTION
## Summary
- Validates plain objects passed as slot props against recognized key names before spreading
- Falls back to default rendering when unrecognized keys are detected (e.g. HTTP headers passed as `header` prop)
- Logs a development-mode warning identifying the invalid keys

## Relates to
Relates to #3626

## Changes
- `packages/react-core/src/v2/lib/slots.tsx` — added validation in `renderSlotElement` for the plain-object branch

## Test plan
- [ ] Valid partial props object (e.g. `{ className: "foo" }`) — works as before
- [ ] Invalid object (e.g. `{ "x-user-id": "alice" }`) — falls back to defaults, warns in dev
- [ ] React element slot — unchanged behavior
- [ ] String slot (className) — unchanged behavior
- [ ] Close button works with invalid header prop (previously broken)