### PR TITLE
feat: add isOpen and onOpenChange props to CopilotSidebar

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -55,6 +55,10 @@ export type CopilotChatProps = Omit<
   labels?: Partial<CopilotChatLabels>;
   chatView?: SlotValue<typeof CopilotChatView>;
   isModalDefaultOpen?: boolean;
+  /** Controlled mode: external source of truth for modal open/close state. */
+  isModalOpen?: boolean;
+  /** Callback fired when the modal wants to change its open state. */
+  onModalOpenChange?: (open: boolean) => void;
   /** Enable multimodal file attachments (images, audio, video, documents). */
   attachments?: AttachmentsConfig;
   /**
@@ -86,6 +90,8 @@ export function CopilotChat({
   labels,
   chatView,
   isModalDefaultOpen,
+  isModalOpen,
+  onModalOpenChange,
   attachments: attachmentsConfig,
   onError,
   throttleMs,
@@ -533,6 +539,8 @@ export function CopilotChat({
       threadId={resolvedThreadId}
       labels={labels}
       isModalDefaultOpen={isModalDefaultOpen}
+      isModalOpen={isModalOpen}
+      onModalOpenChange={onModalOpenChange}
     >
       <div ref={chatContainerRef} style={{ display: "contents" }}>
         {attachmentsEnabled && (

--- a/packages/react-core/src/v2/components/chat/CopilotSidebar.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotSidebar.tsx
@@ -9,10 +9,14 @@ import {
   CopilotSidebarViewProps,
 } from "./CopilotSidebarView";
 
-export type CopilotSidebarProps = Omit<CopilotChatProps, "chatView"> & {
+export type CopilotSidebarProps = Omit<CopilotChatProps, "chatView" | "isModalOpen" | "onModalOpenChange"> & {
   header?: CopilotSidebarViewProps["header"];
   toggleButton?: CopilotSidebarViewProps["toggleButton"];
   defaultOpen?: boolean;
+  /** Controlled mode: external source of truth for open/close state. */
+  isOpen?: boolean;
+  /** Callback fired when the sidebar wants to change its open state. */
+  onOpenChange?: (open: boolean) => void;
   width?: number | string;
 };
 
@@ -20,6 +24,8 @@ export function CopilotSidebar({
   header,
   toggleButton,
   defaultOpen,
+  isOpen,
+  onOpenChange,
   width,
   ...chatProps
 }: CopilotSidebarProps) {
@@ -65,6 +71,8 @@ export function CopilotSidebar({
         welcomeScreen={CopilotSidebarView.WelcomeScreen}
         {...chatProps}
         isModalDefaultOpen={defaultOpen}
+        isModalOpen={isOpen}
+        onModalOpenChange={onOpenChange}
         chatView={SidebarViewOverride}
       />
     </>

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -58,12 +58,16 @@ export interface CopilotChatConfigurationProviderProps {
   agentId?: string;
   threadId?: string;
   isModalDefaultOpen?: boolean;
+  /** Controlled mode: external source of truth for modal open/close state. */
+  isModalOpen?: boolean;
+  /** Callback fired when the modal wants to change its open state. */
+  onModalOpenChange?: (open: boolean) => void;
 }
 
 // Provider component
 export const CopilotChatConfigurationProvider: React.FC<
   CopilotChatConfigurationProviderProps
-> = ({ children, labels, agentId, threadId, isModalDefaultOpen }) => {
+> = ({ children, labels, agentId, threadId, isModalDefaultOpen, isModalOpen: externalIsOpen, onModalOpenChange }) => {
   const parentConfig = useContext(CopilotChatConfiguration);
 
   // Stabilize labels references so that inline objects (new reference on every
@@ -94,6 +98,10 @@ export const CopilotChatConfigurationProvider: React.FC<
 
   const resolvedDefaultOpen = isModalDefaultOpen ?? true;
 
+  // Controlled vs uncontrolled mode:
+  // When externalIsOpen is provided, the consumer owns the open/close state.
+  const isControlled = externalIsOpen !== undefined;
+
   const [internalModalOpen, setInternalModalOpen] =
     useState<boolean>(resolvedDefaultOpen);
 
@@ -106,11 +114,14 @@ export const CopilotChatConfigurationProvider: React.FC<
   // "outer hook always returns true" regression (CPK-7152 Behavior B).
   const setAndSync = useCallback(
     (open: boolean) => {
-      setInternalModalOpen(open);
+      if (!isControlled) {
+        setInternalModalOpen(open);
+      }
+      onModalOpenChange?.(open);
       parentConfig?.setModalOpen(open);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [parentConfig?.setModalOpen],
+    [parentConfig?.setModalOpen, isControlled, onModalOpenChange],
   );
 
   // Sync parent → child: when an ancestor's modal state is changed externally
@@ -126,15 +137,20 @@ export const CopilotChatConfigurationProvider: React.FC<
       return;
     }
     if (parentConfig?.isModalOpen === undefined) return;
-    setInternalModalOpen(parentConfig.isModalOpen);
-  }, [parentConfig?.isModalOpen, hasExplicitDefault]);
+    if (!isControlled) {
+      setInternalModalOpen(parentConfig.isModalOpen);
+    }
+  }, [parentConfig?.isModalOpen, hasExplicitDefault, isControlled]);
 
-  const resolvedIsModalOpen = hasExplicitDefault
-    ? internalModalOpen
-    : (parentConfig?.isModalOpen ?? internalModalOpen);
-  const resolvedSetModalOpen = hasExplicitDefault
+  // In controlled mode, use externalIsOpen; otherwise fall back to internal state.
+  const resolvedIsModalOpen = isControlled
+    ? externalIsOpen
+    : hasExplicitDefault
+      ? internalModalOpen
+      : (parentConfig?.isModalOpen ?? internalModalOpen);
+  const resolvedSetModalOpen = hasExplicitDefault || isControlled
     ? setAndSync
-    : (parentConfig?.setModalOpen ?? setInternalModalOpen);
+    : (parentConfig?.setModalOpen ?? setAndSync);
 
   const configurationValue: CopilotChatConfigurationValue = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- Adds `isOpen` and `onOpenChange` props to `CopilotSidebar` following the standard React controlled/uncontrolled pattern
- When `isOpen` is provided, sidebar uses it as source of truth (controlled mode)
- When `isOpen` is undefined, falls back to internal state with `defaultOpen` (existing behavior preserved)
- `onOpenChange` fires on every state change regardless of mode

## Relates to
Relates to #3627

## Changes
- `packages/react-core/src/v2/components/chat/CopilotSidebar.tsx` — new `isOpen` and `onOpenChange` props
- `packages/react-core/src/v2/components/chat/CopilotChat.tsx` — thread `isModalOpen`/`onModalOpenChange` props
- `packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx` — controlled/uncontrolled state logic

## Test plan
- [ ] `<CopilotSidebar defaultOpen={false} />` — uncontrolled, works exactly as before
- [ ] `<CopilotSidebar isOpen={isOpen} onOpenChange={setIsOpen} />` — controlled mode
- [ ] External button toggles sidebar open/close via `setIsOpen(!isOpen)`
- [ ] Close button inside sidebar calls `onOpenChange(false)`
- [ ] No `isOpen` prop — fully backward compatible