### PR TITLE
fix: guard redirect report to only run on schedule/dispatch

### DIFF
--- a/.github/workflows/showcase_redirect-report.yml
+++ b/.github/workflows/showcase_redirect-report.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   decommission-report:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Same fix as #3730 for the smoke monitor — push events trigger ghost runs with no jobs. Stops the noisy GitHub notifications.