### PR TITLE
fix(runtime): widen TanStack message content type for adapter compat

### DIFF
--- a/examples/v2/react-router/app/env.d.ts
+++ b/examples/v2/react-router/app/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/v2/react-router/app/routes/_index.tsx
+++ b/examples/v2/react-router/app/routes/_index.tsx
@@ -40,11 +40,7 @@ export default function Index() {
             className="h-full w-full"
             attachments={{ enabled: true }}
             onError={(event) => {
-              console.error(
-                "[CopilotChat] Error:",
-                event.code,
-                event.error.message,
-              );
+              console.error("[CopilotChat] Error:", event);
             }}
           />
         </div>

--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -11,24 +11,32 @@ import {
 } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
 
+type ContentPartSource =
+  | { type: "data"; value: string; mimeType: string }
+  | { type: "url"; value: string; mimeType?: string };
+
 /**
  * A TanStack AI content part (text, image, audio, video, or document).
  */
 export type TanStackContentPart =
   | { type: "text"; content: string }
-  | {
-      type: "image" | "audio" | "video" | "document";
-      source:
-        | { type: "data"; value: string; mimeType: string }
-        | { type: "url"; value: string; mimeType?: string };
-    };
+  | { type: "image"; source: ContentPartSource }
+  | { type: "audio"; source: ContentPartSource }
+  | { type: "video"; source: ContentPartSource }
+  | { type: "document"; source: ContentPartSource };
 
 /**
  * Message format expected by TanStack AI's `chat()`.
+ *
+ * Content is typed as `any[]` for the multimodal case so messages are directly
+ * passable to any adapter without casts — different adapters constrain which
+ * modalities they accept (e.g. OpenAI only allows text + image).
+ * Use `TanStackContentPart` to inspect individual parts if needed.
  */
 export interface TanStackChatMessage {
   role: "user" | "assistant" | "tool";
-  content: string | null | TanStackContentPart[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: string | null | any[];
   name?: string;
   toolCalls?: Array<{
     id: string;


### PR DESCRIPTION
## Summary

- Widen `TanStackChatMessage.content` from `TanStackContentPart[]`
  to `any[]` so messages from `convertInputToTanStackAI` are directly
  passable to any TanStack AI adapter without `as any` casts
- Split `TanStackContentPart` into a proper discriminated union with
  separate variants per modality
- Add `env.d.ts` with `vite/client` reference for CSS import types
- Fix `onError` callback shape in the example

## Test plan

- [x] All 17 multimodal TanStack tests pass
- [x] All 294 agent tests pass
- [ ] Verify no TS errors in react-router example IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)