### PR TITLE
fix: handle RunErrorEvent across all frontend components

### DIFF
--- a/packages/angular/src/lib/agent.ts
+++ b/packages/angular/src/lib/agent.ts
@@ -47,6 +47,11 @@ export class AgentStore {
       onRunFailed: () => {
         this.#isRunning.set(false);
       },
+      // Protocol-level RUN_ERROR event (distinct from onRunFailed which
+      // handles local exceptions like network errors).
+      onRunErrorEvent: () => {
+        this.#isRunning.set(false);
+      },
     });
 
     destroyRef.onDestroy(() => {

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -73,6 +73,33 @@ class EventEmittingMockAgent extends AbstractAgent {
     }
   }
 
+  // Helper to emit run error event
+  public async emitRunErrorEvent(
+    runId: string,
+    state: State = {},
+    message: string = "error",
+    code: string = "unknown",
+  ) {
+    this.state = state;
+    for (const sub of this.subscribers) {
+      if (sub.onRunErrorEvent) {
+        await sub.onRunErrorEvent({
+          event: {
+            type: EventType.RUN_ERROR,
+            threadId: this.threadId,
+            runId,
+            message,
+            code,
+          },
+          messages: this.messages,
+          state: this.state,
+          agent: this,
+          input: this.createRunInput(runId),
+        });
+      }
+    }
+  }
+
   // Helper to emit state snapshot event
   public async emitStateSnapshot(runId: string, snapshot: State) {
     for (const sub of this.subscribers) {
@@ -799,6 +826,77 @@ describe("StateManager - Edge Cases", () => {
       "msg1",
     );
     expect(runId).toBeUndefined();
+  });
+});
+
+describe("StateManager - RunErrorEvent Handling", () => {
+  let copilotKitCore: CopilotKitCore;
+  let agent: EventEmittingMockAgent;
+
+  beforeEach(() => {
+    copilotKitCore = new CopilotKitCore({});
+    agent = new EventEmittingMockAgent("agent1", "thread1", { count: 0 });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "agent1",
+      agent: agent as any,
+    });
+  });
+
+  it("should track state when run errors", async () => {
+    const runId = "run1";
+    const errorState = { count: 1, error: true };
+
+    await agent.emitRunStarted(runId, { count: 1 });
+    await agent.emitRunErrorEvent(
+      runId,
+      errorState,
+      "something failed",
+      "bad_request",
+    );
+
+    const storedState = copilotKitCore.getStateByRun(
+      "agent1",
+      "thread1",
+      runId,
+    );
+    expect(storedState).toEqual(errorState);
+  });
+
+  it("should allow a new run after a run error (runFinished resets)", async () => {
+    // First run errors out
+    const run1Id = "run1";
+    const run1State = { count: 1, status: "error" };
+
+    await agent.emitRunStarted(run1Id, { count: 1 });
+    await agent.emitRunErrorEvent(run1Id, run1State, "oops", "internal");
+
+    const storedRun1 = copilotKitCore.getStateByRun(
+      "agent1",
+      "thread1",
+      run1Id,
+    );
+    expect(storedRun1).toEqual(run1State);
+
+    // Second run succeeds — verifies runFinished flag was set by error
+    // and resets on the next RUN_STARTED
+    const run2Id = "run2";
+    const run2State = { count: 2, status: "completed" };
+
+    await agent.emitRunStarted(run2Id, { count: 2 });
+    await agent.emitRunFinished(run2Id, run2State);
+
+    const storedRun2 = copilotKitCore.getStateByRun(
+      "agent1",
+      "thread1",
+      run2Id,
+    );
+    expect(storedRun2).toEqual(run2State);
+
+    // Both runs are tracked independently
+    const runIds = copilotKitCore.getRunIdsForThread("agent1", "thread1");
+    expect(runIds).toHaveLength(2);
+    expect(runIds).toContain(run1Id);
+    expect(runIds).toContain(run2Id);
   });
 });
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -241,7 +241,12 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       onRunFinalized: () => {
         this.isRunning = false;
       },
+      // Local exception (network error, deserialization failure, etc.)
       onRunFailed: () => {
+        this.isRunning = false;
+      },
+      // Protocol-level RUN_ERROR event from the backend
+      onRunErrorEvent: () => {
         this.isRunning = false;
       },
     });

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -115,6 +115,12 @@ export class StateManager {
         runFinished = true;
         this.handleRunFinished(agent, effectiveInput(input), state);
       },
+      // A run error terminates the run — treat identically to finished for cleanup
+      onRunErrorEvent: ({ input, state }) => {
+        if (revoked) return;
+        runFinished = true;
+        this.handleRunFinished(agent, effectiveInput(input), state);
+      },
       onStateSnapshotEvent: ({ event, input, state }) => {
         if (revoked) return;
         this.handleStateSnapshot(agent, event, effectiveInput(input), state);

--- a/packages/react-core/src/hooks/use-agent-nodename.ts
+++ b/packages/react-core/src/hooks/use-agent-nodename.ts
@@ -18,6 +18,9 @@ export function useAgentNodeName(agentName?: string) {
       onRunFinishedEvent: () => {
         nodeNameRef.current = "end";
       },
+      onRunErrorEvent: () => {
+        nodeNameRef.current = "end";
+      },
     };
 
     const subscription = agent.subscribe(subscriber);


### PR DESCRIPTION
## Summary

When the backend emits `RunErrorEvent` via the AG-UI protocol, several frontend components did not handle it, causing the UI to show an infinite spinner after backend errors.

## Changes

### Bug fixes (4 components)
- **`ProxiedCopilotRuntimeAgent`** (`packages/core/src/agent.ts`): `isRunning` stayed `true` after `RUN_ERROR`, causing `data-copilot-running` to never transition to `"false"`
- **`StateManager`** (`packages/core/src/core/state-manager.ts`): `activeRun` entries never cleaned up, `runFinished` flag never set — stale state on subsequent runs
- **`CopilotKitAgent` (Angular)** (`packages/angular/src/lib/agent.ts`): Same `isRunning` bug as the proxy agent
- **`useAgentNodeName`** (`packages/react-core/src/hooks/use-agent-nodename.ts`): Node name stuck at last step instead of `"end"` after error

### Tests
- Added `emitRunErrorEvent` to `EventEmittingMockAgent` test helper
- Added 2 tests verifying StateManager properly tracks state on error and resets for subsequent runs

### Key distinction
`onRunErrorEvent` handles **protocol-level** `RUN_ERROR` events from the backend (e.g., unhandled exception in agent flow). `onRunFailed` handles **local exceptions** (network errors, deserialization failures). Both need to reset `isRunning` but fire under different conditions.

## Context

Found while adding e2e tests for CrewAI's `ErrorFlow` in ag-ui-protocol/ag-ui#1478. The error flow test (`errorFlowPage.spec.ts`) timed out because `data-copilot-running` never transitioned to `"false"` after `RunErrorEvent`.

## Test plan

- [x] All 337 existing tests pass (including 2 new StateManager tests)
- [x] Formatted with oxfmt
- [ ] Verify error flow e2e test in ag-ui passes after this fix is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)