### PR TITLE
Fix showcase drift detection: use npm ci for test deps

### DIFF
--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -31,16 +31,13 @@ jobs:
         with:
           node-version: 20
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       - name: Install dependencies
         working-directory: showcase/tests
-        run: pnpm install
+        run: npm ci
 
       - name: Install Playwright
         working-directory: showcase/tests
-        run: npx playwright install chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Run L1-L3 tests
         working-directory: showcase/tests


### PR DESCRIPTION
## Summary

Showcase drift detection has been failing since the LFS fix landed because `pnpm install` doesn't work in `showcase/tests/` — it only has `package-lock.json`, not `pnpm-lock.yaml`.

Changed `pnpm install` → `npm ci` and removed the unnecessary `pnpm/action-setup` step. Also added `--with-deps` to Playwright install for OS dependencies.

Closes #3689

## Test plan

- [ ] Next scheduled drift detection run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)