### PR TITLE
docs(langgraph): document RunnableConfig import for state rendering

### DIFF
--- a/docs/content/docs/integrations/langgraph/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/state-rendering.mdx
@@ -73,6 +73,7 @@ Use state rendering when you want to:
         ```python title="agent.py"
         import asyncio
         from copilotkit.langgraph import copilotkit_emit_state # [!code highlight]
+        from langchain_core.runnables import RunnableConfig
 
         async def chat_node(state: AgentState, config: RunnableConfig):
             state["searches"] = [


### PR DESCRIPTION
## Summary

Documents the missing Python import for `RunnableConfig` in the LangGraph **State rendering** guide so copy-pasted snippets do not raise `NameError: name 'RunnableConfig' is not defined`.

## Changes

- Add `from langchain_core.runnables import RunnableConfig` to the Python `chat_node` example in `docs/content/docs/integrations/langgraph/generative-ui/state-rendering.mdx`.

## Why

The example annotates `config: RunnableConfig` but did not show the import; `RunnableConfig` is provided by `langchain_core.runnables`.