### PR TITLE
fix: restore thread routes dropped by fetch handler rewrite

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/fetch-router.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/fetch-router.test.ts
@@ -50,6 +50,60 @@ describe("fetch-router", () => {
       expect(result).toBeNull();
     });
 
+    it("matches GET /threads", () => {
+      const result = matchRoute("/api/copilotkit/threads", basePath);
+      expect(result).toEqual({ method: "threads/list" });
+    });
+
+    it("matches POST /threads/subscribe", () => {
+      const result = matchRoute("/api/copilotkit/threads/subscribe", basePath);
+      expect(result).toEqual({ method: "threads/subscribe" });
+    });
+
+    it("matches PATCH /threads/:threadId", () => {
+      const result = matchRoute(
+        "/api/copilotkit/threads/thread-abc",
+        basePath,
+      );
+      expect(result).toEqual({
+        method: "threads/update",
+        threadId: "thread-abc",
+      });
+    });
+
+    it("matches POST /threads/:threadId/archive", () => {
+      const result = matchRoute(
+        "/api/copilotkit/threads/thread-abc/archive",
+        basePath,
+      );
+      expect(result).toEqual({
+        method: "threads/archive",
+        threadId: "thread-abc",
+      });
+    });
+
+    it("matches GET /threads/:threadId/messages", () => {
+      const result = matchRoute(
+        "/api/copilotkit/threads/thread-abc/messages",
+        basePath,
+      );
+      expect(result).toEqual({
+        method: "threads/messages",
+        threadId: "thread-abc",
+      });
+    });
+
+    it("handles URL-encoded threadId in thread routes", () => {
+      const result = matchRoute(
+        "/api/copilotkit/threads/thread%2F123",
+        basePath,
+      );
+      expect(result).toEqual({
+        method: "threads/update",
+        threadId: "thread/123",
+      });
+    });
+
     it("returns null when basePath is a prefix but not a segment boundary", () => {
       const result = matchRoute("/api/copilotkitextra/info", basePath);
       expect(result).toBeNull();
@@ -122,6 +176,31 @@ describe("fetch-router", () => {
     it("returns null when no known suffix matches", () => {
       const result = matchRoute("/anything/unknown");
       expect(result).toBeNull();
+    });
+
+    it("matches /threads suffix", () => {
+      const result = matchRoute("/anything/threads");
+      expect(result).toEqual({ method: "threads/list" });
+    });
+
+    it("matches /threads/subscribe suffix", () => {
+      const result = matchRoute("/anything/threads/subscribe");
+      expect(result).toEqual({ method: "threads/subscribe" });
+    });
+
+    it("matches /threads/:threadId suffix", () => {
+      const result = matchRoute("/anything/threads/t1");
+      expect(result).toEqual({ method: "threads/update", threadId: "t1" });
+    });
+
+    it("matches /threads/:threadId/archive suffix", () => {
+      const result = matchRoute("/anything/threads/t1/archive");
+      expect(result).toEqual({ method: "threads/archive", threadId: "t1" });
+    });
+
+    it("matches /threads/:threadId/messages suffix", () => {
+      const result = matchRoute("/anything/threads/t1/messages");
+      expect(result).toEqual({ method: "threads/messages", threadId: "t1" });
     });
 
     it("works with deeply nested mount prefix", () => {

--- a/packages/runtime/src/v2/runtime/__tests__/fetch-router.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/fetch-router.test.ts
@@ -61,10 +61,7 @@ describe("fetch-router", () => {
     });
 
     it("matches PATCH /threads/:threadId", () => {
-      const result = matchRoute(
-        "/api/copilotkit/threads/thread-abc",
-        basePath,
-      );
+      const result = matchRoute("/api/copilotkit/threads/thread-abc", basePath);
       expect(result).toEqual({
         method: "threads/update",
         threadId: "thread-abc",

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -320,13 +320,25 @@ function dispatchRoute(
       return handleSubscribeToThreads({ runtime, request });
     case "threads/update":
       if (request.method.toUpperCase() === "DELETE") {
-        return handleDeleteThread({ runtime, request, threadId: route.threadId });
+        return handleDeleteThread({
+          runtime,
+          request,
+          threadId: route.threadId,
+        });
       }
       return handleUpdateThread({ runtime, request, threadId: route.threadId });
     case "threads/archive":
-      return handleArchiveThread({ runtime, request, threadId: route.threadId });
+      return handleArchiveThread({
+        runtime,
+        request,
+        threadId: route.threadId,
+      });
     case "threads/messages":
-      return handleGetThreadMessages({ runtime, request, threadId: route.threadId });
+      return handleGetThreadMessages({
+        runtime,
+        request,
+        threadId: route.threadId,
+      });
   }
 }
 
@@ -403,15 +415,21 @@ function validateHttpMethod(
     case "threads/list":
     case "threads/messages":
       if (method === "GET") return null;
-      return jsonResponse({ error: "Method not allowed" }, 405, { Allow: "GET" });
+      return jsonResponse({ error: "Method not allowed" }, 405, {
+        Allow: "GET",
+      });
 
     case "threads/update":
       if (method === "PATCH" || method === "DELETE") return null;
-      return jsonResponse({ error: "Method not allowed" }, 405, { Allow: "PATCH, DELETE" });
+      return jsonResponse({ error: "Method not allowed" }, 405, {
+        Allow: "PATCH, DELETE",
+      });
 
     default:
       if (method === "POST") return null;
-      return jsonResponse({ error: "Method not allowed" }, 405, { Allow: "POST" });
+      return jsonResponse({ error: "Method not allowed" }, 405, {
+        Allow: "POST",
+      });
   }
 }
 

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -47,6 +47,14 @@ import { handleStopAgent } from "../handlers/handle-stop";
 import { handleGetRuntimeInfo } from "../handlers/get-runtime-info";
 import { handleTranscribe } from "../handlers/handle-transcribe";
 import {
+  handleListThreads,
+  handleSubscribeToThreads,
+  handleUpdateThread,
+  handleArchiveThread,
+  handleDeleteThread,
+  handleGetThreadMessages,
+} from "../handlers/handle-threads";
+import {
   parseMethodCall,
   createJsonRequest,
   expectString,
@@ -306,6 +314,19 @@ function dispatchRoute(
       return handleGetRuntimeInfo({ runtime, request });
     case "transcribe":
       return handleTranscribe({ runtime, request });
+    case "threads/list":
+      return handleListThreads({ runtime, request });
+    case "threads/subscribe":
+      return handleSubscribeToThreads({ runtime, request });
+    case "threads/update":
+      if (request.method.toUpperCase() === "DELETE") {
+        return handleDeleteThread({ runtime, request, threadId: route.threadId });
+      }
+      return handleUpdateThread({ runtime, request, threadId: route.threadId });
+    case "threads/archive":
+      return handleArchiveThread({ runtime, request, threadId: route.threadId });
+    case "threads/messages":
+      return handleGetThreadMessages({ runtime, request, threadId: route.threadId });
   }
 }
 
@@ -376,10 +397,22 @@ function validateHttpMethod(
   route: RouteInfo,
 ): Response | null {
   const method = httpMethod.toUpperCase();
-  if (route.method === "info" && method === "GET") return null;
-  if (route.method !== "info" && method === "POST") return null;
-  const allowed = route.method === "info" ? "GET" : "POST";
-  return jsonResponse({ error: "Method not allowed" }, 405, { Allow: allowed });
+
+  switch (route.method) {
+    case "info":
+    case "threads/list":
+    case "threads/messages":
+      if (method === "GET") return null;
+      return jsonResponse({ error: "Method not allowed" }, 405, { Allow: "GET" });
+
+    case "threads/update":
+      if (method === "PATCH" || method === "DELETE") return null;
+      return jsonResponse({ error: "Method not allowed" }, 405, { Allow: "PATCH, DELETE" });
+
+    default:
+      if (method === "POST") return null;
+      return jsonResponse({ error: "Method not allowed" }, 405, { Allow: "POST" });
+  }
 }
 
 /* ------------------------------------------------------------------------------------------------

--- a/packages/runtime/src/v2/runtime/core/fetch-router.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-router.ts
@@ -108,5 +108,53 @@ function matchSegments(path: string): RouteInfo | null {
     return { method: "agent/stop", agentId, threadId };
   }
 
+  // /threads/subscribe (2 segments)
+  if (
+    len >= 2 &&
+    segments[len - 2] === "threads" &&
+    segments[len - 1] === "subscribe"
+  ) {
+    return { method: "threads/subscribe" };
+  }
+
+  // /threads/:threadId/messages (3 segments)
+  if (
+    len >= 3 &&
+    segments[len - 3] === "threads" &&
+    segments[len - 1] === "messages"
+  ) {
+    const threadId = safeDecodeURIComponent(segments[len - 2]!);
+    if (!threadId) return null;
+    return { method: "threads/messages", threadId };
+  }
+
+  // /threads/:threadId/archive (3 segments)
+  if (
+    len >= 3 &&
+    segments[len - 3] === "threads" &&
+    segments[len - 1] === "archive"
+  ) {
+    const threadId = safeDecodeURIComponent(segments[len - 2]!);
+    if (!threadId) return null;
+    return { method: "threads/archive", threadId };
+  }
+
+  // /threads/:threadId (2 segments) — update or delete
+  if (
+    len >= 2 &&
+    segments[len - 2] === "threads" &&
+    segments[len - 1] !== "subscribe"
+  ) {
+    const threadId = safeDecodeURIComponent(segments[len - 1]!);
+    if (!threadId) return null;
+    // Disambiguated by HTTP method in the handler
+    return { method: "threads/update", threadId };
+  }
+
+  // /threads (1 segment) — list
+  if (len >= 1 && segments[len - 1] === "threads") {
+    return { method: "threads/list" };
+  }
+
   return null;
 }

--- a/packages/runtime/src/v2/runtime/core/hooks.ts
+++ b/packages/runtime/src/v2/runtime/core/hooks.ts
@@ -38,7 +38,12 @@ export type RouteInfo =
   | { method: "agent/connect"; agentId: string }
   | { method: "agent/stop"; agentId: string; threadId: string }
   | { method: "info" }
-  | { method: "transcribe" };
+  | { method: "transcribe" }
+  | { method: "threads/list" }
+  | { method: "threads/subscribe" }
+  | { method: "threads/update"; threadId: string }
+  | { method: "threads/archive"; threadId: string }
+  | { method: "threads/messages"; threadId: string };
 
 /* ------------------------------------------------------------------------------------------------
  * Hook contexts

--- a/packages/runtime/src/v2/runtime/handlers/handle-threads.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-threads.ts
@@ -1,6 +1,7 @@
 export {
   handleArchiveThread,
   handleDeleteThread,
+  handleGetThreadMessages,
   handleListThreads,
   handleSubscribeToThreads,
   handleUpdateThread,

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/threads.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/threads.ts
@@ -231,3 +231,31 @@ export async function handleDeleteThread({
     return errorResponse("Failed to delete thread", 500);
   }
 }
+
+export async function handleGetThreadMessages({
+  runtime,
+  request,
+  threadId,
+}: ThreadMutationParams): Promise<Response> {
+  const intelligenceRuntime = requireIntelligenceRuntime(runtime);
+  if (isHandlerResponse(intelligenceRuntime)) {
+    return intelligenceRuntime;
+  }
+
+  try {
+    const user = await resolveIntelligenceUser({
+      runtime: intelligenceRuntime,
+      request,
+    });
+    if (isHandlerResponse(user)) return user;
+
+    const data = await intelligenceRuntime.intelligence.getThreadMessages({
+      threadId,
+    });
+
+    return Response.json(data);
+  } catch (error) {
+    logger.error({ err: error, threadId }, "Error getting thread messages");
+    return errorResponse("Failed to get thread messages", 500);
+  }
+}


### PR DESCRIPTION
When #3550 was landed, it dropped the thread routes used for the intelligence platform. This restores them and adds tests to ensure they're not dropped again. 