### PR TITLE
docs(microsoft-agent-framework): use dict[] in Python state snippets

### DIFF
--- a/docs/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
@@ -249,7 +249,7 @@ is a situation where a user and an agent are working together to solve a problem
             }
         }
 
-        PREDICT_STATE_CONFIG: Dict[str, Dict[str, str]] = {
+        PREDICT_STATE_CONFIG: dict[str, dict[str, str]] = {
             "searches": {
                 "tool": "update_searches",
                 "tool_argument": "searches",

--- a/docs/content/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-write.mdx
+++ b/docs/content/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-write.mdx
@@ -63,7 +63,7 @@ You can use this when you need to update agent state from your application — f
             }
         }
 
-        PREDICT_STATE_CONFIG: Dict[str, Dict[str, str]] = {
+        PREDICT_STATE_CONFIG: dict[str, dict[str, str]] = {
             "language": {"tool": "update_language", "tool_argument": "language"}
         }
 

--- a/showcase/shell/src/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
+++ b/showcase/shell/src/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
@@ -249,7 +249,7 @@ is a situation where a user and an agent are working together to solve a problem
             }
         }
 
-        PREDICT_STATE_CONFIG: Dict[str, Dict[str, str]] = {
+        PREDICT_STATE_CONFIG: dict[str, dict[str, str]] = {
             "searches": {
                 "tool": "update_searches",
                 "tool_argument": "searches",

--- a/showcase/shell/src/content/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell/src/content/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-write.mdx
@@ -63,7 +63,7 @@ You can use this when you need to update agent state from your application — f
             }
         }
 
-        PREDICT_STATE_CONFIG: Dict[str, Dict[str, str]] = {
+        PREDICT_STATE_CONFIG: dict[str, dict[str, str]] = {
             "language": {"tool": "update_language", "tool_argument": "language"}
         }
 


### PR DESCRIPTION
## Summary

Updates Microsoft Agent Framework **Python** doc snippets to use built-in `dict[...]` instead of `typing.Dict[...]` so copy-pasted code does not hit `NameError: name 'Dict' is not defined` when `Dict` is not imported (notably `PREDICT_STATE_CONFIG` in **Writing agent state**).

## Changes

- `PREDICT_STATE_CONFIG` and related `STATE_SCHEMA` annotations: `Dict[...]` → `dict[...]`
- Drop unused `from typing import Dict` / `Dict` from combined imports where applicable
- Keep **docs** and **showcase** Microsoft Agent Framework pages in sync

## Files

- `docs/content/docs/integrations/microsoft-agent-framework/shared-state/in-app-agent-write.mdx`
- `docs/content/docs/integrations/microsoft-agent-framework/shared-state/predictive-state-updates.mdx`
- `docs/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx`


## Checklist

- [ ] Docs / showcase pages render as expected (code blocks unchanged aside from types)