### PR TITLE
fix: showcase drift detection compares against showcase-affecting commits, not HEAD

### DIFF
--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -189,8 +189,23 @@ jobs:
             strands ms-agent-python ms-agent-dotnet claude-sdk-python
             claude-sdk-typescript langroid spring-ai aimock
           )
-          MAIN_SHA=$(git ls-remote https://github.com/${{ github.repository }}.git main | cut -f1)
-          echo "Main SHA: ${MAIN_SHA:0:8}"
+          # Compare against the last commits that touched showcase-related paths,
+          # NOT main HEAD. Deploys only trigger on showcase/ and examples/integrations/
+          # changes, so non-showcase commits shouldn't make images appear stale.
+          SHOWCASE_SHA=$(gh api "repos/${{ github.repository }}/commits?sha=main&path=showcase&per_page=1" --jq '.[0].sha // empty') || {
+            echo "::warning::Failed to fetch showcase/ commit SHA"
+            SHOWCASE_SHA=""
+          }
+          EXAMPLES_SHA=$(gh api "repos/${{ github.repository }}/commits?sha=main&path=examples/integrations&per_page=1" --jq '.[0].sha // empty') || {
+            echo "::warning::Failed to fetch examples/integrations/ commit SHA"
+            EXAMPLES_SHA=""
+          }
+          echo "Last showcase/ SHA: ${SHOWCASE_SHA:0:8}, Last examples/integrations/ SHA: ${EXAMPLES_SHA:0:8}"
+
+          if [ -z "$SHOWCASE_SHA" ] && [ -z "$EXAMPLES_SHA" ]; then
+            echo "::warning::Could not resolve any path-specific SHAs — skipping drift check"
+            echo "has_stale=false" >> "$GITHUB_OUTPUT"
+          else
 
           for SVC in "${SERVICES[@]}"; do
             PKG="showcase-${SVC}"
@@ -202,8 +217,17 @@ jobs:
               continue  # No package versions — new service, not yet built
             fi
 
-            if echo "$TAGS" | grep -q "$MAIN_SHA"; then
-              continue  # Latest version includes main SHA — up to date
+            # Image is up to date if it matches EITHER the last showcase/ or
+            # examples/integrations/ commit (deploy triggers on both paths)
+            UP_TO_DATE=false
+            if [ -n "$SHOWCASE_SHA" ] && echo "$TAGS" | grep -q "$SHOWCASE_SHA"; then
+              UP_TO_DATE=true
+            fi
+            if [ -n "$EXAMPLES_SHA" ] && echo "$TAGS" | grep -q "$EXAMPLES_SHA"; then
+              UP_TO_DATE=true
+            fi
+            if [ "$UP_TO_DATE" = true ]; then
+              continue
             fi
 
             echo "  ${SVC}: stale (tags: ${TAGS:0:60})"
@@ -238,6 +262,8 @@ jobs:
             STATE=$(cat smoke-state.json)
             echo "$STATE" | jq 'del(.image_drift_services)' > smoke-state.json
           fi
+
+          fi  # end SHA guard
 
       - name: Trigger rebuild for stale services
         if: steps.image_drift.outputs.has_stale == 'true'


### PR DESCRIPTION
## Summary

The showcase image drift detection compared image tags against `main` HEAD SHA, but deploys only trigger when `showcase/` or `examples/integrations/` paths change. Any non-showcase commit to main (package bumps, workflow changes, docs, etc.) made ALL images appear stale, triggering unnecessary rebuild workflows and Slack alerts.

## Root Cause

```bash
# Before: always stale after non-showcase commits
MAIN_SHA=$(git ls-remote ... main | cut -f1)
```

## Fix

Query the GitHub API for the last commit that actually touched showcase-related paths, then check image tags against those SHAs:

```bash
SHOWCASE_SHA=$(gh api "repos/.../commits?path=showcase&per_page=1" --jq '.[0].sha')
EXAMPLES_SHA=$(gh api "repos/.../commits?path=examples/integrations&per_page=1" --jq '.[0].sha')
# Image is up-to-date if it matches EITHER SHA
```

## Impact

- No more false-positive drift alerts flooding #oss-alerts
- No more unnecessary rebuild triggers for every non-showcase commit
- Drift detection now only fires when showcase code actually changed but images weren't rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)