### PR TITLE
fix(react-ui): remove min-height from CopilotSidebarContentWrapper

### DIFF
--- a/packages/react-ui/src/css/sidebar.css
+++ b/packages/react-ui/src/css/sidebar.css
@@ -37,19 +37,6 @@
   overflow: visible;
   margin-right: 0px;
   transition: margin-right 0.3s ease;
-  min-height: 100vh;
-  min-height: 100dvh;
-  height: 100%;
-}
-
-.copilotKitSidebarContentWrapper > .copilotKitModalChildrenWrapper {
-  min-height: 100%;
-  height: 100%;
-}
-
-.copilotKitSidebarContentWrapper > .copilotKitModalChildrenWrapper > * {
-  min-height: 100%;
-  height: 100%;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary

- `818e4e767` added `min-height: 100vh`, `height: 100%` to `.copilotKitSidebarContentWrapper` and its children to support full-height content inside the sidebar
- This caused empty space equal to the viewport height to appear **below the app content** whenever `CopilotSidebar` was mounted, even when collapsed
- The wrapper only needs `margin-right` to push content left when the sidebar opens — it doesn't need to control its own height
- Remove the three height rules; child layout is the app's responsibility

## Test plan

- [ ] Mount `CopilotSidebar` — no empty space below app content when sidebar is collapsed
- [ ] Open sidebar — page content shifts left correctly via `margin-right`
- [ ] Close sidebar — margin-right transitions back to 0, no blank space
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)