### PR TITLE
fix: pin @ag-ui/client to 0.0.52 in CLI templates

### DIFF
--- a/examples/integrations/a2a-middleware/package.json
+++ b/examples/integrations/a2a-middleware/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@a2a-js/sdk": "latest",
     "@ag-ui/a2a-middleware": "0.0.2",
-    "@ag-ui/client": "0.0.40",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "latest",
     "@copilotkit/react-ui": "latest",
     "@copilotkit/runtime": "latest",
@@ -36,6 +36,6 @@
     "typescript": "^5"
   },
   "overrides": {
-    "@ag-ui/client": "0.0.40"
+    "@ag-ui/client": "0.0.52"
   }
 }

--- a/examples/integrations/adk/package.json
+++ b/examples/integrations/adk/package.json
@@ -13,7 +13,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.42",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "1.52.1",
     "@copilotkit/react-ui": "1.52.1",
     "@copilotkit/runtime": "1.52.1",

--- a/examples/integrations/agent-spec/package.json
+++ b/examples/integrations/agent-spec/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@a2ui/lit": "^0.8.1",
     "@ag-ui/a2ui-middleware": "^0.0.2",
-    "@ag-ui/client": "^0.0.46",
+    "@ag-ui/client": "0.0.52",
     "@ag-ui/core": "^0.0.46",
     "@ag-ui/encoder": "^0.0.46",
     "@ag-ui/proto": "^0.0.46",

--- a/examples/integrations/agno/package.json
+++ b/examples/integrations/agno/package.json
@@ -12,7 +12,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "latest",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "1.52.1",
     "@copilotkit/react-ui": "1.52.1",
     "@copilotkit/runtime": "1.52.1",

--- a/examples/integrations/crewai-flows/package.json
+++ b/examples/integrations/crewai-flows/package.json
@@ -12,7 +12,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.42",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "1.50.0",
     "@copilotkit/react-ui": "1.50.0",
     "@copilotkit/runtime": "1.50.0",

--- a/examples/integrations/mastra/package.json
+++ b/examples/integrations/mastra/package.json
@@ -11,7 +11,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.42",
+    "@ag-ui/client": "0.0.52",
     "@ag-ui/mastra": "beta",
     "@ai-sdk/openai": "^2.0.42",
     "@copilotkit/react-core": "1.51.1",

--- a/examples/integrations/ms-agent-framework-dotnet/package.json
+++ b/examples/integrations/ms-agent-framework-dotnet/package.json
@@ -14,7 +14,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.46",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "1.52.1",
     "@copilotkit/react-ui": "1.52.1",
     "@copilotkit/runtime": "1.52.1",

--- a/examples/integrations/ms-agent-framework-python/package.json
+++ b/examples/integrations/ms-agent-framework-python/package.json
@@ -14,7 +14,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.42",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "1.50.0",
     "@copilotkit/react-ui": "1.50.0",
     "@copilotkit/runtime": "1.50.0",

--- a/examples/integrations/pydantic-ai/package.json
+++ b/examples/integrations/pydantic-ai/package.json
@@ -13,7 +13,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.43",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "1.51.2",
     "@copilotkit/react-ui": "1.51.2",
     "@copilotkit/runtime": "1.51.2",

--- a/examples/integrations/strands-python/package.json
+++ b/examples/integrations/strands-python/package.json
@@ -12,7 +12,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.42",
+    "@ag-ui/client": "0.0.52",
     "@copilotkit/react-core": "1.52.1",
     "@copilotkit/react-ui": "1.52.1",
     "@copilotkit/runtime": "1.52.1",


### PR DESCRIPTION
## Summary

- All CLI-scaffolded templates imported `HttpAgent` from `@ag-ui/client` but pinned it at stale versions (`0.0.40`–`0.0.46`)
- `@copilotkit/runtime@1.55.2` ships with `@ag-ui/client@0.0.52`, which added `private _debug`, `private _debugLogger`, and a `debugLogger` getter to `AbstractAgent`
- npm installs two copies; TypeScript's nominal typing for private class members rejects `HttpAgent` (old copy) as assignable to `AbstractAgent` (new copy), breaking `next build` in every CLI-scaffolded project
- Fix: pin all templates to `@ag-ui/client@0.0.52` to match runtime

## Root cause (precise)

`AbstractAgent` in `0.0.52` gained private fields. TypeScript requires that private members in a class type come from the **same class declaration** — so `HttpAgent` from `0.0.42` (which extends `AbstractAgent@0.0.42`) is not assignable to `AbstractAgent@0.0.52`, even though the shapes are otherwise identical. The error surfaces as `HttpAgent is missing: _debug, _debugLogger, debugLogger`.

## Test plan

- [ ] Scaffold a new project from any of the affected templates (adk, agno, crewai-flows, pydantic-ai, strands, ms-agent-*)
- [ ] Run `npm install && npm run build` — should complete without type errors
- [ ] Verify `HttpAgent` resolves from the same `@ag-ui/client` copy as `@copilotkit/runtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)