### PR TITLE
ci: restrict release workflows to main branch only

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -30,6 +30,7 @@ env:
 
 jobs:
   create-release-pr:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Add if: github.ref == 'refs/heads/main' to the `release / create-pr` job. Running from a feature branch will skip immediately.
