### PR TITLE
Fix drift detection: run only integration-smoke tests

### DIFF
--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -43,14 +43,14 @@ jobs:
         working-directory: showcase/tests
         env:
           CI: true
-        run: npx playwright test --grep "@health|@agent|@chat" --reporter=github
+        run: npx playwright test integration-smoke --grep "@health|@agent|@chat" --reporter=github
 
       - name: Run L4 tests (daily only)
         if: github.event.schedule == '0 0 * * *' || github.event_name == 'workflow_dispatch'
         working-directory: showcase/tests
         env:
           CI: true
-        run: npx playwright test --grep "@tools" --reporter=github
+        run: npx playwright test integration-smoke --grep "@tools" --reporter=github
 
       - name: Post failure to Slack
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
## Summary

The drift detection workflow runs `npx playwright test --grep "@health|@agent|@chat"` which matches BOTH `integration-smoke.spec.ts` (deployed Railway backends) and `starter-smoke.spec.ts` (Docker-built starters). The starter-smoke tests try to connect to `localhost:3000` which doesn't exist in CI, causing all runs to fail.

Fix: scope to `npx playwright test integration-smoke --grep ...` so only the showcase integration tests run.

## Test plan

- [x] Verified locally: 13 integration-smoke tests pass, 0 starter-smoke tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)