### PR TITLE
fix: set human_input_mode=NEVER on ag2 showcase agent

### DIFF
--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -40,17 +40,37 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run L1-L3 tests
+        id: l1_l3
         working-directory: showcase/tests
         env:
           CI: true
-        run: npx playwright test integration-smoke --grep "@health|@agent|@chat" --reporter=github
+        run: |
+          npx playwright test integration-smoke --grep "@health|@agent|@chat" --reporter=github 2>&1 | tee /tmp/e2e-output.log
+          exit ${PIPESTATUS[0]}
 
       - name: Run L4 tests (daily only)
+        id: l4
         if: github.event.schedule == '0 0 * * *' || github.event_name == 'workflow_dispatch'
         working-directory: showcase/tests
         env:
           CI: true
-        run: npx playwright test integration-smoke --grep "@tools" --reporter=github
+        run: |
+          npx playwright test integration-smoke --grep "@tools" --reporter=github 2>&1 | tee -a /tmp/e2e-output.log
+          exit ${PIPESTATUS[0]}
+
+      - name: Extract failure summary
+        id: failures
+        if: failure()
+        run: |
+          # Extract failed test names and error messages from playwright output
+          DETAILS=$(grep -E "^\s+\d+\)|Error:" /tmp/e2e-output.log 2>/dev/null | head -15 | sed 's/"/\\"/g' || echo "See CI logs for details")
+          DETAILS="${DETAILS:0:1200}"
+
+          {
+            echo "details<<EOFEOF"
+            echo "$DETAILS"
+            echo "EOFEOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post failure to Slack
         if: failure() && github.event_name == 'schedule'
@@ -59,7 +79,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload: |
-            { "text": ":x: *Showcase E2E suite failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
+            { "text": ":x: *Showcase E2E suite failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\n\n```\n${{ steps.failures.outputs.details }}\n```" }
 
       - name: Create issue on failure
         if: failure()

--- a/showcase/packages/ag2/src/agents/agent.py
+++ b/showcase/packages/ag2/src/agents/agent.py
@@ -101,6 +101,7 @@ agent = ConversableAgent(
         "and friendly in your responses."
     ),
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
+    human_input_mode="NEVER",
     functions=[get_weather],
 )
 

--- a/showcase/tests/e2e/integration-smoke.spec.ts
+++ b/showcase/tests/e2e/integration-smoke.spec.ts
@@ -211,7 +211,7 @@ const activeIntegrations = DEPLOYED_ONLY
 
 test.describe("Level 1: Backend Health @health", () => {
   for (const integration of activeIntegrations) {
-    test(`[health] ${integration.slug} backend is healthy @health`, async ({
+    test(`[L1: health] ${integration.slug} backend is healthy @health`, async ({
       request,
     }) => {
       const result = await checkHealth(request, integration.backendUrl);
@@ -229,7 +229,7 @@ test.describe("Level 1: Backend Health @health", () => {
 
 test.describe("Level 2: Agent Endpoint @agent", () => {
   for (const integration of activeIntegrations) {
-    test(`[agent] ${integration.slug} agent endpoint responds (not 404) @agent`, async ({
+    test(`[L2: agent] ${integration.slug} agent endpoint responds (not 404) @agent`, async ({
       request,
     }) => {
       const result = await checkAgentEndpoint(request, integration.backendUrl);
@@ -251,7 +251,7 @@ test.describe("Level 2: Agent Endpoint @agent", () => {
 
 test.describe("Level 3: Round-trip Chat @chat", () => {
   for (const integration of activeIntegrations) {
-    test(`[chat] ${integration.slug} responds to a message @chat`, async ({
+    test(`[L3: chat] ${integration.slug} responds to a message @chat`, async ({
       page,
     }) => {
       test.slow(); // Allow extra time for cold starts
@@ -285,7 +285,7 @@ test.describe("Level 4: Tool Rendering @tools", () => {
   );
 
   for (const integration of toolIntegrations) {
-    test(`[tools] ${integration.slug} renders tool results @tools`, async ({
+    test(`[L4: tools] ${integration.slug} renders tool results @tools`, async ({
       page,
     }) => {
       test.slow();


### PR DESCRIPTION
## Summary

Two fixes:

### 1. AG2 showcase agent blocks on human feedback
The `ConversableAgent` defaults to `human_input_mode="TERMINATE"`, which prompts for user feedback when the conversation terminates. In the AG-UI streaming context via `AGUIStream`, this blocks with:
> "Please give feedback to the sender. Press enter to skip and use auto-reply, or type 'exit' to stop the conversation:"

This was broken from day one (showcase deployed April 8, first L4 test ran April 9 and failed). The ag2 image was never rebuilt since — the unpinned `ag2>=0.9.0` dep resolved to 0.11.5 at build time.

Fix: set `human_input_mode="NEVER"`.

### 2. Showcase E2E Slack alerts lack detail
The Slack notification only said "Showcase E2E suite failed" with a link. Now captures playwright output and includes failed test names + error messages:

```
❌ Showcase E2E suite failed
View run

  1) [L4: tools] ag2 renders tool results @tools
    Error: ag2 response doesn't contain weather info: "Please give feedback..."
```

Test names now carry their level prefix (`[L1: health]`, `[L2: agent]`, `[L3: chat]`, `[L4: tools]`) so you can tell what broke from the Slack message alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)