### PR TITLE
docs: add human_input_mode=NEVER to all AG2 code snippets

### DIFF
--- a/docs/content/docs/integrations/ag2/auth.mdx
+++ b/docs/content/docs/integrations/ag2/auth.mdx
@@ -72,6 +72,7 @@ agent = ConversableAgent(
     name="assistant",
     system_message="You are a helpful assistant.",
     llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)
@@ -140,6 +141,7 @@ agent = ConversableAgent(
     name="assistant",
     system_message="You are a helpful assistant.",
     llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+    human_input_mode="NEVER",
 )
 
 stream = AGUIStream(agent)

--- a/docs/content/docs/integrations/ag2/frontend-tools.mdx
+++ b/docs/content/docs/integrations/ag2/frontend-tools.mdx
@@ -100,6 +100,7 @@ Without frontend actions, agents are limited to just processing and returning da
                     name="assistant",
                     system_message="You are a helpful assistant.",
                     llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+                    human_input_mode="NEVER",
                 )
 
                 stream = AGUIStream(agent)

--- a/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
+++ b/docs/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
@@ -67,6 +67,7 @@ is a situation where a user and an agent are working together to solve a problem
             "Use `add_search` once per query, then call `run_searches`."
         ),
         llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+        human_input_mode="NEVER",
     )
 
 

--- a/docs/content/docs/integrations/ag2/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/integrations/ag2/generative-ui/tool-rendering.mdx
@@ -43,6 +43,7 @@ Start your AG2 backend with a `/chat` endpoint and connect CopilotKit to that en
             name="assistant",
             system_message="You are a helpful assistant.",
             llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+            human_input_mode="NEVER",
         )
 
         @agent.register_for_llm(

--- a/docs/content/docs/integrations/ag2/human-in-the-loop.mdx
+++ b/docs/content/docs/integrations/ag2/human-in-the-loop.mdx
@@ -116,6 +116,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
                 "After it returns, call `store_user_choice` with the selected value."
             ),
             llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+            human_input_mode="NEVER",
         )
 
         @agent.register_for_llm(description="Store the latest user choice in shared state.")

--- a/docs/content/docs/integrations/ag2/readables.mdx
+++ b/docs/content/docs/integrations/ag2/readables.mdx
@@ -118,6 +118,7 @@ This context can then be shared with your AG2 backend.
                                 "Call `get_colleagues` before suggesting recipients."
                             ),
                             llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+                            human_input_mode="NEVER",
                         )
 
                         @agent.register_for_llm(description="Return the current user's colleagues from CopilotKit readables.")
@@ -204,6 +205,7 @@ This context can then be shared with your AG2 backend.
                             name="assistant",
                             system_message="You are a helpful assistant.",
                             llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+                            human_input_mode="NEVER",
                         )
 
                         @agent.register_for_llm(description="Read colleagues from CopilotKit readable context.")

--- a/docs/content/docs/integrations/ag2/shared-state/read.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/read.mdx
@@ -65,6 +65,7 @@ state updates, you can reflect these updates natively in your application.
             "Always respond in the current language."
         ),
         llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+        human_input_mode="NEVER",
     )
 
     @agent.register_for_llm(description="Update the language in shared state.")

--- a/docs/content/docs/integrations/ag2/shared-state/write.mdx
+++ b/docs/content/docs/integrations/ag2/shared-state/write.mdx
@@ -64,6 +64,7 @@ You can use this when you want to keep your interface and backend agent state sy
             "Always respond in the current language."
         ),
         llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
+        human_input_mode="NEVER",
     )
 
     @agent.register_for_llm(description="Update the language in shared state.")


### PR DESCRIPTION
## Summary

All AG2 doc examples were missing `human_input_mode="NEVER"` on `ConversableAgent`, causing users who copy-paste the code to hit "Please give feedback to the sender..." prompts instead of getting tool results.

See: [AG2 human_input_mode Bug — All Examples Missing NEVER (Notion)](https://www.notion.so/3403aa381852819db3e6ce2759f16e2e)

## Files changed (8 files, 10 instances)

- `docs/.../ag2/generative-ui/tool-rendering.mdx` (1)
- `docs/.../ag2/generative-ui/state-rendering.mdx` (1)
- `docs/.../ag2/human-in-the-loop.mdx` (1)
- `docs/.../ag2/readables.mdx` (2)
- `docs/.../ag2/frontend-tools.mdx` (1)
- `docs/.../ag2/auth.mdx` (2)
- `docs/.../ag2/shared-state/read.mdx` (1)
- `docs/.../ag2/shared-state/write.mdx` (1)

## Related

- CopilotKit/CopilotKit#3777 (showcase fix — merged)
- ag-ui-protocol/ag-ui#1486 (dojo examples fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)