### PR TITLE
fix: docs sync PR step — stage and commit review items before creating PR

### DIFF
--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -98,6 +98,15 @@ jobs:
 
           git checkout -b "$BRANCH"
 
+          # Stage any remaining unstaged changes (review items the sync script flagged)
+          git add showcase/shell/src/content/
+          if git diff --cached --quiet; then
+            echo "No review items to commit — skipping PR"
+            exit 0
+          fi
+          git commit -m "Docs sync: files needing review (${SHORT_SHA})"
+          git push origin "$BRANCH"
+
           # The review-items.txt was written by the sync script
           REVIEW_ITEMS=$(cat review-items.txt 2>/dev/null || echo "See sync output for details")
 


### PR DESCRIPTION
## Summary

- Fixes the \"Create PR for review items\" step in the docs sync workflow
- The step was creating a branch but never staging/committing the review-item files before calling `gh pr create`, causing `No commits between main and docs-sync-review/...`
- Now stages remaining content changes, commits them, pushes the branch, then creates the PR
- If no review items are actually changed, exits cleanly instead of failing

## Test plan

- [ ] Trigger docs sync workflow manually and verify it handles both `auto_push` and `push_and_pr` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)