### PR TITLE
fix: docs sync Slack notifications fire even when PR step fails

### DIFF
--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -79,7 +79,7 @@ jobs:
           echo "files_changed=${CHANGED}" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack (auto-push)
-        if: steps.sync.outputs.action == 'auto_push'
+        if: always() && steps.push.outcome == 'success'
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
@@ -138,7 +138,7 @@ jobs:
             --head "$BRANCH"
 
       - name: Notify Slack (review needed)
-        if: steps.sync.outputs.action == 'push_and_pr'
+        if: always() && steps.sync.outputs.action == 'push_and_pr'
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}


### PR DESCRIPTION
## Summary

- Slack auto-push notification now fires whenever the push step succeeds (both `auto_push` and `push_and_pr` paths), not just on `auto_push`
- Slack review-needed notification now uses `always()` so it fires even if the PR creation step fails

## Test plan

- [ ] Retrigger docs sync workflow and verify Slack notification arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)