### PR TITLE
fix(sdk-python): copilotkit_interrupt handles non-list resume values (#3096)

### DIFF
--- a/sdk-python/copilotkit/langgraph.py
+++ b/sdk-python/copilotkit/langgraph.py
@@ -497,6 +497,13 @@ def copilotkit_interrupt(
         "__copilotkit_interrupt_value__": interrupt_values,
         "__copilotkit_messages__": [interrupt_message]
     })
-    answer = response[-1].content
+    if isinstance(response, str):
+        answer = response
+    elif isinstance(response, dict):
+        answer = json.dumps(response)
+    elif isinstance(response, list):
+        answer = response[-1].content
+    else:
+        answer = str(response)
 
     return answer, response

--- a/sdk-python/tests/test_interrupt_resume.py
+++ b/sdk-python/tests/test_interrupt_resume.py
@@ -1,0 +1,45 @@
+"""Tests for #3096: copilotkit_interrupt crashes on non-list resume values."""
+
+import pytest
+import json
+from unittest.mock import patch, MagicMock
+
+
+class TestInterruptNonListResume:
+    """Verify copilotkit_interrupt handles string/dict resume values without crashing."""
+
+    @patch("copilotkit.langgraph.interrupt")
+    def test_string_resume_value(self, mock_interrupt):
+        """When LangGraph 1.x returns a string resume value, should not crash."""
+        mock_interrupt.return_value = "user approved"
+
+        from copilotkit.langgraph import copilotkit_interrupt
+        answer, response = copilotkit_interrupt(message="Do you approve?")
+
+        assert answer == "user approved"
+        assert response == "user approved"
+
+    @patch("copilotkit.langgraph.interrupt")
+    def test_dict_resume_value(self, mock_interrupt):
+        """When LangGraph 1.x returns a dict resume value, should return JSON string."""
+        mock_interrupt.return_value = {"approved": True, "reason": "looks good"}
+
+        from copilotkit.langgraph import copilotkit_interrupt
+        answer, response = copilotkit_interrupt(message="Do you approve?")
+
+        parsed = json.loads(answer)
+        assert parsed["approved"] is True
+        assert parsed["reason"] == "looks good"
+
+    @patch("copilotkit.langgraph.interrupt")
+    def test_list_resume_value_still_works(self, mock_interrupt):
+        """Existing behavior: list resume values should still use [-1].content."""
+        mock_msg = MagicMock()
+        mock_msg.content = "yes"
+        mock_interrupt.return_value = [mock_msg]
+
+        from copilotkit.langgraph import copilotkit_interrupt
+        answer, response = copilotkit_interrupt(message="Do you approve?")
+
+        assert answer == "yes"
+        assert response == [mock_msg]


### PR DESCRIPTION
## Summary
- `copilotkit_interrupt` now handles string and dict resume values from LangGraph 1.x's `interrupt()`
- Previously crashed with `AttributeError: 'str' object has no attribute 'content'` or `KeyError: -1`
- Type-checks response: str returned directly, dict JSON-serialized, list uses existing `[-1].content` path

## Test plan
- [x] Red-green test: string resume value returns without crash
- [x] Red-green test: dict resume value returns JSON string
- [x] Test: list resume value still works (existing behavior)
- [x] Full test suite passes (15/15)

Closes #3096