### PR TITLE
fix: increase Anthropic adapter default max_tokens to 4096

### DIFF
--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -350,7 +350,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
         system: cachedSystemPrompt,
         model: this.model,
         messages: cachedMessages,
-        max_tokens: forwardedParameters?.maxTokens || 1024,
+        max_tokens: forwardedParameters?.maxTokens || 4096,
         ...(forwardedParameters?.temperature
           ? { temperature: forwardedParameters.temperature }
           : {}),

--- a/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
+++ b/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
@@ -375,3 +375,102 @@ describe("AnthropicAdapter", () => {
     });
   });
 });
+
+describe("AnthropicAdapter max_tokens default", () => {
+  let mockAnthropicCreate: any;
+  let mockEventSource: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should default max_tokens to 4096 when not specified", async () => {
+    const mockAnthropic = {
+      messages: {
+        create: vi.fn(),
+      },
+    };
+
+    const adapter = new AnthropicAdapter({ anthropic: mockAnthropic as any });
+    mockAnthropicCreate = mockAnthropic.messages.create;
+
+    mockAnthropicCreate.mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {},
+    });
+
+    mockEventSource = {
+      stream: vi.fn((callback) => {
+        const mockStream = {
+          sendTextMessageStart: vi.fn(),
+          sendTextMessageContent: vi.fn(),
+          sendTextMessageEnd: vi.fn(),
+          sendActionExecutionStart: vi.fn(),
+          sendActionExecutionArgs: vi.fn(),
+          sendActionExecutionEnd: vi.fn(),
+          complete: vi.fn(),
+        };
+        callback(mockStream);
+        return Promise.resolve();
+      }),
+    };
+
+    const systemMessage = new TextMessage("system", "System message");
+    const userMessage = new TextMessage("user", "Hello");
+
+    await adapter.process({
+      threadId: "test-thread",
+      messages: [systemMessage, userMessage],
+      actions: [],
+      eventSource: mockEventSource,
+      forwardedParameters: {},
+    });
+
+    const createCallArgs = mockAnthropicCreate.mock.calls[0][0];
+    expect(createCallArgs.max_tokens).toBe(4096);
+  });
+
+  it("should use provided maxTokens when specified", async () => {
+    const mockAnthropic = {
+      messages: {
+        create: vi.fn(),
+      },
+    };
+
+    const adapter = new AnthropicAdapter({ anthropic: mockAnthropic as any });
+    mockAnthropicCreate = mockAnthropic.messages.create;
+
+    mockAnthropicCreate.mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {},
+    });
+
+    mockEventSource = {
+      stream: vi.fn((callback) => {
+        const mockStream = {
+          sendTextMessageStart: vi.fn(),
+          sendTextMessageContent: vi.fn(),
+          sendTextMessageEnd: vi.fn(),
+          sendActionExecutionStart: vi.fn(),
+          sendActionExecutionArgs: vi.fn(),
+          sendActionExecutionEnd: vi.fn(),
+          complete: vi.fn(),
+        };
+        callback(mockStream);
+        return Promise.resolve();
+      }),
+    };
+
+    const systemMessage = new TextMessage("system", "System message");
+    const userMessage = new TextMessage("user", "Hello");
+
+    await adapter.process({
+      threadId: "test-thread",
+      messages: [systemMessage, userMessage],
+      actions: [],
+      eventSource: mockEventSource,
+      forwardedParameters: { maxTokens: 8192 },
+    });
+
+    const createCallArgs = mockAnthropicCreate.mock.calls[0][0];
+    expect(createCallArgs.max_tokens).toBe(8192);
+  });
+});


### PR DESCRIPTION
## Summary
- Default `max_tokens` was hardcoded to 1024, causing truncated responses for most use cases
- Increased default from 1024 to 4096 while still respecting user-provided `maxTokens`

Fixes #2354

## Test plan
- [x] Added test verifying default max_tokens is 4096 when not specified
- [x] Added test verifying user-provided maxTokens is passed through
- [x] All existing anthropic adapter tests pass