### PR TITLE
fix: replace hardcoded width 97% with 100% on messages footer

### DIFF
--- a/packages/react-ui/src/css/messages.css
+++ b/packages/react-ui/src/css/messages.css
@@ -21,7 +21,8 @@
   margin: 8px auto 0 auto;
   justify-content: flex-start;
   flex-direction: column;
-  width: 97%;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .copilotKitMessages::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- `.copilotKitMessagesFooter` used `width: 97%` which caused horizontal overflow in constrained containers
- Changed to `width: 100%` with `box-sizing: border-box` so padding is included in the width calculation

Fixes #2325

## Test plan
- [x] All react-ui tests pass
- [ ] Visual verification: render CopilotKit chat in a constrained container (e.g. 300px sidebar) and confirm no horizontal scrollbar appears