### PR TITLE
fix: surface TOAST/BANNER errors when showDevConsole=false

### DIFF
--- a/packages/react-core/src/components/copilot-provider/__tests__/error-visibility-prod.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/error-visibility-prod.test.tsx
@@ -1,0 +1,65 @@
+import { vi, describe, it, expect, beforeEach, type Mock } from "vitest";
+
+// Mock modules before imports
+vi.mock("../../../utils/dev-console", () => ({
+  shouldShowDevConsole: vi.fn(),
+}));
+
+vi.mock("../../../context/copilot-context", () => ({
+  useCopilotContext: vi.fn(),
+}));
+
+vi.mock("../../toast/toast-provider", () => ({
+  useToast: vi.fn(),
+}));
+
+vi.mock("@copilotkit/runtime-client-gql", () => ({
+  loadMessagesFromJsonRepresentation: vi.fn(),
+}));
+
+import { shouldShowDevConsole } from "../../../utils/dev-console";
+import { ErrorVisibility, CopilotKitErrorCode } from "@copilotkit/shared";
+
+describe("Error visibility when showDevConsole=false (#2431)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should NOT suppress errors with toast visibility when isDev is false", () => {
+    // Simulate production: shouldShowDevConsole returns false
+    (shouldShowDevConsole as Mock).mockReturnValue(false);
+
+    const isDev = shouldShowDevConsole(false);
+    expect(isDev).toBe(false);
+
+    // A TOAST-visible error should still be surfaced in production
+    const visibility = ErrorVisibility.TOAST;
+    const shouldSurface =
+      visibility === ErrorVisibility.TOAST ||
+      visibility === ErrorVisibility.BANNER;
+
+    expect(shouldSurface).toBe(true);
+  });
+
+  it("should suppress DEV_ONLY errors when isDev is false", () => {
+    (shouldShowDevConsole as Mock).mockReturnValue(false);
+
+    const isDev = shouldShowDevConsole(false);
+    const visibility = ErrorVisibility.DEV_ONLY;
+
+    // DEV_ONLY errors should be suppressed when not in dev mode
+    const shouldSuppress = !isDev && visibility === ErrorVisibility.DEV_ONLY;
+    expect(shouldSuppress).toBe(true);
+  });
+
+  it("should suppress SILENT errors regardless of isDev", () => {
+    (shouldShowDevConsole as Mock).mockReturnValue(false);
+
+    const visibility = ErrorVisibility.SILENT;
+    const shouldSurface =
+      visibility === ErrorVisibility.TOAST ||
+      visibility === ErrorVisibility.BANNER;
+
+    expect(shouldSurface).toBe(false);
+  });
+});

--- a/packages/react-core/src/components/copilot-provider/__tests__/error-visibility-prod.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/error-visibility-prod.test.tsx
@@ -1,65 +1,70 @@
-import { vi, describe, it, expect, beforeEach, type Mock } from "vitest";
+import { describe, it, expect } from "vitest";
+import { ErrorVisibility } from "@copilotkit/shared";
+import { getErrorSuppression } from "../copilot-messages";
 
-// Mock modules before imports
-vi.mock("../../../utils/dev-console", () => ({
-  shouldShowDevConsole: vi.fn(),
-}));
+/**
+ * Regression tests for #2431: error visibility when showDevConsole=false.
+ *
+ * The bug: `routeError` returned early for ALL errors when `isDev` was false,
+ * suppressing TOAST and BANNER errors that should always reach the user.
+ *
+ * The fix: only SILENT and DEV_ONLY errors are suppressed in production;
+ * TOAST, BANNER, and untagged errors are always surfaced.
+ */
+describe("getErrorSuppression — error visibility routing (#2431)", () => {
+  // --- Production (isDev = false) ---
 
-vi.mock("../../../context/copilot-context", () => ({
-  useCopilotContext: vi.fn(),
-}));
-
-vi.mock("../../toast/toast-provider", () => ({
-  useToast: vi.fn(),
-}));
-
-vi.mock("@copilotkit/runtime-client-gql", () => ({
-  loadMessagesFromJsonRepresentation: vi.fn(),
-}));
-
-import { shouldShowDevConsole } from "../../../utils/dev-console";
-import { ErrorVisibility, CopilotKitErrorCode } from "@copilotkit/shared";
-
-describe("Error visibility when showDevConsole=false (#2431)", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  it("surfaces TOAST errors in production", () => {
+    expect(getErrorSuppression(ErrorVisibility.TOAST, false)).toBeNull();
   });
 
-  it("should NOT suppress errors with toast visibility when isDev is false", () => {
-    // Simulate production: shouldShowDevConsole returns false
-    (shouldShowDevConsole as Mock).mockReturnValue(false);
-
-    const isDev = shouldShowDevConsole(false);
-    expect(isDev).toBe(false);
-
-    // A TOAST-visible error should still be surfaced in production
-    const visibility = ErrorVisibility.TOAST;
-    const shouldSurface =
-      visibility === ErrorVisibility.TOAST ||
-      visibility === ErrorVisibility.BANNER;
-
-    expect(shouldSurface).toBe(true);
+  it("surfaces BANNER errors in production", () => {
+    expect(getErrorSuppression(ErrorVisibility.BANNER, false)).toBeNull();
   });
 
-  it("should suppress DEV_ONLY errors when isDev is false", () => {
-    (shouldShowDevConsole as Mock).mockReturnValue(false);
-
-    const isDev = shouldShowDevConsole(false);
-    const visibility = ErrorVisibility.DEV_ONLY;
-
-    // DEV_ONLY errors should be suppressed when not in dev mode
-    const shouldSuppress = !isDev && visibility === ErrorVisibility.DEV_ONLY;
-    expect(shouldSuppress).toBe(true);
+  it("suppresses DEV_ONLY errors in production", () => {
+    expect(getErrorSuppression(ErrorVisibility.DEV_ONLY, false)).not.toBeNull();
   });
 
-  it("should suppress SILENT errors regardless of isDev", () => {
-    (shouldShowDevConsole as Mock).mockReturnValue(false);
+  it("suppresses SILENT errors in production", () => {
+    expect(getErrorSuppression(ErrorVisibility.SILENT, false)).not.toBeNull();
+  });
 
-    const visibility = ErrorVisibility.SILENT;
-    const shouldSurface =
-      visibility === ErrorVisibility.TOAST ||
-      visibility === ErrorVisibility.BANNER;
+  it("surfaces errors with no visibility tag in production", () => {
+    expect(getErrorSuppression(undefined, false)).toBeNull();
+  });
 
-    expect(shouldSurface).toBe(false);
+  // --- Development (isDev = true) ---
+
+  it("surfaces TOAST errors in development", () => {
+    expect(getErrorSuppression(ErrorVisibility.TOAST, true)).toBeNull();
+  });
+
+  it("surfaces BANNER errors in development", () => {
+    expect(getErrorSuppression(ErrorVisibility.BANNER, true)).toBeNull();
+  });
+
+  it("surfaces DEV_ONLY errors in development", () => {
+    expect(getErrorSuppression(ErrorVisibility.DEV_ONLY, true)).toBeNull();
+  });
+
+  it("suppresses SILENT errors in development", () => {
+    expect(getErrorSuppression(ErrorVisibility.SILENT, true)).not.toBeNull();
+  });
+
+  it("surfaces errors with no visibility tag in development", () => {
+    expect(getErrorSuppression(undefined, true)).toBeNull();
+  });
+
+  // --- Log prefix strings ---
+
+  it("returns a 'Silent Error' prefix for SILENT visibility", () => {
+    const prefix = getErrorSuppression(ErrorVisibility.SILENT, false);
+    expect(prefix).toContain("Silent");
+  });
+
+  it("returns a 'hidden in production' prefix for DEV_ONLY visibility", () => {
+    const prefix = getErrorSuppression(ErrorVisibility.DEV_ONLY, false);
+    expect(prefix).toContain("hidden in production");
   });
 });

--- a/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
@@ -31,6 +31,33 @@ import {
 } from "@copilotkit/shared";
 import { Suggestion } from "@copilotkit/core";
 
+/**
+ * Determine whether a GraphQL error should be suppressed based on its visibility
+ * and whether the dev console is active.
+ *
+ * Returns `null` when the error should be surfaced to the UI, or a log prefix
+ * string when the error should be suppressed (logged to console only).
+ *
+ * Exported for unit testing.
+ */
+export function getErrorSuppression(
+  visibility: ErrorVisibility | undefined,
+  isDev: boolean,
+): string | null {
+  // Silent errors are always suppressed
+  if (visibility === ErrorVisibility.SILENT) {
+    return "CopilotKit Silent Error:";
+  }
+
+  // DEV_ONLY errors are suppressed in production
+  if (!isDev && visibility === ErrorVisibility.DEV_ONLY) {
+    return "CopilotKit Error (hidden in production):";
+  }
+
+  // All other visibilities (TOAST, BANNER, undefined) are always surfaced
+  return null;
+}
+
 // Helper to determine if error should show as banner based on visibility and legacy patterns
 function shouldShowAsBanner(gqlError: GraphQLError): boolean {
   const extensions = gqlError.extensions;
@@ -224,18 +251,9 @@ export function CopilotMessages({ children }: { children: ReactNode }) {
           const visibility = extensions?.visibility as ErrorVisibility;
           const isDev = shouldShowDevConsole(showDevConsole);
 
-          // Silent errors - just log
-          if (visibility === ErrorVisibility.SILENT) {
-            console.error("CopilotKit Silent Error:", gqlError.message);
-            return;
-          }
-
-          // DEV_ONLY errors are suppressed in production
-          if (!isDev && visibility === ErrorVisibility.DEV_ONLY) {
-            console.error(
-              "CopilotKit Error (hidden in production):",
-              gqlError.message,
-            );
+          const suppression = getErrorSuppression(visibility, isDev);
+          if (suppression) {
+            console.error(suppression, gqlError.message);
             return;
           }
 

--- a/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilot-messages.tsx
@@ -224,7 +224,14 @@ export function CopilotMessages({ children }: { children: ReactNode }) {
           const visibility = extensions?.visibility as ErrorVisibility;
           const isDev = shouldShowDevConsole(showDevConsole);
 
-          if (!isDev) {
+          // Silent errors - just log
+          if (visibility === ErrorVisibility.SILENT) {
+            console.error("CopilotKit Silent Error:", gqlError.message);
+            return;
+          }
+
+          // DEV_ONLY errors are suppressed in production
+          if (!isDev && visibility === ErrorVisibility.DEV_ONLY) {
             console.error(
               "CopilotKit Error (hidden in production):",
               gqlError.message,
@@ -232,12 +239,7 @@ export function CopilotMessages({ children }: { children: ReactNode }) {
             return;
           }
 
-          // Silent errors - just log
-          if (visibility === ErrorVisibility.SILENT) {
-            console.error("CopilotKit Silent Error:", gqlError.message);
-            return;
-          }
-
+          // TOAST and BANNER errors are always surfaced, even in production
           // All other errors (including DEV_ONLY) show as banners for consistency
           const ckError = createStructuredError(gqlError);
           if (ckError) {
@@ -259,19 +261,14 @@ export function CopilotMessages({ children }: { children: ReactNode }) {
         // Process all errors as banners
         graphQLErrors.forEach(routeError);
       } else {
-        const isDev = shouldShowDevConsole(showDevConsole);
-        if (!isDev) {
-          console.error("CopilotKit Error (hidden in production):", error);
-        } else {
-          // Route non-GraphQL errors to banner as well
-          const fallbackError = new CopilotKitError({
-            message: error?.message || String(error),
-            code: CopilotKitErrorCode.UNKNOWN,
-          });
-          setBannerError(fallbackError);
-          // Trace the non-GraphQL error
-          traceUIError(fallbackError, error);
-        }
+        // Non-GraphQL errors are always surfaced to the user
+        const fallbackError = new CopilotKitError({
+          message: error?.message || String(error),
+          code: CopilotKitErrorCode.UNKNOWN,
+        });
+        setBannerError(fallbackError);
+        // Trace the non-GraphQL error
+        traceUIError(fallbackError, error);
       }
     },
     [setBannerError, showDevConsole, traceUIError],


### PR DESCRIPTION
## Summary
- Fixes #2431
- The `routeError` function in `copilot-messages.tsx` returned early when `showDevConsole=false`, suppressing ALL errors including user-visible ones (TOAST and BANNER visibility)
- Now only `DEV_ONLY` and `SILENT` errors are suppressed in production; `TOAST` and `BANNER` errors are always surfaced to the chat UI
- Also fixes the non-GraphQL error handler which had the same early-return bug

## Test plan
- [x] Added `error-visibility-prod.test.tsx` covering TOAST, DEV_ONLY, and SILENT visibility behavior
- [x] All 1073 existing react-core tests pass
- [x] Build passes