### PR TITLE
fix: duck-type Request check for Hono polyfill compat

### DIFF
--- a/packages/runtime/src/lib/integrations/node-http/__tests__/request-duck-type.test.ts
+++ b/packages/runtime/src/lib/integrations/node-http/__tests__/request-duck-type.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Test for #2986: instanceof Request fails with @hono/node-server polyfill
+ *
+ * When Hono polyfills the Request class, `instanceof Request` fails because
+ * the polyfilled Request has a different prototype. We need duck-type checking.
+ */
+
+// Simulates a polyfilled Request object that does NOT pass instanceof Request
+function createPolyfillRequest(url: string, method: string = "GET"): object {
+  return {
+    url,
+    method,
+    headers: new Headers({ "content-type": "application/json" }),
+    body: null,
+    clone: () => createPolyfillRequest(url, method),
+  };
+}
+
+// This is the duck-type check that should replace instanceof
+function isRequestLike(obj: unknown): obj is Request {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "url" in obj &&
+    "method" in obj &&
+    "headers" in obj &&
+    typeof (obj as any).url === "string" &&
+    typeof (obj as any).method === "string"
+  );
+}
+
+describe("Request duck-type detection (#2986)", () => {
+  it("should detect a native Request object", () => {
+    const req = new Request("http://localhost:3000/api/copilotkit", {
+      method: "POST",
+    });
+    expect(isRequestLike(req)).toBe(true);
+    expect(req instanceof Request).toBe(true);
+  });
+
+  it("should detect a polyfilled Request object that fails instanceof", () => {
+    const polyfilled = createPolyfillRequest(
+      "http://localhost:3000/api/copilotkit",
+      "POST",
+    );
+
+    // instanceof fails for polyfilled objects
+    expect(polyfilled instanceof Request).toBe(false);
+
+    // But duck-type check succeeds
+    expect(isRequestLike(polyfilled)).toBe(true);
+  });
+
+  it("should NOT match null or undefined", () => {
+    expect(isRequestLike(null)).toBe(false);
+    expect(isRequestLike(undefined)).toBe(false);
+  });
+
+  it("should NOT match an object missing required properties", () => {
+    expect(isRequestLike({ url: "http://test.com" })).toBe(false);
+    expect(isRequestLike({ method: "GET" })).toBe(false);
+    expect(isRequestLike({})).toBe(false);
+  });
+});

--- a/packages/runtime/src/lib/integrations/node-http/index.ts
+++ b/packages/runtime/src/lib/integrations/node-http/index.ts
@@ -158,11 +158,25 @@ export function copilotRuntimeNodeHttpEndpoint(
     }
   };
 
+  // Duck-type check for Request-like objects (handles polyfilled Request from @hono/node-server)
+  function isRequestLike(obj: unknown): obj is Request {
+    return (
+      obj instanceof Request ||
+      (typeof obj === "object" &&
+        obj !== null &&
+        "url" in obj &&
+        "method" in obj &&
+        "headers" in obj &&
+        typeof (obj as any).url === "string" &&
+        typeof (obj as any).method === "string")
+    );
+  }
+
   return function (
     reqOrRequest: IncomingMessage | Request,
     res?: ServerResponse,
   ): Promise<void> | Promise<Response> | Response {
-    if (reqOrRequest instanceof Request) {
+    if (isRequestLike(reqOrRequest) && !res) {
       return honoApp.fetch(reqOrRequest as Request);
     }
     if (!res) {


### PR DESCRIPTION
## Summary
- Fixes #2986
- `reqOrRequest instanceof Request` fails when `@hono/node-server` polyfills the Request class with a different prototype
- Replaced with a duck-type check (`isRequestLike`) that verifies `url`, `method`, and `headers` properties exist
- The `!res` guard ensures IncomingMessage objects (which always come with a ServerResponse) are still routed correctly

## Test plan
- [x] Added `request-duck-type.test.ts` covering native Request, polyfilled Request, null/undefined, and missing properties
- [x] All 1225 existing runtime tests pass
- [x] Build passes