### PR TITLE
fix: guard filterAdjacentAgentStateMessages against undefined messages (#1691)

### DIFF
--- a/packages/runtime-client-gql/src/client/__tests__/conversion.test.ts
+++ b/packages/runtime-client-gql/src/client/__tests__/conversion.test.ts
@@ -62,3 +62,17 @@ describe("getPartialArguments non-object guard", () => {
     expect((messages[0] as any).arguments).toEqual({});
   });
 });
+
+import { filterAdjacentAgentStateMessages } from "../conversion";
+
+describe("filterAdjacentAgentStateMessages", () => {
+  it("returns empty array when called with undefined messages", () => {
+    const result = filterAdjacentAgentStateMessages(undefined as any);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when called with null messages", () => {
+    const result = filterAdjacentAgentStateMessages(null as any);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/runtime-client-gql/src/client/conversion.ts
+++ b/packages/runtime-client-gql/src/client/conversion.ts
@@ -89,7 +89,7 @@ export function filterAdjacentAgentStateMessages(
   const filteredMessages: GenerateCopilotResponseMutation["generateCopilotResponse"]["messages"] =
     [];
 
-  messages.forEach((message, i) => {
+  (messages || []).forEach((message, i) => {
     // keep all other message types
     if (message.__typename !== "AgentStateMessageOutput") {
       filteredMessages.push(message);


### PR DESCRIPTION
## Summary
- `filterAdjacentAgentStateMessages` called `.forEach` on the `messages` parameter without null-checking, causing a `TypeError` when messages was `undefined` or `null`
- Added `(messages || [])` guard so the function returns an empty array instead of crashing
- Added tests for both `undefined` and `null` inputs

## Test plan
- [x] New test: call with `undefined` -- returns `[]`
- [x] New test: call with `null` -- returns `[]`
- [x] All existing conversion tests still pass (131 tests)