### PR TITLE
fix: exclude tools with available:"disabled" from buildFrontendTools (#3020)

### DIFF
--- a/packages/core/src/core/__tests__/run-handler-available.test.ts
+++ b/packages/core/src/core/__tests__/run-handler-available.test.ts
@@ -87,3 +87,29 @@ describe("RunHandler tool available filtering", () => {
     expect(tools).toHaveLength(1);
   });
 });
+
+describe("RunHandler tool available:'disabled' filtering", () => {
+  it("excludes tools with available: 'disabled' (string) from buildFrontendTools", () => {
+    const runHandler = createRunHandler();
+    runHandler.initialize([
+      {
+        name: "enabledTool",
+        description: "An enabled tool",
+        parameters: z.object({ x: z.string() }),
+      },
+      {
+        name: "disabledStringTool",
+        description: "A disabled tool via string",
+        available: "disabled" as any,
+        parameters: z.object({ y: z.string() }),
+      },
+    ]);
+
+    const tools = runHandler.buildFrontendTools();
+    const toolNames = tools.map((t) => t.name);
+
+    expect(toolNames).toContain("enabledTool");
+    expect(toolNames).not.toContain("disabledStringTool");
+    expect(tools).toHaveLength(1);
+  });
+});

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -854,7 +854,7 @@ export class RunHandler {
     return this._tools
       .filter(
         (tool) =>
-          tool.available !== false &&
+          tool.available !== false && tool.available !== "disabled" &&
           (!tool.agentId || tool.agentId === agentId),
       )
       .map((tool) => ({

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -854,7 +854,8 @@ export class RunHandler {
     return this._tools
       .filter(
         (tool) =>
-          tool.available !== false && tool.available !== "disabled" &&
+          tool.available !== false &&
+          tool.available !== "disabled" &&
           (!tool.agentId || tool.agentId === agentId),
       )
       .map((tool) => ({


### PR DESCRIPTION
## Summary
- `buildFrontendTools` only checked `tool.available !== false` but the `available` field can also be the string `"disabled"`, which is truthy
- Added `tool.available !== "disabled"` to the filter so disabled tools are properly excluded
- Added test verifying tools with `available: "disabled"` are filtered out

## Test plan
- [x] New test: tool with `available: "disabled"` is excluded from `buildFrontendTools`
- [x] All existing available-filtering tests still pass
- [x] Full core test suite passes (338 tests)