### PR TITLE
fix: return null instead of throwing in useRenderCustomMessages (#3497)

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-render-custom-messages.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-render-custom-messages.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRenderCustomMessages } from "../use-render-custom-messages";
+import { CopilotKitProvider } from "../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../providers/CopilotChatConfigurationProvider";
+
+/**
+ * Regression test for #3497: useRenderCustomMessages throws "Agent not found"
+ * when the agent is undefined during the connecting state.
+ *
+ * During initial connection, the agent may not yet be registered in the
+ * CopilotKit registry. The hook should return null gracefully instead of
+ * throwing an error.
+ */
+describe("useRenderCustomMessages (#3497)", () => {
+  it("returns null instead of throwing when agent is not found", () => {
+    // Render the hook inside a CopilotKitProvider with an agentId that
+    // does NOT exist in the registry (simulating connecting state).
+    // The hook should not throw.
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <CopilotKitProvider
+        renderCustomMessages={[
+          {
+            agentId: "nonexistent-agent",
+            render: () => <div>Custom</div>,
+          },
+        ]}
+      >
+        <CopilotChatConfigurationProvider
+          agentId="nonexistent-agent"
+          threadId="test-thread"
+        >
+          {children}
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>
+    );
+
+    const { result } = renderHook(() => useRenderCustomMessages(), { wrapper });
+
+    // The hook should return a function (the render function), not throw
+    // When called, it should handle missing agent gracefully
+    if (typeof result.current === "function") {
+      const output = result.current({
+        message: { id: "msg-1", role: "assistant", content: "test" },
+        position: "after",
+      });
+      // Should return null since agent isn't found
+      expect(output).toBeNull();
+    } else {
+      // If result.current is null, that's also acceptable
+      expect(result.current).toBeNull();
+    }
+  });
+});

--- a/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-custom-messages.tsx
@@ -45,7 +45,7 @@ export function useRenderCustomMessages() {
     const registryAgent = copilotkit.getAgent(agentId);
     const agent = getThreadClone(registryAgent, threadId) ?? registryAgent;
     if (!agent) {
-      throw new Error("Agent not found");
+      return null;
     }
 
     const messagesIdsInRun = resolvedRunId


### PR DESCRIPTION
## Summary
- useRenderCustomMessages threw "Agent not found" when the agent was undefined during the connecting state
- Changed the throw to return null, allowing the component to render gracefully while the agent is being resolved

## Test plan
- [x] Red-green verified: test calls hook with nonexistent agent, asserts returns null not throws
- [x] Full react-core test suite passes (1071 tests)
- [x] Build passes

Closes #3497