### PR TITLE
fix: guard CopilotListeners against empty agents map (#3249)

### DIFF
--- a/packages/react-core/src/components/CopilotListeners.tsx
+++ b/packages/react-core/src/components/CopilotListeners.tsx
@@ -60,15 +60,26 @@ const usePredictStateSubscription = (agent?: AbstractAgent) => {
   }, [agent, getSubscriber]);
 };
 
-export function CopilotListeners() {
-  const { copilotkit } = useCopilotKit();
+function CopilotListenersAgentSubscription() {
   const existingConfig = useCopilotChatConfiguration();
   const resolvedAgentId = existingConfig?.agentId;
-  const { setBannerError } = useToast();
 
   const { agent } = useAgent({ agentId: resolvedAgentId });
 
   usePredictStateSubscription(agent);
+
+  return null;
+}
+
+export function CopilotListeners() {
+  const { copilotkit } = useCopilotKit();
+  const { setBannerError } = useToast();
+
+  // Only render the agent subscription when agents are registered or a runtime
+  // is configured. Without this guard, useAgent() throws when the agents map is
+  // empty and no runtimeUrl is set (#3249).
+  const hasAgents = Object.keys(copilotkit.agents ?? {}).length > 0;
+  const hasRuntime = copilotkit.runtimeUrl !== undefined;
 
   useEffect(() => {
     const subscriber: CopilotKitCoreSubscriber = {
@@ -122,5 +133,5 @@ export function CopilotListeners() {
     };
   }, [copilotkit?.subscribe]);
 
-  return null;
+  return (hasAgents || hasRuntime) ? <CopilotListenersAgentSubscription /> : null;
 }

--- a/packages/react-core/src/components/CopilotListeners.tsx
+++ b/packages/react-core/src/components/CopilotListeners.tsx
@@ -133,5 +133,5 @@ export function CopilotListeners() {
     };
   }, [copilotkit?.subscribe]);
 
-  return (hasAgents || hasRuntime) ? <CopilotListenersAgentSubscription /> : null;
+  return hasAgents || hasRuntime ? <CopilotListenersAgentSubscription /> : null;
 }

--- a/packages/react-core/src/components/__tests__/CopilotListeners.test.tsx
+++ b/packages/react-core/src/components/__tests__/CopilotListeners.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { CopilotListeners } from "../CopilotListeners";
+import { CopilotKitProvider } from "../../v2/providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../v2/providers/CopilotChatConfigurationProvider";
+import { ToastProvider } from "../toast/toast-provider";
+
+/**
+ * Regression test for #3249: CopilotListeners throws when no agents registered.
+ *
+ * When CopilotKitProvider has no agents registered (empty agents map) and no
+ * runtimeUrl, useAgent() inside CopilotListeners throws. The component should
+ * handle this gracefully and render null without crashing.
+ */
+describe("CopilotListeners (#3249)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("does not throw when no agents are registered", () => {
+    // No agents, no runtimeUrl - should not crash
+    expect(() => {
+      render(
+        <ToastProvider enabled={false}>
+          <CopilotKitProvider>
+            <CopilotChatConfigurationProvider
+              agentId="default"
+              threadId="test-thread"
+            >
+              <CopilotListeners />
+            </CopilotChatConfigurationProvider>
+          </CopilotKitProvider>
+        </ToastProvider>,
+      );
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- CopilotListeners called useAgent() unconditionally, which throws when no agents are registered and no runtimeUrl is configured
- Split into CopilotListeners (outer, handles error subscription) and CopilotListenersAgentSubscription (inner, uses useAgent)
- Inner component only renders when agents exist or a runtime is configured

## Test plan
- [x] Red-green verified: render CopilotListeners with no agents, assert no throw
- [x] Full react-core test suite passes (1071 tests)
- [x] Build passes

Closes #3249