### PR TITLE
fix: replace non-unique provider IDs like txt-0 with UUIDs (#3410, #3623)

### DIFF
--- a/packages/runtime/src/agent/__tests__/provider-id-collision.test.ts
+++ b/packages/runtime/src/agent/__tests__/provider-id-collision.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { BuiltInAgent } from "../index";
+import { EventType, type RunAgentInput } from "@ag-ui/client";
+import { streamText } from "ai";
+import {
+  mockStreamTextResponse,
+  textDelta,
+  finish,
+  collectEvents,
+} from "./test-helpers";
+
+// Mock the ai module
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+  tool: vi.fn((config) => config),
+  stepCountIs: vi.fn((count: number) => ({ type: "stepCount", count })),
+}));
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => (modelId: string) => ({
+    specificationVersion: "v3",
+    modelId,
+    provider: "openai",
+  })),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({
+    specificationVersion: "v3",
+    modelId,
+    provider: "anthropic",
+  })),
+}));
+
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: vi.fn(() => (modelId: string) => ({
+    specificationVersion: "v3",
+    modelId,
+    provider: "google",
+  })),
+}));
+
+describe("Provider ID collision (#3410, #3623)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.OPENAI_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should replace text-start providedId "txt-0" with a UUID', async () => {
+    const agent = new BuiltInAgent({ model: "openai:gpt-4o-mini" });
+
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([
+        { type: "text-start", id: "txt-0" },
+        textDelta("Hello"),
+        finish(),
+      ]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread-1",
+      runId: "run-1",
+      messages: [{ id: "1", role: "user", content: "Hi" }],
+      tools: [],
+      context: [],
+      state: {},
+    };
+
+    const events = await collectEvents(agent["run"](input));
+
+    // Find the TEXT_MESSAGE_CHUNK event and check its messageId
+    const textChunks = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+    );
+    expect(textChunks.length).toBeGreaterThan(0);
+    const messageId = (textChunks[0] as any).messageId;
+
+    // The messageId should NOT be "txt-0" — it should be a UUID
+    expect(messageId).not.toBe("txt-0");
+    // UUID v4 pattern
+    expect(messageId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('should replace reasoning-start providedId "reasoning-0" with a UUID', async () => {
+    const agent = new BuiltInAgent({ model: "openai:gpt-4o-mini" });
+
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([
+        { type: "reasoning-start", id: "reasoning-0" },
+        { type: "reasoning-delta", text: "Thinking..." },
+        { type: "reasoning-end" },
+        { type: "text-start", id: "txt-0" },
+        textDelta("Answer"),
+        finish(),
+      ]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread-2",
+      runId: "run-2",
+      messages: [{ id: "1", role: "user", content: "Hi" }],
+      tools: [],
+      context: [],
+      state: {},
+    };
+
+    const events = await collectEvents(agent["run"](input));
+
+    // Find REASONING_START event
+    const reasoningStarts = events.filter(
+      (e) => e.type === EventType.REASONING_START,
+    );
+    expect(reasoningStarts.length).toBeGreaterThan(0);
+    const reasoningId = (reasoningStarts[0] as any).messageId;
+
+    // Should NOT be "reasoning-0"
+    expect(reasoningId).not.toBe("reasoning-0");
+    expect(reasoningId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('should replace providedId "msg-0" with a UUID', async () => {
+    const agent = new BuiltInAgent({ model: "openai:gpt-4o-mini" });
+
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([
+        { type: "text-start", id: "msg-0" },
+        textDelta("Hello"),
+        finish(),
+      ]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread-3",
+      runId: "run-3",
+      messages: [{ id: "1", role: "user", content: "Hi" }],
+      tools: [],
+      context: [],
+      state: {},
+    };
+
+    const events = await collectEvents(agent["run"](input));
+
+    const textChunks = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+    );
+    expect(textChunks.length).toBeGreaterThan(0);
+    const messageId = (textChunks[0] as any).messageId;
+
+    expect(messageId).not.toBe("msg-0");
+    expect(messageId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("should preserve legitimate provider IDs", async () => {
+    const agent = new BuiltInAgent({ model: "openai:gpt-4o-mini" });
+
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([
+        { type: "text-start", id: "custom-msg-id-123" },
+        textDelta("Hello"),
+        finish(),
+      ]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread-4",
+      runId: "run-4",
+      messages: [{ id: "1", role: "user", content: "Hi" }],
+      tools: [],
+      context: [],
+      state: {},
+    };
+
+    const events = await collectEvents(agent["run"](input));
+
+    const textChunks = events.filter(
+      (e) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+    );
+    expect(textChunks.length).toBeGreaterThan(0);
+    // Legitimate IDs should be preserved
+    expect((textChunks[0] as any).messageId).toBe("custom-msg-id-123");
+  });
+});

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -1234,13 +1234,17 @@ export class BuiltInAgent extends AbstractAgent {
                 break;
               }
               case "reasoning-start": {
-                // Use SDK-provided id, or generate a fresh UUID if id is falsy/"0"
-                // to prevent consecutive reasoning blocks from sharing a messageId
+                // Use SDK-provided id, or generate a fresh UUID if the id is falsy,
+                // "0", or matches the non-unique pattern emitted by @ai-sdk/openai-compatible
+                // (e.g. "txt-0", "reasoning-0", "msg-0").
                 const providedId = "id" in part ? part.id : undefined;
-                reasoningMessageId =
-                  providedId && providedId !== "0"
-                    ? (providedId as typeof reasoningMessageId)
-                    : randomUUID();
+                const isNonUniqueId =
+                  !providedId ||
+                  providedId === "0" ||
+                  /^(txt|reasoning|msg)-0$/.test(providedId);
+                reasoningMessageId = isNonUniqueId
+                  ? randomUUID()
+                  : (providedId as typeof reasoningMessageId);
                 const reasoningStartEvent: ReasoningStartEvent = {
                   type: EventType.REASONING_START,
                   messageId: reasoningMessageId,
@@ -1308,12 +1312,16 @@ export class BuiltInAgent extends AbstractAgent {
 
               case "text-start": {
                 // New text message starting - use the SDK-provided id
-                // Use randomUUID() if part.id is falsy or "0" to prevent message merging issues
+                // Use randomUUID() if part.id is falsy, "0", or matches the non-unique
+                // pattern emitted by @ai-sdk/openai-compatible (e.g. "txt-0", "msg-0").
                 const providedId = "id" in part ? part.id : undefined;
-                messageId =
-                  providedId && providedId !== "0"
-                    ? (providedId as typeof messageId)
-                    : randomUUID();
+                const isNonUniqueTextId =
+                  !providedId ||
+                  providedId === "0" ||
+                  /^(txt|reasoning|msg)-0$/.test(providedId);
+                messageId = isNonUniqueTextId
+                  ? randomUUID()
+                  : (providedId as typeof messageId);
                 break;
               }
 


### PR DESCRIPTION
## Summary

- Providers like `@ai-sdk/openai-compatible` emit sequential IDs (`txt-0`, `reasoning-0`, `msg-0`) that are treated as unique but collide across requests
- The existing check only caught the literal `"0"` — expanded to match the `^(txt|reasoning|msg)-0$` pattern
- Both `text-start` and `reasoning-start` event handlers now use `randomUUID()` for these non-unique IDs

## Test plan

- [x] Added `provider-id-collision.test.ts` with 4 tests covering txt-0, reasoning-0, msg-0, and legitimate ID preservation
- [x] All 1226 runtime tests pass (including existing config-tools-execution tests)

Fixes #3410, #3623