### PR TITLE
fix: pass hookParams to onAfterRequest instead of empty object (#2124)

### DIFF
--- a/packages/runtime/src/lib/runtime/__tests__/on-after-request.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/on-after-request.test.ts
@@ -20,22 +20,103 @@ describe("onAfterRequest middleware (#2124)", () => {
       runtime: {} as any,
       response: new Response("test"),
       path: "/api/copilotkit",
-      messages: [{ id: "msg-1", role: "assistant", content: "Hello" }],
+      messages: [
+        { id: "msg-1", role: "user", content: "Hi there" },
+        { id: "msg-2", role: "assistant", content: "Hello" },
+        { id: "msg-3", role: "tool", content: "result", toolCallId: "tc-1" },
+      ],
       threadId: "thread-123",
       runId: "run-456",
     };
 
     await (afterRequestMw as Function)(fakeHookParams);
 
-    // The onAfterRequest callback should have been called
     expect(onAfterRequest).toHaveBeenCalledTimes(1);
 
-    // CRITICAL: It should NOT be called with an empty object
     const callArg = onAfterRequest.mock.calls[0][0];
+
+    // Should NOT be called with an empty object
     expect(callArg).not.toEqual({});
 
-    // It should receive the hookParams (or at least threadId/messages)
+    // Verify all OnAfterRequestOptions fields are present
     expect(callArg).toHaveProperty("threadId", "thread-123");
     expect(callArg).toHaveProperty("runId", "run-456");
+    expect(callArg).toHaveProperty("url", "/api/copilotkit");
+    expect(callArg).toHaveProperty("properties");
+    expect(callArg.properties).toEqual({});
+
+    // Verify message splitting: user messages → inputMessages, others → outputMessages
+    expect(callArg.inputMessages).toHaveLength(1);
+    expect(callArg.inputMessages[0]).toMatchObject({
+      id: "msg-1",
+      role: "user",
+    });
+
+    expect(callArg.outputMessages).toHaveLength(2);
+    expect(callArg.outputMessages[0]).toMatchObject({
+      id: "msg-2",
+      role: "assistant",
+    });
+    expect(callArg.outputMessages[1]).toMatchObject({
+      id: "msg-3",
+      role: "tool",
+    });
+  });
+
+  it("should handle undefined messages gracefully", async () => {
+    const onAfterRequest = vi.fn();
+
+    const runtime = new CopilotRuntime({
+      middleware: {
+        onAfterRequest,
+      },
+    });
+
+    const afterRequestMw = runtime.instance.afterRequestMiddleware;
+
+    const fakeHookParams = {
+      runtime: {} as any,
+      response: new Response("test"),
+      path: "/api/copilotkit",
+      // messages intentionally omitted (undefined)
+      threadId: "thread-789",
+    };
+
+    await (afterRequestMw as Function)(fakeHookParams);
+
+    expect(onAfterRequest).toHaveBeenCalledTimes(1);
+
+    const callArg = onAfterRequest.mock.calls[0][0];
+    expect(callArg.threadId).toBe("thread-789");
+    expect(callArg.inputMessages).toEqual([]);
+    expect(callArg.outputMessages).toEqual([]);
+  });
+
+  it("should default threadId to empty string when undefined", async () => {
+    const onAfterRequest = vi.fn();
+
+    const runtime = new CopilotRuntime({
+      middleware: {
+        onAfterRequest,
+      },
+    });
+
+    const afterRequestMw = runtime.instance.afterRequestMiddleware;
+
+    const fakeHookParams = {
+      runtime: {} as any,
+      response: new Response("test"),
+      path: "/api/copilotkit",
+      messages: [],
+      // threadId intentionally omitted
+    };
+
+    await (afterRequestMw as Function)(fakeHookParams);
+
+    expect(onAfterRequest).toHaveBeenCalledTimes(1);
+
+    const callArg = onAfterRequest.mock.calls[0][0];
+    expect(callArg.threadId).toBe("");
+    expect(callArg.runId).toBeUndefined();
   });
 });

--- a/packages/runtime/src/lib/runtime/__tests__/on-after-request.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/on-after-request.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { CopilotRuntime } from "../copilot-runtime";
+
+describe("onAfterRequest middleware (#2124)", () => {
+  it("should pass hookParams to onAfterRequest, not an empty object", async () => {
+    const onAfterRequest = vi.fn();
+
+    const runtime = new CopilotRuntime({
+      middleware: {
+        onAfterRequest,
+      },
+    });
+
+    // Access the internal afterRequestMiddleware function
+    const afterRequestMw = runtime.instance.afterRequestMiddleware;
+    expect(afterRequestMw).toBeDefined();
+
+    // Simulate calling the middleware with hookParams (as the v2 runtime would)
+    const fakeHookParams = {
+      runtime: {} as any,
+      response: new Response("test"),
+      path: "/api/copilotkit",
+      messages: [{ id: "msg-1", role: "assistant", content: "Hello" }],
+      threadId: "thread-123",
+      runId: "run-456",
+    };
+
+    await (afterRequestMw as Function)(fakeHookParams);
+
+    // The onAfterRequest callback should have been called
+    expect(onAfterRequest).toHaveBeenCalledTimes(1);
+
+    // CRITICAL: It should NOT be called with an empty object
+    const callArg = onAfterRequest.mock.calls[0][0];
+    expect(callArg).not.toEqual({});
+
+    // It should receive the hookParams (or at least threadId/messages)
+    expect(callArg).toHaveProperty("threadId", "thread-123");
+    expect(callArg).toHaveProperty("runId", "run-456");
+  });
+});

--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -590,18 +590,22 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
       params?.afterRequestMiddleware?.(hookParams);
 
       if (params?.middleware?.onAfterRequest) {
+        const messages = hookParams.messages ?? [];
         params.middleware.onAfterRequest({
           threadId: hookParams.threadId ?? "",
           runId: hookParams.runId,
-          inputMessages: (hookParams.messages ?? []).filter(
-            (m: any) => "role" in m && m.role === "user",
-          ),
-          outputMessages: (hookParams.messages ?? []).filter(
-            (m: any) => "role" in m && m.role !== "user",
-          ),
+          inputMessages: messages.filter(
+            (m): m is typeof m & { role: string } =>
+              "role" in m && m.role === "user",
+          ) as unknown as Message[],
+          outputMessages: messages.filter(
+            (m): m is typeof m & { role: string } =>
+              "role" in m && m.role !== "user",
+          ) as unknown as Message[],
+          // TODO: forward actual properties once the after-request hook has access to the request body
           properties: {},
           url: hookParams.path,
-        });
+        } satisfies OnAfterRequestOptions);
       }
     };
   }

--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -590,9 +590,18 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
       params?.afterRequestMiddleware?.(hookParams);
 
       if (params?.middleware?.onAfterRequest) {
-        // TODO: provide old expected params here when available
-        // @ts-expect-error -- missing arguments.
-        params.middleware.onAfterRequest({});
+        params.middleware.onAfterRequest({
+          threadId: hookParams.threadId ?? "",
+          runId: hookParams.runId,
+          inputMessages: (hookParams.messages ?? []).filter(
+            (m: any) => "role" in m && m.role === "user",
+          ),
+          outputMessages: (hookParams.messages ?? []).filter(
+            (m: any) => "role" in m && m.role !== "user",
+          ),
+          properties: {},
+          url: hookParams.path,
+        });
       }
     };
   }


### PR DESCRIPTION
## Summary

- `onAfterRequest` middleware callback was called with `{}` instead of actual hook parameters
- Now forwards `threadId`, `runId`, `inputMessages`, `outputMessages`, and `url` from the v2 runtime's `hookParams`
- The `onBeforeRequest` handler at line 566 already did this correctly; this fix makes `onAfterRequest` consistent

## Test plan

- [x] Added `on-after-request.test.ts` verifying the callback receives threadId and runId (not empty object)
- [x] All 1226 runtime tests pass

Fixes #2124