### PR TITLE
fix: add Slack alerts across all showcase workflows

### DIFF
--- a/.github/workflows/showcase_capture-previews.yml
+++ b/.github/workflows/showcase_capture-previews.yml
@@ -30,14 +30,16 @@ jobs:
     name: Capture Preview GIFs
     runs-on: ubuntu-latest
     # Disabled — preview GIFs removed from repo, awaiting external storage setup
-    # Loop prevention: when re-enabled, the second condition prevents an infinite cycle:
+    # Loop prevention: when re-enabled, the conditions below prevent an infinite cycle:
     #   capture commits registry.json → push matches showcase/** → deploy runs →
-    #   workflow_run triggers capture again. We break the loop by skipping when the
-    #   deploy was triggered by this workflow's own commit (identified by commit message).
+    #   workflow_run triggers capture again. We break the loop by skipping when either
+    #   trigger path was caused by this workflow's own commit (identified by commit message).
     if: >-
       false &&
       (github.event_name != 'workflow_run' ||
-       !startsWith(github.event.workflow_run.head_commit.message, 'Auto-capture preview GIFs'))
+       !startsWith(github.event.workflow_run.head_commit.message, 'Auto-capture preview GIFs')) &&
+      (github.event_name != 'push' ||
+       !startsWith(github.event.head_commit.message, 'Auto-capture preview GIFs'))
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/showcase_capture-previews.yml
+++ b/.github/workflows/showcase_capture-previews.yml
@@ -30,7 +30,14 @@ jobs:
     name: Capture Preview GIFs
     runs-on: ubuntu-latest
     # Disabled — preview GIFs removed from repo, awaiting external storage setup
-    if: false
+    # Loop prevention: when re-enabled, the second condition prevents an infinite cycle:
+    #   capture commits registry.json → push matches showcase/** → deploy runs →
+    #   workflow_run triggers capture again. We break the loop by skipping when the
+    #   deploy was triggered by this workflow's own commit (identified by commit message).
+    if: >-
+      false &&
+      (github.event_name != 'workflow_run' ||
+       !startsWith(github.event.workflow_run.head_commit.message, 'Auto-capture preview GIFs'))
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -220,3 +220,19 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{"query":"mutation { serviceInstanceRedeploy(serviceId: \"${{ matrix.service.railway_id }}\", environmentId: \"${{ env.RAILWAY_ENV_ID }}\") }"}' \
             && echo "Deploy triggered for ${{ matrix.service.dispatch_name }}"
+
+  notify:
+    needs: [build]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Collect results and notify Slack
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ needs.build.result == 'success' && ':white_check_mark: *Showcase deploy*: all services deployed to Railway' || needs.build.result == 'skipped' && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED (result: {0})', needs.build.result) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            }

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -222,7 +222,7 @@ jobs:
             && echo "Deploy triggered for ${{ matrix.service.dispatch_name }}"
 
   notify:
-    needs: [build]
+    needs: [detect-changes, check-lockfile, build]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -234,5 +234,5 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "${{ needs.build.result == 'success' && ':white_check_mark: *Showcase deploy*: all services deployed to Railway' || needs.build.result == 'skipped' && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED (result: {0})', needs.build.result) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+              "text": "${{ (needs.detect-changes.result == 'failure' || needs.check-lockfile.result == 'failure') && format(':x: *Showcase deploy*: FAILED (pre-build check)') || needs.build.result == 'success' && ':white_check_mark: *Showcase deploy*: all services deployed to Railway' || (needs.build.result == 'skipped' && needs.detect-changes.result == 'success') && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED (result: {0})', needs.build.result) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
             }

--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -134,3 +134,12 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             { "text": ":warning: *Docs sync*: files needing manual review — see workflow run for details\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
+
+      - name: Notify Slack (failure)
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ":x: *Docs sync*: workflow failed | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }

--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -109,10 +109,10 @@ jobs:
             --head "$BRANCH")
 
           echo "Created PR: $PR_URL"
-          gh pr merge "$PR_URL" --merge
-
           echo "files_changed=${CHANGED}" >> "$GITHUB_OUTPUT"
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+          gh pr merge "$PR_URL" --merge
 
       - name: Notify Slack (auto-sync)
         if: always() && steps.push.outcome == 'success' && steps.push.outputs.files_changed != '0'
@@ -122,6 +122,15 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             { "text": ":arrows_counterclockwise: *Docs sync*: auto-merged ${{ steps.push.outputs.files_changed || '?' }} file(s)\n${{ steps.push.outputs.pr_url || '' }}\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
+
+      - name: Notify Slack (merge failed)
+        if: failure() && steps.push.outputs.pr_url != ''
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ":warning: *Docs sync*: PR created but auto-merge FAILED — needs manual merge\n${{ steps.push.outputs.pr_url }}\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
 
       # Review items = files the sync script flagged but did NOT write to disk
       # (local modifications, files deleted on main). No file changes to propose —
@@ -136,7 +145,7 @@ jobs:
             { "text": ":warning: *Docs sync*: files needing manual review — see workflow run for details\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
 
       - name: Notify Slack (failure)
-        if: failure()
+        if: failure() && steps.push.outputs.pr_url == ''
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}

--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -73,7 +73,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post failure to Slack
-        if: failure() && github.event_name == 'schedule'
+        if: failure()
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
@@ -235,3 +235,12 @@ jobs:
                 body,
               });
             }
+
+      - name: Notify Slack (version drift)
+        if: steps.python_drift.outputs.report != '' || steps.npm_drift.outputs.report != ''
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ":warning: *Version drift*: dependency updates available — see GitHub issue | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }

--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -244,3 +244,12 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             { "text": ":warning: *Version drift*: dependency updates available — see GitHub issue | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
+
+      - name: Notify Slack (version drift failure)
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ":x: *Version drift check*: failed | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }

--- a/.github/workflows/showcase_qa-sync.yml
+++ b/.github/workflows/showcase_qa-sync.yml
@@ -44,3 +44,12 @@ jobs:
         env:
           NOTION_API_KEY: ${{ secrets.SHOWCASE_NOTION_API_KEY }}
         run: npx tsx sync-qa-to-notion.ts
+
+      - name: Notify Slack (failure)
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ":x: *QA sync to Notion*: failed | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }

--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -270,13 +270,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          FAILED=""
           for SVC in ${{ steps.image_drift.outputs.stale_services }}; do
             echo "Triggering rebuild for ${SVC}..."
-            gh workflow run showcase_deploy.yml -f service="${SVC}"
+            if ! gh workflow run showcase_deploy.yml -f service="${SVC}"; then
+              echo "::warning::Failed to trigger rebuild for ${SVC}"
+              FAILED="${FAILED} ${SVC}"
+            fi
           done
+          if [ -n "$FAILED" ]; then
+            echo "::error::Failed to trigger rebuilds for:${FAILED}"
+            exit 1
+          fi
 
       - name: Alert image drift to Slack
-        if: steps.image_drift.outputs.has_stale == 'true'
+        if: always() && steps.image_drift.outputs.has_stale == 'true'
         run: |
           HEADER=":package: *Image drift detected — rebuilds triggered:*"
           BODY=$(cat image-drift.txt)
@@ -284,7 +292,7 @@ jobs:
           jq -n --rawfile text drift-message.txt '{"text": $text}' > drift-payload.json
 
       - name: Post image drift to Slack
-        if: steps.image_drift.outputs.has_stale == 'true'
+        if: always() && steps.image_drift.outputs.has_stale == 'true'
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}

--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -272,7 +272,7 @@ jobs:
         run: |
           for SVC in ${{ steps.image_drift.outputs.stale_services }}; do
             echo "Triggering rebuild for ${SVC}..."
-            gh workflow run showcase_deploy.yml -f service="${SVC}" || echo "  Failed to trigger ${SVC}"
+            gh workflow run showcase_deploy.yml -f service="${SVC}"
           done
 
       - name: Alert image drift to Slack
@@ -290,6 +290,15 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload-file-path: drift-payload.json
+
+      - name: Notify Slack (workflow failure)
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ":x: *Smoke monitor*: workflow failed | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
 
       - name: Save state to cache
         if: always()

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -53,3 +53,12 @@ jobs:
       - name: Build showcase shell
         working-directory: showcase/shell
         run: npm run build
+
+      - name: Notify Slack (failure)
+        if: failure() && github.event_name == 'push'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            { "text": ":x: *Showcase validate*: failed | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }

--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -114,7 +114,7 @@ jobs:
           retention-days: 7
 
       - name: Alert Slack on failure
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}


### PR DESCRIPTION
## Summary

Comprehensive Slack alerting across all showcase workflows:

- **showcase_deploy.yml** — success/failure notifications (was completely silent)
- **showcase_docs-sync.yml** — failure notification for script crashes and token failures
- **showcase_validate.yml** — failure notification on main push (not PRs)
- **showcase_qa-sync.yml** — failure notification
- **showcase_smoke-monitor.yml** — removed silent `|| echo` on rebuild trigger, added workflow failure alert
- **showcase_drift-detection.yml** — expanded E2E failure alert to include manual dispatch, added version drift Slack alert
- **starter-smoke.yml** — expanded failure alert to include post-release workflow_run triggers
- **showcase_capture-previews.yml** — loop prevention guard for when re-enabled

## Test plan

- [ ] Trigger docs sync, verify Slack alerts fire
- [ ] Verify deploy workflow sends success notification after next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)