### PR TITLE
fix: batch community bug fixes (#2158, #2159, #2194, #2234, #2296, #2405, #2450, #2504, #2615)

### DIFF
--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -76,7 +76,7 @@ export interface CopilotKitProps extends Omit<
    * }
    * ```
    */
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | (() => Record<string, string>);
 
   /**
    * The children to be rendered within the CopilotKit.

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -311,7 +311,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       publicApiKey: publicApiKey,
       ...(cloud ? { cloud } : {}),
       chatApiEndpoint: chatApiEndpoint,
-      headers: props.headers || {},
+      headers: typeof props.headers === "function" ? props.headers() : (props.headers || {}),
       properties: props.properties || {},
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -311,7 +311,10 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       publicApiKey: publicApiKey,
       ...(cloud ? { cloud } : {}),
       chatApiEndpoint: chatApiEndpoint,
-      headers: typeof props.headers === "function" ? props.headers() : (props.headers || {}),
+      headers:
+        typeof props.headers === "function"
+          ? props.headers()
+          : props.headers || {},
       properties: props.properties || {},
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -137,7 +137,12 @@ type MarkdownProps = {
   rehypePlugins?: Options["rehypePlugins"];
 };
 
-export const Markdown = ({ content, components, remarkPlugins, rehypePlugins }: MarkdownProps) => {
+export const Markdown = ({
+  content,
+  components,
+  remarkPlugins,
+  rehypePlugins,
+}: MarkdownProps) => {
   const mergedComponents = useMemo(
     () => ({ ...defaultComponents, ...components }),
     [components],

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -97,9 +97,9 @@ const defaultComponents: Components = {
     </h6>
   ),
   p: ({ children, ...props }) => (
-    <p className="copilotKitMarkdownElement" {...props}>
+    <div className="copilotKitMarkdownElement copilotKitParagraph" {...props}>
       {children}
-    </p>
+    </div>
   ),
   pre: ({ children, ...props }) => (
     <pre className="copilotKitMarkdownElement" {...props}>
@@ -133,9 +133,11 @@ const MemoizedReactMarkdown: FC<Options> = memo(
 type MarkdownProps = {
   content: string;
   components?: Components;
+  remarkPlugins?: Options["remarkPlugins"];
+  rehypePlugins?: Options["rehypePlugins"];
 };
 
-export const Markdown = ({ content, components }: MarkdownProps) => {
+export const Markdown = ({ content, components, remarkPlugins, rehypePlugins }: MarkdownProps) => {
   const mergedComponents = useMemo(
     () => ({ ...defaultComponents, ...components }),
     [components],
@@ -147,8 +149,9 @@ export const Markdown = ({ content, components }: MarkdownProps) => {
         remarkPlugins={[
           remarkGfm,
           [remarkMath, { singleDollarTextMath: false }],
+          ...(remarkPlugins || []),
         ]}
-        rehypePlugins={[rehypeRaw]}
+        rehypePlugins={[rehypeRaw, ...(rehypePlugins || [])]}
       >
         {content}
       </MemoizedReactMarkdown>

--- a/packages/react-ui/src/components/chat/index.tsx
+++ b/packages/react-ui/src/components/chat/index.tsx
@@ -2,6 +2,8 @@ export * from "./props";
 export { CopilotPopup } from "./Popup";
 export { CopilotSidebar } from "./Sidebar";
 export { CopilotChat } from "./Chat";
+export { CopilotModal } from "./Modal";
+export type { CopilotModalProps } from "./Modal";
 export { Markdown } from "./Markdown";
 export { AssistantMessage } from "./messages/AssistantMessage";
 export { UserMessage } from "./messages/UserMessage";

--- a/packages/react-ui/src/components/chat/props.ts
+++ b/packages/react-ui/src/components/chat/props.ts
@@ -121,12 +121,12 @@ export interface MessagesProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Map of message IDs to their feedback state
@@ -217,12 +217,12 @@ export interface AssistantMessageProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * The feedback state for this message ("thumbsUp" or "thumbsDown")
@@ -313,12 +313,12 @@ export interface RenderMessageProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Map of message IDs to their feedback state

--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -70,12 +70,19 @@ export interface AnthropicAdapterParams {
    * See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
    */
   promptCaching?: AnthropicPromptCachingConfig;
+
+  /**
+   * Optional maximum input token limit. Overrides the default limit
+   * used when trimming messages to fit the context window.
+   */
+  maxInputTokens?: number;
 }
 
 export class AnthropicAdapter implements CopilotServiceAdapter {
   public model: string = DEFAULT_MODEL;
   public provider = "anthropic";
   private promptCaching: AnthropicPromptCachingConfig;
+  private maxInputTokens?: number;
 
   private _anthropic: Anthropic;
   public get anthropic(): Anthropic {
@@ -94,6 +101,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
       this.model = params.model;
     }
     this.promptCaching = params?.promptCaching || { enabled: false };
+    this.maxInputTokens = params?.maxInputTokens;
   }
 
   getLanguageModel(): LanguageModel {
@@ -244,6 +252,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
       forwardedParameters,
     } = request;
     const tools = actions.map(convertActionInputToAnthropicTool);
+    const knownActionNames = new Set(actions.map((a) => a.name));
 
     const messages = [...rawMessages];
 
@@ -322,6 +331,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
       anthropicMessages,
       tools,
       model,
+      this.maxInputTokens,
     );
 
     // Apply prompt caching if enabled
@@ -381,6 +391,11 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
                 filterThinkingTextBuffer.reset();
                 mode = "message";
               } else if (chunk.content_block.type === "tool_use") {
+                if (!knownActionNames.has(chunk.content_block.name)) {
+                  // Unknown tool - skip execution to prevent crashes
+                  mode = null;
+                  continue;
+                }
                 currentToolCallId = chunk.content_block.id;
                 eventStream$.sendActionExecutionStart({
                   actionExecutionId: currentToolCallId,

--- a/packages/runtime/src/service-adapters/anthropic/utils.ts
+++ b/packages/runtime/src/service-adapters/anthropic/utils.ts
@@ -49,7 +49,38 @@ export function limitMessagesToTokenCount(
     maxTokens -= numTokens;
   }
 
-  return result;
+  // Post-process: ensure every tool_result has a matching tool_use
+  // Token trimming may have removed the assistant message containing tool_use
+  // while keeping the user message with tool_result, which Anthropic rejects.
+  const toolUseIds = new Set<string>();
+  for (const msg of result) {
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (block.type === "tool_use") {
+          toolUseIds.add(block.id);
+        }
+      }
+    }
+  }
+
+  const filtered = result.filter((msg: any) => {
+    if (msg.role === "user" && Array.isArray(msg.content)) {
+      const hasOrphanedToolResult = msg.content.some(
+        (block: any) => block.type === "tool_result" && !toolUseIds.has(block.tool_use_id),
+      );
+      if (hasOrphanedToolResult) {
+        // Remove orphaned tool_result blocks; keep the message if other content remains
+        const remaining = msg.content.filter(
+          (block: any) => block.type !== "tool_result" || toolUseIds.has(block.tool_use_id),
+        );
+        if (remaining.length === 0) return false;
+        msg.content = remaining;
+      }
+    }
+    return true;
+  });
+
+  return filtered;
 }
 
 const MAX_TOKENS = 128000;

--- a/packages/runtime/src/service-adapters/anthropic/utils.ts
+++ b/packages/runtime/src/service-adapters/anthropic/utils.ts
@@ -66,12 +66,14 @@ export function limitMessagesToTokenCount(
   const filtered = result.filter((msg: any) => {
     if (msg.role === "user" && Array.isArray(msg.content)) {
       const hasOrphanedToolResult = msg.content.some(
-        (block: any) => block.type === "tool_result" && !toolUseIds.has(block.tool_use_id),
+        (block: any) =>
+          block.type === "tool_result" && !toolUseIds.has(block.tool_use_id),
       );
       if (hasOrphanedToolResult) {
         // Remove orphaned tool_result blocks; keep the message if other content remains
         const remaining = msg.content.filter(
-          (block: any) => block.type !== "tool_result" || toolUseIds.has(block.tool_use_id),
+          (block: any) =>
+            block.type !== "tool_result" || toolUseIds.has(block.tool_use_id),
         );
         if (remaining.length === 0) return false;
         msg.content = remaining;

--- a/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -199,7 +199,12 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
     let openaiMessages = filteredMessages.map((m) =>
       convertMessageToOpenAIMessage(m, { keepSystemRole: this.keepSystemRole }),
     );
-    openaiMessages = limitMessagesToTokenCount(openaiMessages, tools, model, this.maxInputTokens);
+    openaiMessages = limitMessagesToTokenCount(
+      openaiMessages,
+      tools,
+      model,
+      this.maxInputTokens,
+    );
 
     let toolChoice: any = forwardedParameters?.toolChoice;
     if (forwardedParameters?.toolChoice === "function") {

--- a/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -96,6 +96,12 @@ export interface OpenAIAdapterParams {
    * @default false
    */
   keepSystemRole?: boolean;
+
+  /**
+   * Optional maximum input token limit. Overrides the default model-based limit
+   * used when trimming messages to fit the context window.
+   */
+  maxInputTokens?: number;
 }
 
 export class OpenAIAdapter implements CopilotServiceAdapter {
@@ -105,6 +111,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
   private disableParallelToolCalls: boolean = false;
   private _openai: OpenAI;
   private keepSystemRole: boolean = false;
+  private maxInputTokens?: number;
 
   public get openai(): OpenAI {
     return this._openai;
@@ -124,6 +131,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
     }
     this.disableParallelToolCalls = params?.disableParallelToolCalls || false;
     this.keepSystemRole = params?.keepSystemRole ?? false;
+    this.maxInputTokens = params?.maxInputTokens;
   }
 
   getLanguageModel(): LanguageModel {
@@ -191,7 +199,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
     let openaiMessages = filteredMessages.map((m) =>
       convertMessageToOpenAIMessage(m, { keepSystemRole: this.keepSystemRole }),
     );
-    openaiMessages = limitMessagesToTokenCount(openaiMessages, tools, model);
+    openaiMessages = limitMessagesToTokenCount(openaiMessages, tools, model, this.maxInputTokens);
 
     let toolChoice: any = forwardedParameters?.toolChoice;
     if (forwardedParameters?.toolChoice === "function") {

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -18,6 +18,22 @@ except ImportError:
     from langchain_core.messages import BaseMessage, SystemMessage
     
 from langchain_core.runnables import RunnableConfig, ensure_config
+
+def _serialize_state(state):
+    """Recursively convert Pydantic BaseModel instances to dicts for serialization."""
+    try:
+        from pydantic import BaseModel as PydanticBaseModel
+    except ImportError:
+        return state
+
+    if isinstance(state, PydanticBaseModel):
+        return state.model_dump()
+    elif isinstance(state, dict):
+        return {k: _serialize_state(v) for k, v in state.items()}
+    elif isinstance(state, (list, tuple)):
+        return type(state)(_serialize_state(item) for item in state)
+    return state
+
 from langchain_core.messages import HumanMessage
 
 from partialjson.json_parser import JSONParser
@@ -590,6 +606,9 @@ class LangGraphAgent(Agent):
 
         # Filter by schema keys if available
         state = self.filter_state_on_schema_keys(state, 'output')
+
+        # Convert Pydantic BaseModel instances to dicts for serialization
+        state = _serialize_state(state)
 
         return langchain_dumps({
             "event": "on_copilotkit_state_sync",


### PR DESCRIPTION
## Summary

Batch of community-reported bug fixes:

- **#2194**: Export `CopilotModal` and `CopilotModalProps` from `@copilotkit/react-ui`
- **#2234**: Replace `<p>` with `<div>` in Markdown component to prevent p>div hydration errors
- **#2296**: Add `remarkPlugins`/`rehypePlugins` props to Markdown component
- **#2615**: Add optional `isActive` toggle parameter to `onThumbsUp`/`onThumbsDown` callbacks
- **#2159**: Accept `(() => Record<string, string>)` in addition to static `Record` for `headers` prop
- **#2405**: Add optional `maxInputTokens` to OpenAI and Anthropic adapter constructors
- **#2504**: Skip `tool_use` blocks for unknown tools in Anthropic adapter instead of crashing
- **#2450**: Post-process token-trimmed messages to ensure every `tool_result` has a matching `tool_use`
- **#2158**: Convert Pydantic `BaseModel` instances to dicts before `langchain_dumps` serialization

## Test plan

- [x] All 1221 runtime tests pass
- [x] All three modified packages build successfully (`@copilotkit/runtime`, `@copilotkit/react-core`, `@copilotkit/react-ui`)
- [x] oxfmt formatting verified
- [ ] Manual verification of Markdown hydration fix in SSR context
- [ ] Manual verification of Pydantic serialization with BaseModel state