### PR TITLE
fix: strip leaked TextAfterCursor/TextBeforeCursor tags from autosuggestions (#772)

### DIFF
--- a/packages/react-textarea/src/hooks/make-autosuggestions-function/use-make-standard-autosuggestions-function.tsx
+++ b/packages/react-textarea/src/hooks/make-autosuggestions-function/use-make-standard-autosuggestions-function.tsx
@@ -113,6 +113,11 @@ export function useMakeStandardAutosuggestionFunction(
           }
         }
 
+        // Strip any leaked TextAfterCursor/TextBeforeCursor tags from the suggestion
+        result = result
+          .replace(/<\/?TextAfterCursor>/g, "")
+          .replace(/<\/?TextBeforeCursor>/g, "");
+
         return result;
       });
 


### PR DESCRIPTION
Fixes #772

Red-green tested locally.