### PR TITLE
fix: prevent Enter key from sending during IME composition (#1862)

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -434,7 +434,7 @@ export function CopilotChatInput({
       }
     }
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       if (isProcessing) {
         onStop?.();


### PR DESCRIPTION
Fixes #1862

Red-green tested locally.