### PR TITLE
fix: allow maxTokens override for unrecognized OpenAI-compatible models (#1950)

### DIFF
--- a/packages/runtime/src/service-adapters/openai/utils.ts
+++ b/packages/runtime/src/service-adapters/openai/utils.ts
@@ -60,8 +60,11 @@ export function limitMessagesToTokenCount(
   return result;
 }
 
-export function maxTokensForOpenAIModel(model: string): number {
-  return maxTokensByModel[model] || DEFAULT_MAX_TOKENS;
+export function maxTokensForOpenAIModel(
+  model: string,
+  overrideMaxTokens?: number,
+): number {
+  return maxTokensByModel[model] || overrideMaxTokens || DEFAULT_MAX_TOKENS;
 }
 
 const DEFAULT_MAX_TOKENS = 128000;


### PR DESCRIPTION
Fixes #1950

Red-green tested locally.