### PR TITLE
fix: support OpenAI SDK v5 by falling back from openai.beta to openai.chat.completions (#1979)

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -117,7 +117,7 @@
     "graphql-scalars": "^1.23.0",
     "graphql-yoga": "^5.3.1",
     "hono": "^4.11.4",
-    "openai": "^4.85.1",
+    "openai": "^4.85.1 || ^5.0.0",
     "partial-json": "^0.1.7",
     "phoenix": "^1.8.4",
     "pino": "^9.2.0",
@@ -160,7 +160,8 @@
     "@langchain/langgraph-sdk": ">=0.1.2",
     "@langchain/openai": ">=0.4.2",
     "groq-sdk": ">=0.3.0 <1.0.0",
-    "langchain": ">=0.3.3"
+    "langchain": ">=0.3.3",
+    "openai": "^4.85.1 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -117,7 +117,7 @@
     "graphql-scalars": "^1.23.0",
     "graphql-yoga": "^5.3.1",
     "hono": "^4.11.4",
-    "openai": "^4.85.1 || ^5.0.0",
+    "openai": "^4.85.1 || >=5.0.0",
     "partial-json": "^0.1.7",
     "phoenix": "^1.8.4",
     "pino": "^9.2.0",
@@ -161,7 +161,7 @@
     "@langchain/openai": ">=0.4.2",
     "groq-sdk": ">=0.3.0 <1.0.0",
     "langchain": ">=0.3.3",
-    "openai": "^4.85.1 || ^5.0.0"
+    "openai": "^4.85.1 || >=5.0.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {

--- a/packages/runtime/src/service-adapters/openai/__tests__/openai-v5-compat.test.ts
+++ b/packages/runtime/src/service-adapters/openai/__tests__/openai-v5-compat.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from "vitest";
+import { isOpenAIV5, getChatCompletionsForStreaming } from "../utils";
+import type OpenAI from "openai";
+
+/**
+ * Tests for OpenAI SDK v4/v5 compatibility layer.
+ *
+ * In v5, the `beta.chat` namespace was removed and promoted to `chat`.
+ * In v5, methods with multiple path params switched to named params
+ * (e.g. runs.retrieve(runId, { thread_id }) instead of runs.retrieve(threadId, runId)).
+ */
+
+function createMockV4Client() {
+  const streamFn = vi.fn();
+  return {
+    client: {
+      beta: {
+        chat: {
+          completions: { stream: streamFn },
+        },
+        threads: {
+          create: vi.fn(),
+          runs: {
+            retrieve: vi.fn(),
+            stream: vi.fn(),
+            submitToolOutputsStream: vi.fn(),
+          },
+          messages: {
+            create: vi.fn(),
+          },
+        },
+      },
+      chat: {
+        completions: {
+          stream: vi.fn(), // exists but should NOT be used for streaming in v4
+        },
+      },
+    } as unknown as OpenAI,
+    streamFn,
+  };
+}
+
+function createMockV5Client() {
+  const streamFn = vi.fn();
+  return {
+    client: {
+      // v5: beta.chat is gone, only beta.threads remains
+      beta: {
+        threads: {
+          create: vi.fn(),
+          runs: {
+            retrieve: vi.fn(),
+            stream: vi.fn(),
+            submitToolOutputsStream: vi.fn(),
+          },
+          messages: {
+            create: vi.fn(),
+          },
+        },
+      },
+      chat: {
+        completions: {
+          stream: streamFn,
+        },
+      },
+    } as unknown as OpenAI,
+    streamFn,
+  };
+}
+
+describe("isOpenAIV5", () => {
+  it("returns false for a v4 client (beta.chat exists)", () => {
+    const { client } = createMockV4Client();
+    expect(isOpenAIV5(client)).toBe(false);
+  });
+
+  it("returns true for a v5 client (beta.chat does not exist)", () => {
+    const { client } = createMockV5Client();
+    expect(isOpenAIV5(client)).toBe(true);
+  });
+
+  it("returns true when beta is entirely missing", () => {
+    const client = { chat: { completions: {} } } as unknown as OpenAI;
+    expect(isOpenAIV5(client)).toBe(true);
+  });
+});
+
+describe("getChatCompletionsForStreaming", () => {
+  it("returns beta.chat.completions for a v4 client", () => {
+    const { client } = createMockV4Client();
+    const completions = getChatCompletionsForStreaming(client);
+    // Should be the beta version, not the top-level one
+    expect(completions).toBe(
+      (client as unknown as Record<string, any>).beta.chat.completions,
+    );
+  });
+
+  it("returns chat.completions for a v5 client", () => {
+    const { client } = createMockV5Client();
+    const completions = getChatCompletionsForStreaming(client);
+    expect(completions).toBe(client.chat.completions);
+  });
+
+  it("stream() on v4 calls beta.chat.completions.stream", () => {
+    const { client, streamFn } = createMockV4Client();
+    const completions = getChatCompletionsForStreaming(client);
+    (completions as any).stream({ model: "gpt-4o", messages: [] });
+    expect(streamFn).toHaveBeenCalledWith({ model: "gpt-4o", messages: [] });
+  });
+
+  it("stream() on v5 calls chat.completions.stream", () => {
+    const { client, streamFn } = createMockV5Client();
+    const completions = getChatCompletionsForStreaming(client);
+    (completions as any).stream({ model: "gpt-4o", messages: [] });
+    expect(streamFn).toHaveBeenCalledWith({ model: "gpt-4o", messages: [] });
+  });
+});
+
+describe("OpenAI Assistant Adapter v5 named path params", () => {
+  /**
+   * These tests verify that the assistant adapter correctly dispatches
+   * to the right calling convention based on SDK version.
+   * v4: runs.retrieve(threadId, runId)
+   * v5: runs.retrieve(runId, { thread_id: threadId })
+   */
+
+  it("v4 runs.retrieve is called with positional args (threadId, runId)", () => {
+    const { client } = createMockV4Client();
+    const retrieveFn = (client as any).beta.threads.runs.retrieve;
+
+    // Simulate the v4 call pattern from the adapter
+    if (!isOpenAIV5(client)) {
+      retrieveFn("thread_abc", "run_xyz");
+    }
+
+    expect(retrieveFn).toHaveBeenCalledWith("thread_abc", "run_xyz");
+  });
+
+  it("v5 runs.retrieve is called with named path params (runId, { thread_id })", () => {
+    const { client } = createMockV5Client();
+    const retrieveFn = (client as any).beta.threads.runs.retrieve;
+
+    // Simulate the v5 call pattern from the adapter
+    if (isOpenAIV5(client)) {
+      retrieveFn("run_xyz", { thread_id: "thread_abc" });
+    }
+
+    expect(retrieveFn).toHaveBeenCalledWith("run_xyz", {
+      thread_id: "thread_abc",
+    });
+  });
+
+  it("v4 submitToolOutputsStream is called with positional args", () => {
+    const { client } = createMockV4Client();
+    const submitFn = (client as any).beta.threads.runs.submitToolOutputsStream;
+    const body = { tool_outputs: [{ tool_call_id: "tc_1", output: "result" }] };
+
+    if (!isOpenAIV5(client)) {
+      submitFn("thread_abc", "run_xyz", body);
+    }
+
+    expect(submitFn).toHaveBeenCalledWith("thread_abc", "run_xyz", body);
+  });
+
+  it("v5 submitToolOutputsStream is called with named path params", () => {
+    const { client } = createMockV5Client();
+    const submitFn = (client as any).beta.threads.runs.submitToolOutputsStream;
+    const body = { tool_outputs: [{ tool_call_id: "tc_1", output: "result" }] };
+
+    if (isOpenAIV5(client)) {
+      submitFn("run_xyz", { thread_id: "thread_abc", ...body });
+    }
+
+    expect(submitFn).toHaveBeenCalledWith("run_xyz", {
+      thread_id: "thread_abc",
+      ...body,
+    });
+  });
+});

--- a/packages/runtime/src/service-adapters/openai/__tests__/openai-v5-compat.test.ts
+++ b/packages/runtime/src/service-adapters/openai/__tests__/openai-v5-compat.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { isOpenAIV5, getChatCompletionsForStreaming } from "../utils";
+import {
+  isOpenAIV5,
+  getChatCompletionsForStreaming,
+  retrieveThreadRun,
+  submitToolOutputsStream,
+} from "../utils";
 import type OpenAI from "openai";
 
 /**
@@ -21,7 +26,7 @@ function createMockV4Client() {
         threads: {
           create: vi.fn(),
           runs: {
-            retrieve: vi.fn(),
+            retrieve: vi.fn().mockResolvedValue({ id: "run_xyz" }),
             stream: vi.fn(),
             submitToolOutputsStream: vi.fn(),
           },
@@ -49,7 +54,7 @@ function createMockV5Client() {
         threads: {
           create: vi.fn(),
           runs: {
-            retrieve: vi.fn(),
+            retrieve: vi.fn().mockResolvedValue({ id: "run_xyz" }),
             stream: vi.fn(),
             submitToolOutputsStream: vi.fn(),
           },
@@ -90,9 +95,7 @@ describe("getChatCompletionsForStreaming", () => {
     const { client } = createMockV4Client();
     const completions = getChatCompletionsForStreaming(client);
     // Should be the beta version, not the top-level one
-    expect(completions).toBe(
-      (client as unknown as Record<string, any>).beta.chat.completions,
-    );
+    expect(completions).not.toBe(client.chat.completions);
   });
 
   it("returns chat.completions for a v5 client", () => {
@@ -104,72 +107,67 @@ describe("getChatCompletionsForStreaming", () => {
   it("stream() on v4 calls beta.chat.completions.stream", () => {
     const { client, streamFn } = createMockV4Client();
     const completions = getChatCompletionsForStreaming(client);
-    (completions as any).stream({ model: "gpt-4o", messages: [] });
+    completions.stream({ model: "gpt-4o", messages: [] });
     expect(streamFn).toHaveBeenCalledWith({ model: "gpt-4o", messages: [] });
   });
 
   it("stream() on v5 calls chat.completions.stream", () => {
     const { client, streamFn } = createMockV5Client();
     const completions = getChatCompletionsForStreaming(client);
-    (completions as any).stream({ model: "gpt-4o", messages: [] });
+    completions.stream({ model: "gpt-4o", messages: [] });
     expect(streamFn).toHaveBeenCalledWith({ model: "gpt-4o", messages: [] });
   });
 });
 
-describe("OpenAI Assistant Adapter v5 named path params", () => {
-  /**
-   * These tests verify that the assistant adapter correctly dispatches
-   * to the right calling convention based on SDK version.
-   * v4: runs.retrieve(threadId, runId)
-   * v5: runs.retrieve(runId, { thread_id: threadId })
-   */
-
-  it("v4 runs.retrieve is called with positional args (threadId, runId)", () => {
+describe("retrieveThreadRun", () => {
+  it("v4: calls retrieve with positional args (threadId, runId)", async () => {
     const { client } = createMockV4Client();
-    const retrieveFn = (client as any).beta.threads.runs.retrieve;
+    const retrieveFn = client.beta.threads.runs.retrieve as ReturnType<
+      typeof vi.fn
+    >;
 
-    // Simulate the v4 call pattern from the adapter
-    if (!isOpenAIV5(client)) {
-      retrieveFn("thread_abc", "run_xyz");
-    }
+    await retrieveThreadRun(client, "thread_abc", "run_xyz");
 
     expect(retrieveFn).toHaveBeenCalledWith("thread_abc", "run_xyz");
   });
 
-  it("v5 runs.retrieve is called with named path params (runId, { thread_id })", () => {
+  it("v5: calls retrieve with named path params (runId, { thread_id })", async () => {
     const { client } = createMockV5Client();
-    const retrieveFn = (client as any).beta.threads.runs.retrieve;
+    const retrieveFn = client.beta.threads.runs.retrieve as ReturnType<
+      typeof vi.fn
+    >;
 
-    // Simulate the v5 call pattern from the adapter
-    if (isOpenAIV5(client)) {
-      retrieveFn("run_xyz", { thread_id: "thread_abc" });
-    }
+    await retrieveThreadRun(client, "thread_abc", "run_xyz");
 
     expect(retrieveFn).toHaveBeenCalledWith("run_xyz", {
       thread_id: "thread_abc",
     });
   });
+});
 
-  it("v4 submitToolOutputsStream is called with positional args", () => {
+describe("submitToolOutputsStream", () => {
+  it("v4: calls with positional args (threadId, runId, body)", () => {
     const { client } = createMockV4Client();
-    const submitFn = (client as any).beta.threads.runs.submitToolOutputsStream;
-    const body = { tool_outputs: [{ tool_call_id: "tc_1", output: "result" }] };
+    const submitFn = client.beta.threads.runs
+      .submitToolOutputsStream as ReturnType<typeof vi.fn>;
+    const body = {
+      tool_outputs: [{ tool_call_id: "tc_1", output: "result" }],
+    };
 
-    if (!isOpenAIV5(client)) {
-      submitFn("thread_abc", "run_xyz", body);
-    }
+    submitToolOutputsStream(client, "thread_abc", "run_xyz", body);
 
     expect(submitFn).toHaveBeenCalledWith("thread_abc", "run_xyz", body);
   });
 
-  it("v5 submitToolOutputsStream is called with named path params", () => {
+  it("v5: calls with named path params (runId, { thread_id, ...body })", () => {
     const { client } = createMockV5Client();
-    const submitFn = (client as any).beta.threads.runs.submitToolOutputsStream;
-    const body = { tool_outputs: [{ tool_call_id: "tc_1", output: "result" }] };
+    const submitFn = client.beta.threads.runs
+      .submitToolOutputsStream as ReturnType<typeof vi.fn>;
+    const body = {
+      tool_outputs: [{ tool_call_id: "tc_1", output: "result" }],
+    };
 
-    if (isOpenAIV5(client)) {
-      submitFn("run_xyz", { thread_id: "thread_abc", ...body });
-    }
+    submitToolOutputsStream(client, "thread_abc", "run_xyz", body);
 
     expect(submitFn).toHaveBeenCalledWith("run_xyz", {
       thread_id: "thread_abc",

--- a/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -205,7 +205,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
     try {
       const openai = this.ensureOpenAI();
       const completions = getChatCompletionsForStreaming(openai);
-      const stream = (completions as typeof openai.chat.completions).stream({
+      const stream = completions.stream({
         model: model,
         stream: true,
         messages: openaiMessages,

--- a/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -61,6 +61,7 @@ import {
   convertActionInputToOpenAITool,
   convertMessageToOpenAIMessage,
   limitMessagesToTokenCount,
+  getChatCompletionsForStreaming,
 } from "./utils";
 import { randomUUID } from "@copilotkit/shared";
 import { convertServiceAdapterError, getSdkClientOptions } from "../shared";
@@ -203,7 +204,8 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
 
     try {
       const openai = this.ensureOpenAI();
-      const stream = openai.beta.chat.completions.stream({
+      const completions = getChatCompletionsForStreaming(openai);
+      const stream = (completions as typeof openai.chat.completions).stream({
         model: model,
         stream: true,
         messages: openaiMessages,

--- a/packages/runtime/src/service-adapters/openai/openai-assistant-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-assistant-adapter.ts
@@ -43,7 +43,8 @@ import {
   convertActionInputToOpenAITool,
   convertMessageToOpenAIMessage,
   convertSystemMessageToAssistantAPI,
-  isOpenAIV5,
+  retrieveThreadRun,
+  submitToolOutputsStream,
 } from "./utils";
 import { RuntimeEventSource } from "../events";
 import { ActionInput } from "../../graphql/inputs/action.input";
@@ -187,13 +188,7 @@ export class OpenAIAssistantAdapter implements CopilotServiceAdapter {
     eventSource: RuntimeEventSource,
   ) {
     const openai = this.ensureOpenAI();
-    // v5 uses named path params: retrieve(runId, { thread_id })
-    // v4 uses positional: retrieve(threadId, runId)
-    let run = isOpenAIV5(openai)
-      ? await (openai.beta.threads.runs.retrieve as Function)(runId, {
-          thread_id: threadId,
-        })
-      : await openai.beta.threads.runs.retrieve(threadId, runId);
+    let run = await retrieveThreadRun(openai, threadId, runId);
 
     if (!run.required_action) {
       throw new Error("No tool outputs required");
@@ -226,22 +221,10 @@ export class OpenAIAssistantAdapter implements CopilotServiceAdapter {
         };
       });
 
-    // v5 uses named path params: submitToolOutputsStream(runId, { thread_id, ...body })
-    // v4 uses positional: submitToolOutputsStream(threadId, runId, body)
-    const toolOutputBody = {
+    const stream = submitToolOutputsStream(openai, threadId, runId, {
       tool_outputs: toolOutputs,
       ...(this.disableParallelToolCalls && { parallel_tool_calls: false }),
-    };
-    const stream = isOpenAIV5(openai)
-      ? (openai.beta.threads.runs.submitToolOutputsStream as Function)(runId, {
-          thread_id: threadId,
-          ...toolOutputBody,
-        })
-      : openai.beta.threads.runs.submitToolOutputsStream(
-          threadId,
-          runId,
-          toolOutputBody,
-        );
+    });
 
     await this.streamResponse(stream, eventSource);
     return runId;

--- a/packages/runtime/src/service-adapters/openai/openai-assistant-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-assistant-adapter.ts
@@ -43,6 +43,7 @@ import {
   convertActionInputToOpenAITool,
   convertMessageToOpenAIMessage,
   convertSystemMessageToAssistantAPI,
+  isOpenAIV5,
 } from "./utils";
 import { RuntimeEventSource } from "../events";
 import { ActionInput } from "../../graphql/inputs/action.input";
@@ -186,7 +187,13 @@ export class OpenAIAssistantAdapter implements CopilotServiceAdapter {
     eventSource: RuntimeEventSource,
   ) {
     const openai = this.ensureOpenAI();
-    let run = await openai.beta.threads.runs.retrieve(threadId, runId);
+    // v5 uses named path params: retrieve(runId, { thread_id })
+    // v4 uses positional: retrieve(threadId, runId)
+    let run = isOpenAIV5(openai)
+      ? await (openai.beta.threads.runs.retrieve as Function)(runId, {
+          thread_id: threadId,
+        })
+      : await openai.beta.threads.runs.retrieve(threadId, runId);
 
     if (!run.required_action) {
       throw new Error("No tool outputs required");
@@ -219,14 +226,22 @@ export class OpenAIAssistantAdapter implements CopilotServiceAdapter {
         };
       });
 
-    const stream = openai.beta.threads.runs.submitToolOutputsStream(
-      threadId,
-      runId,
-      {
-        tool_outputs: toolOutputs,
-        ...(this.disableParallelToolCalls && { parallel_tool_calls: false }),
-      },
-    );
+    // v5 uses named path params: submitToolOutputsStream(runId, { thread_id, ...body })
+    // v4 uses positional: submitToolOutputsStream(threadId, runId, body)
+    const toolOutputBody = {
+      tool_outputs: toolOutputs,
+      ...(this.disableParallelToolCalls && { parallel_tool_calls: false }),
+    };
+    const stream = isOpenAIV5(openai)
+      ? (openai.beta.threads.runs.submitToolOutputsStream as Function)(runId, {
+          thread_id: threadId,
+          ...toolOutputBody,
+        })
+      : openai.beta.threads.runs.submitToolOutputsStream(
+          threadId,
+          runId,
+          toolOutputBody,
+        );
 
     await this.streamResponse(stream, eventSource);
     return runId;

--- a/packages/runtime/src/service-adapters/openai/utils.ts
+++ b/packages/runtime/src/service-adapters/openai/utils.ts
@@ -12,14 +12,35 @@ import {
 import { parseJson } from "@copilotkit/shared";
 
 /**
+ * OpenAI v4 exposes streaming completions under `beta.chat.completions`.
+ * v5 removed `beta.chat` and promoted streaming to `chat.completions`.
+ * These interfaces model the v4-specific shape so we can detect and access
+ * the beta namespace safely without `as any`.
+ */
+interface OpenAIV4BetaChat {
+  chat: {
+    completions: OpenAI["chat"]["completions"];
+  };
+}
+
+interface OpenAIV4Beta extends OpenAI.Beta {
+  chat: OpenAIV4BetaChat["chat"];
+}
+
+/**
+ * Type guard: checks whether the OpenAI client has the v4-era `beta.chat`
+ * namespace. Returns `false` for v5+ clients where `beta.chat` was removed.
+ */
+function hasV4BetaChat(beta: OpenAI["beta"] | undefined): beta is OpenAIV4Beta {
+  return beta != null && "chat" in beta && (beta as OpenAIV4Beta).chat != null;
+}
+
+/**
  * Detects whether the provided OpenAI client is v5+ by checking for the
  * removal of the `beta.chat` namespace (which was promoted to `chat` in v5).
  */
 export function isOpenAIV5(openai: OpenAI): boolean {
-  return (
-    !(openai as Record<string, unknown>).beta ||
-    !((openai as Record<string, unknown>).beta as Record<string, unknown>).chat
-  );
+  return !hasV4BetaChat(openai.beta);
 }
 
 /**
@@ -27,15 +48,66 @@ export function isOpenAIV5(openai: OpenAI): boolean {
  * In v4 this lives under `openai.beta.chat.completions`;
  * in v5 it was promoted to `openai.chat.completions`.
  */
-export function getChatCompletionsForStreaming(openai: OpenAI) {
-  if (isOpenAIV5(openai)) {
-    return openai.chat.completions;
+export function getChatCompletionsForStreaming(
+  openai: OpenAI,
+): OpenAI["chat"]["completions"] {
+  if (hasV4BetaChat(openai.beta)) {
+    return openai.beta.chat.completions;
   }
-  return (
-    openai as Record<string, unknown> & {
-      beta: { chat: { completions: unknown } };
-    }
-  ).beta.chat.completions;
+  return openai.chat.completions;
+}
+
+/**
+ * Retrieves a thread run, handling the v4→v5 API signature change.
+ * v4: retrieve(threadId, runId)
+ * v5: retrieve(runId, { thread_id: threadId })
+ */
+export async function retrieveThreadRun(
+  openai: OpenAI,
+  threadId: string,
+  runId: string,
+): Promise<OpenAI.Beta.Threads.Runs.Run> {
+  if (isOpenAIV5(openai)) {
+    // v5 switched to named path params. The type definitions from whichever
+    // SDK version is installed won't match both signatures, so we call through
+    // a generic function reference. This is the one unavoidable boundary
+    // between two incompatible SDK type surfaces.
+    const retrieve = openai.beta.threads.runs.retrieve as {
+      (...args: unknown[]): Promise<OpenAI.Beta.Threads.Runs.Run>;
+    };
+    return retrieve(runId, { thread_id: threadId });
+  }
+  return openai.beta.threads.runs.retrieve(threadId, runId);
+}
+
+/**
+ * Submits tool outputs as a stream, handling the v4→v5 API signature change.
+ * v4: submitToolOutputsStream(threadId, runId, body)
+ * v5: submitToolOutputsStream(runId, { thread_id, ...body })
+ */
+export function submitToolOutputsStream(
+  openai: OpenAI,
+  threadId: string,
+  runId: string,
+  body: {
+    tool_outputs: Array<{ tool_call_id: string; output: string }>;
+    parallel_tool_calls?: false;
+  },
+) {
+  if (isOpenAIV5(openai)) {
+    // Same boundary as retrieveThreadRun — v5 uses named path params.
+    const submit = openai.beta.threads.runs.submitToolOutputsStream as {
+      (
+        ...args: unknown[]
+      ): ReturnType<typeof openai.beta.threads.runs.submitToolOutputsStream>;
+    };
+    return submit(runId, { thread_id: threadId, ...body });
+  }
+  return openai.beta.threads.runs.submitToolOutputsStream(
+    threadId,
+    runId,
+    body,
+  );
 }
 
 export function limitMessagesToTokenCount(

--- a/packages/runtime/src/service-adapters/openai/utils.ts
+++ b/packages/runtime/src/service-adapters/openai/utils.ts
@@ -1,3 +1,4 @@
+import type OpenAI from "openai";
 import { Message } from "../../graphql/types/converted";
 import { ActionInput } from "../../graphql/inputs/action.input";
 import {
@@ -9,6 +10,33 @@ import {
   ChatCompletionDeveloperMessageParam,
 } from "openai/resources/chat";
 import { parseJson } from "@copilotkit/shared";
+
+/**
+ * Detects whether the provided OpenAI client is v5+ by checking for the
+ * removal of the `beta.chat` namespace (which was promoted to `chat` in v5).
+ */
+export function isOpenAIV5(openai: OpenAI): boolean {
+  return (
+    !(openai as Record<string, unknown>).beta ||
+    !((openai as Record<string, unknown>).beta as Record<string, unknown>).chat
+  );
+}
+
+/**
+ * Returns the chat completions object that supports `.stream()`.
+ * In v4 this lives under `openai.beta.chat.completions`;
+ * in v5 it was promoted to `openai.chat.completions`.
+ */
+export function getChatCompletionsForStreaming(openai: OpenAI) {
+  if (isOpenAIV5(openai)) {
+    return openai.chat.completions;
+  }
+  return (
+    openai as Record<string, unknown> & {
+      beta: { chat: { completions: unknown } };
+    }
+  ).beta.chat.completions;
+}
 
 export function limitMessagesToTokenCount(
   messages: any[],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2455,7 +2455,7 @@ importers:
         specifier: '>=0.3.3'
         version: 1.2.7(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.76))
       openai:
-        specifier: ^4.85.1 || ^5.0.0
+        specifier: ^4.85.1 || >=5.0.0
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
       partial-json:
         specifier: ^0.1.7
@@ -34609,6 +34609,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  axios@1.13.2(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.3)
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axobject-query@4.1.0: {}
 
   b4a@1.7.3: {}
@@ -38930,7 +38938,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 18.19.130
       '@types/tough-cookie': 4.0.5
-      axios: 1.13.2
+      axios: 1.13.2(debug@4.4.3)
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.6.1
@@ -38940,7 +38948,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.13.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -44504,7 +44512,7 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.13.2):
     dependencies:
       axios: 1.13.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2455,7 +2455,7 @@ importers:
         specifier: '>=0.3.3'
         version: 1.2.7(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.1(zod@3.25.76))
       openai:
-        specifier: ^4.85.1
+        specifier: ^4.85.1 || ^5.0.0
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
       partial-json:
         specifier: ^0.1.7
@@ -34609,14 +34609,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.13.2(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axobject-query@4.1.0: {}
 
   b4a@1.7.3: {}
@@ -38938,7 +38930,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 18.19.130
       '@types/tough-cookie': 4.0.5
-      axios: 1.13.2(debug@4.4.3)
+      axios: 1.13.2
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.6.1
@@ -38948,7 +38940,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.13.2)
+      retry-axios: 2.6.0(axios@1.13.2(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -44512,7 +44504,7 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  retry-axios@2.6.0(axios@1.13.2):
+  retry-axios@2.6.0(axios@1.13.2(debug@4.4.3)):
     dependencies:
       axios: 1.13.2
 


### PR DESCRIPTION
Fixes #1979

## Summary

- Add `isOpenAIV5()` detection helper that checks whether `beta.chat` was removed (v5 promoted it to `chat.completions`)
- Add `getChatCompletionsForStreaming()` helper that routes to the correct completions namespace per SDK version
- Migrate `OpenAIAdapter` to use the new helper instead of direct `beta.chat.completions` access
- Migrate `OpenAIAssistantAdapter` `runs.retrieve()` and `submitToolOutputsStream()` to use v5 named path params (e.g. `retrieve(runId, { thread_id })` instead of positional `retrieve(threadId, runId)`)
- Add `openai` to peerDependencies with `^4.85.1 || ^5.0.0` range
- Add 11 unit tests covering v4/v5 detection, streaming dispatch, and named path param calling conventions

## Notes

The remaining `openai.beta.threads.*` calls (`threads.create`, `messages.create`, `runs.stream`) do NOT need migration because:
1. `beta.threads` still exists in v5 (only `beta.chat` was removed)
2. These methods have single path params, so their signatures are unchanged

## Test plan

- [x] All 11 v5 compat tests pass (`nx run @copilotkit/runtime:test`)
- [x] Runtime package builds successfully (`nx run @copilotkit/runtime:build`)
- [x] Pre-commit hooks pass (lint, format, publint, attw)