### PR TITLE
fix: increase LangGraph agent pagination limit from 10 to 100 (#2056)

### DIFF
--- a/packages/cli/src/lib/init/scaffold/langgraph-assistants.ts
+++ b/packages/cli/src/lib/init/scaffold/langgraph-assistants.ts
@@ -25,7 +25,7 @@ export async function getLangGraphAgents(url: string, langSmithApiKey: string) {
           "X-Api-Key": langSmithApiKey,
         },
         body: JSON.stringify({
-          limit: 10,
+          limit: 100,
           offset: 0,
         }),
       },


### PR DESCRIPTION
Fixes #2056

Red-green tested locally.