### PR TITLE
fix: export CopilotModal and CopilotModalProps from react-ui (#2194)

### DIFF
--- a/packages/react-ui/src/components/chat/index.tsx
+++ b/packages/react-ui/src/components/chat/index.tsx
@@ -2,6 +2,8 @@ export * from "./props";
 export { CopilotPopup } from "./Popup";
 export { CopilotSidebar } from "./Sidebar";
 export { CopilotChat } from "./Chat";
+export { CopilotModal } from "./Modal";
+export type { CopilotModalProps } from "./Modal";
 export { Markdown } from "./Markdown";
 export { AssistantMessage } from "./messages/AssistantMessage";
 export { UserMessage } from "./messages/UserMessage";


### PR DESCRIPTION
## Summary

Fixes #2194

`CopilotModal` and `CopilotModalProps` were not exported from `@copilotkit/react-ui`, making them inaccessible to consumers. Adds both exports to the chat barrel file.

## Test plan

- [ ] Verify `CopilotModal` and `CopilotModalProps` are importable from `@copilotkit/react-ui`