### PR TITLE
fix: add isActive toggle parameter to onThumbsUp/onThumbsDown callbacks (#2615)

### DIFF
--- a/packages/react-ui/src/components/chat/props.ts
+++ b/packages/react-ui/src/components/chat/props.ts
@@ -121,12 +121,12 @@ export interface MessagesProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Map of message IDs to their feedback state
@@ -217,12 +217,12 @@ export interface AssistantMessageProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * The feedback state for this message ("thumbsUp" or "thumbsDown")
@@ -313,12 +313,12 @@ export interface RenderMessageProps {
   /**
    * Callback function for thumbs up feedback
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Callback function for thumbs down feedback
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Map of message IDs to their feedback state


### PR DESCRIPTION
## Summary

Fixes #2615

Adds an optional `isActive` boolean parameter to `onThumbsUp` and `onThumbsDown` callback signatures across `MessagesProps`, `AssistantMessageProps`, and `RenderMessageProps`. This allows consumers to know whether the feedback button is being toggled on or off.

## Test plan

- [ ] Verify thumbs up/down callbacks receive `isActive` parameter
- [ ] Verify existing consumers without the parameter still work