### PR TITLE
fix: accept function returning headers in addition to static Record (#2159)

### DIFF
--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -76,7 +76,7 @@ export interface CopilotKitProps extends Omit<
    * }
    * ```
    */
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | (() => Record<string, string>);
 
   /**
    * The children to be rendered within the CopilotKit.

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -311,7 +311,10 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       publicApiKey: publicApiKey,
       ...(cloud ? { cloud } : {}),
       chatApiEndpoint: chatApiEndpoint,
-      headers: props.headers || {},
+      headers:
+        typeof props.headers === "function"
+          ? props.headers()
+          : props.headers || {},
       properties: props.properties || {},
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,


### PR DESCRIPTION
## Summary

Fixes #2159

The `headers` prop on `CopilotKit` only accepted a static `Record<string, string>`. This adds support for passing a function `(() => Record<string, string>)` that is evaluated at request time, enabling dynamic headers (e.g., for rotating auth tokens).

## Test plan

- [ ] Verify static `headers` Record still works
- [ ] Verify function-returning headers are called and values used