### PR TITLE
fix: use div instead of p tag in Markdown to prevent hydration errors (#2234)

### DIFF
--- a/packages/react-ui/src/components/chat/Markdown.test.ts
+++ b/packages/react-ui/src/components/chat/Markdown.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "fs";
-import { resolve, dirname } from "path";
-import { fileURLToPath } from "url";
+import { resolve } from "path";
 
 /**
  * These tests verify that CSS selectors in markdown.css correctly target
@@ -49,6 +48,16 @@ describe("Markdown CSS/component selector consistency", () => {
     const pSection = tsxContent.match(/p:\s*\([^)]*\)\s*=>\s*\([^)]+\)/s);
     expect(pSection).not.toBeNull();
     expect(pSection![0]).toContain("copilotKitMarkdownElement");
+  });
+
+  it("should use .copilotKitParagraph (not p) inside blockquote selector", () => {
+    // After p->div, blockquote nested paragraph selector must target the class
+    expect(cssContent).toMatch(
+      /blockquote\.copilotKitMarkdownElement\s+\.copilotKitParagraph\s*\{/,
+    );
+    expect(cssContent).not.toMatch(
+      /blockquote\.copilotKitMarkdownElement\s+p\s*\{/,
+    );
   });
 
   describe("other element selectors remain valid", () => {

--- a/packages/react-ui/src/components/chat/Markdown.test.ts
+++ b/packages/react-ui/src/components/chat/Markdown.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * These tests verify that CSS selectors in markdown.css correctly target
+ * the class names used by the Markdown component. When the p tag was changed
+ * to a div (to fix hydration errors), the CSS selectors must use class-only
+ * selectors instead of element-qualified selectors for paragraphs.
+ */
+
+const cssPath = resolve(__dirname, "../../css/markdown.css");
+const tsxPath = resolve(__dirname, "Markdown.tsx");
+
+const cssContent = readFileSync(cssPath, "utf-8");
+const tsxContent = readFileSync(tsxPath, "utf-8");
+
+describe("Markdown CSS/component selector consistency", () => {
+  it("should not use p.copilotKitMarkdownElement selector in CSS", () => {
+    // After the p->div change, CSS must not use element-qualified p selectors
+    expect(cssContent).not.toMatch(/\bp\.copilotKitMarkdownElement\b/);
+  });
+
+  it("should have .copilotKitParagraph selector in CSS for paragraph styling", () => {
+    expect(cssContent).toMatch(/\.copilotKitParagraph\s*\{/);
+  });
+
+  it("should have .copilotKitParagraph:not(:last-child) selector for paragraph spacing", () => {
+    expect(cssContent).toMatch(/\.copilotKitParagraph:not\(:last-child\)/);
+  });
+
+  it("should use copilotKitParagraph class on the paragraph component", () => {
+    // The p component override in Markdown.tsx should include copilotKitParagraph
+    expect(tsxContent).toMatch(/copilotKitParagraph/);
+  });
+
+  it("should render a div instead of p for the paragraph component", () => {
+    // The paragraph component should use <div> to avoid hydration errors
+    // when block-level elements are nested inside markdown paragraphs
+    const pComponentMatch = tsxContent.match(
+      /p:\s*\(\{[^}]*\}\)\s*=>\s*\(\s*<(\w+)/,
+    );
+    expect(pComponentMatch).not.toBeNull();
+    expect(pComponentMatch![1]).toBe("div");
+  });
+
+  it("should still have copilotKitMarkdownElement class on the paragraph div", () => {
+    // The div should retain the base class for any shared styling
+    const pSection = tsxContent.match(/p:\s*\([^)]*\)\s*=>\s*\([^)]+\)/s);
+    expect(pSection).not.toBeNull();
+    expect(pSection![0]).toContain("copilotKitMarkdownElement");
+  });
+
+  describe("other element selectors remain valid", () => {
+    const elementSelectors = [
+      { element: "h1", selector: "h1.copilotKitMarkdownElement" },
+      { element: "h2", selector: "h2.copilotKitMarkdownElement" },
+      { element: "h3", selector: "h3.copilotKitMarkdownElement" },
+      { element: "h4", selector: "h4.copilotKitMarkdownElement" },
+      { element: "h5", selector: "h5.copilotKitMarkdownElement" },
+      { element: "h6", selector: "h6.copilotKitMarkdownElement" },
+      { element: "a", selector: "a.copilotKitMarkdownElement" },
+      { element: "pre", selector: "pre.copilotKitMarkdownElement" },
+      {
+        element: "blockquote",
+        selector: "blockquote.copilotKitMarkdownElement",
+      },
+      { element: "ul", selector: "ul.copilotKitMarkdownElement" },
+      { element: "li", selector: "li.copilotKitMarkdownElement" },
+    ];
+
+    for (const { element, selector } of elementSelectors) {
+      it(`should have ${element} component rendering <${element}> with copilotKitMarkdownElement class`, () => {
+        // Verify the component still uses the actual HTML element
+        // Some components use arrow syntax, others use function syntax
+        const arrowRegex = new RegExp(
+          `${element}:\\s*\\(\\{[^}]*\\}\\)\\s*=>\\s*\\(\\s*<${element}[\\s\\S]*?copilotKitMarkdownElement`,
+        );
+        const funcRegex = new RegExp(
+          `${element}\\([^)]*\\)\\s*\\{[\\s\\S]*?<${element}[\\s\\S]*?copilotKitMarkdownElement`,
+        );
+        const matches =
+          arrowRegex.test(tsxContent) || funcRegex.test(tsxContent);
+        expect(matches).toBe(true);
+      });
+
+      it(`should have CSS selector ${selector}`, () => {
+        expect(cssContent).toContain(selector);
+      });
+    }
+  });
+});

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -97,9 +97,9 @@ const defaultComponents: Components = {
     </h6>
   ),
   p: ({ children, ...props }) => (
-    <p className="copilotKitMarkdownElement" {...props}>
+    <div className="copilotKitMarkdownElement copilotKitParagraph" {...props}>
       {children}
-    </p>
+    </div>
   ),
   pre: ({ children, ...props }) => (
     <pre className="copilotKitMarkdownElement" {...props}>

--- a/packages/react-ui/src/css/markdown.css
+++ b/packages/react-ui/src/css/markdown.css
@@ -47,14 +47,14 @@ a.copilotKitMarkdownElement {
   text-decoration: underline;
 }
 
-p.copilotKitMarkdownElement {
+.copilotKitParagraph {
   padding: 0px;
   margin: 0px;
   line-height: 1.75;
   font-size: 1rem;
 }
 
-p.copilotKitMarkdownElement:not(:last-child),
+.copilotKitParagraph:not(:last-child),
 pre.copilotKitMarkdownElement:not(:last-child),
 ol.copilotKitMarkdownElement:not(:last-child),
 ul.copilotKitMarkdownElement:not(:last-child),

--- a/packages/react-ui/src/css/markdown.css
+++ b/packages/react-ui/src/css/markdown.css
@@ -70,7 +70,7 @@ blockquote.copilotKitMarkdownElement {
   padding-left: 10px;
 }
 
-blockquote.copilotKitMarkdownElement p {
+blockquote.copilotKitMarkdownElement .copilotKitParagraph {
   padding: 0.7em 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #2234

React's hydration fails when block-level elements (like `<div>`) are nested inside `<p>` tags in the Markdown component. Replaces the `<p>` wrapper with `<div>` (adding `copilotKitParagraph` class for styling) to prevent SSR hydration mismatches.

## Test plan

- [ ] Verify Markdown rendering in SSR context has no hydration errors
- [ ] Verify paragraph styling is preserved via `copilotKitParagraph` class