### PR TITLE
fix: add configurable maxInputTokens to OpenAI and Anthropic adapters (#2405)

### DIFF
--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -70,12 +70,19 @@ export interface AnthropicAdapterParams {
    * See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
    */
   promptCaching?: AnthropicPromptCachingConfig;
+
+  /**
+   * Optional maximum input token limit. Overrides the default limit
+   * used when trimming messages to fit the context window.
+   */
+  maxInputTokens?: number;
 }
 
 export class AnthropicAdapter implements CopilotServiceAdapter {
   public model: string = DEFAULT_MODEL;
   public provider = "anthropic";
   private promptCaching: AnthropicPromptCachingConfig;
+  private maxInputTokens?: number;
 
   private _anthropic: Anthropic;
   public get anthropic(): Anthropic {
@@ -94,6 +101,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
       this.model = params.model;
     }
     this.promptCaching = params?.promptCaching || { enabled: false };
+    this.maxInputTokens = params?.maxInputTokens;
   }
 
   getLanguageModel(): LanguageModel {
@@ -322,6 +330,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
       anthropicMessages,
       tools,
       model,
+      this.maxInputTokens,
     );
 
     // Apply prompt caching if enabled

--- a/packages/runtime/src/service-adapters/openai/openai-adapter.ts
+++ b/packages/runtime/src/service-adapters/openai/openai-adapter.ts
@@ -97,6 +97,12 @@ export interface OpenAIAdapterParams {
    * @default false
    */
   keepSystemRole?: boolean;
+
+  /**
+   * Optional maximum input token limit. Overrides the default model-based limit
+   * used when trimming messages to fit the context window.
+   */
+  maxInputTokens?: number;
 }
 
 export class OpenAIAdapter implements CopilotServiceAdapter {
@@ -106,6 +112,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
   private disableParallelToolCalls: boolean = false;
   private _openai: OpenAI;
   private keepSystemRole: boolean = false;
+  private maxInputTokens?: number;
 
   public get openai(): OpenAI {
     return this._openai;
@@ -125,6 +132,7 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
     }
     this.disableParallelToolCalls = params?.disableParallelToolCalls || false;
     this.keepSystemRole = params?.keepSystemRole ?? false;
+    this.maxInputTokens = params?.maxInputTokens;
   }
 
   getLanguageModel(): LanguageModel {
@@ -192,7 +200,12 @@ export class OpenAIAdapter implements CopilotServiceAdapter {
     let openaiMessages = filteredMessages.map((m) =>
       convertMessageToOpenAIMessage(m, { keepSystemRole: this.keepSystemRole }),
     );
-    openaiMessages = limitMessagesToTokenCount(openaiMessages, tools, model);
+    openaiMessages = limitMessagesToTokenCount(
+      openaiMessages,
+      tools,
+      model,
+      this.maxInputTokens,
+    );
 
     let toolChoice: any = forwardedParameters?.toolChoice;
     if (forwardedParameters?.toolChoice === "function") {


### PR DESCRIPTION
## Summary

Fixes #2405

Both OpenAI and Anthropic adapters used a hardcoded token limit for message trimming. This adds an optional `maxInputTokens` constructor parameter to both adapter classes, allowing consumers to override the default context window limit.

## Test plan

- [ ] Verify default behavior unchanged when `maxInputTokens` not provided
- [ ] Verify custom `maxInputTokens` is passed through to `limitMessagesToTokenCount`