### PR TITLE
fix: skip unknown tool_use blocks in Anthropic adapter (#2504)

### DIFF
--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -376,8 +376,8 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
             if (chunk.type === "message_start") {
               currentMessageId = chunk.message.id;
             } else if (chunk.type === "content_block_start") {
-              hasReceivedContent = true;
               if (chunk.content_block.type === "text") {
+                hasReceivedContent = true;
                 didOutputText = false;
                 filterThinkingTextBuffer.reset();
                 mode = "message";
@@ -387,6 +387,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
                   mode = null;
                   continue;
                 }
+                hasReceivedContent = true;
                 currentToolCallId = chunk.content_block.id;
                 eventStream$.sendActionExecutionStart({
                   actionExecutionId: currentToolCallId,

--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -244,6 +244,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
       forwardedParameters,
     } = request;
     const tools = actions.map(convertActionInputToAnthropicTool);
+    const knownActionNames = new Set(actions.map((a) => a.name));
 
     const messages = [...rawMessages];
 
@@ -381,6 +382,11 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
                 filterThinkingTextBuffer.reset();
                 mode = "message";
               } else if (chunk.content_block.type === "tool_use") {
+                if (!knownActionNames.has(chunk.content_block.name)) {
+                  // Unknown tool - skip execution to prevent crashes
+                  mode = null;
+                  continue;
+                }
                 currentToolCallId = chunk.content_block.id;
                 eventStream$.sendActionExecutionStart({
                   actionExecutionId: currentToolCallId,

--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -396,6 +396,10 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
                 mode = "function";
               }
             } else if (chunk.type === "content_block_delta") {
+              if (mode === null) {
+                // Skip deltas for unknown/skipped content blocks
+                continue;
+              }
               if (chunk.delta.type === "text_delta") {
                 const text = filterThinkingTextBuffer.onTextChunk(
                   chunk.delta.text,

--- a/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
+++ b/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
@@ -374,4 +374,173 @@ describe("AnthropicAdapter", () => {
       });
     });
   });
+
+  describe("Unknown Tool Use Handling", () => {
+    it("should skip unknown tool_use blocks without crashing", async () => {
+      const systemMessage = new TextMessage("system", "System message");
+      const userMessage = new TextMessage("user", "Do something");
+
+      // Mock Anthropic to return a stream with an unknown tool_use block
+      mockAnthropicCreate.mockResolvedValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: "message_start", message: { id: "msg-1" } };
+          // Unknown tool_use block — tool name not in the actions list
+          yield {
+            type: "content_block_start",
+            content_block: {
+              type: "tool_use",
+              id: "tool-unknown",
+              name: "nonexistent_tool",
+            },
+          };
+          yield {
+            type: "content_block_delta",
+            delta: { type: "input_json_delta", partial_json: '{"query":' },
+          };
+          yield {
+            type: "content_block_delta",
+            delta: { type: "input_json_delta", partial_json: '"test"}' },
+          };
+          yield { type: "content_block_stop" };
+          // Then a normal text block
+          yield {
+            type: "content_block_start",
+            content_block: { type: "text" },
+          };
+          yield {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Here is the result." },
+          };
+          yield { type: "content_block_stop" };
+        },
+      });
+
+      const mockStream = {
+        sendTextMessageStart: vi.fn(),
+        sendTextMessageContent: vi.fn(),
+        sendTextMessageEnd: vi.fn(),
+        sendActionExecutionStart: vi.fn(),
+        sendActionExecutionArgs: vi.fn(),
+        sendActionExecutionEnd: vi.fn(),
+        complete: vi.fn(),
+      };
+
+      let streamCallbackDone: Promise<void>;
+      mockEventSource.stream.mockImplementation((callback: any) => {
+        streamCallbackDone = callback(mockStream);
+      });
+
+      await adapter.process({
+        threadId: "test-thread",
+        messages: [systemMessage, userMessage],
+        actions: [
+          {
+            name: "known_tool",
+            description: "A known tool",
+            parameters: [],
+            jsonSchema: '{"type":"object","properties":{}}',
+          },
+        ],
+        eventSource: mockEventSource,
+        forwardedParameters: {},
+      });
+
+      // Wait for async stream processing to complete
+      await streamCallbackDone!;
+
+      // Should NOT have sent action execution events for the unknown tool
+      expect(mockStream.sendActionExecutionStart).not.toHaveBeenCalled();
+      expect(mockStream.sendActionExecutionArgs).not.toHaveBeenCalled();
+      expect(mockStream.sendActionExecutionEnd).not.toHaveBeenCalled();
+
+      // Should still process the text block normally
+      expect(mockStream.sendTextMessageStart).toHaveBeenCalled();
+      expect(mockStream.sendTextMessageContent).toHaveBeenCalledWith({
+        messageId: "msg-1",
+        content: "Here is the result.",
+      });
+      expect(mockStream.sendTextMessageEnd).toHaveBeenCalled();
+      expect(mockStream.complete).toHaveBeenCalled();
+    });
+
+    it("should trigger fallback when only unknown tool_use blocks are returned", async () => {
+      const systemMessage = new TextMessage("system", "System message");
+      const userMessage = new TextMessage("user", "Do something");
+
+      const toolExecution = new ActionExecutionMessage({
+        id: "tool-prev",
+        name: "someAction",
+        arguments: "{}",
+      });
+
+      const toolResult = new ResultMessage({
+        actionExecutionId: "tool-prev",
+        result: "Previous result",
+      });
+
+      // Mock Anthropic to return ONLY an unknown tool_use block
+      mockAnthropicCreate.mockResolvedValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: "message_start", message: { id: "msg-1" } };
+          yield {
+            type: "content_block_start",
+            content_block: {
+              type: "tool_use",
+              id: "tool-unknown",
+              name: "nonexistent_tool",
+            },
+          };
+          yield {
+            type: "content_block_delta",
+            delta: { type: "input_json_delta", partial_json: "{}" },
+          };
+          yield { type: "content_block_stop" };
+        },
+      });
+
+      const mockStream = {
+        sendTextMessageStart: vi.fn(),
+        sendTextMessageContent: vi.fn(),
+        sendTextMessageEnd: vi.fn(),
+        sendActionExecutionStart: vi.fn(),
+        sendActionExecutionArgs: vi.fn(),
+        sendActionExecutionEnd: vi.fn(),
+        complete: vi.fn(),
+      };
+
+      let streamCallbackDone: Promise<void>;
+      mockEventSource.stream.mockImplementation((callback: any) => {
+        streamCallbackDone = callback(mockStream);
+      });
+
+      await adapter.process({
+        threadId: "test-thread",
+        messages: [systemMessage, userMessage, toolExecution, toolResult],
+        actions: [
+          {
+            name: "known_tool",
+            description: "A known tool",
+            parameters: [],
+            jsonSchema: '{"type":"object","properties":{}}',
+          },
+        ],
+        eventSource: mockEventSource,
+        forwardedParameters: {},
+      });
+
+      // Wait for async stream processing to complete
+      await streamCallbackDone!;
+
+      // Should NOT have sent action execution events
+      expect(mockStream.sendActionExecutionStart).not.toHaveBeenCalled();
+
+      // Should trigger fallback since hasReceivedContent should be false
+      expect(mockStream.sendTextMessageStart).toHaveBeenCalled();
+      expect(mockStream.sendTextMessageContent).toHaveBeenCalledWith({
+        messageId: expect.any(String),
+        content: "Previous result",
+      });
+      expect(mockStream.sendTextMessageEnd).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2504

When Anthropic returns a `tool_use` block for a tool not registered in the current action set, the adapter would crash trying to process it. This adds a check against known action names and skips unknown tool_use blocks gracefully.

## Test plan

- [ ] Verify known tools are still processed normally
- [ ] Verify unknown tool_use blocks are skipped without crashing