### PR TITLE
fix: remove unstable key on CodeBlock to prevent flickering during streaming

### DIFF
--- a/.changeset/stable-codeblock-keys.md
+++ b/.changeset/stable-codeblock-keys.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/react-ui": patch
----
-
-fix: remove unstable key on CodeBlock to prevent flickering during streaming

--- a/.changeset/stable-codeblock-keys.md
+++ b/.changeset/stable-codeblock-keys.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+fix: remove unstable key on CodeBlock to prevent flickering during streaming

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -59,7 +59,6 @@ const defaultComponents: Components = {
 
     return (
       <CodeBlock
-        key={Math.random()}
         language={(match && match[1]) || ""}
         value={String(children).replace(/\n$/, "")}
         {...props}


### PR DESCRIPTION
## Summary

- Removes the `key` prop from `CodeBlock` in `Markdown.tsx` entirely
- The original `Math.random()` key caused React to remount the component on every render, producing visible flickering
- A content-based key (language + content prefix) still changes every streaming token, causing the same problem
- Without an explicit key, React uses positional identity — stable across re-renders while content streams in

Closes #2669

## Test plan

- [x] `@copilotkit/react-ui` tests pass
- [x] `@copilotkit/react-ui` build succeeds
- [ ] Manual: verify code blocks no longer flicker during streaming in chat UI