### PR TITLE
fix: skip version check when showDevConsole is false

### DIFF
--- a/packages/react-ui/src/components/dev-console/console.tsx
+++ b/packages/react-ui/src/components/dev-console/console.tsx
@@ -84,13 +84,16 @@ export function CopilotDevConsole() {
   };
 
   useEffect(() => {
+    if (!showDevConsole) {
+      return;
+    }
     if (dontRunTwiceInDevMode.current === true) {
       return;
     }
     dontRunTwiceInDevMode.current = true;
 
     checkForUpdates();
-  }, []);
+  }, [showDevConsole]);
 
   if (!showDevConsole) {
     return null;


### PR DESCRIPTION
## Summary

- `checkForUpdates()` in dev console is now gated on `showDevConsole`, preventing unnecessary network requests when the console is disabled

Closes #2751

## Test plan

- [x] `@copilotkit/react-core` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)