### PR TITLE
fix: always generate unique message IDs in LangChain adapter

### DIFF
--- a/packages/runtime/src/service-adapters/langchain/utils.ts
+++ b/packages/runtime/src/service-adapters/langchain/utils.ts
@@ -269,7 +269,7 @@ export async function streamLangChainResponse({
             });
           } else if (content) {
             mode = "message";
-            currentMessageId = value.lc_kwargs?.id || randomId();
+            currentMessageId = randomId();
             eventStream$.sendTextMessageStart({ messageId: currentMessageId });
           }
         }


### PR DESCRIPTION
## Summary

- LangChain adapter now always uses `randomId()` for message stream IDs instead of relying on `lc_kwargs.id` (which GoogleGenerativeAI sets to `"0"` for all messages)

Closes #2929

## Test plan

- [x] `@copilotkit/runtime` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)