### PR TITLE
fix: wrap Button with forwardRef for Radix DropdownMenuTrigger

### DIFF
--- a/packages/react-core/src/v2/components/ui/button.tsx
+++ b/packages/react-core/src/v2/components/ui/button.tsx
@@ -99,25 +99,26 @@ const buttonVariants = cva(
   },
 );
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean;
+    }
+>(function Button(
+  { className, variant, size, asChild = false, ...props },
+  ref,
+) {
   const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
   );
-}
+});
 
 export { Button, buttonVariants };


### PR DESCRIPTION
## Summary

- `Button` component wrapped with `React.forwardRef` to fix ref warning from Radix UI's `DropdownMenuTrigger asChild` pattern

Closes #2947

## Test plan

- [x] All affected packages build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)