### PR TITLE
fix: batch of community bug fixes (X6)

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -384,6 +384,12 @@ export function CopilotChatInput({
   );
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Skip key handling during IME composition (e.g. CJK input).
+    // The compositionend event will fire separately when composition ends.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) {
+      return;
+    }
+
     if (commandQuery !== null && mode === "input") {
       if (e.key === "ArrowDown") {
         if (filteredCommands.length > 0) {
@@ -455,10 +461,12 @@ export function CopilotChatInput({
 
     onSubmitMessage(trimmed);
 
+    // Always clear the input after sending, including controlled mode.
+    // In controlled mode, onChange("") notifies the parent to reset its state.
     if (!isControlled) {
       setInternalValue("");
-      onChange?.("");
     }
+    onChange?.("");
 
     if (inputRef.current) {
       inputRef.current.focus();
@@ -470,6 +478,12 @@ export function CopilotChatInput({
     value: resolvedValue,
     onChange: handleChange,
     onKeyDown: handleKeyDown,
+    onCompositionStart: () => {
+      isComposingRef.current = true;
+    },
+    onCompositionEnd: () => {
+      isComposingRef.current = false;
+    },
     autoFocus: autoFocus,
     className: twMerge(
       "cpk:w-full cpk:py-3",
@@ -612,9 +626,14 @@ export function CopilotChatInput({
     }
   };
 
+  // Track whether an IME composition is active so we can avoid
+  // resetting textarea.value during measurement (which would break
+  // the composition session).
+  const isComposingRef = useRef(false);
+
   const ensureMeasurements = useCallback(() => {
     const textarea = inputRef.current;
-    if (!textarea) {
+    if (!textarea || isComposingRef.current) {
       return;
     }
 

--- a/packages/react-ui/src/components/chat/Messages.tsx
+++ b/packages/react-ui/src/components/chat/Messages.tsx
@@ -112,9 +112,9 @@ export const Messages = ({
             />
           );
         })}
-        {messages[messages.length - 1]?.role === "user" && inProgress && (
-          <LoadingIcon />
-        )}
+        {inProgress &&
+          (messages[messages.length - 1]?.role === "user" ||
+            messages[messages.length - 1]?.role === "tool") && <LoadingIcon />}
         {interrupt}
         {chatError && ErrorMessage && (
           <ErrorMessage error={chatError} isCurrentMessage />

--- a/packages/runtime/src/v2/runtime/core/middleware-sse-parser.ts
+++ b/packages/runtime/src/v2/runtime/core/middleware-sse-parser.ts
@@ -167,14 +167,24 @@ export async function parseSSEResponse(
         break;
       }
 
-      case "TOOL_CALL_RESULT":
+      case "TOOL_CALL_RESULT": {
+        // langchain-mcp-adapters may send content as an array of
+        // {type:"text", text:string} objects instead of a plain string.
+        let resultContent = event.content;
+        if (Array.isArray(resultContent)) {
+          resultContent = resultContent
+            .filter((part: any) => part && typeof part.text === "string")
+            .map((part: any) => part.text)
+            .join("");
+        }
         messagesById.set(event.messageId, {
           id: event.messageId,
           role: "tool",
-          content: event.content,
+          content: resultContent,
           toolCallId: event.toolCallId,
         });
         break;
+      }
     }
   }
 

--- a/packages/shared/src/standard-schema.ts
+++ b/packages/shared/src/standard-schema.ts
@@ -61,10 +61,24 @@ export function schemaToJsonSchema(
     return schema["~standard"].jsonSchema.input({ target: "draft-07" });
   }
 
-  // 2. Zod v3 fallback
+  // 2. Zod fallback (v3 and v4)
   const vendor = schema["~standard"].vendor;
-  if (vendor === "zod" && options?.zodToJsonSchema) {
+  if ((vendor === "zod" || vendor === "zod4") && options?.zodToJsonSchema) {
     return options.zodToJsonSchema(schema, { $refStrategy: "none" });
+  }
+
+  // 3. Zod-like schema detected by _def property (handles Zod v4 mini)
+  if (
+    options?.zodToJsonSchema &&
+    typeof schema === "object" &&
+    schema !== null &&
+    "_def" in (schema as any)
+  ) {
+    try {
+      return options.zodToJsonSchema(schema, { $refStrategy: "none" });
+    } catch {
+      // fall through to error below
+    }
   }
 
   throw new Error(

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -16,11 +16,17 @@ keywords = [
   "langsmith",
   "langserve",
 ]
+classifiers = [
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 packages = [{ include = "copilotkit" }]
 include = ["copilotkit/*.json"]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<4"
 langgraph = { version = ">=0.3.25,<2" }
 langchain = { version = ">=0.3.0" }
 crewai = { version = "0.118.0", optional = true }


### PR DESCRIPTION
## Summary

Batch of fixes for 6 community-reported issues:

- **#2922** — langchain-mcp-adapters sends TOOL_CALL_RESULT content as array instead of string. Normalize to string by extracting text parts.
- **#3055** — Loading indicator not shown during tool execution. Extended the check to also show spinner when last message has role "tool".
- **#3156** — Python 3.13+ not supported. Widened version constraint from `<3.13` to `<4` and added classifier.
- **#3318** — No IME composition handling in chat input. Added `isComposing` guard to skip Enter handling and prevent textarea measurement from disrupting composition.
- **#3593** — Controlled chat input not cleared after send. Now always calls `onChange("")` so controlled parents can reset.
- **#3636** — useFrontendTool broken with Zod v4. Extended schema conversion to match `zod4` vendor and detect Zod schemas by `_def` property.

## Issues NOT addressed (and why)

- **#2932** (duplicate frontend tool executions) — Existing dedup guard at run-handler level already checks for tool results. Could not identify the duplicate execution path without reproduction.
- **#2959** (mdast-util-to-hast vuln) — Requires react-markdown v8→v10 major upgrade with breaking API changes. Too risky for a blitz fix.
- **#3064** (suggestionView not rendering) — The slot rendering code appears correct. Needs reproduction to understand the actual failure path.
- **#3129** (initialMessages from agent config) — Requires deep understanding of agent config propagation flow. Needs more investigation.
- **#3499** (useAgent scroll jumping) — Attempted rAF batching but it breaks synchronous update expectations in throttle tests. Needs a different approach.
- **#3644** (duplicate assistant message IDs) — The ID generation happens in the ag-ui client/runtime event processing, not in finalize-events.ts. Needs deeper investigation of the event stream.

## Test plan

- [x] `@copilotkit/shared` tests pass (132/132)
- [x] `@copilotkit/runtime` tests pass (1221/1221)
- [x] `@copilotkit/react-core` tests pass (1070/1070)
- [x] `@copilotkit/react-ui` tests pass (2/2)
- [x] All modified packages build successfully
- [x] Formatter check passes (oxfmt)