### PR TITLE
fix: normalize array content in TOOL_CALL_RESULT for MCP adapters

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/middleware-sse-parser.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/middleware-sse-parser.test.ts
@@ -83,6 +83,56 @@ describe("parseSSEResponse", () => {
     });
   });
 
+  it("normalizes array content in TOOL_CALL_RESULT (MCP adapters)", async () => {
+    const response = buildSSEResponse([
+      { type: "RUN_STARTED", threadId: "t-1", runId: "r-1" },
+      {
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "tc-1",
+        messageId: "m-result",
+        role: "tool",
+        content: [
+          { type: "text", text: '{"metric":"cpu","value":42}' },
+          { type: "text", text: " extra info" },
+        ],
+      },
+      { type: "RUN_FINISHED", threadId: "t-1", runId: "r-1" },
+    ]);
+    const result = await parseSSEResponse(response);
+    expect(result.messages).toContainEqual({
+      id: "m-result",
+      role: "tool",
+      content: '{"metric":"cpu","value":42} extra info',
+      toolCallId: "tc-1",
+    });
+  });
+
+  it("filters non-text parts when normalizing array content in TOOL_CALL_RESULT", async () => {
+    const response = buildSSEResponse([
+      { type: "RUN_STARTED", threadId: "t-1", runId: "r-1" },
+      {
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "tc-1",
+        messageId: "m-result",
+        role: "tool",
+        content: [
+          { type: "text", text: "valid" },
+          { type: "image", data: "binary" },
+          null,
+          { type: "text", text: " part" },
+        ],
+      },
+      { type: "RUN_FINISHED", threadId: "t-1", runId: "r-1" },
+    ]);
+    const result = await parseSSEResponse(response);
+    expect(result.messages).toContainEqual({
+      id: "m-result",
+      role: "tool",
+      content: "valid part",
+      toolCallId: "tc-1",
+    });
+  });
+
   it("uses MESSAGES_SNAPSHOT when present", async () => {
     const snapshotMessages = [
       { id: "u-1", role: "user", content: "hi" },

--- a/packages/runtime/src/v2/runtime/core/middleware-sse-parser.ts
+++ b/packages/runtime/src/v2/runtime/core/middleware-sse-parser.ts
@@ -167,14 +167,24 @@ export async function parseSSEResponse(
         break;
       }
 
-      case "TOOL_CALL_RESULT":
+      case "TOOL_CALL_RESULT": {
+        // langchain-mcp-adapters may send content as an array of
+        // {type:"text", text:string} objects instead of a plain string.
+        let resultContent = event.content;
+        if (Array.isArray(resultContent)) {
+          resultContent = resultContent
+            .filter((part: any) => part && typeof part.text === "string")
+            .map((part: any) => part.text)
+            .join("");
+        }
         messagesById.set(event.messageId, {
           id: event.messageId,
           role: "tool",
-          content: event.content,
+          content: resultContent,
           toolCallId: event.toolCallId,
         });
         break;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- langchain-mcp-adapters sends tool call result content as an array of `{type:"text", text:string}` objects
- Extracts and joins text parts so downstream consumers always receive a plain string

Closes #2922