### PR TITLE
fix: show loading indicator during tool execution

### DIFF
--- a/packages/react-ui/src/components/chat/Messages.tsx
+++ b/packages/react-ui/src/components/chat/Messages.tsx
@@ -112,9 +112,9 @@ export const Messages = ({
             />
           );
         })}
-        {messages[messages.length - 1]?.role === "user" && inProgress && (
-          <LoadingIcon />
-        )}
+        {inProgress &&
+          (messages[messages.length - 1]?.role === "user" ||
+            messages[messages.length - 1]?.role === "tool") && <LoadingIcon />}
         {interrupt}
         {chatError && ErrorMessage && (
           <ErrorMessage error={chatError} isCurrentMessage />


### PR DESCRIPTION
## Summary
- The loading spinner only appeared when the last message had role "user"
- During tool execution the last message can have role "tool", hiding the indicator
- Now also show it when the trailing message is a tool result

Closes #3055