### PR TITLE
fix: add Zod v4 compatibility for schema-to-JSON conversion

### DIFF
--- a/packages/shared/src/__tests__/standard-schema.test.ts
+++ b/packages/shared/src/__tests__/standard-schema.test.ts
@@ -210,6 +210,98 @@ describe("schemaToJsonSchema", () => {
     });
   });
 
+  describe("Zod v4 schemas (via toJSONSchema method)", () => {
+    it("calls toJSONSchema() when the method exists on the schema", () => {
+      const expectedOutput = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      };
+
+      const mockZod4Schema: StandardSchemaV1 = {
+        "~standard": {
+          version: 1,
+          vendor: "zod",
+          validate: (value: unknown) => ({ value }),
+        },
+        toJSONSchema: () => expectedOutput,
+      } as any;
+
+      const result = schemaToJsonSchema(mockZod4Schema);
+      expect(result).toEqual(expectedOutput);
+    });
+
+    it("uses toJSONSchema() even without zodToJsonSchema option", () => {
+      const mockZod4Schema: StandardSchemaV1 = {
+        "~standard": {
+          version: 1,
+          vendor: "zod",
+          validate: (value: unknown) => ({ value }),
+        },
+        toJSONSchema: () => ({
+          type: "object",
+          properties: { city: { type: "string" } },
+        }),
+      } as any;
+
+      // No options passed — toJSONSchema() should still work
+      const result = schemaToJsonSchema(mockZod4Schema);
+      expect(result).toHaveProperty("properties.city.type", "string");
+    });
+
+    it("prefers toJSONSchema() over zodToJsonSchema fallback for Zod v4", () => {
+      const mockZod4Schema: StandardSchemaV1 = {
+        "~standard": {
+          version: 1,
+          vendor: "zod",
+          validate: (value: unknown) => ({ value }),
+        },
+        toJSONSchema: () => ({
+          type: "object",
+          properties: { fromNative: { type: "boolean" } },
+        }),
+      } as any;
+
+      const zodFallback = () => ({
+        type: "object",
+        properties: { fromFallback: { type: "boolean" } },
+      });
+
+      const result = schemaToJsonSchema(mockZod4Schema, {
+        zodToJsonSchema: zodFallback,
+      });
+
+      expect(result).toHaveProperty("properties.fromNative");
+      expect(result).not.toHaveProperty("properties.fromFallback");
+    });
+
+    it("prefers ~standard.jsonSchema over toJSONSchema()", () => {
+      const mockSchema = {
+        "~standard": {
+          version: 1,
+          vendor: "zod",
+          validate: (value: unknown) => ({ value }),
+          jsonSchema: {
+            input: () => ({
+              type: "object",
+              properties: { fromStandard: { type: "boolean" } },
+            }),
+          },
+        },
+        toJSONSchema: () => ({
+          type: "object",
+          properties: { fromToJSONSchema: { type: "boolean" } },
+        }),
+      };
+
+      const result = schemaToJsonSchema(mockSchema);
+
+      // Standard JSON Schema V1 should take priority
+      expect(result).toHaveProperty("properties.fromStandard");
+      expect(result).not.toHaveProperty("properties.fromToJSONSchema");
+    });
+  });
+
   describe("Error handling", () => {
     it("throws when schema has no jsonSchema support and no zodToJsonSchema", () => {
       const mockSchema: StandardSchemaV1 = {

--- a/packages/shared/src/standard-schema.ts
+++ b/packages/shared/src/standard-schema.ts
@@ -48,9 +48,10 @@ function hasStandardJsonSchema(
  * Strategy:
  * 1. If the schema implements Standard JSON Schema V1 (`~standard.jsonSchema`),
  *    call `schema['~standard'].jsonSchema.input({ target: 'draft-07' })`.
- * 2. If the schema is a Zod v3 schema (`~standard.vendor === 'zod'`), use the
+ * 2. If the schema exposes a `toJSONSchema()` method (Zod v4), call it directly.
+ * 3. If the schema is a Zod v3 schema (`~standard.vendor === 'zod'`), use the
  *    injected `zodToJsonSchema()` function.
- * 3. Otherwise throw a descriptive error.
+ * 4. Otherwise throw a descriptive error.
  */
 export function schemaToJsonSchema(
   schema: StandardSchemaV1,
@@ -61,7 +62,12 @@ export function schemaToJsonSchema(
     return schema["~standard"].jsonSchema.input({ target: "draft-07" });
   }
 
-  // 2. Zod v3 fallback
+  // 2. Zod v4 native — exposes toJSONSchema() on the schema itself
+  if (typeof (schema as any).toJSONSchema === "function") {
+    return (schema as any).toJSONSchema() as Record<string, unknown>;
+  }
+
+  // 3. Zod v3 fallback
   const vendor = schema["~standard"].vendor;
   if (vendor === "zod" && options?.zodToJsonSchema) {
     return options.zodToJsonSchema(schema, { $refStrategy: "none" });


### PR DESCRIPTION
## Summary
- Detects Zod v4 schemas by checking for `toJSONSchema()` method on the schema object
- Calls `schema.toJSONSchema()` directly for Zod v4 (avoids `zod-to-json-schema` v3, which can't handle Zod v4 internals)
- Preserves existing Zod v3 path via injected `zodToJsonSchema` fallback
- Removes dead `vendor === "zod4"` check (Zod v4 reports vendor as `"zod"`, not `"zod4"`)
- Removes `_def` duck-typing fallback (unnecessary with `toJSONSchema` detection)

### Priority order:
1. Standard JSON Schema V1 (`~standard.jsonSchema.input`)
2. Zod v4 native (`schema.toJSONSchema()`)
3. Zod v3 fallback (injected `zodToJsonSchema`)

### Tests added:
- Verifies `toJSONSchema()` is called when present
- Verifies it works without `zodToJsonSchema` option
- Verifies it takes priority over `zodToJsonSchema` fallback
- Verifies `~standard.jsonSchema` still takes top priority over `toJSONSchema()`

Closes #3636