### PR TITLE
fix: batch fixes for issues #3141, #3217, #3631, #3637, #3741, #1748, #1921, #1936

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
       "serve-static@<=1.16.0": "1.16.0",
       "prismjs@<=1.30.0": "1.30.0",
       "pino@<=10.1.1": "10.1.1",
-      "@copilotkit/license-verifier": "0.0.1-a1"
+      "@copilotkit/license-verifier": "0.0.1-a1",
+      "defu@<=6.1.4": ">=6.1.5"
     }
   }
 }

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -99,6 +99,7 @@ export class AgentRegistry {
   initialize(agents: Record<string, AbstractAgent>): void {
     this.localAgents = this.assignAgentIds(agents);
     this.applyHeadersToAgents(this.localAgents);
+    this.applyCredentialsToAgents(this.localAgents);
     this._agents = this.localAgents;
   }
 
@@ -140,6 +141,7 @@ export class AgentRegistry {
     this.localAgents = agents;
     this._agents = { ...this.localAgents, ...this.remoteAgents };
     this.applyHeadersToAgents(this._agents);
+    this.applyCredentialsToAgents(this._agents);
     void this.notifyAgentsChanged();
   }
 
@@ -150,6 +152,7 @@ export class AgentRegistry {
     this.validateAndAssignAgentId(id, agent);
     this.localAgents[id] = agent;
     this.applyHeadersToAgent(agent);
+    this.applyCredentialsToAgent(agent);
     this._agents = { ...this.localAgents, ...this.remoteAgents };
     void this.notifyAgentsChanged();
   }

--- a/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
@@ -47,6 +47,7 @@ const ToolCallRenderer = React.memo(
       return (
         <RenderComponent
           name={toolName}
+          toolCallId={toolCall.id}
           args={args}
           status={ToolCallStatus.Complete}
           result={toolMessage.content}
@@ -56,6 +57,7 @@ const ToolCallRenderer = React.memo(
       return (
         <RenderComponent
           name={toolName}
+          toolCallId={toolCall.id}
           args={args}
           status={ToolCallStatus.Executing}
           result={undefined}
@@ -65,6 +67,7 @@ const ToolCallRenderer = React.memo(
       return (
         <RenderComponent
           name={toolName}
+          toolCallId={toolCall.id}
           args={args}
           status={ToolCallStatus.InProgress}
           result={undefined}

--- a/packages/react-core/src/v2/types/react-tool-call-renderer.ts
+++ b/packages/react-core/src/v2/types/react-tool-call-renderer.ts
@@ -12,18 +12,21 @@ export interface ReactToolCallRenderer<T = unknown> {
   render: React.ComponentType<
     | {
         name: string;
+        toolCallId: string;
         args: Partial<T>;
         status: ToolCallStatus.InProgress;
         result: undefined;
       }
     | {
         name: string;
+        toolCallId: string;
         args: T;
         status: ToolCallStatus.Executing;
         result: undefined;
       }
     | {
         name: string;
+        toolCallId: string;
         args: T;
         status: ToolCallStatus.Complete;
         result: string;

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -137,7 +137,11 @@ type MarkdownProps = {
   urlTransform?: Options["urlTransform"];
 };
 
-export const Markdown = ({ content, components, urlTransform }: MarkdownProps) => {
+export const Markdown = ({
+  content,
+  components,
+  urlTransform,
+}: MarkdownProps) => {
   const mergedComponents = useMemo(
     () => ({ ...defaultComponents, ...components }),
     [components],

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -127,15 +127,17 @@ const MemoizedReactMarkdown: FC<Options> = memo(
   ReactMarkdown,
   (prevProps, nextProps) =>
     prevProps.children === nextProps.children &&
-    prevProps.components === nextProps.components,
+    prevProps.components === nextProps.components &&
+    prevProps.urlTransform === nextProps.urlTransform,
 );
 
 type MarkdownProps = {
   content: string;
   components?: Components;
+  urlTransform?: Options["urlTransform"];
 };
 
-export const Markdown = ({ content, components }: MarkdownProps) => {
+export const Markdown = ({ content, components, urlTransform }: MarkdownProps) => {
   const mergedComponents = useMemo(
     () => ({ ...defaultComponents, ...components }),
     [components],
@@ -149,6 +151,7 @@ export const Markdown = ({ content, components }: MarkdownProps) => {
           [remarkMath, { singleDollarTextMath: false }],
         ]}
         rehypePlugins={[rehypeRaw]}
+        {...(urlTransform ? { urlTransform } : {})}
       >
         {content}
       </MemoizedReactMarkdown>

--- a/packages/runtime/src/lib/runtime/__tests__/mcp-tools-utils.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/mcp-tools-utils.test.ts
@@ -206,8 +206,18 @@ describe("MCP Tools Utils", () => {
             description: "Object with properties: theme, notifications",
             required: false,
             attributes: [
-              { name: "theme", type: "string", description: "", required: false },
-              { name: "notifications", type: "boolean", description: "", required: false },
+              {
+                name: "theme",
+                type: "string",
+                description: "",
+                required: false,
+              },
+              {
+                name: "notifications",
+                type: "boolean",
+                description: "",
+                required: false,
+              },
             ],
           },
         ],

--- a/packages/runtime/src/lib/runtime/__tests__/mcp-tools-utils.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/mcp-tools-utils.test.ts
@@ -110,10 +110,14 @@ describe("MCP Tools Utils", () => {
       });
       expect(result[1]).toEqual({
         name: "objectArray",
-        type: "array",
+        type: "object[]",
         description:
           "Array of objects Array of objects with properties: name, value",
         required: false,
+        attributes: [
+          { name: "name", type: "string", description: "", required: false },
+          { name: "value", type: "number", description: "", required: false },
+        ],
       });
     });
 
@@ -147,6 +151,7 @@ describe("MCP Tools Utils", () => {
         type: "string",
         description: "Status value Allowed values: active | inactive | pending",
         required: true,
+        enum: ["active", "inactive", "pending"],
       });
       expect(result[1]).toEqual({
         name: "priority",
@@ -192,6 +197,20 @@ describe("MCP Tools Utils", () => {
         description:
           "User object Object with properties: name, email, preferences",
         required: true,
+        attributes: [
+          { name: "name", type: "string", description: "", required: false },
+          { name: "email", type: "string", description: "", required: false },
+          {
+            name: "preferences",
+            type: "object",
+            description: "Object with properties: theme, notifications",
+            required: false,
+            attributes: [
+              { name: "theme", type: "string", description: "", required: false },
+              { name: "notifications", type: "boolean", description: "", required: false },
+            ],
+          },
+        ],
       });
     });
 

--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -427,10 +427,26 @@ export class CopilotRuntime<const T extends Parameter[] | [] = []> {
       }
 
       if (isAgentsListEmpty) {
-        const model =
-          serviceAdapter.getLanguageModel?.() ??
-          `${serviceAdapter.provider}/${serviceAdapter.model}`;
-        agentsList.default = new BuiltInAgent({ model });
+        const languageModel = serviceAdapter.getLanguageModel?.();
+        if (languageModel) {
+          // Adapter exposes a pre-configured LanguageModel (e.g. OpenAI/Anthropic adapters)
+          agentsList.default = new BuiltInAgent({ model: languageModel });
+        } else if (serviceAdapter.provider && serviceAdapter.model) {
+          // Adapter exposes provider/model strings
+          agentsList.default = new BuiltInAgent({
+            model: `${serviceAdapter.provider}/${serviceAdapter.model}`,
+          });
+        } else {
+          throw new CopilotKitMisuseError({
+            message:
+              `Service adapter "${serviceAdapter.name ?? "unknown"}" does not provide model information. ` +
+              `When using adapters like LangChainAdapter without an explicit agents list, ` +
+              `please provide a default agent in the runtime config. Example:\n` +
+              `  new CopilotRuntime({\n` +
+              `    agents: { default: new BuiltInAgent({ model: "openai/gpt-4o" }) }\n` +
+              `  })`,
+          });
+        }
       }
 
       const actions = this.params?.actions;

--- a/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
+++ b/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
@@ -85,30 +85,65 @@ export function extractParametersFromSchema(
         }
       }
 
-      // Handle enums
+      // Handle enums — preserve as structured data for Zod conversion
+      let enumValues: string[] | undefined;
       if (paramDef.enum && Array.isArray(paramDef.enum)) {
-        const enumValues = paramDef.enum.join(" | ");
+        enumValues = paramDef.enum.map(String);
+        const enumDisplay = enumValues.join(" | ");
         description =
           description +
           (description ? " " : "") +
-          `Allowed values: ${enumValues}`;
+          `Allowed values: ${enumDisplay}`;
       }
 
-      // Handle objects with properties
+      // Handle objects with properties — recurse to preserve nested structure
+      let attributes: Parameter[] | undefined;
       if (type === "object" && paramDef.properties) {
         const objectProperties = Object.keys(paramDef.properties).join(", ");
         description =
           description +
           (description ? " " : "") +
           `Object with properties: ${objectProperties}`;
+        // Recursively extract nested parameters
+        attributes = extractParametersFromSchema({
+          parameters: {
+            properties: paramDef.properties,
+            required: paramDef.required || [],
+          },
+        });
       }
 
-      parameters.push({
+      // Handle object arrays — recurse into item schema
+      if (type === "array" && paramDef.items?.type === "object" && paramDef.items?.properties) {
+        attributes = extractParametersFromSchema({
+          parameters: {
+            properties: paramDef.items.properties,
+            required: paramDef.items.required || [],
+          },
+        });
+      }
+
+      const param: any = {
         name: paramName,
         type: type,
         description: description,
         required: requiredParams.has(paramName),
-      });
+      };
+
+      // Preserve enum values for string parameters
+      if (type === "string" && enumValues) {
+        param.enum = enumValues;
+      }
+
+      // Preserve nested attributes for object and object[] types
+      if (attributes && attributes.length > 0) {
+        param.attributes = attributes;
+        if (type === "array") {
+          param.type = "object[]";
+        }
+      }
+
+      parameters.push(param);
     }
   }
 

--- a/packages/runtime/src/lib/runtime/retry-utils.ts
+++ b/packages/runtime/src/lib/runtime/retry-utils.ts
@@ -7,6 +7,8 @@ export const RETRY_CONFIG = {
   maxDelayMs: 5000,
   // HTTP status codes that should be retried
   retryableStatusCodes: [502, 503, 504, 408, 429],
+  // Maximum Retry-After value (in seconds) we're willing to honor
+  maxRetryAfterSeconds: 60,
   // Network error patterns that should be retried
   retryableErrorMessages: [
     "fetch failed",
@@ -44,6 +46,28 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Parse the Retry-After header value into milliseconds.
+// Returns undefined if the header is missing or unparseable.
+export function parseRetryAfter(response: Response): number | undefined {
+  const retryAfter = response.headers.get("Retry-After");
+  if (!retryAfter) return undefined;
+
+  // Try as seconds (integer)
+  const seconds = Number(retryAfter);
+  if (!Number.isNaN(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  // Try as HTTP-date
+  const date = Date.parse(retryAfter);
+  if (!Number.isNaN(date)) {
+    const delayMs = date - Date.now();
+    return delayMs > 0 ? delayMs : 0;
+  }
+
+  return undefined;
+}
+
 // Calculate exponential backoff delay
 export function calculateDelay(attempt: number): number {
   const delay = RETRY_CONFIG.baseDelayMs * Math.pow(2, attempt);
@@ -67,7 +91,23 @@ export async function fetchWithRetry(
         isRetryableError(null, response) &&
         attempt < RETRY_CONFIG.maxRetries
       ) {
-        const delay = calculateDelay(attempt);
+        let delay = calculateDelay(attempt);
+
+        // Honor Retry-After header on 429 responses
+        if (response.status === 429) {
+          const retryAfterMs = parseRetryAfter(response);
+          if (retryAfterMs !== undefined) {
+            const maxMs = RETRY_CONFIG.maxRetryAfterSeconds * 1000;
+            if (retryAfterMs > maxMs) {
+              throw new Error(
+                `Server requested Retry-After of ${Math.ceil(retryAfterMs / 1000)}s ` +
+                  `which exceeds the maximum of ${RETRY_CONFIG.maxRetryAfterSeconds}s`,
+              );
+            }
+            delay = retryAfterMs;
+          }
+        }
+
         logger?.warn(
           `Request to ${url} failed with status ${response.status}. ` +
             `Retrying attempt ${attempt + 1}/${RETRY_CONFIG.maxRetries + 1} in ${delay}ms.`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   prismjs@<=1.30.0: 1.30.0
   pino@<=10.1.1: 10.1.1
   '@copilotkit/license-verifier': 0.0.1-a1
+  defu@<=6.1.4: '>=6.1.5'
 
 pnpmfileChecksum: sha256-Yeprb3L5TyOmoppd3E/Q880zwJi1e3M2rgrViqRvicc=
 
@@ -13466,8 +13467,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -36370,7 +36371,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   degenerator@5.0.1:
     dependencies:
@@ -46301,7 +46302,7 @@ snapshots:
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
-      defu: 6.1.4
+      defu: 6.1.7
       empathic: 2.0.0
       hookable: 6.0.1
       import-without-cache: 0.2.5
@@ -46330,7 +46331,7 @@ snapshots:
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
-      defu: 6.1.4
+      defu: 6.1.7
       empathic: 2.0.0
       hookable: 6.0.1
       import-without-cache: 0.2.5
@@ -46359,7 +46360,7 @@ snapshots:
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
-      defu: 6.1.4
+      defu: 6.1.7
       empathic: 2.0.0
       hookable: 6.0.1
       import-without-cache: 0.2.5

--- a/sdk-python/copilotkit/langgraph.py
+++ b/sdk-python/copilotkit/langgraph.py
@@ -142,9 +142,19 @@ def langchain_messages_to_copilotkit(
         if hasattr(message, "content"):
             content = message.content
 
-            # Check if content is a list and use the first element
+            # Content can be a list of content blocks (e.g. Anthropic models).
+            # Extract and concatenate all text parts instead of only taking
+            # the first element.
             if isinstance(content, list):
-                content = content[0] if content else ""
+                text_parts = []
+                for part in content:
+                    if isinstance(part, str):
+                        text_parts.append(part)
+                    elif isinstance(part, dict) and part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+                    elif isinstance(part, dict) and "text" in part:
+                        text_parts.append(part.get("text", ""))
+                content = "".join(text_parts)
 
             # Anthropic models return a dict with a "text" key
             if isinstance(content, dict):


### PR DESCRIPTION
## Summary

Batch of 8 bug fixes (5 HIGH, 3 MEDIUM priority):

- **#3141** — Forward credentials on all agent registration paths (HIGH)
  - `applyCredentialsToAgents`/`applyCredentialsToAgent` were defined but never called from `initialize()`, `setAgents__unsafe_dev_only()`, or `addAgent__unsafe_dev_only()`

- **#3217** — Prevent "Unknown provider" regression for LangChainAdapter (HIGH)
  - When `getLanguageModel()` returns null and `provider`/`model` are undefined, code constructed `"undefined/undefined"` as model string. Now checks each source explicitly and throws a clear error

- **#3631** — Patch defu CVE prototype pollution (HIGH)
  - Added pnpm override for `defu@<=6.1.4` to `>=6.1.5`

- **#3637** — Honor Retry-After header on 429 responses (HIGH)
  - Parse Retry-After as seconds or HTTP-date, use as retry delay. Throw if server requests wait > 60s

- **#3741** — Pass toolCallId to useRenderTool render components (HIGH)
  - Added `toolCallId` prop to all three status branches and updated `ReactToolCallRenderer` type

- **#1748** — Extract all text parts when AIMessage content is a list (MEDIUM)
  - Python SDK now iterates all content parts instead of only taking `content[0]`

- **#1921** — Pass urlTransform prop through to ReactMarkdown (MEDIUM)
  - Added `urlTransform` as optional prop with passthrough and memo comparison

- **#1936** — Preserve jsonSchema structure in MCP tool parameter extraction (MEDIUM)
  - `extractParametersFromSchema` now preserves enum values, recursively extracts nested object attributes, and handles object arrays

**Skipped:** #1937 (async headers) — overlaps with #2159, deferred to X2

## Test plan

- [x] MCP tools unit tests pass (17/17)
- [x] All affected packages build successfully
- [x] Formatted with oxfmt