### PR TITLE
fix: forward credentials on all agent registration paths

### DIFF
--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -99,6 +99,7 @@ export class AgentRegistry {
   initialize(agents: Record<string, AbstractAgent>): void {
     this.localAgents = this.assignAgentIds(agents);
     this.applyHeadersToAgents(this.localAgents);
+    this.applyCredentialsToAgents(this.localAgents);
     this._agents = this.localAgents;
   }
 
@@ -140,6 +141,7 @@ export class AgentRegistry {
     this.localAgents = agents;
     this._agents = { ...this.localAgents, ...this.remoteAgents };
     this.applyHeadersToAgents(this._agents);
+    this.applyCredentialsToAgents(this._agents);
     void this.notifyAgentsChanged();
   }
 
@@ -150,6 +152,7 @@ export class AgentRegistry {
     this.validateAndAssignAgentId(id, agent);
     this.localAgents[id] = agent;
     this.applyHeadersToAgent(agent);
+    this.applyCredentialsToAgent(agent);
     this._agents = { ...this.localAgents, ...this.remoteAgents };
     void this.notifyAgentsChanged();
   }


### PR DESCRIPTION
Closes #3141

`applyCredentialsToAgents`/`applyCredentialsToAgent` were defined but never called from `initialize()`, `setAgents__unsafe_dev_only()`, or `addAgent__unsafe_dev_only()`. Only remote agents received credentials via constructor. Local agents now receive credentials alongside headers.

Split from #3838.