### PR TITLE
fix: pass toolCallId to useRenderTool render components

### DIFF
--- a/.changeset/five-avocados-visit.md
+++ b/.changeset/five-avocados-visit.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-core": patch
+---
+
+fix: pass toolCallId to useRenderTool render components

--- a/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
@@ -47,6 +47,7 @@ const ToolCallRenderer = React.memo(
       return (
         <RenderComponent
           name={toolName}
+          toolCallId={toolCall.id}
           args={args}
           status={ToolCallStatus.Complete}
           result={toolMessage.content}
@@ -56,6 +57,7 @@ const ToolCallRenderer = React.memo(
       return (
         <RenderComponent
           name={toolName}
+          toolCallId={toolCall.id}
           args={args}
           status={ToolCallStatus.Executing}
           result={undefined}
@@ -65,6 +67,7 @@ const ToolCallRenderer = React.memo(
       return (
         <RenderComponent
           name={toolName}
+          toolCallId={toolCall.id}
           args={args}
           status={ToolCallStatus.InProgress}
           result={undefined}

--- a/packages/react-core/src/v2/hooks/use-render-tool.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-tool.tsx
@@ -7,6 +7,7 @@ const EMPTY_DEPS: ReadonlyArray<unknown> = [];
 
 export interface RenderToolInProgressProps<S extends StandardSchemaV1> {
   name: string;
+  toolCallId: string;
   parameters: Partial<InferSchemaOutput<S>>;
   status: "inProgress";
   result: undefined;
@@ -14,6 +15,7 @@ export interface RenderToolInProgressProps<S extends StandardSchemaV1> {
 
 export interface RenderToolExecutingProps<S extends StandardSchemaV1> {
   name: string;
+  toolCallId: string;
   parameters: InferSchemaOutput<S>;
   status: "executing";
   result: undefined;
@@ -21,6 +23,7 @@ export interface RenderToolExecutingProps<S extends StandardSchemaV1> {
 
 export interface RenderToolCompleteProps<S extends StandardSchemaV1> {
   name: string;
+  toolCallId: string;
   parameters: InferSchemaOutput<S>;
   status: "complete";
   result: string;

--- a/packages/react-core/src/v2/types/defineToolCallRenderer.ts
+++ b/packages/react-core/src/v2/types/defineToolCallRenderer.ts
@@ -14,18 +14,21 @@ import { ToolCallStatus } from "@copilotkit/core";
 type RenderProps<T> =
   | {
       name: string;
+      toolCallId: string;
       args: Partial<T>;
       status: ToolCallStatus.InProgress;
       result: undefined;
     }
   | {
       name: string;
+      toolCallId: string;
       args: T;
       status: ToolCallStatus.Executing;
       result: undefined;
     }
   | {
       name: string;
+      toolCallId: string;
       args: T;
       status: ToolCallStatus.Complete;
       result: string;

--- a/packages/react-core/src/v2/types/react-tool-call-renderer.ts
+++ b/packages/react-core/src/v2/types/react-tool-call-renderer.ts
@@ -12,18 +12,21 @@ export interface ReactToolCallRenderer<T = unknown> {
   render: React.ComponentType<
     | {
         name: string;
+        toolCallId: string;
         args: Partial<T>;
         status: ToolCallStatus.InProgress;
         result: undefined;
       }
     | {
         name: string;
+        toolCallId: string;
         args: T;
         status: ToolCallStatus.Executing;
         result: undefined;
       }
     | {
         name: string;
+        toolCallId: string;
         args: T;
         status: ToolCallStatus.Complete;
         result: string;


### PR DESCRIPTION
Closes #3741

Add `toolCallId` prop to all three status branches (InProgress, Executing, Complete) of the ToolCallRenderer, and update the `ReactToolCallRenderer` type to include it in the discriminated union.

Split from #3838.