### PR TITLE
fix: pass urlTransform prop through to ReactMarkdown

### DIFF
--- a/.changeset/little-pears-tell.md
+++ b/.changeset/little-pears-tell.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/react-ui": patch
+---
+
+fix: pass urlTransform prop through to ReactMarkdown

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -155,7 +155,7 @@ export const Markdown = ({
           [remarkMath, { singleDollarTextMath: false }],
         ]}
         rehypePlugins={[rehypeRaw]}
-        {...(urlTransform ? { urlTransform } : {})}
+        {...(urlTransform !== undefined ? { urlTransform } : {})}
       >
         {content}
       </MemoizedReactMarkdown>

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -127,15 +127,21 @@ const MemoizedReactMarkdown: FC<Options> = memo(
   ReactMarkdown,
   (prevProps, nextProps) =>
     prevProps.children === nextProps.children &&
-    prevProps.components === nextProps.components,
+    prevProps.components === nextProps.components &&
+    prevProps.urlTransform === nextProps.urlTransform,
 );
 
 type MarkdownProps = {
   content: string;
   components?: Components;
+  urlTransform?: Options["urlTransform"];
 };
 
-export const Markdown = ({ content, components }: MarkdownProps) => {
+export const Markdown = ({
+  content,
+  components,
+  urlTransform,
+}: MarkdownProps) => {
   const mergedComponents = useMemo(
     () => ({ ...defaultComponents, ...components }),
     [components],
@@ -149,6 +155,7 @@ export const Markdown = ({ content, components }: MarkdownProps) => {
           [remarkMath, { singleDollarTextMath: false }],
         ]}
         rehypePlugins={[rehypeRaw]}
+        {...(urlTransform ? { urlTransform } : {})}
       >
         {content}
       </MemoizedReactMarkdown>


### PR DESCRIPTION
Closes #1921

The Markdown component accepted `components` but not `urlTransform`, preventing users from customizing URL sanitization. Added `urlTransform` as an optional prop with passthrough to `MemoizedReactMarkdown`.

Split from #3838.