### PR TITLE
fix: preserve jsonSchema structure in MCP tool parameter extraction

### DIFF
--- a/.changeset/empty-mails-applaud.md
+++ b/.changeset/empty-mails-applaud.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix: preserve jsonSchema structure in MCP tool parameter extraction

--- a/packages/runtime/src/lib/runtime/__tests__/mcp-tools-utils.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/mcp-tools-utils.test.ts
@@ -110,10 +110,14 @@ describe("MCP Tools Utils", () => {
       });
       expect(result[1]).toEqual({
         name: "objectArray",
-        type: "array",
+        type: "object[]",
         description:
           "Array of objects Array of objects with properties: name, value",
         required: false,
+        attributes: [
+          { name: "name", type: "string", description: "", required: false },
+          { name: "value", type: "number", description: "", required: false },
+        ],
       });
     });
 
@@ -147,6 +151,7 @@ describe("MCP Tools Utils", () => {
         type: "string",
         description: "Status value Allowed values: active | inactive | pending",
         required: true,
+        enum: ["active", "inactive", "pending"],
       });
       expect(result[1]).toEqual({
         name: "priority",
@@ -192,6 +197,30 @@ describe("MCP Tools Utils", () => {
         description:
           "User object Object with properties: name, email, preferences",
         required: true,
+        attributes: [
+          { name: "name", type: "string", description: "", required: false },
+          { name: "email", type: "string", description: "", required: false },
+          {
+            name: "preferences",
+            type: "object",
+            description: "Object with properties: theme, notifications",
+            required: false,
+            attributes: [
+              {
+                name: "theme",
+                type: "string",
+                description: "",
+                required: false,
+              },
+              {
+                name: "notifications",
+                type: "boolean",
+                description: "",
+                required: false,
+              },
+            ],
+          },
+        ],
       });
     });
 

--- a/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
+++ b/packages/runtime/src/lib/runtime/mcp-tools-utils.ts
@@ -85,30 +85,65 @@ export function extractParametersFromSchema(
         }
       }
 
-      // Handle enums
+      // Handle enums — preserve as structured data for Zod conversion
+      let enumValues: string[] | undefined;
       if (paramDef.enum && Array.isArray(paramDef.enum)) {
-        const enumValues = paramDef.enum.join(" | ");
+        enumValues = paramDef.enum.map(String);
+        const enumDisplay = enumValues.join(" | ");
         description =
           description +
           (description ? " " : "") +
-          `Allowed values: ${enumValues}`;
+          `Allowed values: ${enumDisplay}`;
       }
 
-      // Handle objects with properties
+      // Handle objects with properties — recurse to preserve nested structure
+      let attributes: Parameter[] | undefined;
       if (type === "object" && paramDef.properties) {
         const objectProperties = Object.keys(paramDef.properties).join(", ");
         description =
           description +
           (description ? " " : "") +
           `Object with properties: ${objectProperties}`;
+        // Recursively extract nested parameters
+        attributes = extractParametersFromSchema({
+          parameters: {
+            properties: paramDef.properties,
+            required: paramDef.required || [],
+          },
+        });
       }
 
-      parameters.push({
+      // Handle object arrays — recurse into item schema
+      if (type === "array" && paramDef.items?.type === "object" && paramDef.items?.properties) {
+        attributes = extractParametersFromSchema({
+          parameters: {
+            properties: paramDef.items.properties,
+            required: paramDef.items.required || [],
+          },
+        });
+      }
+
+      const param: any = {
         name: paramName,
         type: type,
         description: description,
         required: requiredParams.has(paramName),
-      });
+      };
+
+      // Preserve enum values for string parameters
+      if (type === "string" && enumValues) {
+        param.enum = enumValues;
+      }
+
+      // Preserve nested attributes for object and object[] types
+      if (attributes && attributes.length > 0) {
+        param.attributes = attributes;
+        if (type === "array") {
+          param.type = "object[]";
+        }
+      }
+
+      parameters.push(param);
     }
   }
 


### PR DESCRIPTION
Closes #1936

`extractParametersFromSchema` now preserves enum values as structured data on string parameters, recursively extracts nested object attributes, and converts object arrays to `object[]` type with attributes. This ensures complex MCP tool schemas survive the `Parameter[]` -> Zod conversion without losing nested structure.

Split from #3838.