### PR TITLE
fix: scope .dark CSS selectors to CopilotKit elements

### DIFF
--- a/examples/e2e/tests/v1.x/dark-mode-scoping.spec.ts
+++ b/examples/e2e/tests/v1.x/dark-mode-scoping.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression test for #2920 — .dark CSS selectors must be scoped to CopilotKit
+ * elements, not leak into the host application.
+ *
+ * Before the fix (main), selectors like `.dark, html.dark, body.dark` applied
+ * `color: white` and `color: rgb(69, 69, 69)` directly to the .dark element
+ * itself, cascading into every child — including host app content.
+ *
+ * After the fix (#3850), selectors are scoped:
+ *   `.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton`
+ *   `.dark .poweredBy`
+ * so only CopilotKit elements receive the dark mode overrides.
+ */
+import { test, expect } from "@playwright/test";
+
+const EXAMPLE = process.env.EXAMPLE ?? "form-filling";
+
+test.describe("dark mode CSS scoping (#2920)", () => {
+  // This test relies on an app that uses .dark class (e.g. form-filling)
+  test.skip(EXAMPLE !== "form-filling", `EXAMPLE=${EXAMPLE}`);
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".copilotKitWindow.open").waitFor({ timeout: 10_000 });
+  });
+
+  test("enabling .dark class does not leak CopilotKit styles to host elements", async ({
+    page,
+  }) => {
+    // Grab a host-app element that should never be styled by CopilotKit CSS.
+    // In form-filling the <body> itself or a top-level container works.
+    const body = page.locator("body");
+
+    // Record the body's color BEFORE toggling dark mode
+    const colorBefore = await body.evaluate(
+      (el) => window.getComputedStyle(el).color,
+    );
+
+    // Toggle dark mode by adding .dark to <html>
+    await page.evaluate(() => document.documentElement.classList.add("dark"));
+
+    // Wait a tick for styles to recompute
+    await page.waitForTimeout(100);
+
+    const colorAfter = await body.evaluate(
+      (el) => window.getComputedStyle(el).color,
+    );
+
+    // The bug on main: .dark { color: rgb(69, 69, 69) !important } would
+    // override the body's color. With the fix, the body color should be
+    // determined solely by the host app's own .dark styles, NOT by CopilotKit.
+    //
+    // We verify the body color is NOT rgb(69, 69, 69) — the specific value
+    // that the broken CopilotKit input.css `.dark` rule forced.
+    expect(colorAfter).not.toBe("rgb(69, 69, 69)");
+
+    // Also verify the body color is NOT white from console.css's leaked
+    // `.dark { color: white }` — unless the host app itself sets white,
+    // which form-filling's .dark does set foreground to near-white.
+    // So we check that the actual color comes from the host app's CSS vars,
+    // not from CopilotKit's hardcoded values.
+  });
+
+  test("CopilotKit poweredBy gets correct dark mode color", async ({
+    page,
+  }) => {
+    // Toggle dark mode
+    await page.evaluate(() => document.documentElement.classList.add("dark"));
+    await page.waitForTimeout(100);
+
+    const poweredBy = page.locator(".poweredBy");
+
+    // With the fix, .dark .poweredBy { color: rgb(69, 69, 69) !important }
+    // should apply to the poweredBy element specifically.
+    const count = await poweredBy.count();
+    if (count > 0) {
+      const color = await poweredBy
+        .first()
+        .evaluate((el) => window.getComputedStyle(el).color);
+      expect(color).toBe("rgb(69, 69, 69)");
+    }
+  });
+
+  test("screenshot: dark mode side-by-side comparison", async ({ page }) => {
+    // Light mode screenshot
+    await page.evaluate(() =>
+      document.documentElement.classList.remove("dark"),
+    );
+    await page.waitForTimeout(200);
+    const lightScreenshot = await page.screenshot({ fullPage: true });
+    expect(lightScreenshot).toBeTruthy();
+
+    // Dark mode screenshot
+    await page.evaluate(() => document.documentElement.classList.add("dark"));
+    await page.waitForTimeout(200);
+    const darkScreenshot = await page.screenshot({ fullPage: true });
+    expect(darkScreenshot).toBeTruthy();
+
+    // Visual regression: dark mode screenshot should differ from light mode
+    // (if they're identical, dark mode styles aren't applying at all)
+    expect(Buffer.compare(lightScreenshot, darkScreenshot)).not.toBe(0);
+  });
+
+  test("dark mode styles only target CopilotKit elements", async ({ page }) => {
+    // Add a marker element outside CopilotKit to detect style leaks
+    await page.evaluate(() => {
+      const marker = document.createElement("div");
+      marker.id = "leak-detector";
+      marker.textContent = "Leak detector";
+      document.body.prepend(marker);
+    });
+
+    // Record marker color before dark mode
+    const markerColorLight = await page
+      .locator("#leak-detector")
+      .evaluate((el) => window.getComputedStyle(el).color);
+
+    // Enable dark mode
+    await page.evaluate(() => document.documentElement.classList.add("dark"));
+    await page.waitForTimeout(100);
+
+    const markerColorDark = await page
+      .locator("#leak-detector")
+      .evaluate((el) => window.getComputedStyle(el).color);
+
+    // The leak detector element should NOT have its color changed by
+    // CopilotKit's .dark CSS rules. If it does, that's a style leak.
+    //
+    // Note: The host app's own .dark { --foreground: ... } will change colors
+    // via CSS variables, which is fine. What we're checking is that
+    // CopilotKit doesn't force rgb(69, 69, 69) or white via its own rules.
+    expect(markerColorDark).not.toBe("rgb(69, 69, 69)");
+  });
+});

--- a/examples/e2e/tests/v1.x/dark-mode-scoping.spec.ts
+++ b/examples/e2e/tests/v1.x/dark-mode-scoping.spec.ts
@@ -31,11 +31,6 @@ test.describe("dark mode CSS scoping (#2920)", () => {
     // In form-filling the <body> itself or a top-level container works.
     const body = page.locator("body");
 
-    // Record the body's color BEFORE toggling dark mode
-    const colorBefore = await body.evaluate(
-      (el) => window.getComputedStyle(el).color,
-    );
-
     // Toggle dark mode by adding .dark to <html>
     await page.evaluate(() => document.documentElement.classList.add("dark"));
 
@@ -53,12 +48,6 @@ test.describe("dark mode CSS scoping (#2920)", () => {
     // We verify the body color is NOT rgb(69, 69, 69) — the specific value
     // that the broken CopilotKit input.css `.dark` rule forced.
     expect(colorAfter).not.toBe("rgb(69, 69, 69)");
-
-    // Also verify the body color is NOT white from console.css's leaked
-    // `.dark { color: white }` — unless the host app itself sets white,
-    // which form-filling's .dark does set foreground to near-white.
-    // So we check that the actual color comes from the host app's CSS vars,
-    // not from CopilotKit's hardcoded values.
   });
 
   test("CopilotKit poweredBy gets correct dark mode color", async ({
@@ -73,12 +62,12 @@ test.describe("dark mode CSS scoping (#2920)", () => {
     // With the fix, .dark .poweredBy { color: rgb(69, 69, 69) !important }
     // should apply to the poweredBy element specifically.
     const count = await poweredBy.count();
-    if (count > 0) {
-      const color = await poweredBy
-        .first()
-        .evaluate((el) => window.getComputedStyle(el).color);
-      expect(color).toBe("rgb(69, 69, 69)");
-    }
+    test.skip(count === 0, "No .poweredBy element found — skipping");
+
+    const color = await poweredBy
+      .first()
+      .evaluate((el) => window.getComputedStyle(el).color);
+    expect(color).toBe("rgb(69, 69, 69)");
   });
 
   test("screenshot: dark mode side-by-side comparison", async ({ page }) => {
@@ -109,11 +98,6 @@ test.describe("dark mode CSS scoping (#2920)", () => {
       marker.textContent = "Leak detector";
       document.body.prepend(marker);
     });
-
-    // Record marker color before dark mode
-    const markerColorLight = await page
-      .locator("#leak-detector")
-      .evaluate((el) => window.getComputedStyle(el).color);
 
     // Enable dark mode
     await page.evaluate(() => document.documentElement.classList.add("dark"));

--- a/packages/react-ui/src/css/colors.css
+++ b/packages/react-ui/src/css/colors.css
@@ -48,7 +48,7 @@ html.dark,
 body.dark,
 [data-theme="dark"],
 html[style*="color-scheme: dark"],
-body[style*="color-scheme: dark"] :root {
+body[style*="color-scheme: dark"] {
   /* Main brand/action color - used for buttons, interactive elements */
   --copilot-kit-primary-color: rgb(255, 255, 255);
   /* Color that contrasts with primary - used for text on primary elements */

--- a/packages/react-ui/src/css/console.css
+++ b/packages/react-ui/src/css/console.css
@@ -87,17 +87,27 @@
 html.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
 body.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
 [data-theme="dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
-html[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
-body[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton {
+html[style*="color-scheme: dark"]
+  .copilotKitDevConsole
+  .copilotKitDebugMenuTriggerButton,
+body[style*="color-scheme: dark"]
+  .copilotKitDevConsole
+  .copilotKitDebugMenuTriggerButton {
   color: white;
 }
 
 .dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
 html.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
 body.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
-[data-theme="dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
-html[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
-body[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover {
+[data-theme="dark"]
+  .copilotKitDevConsole
+  .copilotKitDebugMenuTriggerButton:hover,
+html[style*="color-scheme: dark"]
+  .copilotKitDevConsole
+  .copilotKitDebugMenuTriggerButton:hover,
+body[style*="color-scheme: dark"]
+  .copilotKitDevConsole
+  .copilotKitDebugMenuTriggerButton:hover {
   background-color: color-mix(
     in srgb,
     var(--copilot-kit-dev-console-bg) 20%,

--- a/packages/react-ui/src/css/console.css
+++ b/packages/react-ui/src/css/console.css
@@ -83,25 +83,21 @@
   color: var(--copilot-kit-dev-console-text);
 }
 
-.dark,
-html.dark,
-body.dark,
-[data-theme="dark"],
-html[style*="color-scheme: dark"],
-body[style*="color-scheme: dark"]
-  .copilotKitDevConsole
-  .copilotKitDebugMenuTriggerButton {
+.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+html.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+body.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+[data-theme="dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+html[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+body[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton {
   color: white;
 }
 
-.dark,
-html.dark,
-body.dark,
-[data-theme="dark"],
-html[style*="color-scheme: dark"],
-body[style*="color-scheme: dark"]
-  .copilotKitDevConsole
-  .copilotKitDebugMenuTriggerButton:hover {
+.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+html.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+body.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+[data-theme="dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+html[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+body[style*="color-scheme: dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover {
   background-color: color-mix(
     in srgb,
     var(--copilot-kit-dev-console-bg) 20%,

--- a/packages/react-ui/src/css/input.css
+++ b/packages/react-ui/src/css/input.css
@@ -145,11 +145,11 @@
   margin: 0 !important;
 }
 
-.dark,
-html.dark,
-body.dark,
-[data-theme="dark"],
-html[style*="color-scheme: dark"],
+.dark .poweredBy,
+html.dark .poweredBy,
+body.dark .poweredBy,
+[data-theme="dark"] .poweredBy,
+html[style*="color-scheme: dark"] .poweredBy,
 body[style*="color-scheme: dark"] .poweredBy {
   color: rgb(69, 69, 69) !important;
 }


### PR DESCRIPTION
## Summary

- **console.css + input.css:** Scope `.dark` CSS selectors to CopilotKit container elements (`.copilotKitDevConsole .copilotKitDebugMenuTriggerButton` and `.poweredBy` respectively). The original selectors had bare `.dark,` as standalone entries in comma-separated selector lists, which applied styles to *any* element with class `.dark` instead of scoping to CopilotKit elements.
- **colors.css:** Remove broken `:root` pseudo-element from `body[style*="color-scheme: dark"] :root` — `:root` is `<html>`, which cannot be a descendant of `<body>`, so this selector never matched anything.
- **E2E tests:** 4 Playwright regression tests verifying dark mode styles don't leak into host application elements.

Prevents CopilotKit dark-mode styles from leaking into the host application.

Closes #2920

---
*Split from #3847*