### PR TITLE
fix: support dynamic headers function prop for auth token refresh

### DIFF
--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -68,15 +68,19 @@ export interface CopilotKitProps extends Omit<
 
   /**
    * Additional headers to be sent with the request.
+   * Can be a static object or a function that returns headers dynamically
+   * (useful for refreshing auth tokens).
    *
    * For example:
-   * ```json
-   * {
-   *   "Authorization": "Bearer X"
-   * }
+   * ```tsx
+   * // Static headers
+   * headers={{ "Authorization": "Bearer X" }}
+   *
+   * // Dynamic headers (re-evaluated on each render)
+   * headers={() => ({ "Authorization": `Bearer ${getToken()}` })}
    * ```
    */
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | (() => Record<string, string>);
 
   /**
    * The children to be rendered within the CopilotKit.

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -311,7 +311,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       publicApiKey: publicApiKey,
       ...(cloud ? { cloud } : {}),
       chatApiEndpoint: chatApiEndpoint,
-      headers: props.headers || {},
+      headers: typeof props.headers === "function" ? props.headers() : (props.headers || {}),
       properties: props.properties || {},
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -311,7 +311,10 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       publicApiKey: publicApiKey,
       ...(cloud ? { cloud } : {}),
       chatApiEndpoint: chatApiEndpoint,
-      headers: typeof props.headers === "function" ? props.headers() : (props.headers || {}),
+      headers:
+        typeof props.headers === "function"
+          ? props.headers()
+          : props.headers || {},
       properties: props.properties || {},
       transcribeAudioUrl: props.transcribeAudioUrl,
       textToSpeechUrl: props.textToSpeechUrl,

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -390,7 +390,8 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   const hasLocalAgents = mergedAgents && Object.keys(mergedAgents).length > 0;
 
   // Resolve headers from function or static object
-  const headers = typeof headersProp === "function" ? headersProp() : headersProp;
+  const headers =
+    typeof headersProp === "function" ? headersProp() : headersProp;
 
   // Merge a provided publicApiKey into headers (without overwriting an explicit header).
   const mergedHeaders = useMemo(() => {

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -112,7 +112,7 @@ export const useLicenseContext = (): LicenseContextValue =>
 export interface CopilotKitProviderProps {
   children: ReactNode;
   runtimeUrl?: string;
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | (() => Record<string, string>);
   /**
    * Credentials mode for fetch requests (e.g., "include" for HTTP-only cookies in cross-origin requests).
    */
@@ -263,7 +263,7 @@ function useStableArrayProp<T>(
 export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   children,
   runtimeUrl,
-  headers = {},
+  headers: headersProp = {},
   credentials,
   publicApiKey,
   publicLicenseKey,
@@ -388,6 +388,9 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     [agents, selfManagedAgents],
   );
   const hasLocalAgents = mergedAgents && Object.keys(mergedAgents).length > 0;
+
+  // Resolve headers from function or static object
+  const headers = typeof headersProp === "function" ? headersProp() : headersProp;
 
   // Merge a provided publicApiKey into headers (without overwriting an explicit header).
   const mergedHeaders = useMemo(() => {


### PR DESCRIPTION
## Summary
- Allow `headers` prop on CopilotKit provider to accept a function in addition to a static object
- Enables dynamic auth token refresh by evaluating headers at request time

**Note:** This PR may overlap with #3819 (fix/issue-2159) which also touches headers props. Review both for potential conflicts.

Closes #2779

---
*Split from #3847*