### PR TITLE
fix: support per-request agent factory function (#2941)

### DIFF
--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -35,8 +35,13 @@ import {
   type CopilotRuntimeOptions,
   type CopilotRuntimeOptions as CopilotRuntimeOptionsVNext,
   type AgentRunner,
+  type AgentsConfig,
+  type AgentsFactory,
+  type AgentFactoryContext,
   InMemoryAgentRunner,
 } from "../../v2/runtime";
+
+export type { AgentsConfig, AgentsFactory, AgentFactoryContext };
 import { TelemetryAgentRunner } from "./telemetry-agent-runner";
 import telemetry from "../telemetry-client";
 
@@ -318,7 +323,7 @@ interface CopilotRuntimeConstructorParams<T extends Parameter[] | [] = []>
    *  – the `MaybePromise<NonEmptyRecord<T>>` constraint in `CopilotRuntimeOptionsVNext`
    *  – the `Record<string, AbstractAgent>` constraint in `both
    */
-  agents?: MaybePromise<NonEmptyRecord<Record<string, AbstractAgent>>>;
+  agents?: AgentsConfig;
 }
 
 /**

--- a/packages/runtime/src/v2/runtime/__tests__/agents-factory.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/agents-factory.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+import { HttpAgent } from "@ag-ui/client";
+import {
+  resolveAgents,
+  type AgentsConfig,
+  type AgentFactoryContext,
+} from "../core/runtime";
+import { handleRunAgent } from "../handlers/handle-run";
+import { handleGetRuntimeInfo } from "../handlers/get-runtime-info";
+import { CopilotRuntime } from "../core/runtime";
+
+function createMockAgent(name = "test") {
+  return new HttpAgent({ url: `https://example.com/${name}` });
+}
+
+function createMockRuntime(agents: AgentsConfig) {
+  return {
+    agents,
+    transcriptionService: undefined,
+    beforeRequestMiddleware: undefined,
+    afterRequestMiddleware: undefined,
+    runner: { stop: vi.fn().mockResolvedValue(true) },
+    mode: "sse",
+  } as unknown as CopilotRuntime;
+}
+
+function createMockRequest(headers?: Record<string, string>) {
+  return new Request("https://example.com/agent/test/run", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({ threadId: "thread-1", messages: [], state: {} }),
+  });
+}
+
+describe("resolveAgents", () => {
+  it("resolves a static record", async () => {
+    const agents = { default: createMockAgent() };
+    const result = await resolveAgents(agents);
+    expect(result).toBe(agents);
+  });
+
+  it("resolves a Promise", async () => {
+    const agents = { default: createMockAgent() };
+    const result = await resolveAgents(Promise.resolve(agents));
+    expect(result).toEqual(agents);
+  });
+
+  it("calls a factory function with request context", async () => {
+    const agent = createMockAgent();
+    const factory = vi.fn().mockReturnValue({ default: agent });
+    const request = createMockRequest({ "x-tenant-id": "tenant-123" });
+
+    const result = await resolveAgents(factory, request);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith({ request });
+    expect(result).toEqual({ default: agent });
+  });
+
+  it("calls an async factory function", async () => {
+    const agent = createMockAgent();
+    const factory = vi.fn().mockResolvedValue({ default: agent });
+    const request = createMockRequest();
+
+    const result = await resolveAgents(factory, request);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ default: agent });
+  });
+
+  it("throws when factory is used without a request", async () => {
+    const factory = vi.fn().mockReturnValue({ default: createMockAgent() });
+
+    await expect(resolveAgents(factory)).rejects.toThrow(
+      "Agent factory function requires a request context",
+    );
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("factory can read request headers for per-tenant resolution", async () => {
+    const tenantAgentA = createMockAgent("tenant-a");
+    const tenantAgentB = createMockAgent("tenant-b");
+
+    const factory = ({ request }: AgentFactoryContext) => {
+      const tenantId = request.headers.get("x-tenant-id");
+      if (tenantId === "a") return { default: tenantAgentA };
+      return { default: tenantAgentB };
+    };
+
+    const requestA = createMockRequest({ "x-tenant-id": "a" });
+    const requestB = createMockRequest({ "x-tenant-id": "b" });
+
+    const resultA = await resolveAgents(factory, requestA);
+    expect(resultA.default).toBe(tenantAgentA);
+
+    const resultB = await resolveAgents(factory, requestB);
+    expect(resultB.default).toBe(tenantAgentB);
+  });
+});
+
+describe("handleRunAgent with agents factory", () => {
+  it("returns 404 when factory returns no matching agent", async () => {
+    const factory = vi.fn().mockReturnValue({
+      other: createMockAgent("other"),
+    });
+    const runtime = createMockRuntime(factory);
+    const request = createMockRequest();
+
+    const response = await handleRunAgent({
+      runtime,
+      request,
+      agentId: "nonexistent",
+    });
+
+    expect(response.status).toBe(404);
+    expect(factory).toHaveBeenCalledWith({ request });
+  });
+});
+
+describe("handleGetRuntimeInfo with agents factory", () => {
+  it("resolves factory and lists agents", async () => {
+    const factory = vi.fn().mockReturnValue({
+      support: createMockAgent("support"),
+      technical: createMockAgent("technical"),
+    });
+    const runtime = createMockRuntime(factory);
+    const request = createMockRequest();
+
+    const response = await handleGetRuntimeInfo({ runtime, request });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(Object.keys(body.agents)).toContain("support");
+    expect(Object.keys(body.agents)).toContain("technical");
+    expect(factory).toHaveBeenCalledWith({ request });
+  });
+});

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -56,9 +56,70 @@ interface CopilotRuntimeMiddlewares {
   openGenerativeUI?: OpenGenerativeUIConfig;
 }
 
+/**
+ * Context passed to agent factory functions for per-request agent resolution.
+ */
+export interface AgentFactoryContext {
+  /** The incoming HTTP request. */
+  request: Request;
+}
+
+/**
+ * A function that dynamically creates agents on a per-request basis.
+ * Useful for multi-tenant scenarios or request-scoped agent configuration.
+ */
+export type AgentsFactory = (
+  ctx: AgentFactoryContext,
+) => MaybePromise<NonEmptyRecord<Record<string, AbstractAgent>>>;
+
+/**
+ * Agents can be provided as:
+ * - A static record of agents
+ * - A Promise that resolves to a record of agents
+ * - A factory function that receives request context and returns agents (or a Promise of agents)
+ */
+export type AgentsConfig =
+  | MaybePromise<NonEmptyRecord<Record<string, AbstractAgent>>>
+  | AgentsFactory;
+
+/**
+ * Resolve an AgentsConfig value to a concrete record of agents.
+ * If the config is a factory function, it is called with the given request context.
+ * Otherwise it is awaited directly (static record or Promise).
+ */
+export async function resolveAgents(
+  agents: AgentsConfig,
+  request?: Request,
+): Promise<Record<string, AbstractAgent>> {
+  if (typeof agents === "function") {
+    if (!request) {
+      throw new Error(
+        "Agent factory function requires a request context, but none was provided.",
+      );
+    }
+    return agents({ request });
+  }
+  return agents;
+}
+
 interface BaseCopilotRuntimeOptions extends CopilotRuntimeMiddlewares {
-  /** Map of available agents (loaded lazily is fine). */
-  agents: MaybePromise<NonEmptyRecord<Record<string, AbstractAgent>>>;
+  /**
+   * Map of available agents, or a factory function for per-request agent resolution.
+   *
+   * Static record:
+   * ```ts
+   * agents: { support: new SupportAgent(), technical: new TechnicalAgent() }
+   * ```
+   *
+   * Factory function (called per-request):
+   * ```ts
+   * agents: ({ request }) => {
+   *   const tenantId = request.headers.get("x-tenant-id");
+   *   return { default: createAgentForTenant(tenantId) };
+   * }
+   * ```
+   */
+  agents: AgentsConfig;
   /** Optional transcription service for audio processing. */
   transcriptionService?: TranscriptionService;
   /** Optional *before* middleware – callback function or webhook URL. */

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -1,4 +1,8 @@
-import { CopilotRuntimeLike, isIntelligenceRuntime } from "../core/runtime";
+import {
+  CopilotRuntimeLike,
+  isIntelligenceRuntime,
+  resolveAgents,
+} from "../core/runtime";
 import {
   AgentDescription,
   RuntimeInfo,
@@ -26,9 +30,10 @@ interface HandleGetRuntimeInfoParameters {
 
 export async function handleGetRuntimeInfo({
   runtime,
+  request,
 }: HandleGetRuntimeInfoParameters) {
   try {
-    const agents = await runtime.agents;
+    const agents = await resolveAgents(runtime.agents, request);
 
     const agentsDict = Object.entries(agents).reduce(
       (acc, [name, agent]) => {

--- a/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
@@ -29,7 +29,7 @@ export async function handleConnectAgent({
   });
 
   try {
-    const agent = await cloneAgentForRequest(runtime, agentId);
+    const agent = await cloneAgentForRequest(runtime, agentId, request);
     if (agent instanceof Response) {
       return agent;
     }

--- a/packages/runtime/src/v2/runtime/handlers/handle-run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-run.ts
@@ -30,7 +30,7 @@ export async function handleRunAgent({
   });
 
   try {
-    const agent = await cloneAgentForRequest(runtime, agentId);
+    const agent = await cloneAgentForRequest(runtime, agentId, request);
     if (agent instanceof Response) {
       return agent;
     }

--- a/packages/runtime/src/v2/runtime/handlers/handle-stop.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-stop.ts
@@ -1,4 +1,5 @@
 import type { CopilotRuntimeLike } from "../core/runtime";
+import { resolveAgents } from "../core/runtime";
 import { EventType } from "@ag-ui/client";
 
 interface StopAgentParameters {
@@ -15,7 +16,7 @@ export async function handleStopAgent({
   threadId,
 }: StopAgentParameters) {
   try {
-    const agents = await runtime.agents;
+    const agents = await resolveAgents(runtime.agents, request);
 
     if (!agents[agentId]) {
       return new Response(

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
@@ -99,7 +99,7 @@ async function runTitleGenerationAttempt(params: {
   prompt: string;
 }): Promise<string | null> {
   const { runtime, request, agentId, threadId, prompt } = params;
-  const agent = await cloneAgentForRequest(runtime, agentId);
+  const agent = await cloneAgentForRequest(runtime, agentId, request);
   if (isHandlerResponse(agent)) {
     logger.warn(
       { agentId, threadId },

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -5,7 +5,7 @@ import {
 } from "@ag-ui/client";
 import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
 import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
-import { CopilotRuntimeLike } from "../../core/runtime";
+import { CopilotRuntimeLike, resolveAgents } from "../../core/runtime";
 import { OpenGenerativeUIMiddleware } from "../../open-generative-ui-middleware";
 import { extractForwardableHeaders } from "../header-utils";
 import { logger } from "@copilotkit/shared";
@@ -28,8 +28,9 @@ export interface ConnectRequestBody extends RunAgentInput {
 export async function cloneAgentForRequest(
   runtime: CopilotRuntimeLike,
   agentId: string,
+  request?: Request,
 ): Promise<AbstractAgent | Response> {
-  const agents = await runtime.agents;
+  const agents = await resolveAgents(runtime.agents, request);
 
   if (!agents[agentId]) {
     return new Response(


### PR DESCRIPTION
## Summary

- Adds `AgentsFactory` type and `AgentsConfig` union so the `agents` runtime option now accepts a factory function `({ request }) => agents` in addition to a static record or Promise
- The factory receives the incoming `Request` object, enabling multi-tenant and request-scoped agent configuration
- All internal agent resolution sites (`cloneAgentForRequest`, `handleStopAgent`, `handleGetRuntimeInfo`) now use the new `resolveAgents()` helper which handles all three forms

Closes #2941

## Test plan

- [x] New `agents-factory.test.ts` with 8 tests covering static, Promise, sync factory, async factory, missing-request error, per-tenant header routing
- [x] All 36 existing handler tests pass unchanged
- [x] Runtime package builds cleanly