### PR TITLE
fix: batch useAgent forceUpdate calls to prevent scroll jumping (#3499)

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
@@ -313,7 +313,7 @@ describe("useAgent throttleMs", () => {
     expect(screen.getByTestId("count").textContent).toBe("3");
   });
 
-  it("with throttleMs, onStateChanged still fires immediately", () => {
+  it("with throttleMs, onStateChanged still fires immediately", async () => {
     const TestComponent = createTestComponent({
       updates: [
         UseAgentUpdate.OnMessagesChanged,
@@ -330,8 +330,8 @@ describe("useAgent throttleMs", () => {
       notifyMessagesChanged(mockAgent);
     });
 
-    // Fire onStateChanged 10ms later — should render immediately, not throttled
-    act(() => {
+    // Fire onStateChanged 10ms later — fires via microtask batch (not synchronously)
+    await act(async () => {
       vi.advanceTimersByTime(10);
       mockAgent.state = { count: 42 };
       notifyStateChanged(mockAgent);
@@ -372,7 +372,7 @@ describe("useAgent throttleMs", () => {
     expect(renderCount.current).toBe(countBeforeUnmount);
   });
 
-  it("with throttleMs and updates excluding OnMessagesChanged, throttle is a no-op", () => {
+  it("with throttleMs and updates excluding OnMessagesChanged, throttle is a no-op", async () => {
     const TestComponent = createTestComponent({
       updates: [UseAgentUpdate.OnStateChanged],
       throttleMs: 100,
@@ -380,8 +380,8 @@ describe("useAgent throttleMs", () => {
 
     render(<TestComponent />);
 
-    // Only onStateChanged is subscribed — should fire immediately
-    act(() => {
+    // Only onStateChanged is subscribed — fires via microtask batch
+    await act(async () => {
       mockAgent.state = { value: "test" };
       notifyStateChanged(mockAgent);
     });
@@ -649,7 +649,7 @@ describe("useAgent throttleMs", () => {
     expect(renderCount.current).toBe(rendersAfterMount + 1);
   });
 
-  it("with throttleMs, onRunInitialized still fires immediately during throttle window", () => {
+  it("with throttleMs, onRunInitialized still fires immediately during throttle window", async () => {
     const renderCount = { current: 0 };
     const TestComponent = createTestComponent({
       updates: [
@@ -670,13 +670,13 @@ describe("useAgent throttleMs", () => {
     });
     expect(renderCount.current).toBe(rendersAfterMount + 1);
 
-    // Fire onRunInitialized 10ms later — should render immediately
-    act(() => {
+    // Fire onRunInitialized 10ms later — fires via microtask batch
+    await act(async () => {
       vi.advanceTimersByTime(10);
       notifyRunInitialized(mockAgent);
     });
 
-    // Run status notification is NOT throttled — renders immediately
+    // Run status notification fires via microtask batch
     expect(renderCount.current).toBe(rendersAfterMount + 2);
   });
 

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -281,6 +281,25 @@ export function useAgent({
     let timerId: ReturnType<typeof setTimeout> | null = null;
     let active = true;
 
+    // Microtask-batched forceUpdate: coalesces multiple synchronous
+    // notifications (e.g. OnStateChanged + OnRunStatusChanged firing in the
+    // same tick) into a single React re-render. This prevents the scroll
+    // jumping described in #3499 where rapid unbatched forceUpdate calls
+    // cause brief content height fluctuations during streaming.
+    let batchScheduled = false;
+    const batchedForceUpdate = () => {
+      if (!active) return;
+      if (!batchScheduled) {
+        batchScheduled = true;
+        queueMicrotask(() => {
+          batchScheduled = false;
+          if (active) {
+            forceUpdate();
+          }
+        });
+      }
+    };
+
     if (updateFlags.includes(UseAgentUpdate.OnMessagesChanged)) {
       const ms = effectiveThrottleMs;
       if (ms > 0) {
@@ -324,13 +343,13 @@ export function useAgent({
     }
 
     if (updateFlags.includes(UseAgentUpdate.OnStateChanged)) {
-      handlers.onStateChanged = forceUpdate;
+      handlers.onStateChanged = batchedForceUpdate;
     }
 
     if (updateFlags.includes(UseAgentUpdate.OnRunStatusChanged)) {
-      handlers.onRunInitialized = forceUpdate;
-      handlers.onRunFinalized = forceUpdate;
-      handlers.onRunFailed = forceUpdate;
+      handlers.onRunInitialized = batchedForceUpdate;
+      handlers.onRunFinalized = batchedForceUpdate;
+      handlers.onRunFailed = batchedForceUpdate;
     }
 
     const subscription = agent.subscribe(handlers);


### PR DESCRIPTION
## Summary
- Coalesces `OnStateChanged` and `OnRunStatusChanged` notifications in `useAgent` using `queueMicrotask`, so multiple synchronous events within the same tick produce a single React re-render
- Eliminates scroll jumping during streaming caused by rapid unbatched `forceUpdate()` calls that trigger brief content height fluctuations in `use-stick-to-bottom`
- `OnMessagesChanged` retains its existing behavior (direct or throttled via `throttleMs`)

## Test plan
- [x] All 1070 existing `@copilotkit/react-core` tests pass
- [x] Updated 3 throttle tests to account for microtask-batched state/run-status updates
- [ ] Manual: verify scroll no longer jumps during streaming with `useAgent` subscribed to multiple update types

Closes #3499