### PR TITLE
fix: harden release system — registry error handling, tag check, prerelease tests

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -74,6 +74,20 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
+      - name: Check for pre-existing tags
+        run: |
+          SCOPE="${{ steps.meta.outputs.scope }}"
+          VERSION="${{ steps.publish.outputs.version }}"
+          if [ "$SCOPE" == "monorepo" ]; then
+            TAG="v${VERSION}"
+          else
+            TAG="${SCOPE}/v${VERSION}"
+          fi
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: Tag $TAG already exists" >&2
+            exit 1
+          fi
+
       - name: Create and push git tag
         run: |
           SCOPE="${{ steps.meta.outputs.scope }}"

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -76,6 +76,10 @@ function main() {
   console.log("\nBuilding packages...");
   run("pnpm", ["run", "build"]);
 
+  // Run tests before publishing
+  console.log("\nRunning tests...");
+  run("pnpm", ["run", "test"]);
+
   // Publish each package
   console.log("\nPublishing packages...");
   for (const p of getPackagesForScope(scope)) {

--- a/scripts/release/publish-release.ts
+++ b/scripts/release/publish-release.ts
@@ -47,12 +47,15 @@ function getPublishedVersion(packageName: string): string | null {
     return result.stdout.trim() || null;
   }
   // E404 means package doesn't exist on registry — genuinely not published
-  if (result.stderr?.includes("E404") || result.stderr?.includes("is not in this registry")) {
+  if (
+    result.stderr?.includes("E404") ||
+    result.stderr?.includes("is not in this registry")
+  ) {
     return null;
   }
   // Any other error (network, auth, rate limit) should stop the release
   throw new Error(
-    `npm registry check failed for ${packageName}: ${result.stderr?.trim() || "unknown error"}`
+    `npm registry check failed for ${packageName}: ${result.stderr?.trim() || "unknown error"}`,
   );
 }
 
@@ -100,7 +103,9 @@ async function main() {
   try {
     published = getPublishedVersion(scopeConfig.versionSource);
   } catch (err: any) {
-    console.error(`Registry check failed — aborting release to avoid publishing over an existing version.`);
+    console.error(
+      `Registry check failed — aborting release to avoid publishing over an existing version.`,
+    );
     console.error(err.message);
     process.exit(1);
   }

--- a/scripts/release/publish-release.ts
+++ b/scripts/release/publish-release.ts
@@ -43,8 +43,17 @@ function getPublishedVersion(packageName: string): string | null {
     encoding: "utf8",
     timeout: 15000,
   });
-  if (result.status !== 0) return null;
-  return result.stdout.trim() || null;
+  if (result.status === 0) {
+    return result.stdout.trim() || null;
+  }
+  // E404 means package doesn't exist on registry — genuinely not published
+  if (result.stderr?.includes("E404") || result.stderr?.includes("is not in this registry")) {
+    return null;
+  }
+  // Any other error (network, auth, rate limit) should stop the release
+  throw new Error(
+    `npm registry check failed for ${packageName}: ${result.stderr?.trim() || "unknown error"}`
+  );
 }
 
 function isGreaterVersion(next: string, current: string): boolean {
@@ -87,7 +96,14 @@ async function main() {
   }
 
   // Safety check: refuse to publish if version isn't greater than what's on npm
-  const published = getPublishedVersion(scopeConfig.versionSource);
+  let published: string | null;
+  try {
+    published = getPublishedVersion(scopeConfig.versionSource);
+  } catch (err: any) {
+    console.error(`Registry check failed — aborting release to avoid publishing over an existing version.`);
+    console.error(err.message);
+    process.exit(1);
+  }
   if (published) {
     console.log(`Currently published version: ${published}`);
     if (!isGreaterVersion(version, published)) {


### PR DESCRIPTION
## Summary

Ports 3 proven patterns from ag-ui's release system to CopilotKit.

### C1: Registry error vs 404 distinction
`getPublishedVersion` in `publish-release.ts` now distinguishes between npm E404 (package genuinely not published — proceed) and real errors (network timeout, auth failure, rate limit — stop). Previously all errors returned `null`, silently bypassing the version guard.

### C2: Pre-existing tag check
Added a check in `publish-release.yml` that verifies the tag doesn't already exist before attempting to create it. Prevents the "published but no tag" state on retries.

### C3: Pre-publish tests in prerelease
Added `pnpm run test` between build and publish in the canary workflow. A broken canary erodes trust in the prerelease channel.

**Cross-pollination context:** [Notion page](https://www.notion.so/3413aa38185281828aa1dfa014808ddc)
The ag-ui side (strict version ordering, AI release notes, atomic PR creation) ships via ag-ui PR #1487.

## Test plan

- [ ] Verify `getPublishedVersion` returns null on E404 but throws on network errors
- [ ] Verify pre-existing tag check fails fast before publish
- [ ] Verify prerelease workflow runs tests before canary publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)