### PR TITLE
fix: version drift Slack alert links directly to GitHub issue

### DIFF
--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -189,6 +189,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create drift report issue
+        id: drift_issue
         if: steps.python_drift.outputs.report != '' || steps.npm_drift.outputs.report != ''
         uses: actions/github-script@v7
         with:
@@ -219,14 +220,16 @@ jobs:
               state: 'open',
             });
 
+            let issueUrl;
             if (issues.length === 0) {
-              await github.rest.issues.create({
+              const { data: created } = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title,
                 body,
                 labels: ['showcase-drift', 'version-drift'],
               });
+              issueUrl = created.html_url;
             } else {
               await github.rest.issues.update({
                 owner: context.repo.owner,
@@ -234,7 +237,9 @@ jobs:
                 issue_number: issues[0].number,
                 body,
               });
+              issueUrl = issues[0].html_url;
             }
+            core.setOutput('issue_url', issueUrl);
 
       - name: Notify Slack (version drift)
         if: steps.python_drift.outputs.report != '' || steps.npm_drift.outputs.report != ''
@@ -243,7 +248,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload: |
-            { "text": ":warning: *Version drift*: dependency updates available — see GitHub issue | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
+            { "text": ":warning: *Version drift*: dependency updates available | <${{ steps.drift_issue.outputs.issue_url }}|View issue>" }
 
       - name: Notify Slack (version drift failure)
         if: failure()


### PR DESCRIPTION
## Summary

- Version drift Slack notification now links directly to the GitHub issue instead of just saying "see GitHub issue"
- Captures issue URL from both create and update code paths via `core.setOutput`
- Message changed from generic "see GitHub issue | View run" to clickable "View issue" link

## Test plan

- [ ] Next weekly drift run (or manual dispatch) produces Slack message with clickable issue link

🤖 Generated with [Claude Code](https://claude.com/claude-code)