### PR TITLE
docs(langgraph): document runAgent once via useEffect in configurable…

### DIFF
--- a/docs/content/docs/integrations/langgraph/configurable.mdx
+++ b/docs/content/docs/integrations/langgraph/configurable.mdx
@@ -29,7 +29,7 @@ First, pass the configuration properties as you would like to receive them in th
 
 ```tsx title="app/page.tsx"
 import { useAgent } from "@copilotkit/react-core/v2"; // [!code highlight]
-
+import { useEffect } from "react";
 function YourMainContent() {
   // ...
 
@@ -40,16 +40,18 @@ function YourMainContent() {
 
   // Pass configuration when running the agent
   // [!code highlight:8]
-  agent.runAgent({
-    forwardedProps: {
-      config: {
-        configurable: {
-          authToken: 'example-token'
-        },
-        recursion_limit: 50,
+  useEffect(() => {
+    agent.runAgent({
+      forwardedProps: {
+        config: {
+          configurable: {
+            authToken: 'example-token'
+          },
+          recursion_limit: 50,
+        }
       }
-    }
-  });
+    });
+  }, []);
 
   // ...
 

--- a/showcase/shell/src/content/docs/integrations/langgraph/configurable.mdx
+++ b/showcase/shell/src/content/docs/integrations/langgraph/configurable.mdx
@@ -28,10 +28,13 @@ By default, LangGraph agents are invoked with a `config` argument. This config h
 <Steps>
 <Step>
 ### Pass configuration from the frontend
-First, pass the configuration properties as you would like to receive them in the agent
+First, pass the configuration properties as you would like to receive them in the agent.
+
+Do not call `runAgent` directly in the component body: it would run on every render and can trigger errors such as **thread is already processing**. Use a `useEffect` with an empty dependency array (or call `runAgent` from an event handler) when you want to start the run once with a given config.
 
 ```tsx title="app/page.tsx"
-
+import { useAgent } from "@copilotkit/react-core/v2"; // [!code highlight]
+import { useEffect } from "react";
 function YourMainContent() {
   // ...
 
@@ -42,16 +45,18 @@ function YourMainContent() {
 
   // Pass configuration when running the agent
   // [!code highlight:8]
-  agent.runAgent({
-    forwardedProps: {
-      config: {
-        configurable: {
-          authToken: 'example-token'
-        },
-        recursion_limit: 50,
+  useEffect(() => {
+    agent.runAgent({
+      forwardedProps: {
+        config: {
+          configurable: {
+            authToken: 'example-token'
+          },
+          recursion_limit: 50,
+        }
       }
-    }
-  });
+    });
+  }, []);
 
   // ...
 


### PR DESCRIPTION
## Summary

Documents that `agent.runAgent` should not be called directly in the React component render path, because it can run on every re-render and overlap with an in-flight thread (e.g. **thread is already processing**). The LangGraph **Configurable** guide now calls this out and keeps the example using `useEffect` with an empty dependency array for a one-shot start, with event handlers noted as an alternative.

## Changes

- `docs/content/docs/integrations/langgraph/configurable.mdx` — add guidance above the snippet; snippet remains `useEffect`-wrapped `runAgent` with `forwardedProps.config`.
- `showcase/shell/src/content/docs/integrations/langgraph/configurable.mdx` — align copy and snippet with the main docs (imports + `useEffect`).
