### PR TITLE
fix: inspector not receiving AG-UI events from per-thread agent clones

### DIFF
--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -153,6 +153,15 @@ export interface CopilotKitCoreSubscriber {
     code: CopilotKitCoreErrorCode;
     context: Record<string, any>;
   }) => void | Promise<void>;
+  /**
+   * Fired when an agent run or connect begins. The `agent` may be a per-thread
+   * clone that is not present in `core.agents`. Subscribers (e.g. the inspector)
+   * can use this to subscribe to the clone's AG-UI events.
+   */
+  onAgentRunStarted?: (event: {
+    copilotkit: CopilotKitCore;
+    agent: AbstractAgent;
+  }) => void | Promise<void>;
 }
 
 // Subscription object returned by subscribe()

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -206,6 +206,18 @@ export class RunHandler {
         };
       }
 
+      // Notify subscribers (e.g. the inspector) about the agent that is about
+      // to run. This is critical for per-thread clones that are not present in
+      // the agent registry and would otherwise be invisible to subscribers.
+      await this._internal.notifySubscribers(
+        (subscriber) =>
+          subscriber.onAgentRunStarted?.({
+            copilotkit: this.core,
+            agent,
+          }),
+        "Subscriber onAgentRunStarted error:",
+      );
+
       const runAgentResult = await agent.connectAgent(
         {
           forwardedProps: this._internal.properties,
@@ -281,6 +293,18 @@ export class RunHandler {
     // onAgentsChanged). The composite-key logic in StateManager means this
     // does not overwrite the registry agent's subscription.
     this._internal.subscribeAgentToStateManager(agent);
+
+    // Notify subscribers (e.g. the inspector) about the agent that is about
+    // to run. This is critical for per-thread clones that are not present in
+    // the agent registry and would otherwise be invisible to subscribers.
+    await this._internal.notifySubscribers(
+      (subscriber) =>
+        subscriber.onAgentRunStarted?.({
+          copilotkit: this.core,
+          agent,
+        }),
+      "Subscriber onAgentRunStarted error:",
+    );
 
     // Set up abort controller and agent.abortRun() intercept only for the
     // top-level call. Recursive follow-up calls from processAgentResult

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -287,6 +287,14 @@ export class WebInspectorElement extends LitElement {
       onAgentsChanged: ({ agents }) => {
         this.processAgentsChanged(agents);
       },
+      onAgentRunStarted: ({ agent }) => {
+        // Per-thread clones are not in the agent registry, so
+        // onAgentsChanged never fires for them. Subscribe here so
+        // the inspector captures their AG-UI events.
+        if (agent?.agentId) {
+          this.subscribeToAgent(agent);
+        }
+      },
       onContextChanged: ({ context }) => {
         this.contextStore = this.normalizeContextStore(context);
         this.requestUpdate();


### PR DESCRIPTION
## Summary

Fixes the inspector showing no AG-UI events.

`useAgent()` returns per-thread clones (via `getOrCreateThreadClone`) that are not in the agent registry. The inspector subscribed to registry agents via `onAgentsChanged`, so it never received events from clones — resulting in an empty event panel.

Adds an `onAgentRunStarted` subscriber event to `CopilotKitCoreSubscriber` that fires before `connectAgent()` and `runAgent()`, passing the actual agent instance (which may be a per-thread clone). The inspector subscribes to that agent's events, matching the existing `StateManager` pattern (`subscribeAgentToStateManager`).

Per-thread cloning remains enabled — this does **not** touch `useAgent` or revert any cloning logic.

## Changes

| File | What |
|------|------|
| `packages/core/src/core/core.ts` | Add `onAgentRunStarted` to `CopilotKitCoreSubscriber` interface |
| `packages/core/src/core/run-handler.ts` | Fire `onAgentRunStarted` in both `connectAgent()` and `runAgent()` |
| `packages/web-inspector/src/index.ts` | Handle `onAgentRunStarted` by subscribing to the clone agent |

## Test plan

- [x] All 337 `@copilotkit/core` tests pass
- [x] All 2 `@copilotkit/web-inspector` tests pass
- [x] Both packages build cleanly
- [x] `oxfmt --check` passes
- [ ] Manual: open an app with `showDevConsole={true}`, send a message, verify AG-UI events appear in the inspector