### PR TITLE
Fix docs sync: upgrade token action to v2, add failure context

### DIFF
--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Generate bot token
         id: bot-token
         if: steps.sync.outputs.action == 'auto_push' || steps.sync.outputs.action == 'push_and_pr'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: 1108748
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
@@ -151,4 +151,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload: |
-            { "text": ":x: *Docs sync*: workflow failed | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
+            { "text": ":x: *Docs sync*: workflow failed\n*Failed step:* ${{ steps.sync.outcome == 'failure' && 'sync-docs script' || steps.bot-token.outcome == 'failure' && 'bot token generation (check DEVOPS_BOT_PRIVATE_KEY secret)' || steps.push.outcome == 'failure' && 'push/PR creation' || 'unknown' }} | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }


### PR DESCRIPTION
## Summary
- Upgrade `actions/create-github-app-token` from v1 to v2 — v1 fails with `Invalid keyData` on certain PEM formats (SubtleCrypto.importKey() limitation)
- Add step-level failure info to the Slack failure notification so we know WHICH step failed instead of just "workflow failed"

## Context
The docs sync has been failing since the last main push with `DOMException [DataError]: Invalid keyData`. The Slack alert just says "workflow failed" with no detail about what broke.

If upgrading to v2 doesn't fix it, the `DEVOPS_BOT_PRIVATE_KEY` secret needs to be regenerated in the GitHub App settings and re-saved as a repo secret.

## Test plan
- [ ] Merge and trigger docs sync workflow (push to main or workflow_dispatch)
- [ ] Verify bot token generation succeeds
- [ ] If still failing, regenerate the private key at https://github.com/organizations/CopilotKit/settings/apps/copilotkit-devops-bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)