### PR TITLE
fix: smoke monitor rebuilds include shared tools copy

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -199,6 +199,21 @@ jobs:
           echo "$ARGS" >> $GITHUB_OUTPUT
           echo "BUILDARGS_EOF" >> $GITHUB_OUTPUT
 
+      - name: Copy shared modules into build context
+        run: |
+          CONTEXT="${{ matrix.service.context }}"
+          if [ -d "showcase/shared/python" ] && [ -d "$CONTEXT" ]; then
+            cp -r showcase/shared/python "$CONTEXT/shared_python"
+          fi
+          if [ -d "showcase/shared/frontend/src" ] && [ -d "$CONTEXT" ]; then
+            mkdir -p "$CONTEXT/shared_frontend/src"
+            cp -r showcase/shared/frontend/src/ "$CONTEXT/shared_frontend/src/"
+          fi
+          if [ -d "showcase/shared/typescript/tools" ] && [ -d "$CONTEXT" ]; then
+            mkdir -p "$CONTEXT/shared_typescript/tools"
+            cp -r showcase/shared/typescript/tools/ "$CONTEXT/shared_typescript/tools/"
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

The smoke monitor's drift-triggered rebuilds fail because the deploy workflow doesn't copy shared modules (shared_python/, shared_frontend/src/, shared_typescript/tools/) into each package's Docker build context before building.

- Adds a "Copy shared modules into build context" step to `showcase_deploy.yml`, placed between the build-args prep and the Docker build step
- The step conditionally copies each shared directory only if it exists, so it's safe for packages that don't use shared modules
- Fixes rebuilds triggered via `workflow_dispatch` (from smoke monitor drift detection) and manual dispatches alike