### PR TITLE
fix: showcase Docker builds — webpack alias for shared package

### DIFF
--- a/showcase/packages/ag2/next.config.ts
+++ b/showcase/packages/ag2/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/agno/next.config.ts
+++ b/showcase/packages/agno/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/claude-sdk-python/next.config.ts
+++ b/showcase/packages/claude-sdk-python/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/claude-sdk-typescript/next.config.ts
+++ b/showcase/packages/claude-sdk-typescript/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/crewai-crews/next.config.ts
+++ b/showcase/packages/crewai-crews/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/google-adk/next.config.ts
+++ b/showcase/packages/google-adk/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/langgraph-fastapi/next.config.ts
+++ b/showcase/packages/langgraph-fastapi/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/langgraph-python/next.config.ts
+++ b/showcase/packages/langgraph-python/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/langgraph-typescript/next.config.ts
+++ b/showcase/packages/langgraph-typescript/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   serverExternalPackages: ["@copilotkit/runtime"],
   // Allow iframe embedding from the showcase shell
   async headers() {
@@ -20,6 +20,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/langroid/next.config.ts
+++ b/showcase/packages/langroid/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/llamaindex/next.config.ts
+++ b/showcase/packages/llamaindex/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/mastra/next.config.ts
+++ b/showcase/packages/mastra/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   serverExternalPackages: ["@copilotkit/runtime"],
   typescript: {
     // Mastra beta packages have unstable types
@@ -24,6 +24,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/ms-agent-dotnet/next.config.ts
+++ b/showcase/packages/ms-agent-dotnet/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/ms-agent-python/next.config.ts
+++ b/showcase/packages/ms-agent-python/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/pydantic-ai/next.config.ts
+++ b/showcase/packages/pydantic-ai/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/spring-ai/next.config.ts
+++ b/showcase/packages/spring-ai/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 

--- a/showcase/packages/strands/next.config.ts
+++ b/showcase/packages/strands/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@copilotkit/showcase-shared"],
   // Allow iframe embedding from the showcase shell
   async headers() {
     return [
@@ -19,6 +19,13 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+    };
+    return config;
   },
 };
 


### PR DESCRIPTION
## Summary

- Remove `transpilePackages: ["@copilotkit/showcase-shared"]` from all 17 showcase package `next.config.ts` files
- Add explicit webpack resolve alias pointing `@copilotkit/showcase-shared` to `shared_frontend/src`
- `transpilePackages` causes Next.js to look in `node_modules` first, which fails in Docker where the shared code is copied directly into the build context via `shared_frontend/src/`

## Test plan

- [x] Built ag2 Docker image locally — `next build` succeeds with the webpack alias
- [ ] CI deploy pipeline builds all showcase packages successfully