### PR TITLE
fix: webpack alias uses process.cwd() for Docker compatibility

### DIFF
--- a/showcase/packages/ag2/next.config.ts
+++ b/showcase/packages/ag2/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/agno/next.config.ts
+++ b/showcase/packages/agno/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/claude-sdk-python/next.config.ts
+++ b/showcase/packages/claude-sdk-python/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/claude-sdk-typescript/next.config.ts
+++ b/showcase/packages/claude-sdk-typescript/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/crewai-crews/next.config.ts
+++ b/showcase/packages/crewai-crews/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/google-adk/next.config.ts
+++ b/showcase/packages/google-adk/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/langgraph-fastapi/next.config.ts
+++ b/showcase/packages/langgraph-fastapi/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/langgraph-python/next.config.ts
+++ b/showcase/packages/langgraph-python/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/langgraph-typescript/next.config.ts
+++ b/showcase/packages/langgraph-typescript/next.config.ts
@@ -24,7 +24,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/langroid/next.config.ts
+++ b/showcase/packages/langroid/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/llamaindex/next.config.ts
+++ b/showcase/packages/llamaindex/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/mastra/next.config.ts
+++ b/showcase/packages/mastra/next.config.ts
@@ -28,7 +28,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/ms-agent-dotnet/next.config.ts
+++ b/showcase/packages/ms-agent-dotnet/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/ms-agent-python/next.config.ts
+++ b/showcase/packages/ms-agent-python/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/pydantic-ai/next.config.ts
+++ b/showcase/packages/pydantic-ai/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/spring-ai/next.config.ts
+++ b/showcase/packages/spring-ai/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },

--- a/showcase/packages/strands/next.config.ts
+++ b/showcase/packages/strands/next.config.ts
@@ -23,7 +23,7 @@ const nextConfig: NextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@copilotkit/showcase-shared": path.resolve(__dirname, "shared_frontend/src"),
+      "@copilotkit/showcase-shared": path.resolve(process.cwd(), "shared_frontend/src"),
     };
     return config;
   },


### PR DESCRIPTION
\_\_dirname is unreliable in Next.js .ts config transpilation inside Docker. process.cwd() resolves correctly to /app.