### PR TITLE
fix: update langgraph example model to gpt-5.4

### DIFF
--- a/examples/integrations/langgraph-python/apps/agent/main.py
+++ b/examples/integrations/langgraph-python/apps/agent/main.py
@@ -15,7 +15,7 @@ from src.a2ui_dynamic_schema import generate_a2ui
 from src.a2ui_fixed_schema import search_flights
 
 agent = create_agent(
-    model="openai:gpt-4.1",
+    model="openai:gpt-5.4",
     tools=[query_data, *todo_tools, generate_a2ui, search_flights],
     middleware=[CopilotKitMiddleware()],
     state_schema=AgentState,


### PR DESCRIPTION
## Summary
- Update the LangGraph Python example agent model from `gpt-4.1` to `gpt-5.4`

## Test plan
- [ ] Verify the langgraph-python example runs with the updated model