### PR TITLE
fix: remove test-integration-tmp from CI workflows

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -51,7 +51,6 @@ on:
           - starter-strands
           - aimock
           - shell-dojolike
-          - test-integration-tmp
 
 concurrency:
   group: showcase-deploy-${{ github.ref }}
@@ -66,7 +65,6 @@ jobs:
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
       has_changes: ${{ steps.build-matrix.outputs.has_changes }}
-      test_integration_tmp: ${{ steps.changes.outputs.test_integration_tmp }}
     steps:
       - uses: actions/checkout@v4
 
@@ -80,8 +78,6 @@ jobs:
               - 'showcase/shared/**'
               - 'showcase/scripts/**'
               - 'showcase/packages/*/manifest.yaml'
-            test_integration_tmp:
-              - 'showcase/packages/test-integration-tmp/**'
             langgraph: 'showcase/packages/langgraph-python/**'
             mastra: 'showcase/packages/mastra/**'
             crewai_crews: 'showcase/packages/crewai-crews/**'
@@ -294,45 +290,3 @@ jobs:
               "text": "${{ (needs.detect-changes.result == 'failure' || needs.check-lockfile.result == 'failure') && format(':x: *Showcase deploy*: FAILED (pre-build check)') || needs.build.result == 'success' && ':white_check_mark: *Showcase deploy*: all services deployed to Railway' || (needs.build.result == 'skipped' && needs.detect-changes.result == 'success') && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED (result: {0})', needs.build.result) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
             }
 
-  build-test_integration_tmp:
-    name: Build & Push Test Integration
-    needs: [detect-changes, check-lockfile]
-    if: |
-      needs.detect-changes.outputs.test_integration_tmp == 'true' ||
-      github.event.inputs.service == 'test-integration-tmp' ||
-      github.event.inputs.service == 'all'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: showcase/packages/test-integration-tmp
-          push: true
-          tags: |
-            ghcr.io/copilotkit/showcase-test-integration-tmp:latest
-            ghcr.io/copilotkit/showcase-test-integration-tmp:${{ github.sha }}
-          cache-from: type=gha,scope=test_integration_tmp
-          cache-to: type=gha,scope=test_integration_tmp,mode=max
-
-      - name: Trigger Railway deploy
-        run: |
-          curl -sf -X POST https://backboard.railway.com/graphql/v2 \
-            -H "Authorization: Bearer ${{ secrets.RAILWAY_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"query":"mutation { serviceInstanceRedeploy(serviceId: \"RAILWAY_SERVICE_ID\", environmentId: \"b14919f4-6417-429f-848d-c6ae2201e04f\") }"}' \
-            && echo "test-integration-tmp deploy triggered"


### PR DESCRIPTION
## Summary

- Remove `test-integration-tmp` from showcase deploy workflow (dispatch options, path filter, output, entire job block)
- Remove `test-integration-tmp` from starter-smoke test matrix

The `showcase/packages/test-integration-tmp/` directory doesn't exist — these CI entries cause guaranteed failures on every run.

## Test plan

- [x] Deploy workflow validates (no YAML syntax errors)
- [x] Starter smoke matrix no longer includes test-integration-tmp