### PR TITLE
fix: starter Docker build failures (spring-ai, ms-agent-dotnet, mastra)

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -616,7 +616,9 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
   if (!fs.existsSync(dockerfileSrc)) {
     throw new Error(`Dockerfile missing for ${fw.slug}: ${dockerfileSrc}`);
   }
-  fs.copyFileSync(dockerfileSrc, path.join(outDir, "Dockerfile"));
+  let dockerfileContent = fs.readFileSync(dockerfileSrc, "utf-8");
+  dockerfileContent = substituteVars(dockerfileContent, vars);
+  fs.writeFileSync(path.join(outDir, "Dockerfile"), dockerfileContent);
 
   // 6. Generate entrypoint.sh
   const entrypointTemplate = fs.readFileSync(

--- a/showcase/starters/ag2/Dockerfile
+++ b/showcase/starters/ag2/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/agno/Dockerfile
+++ b/showcase/starters/agno/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-python/Dockerfile
+++ b/showcase/starters/claude-sdk-python/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-typescript/Dockerfile
+++ b/showcase/starters/claude-sdk-typescript/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --legacy-peer-deps
 COPY src/ ./src/
-COPY agent/ ./agent/
 COPY next.config.ts tsconfig.json postcss.config.mjs ./
+# Copy agent code (location varies by framework, e.g. agent/ or src/mastra/)
+COPY agent/ ./agent/
 RUN npm run build
 
 # Stage 2: Production image
@@ -24,7 +25,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/crewai-crews/Dockerfile
+++ b/showcase/starters/crewai-crews/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/google-adk/Dockerfile
+++ b/showcase/starters/google-adk/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-fastapi/Dockerfile
+++ b/showcase/starters/langgraph-fastapi/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-python/Dockerfile
+++ b/showcase/starters/langgraph-python/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-typescript/Dockerfile
+++ b/showcase/starters/langgraph-typescript/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --legacy-peer-deps
 COPY src/ ./src/
-COPY agent/ ./agent/
 COPY next.config.ts tsconfig.json postcss.config.mjs ./
+# Copy agent code (location varies by framework, e.g. agent/ or src/mastra/)
+COPY agent/ ./agent/
 RUN npm run build
 
 # Stage 2: Production image
@@ -24,7 +25,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langroid/Dockerfile
+++ b/showcase/starters/langroid/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/llamaindex/Dockerfile
+++ b/showcase/starters/llamaindex/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/mastra/Dockerfile
+++ b/showcase/starters/mastra/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --legacy-peer-deps
 COPY src/ ./src/
-COPY agent/ ./agent/
 COPY next.config.ts tsconfig.json postcss.config.mjs ./
+# Copy agent code (location varies by framework, e.g. agent/ or src/mastra/)
+COPY src/mastra/ ./src/mastra/
 RUN npm run build
 
 # Stage 2: Production image
@@ -18,13 +19,13 @@ COPY --from=frontend /app/node_modules ./node_modules
 COPY --from=frontend /app/package.json ./
 
 # Agent code
-COPY agent/ ./agent/
+COPY src/mastra/ ./src/mastra/
 
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-dotnet/Dockerfile
+++ b/showcase/starters/ms-agent-dotnet/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=dotnet-builder /agent/publish ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-python/Dockerfile
+++ b/showcase/starters/ms-agent-python/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/pydantic-ai/Dockerfile
+++ b/showcase/starters/pydantic-ai/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/spring-ai/Dockerfile
+++ b/showcase/starters/spring-ai/Dockerfile
@@ -8,10 +8,10 @@ COPY next.config.ts tsconfig.json postcss.config.mjs ./
 RUN npm run build
 
 # Stage 2: Build Java agent
-FROM eclipse-temurin:21-jdk AS java-builder
+FROM maven:3-eclipse-temurin-21 AS java-builder
 WORKDIR /agent
 COPY agent/ ./
-RUN ./mvnw -B package -DskipTests
+RUN mvn -B package -DskipTests
 
 # Stage 3: Production image with Node.js + Java
 FROM eclipse-temurin:21-jre AS runner
@@ -35,7 +35,7 @@ COPY --from=java-builder /agent/target/*.jar ./agent/app.jar
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/strands/Dockerfile
+++ b/showcase/starters/strands/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.dotnet
+++ b/showcase/starters/template/dockerfiles/Dockerfile.dotnet
@@ -35,7 +35,7 @@ COPY --from=dotnet-builder /agent/publish ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.java
+++ b/showcase/starters/template/dockerfiles/Dockerfile.java
@@ -8,10 +8,10 @@ COPY next.config.ts tsconfig.json postcss.config.mjs ./
 RUN npm run build
 
 # Stage 2: Build Java agent
-FROM eclipse-temurin:21-jdk AS java-builder
+FROM maven:3-eclipse-temurin-21 AS java-builder
 WORKDIR /agent
 COPY agent/ ./
-RUN ./mvnw -B package -DskipTests
+RUN mvn -B package -DskipTests
 
 # Stage 3: Production image with Node.js + Java
 FROM eclipse-temurin:21-jre AS runner
@@ -35,7 +35,7 @@ COPY --from=java-builder /agent/target/*.jar ./agent/app.jar
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.python
+++ b/showcase/starters/template/dockerfiles/Dockerfile.python
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.typescript
+++ b/showcase/starters/template/dockerfiles/Dockerfile.typescript
@@ -4,8 +4,9 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --legacy-peer-deps
 COPY src/ ./src/
-COPY agent/ ./agent/
 COPY next.config.ts tsconfig.json postcss.config.mjs ./
+# Copy agent code (location varies by framework, e.g. agent/ or src/mastra/)
+COPY {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
 RUN npm run build
 
 # Stage 2: Production image
@@ -18,13 +19,13 @@ COPY --from=frontend /app/node_modules ./node_modules
 COPY --from=frontend /app/package.json ./
 
 # Agent code
-COPY agent/ ./agent/
+COPY {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
 
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN addgroup --system --gid 1001 app && adduser --system --uid 1001 --gid 1001 app
+RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
 USER app
 
 EXPOSE 10000


### PR DESCRIPTION
## Summary

Fixes 3 starter Docker build failures discovered after #3896 merged:

- **spring-ai**: `mvnw` not found — switched to `maven:3-eclipse-temurin-21` base image with `mvn`
- **ms-agent-dotnet**: `addgroup --system` not available — switched to `groupadd`/`useradd` (aspnet image)
- **mastra**: `COPY agent/` fails — Dockerfiles now use `{{AGENT_DIR}}` template variable (`src/mastra/` for mastra, `agent/` for others)
- **All Dockerfiles**: Consistent `groupadd`/`useradd` across all 4 language templates

Fixes applied to templates (source of truth), generation script updated to substitute vars in Dockerfiles, all 17 starters regenerated.

## Test plan

- [x] 537 vitest tests pass
- [x] Drift check: `--check` exits 0
- [ ] Docker builds for spring-ai, ms-agent-dotnet, mastra succeed (CI will verify)