### PR TITLE
fix: add AG-UI SDK build-from-source step to spring-ai Dockerfile

### DIFF
--- a/showcase/starters/spring-ai/Dockerfile
+++ b/showcase/starters/spring-ai/Dockerfile
@@ -7,8 +7,23 @@ COPY src/ ./src/
 COPY next.config.ts tsconfig.json postcss.config.mjs ./
 RUN npm run build
 
-# Stage 2: Build Java agent
+# Stage 2: Build AG-UI Java SDK from source + Java agent
 FROM maven:3-eclipse-temurin-21 AS java-builder
+
+# AG-UI community artifacts aren't on Maven Central yet — build from source
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+ENV GIT_LFS_SKIP_SMUDGE=1
+RUN git clone --depth 1 https://github.com/ag-ui-protocol/ag-ui.git /ag-ui && \
+    cd /ag-ui/sdks/community/java && \
+    mvn install \
+        -pl servers/spring,integrations/spring-ai -am \
+        -DskipTests -Dgpg.skip=true \
+        -Dmaven.javadoc.skip=true -Djavadoc.skip=true \
+        -Dmaven.source.skip=true -Dcheckstyle.skip=true \
+        -Dmaven.site.skip=true -Dreporting.skip=true \
+        -Dassembly.skipAssembly=true \
+        -B
+
 WORKDIR /agent
 COPY agent/ ./
 RUN mvn -B package -DskipTests

--- a/showcase/starters/template/dockerfiles/Dockerfile.java
+++ b/showcase/starters/template/dockerfiles/Dockerfile.java
@@ -7,8 +7,23 @@ COPY src/ ./src/
 COPY next.config.ts tsconfig.json postcss.config.mjs ./
 RUN npm run build
 
-# Stage 2: Build Java agent
+# Stage 2: Build AG-UI Java SDK from source + Java agent
 FROM maven:3-eclipse-temurin-21 AS java-builder
+
+# AG-UI community artifacts aren't on Maven Central yet — build from source
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+ENV GIT_LFS_SKIP_SMUDGE=1
+RUN git clone --depth 1 https://github.com/ag-ui-protocol/ag-ui.git /ag-ui && \
+    cd /ag-ui/sdks/community/java && \
+    mvn install \
+        -pl servers/spring,integrations/spring-ai -am \
+        -DskipTests -Dgpg.skip=true \
+        -Dmaven.javadoc.skip=true -Djavadoc.skip=true \
+        -Dmaven.source.skip=true -Dcheckstyle.skip=true \
+        -Dmaven.site.skip=true -Dreporting.skip=true \
+        -Dassembly.skipAssembly=true \
+        -B
+
 WORKDIR /agent
 COPY agent/ ./
 RUN mvn -B package -DskipTests


### PR DESCRIPTION
## Summary

- The `com.ag-ui.community` Maven artifacts (spring-ai, java-server, spring) aren't published to Maven Central
- The spring-ai starter Docker build fails at dependency resolution because it tries to fetch them from Central
- The demo package Dockerfile already handles this by cloning the ag-ui repo and running `mvn install` before building — this PR mirrors that approach in the Dockerfile.java template and regenerates the starter

## Changes

- `showcase/starters/template/dockerfiles/Dockerfile.java` — add AG-UI SDK clone + build-from-source step before agent build
- `showcase/starters/spring-ai/Dockerfile` — regenerated from updated template

## Test plan

- [ ] Docker build of spring-ai starter succeeds: `cd showcase/starters/spring-ai && docker build .`
- [ ] Starter consistency check passes: `npx tsx generate-starters.ts --check --slug spring-ai`