### PR TITLE
fix: resolve langgraph-python starter crash from wrong graph path and fragile imports

### DIFF
--- a/showcase/packages/langgraph-python/src/agents/main.py
+++ b/showcase/packages/langgraph-python/src/agents/main.py
@@ -8,8 +8,16 @@ from langgraph.prebuilt import create_react_agent
 from langchain_openai import ChatOpenAI
 
 from src.agents.tools import query_data, get_weather, schedule_meeting
-from src.agents.a2ui_fixed_schema import search_flights
-from src.agents.a2ui_dynamic_schema import generate_a2ui
+
+try:
+    from src.agents.a2ui_fixed_schema import search_flights
+except Exception:
+    search_flights = None
+
+try:
+    from src.agents.a2ui_dynamic_schema import generate_a2ui
+except Exception:
+    generate_a2ui = None
 
 # Import todo_tools but not custom AgentState — newer langgraph requires
 # remaining_steps in state_schema which the custom schema doesn't have
@@ -37,7 +45,7 @@ model = ChatOpenAI(model="gpt-4o-mini")
 
 graph = create_react_agent(
     model=model,
-    tools=[query_data, get_weather, schedule_meeting, search_flights, generate_a2ui]
+    tools=[t for t in [query_data, get_weather, schedule_meeting, search_flights, generate_a2ui] if t]
     + todo_tools,
     prompt=SYSTEM_PROMPT,
 )

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -603,6 +603,16 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
       }
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
       fs.copyFileSync(srcPath, destPath);
+
+      // Rewrite langgraph.json graph paths for the starter layout.
+      // In packages, agents live at src/agents/main.py — but in starters,
+      // they're flattened into the agent dir so the path becomes ./main.py.
+      if (dest.endsWith("langgraph.json")) {
+        let lgContent = fs.readFileSync(destPath, "utf-8");
+        lgContent = lgContent.replace(/\.\/src\/agents\//g, "./");
+        lgContent = lgContent.replace(/\.\/src\/agent\//g, "./");
+        fs.writeFileSync(destPath, lgContent);
+      }
     }
   }
 

--- a/showcase/starters/langgraph-python/agent/langgraph.json
+++ b/showcase/starters/langgraph-python/agent/langgraph.json
@@ -1,6 +1,6 @@
 {
   "dependencies": ["."],
   "graphs": {
-    "sample_agent": "./src/agents/main.py:graph"
+    "sample_agent": "./main.py:graph"
   }
 }

--- a/showcase/starters/langgraph-python/agent/main.py
+++ b/showcase/starters/langgraph-python/agent/main.py
@@ -8,8 +8,16 @@ from langgraph.prebuilt import create_react_agent
 from langchain_openai import ChatOpenAI
 
 from .tools import query_data, get_weather, schedule_meeting
-from .a2ui_fixed_schema import search_flights
-from .a2ui_dynamic_schema import generate_a2ui
+
+try:
+    from .a2ui_fixed_schema import search_flights
+except Exception:
+    search_flights = None
+
+try:
+    from .a2ui_dynamic_schema import generate_a2ui
+except Exception:
+    generate_a2ui = None
 
 # Import todo_tools but not custom AgentState — newer langgraph requires
 # remaining_steps in state_schema which the custom schema doesn't have
@@ -37,7 +45,7 @@ model = ChatOpenAI(model="gpt-4o-mini")
 
 graph = create_react_agent(
     model=model,
-    tools=[query_data, get_weather, schedule_meeting, search_flights, generate_a2ui]
+    tools=[t for t in [query_data, get_weather, schedule_meeting, search_flights, generate_a2ui] if t]
     + todo_tools,
     prompt=SYSTEM_PROMPT,
 )


### PR DESCRIPTION
## Summary

- Fixed `langgraph.json` graph path in the langgraph-python starter: was `./src/agents/main.py:graph` (copied verbatim from demo package), corrected to `./main.py:graph` (matching the flattened starter layout)
- Wrapped A2UI agent imports (`search_flights`, `generate_a2ui`) in try/except in both the demo package and starter, so the agent starts cleanly even when optional dependencies like copilotkit's `ToolRuntime` patch aren't loaded
- Fixed `generate-starters.ts` to rewrite `langgraph.json` graph paths when copying from packages to starters, preventing this drift in future regenerations

## Test plan

- [ ] Run `npx tsx generate-starters.ts --check --slug langgraph-python` (passes)
- [ ] Deploy langgraph-python starter to Railway and verify agent starts without crash
- [ ] Verify core tools (query_data, get_weather, schedule_meeting) work
- [ ] Verify A2UI tools load when copilotkit runtime is available