### PR TITLE
fix: format showcase_deploy.yml

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -289,4 +289,3 @@ jobs:
             {
               "text": "${{ (needs.detect-changes.result == 'failure' || needs.check-lockfile.result == 'failure') && format(':x: *Showcase deploy*: FAILED (pre-build check)') || needs.build.result == 'success' && ':white_check_mark: *Showcase deploy*: all services deployed to Railway' || (needs.build.result == 'skipped' && needs.detect-changes.result == 'success') && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED (result: {0})', needs.build.result) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
             }
-


### PR DESCRIPTION
Remove trailing blank line from `showcase_deploy.yml` to fix `oxfmt --check` failure in `static/quality` CI.