### PR TITLE
fix: guard against non-string child props in a2ui renderers

### DIFF
--- a/examples/integrations/langgraph-python/apps/app/src/app/declarative-generative-ui/renderers.tsx
+++ b/examples/integrations/langgraph-python/apps/app/src/app/declarative-generative-ui/renderers.tsx
@@ -240,7 +240,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -435,7 +435,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/packages/a2ui-renderer/src/react-renderer/create-catalog.tsx
+++ b/packages/a2ui-renderer/src/react-renderer/create-catalog.tsx
@@ -87,7 +87,7 @@ export type CatalogRenderers<D extends CatalogDefinitions> = {
  * // catalog.tsx (React renderers)
  * export const demoCatalog = createCatalog(demoCatalogDefinitions, {
  *   Card: ({ props, children }) => (
- *     <div>{props.title}{props.child && children(props.child)}</div>
+ *     <div>{props.title}{typeof props.child === "string" && children(props.child)}</div>
  *   ),
  * });
  * ```

--- a/showcase/starters/ag2/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/ag2/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/agno/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/agno/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/claude-sdk-python/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/claude-sdk-python/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/claude-sdk-typescript/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/claude-sdk-typescript/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/crewai-crews/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/crewai-crews/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/google-adk/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/google-adk/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/langgraph-fastapi/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/langgraph-fastapi/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/langgraph-python/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/langgraph-python/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/langgraph-typescript/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/langgraph-typescript/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/langroid/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/langroid/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/llamaindex/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/llamaindex/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/mastra/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/mastra/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/ms-agent-dotnet/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/ms-agent-dotnet/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/ms-agent-python/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/ms-agent-python/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/pydantic-ai/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/pydantic-ai/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/spring-ai/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/spring-ai/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/strands/src/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/strands/src/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },

--- a/showcase/starters/template/frontend/components/renderers/a2ui/renderers.tsx
+++ b/showcase/starters/template/frontend/components/renderers/a2ui/renderers.tsx
@@ -256,7 +256,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
             </div>
           )}
         </div>
-        {props.child && children(props.child)}
+        {typeof props.child === "string" && children(props.child)}
       </div>
     ),
 
@@ -451,7 +451,7 @@ const demonstrationCatalogRenderers: CatalogRenderers<DemonstrationCatalogDefini
     Button: ({ props, children }) => {
       return (
         <ActionButton label="Click" doneLabel="Done" action={props.action}>
-          {props.child ? children(props.child) : null}
+          {typeof props.child === "string" ? children(props.child) : null}
         </ActionButton>
       );
     },


### PR DESCRIPTION
## Summary

- Fixes runtime error "Objects are not valid as a React child (found: object with keys {path})" in `DashboardCard` and `Button` a2ui renderers
- The `children()` callback expects a string component ID, but `props.child` can arrive as a DynString path-binding object `{ path: "..." }` at runtime
- Adds `typeof props.child === "string"` guards before calling `children()`, matching the pattern already used by `Row` and `Column` renderers
- Applied across the langgraph-python example, all 18 showcase starters, and the core `create-catalog` JSDoc example (20 files total)

## Test plan

- [ ] Run the `langgraph-python` example app and navigate to the declarative-generative-ui page
- [ ] Trigger the agent to render a `DashboardCard` with a child component — verify no runtime error
- [ ] Verify `DashboardCard` still renders its child content correctly when `props.child` is a valid string ID
- [ ] Verify `Button` with a child `Text` component renders correctly

https://claude.ai/code/session_01UMBqgcRRkgFHSK1ncdMNsZ