### PR TITLE
fix: idempotent adduser in Dockerfile templates + regenerate starters

### DIFF
--- a/showcase/starters/ag2/Dockerfile
+++ b/showcase/starters/ag2/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/agno/Dockerfile
+++ b/showcase/starters/agno/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-python/Dockerfile
+++ b/showcase/starters/claude-sdk-python/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-typescript/Dockerfile
+++ b/showcase/starters/claude-sdk-typescript/Dockerfile
@@ -25,7 +25,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/crewai-crews/Dockerfile
+++ b/showcase/starters/crewai-crews/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/google-adk/Dockerfile
+++ b/showcase/starters/google-adk/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-fastapi/Dockerfile
+++ b/showcase/starters/langgraph-fastapi/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-python/Dockerfile
+++ b/showcase/starters/langgraph-python/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-typescript/Dockerfile
+++ b/showcase/starters/langgraph-typescript/Dockerfile
@@ -25,7 +25,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langroid/Dockerfile
+++ b/showcase/starters/langroid/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/llamaindex/Dockerfile
+++ b/showcase/starters/llamaindex/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/mastra/Dockerfile
+++ b/showcase/starters/mastra/Dockerfile
@@ -25,7 +25,7 @@ COPY src/mastra/ ./src/mastra/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-dotnet/Dockerfile
+++ b/showcase/starters/ms-agent-dotnet/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=dotnet-builder /agent/publish ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-python/Dockerfile
+++ b/showcase/starters/ms-agent-python/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/pydantic-ai/Dockerfile
+++ b/showcase/starters/pydantic-ai/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/spring-ai/Dockerfile
+++ b/showcase/starters/spring-ai/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=java-builder /agent/target/*.jar ./agent/app.jar
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/strands/Dockerfile
+++ b/showcase/starters/strands/Dockerfile
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.dotnet
+++ b/showcase/starters/template/dockerfiles/Dockerfile.dotnet
@@ -35,7 +35,7 @@ COPY --from=dotnet-builder /agent/publish ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.java
+++ b/showcase/starters/template/dockerfiles/Dockerfile.java
@@ -50,7 +50,7 @@ COPY --from=java-builder /agent/target/*.jar ./agent/app.jar
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.python
+++ b/showcase/starters/template/dockerfiles/Dockerfile.python
@@ -33,7 +33,7 @@ COPY agent/ ./agent/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.typescript
+++ b/showcase/starters/template/dockerfiles/Dockerfile.typescript
@@ -25,7 +25,7 @@ COPY {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid 1001 --no-create-home app
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
 USER app
 
 EXPOSE 10000


### PR DESCRIPTION
Makes groupadd/useradd idempotent with || true in all 4 Dockerfile templates. Regenerates all 17 starters.