### PR TITLE
fix: align starter Dockerfiles and entrypoints with working demo packages

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -53,8 +53,8 @@ on:
           - shell-dojolike
 
 concurrency:
-  group: showcase-deploy-${{ github.ref }}
-  cancel-in-progress: true
+  group: showcase-deploy-${{ github.ref }}-${{ github.event.inputs.service || 'auto' }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 env:
   RAILWAY_ENV_ID: "b14919f4-6417-429f-848d-c6ae2201e04f"
@@ -274,18 +274,54 @@ jobs:
             -d '{"query":"mutation { serviceInstanceRedeploy(serviceId: \"${{ matrix.service.railway_id }}\", environmentId: \"${{ env.RAILWAY_ENV_ID }}\") }"}' \
             && echo "Deploy triggered for ${{ matrix.service.dispatch_name }}"
 
+      - name: Verify deploy health
+        if: matrix.service.railway_id != ''
+        run: |
+          # Wait for Railway to pull and start the new image
+          sleep 30
+
+          # Get the service domain from Railway API or construct from naming pattern
+          IMAGE="${{ matrix.service.image }}"
+          # Try the standard domain pattern
+          HEALTH_URL="https://${IMAGE}-production.up.railway.app/api/health"
+
+          echo "Checking health: $HEALTH_URL"
+          for i in $(seq 1 6); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$HEALTH_URL" 2>/dev/null || echo "000")
+            echo "Attempt $i: HTTP $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "Service healthy"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Service did not return 200 after 90s (may still be starting with sleep-on-idle)"
+          # Don't fail the job — sleep-on-idle services may take longer to wake
+          # But log it clearly for visibility
+
   notify:
     needs: [detect-changes, check-lockfile, build]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
+      - name: Build deploy summary
+        id: summary
+        if: needs.detect-changes.result == 'success' && needs.detect-changes.outputs.has_changes == 'true'
+        run: |
+          MATRIX='${{ needs.detect-changes.outputs.matrix }}'
+          SERVICES=$(echo "$MATRIX" | jq -r '[.[].dispatch_name] | join(", ")')
+          COUNT=$(echo "$MATRIX" | jq 'length')
+          echo "services=$SERVICES" >> $GITHUB_OUTPUT
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+
       - name: Collect results and notify Slack
+        if: "${{ secrets.SLACK_WEBHOOK_OSS_ALERTS != '' }}"
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "${{ (needs.detect-changes.result == 'failure' || needs.check-lockfile.result == 'failure') && format(':x: *Showcase deploy*: FAILED (pre-build check)') || needs.build.result == 'success' && ':white_check_mark: *Showcase deploy*: all services deployed to Railway' || (needs.build.result == 'skipped' && needs.detect-changes.result == 'success') && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED (result: {0})', needs.build.result) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+              "text": "${{ (needs.detect-changes.result == 'failure' || needs.check-lockfile.result == 'failure') && format(':x: *Showcase deploy*: FAILED (pre-build check)') || needs.build.result == 'success' && format(':white_check_mark: *Showcase deploy*: {0} service(s) deployed to Railway ({1})', steps.summary.outputs.count, steps.summary.outputs.services) || (needs.build.result == 'skipped' && needs.detect-changes.result == 'success') && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED — {0} service(s) targeted ({1})', steps.summary.outputs.count, steps.summary.outputs.services) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
             }

--- a/packages/shared/src/utils/__tests__/clipboard.test.ts
+++ b/packages/shared/src/utils/__tests__/clipboard.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { copyToClipboard } from "../clipboard";
 
+// Mock navigator for Node 20 environments where it doesn't exist
+if (typeof globalThis.navigator === "undefined") {
+  Object.defineProperty(globalThis, "navigator", {
+    value: { clipboard: { writeText: vi.fn() } },
+    writable: true,
+    configurable: true,
+  });
+}
+
 describe("copyToClipboard", () => {
   let originalClipboard: Clipboard;
 

--- a/showcase/scripts/__tests__/generate-starters.test.ts
+++ b/showcase/scripts/__tests__/generate-starters.test.ts
@@ -301,17 +301,17 @@ describe("generate-starters", () => {
   });
 
   describe("extractUvicornModule()", () => {
-    it("extracts agent.agent:app from pydantic-ai devScript", () => {
+    it("extracts agent_server:app from pydantic-ai devScript", () => {
       const fw = FRAMEWORKS.find((f) => f.slug === "pydantic-ai")!;
-      expect(extractUvicornModule(fw)).toBe("agent.agent:app");
+      expect(extractUvicornModule(fw)).toBe("agent_server:app");
     });
 
-    it("extracts agent.crew:app from crewai-crews devScript", () => {
+    it("extracts agent_server:app from crewai-crews devScript", () => {
       const fw = FRAMEWORKS.find((f) => f.slug === "crewai-crews")!;
-      expect(extractUvicornModule(fw)).toBe("agent.crew:app");
+      expect(extractUvicornModule(fw)).toBe("agent_server:app");
     });
 
-    it("extracts agent.main:app from langgraph-fastapi devScript", () => {
+    it("falls back to agent.main:app for langgraph-fastapi (no uvicorn)", () => {
       const fw = FRAMEWORKS.find((f) => f.slug === "langgraph-fastapi")!;
       expect(extractUvicornModule(fw)).toBe("agent.main:app");
     });
@@ -436,10 +436,10 @@ describe("generate-starters", () => {
   });
 
   describe("getEntrypointBlock()", () => {
-    it("Python: returns uvicorn command with correct module", () => {
+    it("Python: returns uvicorn command with agent_server:app", () => {
       const fw = FRAMEWORKS.find((f) => f.slug === "pydantic-ai")!;
       const block = getEntrypointBlock(fw);
-      expect(block).toContain("uvicorn agent.agent:app");
+      expect(block).toContain("uvicorn agent_server:app");
       expect(block).toContain("kill -0");
     });
 

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -57,7 +57,8 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m langgraph_cli dev --config agent/langgraph.json --host 0.0.0.0 --port 8123 --no-browser"',
+    extraFiles: { "agent/langgraph.json": "langgraph.json" },
   },
   {
     slug: "langgraph-typescript",
@@ -75,7 +76,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "crewai-crews",
@@ -84,7 +85,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.crew:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "ag2",
@@ -93,7 +94,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "agno",
@@ -102,7 +103,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "google-adk",
@@ -111,7 +112,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "langroid",
@@ -120,7 +121,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "llamaindex",
@@ -129,7 +130,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "strands",
@@ -138,7 +139,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "mastra",
@@ -156,7 +157,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "claude-sdk-typescript",
@@ -173,7 +174,7 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentSourceDir: "src/agents",
     agentDir: "agent",
     devScript:
-      'concurrently "next dev --turbopack" "python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload"',
+      'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
   },
   {
     slug: "ms-agent-dotnet",
@@ -367,7 +368,7 @@ fi`;
 function getEntrypointBlock(fw: FrameworkDef): string {
   switch (fw.language) {
     case "python":
-      if (fw.slug === "langgraph-python") {
+      if (fw.slug === "langgraph-python" || fw.slug === "langgraph-fastapi") {
         return `echo "[entrypoint] Starting LangGraph agent server on port 8123..."
 python -m langgraph_cli dev \\
   --config agent/langgraph.json \\
@@ -379,7 +380,7 @@ sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
       return `echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn ${extractUvicornModule(fw)} --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 ${AGENT_HEALTH_CHECK}`;
@@ -493,6 +494,10 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
   }
   fs.mkdirSync(outDir, { recursive: true });
 
+  const isLanggraphPython =
+    fw.language === "python" &&
+    (fw.slug === "langgraph-python" || fw.slug === "langgraph-fastapi");
+
   const vars: Record<string, string> = {
     SLUG: fw.slug,
     NAME: fw.name,
@@ -501,6 +506,9 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     DEV_SCRIPT: fw.devScript,
     AGENT_PORT: "8123",
     DEV_SCRIPT_BLOCK: getEntrypointBlock(fw),
+    AGENT_SERVER_COPY: isLanggraphPython
+      ? "\n"
+      : "\n# Agent server (FastAPI entrypoint)\nCOPY agent_server.py ./\n",
   };
 
   // 1. Copy frontend files into src/
@@ -581,6 +589,37 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     const initPath = path.join(agentDest, "__init__.py");
     if (!fs.existsSync(initPath)) {
       fs.writeFileSync(initPath, "");
+    }
+
+    // Copy agent_server.py for non-langgraph Python starters.
+    // The demo packages use agent_server.py as the FastAPI entrypoint that
+    // wraps the framework-specific agent code. Starters need the same file
+    // with imports rewritten from "agents." to "agent." to match the
+    // starter's directory layout.
+    const isLanggraph =
+      fw.slug === "langgraph-python" || fw.slug === "langgraph-fastapi";
+    if (!isLanggraph) {
+      const agentServerSrc = path.join(pkgDir, "src", "agent_server.py");
+      if (fs.existsSync(agentServerSrc)) {
+        let content = fs.readFileSync(agentServerSrc, "utf-8");
+        // Rewrite imports: "from agents." -> "from agent."
+        content = content.replace(/^from agents\./gm, "from agent.");
+        // Rewrite uvicorn self-reference from agent_server:app to keep working
+        content = content.replace(
+          /uvicorn\.run\(\s*"agent_server:app"/g,
+          'uvicorn.run("agent_server:app"',
+        );
+        // Update the default port to match starter convention (8123)
+        content = content.replace(
+          /os\.getenv\("(?:PORT|AGENT_PORT)",\s*"8000"\)/g,
+          'os.getenv("AGENT_PORT", "8123")',
+        );
+        fs.writeFileSync(path.join(outDir, "agent_server.py"), content);
+      } else {
+        console.warn(
+          `  [warn] agent_server.py missing for ${fw.slug}: ${agentServerSrc}`,
+        );
+      }
     }
   }
 

--- a/showcase/shell/src/data/constraints.json
+++ b/showcase/shell/src/data/constraints.json
@@ -14,12 +14,7 @@
         "subagents",
         "voice"
       ],
-      "excluded": [
-        "tool-rendering",
-        "hitl",
-        "gen-ui-interrupt",
-        "open-gen-ui"
-      ]
+      "excluded": ["tool-rendering", "hitl", "gen-ui-interrupt", "open-gen-ui"]
     },
     "constrained-explicit": {
       "allowed": [
@@ -64,10 +59,7 @@
   },
   "interaction_modalities": {
     "headless": {
-      "excluded": [
-        "open-gen-ui",
-        "voice"
-      ]
+      "excluded": ["open-gen-ui", "voice"]
     }
   }
 }

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -380,11 +380,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -413,9 +409,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -423,9 +417,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -433,9 +425,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -443,9 +433,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -453,9 +441,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -463,9 +449,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -473,9 +457,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -483,9 +465,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -493,9 +473,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -519,11 +497,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -552,9 +526,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -562,9 +534,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -572,9 +542,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -582,9 +550,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -592,9 +558,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -602,9 +566,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -612,9 +574,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -622,9 +582,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -632,9 +590,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -658,11 +614,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -691,9 +643,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -701,9 +651,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -711,9 +659,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -721,9 +667,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -731,9 +675,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -741,9 +683,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -751,9 +691,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -761,9 +699,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -771,9 +707,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -797,11 +731,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -826,9 +756,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -836,9 +764,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -846,9 +772,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -856,9 +780,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -866,9 +788,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -876,9 +796,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -886,9 +804,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -896,9 +812,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -906,9 +820,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -932,11 +844,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -965,9 +873,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -975,9 +881,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -985,9 +889,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -995,9 +897,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1005,9 +905,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1015,9 +913,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1025,9 +921,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1035,9 +929,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1045,9 +937,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1071,11 +961,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1104,9 +990,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1114,9 +998,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1124,9 +1006,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1134,9 +1014,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1144,9 +1022,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1154,9 +1030,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1164,9 +1038,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1174,9 +1046,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1184,9 +1054,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1210,11 +1078,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1239,9 +1103,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1249,9 +1111,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1259,9 +1119,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1269,9 +1127,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1279,9 +1135,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1289,9 +1143,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1299,9 +1151,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1309,9 +1159,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1319,9 +1167,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1345,11 +1191,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1366,9 +1208,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1376,9 +1216,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1386,9 +1224,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1396,9 +1232,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1406,9 +1240,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1416,9 +1248,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1426,9 +1256,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1436,9 +1264,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1446,9 +1272,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1480,11 +1304,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1501,9 +1321,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1511,9 +1329,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1521,9 +1337,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1531,9 +1345,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1541,9 +1353,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1551,9 +1361,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1561,9 +1369,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1571,9 +1377,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1581,9 +1385,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1615,11 +1417,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -1644,9 +1442,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1654,9 +1450,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1664,9 +1458,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1674,9 +1466,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1684,9 +1474,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1694,9 +1482,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1704,9 +1490,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1714,9 +1498,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1724,9 +1506,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1754,11 +1534,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1775,9 +1551,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1785,9 +1559,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1795,9 +1567,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1805,9 +1575,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1815,9 +1583,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1825,9 +1591,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1835,9 +1599,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1845,9 +1607,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1855,9 +1615,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1893,11 +1651,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -1922,9 +1676,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1932,9 +1684,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1942,9 +1692,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1952,9 +1700,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1962,9 +1708,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1972,9 +1716,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1982,9 +1724,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1992,9 +1732,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2002,9 +1740,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2032,11 +1768,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2061,9 +1793,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2071,9 +1801,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2081,9 +1809,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2091,9 +1817,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2101,9 +1825,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2111,9 +1833,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2121,9 +1841,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2131,9 +1849,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2141,9 +1857,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2167,11 +1881,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -2188,9 +1898,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2198,9 +1906,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2208,9 +1914,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2218,9 +1922,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2228,9 +1930,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2238,9 +1938,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2248,9 +1946,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2258,9 +1954,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2268,9 +1962,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2302,11 +1994,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -2331,9 +2019,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2341,9 +2027,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2351,9 +2035,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2361,9 +2043,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2371,9 +2051,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2381,9 +2059,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2391,9 +2067,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2401,9 +2075,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2411,9 +2083,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2437,11 +2107,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -2466,9 +2132,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2476,9 +2140,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2486,9 +2148,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2496,9 +2156,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2506,9 +2164,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2516,9 +2172,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2526,9 +2180,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2536,9 +2188,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2546,9 +2196,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2572,11 +2220,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -2593,9 +2237,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2603,9 +2245,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2613,9 +2253,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2623,9 +2261,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2633,9 +2269,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2643,9 +2277,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2653,9 +2285,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2663,9 +2293,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2673,9 +2301,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }

--- a/showcase/starters/ag2/Dockerfile
+++ b/showcase/starters/ag2/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/ag2/agent_server.py
+++ b/showcase/starters/ag2/agent_server.py
@@ -1,0 +1,49 @@
+"""
+Agent Server for AG2
+
+FastAPI server that hosts the AG2 agent backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+"""
+
+import os
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+from agent.agent import stream
+
+load_dotenv()
+
+app = FastAPI(title="AG2 Agent Server")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+# Mount the AG2 AG-UI endpoint at the root
+# NOTE: must come AFTER route definitions — app.mount("/") shadows all routes defined after it
+app.mount("/", stream.build_asgi())
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/ag2/entrypoint.sh
+++ b/showcase/starters/ag2/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/ag2/package.json
+++ b/showcase/starters/ag2/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/agno/Dockerfile
+++ b/showcase/starters/agno/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/agno/agent_server.py
+++ b/showcase/starters/agno/agent_server.py
@@ -1,0 +1,34 @@
+"""
+Agent Server for Agno
+
+Uses AgentOS with the AG-UI interface to serve the Agno agent.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+"""
+
+import os
+import dotenv
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+from agent.main import agent
+
+dotenv.load_dotenv()
+
+# Build AgentOS and extract the app for serving
+agent_os = AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)])
+app = agent_os.get_app()
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    agent_os.serve(app="agent_server:app", host="0.0.0.0", port=port, reload=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/agno/entrypoint.sh
+++ b/showcase/starters/agno/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/agno/package.json
+++ b/showcase/starters/agno/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/claude-sdk-python/Dockerfile
+++ b/showcase/starters/claude-sdk-python/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/claude-sdk-python/agent_server.py
+++ b/showcase/starters/claude-sdk-python/agent_server.py
@@ -1,0 +1,26 @@
+"""
+Agent Server for Claude Agent SDK (Python)
+
+FastAPI server that hosts the Claude agent backend via AG-UI protocol.
+The Next.js CopilotKit runtime proxies requests here.
+"""
+
+import os
+
+import uvicorn
+from agent.agent import create_app
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = create_app()
+
+
+def main() -> None:
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app", host="0.0.0.0", port=port, reload=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/claude-sdk-python/entrypoint.sh
+++ b/showcase/starters/claude-sdk-python/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/claude-sdk-python/package.json
+++ b/showcase/starters/claude-sdk-python/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/crewai-crews/Dockerfile
+++ b/showcase/starters/crewai-crews/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/crewai-crews/agent_server.py
+++ b/showcase/starters/crewai-crews/agent_server.py
@@ -1,0 +1,46 @@
+"""
+Agent Server for CrewAI (Crews)
+
+FastAPI server that hosts the CrewAI crew backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+"""
+
+import os
+import uvicorn
+from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+from agent.crew import LatestAiDevelopment
+
+load_dotenv()
+
+app = FastAPI(title="CrewAI (Crews) Agent Server")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+add_crewai_crew_fastapi_endpoint(app, LatestAiDevelopment(), "/")
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/crewai-crews/entrypoint.sh
+++ b/showcase/starters/crewai-crews/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.crew:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/crewai-crews/package.json
+++ b/showcase/starters/crewai-crews/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.crew:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/google-adk/Dockerfile
+++ b/showcase/starters/google-adk/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/google-adk/agent_server.py
+++ b/showcase/starters/google-adk/agent_server.py
@@ -1,0 +1,53 @@
+"""
+Agent Server for Google ADK
+
+FastAPI server that hosts the ADK agent backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+"""
+
+import os
+import uvicorn
+from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+from agent.main import sales_pipeline_agent
+
+load_dotenv()
+
+app = FastAPI(title="Google ADK Agent Server")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+adk_agent = ADKAgent(
+    adk_agent=sales_pipeline_agent,
+    user_id="demo_user",
+    session_timeout_seconds=3600,
+    use_in_memory_services=True,
+)
+
+add_adk_fastapi_endpoint(app, adk_agent, path="/")
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/google-adk/entrypoint.sh
+++ b/showcase/starters/google-adk/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/google-adk/package.json
+++ b/showcase/starters/google-adk/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/langgraph-fastapi/Dockerfile
+++ b/showcase/starters/langgraph-fastapi/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/langgraph-fastapi/agent/langgraph.json
+++ b/showcase/starters/langgraph-fastapi/agent/langgraph.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": ["."],
+  "graphs": {
+    "sample_agent": "./src/agent.py:graph"
+  }
+}

--- a/showcase/starters/langgraph-fastapi/entrypoint.sh
+++ b/showcase/starters/langgraph-fastapi/entrypoint.sh
@@ -23,10 +23,14 @@ else
   echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
 fi
 
-echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+echo "[entrypoint] Starting LangGraph agent server on port 8123..."
+python -m langgraph_cli dev \
+  --config agent/langgraph.json \
+  --host 0.0.0.0 \
+  --port 8123 \
+  --no-browser 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
-sleep 2
+sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then
   echo "[entrypoint] Agent server started (PID: $AGENT_PID)"
 else

--- a/showcase/starters/langgraph-fastapi/package.json
+++ b/showcase/starters/langgraph-fastapi/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.main:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m langgraph_cli dev --config agent/langgraph.json --host 0.0.0.0 --port 8123 --no-browser\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/langgraph-python/Dockerfile
+++ b/showcase/starters/langgraph-python/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/langroid/Dockerfile
+++ b/showcase/starters/langroid/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/langroid/agent_server.py
+++ b/showcase/starters/langroid/agent_server.py
@@ -1,0 +1,54 @@
+"""
+Agent Server for Langroid
+
+FastAPI server that hosts the Langroid agent backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+
+Langroid does not have a native AG-UI adapter, so we implement a custom
+SSE endpoint that translates between Langroid's ChatAgent and the AG-UI
+event stream.
+"""
+
+import os
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+from agent.agui_adapter import handle_run
+
+load_dotenv()
+
+app = FastAPI(title="Langroid Agent Server")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.post("/")
+async def run_agent(request: Request):
+    """AG-UI /run endpoint — streams SSE events."""
+    return await handle_run(request)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/langroid/entrypoint.sh
+++ b/showcase/starters/langroid/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/langroid/package.json
+++ b/showcase/starters/langroid/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/llamaindex/Dockerfile
+++ b/showcase/starters/llamaindex/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/llamaindex/agent_server.py
+++ b/showcase/starters/llamaindex/agent_server.py
@@ -1,0 +1,49 @@
+"""
+Agent Server for LlamaIndex
+
+FastAPI server that hosts the LlamaIndex agent backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+
+LlamaIndex's get_ag_ui_workflow_router() returns a FastAPI APIRouter that
+implements the AG-UI protocol, so we just include it directly.
+"""
+
+import os
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from agent.agent import agent_router
+
+load_dotenv()
+
+app = FastAPI(title="LlamaIndex Agent Server")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(agent_router)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/llamaindex/entrypoint.sh
+++ b/showcase/starters/llamaindex/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/llamaindex/package.json
+++ b/showcase/starters/llamaindex/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/ms-agent-python/Dockerfile
+++ b/showcase/starters/ms-agent-python/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/ms-agent-python/agent_server.py
+++ b/showcase/starters/ms-agent-python/agent_server.py
@@ -1,0 +1,73 @@
+"""
+Agent Server for MS Agent Framework (Python)
+
+FastAPI server that hosts the Microsoft Agent Framework agent backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+"""
+
+from __future__ import annotations
+
+import os
+
+import uvicorn
+from agent_framework import BaseChatClient
+from agent_framework.openai import OpenAIChatClient
+from agent_framework_ag_ui import add_agent_framework_fastapi_endpoint
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from agent.agent import create_agent
+
+load_dotenv()
+
+
+def _build_chat_client() -> BaseChatClient:
+    try:
+        if bool(os.getenv("OPENAI_API_KEY")):
+            return OpenAIChatClient(
+                model=os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-4o-mini"),
+                api_key=os.getenv("OPENAI_API_KEY"),
+            )
+
+        raise ValueError("OPENAI_API_KEY environment variable is required")
+
+    except Exception as exc:
+        raise RuntimeError(
+            "Unable to initialize the chat client. Double-check your API credentials."
+        ) from exc
+
+
+chat_client = _build_chat_client()
+my_agent = create_agent(chat_client)
+
+app = FastAPI(title="CopilotKit + Microsoft Agent Framework (Python)")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+add_agent_framework_fastapi_endpoint(
+    app=app,
+    agent=my_agent,
+    path="/",
+)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    """Run the uvicorn server."""
+    host = os.getenv("AGENT_HOST", "0.0.0.0")
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app", host=host, port=port, reload=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/ms-agent-python/entrypoint.sh
+++ b/showcase/starters/ms-agent-python/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/ms-agent-python/package.json
+++ b/showcase/starters/ms-agent-python/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/pydantic-ai/Dockerfile
+++ b/showcase/starters/pydantic-ai/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/pydantic-ai/agent_server.py
+++ b/showcase/starters/pydantic-ai/agent_server.py
@@ -1,0 +1,48 @@
+"""
+Agent Server for PydanticAI
+
+FastAPI server that hosts the PydanticAI agent backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+"""
+
+import os
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+from agent.agent import SalesTodosState, StateDeps, agent
+
+load_dotenv()
+
+app = FastAPI(title="PydanticAI Agent Server")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Health endpoint MUST be registered BEFORE app.mount("/") — mount creates a catch-all
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+# Mount the PydanticAI AG-UI endpoint at the root
+ag_ui_app = agent.to_ag_ui(deps=StateDeps(SalesTodosState()))
+app.mount("/", ag_ui_app)
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/pydantic-ai/entrypoint.sh
+++ b/showcase/starters/pydantic-ai/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/pydantic-ai/package.json
+++ b/showcase/starters/pydantic-ai/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/strands/Dockerfile
+++ b/showcase/starters/strands/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=frontend /app/package.json ./
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
 
+# Agent server (FastAPI entrypoint)
+COPY agent_server.py ./
+
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh

--- a/showcase/starters/strands/agent_server.py
+++ b/showcase/starters/strands/agent_server.py
@@ -1,0 +1,38 @@
+"""
+Agent Server for AWS Strands
+
+FastAPI server that hosts the Strands agent backend.
+The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
+"""
+
+import os
+import uvicorn
+from dotenv import load_dotenv
+
+from ag_ui_strands import create_strands_app
+from agent.agent import agui_agent
+
+load_dotenv()
+
+# Create the FastAPI app from the AG-UI Strands integration
+agent_path = os.getenv("AGENT_PATH", "/")
+app = create_strands_app(agui_agent, agent_path)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+def main():
+    """Run the uvicorn server."""
+    port = int(os.getenv("AGENT_PORT", "8123"))
+    uvicorn.run("agent_server:app",
+        host="0.0.0.0",
+        port=port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/showcase/starters/strands/entrypoint.sh
+++ b/showcase/starters/strands/entrypoint.sh
@@ -24,7 +24,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/strands/package.json
+++ b/showcase/starters/strands/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent.agent:app --host 0.0.0.0 --port 8123 --reload\"",
+    "dev": "concurrently \"next dev --turbopack\" \"python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/showcase/starters/template/dockerfiles/Dockerfile.python
+++ b/showcase/starters/template/dockerfiles/Dockerfile.python
@@ -28,7 +28,7 @@ COPY --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
 COPY agent/ ./agent/
-
+{{AGENT_SERVER_COPY}}
 # Entrypoint
 COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh


### PR DESCRIPTION
## Summary
- Python starters (non-langgraph) now include `agent_server.py` copied from demo packages, with imports rewritten from `agents.*` to `agent.*` for the starter directory layout
- All Python uvicorn starters use `agent_server:app` as the uvicorn module instead of directly referencing framework agent modules that don't export a FastAPI `app` object
- langgraph-fastapi starter now uses `langgraph_cli dev` (matching its demo) instead of uvicorn, with `langgraph.json` properly included
- Dockerfile.python template conditionally includes `COPY agent_server.py` for non-langgraph frameworks

## Test plan
- [x] All 537 showcase tests pass (248 generate-starters + 270 starter-consistency + others)
- [x] Verified `agent_server.py` exists in all 10 non-langgraph Python starters
- [x] Verified langgraph starters correctly omit `agent_server.py`
- [x] Verified import rewrites (`from agents.` -> `from agent.`) in all copied `agent_server.py` files
- [x] Verified langgraph-fastapi now has `agent/langgraph.json` and uses `langgraph_cli dev`