### PR TITLE
fix: responsive iframe height and scrollable starter content

### DIFF
--- a/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
@@ -248,7 +248,7 @@ export function ProfileClient({
                       <iframe
                         src={integration.starter.demo_url}
                         className="w-full rounded-lg border border-[var(--border)]"
-                        style={{ height: "600px" }}
+                        style={{ height: "min(80vh, 900px)" }}
                         sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
                         loading="lazy"
                       />

--- a/showcase/starters/ag2/src/app/globals.css
+++ b/showcase/starters/ag2/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/agno/src/app/globals.css
+++ b/showcase/starters/agno/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/claude-sdk-python/src/app/globals.css
+++ b/showcase/starters/claude-sdk-python/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/claude-sdk-typescript/src/app/globals.css
+++ b/showcase/starters/claude-sdk-typescript/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/crewai-crews/src/app/globals.css
+++ b/showcase/starters/crewai-crews/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/google-adk/src/app/globals.css
+++ b/showcase/starters/google-adk/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/langgraph-fastapi/src/app/globals.css
+++ b/showcase/starters/langgraph-fastapi/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/langgraph-python/src/app/globals.css
+++ b/showcase/starters/langgraph-python/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/langgraph-typescript/src/app/globals.css
+++ b/showcase/starters/langgraph-typescript/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/langroid/src/app/globals.css
+++ b/showcase/starters/langroid/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/llamaindex/src/app/globals.css
+++ b/showcase/starters/llamaindex/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/mastra/src/app/globals.css
+++ b/showcase/starters/mastra/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/ms-agent-dotnet/src/app/globals.css
+++ b/showcase/starters/ms-agent-dotnet/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/ms-agent-python/src/app/globals.css
+++ b/showcase/starters/ms-agent-python/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/pydantic-ai/src/app/globals.css
+++ b/showcase/starters/pydantic-ai/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/spring-ai/src/app/globals.css
+++ b/showcase/starters/spring-ai/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/strands/src/app/globals.css
+++ b/showcase/starters/strands/src/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;

--- a/showcase/starters/template/frontend/app/globals.css
+++ b/showcase/starters/template/frontend/app/globals.css
@@ -15,7 +15,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  overflow: auto;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #fafaf9;


### PR DESCRIPTION
## Summary

- Starter globals.css: `overflow: hidden` → `overflow: auto` so dashboard content scrolls inside the iframe
- Shell iframe: fixed `600px` → `min(80vh, 900px)` for responsive scaling with viewport

The "Add a deal" button and CopilotKit sidebar were getting cut off in the 600px iframe.