### PR TITLE
fix: wider starter hero section, sticky renderer selector above sidebar

### DIFF
--- a/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
@@ -199,10 +199,12 @@ export function ProfileClient({
             Developer Guide
           </a>
         </div>
+      </div>
 
-        {/* Full Starter */}
-        {integration.starter && keyFile && (
-          <section className="mt-10">
+      {/* Full Starter — wider breakout container */}
+      {integration.starter && keyFile && (
+        <div className="mx-auto max-w-[90rem] px-6">
+          <section className="mt-0">
             <div className="rounded-xl border-2 border-[var(--accent)] bg-[var(--bg-elevated)] p-6">
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0">
@@ -413,8 +415,10 @@ export function ProfileClient({
               </div>
             </div>
           </section>
-        )}
+        </div>
+      )}
 
+      <div className="mx-auto max-w-5xl px-6 pb-12">
         {/* Demos */}
         <section className="mt-10">
           <h2 className="mb-4 text-xs font-mono uppercase tracking-widest text-[var(--text-muted)]">

--- a/showcase/starters/ag2/src/app/page.tsx
+++ b/showcase/starters/ag2/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/agno/src/app/page.tsx
+++ b/showcase/starters/agno/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/claude-sdk-python/src/app/page.tsx
+++ b/showcase/starters/claude-sdk-python/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/claude-sdk-typescript/src/app/page.tsx
+++ b/showcase/starters/claude-sdk-typescript/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/crewai-crews/src/app/page.tsx
+++ b/showcase/starters/crewai-crews/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/google-adk/src/app/page.tsx
+++ b/showcase/starters/google-adk/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/langgraph-fastapi/src/app/page.tsx
+++ b/showcase/starters/langgraph-fastapi/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/langgraph-python/src/app/page.tsx
+++ b/showcase/starters/langgraph-python/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/langgraph-typescript/src/app/page.tsx
+++ b/showcase/starters/langgraph-typescript/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/langroid/src/app/page.tsx
+++ b/showcase/starters/langroid/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/llamaindex/src/app/page.tsx
+++ b/showcase/starters/llamaindex/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/mastra/src/app/page.tsx
+++ b/showcase/starters/mastra/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/ms-agent-dotnet/src/app/page.tsx
+++ b/showcase/starters/ms-agent-dotnet/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/ms-agent-python/src/app/page.tsx
+++ b/showcase/starters/ms-agent-python/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/pydantic-ai/src/app/page.tsx
+++ b/showcase/starters/pydantic-ai/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/spring-ai/src/app/page.tsx
+++ b/showcase/starters/spring-ai/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/strands/src/app/page.tsx
+++ b/showcase/starters/strands/src/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>

--- a/showcase/starters/template/frontend/app/page.tsx
+++ b/showcase/starters/template/frontend/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
 
   return (
     <div className="h-screen flex flex-col">
-      <header className="border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
+      <header className="sticky top-0 z-[60] border-b border-[var(--border)] bg-[var(--card)] px-6 py-3 flex items-center justify-between shrink-0">
         <h1 className="text-sm font-bold text-[var(--foreground)]">
           CopilotKit Sales Dashboard
         </h1>


### PR DESCRIPTION
## Summary

- Shell: starter section breaks out to `max-w-[90rem]` (1440px) while header/demos stay at `max-w-5xl` (1024px) — gives the dashboard + sidebar room to breathe
- Starter: renderer selector bar gets `sticky top-0 z-[60]` — stays visible and clickable above the CopilotKit sidebar (z-50)
- All 17 starters regenerated with sticky header