### PR TITLE
fix: clean Slack alert formatting across showcase workflows

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -315,13 +315,32 @@ jobs:
           echo "services=$SERVICES" >> $GITHUB_OUTPUT
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
-      - name: Collect results and notify Slack
+      - name: Build Slack payload
+        if: "${{ secrets.SLACK_WEBHOOK_OSS_ALERTS != '' }}"
+        run: |
+          URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          DETECT="${{ needs.detect-changes.result }}"
+          LOCKFILE="${{ needs.check-lockfile.result }}"
+          BUILD="${{ needs.build.result }}"
+          COUNT="${{ steps.summary.outputs.count }}"
+          SERVICES=$(echo "${{ steps.summary.outputs.services }}" | cut -c1-200)
+
+          if [ "$DETECT" = "failure" ] || [ "$LOCKFILE" = "failure" ]; then
+            MSG=":x: *Showcase deploy*: FAILED (pre-build check)"
+          elif [ "$BUILD" = "success" ]; then
+            MSG=":white_check_mark: *Showcase deploy*: ${COUNT} service(s) deployed to Railway (${SERVICES})"
+          elif [ "$BUILD" = "skipped" ] && [ "$DETECT" = "success" ]; then
+            MSG=":white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy"
+          else
+            MSG=":x: *Showcase deploy*: FAILED — ${COUNT} service(s) targeted (${SERVICES})"
+          fi
+
+          jq -n --arg text "$MSG | <$URL|View run>" '{text: $text}' > /tmp/slack-payload.json
+
+      - name: Post to Slack
         if: "${{ secrets.SLACK_WEBHOOK_OSS_ALERTS != '' }}"
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "${{ (needs.detect-changes.result == 'failure' || needs.check-lockfile.result == 'failure') && format(':x: *Showcase deploy*: FAILED (pre-build check)') || needs.build.result == 'success' && format(':white_check_mark: *Showcase deploy*: {0} service(s) deployed to Railway ({1})', steps.summary.outputs.count, steps.summary.outputs.services) || (needs.build.result == 'skipped' && needs.detect-changes.result == 'success') && ':white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy' || format(':x: *Showcase deploy*: FAILED — {0} service(s) targeted ({1})', steps.summary.outputs.count, steps.summary.outputs.services) }} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
-            }
+          payload-file-path: /tmp/slack-payload.json

--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -72,14 +72,21 @@ jobs:
             echo "EOFEOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Build Slack payload
+        if: failure()
+        run: |
+          SUMMARY=$(echo "${{ steps.failures.outputs.details }}" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
+          URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n --arg text ":x: *Showcase E2E suite failed*\n<$URL|View run>\n\`\`\`$SUMMARY\`\`\`" \
+            '{text: $text}' > /tmp/slack-payload.json
+
       - name: Post failure to Slack
         if: failure()
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload: |
-            { "text": ":x: *Showcase E2E suite failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\n\n```\n${{ steps.failures.outputs.details }}\n```" }
+          payload-file-path: /tmp/slack-payload.json
 
       - name: Create issue on failure
         if: failure()

--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -114,16 +114,21 @@ jobs:
           path: showcase/tests/test-results/
           retention-days: 7
 
+      - name: Build Slack payload
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        run: |
+          SUMMARY=$(echo "${{ steps.failure-cause.outputs.summary }}" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
+          URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n --arg text ":x: *Starter smoke test failing: ${{ matrix.starter }}*\n<$URL|View run>\n\`\`\`$SUMMARY\`\`\`" \
+            '{text: $text}' > /tmp/slack-payload.json
+
       - name: Alert Slack on failure
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": ${{ toJSON(format('Starter smoke test failing: *{0}*\n```{1}```\nRun: {2}/{3}/actions/runs/{4}', matrix.starter, steps.failure-cause.outputs.summary, github.server_url, github.repository, github.run_id)) }}
-            }
+          payload-file-path: /tmp/slack-payload.json
 
       - name: Create GitHub issue on failure
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
## Summary

- **drift-detection**: Split inline payload into `jq`-built file + `payload-file-path`; sanitize playwright output (strip ANSI, head -3, cap 200 chars)
- **starter-smoke**: Replace `toJSON(format(...))` double-encoding with `jq` payload builder
- **showcase_deploy**: Replace 300-char inline ternary with readable shell conditional + `jq`

All three workflows now use the same pattern: build a sanitized JSON file with `jq -n`, then reference it via `payload-file-path`. This eliminates raw `%0A` in Slack messages, unformatted stack traces, and double-encoded JSON.

## Test plan

- [ ] Trigger `showcase_drift-detection.yml` manually — verify Slack alert formats correctly on failure
- [ ] Trigger `starter-smoke.yml` manually — verify Slack alert on a known-failing starter
- [ ] Trigger `showcase_deploy.yml` with `service: shell` — verify deploy notification renders cleanly
- [ ] Confirm no `%0A` or raw escape sequences appear in any Slack message