### PR TITLE
fix: remove test-integration-tmp from starter-smoke (lost in merge)

### DIFF
--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -37,7 +37,6 @@ jobs:
           - strands-python
           - ms-agent-framework-python
           - ms-agent-framework-dotnet
-          - test-integration-tmp
       fail-fast: false
 
     steps:


### PR DESCRIPTION
The #3899 merge only applied the deploy workflow change, not the starter-smoke change. This line causes a guaranteed failure on every PR.