### PR TITLE
fix: pin langgraph versions to prevent runtime crashes

### DIFF
--- a/showcase/packages/langgraph-python/requirements.txt
+++ b/showcase/packages/langgraph-python/requirements.txt
@@ -1,7 +1,7 @@
 copilotkit>=0.1.86
-langchain>=1.2.0
-langchain-openai>=1.1.0
-langchain-anthropic>=1.3.4
-langgraph>=1.1.0
-langgraph-cli[inmem]>=0.4.11
-langgraph-api>=0.7.70
+langchain>=1.2.0,<2.0.0
+langchain-openai>=1.1.0,<2.0.0
+langchain-anthropic>=1.3.4,<2.0.0
+langgraph>=1.1.0,<2.0.0
+langgraph-cli[inmem]>=0.4.11,<0.5.0
+langgraph-api[inmem]>=0.7.70,<0.8.0

--- a/showcase/starters/langgraph-python/src/agents/requirements.txt
+++ b/showcase/starters/langgraph-python/src/agents/requirements.txt
@@ -1,7 +1,7 @@
 copilotkit>=0.1.86
-langchain>=1.2.0
-langchain-openai>=1.1.0
-langchain-anthropic>=1.3.4
-langgraph>=1.1.0
-langgraph-cli[inmem]>=0.4.11
-langgraph-api>=0.7.70
+langchain>=1.2.0,<2.0.0
+langchain-openai>=1.1.0,<2.0.0
+langchain-anthropic>=1.3.4,<2.0.0
+langgraph>=1.1.0,<2.0.0
+langgraph-cli[inmem]>=0.4.11,<0.5.0
+langgraph-api[inmem]>=0.7.70,<0.8.0


### PR DESCRIPTION
Pin langgraph-api to <0.8.0 to prevent langgraph_runtime.database import failure in fresh Docker builds.