### PR TITLE
chore: update CODEOWNERS default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @arielweinberger @mme @ataibarkai @ranst91 @tylerslaton @suhasdeshpande
+* @tylerslaton @jpr5 @ranst91 @marthakelly @mme
 
 # Showcases — demo team owns these alongside core dev
-examples/showcases/ @CopilotKit/demo @arielweinberger @mme @ataibarkai @ranst91 @tylerslaton @suhasdeshpande
+examples/showcases/ @CopilotKit/demo @tylerslaton @jpr5 @ranst91 @marthakelly @mme


### PR DESCRIPTION
## Summary
- Update default CODEOWNERS reviewers to: @tylerslaton @jpr5 @ranst91 @marthakelly @mme
- Remove @arielweinberger, @ataibarkai, and @suhasdeshpande from reviewers
- Update showcase path-specific rule to match the new reviewer list