### PR TITLE
fix: langgraph-python starter agent — 3 root causes fixed, verified locally

### DIFF
--- a/.github/workflows/showcase_template-drift.yml
+++ b/.github/workflows/showcase_template-drift.yml
@@ -1,4 +1,4 @@
-name: "Showcase: Starter Template Drift Detection"
+name: "Showcase: Verify Starters Match Template"
 
 on:
   pull_request:
@@ -28,4 +28,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-      - run: npx tsx showcase/scripts/generate-starters.ts --check
+      - name: Verify generated starters match template output
+        run: |
+          echo "Regenerating starters from template and comparing to committed versions..."
+          echo "If this fails, run: npx tsx showcase/scripts/generate-starters.ts"
+          npx tsx showcase/scripts/generate-starters.ts --check

--- a/showcase/scripts/__tests__/generate-starters.test.ts
+++ b/showcase/scripts/__tests__/generate-starters.test.ts
@@ -181,16 +181,18 @@ describe("generate-starters", () => {
           }
         });
 
-        it("uses relative imports for tools (from .tools import)", () => {
+        it("uses local imports for tools (relative or absolute)", () => {
           const pyFiles = findFiles(agentDir, [".py"]);
           const filesWithToolImport = pyFiles.filter((f) => {
             const content = fs.readFileSync(f, "utf-8");
             return (
               content.includes("from .tools import") ||
-              content.includes("from .tools.")
+              content.includes("from .tools.") ||
+              content.includes("from .tool_wrappers import") ||
+              content.includes(".tools import") // absolute like src.agents.tools
             );
           });
-          // At least one file should have relative tool imports
+          // At least one file should have tool imports
           expect(filesWithToolImport.length).toBeGreaterThan(0);
         });
 

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -607,7 +607,9 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
       fs.renameSync(toolsPy, newName);
       // Update imports in OTHER .py files (not tool_wrappers.py itself)
       // to reference tool_wrappers instead of tools (the wrapper file, not the dir)
-      for (const pyFile of fs.readdirSync(agentDest).filter(f => f.endsWith(".py") && f !== "tool_wrappers.py")) {
+      for (const pyFile of fs
+        .readdirSync(agentDest)
+        .filter((f) => f.endsWith(".py") && f !== "tool_wrappers.py")) {
         const fp = path.join(agentDest, pyFile);
         let content = fs.readFileSync(fp, "utf-8");
         const agentMod = fw.agentDir.replace(/\//g, ".");
@@ -630,7 +632,9 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     // because langgraph_cli loads modules standalone, not as packages
     if (fw.slug.startsWith("langgraph-")) {
       const agentMod = fw.agentDir.replace(/\//g, ".");
-      for (const pyFile of fs.readdirSync(agentDest).filter(f => f.endsWith(".py"))) {
+      for (const pyFile of fs
+        .readdirSync(agentDest)
+        .filter((f) => f.endsWith(".py"))) {
         const fp = path.join(agentDest, pyFile);
         let content = fs.readFileSync(fp, "utf-8");
         // from .X import -> from <agentMod>.X import

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -593,7 +593,54 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
   // For Python: make self-contained by copying shared tools + rewriting imports
   if (fw.language === "python") {
     copySharedPythonTools(agentDest);
+
+    // Always rewrite: remove sys.path.insert and convert shared tool imports
     rewritePythonImportsInDir(agentDest, fw.agentDir);
+
+    // Handle tools.py / tools/ naming collision:
+    // If both tools.py (wrapper) and tools/ (shared tools dir) exist,
+    // rename tools.py to tool_wrappers.py and update imports
+    const toolsPy = path.join(agentDest, "tools.py");
+    const toolsDir = path.join(agentDest, "tools");
+    if (fs.existsSync(toolsPy) && fs.existsSync(toolsDir)) {
+      const newName = path.join(agentDest, "tool_wrappers.py");
+      fs.renameSync(toolsPy, newName);
+      // Update imports in OTHER .py files (not tool_wrappers.py itself)
+      // to reference tool_wrappers instead of tools (the wrapper file, not the dir)
+      for (const pyFile of fs.readdirSync(agentDest).filter(f => f.endsWith(".py") && f !== "tool_wrappers.py")) {
+        const fp = path.join(agentDest, pyFile);
+        let content = fs.readFileSync(fp, "utf-8");
+        const agentMod = fw.agentDir.replace(/\//g, ".");
+        // from <agentMod>.tools import X -> from <agentMod>.tool_wrappers import X
+        content = content.replace(
+          new RegExp(`from ${agentMod}\\.tools import`, "g"),
+          `from ${agentMod}.tool_wrappers import`,
+        );
+        // from .tools import X -> from .tool_wrappers import X
+        // (but NOT from .tools.submodule — those reference the tools/ dir)
+        content = content.replace(
+          /^from \.tools import/gm,
+          "from .tool_wrappers import",
+        );
+        fs.writeFileSync(fp, content);
+      }
+    }
+
+    // For langgraph starters: convert relative imports to absolute
+    // because langgraph_cli loads modules standalone, not as packages
+    if (fw.slug.startsWith("langgraph-")) {
+      const agentMod = fw.agentDir.replace(/\//g, ".");
+      for (const pyFile of fs.readdirSync(agentDest).filter(f => f.endsWith(".py"))) {
+        const fp = path.join(agentDest, pyFile);
+        let content = fs.readFileSync(fp, "utf-8");
+        // from .X import -> from <agentMod>.X import
+        content = content.replace(
+          /^from \.([\w.]+) import/gm,
+          `from ${agentMod}.$1 import`,
+        );
+        fs.writeFileSync(fp, content);
+      }
+    }
 
     const reqSrc = path.join(pkgDir, "requirements.txt");
     if (fs.existsSync(reqSrc)) {

--- a/showcase/starters/ag2/Dockerfile
+++ b/showcase/starters/ag2/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/agno/Dockerfile
+++ b/showcase/starters/agno/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-python/Dockerfile
+++ b/showcase/starters/claude-sdk-python/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/crewai-crews/Dockerfile
+++ b/showcase/starters/crewai-crews/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/google-adk/Dockerfile
+++ b/showcase/starters/google-adk/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-fastapi/Dockerfile
+++ b/showcase/starters/langgraph-fastapi/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-python/Dockerfile
+++ b/showcase/starters/langgraph-python/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-python/src/agents/a2ui_dynamic_schema.py
+++ b/showcase/starters/langgraph-python/src/agents/a2ui_dynamic_schema.py
@@ -17,7 +17,7 @@ from langchain_core.tools import tool as lc_tool
 from langchain_core.messages import SystemMessage
 from langchain_openai import ChatOpenAI
 
-from .tools import (
+from src.agents.tool_wrappers import (
     build_a2ui_operations_from_tool_call,
 )
 

--- a/showcase/starters/langgraph-python/src/agents/a2ui_fixed_schema.py
+++ b/showcase/starters/langgraph-python/src/agents/a2ui_fixed_schema.py
@@ -6,8 +6,8 @@ Schema is loaded from the shared frontend package's flight-schema.json.
 
 from __future__ import annotations
 
-from .tools import search_flights_impl
-from .tools.types import Flight
+from src.agents.tool_wrappers import search_flights_impl
+from src.agents.tools.types import Flight
 
 from langchain_core.tools import tool
 

--- a/showcase/starters/langgraph-python/src/agents/main.py
+++ b/showcase/starters/langgraph-python/src/agents/main.py
@@ -7,7 +7,7 @@ Uses langgraph.prebuilt.create_react_agent with state_modifier for the system pr
 from langgraph.prebuilt import create_react_agent
 from langchain_openai import ChatOpenAI
 
-from .tools import query_data, get_weather, schedule_meeting
+from src.agents.tool_wrappers import query_data, get_weather, schedule_meeting
 
 try:
     from .a2ui_fixed_schema import search_flights

--- a/showcase/starters/langgraph-python/src/agents/todos.py
+++ b/showcase/starters/langgraph-python/src/agents/todos.py
@@ -4,8 +4,8 @@ Sales todo tools for the showcase LangGraph agent.
 Uses Command + ToolMessage for state updates, wrapping shared implementations.
 """
 
-from .tools import manage_sales_todos_impl, get_sales_todos_impl
-from .tools.types import SalesTodo
+from src.agents.tool_wrappers import manage_sales_todos_impl, get_sales_todos_impl
+from src.agents.tools.types import SalesTodo
 
 from langchain.agents import AgentState as BaseAgentState
 from langchain.tools import ToolRuntime, tool

--- a/showcase/starters/langgraph-python/src/agents/tool_wrappers.py
+++ b/showcase/starters/langgraph-python/src/agents/tool_wrappers.py
@@ -4,7 +4,7 @@ Tools for the showcase LangGraph agent.
 Wraps shared implementations with LangGraph @tool decorators.
 """
 
-from .tools import get_weather_impl, query_data_impl, schedule_meeting_impl
+from src.agents.tools import get_weather_impl, query_data_impl, schedule_meeting_impl
 
 from langchain_core.tools import tool
 

--- a/showcase/starters/langroid/Dockerfile
+++ b/showcase/starters/langroid/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/llamaindex/Dockerfile
+++ b/showcase/starters/llamaindex/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-python/Dockerfile
+++ b/showcase/starters/ms-agent-python/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/pydantic-ai/Dockerfile
+++ b/showcase/starters/pydantic-ai/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/strands/Dockerfile
+++ b/showcase/starters/strands/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.python
+++ b/showcase/starters/template/dockerfiles/Dockerfile.python
@@ -35,6 +35,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 
 EXPOSE 10000


### PR DESCRIPTION
## Root causes (all verified locally with docker build + run)

1. **PermissionError**: non-root `USER app` can't create `.langgraph_api` directory — fix: `chown -R app:app /app` before `USER app`
2. **ImportError**: relative imports (`from .tools`) fail when `langgraph_cli` loads modules — fix: absolute imports (`from src.agents.tools`)
3. **ValueError**: `tools.py` file collides with `tools/` directory — fix: rename to `tool_wrappers.py`

## Verified
```
docker build -t test-lgp-starter .
docker run --rm -e OPENAI_API_KEY=test -e PORT=10003 -p 10003:10003 test-lgp-starter
# {"status":"ok","integration":"langgraph-python","agent":"ok"}
```