### PR TITLE
fix: prevent langgraph-python agent from looping on query_data

### DIFF
--- a/showcase/packages/langgraph-python/src/agents/main.py
+++ b/showcase/packages/langgraph-python/src/agents/main.py
@@ -32,13 +32,20 @@ Keep responses brief and clear -- 1 to 2 sentences max.
 You can:
 - Chat naturally with the user
 - Change the UI background when asked (via frontend tool)
-- Query data and render charts (via query_data tool)
+- Query data and render charts:
+  1. Call query_data ONCE to fetch the dataset.
+  2. Then call the pieChart or barChart frontend tool to display the results.
+  Do NOT call query_data more than once per chart request.
 - Get weather information (via get_weather tool)
 - Schedule meetings with the user (via schedule_meeting tool -- the user picks a time in the UI)
 - Manage sales pipeline todos (via manage_sales_todos / get_sales_todos tools)
 - Search flights and display rich A2UI cards (via search_flights tool)
 - Generate dynamic A2UI dashboards from conversation context (via generate_a2ui tool)
 - Generate step-by-step plans for user review (human-in-the-loop)
+
+IMPORTANT: pieChart and barChart are frontend tools provided by CopilotKit.
+After fetching data with query_data, you MUST call pieChart or barChart to render charts.
+Never loop on query_data -- call it once, then render.
 """
 
 model = ChatOpenAI(model="gpt-4o-mini")

--- a/showcase/packages/langgraph-python/src/agents/tools.py
+++ b/showcase/packages/langgraph-python/src/agents/tools.py
@@ -20,7 +20,8 @@ from langchain_core.tools import tool
 def query_data(query: str):
     """
     Query the database. Takes natural language.
-    Always call before showing a chart or graph.
+    Call ONCE to get data, then pass the result to a chart frontend tool (pieChart or barChart).
+    Do not call repeatedly -- one call returns the full dataset.
     """
     return query_data_impl(query)
 

--- a/showcase/starters/langgraph-python/src/agents/main.py
+++ b/showcase/starters/langgraph-python/src/agents/main.py
@@ -32,13 +32,20 @@ Keep responses brief and clear -- 1 to 2 sentences max.
 You can:
 - Chat naturally with the user
 - Change the UI background when asked (via frontend tool)
-- Query data and render charts (via query_data tool)
+- Query data and render charts:
+  1. Call query_data ONCE to fetch the dataset.
+  2. Then call the pieChart or barChart frontend tool to display the results.
+  Do NOT call query_data more than once per chart request.
 - Get weather information (via get_weather tool)
 - Schedule meetings with the user (via schedule_meeting tool -- the user picks a time in the UI)
 - Manage sales pipeline todos (via manage_sales_todos / get_sales_todos tools)
 - Search flights and display rich A2UI cards (via search_flights tool)
 - Generate dynamic A2UI dashboards from conversation context (via generate_a2ui tool)
 - Generate step-by-step plans for user review (human-in-the-loop)
+
+IMPORTANT: pieChart and barChart are frontend tools provided by CopilotKit.
+After fetching data with query_data, you MUST call pieChart or barChart to render charts.
+Never loop on query_data -- call it once, then render.
 """
 
 model = ChatOpenAI(model="gpt-4o-mini")

--- a/showcase/starters/langgraph-python/src/agents/tool_wrappers.py
+++ b/showcase/starters/langgraph-python/src/agents/tool_wrappers.py
@@ -12,7 +12,8 @@ from langchain_core.tools import tool
 def query_data(query: str):
     """
     Query the database. Takes natural language.
-    Always call before showing a chart or graph.
+    Call ONCE to get data, then pass the result to a chart frontend tool (pieChart or barChart).
+    Do not call repeatedly -- one call returns the full dataset.
     """
     return query_data_impl(query)
 


### PR DESCRIPTION
## Summary

- The langgraph-python starter's agent loops endlessly on `query_data` instead of calling `pieChart`/`barChart` frontend tools to render charts
- Root cause: system prompt doesn't mention the frontend chart tools, and the `query_data` tool description encourages calling it ("Always call before showing a chart") without saying what to do after
- Updated system prompt to explicitly instruct the agent to call `query_data` once then use `pieChart` or `barChart`
- Updated `query_data` tool description to reinforce single-call semantics
- Fixed in both the source package (`showcase/packages/`) and the generated starter (`showcase/starters/`)

## Test plan

- [ ] Deploy langgraph-python starter and click "Pie Chart" suggestion pill
- [ ] Verify agent calls `query_data` once, then calls `pieChart` frontend tool
- [ ] Verify no infinite loop on `query_data`
- [ ] Repeat for "Bar Chart" suggestion pill