### PR TITLE
docs: fix useCopilotContext import in thread persistence guides

### DIFF
--- a/docs/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
+++ b/docs/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
@@ -69,7 +69,7 @@ const YourApp = ({ setThreadId }) => {
 CopilotKit provides the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook:
 
 ```tsx
-import { useCopilotContext } from "@copilotkit/react-core/v2";
+import { useCopilotContext } from "@copilotkit/react-core";
 
 const ChangeThreadButton = () => {
   const { threadId, setThreadId } = useCopilotContext();

--- a/docs/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
+++ b/docs/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
@@ -59,7 +59,7 @@ const YourApp = ({ setThreadId }) => {
 CopilotKit will also return the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook. You can use `setThreadId` to change the `threadId`.
 
 ```tsx
-import { useCopilotContext } from "@copilotkit/react-core/v2";
+import { useCopilotContext } from "@copilotkit/react-core";
 
 const ChangeThreadButton = () => {
   const { threadId, setThreadId } = useCopilotContext(); // [!code highlight]

--- a/showcase/shell/src/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
+++ b/showcase/shell/src/content/docs/integrations/crewai-flows/persistence/loading-message-history.mdx
@@ -64,6 +64,8 @@ const YourApp = ({ setThreadId }) => {
 CopilotKit provides the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook:
 
 ```tsx
+import { useCopilotContext } from "@copilotkit/react-core";
+
 const ChangeThreadButton = () => {
   const { threadId, setThreadId } = useCopilotContext();
   return (

--- a/showcase/shell/src/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
+++ b/showcase/shell/src/content/docs/integrations/langgraph/advanced/persistence/loading-message-history.mdx
@@ -55,6 +55,7 @@ const YourApp = ({ setThreadId }) => {
 CopilotKit will also return the current `threadId` and a `setThreadId` function from the `useCopilotContext` hook. You can use `setThreadId` to change the `threadId`.
 
 ```tsx
+import { useCopilotContext } from "@copilotkit/react-core";
 
 const ChangeThreadButton = () => {
   const { threadId, setThreadId } = useCopilotContext(); // [!code highlight]


### PR DESCRIPTION
## Summary
This fixes the `useCopilotContext` import path in the LangGraph and CrewAI Flows thread persistence guides. The docs currently reference `@copilotkit/react-core/v2`, but `useCopilotContext` is exported from `@copilotkit/react-core`.

I also synced the showcase doc copies so the examples stay aligned with the main docs source.

## Validation
I verified that the stale `@copilotkit/react-core/v2` import no longer appears in these guides.

Made with [Cursor](https://cursor.com)