### PR TITLE
fix: align A2UI schema with v0.9 spec, improve path binding prompts

### DIFF
--- a/examples/integrations/langgraph-python/apps/app/package.json
+++ b/examples/integrations/langgraph-python/apps/app/package.json
@@ -8,11 +8,11 @@
     "start": "next start"
   },
   "dependencies": {
-    "@copilotkit/a2ui-renderer": "1.55.2",
-    "@copilotkit/react-core": "1.55.2",
-    "@copilotkit/react-ui": "1.55.2",
-    "@copilotkit/runtime": "1.55.2",
-    "@copilotkit/shared": "1.55.2",
+    "@copilotkit/a2ui-renderer": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/a2ui-renderer@cfeb1c68c43e1c0fc00bcef91ea48b065668218b",
+    "@copilotkit/react-core": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b",
+    "@copilotkit/react-ui": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-ui@cfeb1c68c43e1c0fc00bcef91ea48b065668218b",
+    "@copilotkit/runtime": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@cfeb1c68c43e1c0fc00bcef91ea48b065668218b",
+    "@copilotkit/shared": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-separator": "^1.1.8",

--- a/examples/integrations/langgraph-python/pnpm-lock.yaml
+++ b/examples/integrations/langgraph-python/pnpm-lock.yaml
@@ -29,20 +29,20 @@ importers:
   apps/app:
     dependencies:
       '@copilotkit/a2ui-renderer':
-        specifier: 1.55.2
-        version: 1.55.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/a2ui-renderer@cfeb1c68c43e1c0fc00bcef91ea48b065668218b
+        version: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/a2ui-renderer@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@copilotkit/react-core':
-        specifier: 1.55.2
-        version: 1.55.2(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        specifier: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b
+        version: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       '@copilotkit/react-ui':
-        specifier: 1.55.2
-        version: 1.55.2(@ag-ui/core@0.0.52)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        specifier: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-ui@cfeb1c68c43e1c0fc00bcef91ea48b065668218b
+        version: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-ui@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       '@copilotkit/runtime':
-        specifier: 1.55.2
-        version: 1.55.2(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@langchain/langgraph-sdk@1.8.8(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@opentelemetry/api@1.9.0)(langchain@1.3.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        specifier: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@cfeb1c68c43e1c0fc00bcef91ea48b065668218b
+        version: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@langchain/langgraph-sdk@1.8.8(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@opentelemetry/api@1.9.0)(langchain@1.3.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76)))(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@copilotkit/shared':
-        specifier: 1.55.2
-        version: 1.55.2(@ag-ui/core@0.0.52)
+        specifier: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b
+        version: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -121,8 +121,8 @@ packages:
   '@a2ui/web_core@0.9.0':
     resolution: {integrity: sha512-TsMWuEeuVDsScGIGPy/fWIZu+EOBRfhx6KwjKh3VwY1AwysRenQM8zDr8VrSk14Wck/aBgVxk2zWVrMCK2/s6A==}
 
-  '@ag-ui/a2ui-middleware@0.0.4':
-    resolution: {integrity: sha512-N7goCObceqsCQgFRKBpo/X9D9Q0Jp6ALV+ier2W7WnK3sy0WfY2jAeFhqEaoZRqcNeLTKEt8sDqdtd4TGQE1+w==}
+  '@ag-ui/a2ui-middleware@0.0.5':
+    resolution: {integrity: sha512-nhF8LBzq36BmLR1O3nStxqSpIu1+4//ttqOyQgiXUsKZK1znCyN4q4MBTARrkFa7CuFr3fcNTiZuS4V1HRUHTw==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.40'
       rxjs: 7.8.1
@@ -282,38 +282,44 @@ packages:
     peerDependencies:
       commander: ~13.1.0
 
-  '@copilotkit/a2ui-renderer@1.55.2':
-    resolution: {integrity: sha512-2EmNOFrFxOnjc9im3XP30OiiAF2KC5dc+CVwB+P4KgGhzvoA8Hg4biWkSnkFSd1dxdRp9BYvZ4OR3UTaa+0JQA==}
+  '@copilotkit/a2ui-renderer@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/a2ui-renderer@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/a2ui-renderer@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  '@copilotkit/core@1.55.2':
-    resolution: {integrity: sha512-/IHCRWvXyFKSbFkIWwKMfs/+5629+ljsb467YnPmbOOVNcYguWDhOknUoOq1SJKIK2uJOMcVeje/UHeZsmdmaA==}
+  '@copilotkit/core@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     engines: {node: '>=18'}
 
   '@copilotkit/license-verifier@0.0.1-a1':
     resolution: {integrity: sha512-eTsupi14qPwDhpQBrFC6t4U5rxmHo9nPaHz60gOBPPCu7tTcA8GwEq5QfX/XGfmmKbCX2noL9yto1Pg0A8qQ9g==}
 
-  '@copilotkit/react-core@1.55.2':
-    resolution: {integrity: sha512-nJuJKpdEJk+1Dv6te7Md8plq7ZxVRMxOB1ZKSfEEs8d8ygFFKDcNvEz9Y/zyOBOXv1RaitZRnRdhVymg8ossvA==}
+  '@copilotkit/react-core@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
       zod: '>=3.0.0'
 
-  '@copilotkit/react-ui@1.55.2':
-    resolution: {integrity: sha512-bDuGm133W3i+CK/tr23Oq3kvDwKdd9NEWUlBmkRG2aHmFhhuEFu2zNU5IUY+pebvOMirAAkihh6mRzDf1SJ9gA==}
+  '@copilotkit/react-ui@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-ui@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-ui@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
 
-  '@copilotkit/runtime-client-gql@1.55.2':
-    resolution: {integrity: sha512-TZ1xCPyRTWxrZ7ldUGMzO/pLTu0sUwAjZ3txWo6vhRpJVHmpZPd7begrsHWbIBAtGpdthze0sVyE4MfKbL/h3w==}
+  '@copilotkit/runtime-client-gql@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime-client-gql@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime-client-gql@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
 
-  '@copilotkit/runtime@1.55.2':
-    resolution: {integrity: sha512-7GVs0DA+7EvlwPXn7KpceO92QoaqJWGbKv3he2AreF2L6UWwF1q7dJhDMs/jnq8mcWOlqRCP7W5WhqXfT8r4fA==}
+  '@copilotkit/runtime@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     peerDependencies:
       '@anthropic-ai/sdk': ^0.57.0
       '@langchain/aws': '>=0.1.9'
@@ -324,6 +330,7 @@ packages:
       '@langchain/openai': '>=0.4.2'
       groq-sdk: '>=0.3.0 <1.0.0'
       langchain: '>=0.3.3'
+      openai: ^4.85.1 || >=5.0.0
     peerDependenciesMeta:
       '@anthropic-ai/sdk':
         optional: true
@@ -341,14 +348,18 @@ packages:
         optional: true
       langchain:
         optional: true
+      openai:
+        optional: true
 
-  '@copilotkit/shared@1.55.2':
-    resolution: {integrity: sha512-yVnCY7cZSi09Jf4a6loBNI3+bV96BqSN/0zCXAy5M5KuGWo45RyYstqpYqRzbf/tSulGqAERD5DIiAGKSGO1jg==}
+  '@copilotkit/shared@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     peerDependencies:
       '@ag-ui/core': '>=0.0.48'
 
-  '@copilotkit/web-inspector@1.55.2':
-    resolution: {integrity: sha512-KhK9NF9VBAxSaaLlpJENnCnQVXKNLNAOGhaXt71nKtTg4KVf30pzN8qhnfj/SvZeWLBvdtB9chRC/cPO6TxJAA==}
+  '@copilotkit/web-inspector@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/web-inspector@cfeb1c68c43e1c0fc00bcef91ea48b065668218b':
+    resolution: {tarball: https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/web-inspector@cfeb1c68c43e1c0fc00bcef91ea48b065668218b}
+    version: 1.55.3
     engines: {node: '>=18'}
 
   '@dabh/diagnostics@2.0.8':
@@ -4623,7 +4634,7 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
 
-  '@ag-ui/a2ui-middleware@0.0.4(@ag-ui/client@0.0.52)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.5(@ag-ui/client@0.0.52)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/client': 0.0.52
       clarinet: 0.12.6
@@ -4827,7 +4838,7 @@ snapshots:
     dependencies:
       commander: 13.1.0
 
-  '@copilotkit/a2ui-renderer@1.55.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@copilotkit/a2ui-renderer@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/a2ui-renderer@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@a2ui/web_core': 0.9.0
       clsx: 2.1.1
@@ -4836,10 +4847,10 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
 
-  '@copilotkit/core@1.55.2(@ag-ui/core@0.0.52)(zod@3.25.76)':
+  '@copilotkit/core@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(zod@3.25.76)':
     dependencies:
       '@ag-ui/client': 0.0.52
-      '@copilotkit/shared': 1.55.2(@ag-ui/core@0.0.52)
+      '@copilotkit/shared': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)
       phoenix: 1.8.5
       rxjs: 7.8.1
       zod-to-json-schema: 3.25.1(zod@3.25.76)
@@ -4850,15 +4861,15 @@ snapshots:
 
   '@copilotkit/license-verifier@0.0.1-a1': {}
 
-  '@copilotkit/react-core@1.55.2(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)':
+  '@copilotkit/react-core@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)':
     dependencies:
       '@ag-ui/client': 0.0.52
       '@ag-ui/core': 0.0.52
-      '@copilotkit/a2ui-renderer': 1.55.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@copilotkit/core': 1.55.2(@ag-ui/core@0.0.52)(zod@3.25.76)
-      '@copilotkit/runtime-client-gql': 1.55.2(@ag-ui/core@0.0.52)(graphql@16.13.2)(react@19.2.4)
-      '@copilotkit/shared': 1.55.2(@ag-ui/core@0.0.52)
-      '@copilotkit/web-inspector': 1.55.2(@ag-ui/core@0.0.52)(zod@3.25.76)
+      '@copilotkit/a2ui-renderer': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/a2ui-renderer@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@copilotkit/core': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(zod@3.25.76)
+      '@copilotkit/runtime-client-gql': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime-client-gql@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(graphql@16.13.2)(react@19.2.4)
+      '@copilotkit/shared': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)
+      '@copilotkit/web-inspector': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/web-inspector@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(zod@3.25.76)
       '@jetbrains/websandbox': 1.1.3
       '@lit-labs/react': 2.1.3(@types/react@19.2.10)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4891,11 +4902,11 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@copilotkit/react-ui@1.55.2(@ag-ui/core@0.0.52)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)':
+  '@copilotkit/react-ui@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-ui@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)':
     dependencies:
-      '@copilotkit/react-core': 1.55.2(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
-      '@copilotkit/runtime-client-gql': 1.55.2(@ag-ui/core@0.0.52)(graphql@16.13.2)(react@19.2.4)
-      '@copilotkit/shared': 1.55.2(@ag-ui/core@0.0.52)
+      '@copilotkit/react-core': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/react-core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(graphql@16.13.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+      '@copilotkit/runtime-client-gql': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime-client-gql@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(graphql@16.13.2)(react@19.2.4)
+      '@copilotkit/shared': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)
       '@headlessui/react': 2.2.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-markdown: 10.1.0(@types/react@19.2.10)(react@19.2.4)
@@ -4916,9 +4927,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@copilotkit/runtime-client-gql@1.55.2(@ag-ui/core@0.0.52)(graphql@16.13.2)(react@19.2.4)':
+  '@copilotkit/runtime-client-gql@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime-client-gql@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(graphql@16.13.2)(react@19.2.4)':
     dependencies:
-      '@copilotkit/shared': 1.55.2(@ag-ui/core@0.0.52)
+      '@copilotkit/shared': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)
       '@urql/core': 5.2.0(graphql@16.13.2)
       react: 19.2.4
       untruncate-json: 0.0.1
@@ -4928,9 +4939,9 @@ snapshots:
       - encoding
       - graphql
 
-  '@copilotkit/runtime@1.55.2(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@langchain/langgraph-sdk@1.8.8(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@opentelemetry/api@1.9.0)(langchain@1.3.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@copilotkit/runtime@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@cfworker/json-schema@4.1.1)(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@langchain/langgraph-sdk@1.8.8(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@opentelemetry/api@1.9.0)(langchain@1.3.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76)))(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
-      '@ag-ui/a2ui-middleware': 0.0.4(@ag-ui/client@0.0.52)(rxjs@7.8.1)
+      '@ag-ui/a2ui-middleware': 0.0.5(@ag-ui/client@0.0.52)(rxjs@7.8.1)
       '@ag-ui/client': 0.0.52
       '@ag-ui/core': 0.0.52
       '@ag-ui/encoder': 0.0.52
@@ -4942,7 +4953,7 @@ snapshots:
       '@ai-sdk/mcp': 1.0.35(zod@3.25.76)
       '@ai-sdk/openai': 3.0.52(zod@3.25.76)
       '@copilotkit/license-verifier': 0.0.1-a1
-      '@copilotkit/shared': 1.55.2(@ag-ui/core@0.0.52)
+      '@copilotkit/shared': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)
       '@graphql-yoga/plugin-defer-stream': 3.21.0(graphql-yoga@5.21.0(graphql@16.13.2))(graphql@16.13.2)
       '@hono/node-server': 1.19.9(hono@4.12.10)
       '@langchain/core': 0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))
@@ -4960,7 +4971,6 @@ snapshots:
       graphql-scalars: 1.25.0(graphql@16.13.2)
       graphql-yoga: 5.21.0(graphql@16.13.2)
       hono: 4.12.10
-      openai: 4.104.0(ws@8.19.0)(zod@3.25.76)
       partial-json: 0.1.7
       phoenix: 1.8.5
       pino: 9.14.0
@@ -4974,6 +4984,7 @@ snapshots:
     optionalDependencies:
       '@langchain/langgraph-sdk': 1.8.8(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       langchain: 1.3.1(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      openai: 4.104.0(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@opentelemetry/api'
@@ -4989,7 +5000,7 @@ snapshots:
       - vue
       - zod-to-json-schema
 
-  '@copilotkit/shared@1.55.2(@ag-ui/core@0.0.52)':
+  '@copilotkit/shared@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)':
     dependencies:
       '@ag-ui/client': 0.0.52
       '@ag-ui/core': 0.0.52
@@ -5005,10 +5016,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@copilotkit/web-inspector@1.55.2(@ag-ui/core@0.0.52)(zod@3.25.76)':
+  '@copilotkit/web-inspector@https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/web-inspector@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(zod@3.25.76)':
     dependencies:
       '@ag-ui/client': 0.0.52
-      '@copilotkit/core': 1.55.2(@ag-ui/core@0.0.52)(zod@3.25.76)
+      '@copilotkit/core': https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/core@cfeb1c68c43e1c0fc00bcef91ea48b065668218b(@ag-ui/core@0.0.52)(zod@3.25.76)
       lit: 3.3.2
       lucide: 0.525.0
       marked: 12.0.2
@@ -6343,10 +6354,12 @@ snapshots:
     dependencies:
       '@types/node': 20.19.31
       form-data: 4.0.5
+    optional: true
 
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
+    optional: true
 
   '@types/node@20.19.31':
     dependencies:
@@ -6467,6 +6480,7 @@ snapshots:
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
+    optional: true
 
   ai@6.0.154(zod@3.25.76):
     dependencies:
@@ -6503,7 +6517,8 @@ snapshots:
 
   async@3.2.6: {}
 
-  asynckit@0.4.0: {}
+  asynckit@0.4.0:
+    optional: true
 
   atomic-sleep@1.0.0: {}
 
@@ -6686,6 +6701,7 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+    optional: true
 
   comma-separated-tokens@1.0.8: {}
 
@@ -6998,7 +7014,8 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.3
 
-  delayed-stream@1.0.0: {}
+  delayed-stream@1.0.0:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -7069,6 +7086,7 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+    optional: true
 
   es-toolkit@1.44.0: {}
 
@@ -7289,7 +7307,8 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  form-data-encoder@1.7.2: {}
+  form-data-encoder@1.7.2:
+    optional: true
 
   form-data@4.0.5:
     dependencies:
@@ -7298,6 +7317,7 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+    optional: true
 
   format@0.2.2: {}
 
@@ -7305,6 +7325,7 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
+    optional: true
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -7434,6 +7455,7 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+    optional: true
 
   hasown@2.0.2:
     dependencies:
@@ -7613,6 +7635,7 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+    optional: true
 
   iconv-lite@0.4.24:
     dependencies:
@@ -8673,6 +8696,7 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
+    optional: true
 
   openai@4.104.0(ws@8.19.0)(zod@4.3.6):
     dependencies:
@@ -9637,7 +9661,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
-  undici-types@5.26.5: {}
+  undici-types@5.26.5:
+    optional: true
 
   undici-types@6.21.0: {}
 
@@ -9850,7 +9875,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-streams-polyfill@4.0.0-beta.3: {}
+  web-streams-polyfill@4.0.0-beta.3:
+    optional: true
 
   webidl-conversions@3.0.1: {}
 

--- a/packages/a2ui-renderer/src/react-renderer/catalog-utils.ts
+++ b/packages/a2ui-renderer/src/react-renderer/catalog-utils.ts
@@ -11,7 +11,7 @@ const BASIC_CATALOG_ID =
  * a frontend-provided schema with a server-side one.
  */
 export const A2UI_SCHEMA_CONTEXT_DESCRIPTION =
-  "A2UI Component Schema — available components for generating UI surfaces. Use these component names and props when creating A2UI operations.";
+  "A2UI Component Schema — available components for generating UI surfaces. Use these component names and properties when creating A2UI operations.";
 
 /**
  * Check whether a catalog is a superset of the basic catalog
@@ -85,28 +85,54 @@ export function buildCatalogContextValue(
 }
 
 /**
- * Extract component schemas from a catalog in the same format used by
- * the A2UI middleware (`A2UIComponentSchema[]`). Each component's Zod
- * schema is converted to JSON Schema via zod-to-json-schema.
+ * A2UI v0.9 inline catalog format — matches the structure defined by the
+ * A2UI specification (basic_catalog.json).  Each component is keyed by
+ * name and uses `allOf` to compose ComponentCommon with component-specific
+ * properties so the schema mirrors the flat wire format the LLM must produce.
+ */
+export interface InlineCatalogSchema {
+  catalogId: string;
+  components: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * Extract component schemas from a catalog in the A2UI v0.9 inline catalog
+ * format.  This mirrors `generateInlineCatalog` from `@a2ui/web_core` so
+ * the schema the LLM sees matches the spec and the flat wire format:
+ *
+ *   { "Column": { "allOf": [
+ *       { "$ref": "common_types.json#/$defs/ComponentCommon" },
+ *       { "properties": { "component": {"const":"Column"}, "gap": ..., "children": ... },
+ *         "required": ["component"] }
+ *   ]}}
  *
  * When sent via `useAgentContext` with `A2UI_SCHEMA_CONTEXT_DESCRIPTION`,
  * the middleware can optionally overwrite it with a server-side schema.
  */
 export function extractCatalogComponentSchemas(
   catalog?: Catalog<ComponentApi>,
-): Array<{ name: string; props: Record<string, unknown> }> {
+): InlineCatalogSchema {
   const resolved = catalog ?? basicCatalog;
-  const schemas: Array<{ name: string; props: Record<string, unknown> }> = [];
+  const components: Record<string, Record<string, unknown>> = {};
 
   for (const [name, comp] of resolved.components) {
-    schemas.push({
-      name,
-      props: zodToJsonSchema(comp.schema, { target: "openApi3" }) as Record<
-        string,
-        unknown
-      >,
-    });
+    const zodSchema = zodToJsonSchema(comp.schema, {
+      target: "jsonSchema2019-09",
+    }) as { properties?: Record<string, unknown>; required?: string[] };
+
+    components[name] = {
+      allOf: [
+        { $ref: "common_types.json#/$defs/ComponentCommon" },
+        {
+          properties: {
+            component: { const: name },
+            ...(zodSchema.properties ?? {}),
+          },
+          required: ["component", ...(zodSchema.required ?? [])],
+        },
+      ],
+    };
   }
 
-  return schemas;
+  return { catalogId: resolved.id, components };
 }

--- a/packages/a2ui-renderer/src/react-renderer/index.ts
+++ b/packages/a2ui-renderer/src/react-renderer/index.ts
@@ -34,6 +34,7 @@ export {
   buildCatalogContextValue,
   extractCatalogComponentSchemas,
 } from "./catalog-utils";
+export type { InlineCatalogSchema } from "./catalog-utils";
 
 // Catalog creation — new API (definitions + renderers)
 export { createCatalog, extractSchema } from "./create-catalog";

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -88,7 +88,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/a2ui-middleware": "0.0.4",
+    "@ag-ui/a2ui-middleware": "0.0.5",
     "@ag-ui/client": "0.0.52",
     "@ag-ui/core": "0.0.52",
     "@ag-ui/encoder": "0.0.52",

--- a/packages/shared/src/a2ui-prompts.ts
+++ b/packages/shared/src/a2ui-prompts.ts
@@ -47,43 +47,38 @@ CRITICAL: Do NOT use "/name" (absolute) inside templates — use "name" (relativ
 The container's path ("/items") uses a leading slash (absolute), but all
 components INSIDE the template use paths WITHOUT leading slash.
 
-DATA MODEL:
-The "data" key in the tool args is a plain JSON object that initializes the surface
-data model. Components bound to paths (e.g. "value": { "path": "/form/name" })
-read from and write to this data model. Examples:
-  For forms:  "data": { "form": { "name": "Alice", "email": "" } }
-  For lists:  "data": { "items": [{"name": "Product A"}, {"name": "Product B"}] }
-  For mixed:  "data": { "form": { "query": "" }, "results": [...] }
+COMPONENT VALUES — DEFAULT RULE:
+Use inline literal values for ALL component properties. Pass strings, numbers,
+arrays, and objects directly on the component. Do NOT use { "path": "..." }
+objects unless the property's schema explicitly allows it (see exception below).
+CRITICAL: USING { "path": "..." } ON A PROPERTY THAT DOES NOT DECLARE PATH
+SUPPORT IN ITS SCHEMA WILL CAUSE A RUNTIME CRASH AND BREAK THE ENTIRE UI.
+ALWAYS CHECK THE COMPONENT SCHEMA FIRST — IF THE PROPERTY ONLY ACCEPTS A
+PLAIN TYPE, YOU MUST USE A LITERAL VALUE.
+VERY IMPORTANT: THE APPLICATION WILL BREAK IF YOU DO NOT FOLLOW THIS RULE!
 
-PATH BINDING — CRITICAL SCHEMA RULE:
-Path bindings ({ "path": "/some/path" }) are ONLY allowed on properties whose schema
-explicitly includes them. Check the Available Components schema for each property:
-  - If the schema shows "anyOf": [{"type":"string"}, {"type":"object","properties":{"path":...}}]
-    then the property supports BOTH literal values AND path bindings.
-  - If the schema shows only a plain type (e.g. "type": "array", "type": "string",
-    "type": "number"), then that property accepts ONLY literal values — NOT path bindings.
+For example, a chart's "data" must always be an inline array:
+  "data": [{"label": "Jan", "value": 100}, {"label": "Feb", "value": 200}]
+A metric's "value" must always be an inline string:
+  "value": "$1,200"
 
-NEVER use { "path": "..." } on a property that does not have the anyOf/union type in
-the schema. Doing so will silently break rendering. For example, if a chart component's
-"data" property is defined as "type": "array", you MUST provide the data inline as a
-literal array — do NOT use { "path": "/chartData" }.
+PATH BINDING EXCEPTION — SCHEMA-DRIVEN:
+A few properties accept { "path": "/some/path" } as an alternative to a literal
+value. You can identify these in the Available Components schema: the property
+will list BOTH a literal type AND an object-with-path option. If a property only
+shows a single type (string, number, array, etc.), it does NOT support path
+binding — use a literal value only.
 
-FORMS AND TWO-WAY DATA BINDING:
-To create editable forms, bind input components to data model paths using { "path": "..." }.
-The client automatically writes user input back to the data model at the bound path.
-CRITICAL: Using a literal value (e.g. "value": "") makes the field READ-ONLY.
-You MUST use { "path": "..." } to make inputs editable.
+Path binding is typically used for editable form inputs so the client can write
+user input back to the data model. When building forms:
+- Bind input "value" to a data model path: "value": { "path": "/form/name" }
+- Pre-fill via the "data" tool argument: "data": { "form": { "name": "Alice" } }
+- Capture values on submit via button action context:
+    "action": { "event": { "name": "submit", "context": { "name": { "path": "/form/name" } } } }
 
-Input components use "value" as the binding property:
-  "value": { "path": "/form/fieldName" }
-This works because input components define "value" with the anyOf union type in the schema.
-
-To retrieve form values when a button is clicked, include "context" with path references
-in the button's action. Paths are resolved to their current values at click time:
-  "action": { "event": { "name": "submit", "context": { "userName": { "path": "/form/name" } } } }
-
-To pre-fill form values, pass initial data via the "data" tool argument:
-  "data": { "form": { "name": "Markus" } }`;
+REPEATING CONTENT uses a structural children format (not the same as value binding):
+  children: { componentId: "card-id", path: "/items" }
+Components inside templates use RELATIVE paths (no leading slash): { "path": "name" }.`;
 
 /**
  * Design guidelines — visual design rules, component hierarchy tips,
@@ -108,8 +103,8 @@ Design principles:
     "action": { "event": { "name": "myAction", "context": { "key": "value" } } }
   The "event" key holds an OBJECT with "name" (required) and "context" (optional).
   Do NOT use a flat format like {"event": "name"} — "event" must be an object.
-- For forms: every input MUST use path binding on the "value" property
-  (e.g. "value": { "path": "/form/name" }) to be editable. The submit button's
-  action context MUST reference the same paths to capture the user's input.
+- For forms: check the component schema — if an input's "value" property
+  supports path binding, use it for editable fields. The submit button's
+  action context should reference the same paths to capture user input.
 
 Use the SAME surfaceId as the main surface. Match action names to button action event names.`;

--- a/packages/shared/src/a2ui-prompts.ts
+++ b/packages/shared/src/a2ui-prompts.ts
@@ -55,6 +55,19 @@ read from and write to this data model. Examples:
   For lists:  "data": { "items": [{"name": "Product A"}, {"name": "Product B"}] }
   For mixed:  "data": { "form": { "query": "" }, "results": [...] }
 
+PATH BINDING — CRITICAL SCHEMA RULE:
+Path bindings ({ "path": "/some/path" }) are ONLY allowed on properties whose schema
+explicitly includes them. Check the Available Components schema for each property:
+  - If the schema shows "anyOf": [{"type":"string"}, {"type":"object","properties":{"path":...}}]
+    then the property supports BOTH literal values AND path bindings.
+  - If the schema shows only a plain type (e.g. "type": "array", "type": "string",
+    "type": "number"), then that property accepts ONLY literal values — NOT path bindings.
+
+NEVER use { "path": "..." } on a property that does not have the anyOf/union type in
+the schema. Doing so will silently break rendering. For example, if a chart component's
+"data" property is defined as "type": "array", you MUST provide the data inline as a
+literal array — do NOT use { "path": "/chartData" }.
+
 FORMS AND TWO-WAY DATA BINDING:
 To create editable forms, bind input components to data model paths using { "path": "..." }.
 The client automatically writes user input back to the data model at the bound path.
@@ -63,6 +76,7 @@ You MUST use { "path": "..." } to make inputs editable.
 
 Input components use "value" as the binding property:
   "value": { "path": "/form/fieldName" }
+This works because input components define "value" with the anyOf union type in the schema.
 
 To retrieve form values when a button is clicked, include "context" with path references
 in the button's action. Paths are resolved to their current values at click time:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2341,8 +2341,8 @@ importers:
   packages/runtime:
     dependencies:
       '@ag-ui/a2ui-middleware':
-        specifier: 0.0.4
-        version: 0.0.4(@ag-ui/client@0.0.52)(rxjs@7.8.1)
+        specifier: 0.0.5
+        version: 0.0.5(@ag-ui/client@0.0.52)(rxjs@7.8.1)
       '@ag-ui/client':
         specifier: 0.0.52
         version: 0.0.52
@@ -2927,8 +2927,8 @@ packages:
       '@ag-ui/client': '>=0.0.42'
       '@ag-ui/core': '>=0.0.42'
 
-  '@ag-ui/a2ui-middleware@0.0.4':
-    resolution: {integrity: sha512-N7goCObceqsCQgFRKBpo/X9D9Q0Jp6ALV+ier2W7WnK3sy0WfY2jAeFhqEaoZRqcNeLTKEt8sDqdtd4TGQE1+w==}
+  '@ag-ui/a2ui-middleware@0.0.5':
+    resolution: {integrity: sha512-nhF8LBzq36BmLR1O3nStxqSpIu1+4//ttqOyQgiXUsKZK1znCyN4q4MBTARrkFa7CuFr3fcNTiZuS4V1HRUHTw==}
     peerDependencies:
       '@ag-ui/client': '>=0.0.40'
       rxjs: 7.8.1
@@ -22207,7 +22207,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2ui-middleware@0.0.4(@ag-ui/client@0.0.52)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.5(@ag-ui/client@0.0.52)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/client': 0.0.52
       clarinet: 0.12.6

--- a/sdk-python/copilotkit/a2ui.py
+++ b/sdk-python/copilotkit/a2ui.py
@@ -141,13 +141,27 @@ read from and write to this data model. Examples:
   For lists:  "data": { "items": [{"name": "Product A"}, {"name": "Product B"}] }
   For mixed:  "data": { "form": { "query": "" }, "results": [...] }
 
+PATH BINDING — CRITICAL SCHEMA RULE:
+Path bindings ({ "path": "/some/path" }) are ONLY allowed on properties whose schema
+explicitly includes them. Check the Available Components schema for each property:
+  - If the schema shows "anyOf": [{"type":"string"}, {"type":"object","properties":{"path":...}}]
+    then the property supports BOTH literal values AND path bindings.
+  - If the schema shows only a plain type (e.g. "type": "array", "type": "string",
+    "type": "number"), then that property accepts ONLY literal values — NOT path bindings.
+
+NEVER use { "path": "..." } on a property that does not have the anyOf/union type in
+the schema. Doing so will silently break rendering. For example, if a chart component's
+"data" property is defined as "type": "array", you MUST provide the data inline as a
+literal array — do NOT use { "path": "/chartData" }.
+
 FORMS AND TWO-WAY DATA BINDING:
 To create editable forms, bind input components to data model paths using { "path": "..." }.
 The client automatically writes user input back to the data model at the bound path.
 CRITICAL: Using a literal value (e.g. "value": "") makes the field READ-ONLY.
 You MUST use { "path": "..." } to make inputs editable.
 
-All input components use "value" as the binding property:
+All input components use "value" as the binding property (these work because input
+components define "value" with the anyOf union type in the schema):
 - TextField:     "value": { "path": "/form/fieldName" }
 - CheckBox:      "value": { "path": "/form/isChecked" }
 - Slider:        "value": { "path": "/form/sliderVal" }

--- a/sdk-python/copilotkit/a2ui.py
+++ b/sdk-python/copilotkit/a2ui.py
@@ -133,59 +133,38 @@ The List's own path ("/items") uses a leading slash (absolute), but all
 components INSIDE the template card use paths WITHOUT leading slash.
 Do NOT use "/items/0/name" or "/items/{@key}/name" — just "name".
 
-DATA MODEL:
-The "data" key in the tool args is a plain JSON object that initializes the surface
-data model. Components bound to paths (e.g. "value": { "path": "/form/name" })
-read from and write to this data model. Examples:
-  For forms:  "data": { "form": { "name": "Alice", "email": "" } }
-  For lists:  "data": { "items": [{"name": "Product A"}, {"name": "Product B"}] }
-  For mixed:  "data": { "form": { "query": "" }, "results": [...] }
+COMPONENT VALUES — DEFAULT RULE:
+Use inline literal values for ALL component properties. Pass strings, numbers,
+arrays, and objects directly on the component. Do NOT use { "path": "..." }
+objects unless the property's schema explicitly allows it (see exception below).
+CRITICAL: USING { "path": "..." } ON A PROPERTY THAT DOES NOT DECLARE PATH
+SUPPORT IN ITS SCHEMA WILL CAUSE A RUNTIME CRASH AND BREAK THE ENTIRE UI.
+ALWAYS CHECK THE COMPONENT SCHEMA FIRST — IF THE PROPERTY ONLY ACCEPTS A
+PLAIN TYPE, YOU MUST USE A LITERAL VALUE.
+VERY IMPORTANT: THE APPLICATION WILL BREAK IF YOU DO NOT FOLLOW THIS RULE!
 
-PATH BINDING — CRITICAL SCHEMA RULE:
-Path bindings ({ "path": "/some/path" }) are ONLY allowed on properties whose schema
-explicitly includes them. Check the Available Components schema for each property:
-  - If the schema shows "anyOf": [{"type":"string"}, {"type":"object","properties":{"path":...}}]
-    then the property supports BOTH literal values AND path bindings.
-  - If the schema shows only a plain type (e.g. "type": "array", "type": "string",
-    "type": "number"), then that property accepts ONLY literal values — NOT path bindings.
+For example, a chart's "data" must always be an inline array:
+  "data": [{"label": "Jan", "value": 100}, {"label": "Feb", "value": 200}]
+A metric's "value" must always be an inline string:
+  "value": "$1,200"
 
-NEVER use { "path": "..." } on a property that does not have the anyOf/union type in
-the schema. Doing so will silently break rendering. For example, if a chart component's
-"data" property is defined as "type": "array", you MUST provide the data inline as a
-literal array — do NOT use { "path": "/chartData" }.
+PATH BINDING EXCEPTION — SCHEMA-DRIVEN:
+A few properties accept { "path": "/some/path" } as an alternative to a literal
+value. You can identify these in the Available Components schema: the property
+will list BOTH a literal type AND an object-with-path option. If a property only
+shows a single type (string, number, array, etc.), it does NOT support path
+binding — use a literal value only.
 
-FORMS AND TWO-WAY DATA BINDING:
-To create editable forms, bind input components to data model paths using { "path": "..." }.
-The client automatically writes user input back to the data model at the bound path.
-CRITICAL: Using a literal value (e.g. "value": "") makes the field READ-ONLY.
-You MUST use { "path": "..." } to make inputs editable.
+Path binding is typically used for editable form inputs so the client can write
+user input back to the data model. When building forms:
+- Bind input "value" to a data model path: "value": { "path": "/form/name" }
+- Pre-fill via the "data" tool argument: "data": { "form": { "name": "Alice" } }
+- Capture values on submit via button action context:
+    "action": { "event": { "name": "submit", "context": { "name": { "path": "/form/name" } } } }
 
-All input components use "value" as the binding property (these work because input
-components define "value" with the anyOf union type in the schema):
-- TextField:     "value": { "path": "/form/fieldName" }
-- CheckBox:      "value": { "path": "/form/isChecked" }
-- Slider:        "value": { "path": "/form/sliderVal" }
-- DateTimeInput: "value": { "path": "/form/date" }
-- ChoicePicker:  "value": { "path": "/form/choices" }
-
-To retrieve form values when a button is clicked, include "context" with path references
-in the button's action. Paths are resolved to their current values at click time:
-  "action": { "event": { "name": "submit", "context": { "userName": { "path": "/form/name" } } } }
-
-To pre-fill form values, pass initial data via the "data" tool argument:
-  "data": { "form": { "name": "Markus" } }
-
-FORM EXAMPLE (editable text field with pre-filled value + submit button):
-  "components": [
-    { "id": "root", "component": "Card", "child": "form-col" },
-    { "id": "form-col", "component": "Column", "children": ["name-field", "submit-row"] },
-    { "id": "name-field", "component": "TextField", "label": "Name", "value": { "path": "/form/name" } },
-    { "id": "submit-row", "component": "Row", "justify": "end", "children": ["submit-btn"] },
-    { "id": "submit-btn", "component": "Button", "child": "btn-text", "variant": "primary",
-      "action": { "event": { "name": "submit", "context": { "userName": { "path": "/form/name" } } } } },
-    { "id": "btn-text", "component": "Text", "text": "Submit" }
-  ],
-  "data": { "form": { "name": "Markus" } }"""
+REPEATING CONTENT uses a structural children format (not the same as value binding):
+  children: { componentId: "card-id", path: "/items" }
+Components inside templates use RELATIVE paths (no leading slash): { "path": "name" }."""
 
 DEFAULT_DESIGN_GUIDELINES = """\
 Create polished, visually appealing interfaces:


### PR DESCRIPTION
## Summary
- Replace custom `{ name, props }` schema format with A2UI v0.9 spec-aligned inline catalog format (`allOf` + `properties`) — eliminates LLM "props" nesting confusion
- Restructure generation prompts: inline literal values are the default, path binding is a narrow schema-driven exception
- Bump `@ag-ui/a2ui-middleware` to `0.0.5` in runtime

## Context
LLMs generating dynamic A2UI sometimes produced invalid output:
1. Nesting properties under a `"props"` key (because our schema used `props` as a key)
2. Using `{ "path": "..." }` bindings on properties that only accept literal values (e.g. chart `data`, metric `value`)

Both issues caused silent render failures or runtime crashes.

## Test plan
- [x] Tested with ag-ui dojo — A2UI dynamic schema demo works
- [x] Tested with CopilotKit langgraph-starter — sales dashboard renders correctly
- [x] `@ag-ui/a2ui-middleware@0.0.5` published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)