### PR TITLE
fix: useInterrupt accepts optional agent instance prop

### DIFF
--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { useCopilotKit } from "../providers/CopilotKitProvider";
 import { useAgent } from "./use-agent";
+import type { AbstractAgent } from "@ag-ui/client";
 import type {
   InterruptEvent,
   InterruptRenderProps,
@@ -79,6 +80,13 @@ interface UseInterruptConfigBase<TValue = unknown, TResult = never> {
   enabled?: (event: InterruptEvent<TValue>) => boolean;
   /** Optional agent id. Defaults to the current configured chat agent. */
   agentId?: string;
+  /**
+   * Optional agent instance to subscribe to. When provided, the hook uses
+   * this instance directly instead of creating one internally via `useAgent`.
+   * This is useful in multiplexer setups where the consumer already holds
+   * the agent instance that `runAgent` will execute on.
+   */
+  agent?: AbstractAgent;
 }
 
 export interface UseInterruptInChatConfig<
@@ -183,7 +191,8 @@ export function useInterrupt<
 ): UseInterruptReturn<TRenderInChat> {
   /* eslint-enable @typescript-eslint/no-explicit-any */
   const { copilotkit } = useCopilotKit();
-  const { agent } = useAgent({ agentId: config.agentId });
+  const { agent: internalAgent } = useAgent({ agentId: config.agentId });
+  const agent = config.agent ?? internalAgent;
   const [pendingEvent, setPendingEvent] = useState<InterruptEvent | null>(null);
   const pendingEventRef = useRef(pendingEvent);
   pendingEventRef.current = pendingEvent;


### PR DESCRIPTION
## Summary

- Adds an optional `agent` prop to `useInterrupt` config so consumers can pass their own `AbstractAgent` instance
- When provided, the hook subscribes to that instance instead of creating one internally via `useAgent`
- Falls back to the existing `useAgent({ agentId })` behavior when `agent` is not provided

## Context

DocuSign uses a multiplexer pattern with multiple named agents and `copilotkit.runAgent(agent)`. When migrating from V1 to V2, they found that `useInterrupt` never fires.

**Root cause:** `useInterrupt` internally calls `useAgent({ agentId })` without a `threadId`, getting the bare registry agent. `CopilotChat` generates its own `threadId` via `randomUUID()` and gets a per-thread clone. Events fire on the clone but `useInterrupt` subscribes to the bare agent — different instances, different subscriber arrays.

**Why `useHumanInTheLoop` works fine:** It uses `useFrontendTool()` which registers tools on the global `CopilotKitCore` registry (looked up by name, not by agent instance).

**Longer-term fix:** Memoize `useAgent` by `agentId` so all callers sharing the same ID get the same singleton instance. This PR is the quick unblock.

## Usage

```tsx
const { agent } = useAgent({ agentId: "myAgent" });

useInterrupt({
  agent,              // ← pass the same instance used with runAgent
  agentId: "myAgent",
  render: ({ event, resolve }) => (
    <div>
      <p>{JSON.stringify(event.value)}</p>
      <button onClick={() => resolve({ approved: true })}>Approve</button>
    </div>
  ),
});
```

## Test plan

- [ ] Verify build passes (`nx build @copilotkit/react-core` — confirmed locally)
- [ ] Verify `useInterrupt` without `agent` prop still works as before (fallback path)
- [ ] Verify `useInterrupt` with `agent` prop subscribes to the provided instance
- [ ] Verify multiplexer pattern: `useInterrupt({ agent })` + `copilotkit.runAgent({ agent })` fires interrupts

🤖 Generated with [Claude Code](https://claude.com/claude-code)