### PR TITLE
fix: resolve 3 starter crash root causes crashing 7/17 Railway starters

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -328,6 +328,14 @@ function rewritePythonImports(filePath: string, _agentDir: string): void {
     "$1from .$2 import ",
   );
 
+  // Rewrite "from agents.X import ..." to "from .X import ..."
+  // When the demo "agents/" dir is renamed to "agent/" in starters,
+  // intra-package absolute imports break. Convert to relative imports.
+  content = content.replace(
+    /^(\s*)from agents\.([\w.]+) import /gm,
+    "$1from .$2 import ",
+  );
+
   fs.writeFileSync(filePath, content);
 }
 

--- a/showcase/shared/python/tools/search_flights.py
+++ b/showcase/shared/python/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/ag2/Dockerfile
+++ b/showcase/starters/ag2/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/ag2/agent/tools/search_flights.py
+++ b/showcase/starters/ag2/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/agno/Dockerfile
+++ b/showcase/starters/agno/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/agno/agent/tools/search_flights.py
+++ b/showcase/starters/agno/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/claude-sdk-python/Dockerfile
+++ b/showcase/starters/claude-sdk-python/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/claude-sdk-python/agent/tools/search_flights.py
+++ b/showcase/starters/claude-sdk-python/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/claude-sdk-typescript/Dockerfile
+++ b/showcase/starters/claude-sdk-typescript/Dockerfile
@@ -26,6 +26,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/crewai-crews/Dockerfile
+++ b/showcase/starters/crewai-crews/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/crewai-crews/agent/crew.py
+++ b/showcase/starters/crewai-crews/agent/crew.py
@@ -3,7 +3,7 @@ from crewai.project import CrewBase, agent, crew, task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from typing import List
 
-from agents.tools.custom_tool import (
+from .tools.custom_tool import (
     GetWeatherTool,
     QueryDataTool,
     ScheduleMeetingTool,

--- a/showcase/starters/crewai-crews/agent/tools/search_flights.py
+++ b/showcase/starters/crewai-crews/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/google-adk/Dockerfile
+++ b/showcase/starters/google-adk/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/google-adk/agent/tools/search_flights.py
+++ b/showcase/starters/google-adk/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/langgraph-fastapi/Dockerfile
+++ b/showcase/starters/langgraph-fastapi/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/search_flights.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/langgraph-python/Dockerfile
+++ b/showcase/starters/langgraph-python/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/langgraph-python/src/agents/tools/search_flights.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/langgraph-typescript/Dockerfile
+++ b/showcase/starters/langgraph-typescript/Dockerfile
@@ -26,6 +26,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langroid/Dockerfile
+++ b/showcase/starters/langroid/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/langroid/agent/agui_adapter.py
+++ b/showcase/starters/langroid/agent/agui_adapter.py
@@ -34,7 +34,7 @@ from ag_ui.core import (
 from fastapi import Request
 from fastapi.responses import StreamingResponse
 
-from agents.agent import (
+from .agent import (
     create_agent,
     ALL_TOOLS,
     BACKEND_TOOLS,

--- a/showcase/starters/langroid/agent/tools/search_flights.py
+++ b/showcase/starters/langroid/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/llamaindex/Dockerfile
+++ b/showcase/starters/llamaindex/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/llamaindex/agent/tools/search_flights.py
+++ b/showcase/starters/llamaindex/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/mastra/Dockerfile
+++ b/showcase/starters/mastra/Dockerfile
@@ -26,6 +26,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-dotnet/Dockerfile
+++ b/showcase/starters/ms-agent-dotnet/Dockerfile
@@ -36,6 +36,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-python/Dockerfile
+++ b/showcase/starters/ms-agent-python/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/ms-agent-python/agent/tools/search_flights.py
+++ b/showcase/starters/ms-agent-python/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/pydantic-ai/Dockerfile
+++ b/showcase/starters/pydantic-ai/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/pydantic-ai/agent/tools/search_flights.py
+++ b/showcase/starters/pydantic-ai/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/spring-ai/Dockerfile
+++ b/showcase/starters/spring-ai/Dockerfile
@@ -51,6 +51,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/strands/Dockerfile
+++ b/showcase/starters/strands/Dockerfile
@@ -37,6 +37,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/strands/agent/tools/search_flights.py
+++ b/showcase/starters/strands/agent/tools/search_flights.py
@@ -36,13 +36,17 @@ for _candidate in _SCHEMA_CANDIDATES:
 
 # Fallback: use the schema from the examples directory if present
 if _flight_schema is None:
-    _fallback = Path(__file__).resolve().parents[4] / (
-        "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
-    )
-    if _fallback.exists():
-        with open(_fallback) as _f:
-            _flight_schema = json.load(_f)
-        _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    try:
+        _fallback = Path(__file__).resolve().parents[4] / (
+            "examples/integrations/langgraph-python/apps/agent/src/a2ui/schemas/flight_schema.json"
+        )
+        if _fallback.exists():
+            with open(_fallback) as _f:
+                _flight_schema = json.load(_f)
+            _logger.info("Loaded flight schema from examples fallback: %s", _fallback)
+    except IndexError:
+        # In Docker the file path is too shallow for parents[4]; skip this fallback.
+        pass
 
 # Last resort: inline minimal schema
 if _flight_schema is None:

--- a/showcase/starters/template/dockerfiles/Dockerfile.dotnet
+++ b/showcase/starters/template/dockerfiles/Dockerfile.dotnet
@@ -36,6 +36,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.java
+++ b/showcase/starters/template/dockerfiles/Dockerfile.java
@@ -51,6 +51,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.python
+++ b/showcase/starters/template/dockerfiles/Dockerfile.python
@@ -35,6 +35,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 RUN mkdir -p /app/.langgraph_api && chown -R app:app /app
 USER app
 

--- a/showcase/starters/template/dockerfiles/Dockerfile.typescript
+++ b/showcase/starters/template/dockerfiles/Dockerfile.typescript
@@ -26,6 +26,7 @@ COPY entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
+RUN mkdir -p /home/app && chown app:app /home/app
 USER app
 
 EXPOSE 10000


### PR DESCRIPTION
## Summary

7 out of 17 Railway-deployed starters are returning 502 (CRASHED). Three distinct root causes:

1. **EACCES `/home/app`** (langgraph-typescript, claude-sdk-typescript, mastra) — `npx` at runtime needs a home dir for its cache, but the non-root `app` user was created with `--no-create-home`. Fix: `mkdir -p /home/app && chown app:app /home/app` in all 4 Dockerfile templates.

2. **IndexError `Path.parents[4]`** (agno, claude-sdk-python, ms-agent-python) — `search_flights.py` schema fallback accesses `parents[4]` but Docker path `/app/agent/tools/search_flights.py` only has 4 parents (0-3). Fix: wrap in try/except IndexError in shared source + regenerate.

3. **Wrong import path** (langroid, crewai-crews) — `from agents.X import` but starters use `agent/` (singular). `rewritePythonImports()` in generate-starters.ts now converts these to relative imports.

All fixes applied to upstream sources (templates, shared python, generation script) so drift check passes.

## Test plan

- [x] 251 generate-starters tests pass
- [x] Drift check passes (`--check`)
- [x] Pre-commit hooks pass (lint, format, unit tests)
- [ ] Deploy to Railway and verify all 17 starters return 200