### PR TITLE
feat: deployed starter smoke tests + rendered-tools assertion

### DIFF
--- a/.github/workflows/starter_deployed_smoke.yml
+++ b/.github/workflows/starter_deployed_smoke.yml
@@ -1,0 +1,90 @@
+name: Starter Deployed Smoke Tests
+
+on:
+  schedule:
+    # Every 6 hours — primary safety net for deployed starters
+    - cron: "0 */6 * * *"
+  workflow_run:
+    workflows: ["Showcase: Build & Deploy"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      starter_slug:
+        description: "Optional: test a single starter slug"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+  issues: write
+
+jobs:
+  starter-deployed-smoke:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          lfs: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install test dependencies
+        run: npm ci
+        working-directory: showcase/tests
+
+      - name: Install Playwright
+        working-directory: showcase/tests
+        run: npx playwright install chromium --with-deps
+
+      - name: Run starter deployed smoke tests
+        working-directory: showcase/tests
+        run: npx playwright test e2e/integration-smoke.spec.ts --grep "@starter-health|@starter-agent|@starter-chat"
+        env:
+          STARTER_SLUG: ${{ inputs.starter_slug || '' }}
+
+      - name: Build Slack payload
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        run: |
+          URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          jq -n --arg text ":rotating_light: *Starter Deployed Smoke Test Failed*\n<$URL|View run>" \
+            '{text: $text}' > /tmp/slack-payload.json
+
+      - name: Alert Slack on failure
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        uses: slackapi/slack-github-action@v2.1.0
+        continue-on-error: true
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload-file-path: /tmp/slack-payload.json
+
+      - name: Create GitHub issue on failure
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Starter deployed smoke test failure - ${new Date().toISOString().split('T')[0]}`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'starter-health',
+              state: 'open',
+            });
+            const existing = issues.find(i => i.title === title);
+            if (!existing) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                labels: ['starter-health'],
+                body: `Automated starter deployed smoke test failed.\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+              });
+            }

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -380,7 +380,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -391,6 +395,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/langgraph-python",
         "demo_url": "https://showcase-starter-langgraph-python-production-3f57.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/langgraph-python my-copilotkit-app"
       },
       "features": [
@@ -409,7 +414,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -417,7 +424,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -425,7 +434,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -433,7 +444,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -441,7 +454,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -449,7 +464,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -457,7 +474,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -465,7 +484,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -473,7 +494,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -497,7 +520,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -508,6 +535,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/langgraph-typescript",
         "demo_url": "https://showcase-starter-langgraph-typescript-production-25ca.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/langgraph-typescript my-copilotkit-app"
       },
       "features": [
@@ -526,7 +554,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -534,7 +564,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -542,7 +574,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -550,7 +584,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -558,7 +594,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -566,7 +604,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -574,7 +614,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -582,7 +624,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -590,7 +634,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -614,7 +660,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -625,6 +675,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/langgraph-fastapi",
         "demo_url": "https://showcase-starter-langgraph-fastapi-production-c7d2.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/langgraph-fastapi my-copilotkit-app"
       },
       "features": [
@@ -643,7 +694,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -651,7 +704,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -659,7 +714,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -667,7 +724,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -675,7 +734,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -683,7 +744,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -691,7 +754,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -699,7 +764,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -707,7 +774,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -731,13 +800,18 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/google-adk",
         "demo_url": "https://showcase-starter-google-adk-production-a56a.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/google-adk my-copilotkit-app"
       },
       "features": [
@@ -756,7 +830,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -764,7 +840,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -772,7 +850,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -780,7 +860,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -788,7 +870,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -796,7 +880,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -804,7 +890,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -812,7 +900,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -820,7 +910,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -844,7 +936,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -855,6 +951,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/mastra",
         "demo_url": "https://showcase-starter-mastra-production-3a00.up.railway.app",
+        "deployed": false,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/mastra my-copilotkit-app"
       },
       "features": [
@@ -873,7 +970,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -881,7 +980,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -889,7 +990,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -897,7 +1000,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -905,7 +1010,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -913,7 +1020,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -921,7 +1030,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -929,7 +1040,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -937,7 +1050,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -961,7 +1076,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -972,6 +1091,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/crewai-crews",
         "demo_url": "https://showcase-starter-crewai-crews-production-ad85.up.railway.app",
+        "deployed": false,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/crewai-crews my-copilotkit-app"
       },
       "features": [
@@ -990,7 +1110,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -998,7 +1120,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1006,7 +1130,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1014,7 +1140,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1022,7 +1150,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1030,7 +1160,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1038,7 +1170,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1046,7 +1180,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1054,7 +1190,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1078,13 +1216,18 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/pydantic-ai",
         "demo_url": "https://showcase-starter-pydantic-ai-production-cf5b.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/pydantic-ai my-copilotkit-app"
       },
       "features": [
@@ -1103,7 +1246,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1111,7 +1256,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1119,7 +1266,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1127,7 +1276,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1135,7 +1286,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1143,7 +1296,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1151,7 +1306,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1159,7 +1316,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1167,7 +1326,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1191,7 +1352,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1208,7 +1373,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1216,7 +1383,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1224,7 +1393,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1232,7 +1403,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1240,7 +1413,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1248,7 +1423,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1256,7 +1433,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1264,7 +1443,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1272,7 +1453,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1283,6 +1466,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/claude-sdk-python",
         "demo_url": "https://showcase-starter-claude-sdk-python-production.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/claude-sdk-python my-copilotkit-app"
       }
     },
@@ -1304,7 +1488,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1321,7 +1509,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1329,7 +1519,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1337,7 +1529,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1345,7 +1539,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1353,7 +1549,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1361,7 +1559,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1369,7 +1569,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1377,7 +1579,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1385,7 +1589,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1396,6 +1602,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/claude-sdk-typescript",
         "demo_url": "https://showcase-starter-claude-sdk-typescript-production.up.railway.app",
+        "deployed": false,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/claude-sdk-typescript my-copilotkit-app"
       }
     },
@@ -1417,13 +1624,18 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/agno",
         "demo_url": "https://showcase-starter-agno-production-359f.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/agno my-copilotkit-app"
       },
       "features": [
@@ -1442,7 +1654,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1450,7 +1664,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1458,7 +1674,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1466,7 +1684,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1474,7 +1694,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1482,7 +1704,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1490,7 +1714,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1498,7 +1724,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1506,7 +1734,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1534,7 +1764,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1551,7 +1785,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1559,7 +1795,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1567,7 +1805,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1575,7 +1815,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1583,7 +1825,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1591,7 +1835,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1599,7 +1845,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1607,7 +1855,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1615,7 +1865,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1626,6 +1878,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/ag2",
         "demo_url": "https://showcase-starter-ag2-production.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/ag2 my-copilotkit-app"
       },
       "managed_platform": {
@@ -1651,13 +1904,18 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/llamaindex",
         "demo_url": "https://showcase-starter-llamaindex-production-78fe.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/llamaindex my-copilotkit-app"
       },
       "features": [
@@ -1676,7 +1934,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1684,7 +1944,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1692,7 +1954,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1700,7 +1964,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1708,7 +1974,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1716,7 +1984,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1724,7 +1994,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1732,7 +2004,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1740,7 +2014,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1768,13 +2044,18 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/strands",
         "demo_url": "https://showcase-starter-strands-production-1114.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/strands my-copilotkit-app"
       },
       "features": [
@@ -1793,7 +2074,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1801,7 +2084,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1809,7 +2094,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1817,7 +2104,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1825,7 +2114,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1833,7 +2124,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1841,7 +2134,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1849,7 +2144,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1857,7 +2154,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1881,7 +2180,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1898,7 +2201,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1906,7 +2211,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1914,7 +2221,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1922,7 +2231,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1930,7 +2241,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1938,7 +2251,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1946,7 +2261,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1954,7 +2271,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1962,7 +2281,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1973,6 +2294,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/langroid",
         "demo_url": "https://showcase-starter-langroid-production.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/langroid my-copilotkit-app"
       }
     },
@@ -1994,13 +2316,18 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/ms-agent-python",
         "demo_url": "https://showcase-starter-ms-agent-python-production-d140.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/ms-agent-python my-copilotkit-app"
       },
       "features": [
@@ -2019,7 +2346,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2027,7 +2356,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2035,7 +2366,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2043,7 +2376,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2051,7 +2386,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2059,7 +2396,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2067,7 +2406,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2075,7 +2416,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2083,7 +2426,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2107,13 +2452,18 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/ms-agent-dotnet",
         "demo_url": "https://showcase-starter-ms-agent-dotnet-production-b8cf.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/ms-agent-dotnet my-copilotkit-app"
       },
       "features": [
@@ -2132,7 +2482,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2140,7 +2492,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2148,7 +2502,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2156,7 +2512,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2164,7 +2522,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2172,7 +2532,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2180,7 +2542,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2188,7 +2552,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2196,7 +2562,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2220,7 +2588,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl",
@@ -2237,7 +2609,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2245,7 +2619,9 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2253,7 +2629,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2261,7 +2639,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2269,7 +2649,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2277,7 +2659,9 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2285,7 +2669,9 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2293,7 +2679,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2301,7 +2689,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2312,6 +2702,7 @@
         "description": "Full-featured sales pipeline with 5 GenUI rendering strategies",
         "github_url": "https://github.com/CopilotKit/CopilotKit/tree/main/showcase/starters/spring-ai",
         "demo_url": "https://showcase-starter-spring-ai-production.up.railway.app",
+        "deployed": true,
         "clone_command": "npx degit CopilotKit/CopilotKit/showcase/starters/spring-ai my-copilotkit-app"
       }
     }

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -380,11 +380,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -414,9 +410,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -424,9 +418,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -434,9 +426,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -444,9 +434,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -454,9 +442,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -464,9 +450,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -474,9 +458,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -484,9 +466,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -494,9 +474,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -520,11 +498,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -554,9 +528,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -564,9 +536,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -574,9 +544,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -584,9 +552,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -594,9 +560,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -604,9 +568,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -614,9 +576,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -624,9 +584,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -634,9 +592,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -660,11 +616,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -694,9 +646,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -704,9 +654,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -714,9 +662,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -724,9 +670,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -734,9 +678,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -744,9 +686,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -754,9 +694,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -764,9 +702,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -774,9 +710,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -800,11 +734,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -830,9 +760,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -840,9 +768,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -850,9 +776,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -860,9 +784,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -870,9 +792,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -880,9 +800,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -890,9 +808,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -900,9 +816,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -910,9 +824,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -936,11 +848,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -970,9 +878,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -980,9 +886,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -990,9 +894,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1000,9 +902,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1010,9 +910,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1020,9 +918,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1030,9 +926,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1040,9 +934,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1050,9 +942,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1076,11 +966,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1110,9 +996,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1120,9 +1004,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1130,9 +1012,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1140,9 +1020,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1150,9 +1028,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1160,9 +1036,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1170,9 +1044,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1180,9 +1052,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1190,9 +1060,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1216,11 +1084,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1246,9 +1110,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1256,9 +1118,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1266,9 +1126,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1276,9 +1134,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1286,9 +1142,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1296,9 +1150,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1306,9 +1158,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1316,9 +1166,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1326,9 +1174,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1352,11 +1198,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1373,9 +1215,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1383,9 +1223,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1393,9 +1231,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1403,9 +1239,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1413,9 +1247,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1423,9 +1255,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1433,9 +1263,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1443,9 +1271,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1453,9 +1279,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1488,11 +1312,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1509,9 +1329,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1519,9 +1337,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1529,9 +1345,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1539,9 +1353,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1549,9 +1361,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1559,9 +1369,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1569,9 +1377,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1579,9 +1385,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1589,9 +1393,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1624,11 +1426,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -1654,9 +1452,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1664,9 +1460,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1674,9 +1468,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1684,9 +1476,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1694,9 +1484,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1704,9 +1492,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1714,9 +1500,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1724,9 +1508,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1734,9 +1516,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1764,11 +1544,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -1785,9 +1561,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1795,9 +1569,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1805,9 +1577,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1815,9 +1585,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1825,9 +1593,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1835,9 +1601,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1845,9 +1609,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -1855,9 +1617,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1865,9 +1625,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1904,11 +1662,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -1934,9 +1688,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1944,9 +1696,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1954,9 +1704,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1964,9 +1712,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1974,9 +1720,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1984,9 +1728,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -1994,9 +1736,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2004,9 +1744,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2014,9 +1752,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2044,11 +1780,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2074,9 +1806,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2084,9 +1814,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2094,9 +1822,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2104,9 +1830,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2114,9 +1838,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2124,9 +1846,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2134,9 +1854,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2144,9 +1862,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2154,9 +1870,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2180,11 +1894,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -2201,9 +1911,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2211,9 +1919,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2221,9 +1927,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2231,9 +1935,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2241,9 +1943,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2251,9 +1951,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2261,9 +1959,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2271,9 +1967,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2281,9 +1975,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2316,11 +2008,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -2346,9 +2034,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2356,9 +2042,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2366,9 +2050,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2376,9 +2058,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2386,9 +2066,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2396,9 +2074,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2406,9 +2082,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2416,9 +2090,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2426,9 +2098,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2452,11 +2122,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -2482,9 +2148,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2492,9 +2156,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2502,9 +2164,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2512,9 +2172,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2522,9 +2180,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2532,9 +2188,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2542,9 +2196,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2552,9 +2204,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2562,9 +2212,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2588,11 +2236,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl",
@@ -2609,9 +2253,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2619,9 +2261,7 @@
           "id": "hitl",
           "name": "Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2629,9 +2269,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2639,9 +2277,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2649,9 +2285,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2659,9 +2293,7 @@
           "id": "shared-state-read",
           "name": "Shared State (Reading)",
           "description": "Reading agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read",
           "animated_preview_url": null
         },
@@ -2669,9 +2301,7 @@
           "id": "shared-state-write",
           "name": "Shared State (Writing)",
           "description": "Writing to agent state from UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-write",
           "animated_preview_url": null
         },
@@ -2679,9 +2309,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2689,9 +2317,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }

--- a/showcase/tests/e2e/helpers.ts
+++ b/showcase/tests/e2e/helpers.ts
@@ -35,44 +35,55 @@ export interface ChatResult {
 
 /**
  * Try multiple health endpoint paths, return the first that responds 200.
+ * Supports retries with delay for cold-start scenarios (e.g. Railway starters).
  */
 export async function checkHealth(
   request: APIRequestContext,
   baseUrl: string,
   paths: string[] = ["/api/health", "/health"],
+  retries: number = 0,
+  retryDelayMs: number = 15_000,
 ): Promise<HealthCheckResult> {
-  for (const path of paths) {
-    try {
-      const res = await request.get(`${baseUrl}${path}`, {
-        timeout: 15_000,
-      });
-      if (res.ok()) {
-        return {
-          ok: true,
+  let lastResult: HealthCheckResult = {
+    ok: false,
+    status: 0,
+    path: paths[0],
+    body: "no attempts made",
+  };
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    for (const path of paths) {
+      try {
+        const res = await request.get(`${baseUrl}${path}`, {
+          timeout: 15_000,
+        });
+        if (res.ok()) {
+          return {
+            ok: true,
+            status: res.status(),
+            path,
+            body: await res.text(),
+          };
+        }
+        lastResult = {
+          ok: false,
           status: res.status(),
           path,
           body: await res.text(),
         };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        lastResult = { ok: false, status: 0, path, body: msg };
       }
-    } catch {
-      // try next path
+    }
+
+    // If we have retries left, wait before the next attempt
+    if (attempt < retries) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
   }
-  // All paths failed — report the first one tried
-  try {
-    const res = await request.get(`${baseUrl}${paths[0]}`, {
-      timeout: 10_000,
-    });
-    return {
-      ok: false,
-      status: res.status(),
-      path: paths[0],
-      body: await res.text(),
-    };
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return { ok: false, status: 0, path: paths[0], body: msg };
-  }
+
+  return lastResult;
 }
 
 // ---------------------------------------------------------------------------

--- a/showcase/tests/e2e/integration-smoke.spec.ts
+++ b/showcase/tests/e2e/integration-smoke.spec.ts
@@ -16,6 +16,7 @@
 
 import { test, expect } from "@playwright/test";
 import { checkHealth, checkAgentEndpoint, sendChatMessage } from "./helpers";
+import registry from "../../shell/src/data/registry.json";
 
 // ---------------------------------------------------------------------------
 // Integration registry — source of truth: showcase/shell/src/data/registry.json
@@ -200,10 +201,10 @@ const INTEGRATIONS: Integration[] = [
 ];
 
 // Only test deployed integrations unless SMOKE_ALL=true
-const DEPLOYED_ONLY = process.env.SMOKE_ALL !== "true";
-const activeIntegrations = DEPLOYED_ONLY
-  ? INTEGRATIONS.filter((i) => i.deployed)
-  : INTEGRATIONS;
+const SMOKE_ALL = process.env.SMOKE_ALL === "true";
+const activeIntegrations = SMOKE_ALL
+  ? INTEGRATIONS
+  : INTEGRATIONS.filter((i) => i.deployed);
 
 // ---------------------------------------------------------------------------
 // Level 1: Health checks (@health) — fast, API-only
@@ -315,6 +316,124 @@ test.describe("Level 4: Tool Rendering @tools", () => {
         hasWeatherContent,
         `${integration.slug} response doesn't contain weather info: "${result.responseText}"`,
       ).toBe(true);
+
+      // Check for rendered components (not just text) — catches the query_data
+      // loop bug where the agent returns text but never renders a chart/card.
+      const responseArea = page
+        .locator('[data-testid="copilot-assistant-message"]')
+        .last();
+      const checks = await Promise.all([
+        responseArea
+          .locator(".recharts-wrapper")
+          .first()
+          .isVisible()
+          .catch(() => false),
+        responseArea
+          .locator("svg circle[stroke-dasharray]")
+          .first()
+          .isVisible()
+          .catch(() => false),
+        responseArea
+          .locator('[data-testid="weather-card"]')
+          .first()
+          .isVisible()
+          .catch(() => false),
+        responseArea
+          .locator("canvas")
+          .first()
+          .isVisible()
+          .catch(() => false),
+      ]);
+      const hasRenderedComponent = checks.some(Boolean);
+
+      // Warning for now — upgrade to hard failure after data-testid convention
+      // is established across all integrations
+      if (!hasRenderedComponent) {
+        console.warn(
+          `\u26a0\ufe0f ${integration.slug}: Tool response contains text but no rendered chart/weather component. This would have missed the query_data loop bug.`,
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Deployed Starters: L1-L3 smoke tests (@starter-health, @starter-agent, @starter-chat)
+// ---------------------------------------------------------------------------
+
+interface Starter {
+  slug: string;
+  name: string;
+  demoUrl: string;
+}
+
+type RegistryIntegration = (typeof registry)["integrations"][number];
+
+const STARTER_SLUG = process.env.STARTER_SLUG;
+
+const STARTERS: Starter[] = registry.integrations
+  .filter(
+    (i): i is RegistryIntegration & {
+      starter: NonNullable<RegistryIntegration["starter"]>;
+    } =>
+      Boolean(i.starter?.demo_url) &&
+      (!STARTER_SLUG || i.slug === STARTER_SLUG) &&
+      (SMOKE_ALL || i.starter?.deployed === true),
+  )
+  .map((i) => ({
+    slug: i.slug,
+    name: i.starter.name,
+    demoUrl: i.starter.demo_url,
+  }));
+
+test.describe("Deployed Starters", () => {
+  for (const starter of STARTERS) {
+    // Single test per starter so L2/L3 are naturally skipped when L1 fails.
+    // (fullyParallel: true in playwright.config.ts overrides describe.configure serial mode)
+    test(`[Starter] ${starter.slug} deployed smoke @starter-health @starter-agent @starter-chat`, async ({
+      request,
+      page,
+    }) => {
+      // L1: Health — 3 retries with 15s delay to handle Railway cold starts
+      const health = await checkHealth(
+        request,
+        starter.demoUrl,
+        undefined,
+        3,
+        15_000,
+      );
+      expect(
+        health.ok,
+        `${starter.slug} starter health check failed: status=${health.status} path=${health.path} body=${health.body.slice(0, 500)}`,
+      ).toBe(true);
+
+      // L2: Agent endpoint reachability
+      const agent = await checkAgentEndpoint(request, starter.demoUrl);
+      expect(
+        agent.status,
+        `${starter.slug} starter agent endpoint returned 404. Status=${agent.status} body=${agent.body.slice(0, 500)}`,
+      ).not.toBe(404);
+      expect(
+        agent.ok,
+        `${starter.slug} starter agent endpoint is unreachable: status=${agent.status} body=${agent.body.slice(0, 500)}`,
+      ).toBe(true);
+
+      // L3: Round-trip chat
+      test.slow(); // Allow extra time for cold starts
+      const chat = await sendChatMessage(
+        page,
+        starter.demoUrl,
+        "Hello",
+        "/",
+      );
+      expect(
+        chat.gotResponse,
+        `${starter.slug} starter did not produce an assistant response.`,
+      ).toBe(true);
+      expect(
+        chat.responseText.length,
+        `${starter.slug} starter assistant response was empty`,
+      ).toBeGreaterThan(0);
     });
   }
 });

--- a/showcase/tests/e2e/integration-smoke.spec.ts
+++ b/showcase/tests/e2e/integration-smoke.spec.ts
@@ -373,7 +373,9 @@ const STARTER_SLUG = process.env.STARTER_SLUG;
 
 const STARTERS: Starter[] = registry.integrations
   .filter(
-    (i): i is RegistryIntegration & {
+    (
+      i,
+    ): i is RegistryIntegration & {
       starter: NonNullable<RegistryIntegration["starter"]>;
     } =>
       Boolean(i.starter?.demo_url) &&
@@ -420,12 +422,7 @@ test.describe("Deployed Starters", () => {
 
       // L3: Round-trip chat
       test.slow(); // Allow extra time for cold starts
-      const chat = await sendChatMessage(
-        page,
-        starter.demoUrl,
-        "Hello",
-        "/",
-      );
+      const chat = await sendChatMessage(page, starter.demoUrl, "Hello", "/");
       expect(
         chat.gotResponse,
         `${starter.slug} starter did not produce an assistant response.`,


### PR DESCRIPTION
## Summary

- Add deployed starter L1-L3 smoke tests to `integration-smoke.spec.ts` (health, agent endpoint, chat round-trip) hitting live Railway `demo_url`s from `registry.json`
- Upgrade existing L4 `@tools` test with DOM element assertion (`Promise.all` + `.some()`) to catch bugs like the `query_data` agent loop that produced text but never rendered charts
- Add `deployed` boolean field to all 17 starter objects in `registry.json` (14 healthy, 3 currently down)
- New `starter_deployed_smoke.yml` CI workflow: 6h cron + post-deploy trigger + manual dispatch, with Slack/GitHub issue alerting on failure

### Context

7+ starters were crashing on Railway for hours with no automated detection. The existing test suite only covered integration backends — starters had zero deployed-URL testing. The `agent-looping-on-query_data` bug shipped undetected because L4 only checked text keywords, not rendered components.

### Key design decisions

- URLs read dynamically from `registry.json` (not hardcoded) — new starters auto-tested
- `deployed` field gates which starters run (opt-in via `=== true`), with `SMOKE_ALL` override
- Single-test-per-starter pattern avoids `fullyParallel` config overriding serial mode
- Rendered-tools check is a warning (not hard failure) pending data-testid standardization
- `STARTER_SLUG` env var supports single-starter manual dispatch filtering

### Spec

https://www.notion.so/copilotkit/3433aa3818528112b2b6f65a4fab92d4

## Test plan

- [ ] Verify `@starter-health` tests pass against the 14 deployed starters
- [ ] Verify `@starter-agent` tests pass against deployed starters
- [ ] Verify `@starter-chat` tests produce assistant responses on deployed starters
- [ ] Verify 3 non-deployed starters (mastra, crewai-crews, claude-sdk-typescript) are skipped by default
- [ ] Verify `SMOKE_ALL=true` includes non-deployed starters
- [ ] Verify `STARTER_SLUG=langgraph-python` filters to a single starter
- [ ] Verify rendered-tools warning fires for integrations without chart components
- [ ] Verify CI workflow triggers correctly on manual dispatch
- [ ] Verify Slack + GitHub issue creation on failure path

🤖 Generated with [Claude Code](https://claude.com/claude-code)