### PR TITLE
fix: context-aware Python import rewriting for tools/ directory

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -333,12 +333,23 @@ function rewritePythonImports(filePath: string, _agentDir: string): void {
   // Clean up multiple blank lines
   content = content.replace(/\n{3,}/g, "\n\n");
 
-  // Rewrite "from tools import ..." to "from .tools import ..."
-  content = content.replace(/^from tools import /gm, "from .tools import ");
-  content = content.replace(
-    /^from tools\.(\w+) import /gm,
-    "from .tools.$1 import ",
-  );
+  // Rewrite "from tools import ..." — context-dependent:
+  // Files inside tools/ directory: "from tools import X" → "from . import X"
+  // Files outside tools/ directory: "from tools import X" → "from .tools import X"
+  const isInsideToolsDir = filePath.includes("/tools/");
+  if (isInsideToolsDir) {
+    content = content.replace(/^from tools import /gm, "from . import ");
+    content = content.replace(
+      /^from tools\.(\w+) import /gm,
+      "from .$1 import ",
+    );
+  } else {
+    content = content.replace(/^from tools import /gm, "from .tools import ");
+    content = content.replace(
+      /^from tools\.(\w+) import /gm,
+      "from .tools.$1 import ",
+    );
+  }
 
   // Rewrite "from src.agents.X import ..." to "from .X import ..."
   // This handles main.py style imports like "from src.agents.tools import ..."

--- a/showcase/starters/crewai-crews/agent/tools/custom_tool.py
+++ b/showcase/starters/crewai-crews/agent/tools/custom_tool.py
@@ -12,7 +12,7 @@ from crewai.tools import BaseTool
 from typing import Type
 from pydantic import BaseModel, Field
 
-from .tools import (
+from . import (
     get_weather_impl,
     query_data_impl,
     schedule_meeting_impl,


### PR DESCRIPTION
## Summary

Fixes crewai-crews starter crash: `ModuleNotFoundError: No module named 'agent.tools.tools'`.

The import rewriter rewrites `from tools import X` to `from .tools import X`. Correct for files at agent root, wrong for files *inside* `tools/` — there `.tools` resolves to `tools/tools` (non-existent). Fix: context-aware rewrite using `from . import X` for files inside tools/.

Verified locally with Docker build + import test.

## Test plan

- [x] Docker build + import succeeds
- [x] 502 tests pass, drift check passes
- [ ] Deploy and verify crewai-crews returns 200