### PR TITLE
fix(adk): add AGUIToolset to agent tools so client tools are available

### DIFF
--- a/examples/integrations/adk/agent/main.py
+++ b/examples/integrations/adk/agent/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Dict, Optional
 
-from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
+from ag_ui_adk import ADKAgent, AGUIToolset, add_adk_fastapi_endpoint
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from google.adk.agents import LlmAgent
@@ -166,7 +166,7 @@ proverbs_agent = LlmAgent(
         - "Whats the weather right now" → Use the location "Everywhere ever in the whole wide world"
         - Is it raining in London? → Use the tool with the location "London"
         """,
-    tools=[set_proverbs, get_weather],
+    tools=[set_proverbs, get_weather, AGUIToolset()],
     before_agent_callback=on_before_agent,
     before_model_callback=before_model_modifier,
     after_model_callback=simple_after_model_modifier,

--- a/examples/showcases/adk-dashboard/agent/agent.py
+++ b/examples/showcases/adk-dashboard/agent/agent.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 # ADK imports
-from ag_ui_adk import ADKAgent
+from ag_ui_adk import ADKAgent, AGUIToolset
 from google.adk.agents import Agent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.tools import google_search, FunctionTool
@@ -32,7 +32,7 @@ search_agent = Agent(
 dashboard_agent = Agent(
   name="DashboardAgent",
   model="gemini-2.5-flash",
-  tools=tools + [AgentTool(agent=search_agent)],
+  tools=tools + [AgentTool(agent=search_agent), AGUIToolset()],
 
   # run-loop modifiers
   before_agent_callback=on_before_agent,


### PR DESCRIPTION
## Summary

- `ag_ui_adk` v0.5+ requires `AGUIToolset()` to be explicitly in an agent's tools list — it's replaced at runtime with a `ClientProxyToolset` that proxies frontend tools (`useFrontendTool`, `useCopilotAction`) from the browser
- Both ADK examples were added to the repo after this became required and were never updated, so client tools silently did nothing when triggered from the UI
- Adds `AGUIToolset()` to `examples/integrations/adk` (fixes `setThemeColor`) and `examples/showcases/adk-dashboard` (fixes chart/search tools)

## Why no regression test

AIMock is not properly wired to the Gemini API in the ADK `docker-compose.test.yml` — the `@chat` smoke test currently passes as a false positive (agent throws `RUN_ERROR`, test reads the catch-all error text). A proper regression test requires fixing the AIMock routing first, tracked in [CPK-7399](https://linear.app/copilotkit/issue/CPK-7399/adk-smoke-tests-pass-as-false-positive-aimock-not-wired-to-gemini-api).

## Test plan

- [ ] Run `examples/integrations/adk` locally, ask agent to "Set the theme to green" — background color should change
- [ ] Run `examples/showcases/adk-dashboard` locally, ask agent to show a chart — chart component should render

🤖 Generated with [Claude Code](https://claude.com/claude-code)