### PR TITLE
fix(sdk-python): propagate context and properties into LangGraph agent state

### DIFF
--- a/docs/content/docs/integrations/langgraph/shared-state/context-and-properties.mdx
+++ b/docs/content/docs/integrations/langgraph/shared-state/context-and-properties.mdx
@@ -1,0 +1,96 @@
+---
+title: Context & Properties
+icon: "lucide/PackageOpen"
+description: Access useCopilotReadable context and CopilotKit properties inside your Python agent.
+---
+
+## What is this?
+
+CopilotKit injects two framework-provided fields into your agent's LangGraph state under the
+`copilotkit` key. Both are always available — you don't need to declare them in your state schema.
+
+| Field | Source | Shape |
+|-------|--------|-------|
+| `state["copilotkit"]["context"]` | `useCopilotReadable()` items registered on the frontend | `list[{"value": str, ...}]` |
+| `state["copilotkit"]["properties"]` | `<CopilotKit properties={...} />` on the frontend | `dict[str, Any]` |
+
+## `copilotkit.context` — readable context items
+
+When you call `useCopilotReadable` on the frontend, CopilotKit sends those items to the agent as
+a list of objects with a `"value"` key.
+
+**Frontend**
+```tsx
+useCopilotReadable({
+  description: "Current user",
+  value: "Alice, premium plan, UTC timezone",
+});
+```
+
+**Agent (Python)**
+```python
+def my_node(state: AgentState, config: RunnableConfig):
+    context_entries = state.get("copilotkit", {}).get("context", [])
+    context_text = "\n".join(
+        entry["value"]
+        for entry in context_entries
+        if isinstance(entry, dict) and entry.get("value")
+    )
+    # Use context_text in your system prompt, tool call, etc.
+```
+
+## `copilotkit.properties` — app-level properties
+
+Properties set on the `<CopilotKit>` component are forwarded as a plain dict.
+
+**Frontend**
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  properties={{ appVersion: "2.1", featureFlags: { darkMode: true } }}
+>
+  {children}
+</CopilotKit>
+```
+
+**Agent (Python)**
+```python
+def my_node(state: AgentState, config: RunnableConfig):
+    properties = state.get("copilotkit", {}).get("properties", {})
+    app_version = properties.get("appVersion")
+    feature_flags = properties.get("featureFlags", {})
+```
+
+## Complete example
+
+```python
+from langchain_core.messages import SystemMessage
+from langchain_openai import ChatOpenAI
+
+def chat_node(state: AgentState, config: RunnableConfig):
+    # Build system prompt from readable context
+    context_entries = state.get("copilotkit", {}).get("context", [])
+    context_text = "\n".join(
+        entry["value"] for entry in context_entries if entry.get("value")
+    )
+
+    # Personalise based on app properties
+    properties = state.get("copilotkit", {}).get("properties", {})
+    user_plan = properties.get("plan", "free")
+
+    system = f"""You are a helpful assistant.
+User plan: {user_plan}
+
+Context:
+{context_text}"""
+
+    model = ChatOpenAI(model="gpt-4o-mini")
+    response = model.invoke([SystemMessage(content=system), *state["messages"]], config)
+    return {"messages": response}
+```
+
+<Callout type="info">
+  `copilotkit` is a reserved key — CopilotKit always writes `context`, `actions`, and
+  `properties` into it before your graph runs. Do not declare a custom state field named
+  `copilotkit`, as it will be overwritten.
+</Callout>

--- a/docs/content/docs/integrations/langgraph/shared-state/meta.json
+++ b/docs/content/docs/integrations/langgraph/shared-state/meta.json
@@ -2,6 +2,7 @@
     "pages": [
         "in-app-agent-read",
         "in-app-agent-write",
+        "context-and-properties",
         "state-inputs-outputs",
         "predictive-state-updates"
     ]

--- a/sdk-python/copilotkit/langgraph_agent.py
+++ b/sdk-python/copilotkit/langgraph_agent.py
@@ -111,12 +111,13 @@ def langgraph_default_merge_state( # pylint: disable=unused-argument
 
     new_messages = [message for message in messages if message.id not in existing_message_ids]
 
+    # Preserve any existing copilotkit keys (e.g. context, properties) from the
+    # incoming state, then overwrite actions with the freshly-resolved list.
+    incoming_copilotkit = state.get("copilotkit", {})
     return {
         **state,
         "messages": new_messages,
-        "copilotkit": {
-            "actions": actions
-        }
+        "copilotkit": {**incoming_copilotkit, "actions": actions},
     }
 
 
@@ -231,6 +232,7 @@ class LangGraphAgent(Agent):
             thread_id: str,
             actions: Optional[List[ActionDict]] = None,
             meta_events: Optional[List[MetaEvent]] = None,
+            context: Optional[Any] = None,
             **kwargs
     ):
         node_name = kwargs.get("node_name")
@@ -242,7 +244,8 @@ class LangGraphAgent(Agent):
             actions=actions,
             thread_id=thread_id,
             node_name=node_name,
-            meta_events=meta_events
+            meta_events=meta_events,
+            context=context,
         )
 
     async def prepare_stream( # pylint: disable=too-many-arguments
@@ -256,8 +259,12 @@ class LangGraphAgent(Agent):
             actions: Optional[List[ActionDict]] = None,
             node_name: Optional[str] = None,
             meta_events: Optional[List[MetaEvent]] = None,
+            context: Optional[Any] = None,
     ):
         active_interrupts = agent_state.tasks[0].interrupts if agent_state.tasks and agent_state.tasks[0].interrupts else None
+        # Snapshot copilotkit.context from the original incoming state before any mutation,
+        # so we can restore it after merge_state (which would otherwise clobber it).
+        incoming_copilotkit_context = (state_input or {}).get("copilotkit", {}).get("context", [])
         state_input["messages"] = agent_state.values.get("messages", [])
         current_graph_state = agent_state.values
         langchain_messages = self.convert_messages(messages)
@@ -267,6 +274,12 @@ class LangGraphAgent(Agent):
             actions=actions,
             agent_name=self.name
         )
+        # Ensure copilotkit.context and copilotkit.properties are always present.
+        # merge_state implementations (including custom ones) may rebuild the copilotkit
+        # dict without these keys, so we inject them explicitly here.
+        state.setdefault("copilotkit", {})
+        state["copilotkit"]["context"] = incoming_copilotkit_context
+        state["copilotkit"]["properties"] = context["properties"] if context is not None else {}
         # Only update graph state with keys that merge_state explicitly produced,
         # not keys that were simply passed through from state_input unchanged.
         # This preserves graph-owned state keys that the frontend may have sent stale values for.
@@ -328,7 +341,8 @@ class LangGraphAgent(Agent):
             state: Any,
             config: Optional[dict] = None,
             actions: Optional[List[ActionDict]] = None,
-            message_checkpoint: HumanMessage
+            message_checkpoint: HumanMessage,
+            context: Optional[Any] = None,
     ):
         thread_id = config.get("configurable", {}).get("thread_id")
         time_travel_checkpoint = await self.get_checkpoint_before_message(message_checkpoint.id, thread_id)
@@ -341,12 +355,17 @@ class LangGraphAgent(Agent):
             as_node=time_travel_checkpoint.next[0] if time_travel_checkpoint.next else "__start__"
         )
 
+        # Snapshot context from the current request state (not the checkpoint, which may be stale).
+        incoming_copilotkit_context = (state or {}).get("copilotkit", {}).get("context", [])
         stream_input = cast(Callable, self.merge_state)(
             state=time_travel_checkpoint.values,
             messages=[message_checkpoint],
             actions=actions,
             agent_name=self.name
         )
+        stream_input.setdefault("copilotkit", {})
+        stream_input["copilotkit"]["context"] = incoming_copilotkit_context
+        stream_input["copilotkit"]["properties"] = context["properties"] if context is not None else {}
         stream = self.graph.astream_events(stream_input, fork, version="v2")
         return {
             "stream": stream,
@@ -365,6 +384,7 @@ class LangGraphAgent(Agent):
             actions: Optional[List[ActionDict]] = None,
             node_name: Optional[str] = None,
             meta_events: Optional[List[MetaEvent]] = None,
+            context: Optional[Any] = None,
         ):
         default_config = ensure_config(cast(Any, self.langgraph_config.copy()) if self.langgraph_config else {}) # pylint: disable=line-too-long
         config = {**default_config, **(self.graph.config or {}), **(config or {})}
@@ -387,7 +407,8 @@ class LangGraphAgent(Agent):
             actions=actions,
             thread_id=thread_id,
             node_name=node_name,
-            meta_events=meta_events
+            meta_events=meta_events,
+            context=context,
         )
 
         langchain_messages = self.convert_messages(messages)
@@ -406,6 +427,7 @@ class LangGraphAgent(Agent):
                     config=config,
                     message_checkpoint=last_user_message,
                     actions=actions,
+                    context=context,
                 )
 
         state = prepared_stream_response["state"]

--- a/sdk-python/copilotkit/sdk.py
+++ b/sdk-python/copilotkit/sdk.py
@@ -351,7 +351,8 @@ class CopilotKitRemoteEndpoint:
                 config=config,
                 messages=messages,
                 actions=actions,
-                meta_events=meta_events
+                meta_events=meta_events,
+                context=context,
             )
         except Exception as error:
             raise AgentExecutionException(name, error) from error

--- a/sdk-python/tests/test_copilotkit_context_propagation.py
+++ b/sdk-python/tests/test_copilotkit_context_propagation.py
@@ -1,0 +1,100 @@
+"""Tests for context and properties propagation through the CopilotKit agent pipeline.
+
+Covers the two silent failures fixed in this PR:
+1. langgraph_default_merge_state was rebuilding copilotkit without context, dropping
+   useCopilotReadable items that the TypeScript runtime had correctly placed in state.
+2. CopilotKitContext.properties were never forwarded to agent.execute(), so
+   <CopilotKit properties={...} /> values never reached the agent state.
+"""
+
+import pytest
+from copilotkit.langgraph_agent import langgraph_default_merge_state
+
+
+class TestDefaultMergeStatePreservesContext:
+    """langgraph_default_merge_state must not clobber copilotkit keys it didn't produce."""
+
+    def _make_messages(self):
+        # We don't need real LangChain messages for these tests.
+        return []
+
+    def test_preserves_context_from_incoming_state(self):
+        context_items = [{"value": "User is a premium member"}, {"value": "Timezone: UTC"}]
+        incoming = {
+            "messages": [],
+            "copilotkit": {
+                "context": context_items,
+                "actions": [],
+            },
+        }
+        result = langgraph_default_merge_state(
+            state=incoming,
+            messages=self._make_messages(),
+            actions=[{"name": "get_weather"}],
+            agent_name="test_agent",
+        )
+        assert result["copilotkit"]["context"] == context_items
+
+    def test_fresh_actions_overwrite_old_ones(self):
+        """actions must come from the freshly-resolved list, not the stale incoming state."""
+        incoming = {
+            "messages": [],
+            "copilotkit": {
+                "context": [],
+                "actions": [{"name": "old_action"}],
+            },
+        }
+        new_actions = [{"name": "new_action"}]
+        result = langgraph_default_merge_state(
+            state=incoming,
+            messages=self._make_messages(),
+            actions=new_actions,
+            agent_name="test_agent",
+        )
+        assert result["copilotkit"]["actions"] == new_actions
+
+    def test_preserves_extra_copilotkit_keys(self):
+        """Any other key under copilotkit must survive the merge (regression guard)."""
+        incoming = {
+            "messages": [],
+            "copilotkit": {
+                "context": [],
+                "actions": [],
+                "properties": {"plan": "enterprise"},
+                "some_future_key": "preserved",
+            },
+        }
+        result = langgraph_default_merge_state(
+            state=incoming,
+            messages=self._make_messages(),
+            actions=[],
+            agent_name="test_agent",
+        )
+        assert result["copilotkit"]["some_future_key"] == "preserved"
+        assert result["copilotkit"]["properties"] == {"plan": "enterprise"}
+
+    def test_no_copilotkit_in_incoming_state(self):
+        """Gracefully handles state that has no copilotkit key at all."""
+        incoming = {"messages": []}
+        result = langgraph_default_merge_state(
+            state=incoming,
+            messages=self._make_messages(),
+            actions=[{"name": "tool"}],
+            agent_name="test_agent",
+        )
+        assert result["copilotkit"]["actions"] == [{"name": "tool"}]
+        # context defaults to empty — no KeyError
+        assert "context" not in result["copilotkit"] or result["copilotkit"]["context"] == []
+
+    def test_empty_context_preserved(self):
+        incoming = {
+            "messages": [],
+            "copilotkit": {"context": [], "actions": []},
+        }
+        result = langgraph_default_merge_state(
+            state=incoming,
+            messages=self._make_messages(),
+            actions=[],
+            agent_name="test_agent",
+        )
+        assert result["copilotkit"]["context"] == []

--- a/sdk-python/tests/test_prepare_stream_context_integration.py
+++ b/sdk-python/tests/test_prepare_stream_context_integration.py
@@ -1,0 +1,164 @@
+"""Integration test for context/properties injection through prepare_stream.
+
+This is as close to a real end-to-end verification as we can get without a running
+LangGraph server. It exercises the actual prepare_stream call path, including:
+  - snapshotting copilotkit.context from the original state_input before merge_state
+  - injecting context back after merge_state
+  - injecting properties from CopilotKitContext after merge_state
+  - verifying the state returned for streaming contains both fields
+
+The graph is mocked at the LangGraph boundary and get_schema_keys is patched to
+return (None, None, None) — the same thing a real graph returns when it has no
+explicit input/output schema declared.
+"""
+
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import MagicMock, AsyncMock, patch
+from copilotkit.langgraph_agent import LangGraphAgent
+
+
+def _make_agent_state(graph_values=None):
+    """Minimal stand-in for langgraph's StateSnapshot."""
+    state = MagicMock()
+    state.tasks = []  # no pending interrupts
+    state.values = dict(graph_values or {"messages": []})
+    return state
+
+
+def _make_graph():
+    """Minimal mock of a CompiledStateGraph."""
+    graph = MagicMock()
+    graph.config = None
+    graph.aget_state = AsyncMock()
+    graph.aupdate_state = AsyncMock()
+
+    async def _empty_stream(*args, **kwargs):
+        return
+        yield  # make it an async generator  # noqa: unreachable
+
+    graph.astream_events = _empty_stream
+    return graph
+
+
+@contextmanager
+def _no_schema(agent):
+    """Patch get_schema_keys to behave like a graph with no declared schema."""
+    with patch.object(agent, "get_schema_keys", return_value=(None, None, None)):
+        yield
+
+
+def _run(coro):
+    """Run a coroutine synchronously and leave a fresh event loop for subsequent tests.
+
+    asyncio.run() closes the loop when done, which breaks test files that use the
+    deprecated asyncio.get_event_loop().run_until_complete() pattern. We restore
+    a fresh loop so ordering does not matter.
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def _run_prepare_stream(agent, *, state_input, agent_state, context=None, actions=None, thread_id="test-thread"):
+    """Helper: call prepare_stream synchronously and return the result dict."""
+    config = {"configurable": {"thread_id": thread_id}}
+    with _no_schema(agent):
+        return _run(agent.prepare_stream(
+            state_input=state_input,
+            agent_state=agent_state,
+            config=config,
+            messages=[],
+            thread_id=thread_id,
+            actions=actions or [],
+            context=context,
+        ))
+
+
+class TestPrepareStreamContextInjection:
+    """prepare_stream must inject copilotkit.context and copilotkit.properties
+    from CopilotKitContext into the state used for streaming."""
+
+    def test_useCopilotReadable_context_reaches_stream_state(self):
+        """Items registered with useCopilotReadable arrive in state.copilotkit.context."""
+        context_items = [
+            {"value": "User: Alice, premium plan"},
+            {"value": "Locale: en-US"},
+        ]
+        agent_state = _make_agent_state()
+        agent = LangGraphAgent(name="test", graph=_make_graph())
+
+        state_input = {
+            "messages": [],
+            "copilotkit": {"context": context_items, "actions": []},
+        }
+        copilotkit_context = {"properties": {}, "frontend_url": None, "headers": {}}
+
+        result = _run_prepare_stream(agent, state_input=state_input, agent_state=agent_state, context=copilotkit_context)
+
+        assert result["state"]["copilotkit"]["context"] == context_items
+
+    def test_copilotkit_properties_reach_stream_state(self):
+        """Values from <CopilotKit properties={...} /> arrive in state.copilotkit.properties."""
+        properties = {"appVersion": "3.0", "featureFlags": {"darkMode": True}}
+        agent_state = _make_agent_state()
+        agent = LangGraphAgent(name="test", graph=_make_graph())
+
+        state_input = {"messages": [], "copilotkit": {"context": [], "actions": []}}
+        copilotkit_context = {"properties": properties, "frontend_url": "http://localhost:3000", "headers": {}}
+
+        result = _run_prepare_stream(agent, state_input=state_input, agent_state=agent_state, context=copilotkit_context)
+
+        assert result["state"]["copilotkit"]["properties"] == properties
+
+    def test_both_fields_injected_simultaneously(self):
+        """Both context and properties are present in the same run."""
+        context_items = [{"value": "User is on mobile"}]
+        properties = {"plan": "enterprise", "region": "eu-west"}
+        agent_state = _make_agent_state()
+        agent = LangGraphAgent(name="test", graph=_make_graph())
+
+        state_input = {"messages": [], "copilotkit": {"context": context_items, "actions": []}}
+        copilotkit_context = {"properties": properties, "frontend_url": None, "headers": {}}
+
+        result = _run_prepare_stream(agent, state_input=state_input, agent_state=agent_state, context=copilotkit_context)
+
+        ck = result["state"]["copilotkit"]
+        assert ck["context"] == context_items
+        assert ck["properties"] == properties
+
+    def test_context_survives_fresh_actions_list(self):
+        """The whole point of the fix: merge_state used to wipe context when
+        rebuilding copilotkit. Verify the injected context survives even when
+        a fresh actions list triggers a copilotkit dict rebuild."""
+        context_items = [{"value": "Critical context that must survive"}]
+        agent_state = _make_agent_state()
+        agent = LangGraphAgent(name="test", graph=_make_graph())
+
+        state_input = {"messages": [], "copilotkit": {"context": context_items, "actions": []}}
+
+        result = _run_prepare_stream(
+            agent,
+            state_input=state_input,
+            agent_state=agent_state,
+            context=None,
+            actions=[],  # fresh actions list triggers copilotkit rebuild in merge_state
+        )
+
+        assert result["state"]["copilotkit"]["context"] == context_items
+
+    def test_no_context_no_error(self):
+        """Passing context=None is safe: properties defaults to empty dict."""
+        agent_state = _make_agent_state()
+        agent = LangGraphAgent(name="test", graph=_make_graph())
+
+        state_input = {"messages": [], "copilotkit": {"context": [], "actions": []}}
+
+        result = _run_prepare_stream(agent, state_input=state_input, agent_state=agent_state, context=None)
+
+        assert result["state"]["copilotkit"]["properties"] == {}
+        assert result["state"]["copilotkit"]["context"] == []

--- a/showcase/packages/langgraph-fastapi/src/agents/src/agent.py
+++ b/showcase/packages/langgraph-fastapi/src/agents/src/agent.py
@@ -125,12 +125,20 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     """
     t0 = time.time()
     messages = runtime.state["messages"][:-1]
+
+    # useCopilotReadable() items arrive here as a list of {value: str} objects.
     context_entries = runtime.state.get("copilotkit", {}).get("context", [])
     context_text = "\n\n".join(
         entry.get("value", "")
         for entry in context_entries
         if isinstance(entry, dict) and entry.get("value")
     )
+
+    # <CopilotKit properties={...} /> values arrive as a plain dict.
+    properties = runtime.state.get("copilotkit", {}).get("properties", {})
+    if properties:
+        props_text = "\n".join(f"- {k}: {v}" for k, v in properties.items())
+        context_text = f"App properties:\n{props_text}\n\n{context_text}".strip()
 
     model = ChatOpenAI(model="gpt-4.1")
     model_with_tool = model.bind_tools([render_a2ui], tool_choice="render_a2ui")

--- a/showcase/starters/langgraph-fastapi/src/agents/src/agent.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/src/agent.py
@@ -107,12 +107,20 @@ def generate_a2ui(runtime: ToolRuntime[Any]) -> str:
     """
     t0 = time.time()
     messages = runtime.state["messages"][:-1]
+
+    # useCopilotReadable() items arrive here as a list of {value: str} objects.
     context_entries = runtime.state.get("copilotkit", {}).get("context", [])
     context_text = "\n\n".join(
         entry.get("value", "")
         for entry in context_entries
         if isinstance(entry, dict) and entry.get("value")
     )
+
+    # <CopilotKit properties={...} /> values arrive as a plain dict.
+    properties = runtime.state.get("copilotkit", {}).get("properties", {})
+    if properties:
+        props_text = "\n".join(f"- {k}: {v}" for k, v in properties.items())
+        context_text = f"App properties:\n{props_text}\n\n{context_text}".strip()
 
     model = ChatOpenAI(model="gpt-4.1")
     model_with_tool = model.bind_tools([render_a2ui], tool_choice="render_a2ui")


### PR DESCRIPTION
## Summary

- **`useCopilotReadable` context was silently dropped**: `langgraph_default_merge_state` rebuilt `copilotkit` as `{"actions": actions}` only, clobbering the `context` list the TypeScript runtime had already placed in `state.copilotkit.context`.
- **`<CopilotKit properties={...} />` never reached the agent**: `CopilotKitContext.properties` was extracted in the FastAPI handler but never forwarded through `execute_agent → agent.execute()`, so agents had no way to access it.

Both fields now land cleanly under `state["copilotkit"]` on every agent invocation:
- `state["copilotkit"]["context"]` — `useCopilotReadable` items (list of `{value: str}`)
- `state["copilotkit"]["properties"]` — app-level properties dict

## Changes

- `sdk-python/copilotkit/langgraph_agent.py` — preserve existing `copilotkit` keys in `langgraph_default_merge_state`; thread `context` through `execute → _stream_events → prepare_stream`; snapshot and reinject both fields explicitly after `merge_state`
- `sdk-python/copilotkit/sdk.py` — forward `context` from `execute_agent` to `agent.execute()`
- `sdk-python/tests/test_copilotkit_context_propagation.py` — 5 new unit tests covering context preservation, action overwrite, extra key survival, missing-copilotkit graceful handling
- `showcase/packages/langgraph-fastapi/src/agents/src/agent.py` — demonstrates reading both `context` and `properties` in `generate_a2ui`
- `docs/content/docs/integrations/langgraph/shared-state/context-and-properties.mdx` — new doc page explaining both fields with frontend + agent code examples

## Test plan

- [ ] All 79 existing `sdk-python` tests pass (`poetry run pytest`)
- [ ] 5 new tests in `test_copilotkit_context_propagation.py` pass
- [ ] `useCopilotReadable` items appear in `state["copilotkit"]["context"]` in the agent
- [ ] `<CopilotKit properties={...} />` values appear in `state["copilotkit"]["properties"]` in the agent
- [ ] Custom `merge_state` implementations still work (properties are injected after merge, not inside it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)