### PR TITLE
docs: Tailwind v4 requirement + upgrade guide + runtime warning

### DIFF
--- a/docs/content/docs/(root)/meta.json
+++ b/docs/content/docs/(root)/meta.json
@@ -5,6 +5,7 @@
     "index",
     "quickstart",
     "coding-agents",
+    "tailwind-v4-upgrade",
     "---Basics---",
     "prebuilt-components",
     "custom-look-and-feel",

--- a/docs/content/docs/(root)/tailwind-v4-upgrade.mdx
+++ b/docs/content/docs/(root)/tailwind-v4-upgrade.mdx
@@ -1,0 +1,103 @@
+---
+title: Tailwind CSS v4 Setup
+description: CopilotKit v2 requires Tailwind CSS v4. This guide covers installation, PostCSS configuration, and common migration errors.
+icon: "lucide/Paintbrush"
+keywords: [tailwind v3, tailwind v4, @tailwindcss/postcss, postcss tailwind plugin, tailwindcss is not a function, @layer base error, autoprefixer, tailwind upgrade]
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<Callout type="warn">
+  CopilotKit v2 requires Tailwind CSS v4. **Tailwind v3 is not supported** and will produce broken or unstyled UI.
+</Callout>
+
+## Install
+
+```bash
+npm install tailwindcss@^4 @tailwindcss/postcss@^4
+npm uninstall autoprefixer
+```
+
+Autoprefixer is no longer needed — Tailwind v4 handles vendor prefixes automatically.
+
+## PostCSS config
+
+Replace the v3 plugin with the dedicated v4 PostCSS plugin:
+
+```js title="postcss.config.mjs"
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+```
+
+The old `tailwindcss: {}` and `autoprefixer: {}` entries must be removed. Keeping them will cause a build error.
+
+## Global CSS entry point
+
+Replace the three `@tailwind` directives with a single import:
+
+```css title="globals.css"
+@import "tailwindcss";
+```
+
+## Remove `tailwind.config.js`
+
+Tailwind v4 is configured in CSS, not JavaScript. Delete `tailwind.config.js` (or `tailwind.config.ts`).
+
+If you had custom `content` paths or `theme.extend` values, migrate them to your CSS file:
+
+```css title="globals.css"
+@import "tailwindcss";
+
+/* Replaces "content" in tailwind.config.js */
+@source "../components/**/*.{ts,tsx}";
+
+/* Replaces "theme.extend" in tailwind.config.js */
+@theme {
+  --color-brand: oklch(0.5 0.2 250);
+  --font-display: "Inter", sans-serif;
+}
+```
+
+## Verify the upgrade
+
+After making the changes above, start your dev server. If the page renders without errors and CopilotKit components are styled, the upgrade is complete.
+
+If you see a console warning from CopilotKit about Tailwind v3, your `globals.css` still has the old `@tailwind` directives or PostCSS is still loading the old `tailwindcss` plugin.
+
+## Error → fix reference
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `tailwindcss is not a function` | PostCSS config still has `tailwindcss: {}` | Replace with `"@tailwindcss/postcss": {}` |
+| `Cannot find module 'tailwindcss/plugin'` | Code importing from `tailwindcss/plugin` (v3 API) | Remove or rewrite — v4 uses `@plugin` in CSS |
+| `Unknown at rule @tailwind` | CSS still has `@tailwind base/components/utilities` | Replace with `@import "tailwindcss"` |
+| `Unknown at rule @apply` inside `@layer base` | PostCSS isn't loading `@tailwindcss/postcss` | Check `postcss.config.mjs` has the correct plugin |
+| CopilotKit UI renders unstyled | Styles imported before `@import "tailwindcss"` loads | Ensure `@import "tailwindcss"` is the first line in your CSS |
+| `Error: It looks like you're trying to use a feature that requires PostCSS` | Vite project using Tailwind CLI instead of PostCSS | Add `postcss.config.mjs` with `@tailwindcss/postcss` |
+
+## Using Vite?
+
+If you're using Vite, you can use the dedicated Vite plugin instead of PostCSS:
+
+```bash
+npm install @tailwindcss/vite@^4
+npm uninstall autoprefixer @tailwindcss/postcss
+```
+
+```ts title="vite.config.ts"
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [tailwindcss()],
+});
+```
+
+No `postcss.config.mjs` needed when using the Vite plugin.
+
+## Full upgrade reference
+
+For the complete Tailwind v3→v4 migration guide (including plugins, arbitrary values, and breaking changes), see the [official Tailwind CSS v4 upgrade guide](https://tailwindcss.com/docs/upgrade-guide).

--- a/docs/content/docs/(root)/tailwind-v4-upgrade.mdx
+++ b/docs/content/docs/(root)/tailwind-v4-upgrade.mdx
@@ -2,7 +2,7 @@
 title: Tailwind CSS v4 Setup
 description: CopilotKit v2 requires Tailwind CSS v4. This guide covers installation, PostCSS configuration, and common migration errors.
 icon: "lucide/Paintbrush"
-keywords: [tailwind v3, tailwind v4, @tailwindcss/postcss, postcss tailwind plugin, tailwindcss is not a function, @layer base error, autoprefixer, tailwind upgrade]
+keywords: ["tailwind v3", "tailwind v4", "@tailwindcss/postcss", "postcss tailwind plugin", "tailwindcss is not a function", "@layer base error", "autoprefixer", "tailwind upgrade"]
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";

--- a/docs/snippets/shared/basics/prebuilt-components.mdx
+++ b/docs/snippets/shared/basics/prebuilt-components.mdx
@@ -17,6 +17,10 @@ CopilotKit ships three prebuilt chat components that connect directly to your ag
 
 ## Setup
 
+<Callout type="warn">
+  CopilotKit v2 requires **Tailwind CSS v4**. If your project uses Tailwind v3, upgrade first — see the [Tailwind v4 upgrade guide](/tailwind-v4-upgrade).
+</Callout>
+
 Import the default styles in your root layout:
 
 ```tsx title="layout.tsx"

--- a/docs/snippets/shared/troubleshooting/common-issues.mdx
+++ b/docs/snippets/shared/troubleshooting/common-issues.mdx
@@ -10,6 +10,53 @@ Welcome to the CopilotKit Troubleshooting Guide! Here, you can find answers to c
 
 </Callout>
 
+## CopilotKit UI is unstyled (Tailwind v3 issue)
+
+If the chat panel renders without any styles, or you see layout issues and missing colors, the most common cause is a Tailwind CSS version mismatch.
+
+<Accordions>
+  <Accordion title="Using Tailwind v3 with CopilotKit v2">
+    CopilotKit v2 requires Tailwind CSS v4. If your project still has Tailwind v3 set up, the prebuilt components will not render correctly.
+
+    **Signs you have this problem:**
+    - You see a `[CopilotKit]` warning in the browser console mentioning Tailwind v3
+    - Your `postcss.config.mjs` (or `.js`) has `tailwindcss: {}` and `autoprefixer: {}`
+    - Your CSS still has `@tailwind base; @tailwind components; @tailwind utilities;`
+
+    **Fix:** Follow the [Tailwind v4 upgrade guide](/tailwind-v4-upgrade).
+  </Accordion>
+  <Accordion title='Error: "tailwindcss is not a function"'>
+    Your PostCSS config is loading the old Tailwind v3 plugin. Replace it with the v4 dedicated plugin:
+
+    ```js title="postcss.config.mjs"
+    export default {
+      plugins: {
+        "@tailwindcss/postcss": {},
+      },
+    };
+    ```
+
+    Also run:
+    ```bash
+    npm install @tailwindcss/postcss@^4
+    npm uninstall autoprefixer
+    ```
+  </Accordion>
+  <Accordion title='Error: "Unknown at rule @tailwind"'>
+    Your CSS still uses the old v3 directives. Replace them with a single import:
+
+    ```css title="globals.css"
+    /* Remove this: */
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+
+    /* Add this: */
+    @import "tailwindcss";
+    ```
+  </Accordion>
+</Accordions>
+
 ## I am getting network errors / API not found error
 
 If you're encountering network or API errors, here's how to troubleshoot:

--- a/docs/snippets/shared/troubleshooting/migrate-to-v2.mdx
+++ b/docs/snippets/shared/troubleshooting/migrate-to-v2.mdx
@@ -2,6 +2,10 @@
 
 CopilotKit V2 consolidates the frontend into a single package. Both hooks and UI components are now exported from `@copilotkit/react-core/v2`. Your backend does not need any changes.
 
+<Callout type="warn">
+  **CopilotKit v2 requires Tailwind CSS v4.** If your project uses Tailwind v3, you must upgrade before migrating. See Step 1 below.
+</Callout>
+
 **What's changing:**
 
 | Before | After |
@@ -18,6 +22,14 @@ CopilotKit V2 consolidates the frontend into a single package. Both hooks and UI
 ## Migration Steps
 
 <Steps>
+<Step>
+### Upgrade to Tailwind CSS v4
+
+CopilotKit v2 requires Tailwind CSS v4. If your project uses Tailwind v3, upgrade it now — the components will not render correctly until you do.
+
+See the **[Tailwind v4 upgrade guide](/tailwind-v4-upgrade)** for the exact steps (PostCSS config, CSS entry point, and `tailwind.config.js` removal).
+
+</Step>
 <Step>
 ### Update `@copilotkit/react-core` imports
 

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -264,6 +264,10 @@ function useStableArrayProp<T>(
   return value;
 }
 
+// Module-level flag so the Tailwind warning fires at most once per page load,
+// even under React StrictMode's double-invoke behavior.
+let _tailwindWarningShown = false;
+
 // Provider component
 export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   children,
@@ -717,6 +721,19 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   // so it runs last in the effect queue on the initial mount cycle.
   useEffect(() => {
     didMountRef.current = true;
+  }, []);
+
+  // Remind developers to use Tailwind v4. CopilotKit v2 is not compatible with v3.
+  // Module-level flag ensures this fires at most once per page load (survives StrictMode double-invoke).
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    if (_tailwindWarningShown) return;
+    _tailwindWarningShown = true;
+    console.warn(
+      "[CopilotKit] If your UI appears unstyled, ensure you are using Tailwind CSS v4. " +
+        "Tailwind v3 is not supported.\n" +
+        "Upgrade guide: https://docs.copilotkit.ai/tailwind-v4-upgrade",
+    );
   }, []);
 
   // Sync defaultThrottleMs to the core instance on prop changes.

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -726,7 +726,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   // Remind developers to use Tailwind v4. CopilotKit v2 is not compatible with v3.
   // Module-level flag ensures this fires at most once per page load (survives StrictMode double-invoke).
   useEffect(() => {
-    if (process.env.NODE_ENV === "production") return;
+    if (process.env.NODE_ENV !== "development") return;
     if (_tailwindWarningShown) return;
     _tailwindWarningShown = true;
     console.warn(


### PR DESCRIPTION
## Summary

- Adds a canonical **Tailwind v4 upgrade guide** (`tailwind-v4-upgrade.mdx`) with exact install commands, PostCSS config, Vite path, and an error→fix reference table; includes MCP retrieval keywords
- Adds a **Step 1** to the migrate-to-v2 guide calling out the Tailwind v4 requirement and linking to the canonical page
- Adds a **"CopilotKit UI is unstyled (Tailwind v3 issue)"** section to common-issues with accordion entries for the three most common v3 errors
- Adds a **Callout** in the prebuilt-components docs linking to the upgrade guide
- Adds a **dev-only `console.warn`** in `CopilotKitProvider` — fires unconditionally once per page load in dev mode (StrictMode-safe, no fragile CSS detection), silent in production

## Test plan

- [ ] Verify `tailwind-v4-upgrade.mdx` renders in docs and appears in nav under Getting Started
- [ ] Verify the Callout appears in prebuilt-components docs
- [ ] Verify the new troubleshooting section appears at the top of common-issues
- [ ] Verify Step 1 in migrate-to-v2 links correctly to `/tailwind-v4-upgrade`
- [ ] In a Next.js app in dev mode, confirm the `console.warn` fires once on mount and is silent in production builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)