### PR TITLE
docs(a2ui): recommend injectA2UITool in shared snippet

### DIFF
--- a/docs/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -111,14 +111,12 @@ agent = create_agent(
 <Step>
 ### Configure the runtime (TypeScript)
 
-Enable A2UI in your CopilotRuntime:
+Enable A2UI in your CopilotRuntime. The middleware auto-detects A2UI operations in any tool result, so no tool injection is needed here — the agent's `search_flights` tool returns them directly.
 
 ```typescript title="app/api/copilotkit/route.ts"
 const runtime = new CopilotRuntime({
   agents: { default: myAgent },
-  a2ui: {
-    injectA2UITool: true,
-  },
+  a2ui: {},
 });
 ```
 </Step>

--- a/docs/snippets/shared/generative-ui/a2ui.mdx
+++ b/docs/snippets/shared/generative-ui/a2ui.mdx
@@ -44,18 +44,20 @@ A2UI specifications can be rendered on web, mobile, or any other platform, makin
 
 ### Backend
 
-Enable A2UI in `CopilotRuntime` by passing `a2ui: true`:
+Enable A2UI in `CopilotRuntime` and inject a rendering tool (`render_a2ui`) into your agent so it can produce A2UI surfaces:
 
 ```ts title="app/api/copilotkit/route.ts"
 import { CopilotRuntime } from "@copilotkit/runtime";
 
 const runtime = new CopilotRuntime({
   agents: { default: myAgent },
-  a2ui: true,
+  a2ui: {
+    injectA2UITool: true,
+  },
 });
 ```
 
-This automatically applies `A2UIMiddleware` to all registered agents. Pass an object instead of `true` to customise behaviour — for example, to scope it to specific agents: `a2ui: { agents: ["my-agent"] }`.
+This applies `A2UIMiddleware` to all registered agents and adds `render_a2ui` to the agent's tool list, along with usage guidelines so the LLM knows how to call it. Scope to specific agents with `a2ui: { injectA2UITool: true, agents: ["my-agent"] }`.
 
 Once configured, any A2UI output returned from your agent will automatically be rendered in the chat interface — no additional frontend code required.
 


### PR DESCRIPTION
## Summary
- Shared A2UI snippet (`docs/snippets/shared/generative-ui/a2ui.mdx`) now recommends `a2ui: { injectA2UITool: true }` so framework integrations that don't ship their own rendering tool get `render_a2ui` injected into the agent's tool list, with usage guidelines.
- LangGraph fixed-schema guide (`docs/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx`) drops `injectA2UITool: true` — that guide's Python `search_flights` tool returns A2UI operations directly, which the middleware auto-detects, so tool injection is unnecessary there.

## Why
Previously the shared snippet recommended `a2ui: true` with no tool injection — which only works when the agent already has a path to produce A2UI output. For most integrations where the agent doesn't bring its own rendering tool, that led to surfaces not rendering. Meanwhile the LangGraph fixed-schema page overspecified `injectA2UITool: true` even though its example doesn't need it.

## Test plan
- [ ] Visual check of rendered snippet on the affected integration pages (agno, mastra, llamaindex, pydantic-ai, crewai-flows, microsoft-agent-framework, agent-spec, ag2, built-in-agent, aws-strands, adk, plus `learn/generative-ui/specs/a2ui`)
- [ ] Verify LangGraph fixed-schema example still works with `a2ui: {}`