### PR TITLE
fix: drop --with-deps from starter-smoke Playwright install

### DIFF
--- a/examples/integrations/adk/docker-compose.test.yml
+++ b/examples/integrations/adk/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/adk/docker-compose.test.yml
+++ b/examples/integrations/adk/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/agno/docker-compose.test.yml
+++ b/examples/integrations/agno/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/agno/docker-compose.test.yml
+++ b/examples/integrations/agno/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/crewai-crews/docker-compose.test.yml
+++ b/examples/integrations/crewai-crews/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/crewai-crews/docker-compose.test.yml
+++ b/examples/integrations/crewai-crews/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-fastapi/docker-compose.test.yml
+++ b/examples/integrations/langgraph-fastapi/docker-compose.test.yml
@@ -70,7 +70,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-fastapi/docker-compose.test.yml
+++ b/examples/integrations/langgraph-fastapi/docker-compose.test.yml
@@ -70,7 +70,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-js/docker-compose.test.yml
+++ b/examples/integrations/langgraph-js/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-js/docker-compose.test.yml
+++ b/examples/integrations/langgraph-js/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-python-threads/docker-compose.test.yml
+++ b/examples/integrations/langgraph-python-threads/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-python-threads/docker-compose.test.yml
+++ b/examples/integrations/langgraph-python-threads/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-python/docker-compose.test.yml
+++ b/examples/integrations/langgraph-python/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/langgraph-python/docker-compose.test.yml
+++ b/examples/integrations/langgraph-python/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/llamaindex/docker-compose.test.yml
+++ b/examples/integrations/llamaindex/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/llamaindex/docker-compose.test.yml
+++ b/examples/integrations/llamaindex/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/mastra/docker-compose.test.yml
+++ b/examples/integrations/mastra/docker-compose.test.yml
@@ -47,7 +47,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/mastra/docker-compose.test.yml
+++ b/examples/integrations/mastra/docker-compose.test.yml
@@ -32,6 +32,13 @@ services:
       start_period: 60s
 
   tests:
+    # The image tag (playwright:v1.52.0-noble) pins both the browser binaries
+    # and the system libs bundled in the image. It MUST stay aligned with the
+    # @playwright/test version declared in showcase/tests/package.json — if
+    # the client drifts to a newer version whose required system libs are
+    # missing from this image, `npx playwright install chromium` will fetch
+    # the matching browser binary but cannot install system libs. Bump both
+    # together, or re-add `--with-deps` for that run.
     image: mcr.microsoft.com/playwright:v1.52.0-noble
     working_dir: /tests
     volumes:
@@ -47,7 +54,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/ms-agent-framework-dotnet/docker-compose.test.yml
+++ b/examples/integrations/ms-agent-framework-dotnet/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/ms-agent-framework-dotnet/docker-compose.test.yml
+++ b/examples/integrations/ms-agent-framework-dotnet/docker-compose.test.yml
@@ -69,7 +69,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/ms-agent-framework-python/docker-compose.test.yml
+++ b/examples/integrations/ms-agent-framework-python/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/ms-agent-framework-python/docker-compose.test.yml
+++ b/examples/integrations/ms-agent-framework-python/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/pydantic-ai/docker-compose.test.yml
+++ b/examples/integrations/pydantic-ai/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/pydantic-ai/docker-compose.test.yml
+++ b/examples/integrations/pydantic-ai/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/strands-python/docker-compose.test.yml
+++ b/examples/integrations/strands-python/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:

--- a/examples/integrations/strands-python/docker-compose.test.yml
+++ b/examples/integrations/strands-python/docker-compose.test.yml
@@ -66,7 +66,7 @@ services:
       [
         "bash",
         "-c",
-        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null && npx playwright test starter-smoke --reporter=list",
+        "cd /tests && npm install --no-audit --no-fund 2>/dev/null && npx playwright install chromium 2>/dev/null && npx playwright test starter-smoke --reporter=list",
       ]
 
 volumes:


### PR DESCRIPTION
## Summary

- Removes the flaky, unnecessary `--with-deps` from `npx playwright install chromium` in all 13 starter `docker-compose.test.yml` files
- `mcr.microsoft.com/playwright:v1.52.0-noble` already ships with both Chromium browsers and all required system libs pre-installed; `--with-deps` only forces a redundant `apt-get update && apt-get install`
- That apt-get call is the sole root cause of the recurring scheduled-run failures (Slack alerts every few hours):

  > `tests-1 | Failed to install browsers`
  > `tests-1 | Error: Installation process exited with code: 100`

  preceded by Ubuntu mirror errors like `File has unexpected size (… != …). Mirror sync in progress?` or `Hash Sum mismatch` against `archive.ubuntu.com`. Each matrix job races apt independently, so the failing subset rotates every run (confirmed across runs 24526747926 / 24509673514 / 24495760568 — different 3–5 starters fail each time, always with the identical apt signature). This is flake, not regression.

## Root cause

`npx playwright install chromium --with-deps` executes `apt-get update && apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 …` inside the tests container. When Ubuntu's archive mirrors are mid-sync, apt-get aborts with exit code 100, Playwright surfaces it as "Installation process exited with code: 100", and the `tests` service exits 1 — failing the smoke job.

Verified locally that `npx playwright install chromium` (no `--with-deps`) runs clean in `mcr.microsoft.com/playwright:v1.52.0-noble` and that `/ms-playwright/chromium-1169` is already present in the image — so no deps step is needed.

## Caveat — what happens on a future Playwright client bump

If `@playwright/test` in `showcase/tests/package.json` is bumped to a version newer than what the pinned image tag bundles, `npx playwright install chromium` (still in the command) will download the **matching browser binary** into `/ms-playwright`. That covers the browser itself, but **not system libs** — if the newer browser needs libs that aren't in `v1.52.0-noble`, launch will fail and we would need to either (a) re-add `--with-deps` for that run, or (b) bump the image tag to match. The mastra compose file now carries a code comment calling out this coupling so future bumps keep image tag and client version aligned.

## Test plan

- [ ] Starter smoke workflow run on this PR passes for all 12 matrix entries (exercises the exact code change)
- [ ] Next scheduled run after merge shows zero "exit code: 100" failures in Slack alerts
- [ ] If the Playwright client drifts past the image's bundled browser build, `npx playwright install chromium` downloads the matching browser binary (but missing system libs would need `--with-deps` back, or an image tag bump)

## Follow-up commit — keep playwright install stderr

Addresses CR: stderr from `npx playwright install chromium` is diagnostic signal (network errors, version drift, missing libs). Only the noisy `npm install` step retains `2>/dev/null`; Playwright install stderr is now visible in logs. Image/version coupling is documented inline on `examples/integrations/mastra/docker-compose.test.yml`.