### PR TITLE
fix(showcase/mastra): alias demo agent names to weatherAgent

### DIFF
--- a/showcase/packages/mastra/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/mastra/src/app/api/copilotkit/route.ts
@@ -10,13 +10,46 @@ import { mastra } from "@/mastra";
 // 1. You can use any service adapter here for multi-agent support.
 const serviceAdapter = new ExperimentalEmptyAdapter();
 
+// The Mastra config registers a single local agent (`weatherAgent`), but the
+// demo pages request a variety of agent names (`agentic_chat`,
+// `human_in_the_loop`, etc.). Mirror the crewai-crews pattern and expose the
+// same underlying agent under every name the demos ask for so the runtime can
+// resolve them. `weatherAgent` is also preserved for backend smoke tests.
+const demoAgentNames = [
+  "agentic_chat",
+  "human_in_the_loop",
+  "tool-rendering",
+  "gen-ui-tool-based",
+  "gen-ui-agent",
+  "shared-state-read",
+  "shared-state-write",
+  "shared-state-streaming",
+  "subagents",
+];
+
+function buildAgents() {
+  // @ts-expect-error - ignore for now, typing error (matches upstream pattern)
+  const localAgents = MastraAgent.getLocalAgents({ mastra }) as Record<
+    string,
+    unknown
+  >;
+  const weatherAgent = localAgents.weatherAgent;
+  const agents: Record<string, unknown> = { ...localAgents };
+  if (weatherAgent) {
+    for (const name of demoAgentNames) {
+      agents[name] = weatherAgent;
+    }
+  }
+  return agents;
+}
+
 // 2. Build a Next.js API route that handles the CopilotKit runtime requests.
 export const POST = async (req: NextRequest) => {
   // 3. Create the CopilotRuntime instance and utilize the Mastra AG-UI
   //    integration to get the remote agents. Cache this for performance.
   const runtime = new CopilotRuntime({
     // @ts-expect-error - ignore for now, typing error
-    agents: MastraAgent.getLocalAgents({ mastra }),
+    agents: buildAgents(),
   });
 
   const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({

--- a/showcase/packages/mastra/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/mastra/src/app/api/copilotkit/route.ts
@@ -15,6 +15,12 @@ const serviceAdapter = new ExperimentalEmptyAdapter();
 // `human_in_the_loop`, etc.). Mirror the crewai-crews pattern and expose the
 // same underlying agent under every name the demos ask for so the runtime can
 // resolve them. `weatherAgent` is also preserved for backend smoke tests.
+//
+// NOTE: This aliasing makes demo pages load without agent-name 404s.
+// Demos that depend on specific agent capabilities (HITL interrupts,
+// streaming state, gen-ui steps) remain limited by weatherAgent's features.
+// Full feature parity requires dedicated Mastra agents per demo — see
+// crewai-crews for the precedent pattern.
 const demoAgentNames = [
   "agentic_chat",
   "human_in_the_loop",
@@ -28,19 +34,19 @@ const demoAgentNames = [
 ];
 
 function buildAgents() {
-  // @ts-expect-error - ignore for now, typing error (matches upstream pattern)
-  const localAgents = MastraAgent.getLocalAgents({ mastra }) as Record<
-    string,
-    unknown
-  >;
+  // resourceId is typed as required but only used to tag agents downstream;
+  // empty string matches the pre-aliasing behavior where it was undefined.
+  const localAgents = MastraAgent.getLocalAgents({ mastra, resourceId: "" });
   const weatherAgent = localAgents.weatherAgent;
-  const agents: Record<string, unknown> = { ...localAgents };
-  if (weatherAgent) {
-    for (const name of demoAgentNames) {
-      agents[name] = weatherAgent;
-    }
+  if (!weatherAgent) {
+    throw new Error(
+      "weatherAgent missing from Mastra config — required for demo aliases",
+    );
   }
-  return agents;
+  return {
+    ...localAgents,
+    ...Object.fromEntries(demoAgentNames.map((name) => [name, weatherAgent])),
+  };
 }
 
 // 2. Build a Next.js API route that handles the CopilotKit runtime requests.
@@ -48,7 +54,7 @@ export const POST = async (req: NextRequest) => {
   // 3. Create the CopilotRuntime instance and utilize the Mastra AG-UI
   //    integration to get the remote agents. Cache this for performance.
   const runtime = new CopilotRuntime({
-    // @ts-expect-error - ignore for now, typing error
+    // @ts-expect-error - CopilotRuntime expects MaybePromise<Record<...>>; the spread-widened object literal doesn't structurally match
     agents: buildAgents(),
   });
 

--- a/showcase/packages/mastra/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/mastra/src/app/api/copilotkit/route.ts
@@ -54,7 +54,6 @@ export const POST = async (req: NextRequest) => {
   // 3. Create the CopilotRuntime instance and utilize the Mastra AG-UI
   //    integration to get the remote agents. Cache this for performance.
   const runtime = new CopilotRuntime({
-    // @ts-expect-error - CopilotRuntime expects MaybePromise<Record<...>>; the spread-widened object literal doesn't structurally match
     agents: buildAgents(),
   });
 

--- a/showcase/packages/mastra/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/mastra/src/app/api/copilotkit/route.ts
@@ -34,8 +34,10 @@ const demoAgentNames = [
 ];
 
 function buildAgents() {
-  // resourceId is typed as required but only used to tag agents downstream;
-  // empty string matches the pre-aliasing behavior where it was undefined.
+  // resourceId is typed as required. We pass "" because these demo agents are
+  // stateless — scoping memory to an empty resource bucket is acceptable here.
+  // This is a behavioral change from the pre-aliasing code which omitted the
+  // field entirely; not a no-op.
   const localAgents = MastraAgent.getLocalAgents({ mastra, resourceId: "" });
   const weatherAgent = localAgents.weatherAgent;
   if (!weatherAgent) {


### PR DESCRIPTION
## Summary

- The Mastra showcase package registers only `weatherAgent` in its Mastra config, but the demo pages request names like `agentic_chat`, `human_in_the_loop`, `tool-rendering`, etc. `MastraAgent.getLocalAgents({ mastra })` returns agents keyed by registration name, so the runtime cannot resolve the demo-requested names. This was causing the L3 mastra chat test to fail.
- Mirror the pattern used in `showcase/packages/crewai-crews/src/app/api/copilotkit/route.ts`: wrap `MastraAgent.getLocalAgents` and expose the underlying `weatherAgent` under every name the demo pages ask for. `weatherAgent` itself is preserved so the internal `/api/smoke` route (which calls `agentId: "weatherAgent"`) keeps working.

## Agent names now exposed on the backend

- `weatherAgent` (original Mastra registration — preserved for smoke test)
- `agentic_chat`
- `human_in_the_loop`
- `tool-rendering`
- `gen-ui-tool-based`
- `gen-ui-agent`
- `shared-state-read`
- `shared-state-write`
- `shared-state-streaming`
- `subagents`

The starter (`showcase/starters/mastra`) was checked and is not affected — its route uses `LangGraphAgent` and already registers `sample_agent`, which matches what the starter's page requests.

## Test plan

- [ ] CI L3 mastra chat test passes (the failure this PR targets)
- [ ] `/api/smoke` route still returns 200 (uses `weatherAgent` which is preserved)
- [ ] Demo pages (`/demos/agentic-chat`, `/demos/hitl`, `/demos/tool-rendering`, etc.) can reach the runtime without 404