### PR TITLE
fix(aimock): use valid response schema for broken feature-parity fixtures

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -224,10 +224,18 @@
     },
     {
       "match": {
+        "userMessage": "Based on the following context, write a concise"
+      },
+      "response": {
+        "content": "A short input value used to parameterize the crew's tasks and agents."
+      }
+    },
+    {
+      "match": {
         "userMessage": "plan"
       },
       "response": {
-        "text": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
+        "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
       }
     },
     {
@@ -235,7 +243,7 @@
         "userMessage": "steps"
       },
       "response": {
-        "text": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
+        "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
       }
     },
     {
@@ -243,7 +251,7 @@
         "userMessage": "mars"
       },
       "response": {
-        "text": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
+        "content": "Here is my plan:\n1. Research the topic\n2. Outline key points\n3. Draft the content\n4. Review and refine\n5. Finalize"
       }
     },
     {
@@ -251,7 +259,7 @@
         "userMessage": "dashboard"
       },
       "response": {
-        "text": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
+        "content": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
       }
     },
     {
@@ -259,7 +267,7 @@
         "userMessage": "report"
       },
       "response": {
-        "text": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
+        "content": "Working on your request. Step 1: Gathering data... Step 2: Analyzing results... Step 3: Generating report. Done!"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Five fixtures in `showcase/aimock/feature-parity.json` used an unrecognized `"text"` field instead of `"content"`. aimock's `/v1/chat/completions` handler returns 500 `"Fixture response did not match any known type"` when the response shape doesn't match its discriminators.
- CrewAI's `ChatWithCrewFlow.__init__` calls `generate_input_description_with_ai` at module import time. That prompt contains `"Reporting Analyst"` / `"reports"` text (derived from the `LatestAiDevelopment` crew yaml), which substring-matched the broken `"report"` fixture and produced a 500. CrewAI treated that as `InternalServerError`, crashing the crewai-crews container before uvicorn could bind a port. Railway healthcheck failed → deployment rolled back to the previous ACTIVE build.
- Fix: convert the five broken fixtures (`plan`, `steps`, `mars`, `dashboard`, `report`) from `"text"` to `"content"`, and add a targeted fixture that matches CrewAI's exact startup prompt prefix (`"Based on the following context, write a concise"`) so it wins over the generic fixtures.

## Root cause

aimock discriminators in `helpers.ts` only recognize `content`, `toolCalls`, `error`, etc. — never `text`. Any fixture using `"text"` silently fell through to the 500 branch. See [server.ts:563-663](https://github.com/CopilotKit/aimock/blob/main/src/server.ts#L563) and [helpers.ts:51-80](https://github.com/CopilotKit/aimock/blob/main/src/helpers.ts#L51).

The regression window matches — fixtures landed 2026-04-14 12:52 PDT (5ac07d4d9); Railway aimock picked them up at 2026-04-14T21:57 UTC.

## Verification

Red-green reproduced locally against `@copilotkit/aimock@1.10.0`:

```
PRE-FIX  status: 500
PRE-FIX  body:   {"error":{"message":"Fixture response did not match any known type","type":"server_error"}}

POST-FIX status: 200
POST-FIX body:   {"id":"chatcmpl-...","object":"chat.completion",...,"content":"A short input value used to parameterize the crew's tasks and agents."}
```

Also verified: the five previously-broken user messages (`report`, `plan`, `dashboard`, `mars ... steps`, etc.) all return 200 with valid content after the fix.

## Follow-up (not in this PR)

CrewAI's blocking LLM call at module import is fragile — any aimock hiccup still crashes the container before it can bind a port. That is upstream behavior (`crewai/cli/crew_chat.py:481 generate_input_description_with_ai`) and should be tracked as a separate issue.

## Test plan

- [x] Local: red-green confirmed against `@copilotkit/aimock@1.10.0` — 500 pre-fix, 200 post-fix for CrewAI-style startup prompt
- [x] Local: the five previously-broken fixtures (`plan`, `steps`, `mars`, `dashboard`, `report`) now return 200 + valid content
- [ ] Railway: aimock image rebuilds and picks up new fixtures; crewai-crews next deploy reaches ACTIVE