### PR TITLE
fix(ci): render real newlines in Slack alerts and enrich starter smoke payload

### DIFF
--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -83,6 +83,9 @@ jobs:
           SUMMARY=$(printf '%s' "$DETAILS_RAW" | head -3 \
             | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b[()][A-Za-z0-9]//g' \
             | head -c 200 | iconv -f UTF-8 -t UTF-8//IGNORE)
+          if [ -z "$SUMMARY" ]; then
+            SUMMARY="(no failure detail captured — see job log)"
+          fi
           URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           JOB_URL="${URL}/job/${{ github.job }}"
 

--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -74,19 +74,30 @@ jobs:
 
       - name: Build Slack payload
         if: failure()
+        id: slack-payload
         env:
           DETAILS_RAW: ${{ steps.failures.outputs.details }}
         run: |
-          SUMMARY=$(printf '%s' "$DETAILS_RAW" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
+          # Strip ANSI sequences (SGR, OSC, and G0/G1 charset designators), then truncate
+          # to 200 bytes and drop any trailing partial UTF-8 bytes so we don't emit mojibake.
+          SUMMARY=$(printf '%s' "$DETAILS_RAW" | head -3 \
+            | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b[()][A-Za-z0-9]//g' \
+            | head -c 200 | iconv -f UTF-8 -t UTF-8//IGNORE)
           URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           JOB_URL="${URL}/job/${{ github.job }}"
+
+          SLACK_MSG=$(mktemp)
+          SLACK_PAYLOAD=$(mktemp)
+
           # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
           {
             printf ':x: *Showcase E2E suite failed*\n'
             printf '<%s|View run> · <%s|View job>\n' "$URL" "$JOB_URL"
             printf '```\n%s\n```\n' "$SUMMARY"
-          } > /tmp/slack-message.txt
-          jq -n --rawfile text /tmp/slack-message.txt '{text: $text}' > /tmp/slack-payload.json
+          } > "$SLACK_MSG"
+          jq -n --rawfile text "$SLACK_MSG" '{text: $text}' > "$SLACK_PAYLOAD"
+          rm -f "$SLACK_MSG"
+          echo "payload_path=${SLACK_PAYLOAD}" >> "$GITHUB_OUTPUT"
 
       - name: Post failure to Slack
         if: failure()
@@ -94,7 +105,11 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload-file-path: /tmp/slack-payload.json
+          payload-file-path: ${{ steps.slack-payload.outputs.payload_path }}
+
+      - name: Clean up Slack payload tmpfile
+        if: always() && steps.slack-payload.outputs.payload_path
+        run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
 
       - name: Create issue on failure
         if: failure()

--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -74,11 +74,19 @@ jobs:
 
       - name: Build Slack payload
         if: failure()
+        env:
+          DETAILS_RAW: ${{ steps.failures.outputs.details }}
         run: |
-          SUMMARY=$(echo "${{ steps.failures.outputs.details }}" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
+          SUMMARY=$(printf '%s' "$DETAILS_RAW" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
           URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          jq -n --arg text ":x: *Showcase E2E suite failed*\n<$URL|View run>\n\`\`\`$SUMMARY\`\`\`" \
-            '{text: $text}' > /tmp/slack-payload.json
+          JOB_URL="${URL}/job/${{ github.job }}"
+          # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
+          {
+            printf ':x: *Showcase E2E suite failed*\n'
+            printf '<%s|View run> · <%s|View job>\n' "$URL" "$JOB_URL"
+            printf '```\n%s\n```\n' "$SUMMARY"
+          } > /tmp/slack-message.txt
+          jq -n --rawfile text /tmp/slack-message.txt '{text: $text}' > /tmp/slack-payload.json
 
       - name: Post failure to Slack
         if: failure()

--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -125,6 +125,9 @@ jobs:
           SUMMARY=$(printf '%s' "$SUMMARY_RAW" | head -3 \
             | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b[()][A-Za-z0-9]//g' \
             | head -c 200 | iconv -f UTF-8 -t UTF-8//IGNORE)
+          if [ -z "$SUMMARY" ]; then
+            SUMMARY="(no failure detail captured — see job log)"
+          fi
           URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           JOB_URL="${URL}/job/${{ github.job }}"
 

--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -115,19 +115,31 @@ jobs:
 
       - name: Build Slack payload
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        id: slack-payload
         env:
           SUMMARY_RAW: ${{ steps.failure-cause.outputs.summary }}
+          STARTER: ${{ matrix.starter }}
         run: |
-          SUMMARY=$(printf '%s' "$SUMMARY_RAW" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
+          # Strip ANSI sequences (SGR, OSC, and G0/G1 charset designators), then truncate
+          # to 200 bytes and drop any trailing partial UTF-8 bytes so we don't emit mojibake.
+          SUMMARY=$(printf '%s' "$SUMMARY_RAW" | head -3 \
+            | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b[()][A-Za-z0-9]//g' \
+            | head -c 200 | iconv -f UTF-8 -t UTF-8//IGNORE)
           URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           JOB_URL="${URL}/job/${{ github.job }}"
+
+          SLACK_MSG=$(mktemp)
+          SLACK_PAYLOAD=$(mktemp)
+
           # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
           {
-            printf ':x: *Starter smoke test failing: %s*\n' "${{ matrix.starter }}"
+            printf ':x: *Starter smoke test failing: %s*\n' "$STARTER"
             printf '<%s|View run> · <%s|View job>\n' "$URL" "$JOB_URL"
             printf '```\n%s\n```\n' "$SUMMARY"
-          } > /tmp/slack-message.txt
-          jq -n --rawfile text /tmp/slack-message.txt '{text: $text}' > /tmp/slack-payload.json
+          } > "$SLACK_MSG"
+          jq -n --rawfile text "$SLACK_MSG" '{text: $text}' > "$SLACK_PAYLOAD"
+          rm -f "$SLACK_MSG"
+          echo "payload_path=${SLACK_PAYLOAD}" >> "$GITHUB_OUTPUT"
 
       - name: Alert Slack on failure
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
@@ -135,7 +147,11 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload-file-path: /tmp/slack-payload.json
+          payload-file-path: ${{ steps.slack-payload.outputs.payload_path }}
+
+      - name: Clean up Slack payload tmpfile
+        if: always() && steps.slack-payload.outputs.payload_path
+        run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
 
       - name: Create GitHub issue on failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -115,11 +115,19 @@ jobs:
 
       - name: Build Slack payload
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        env:
+          SUMMARY_RAW: ${{ steps.failure-cause.outputs.summary }}
         run: |
-          SUMMARY=$(echo "${{ steps.failure-cause.outputs.summary }}" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
+          SUMMARY=$(printf '%s' "$SUMMARY_RAW" | head -3 | sed 's/\x1b\[[0-9;]*m//g' | cut -c1-200)
           URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          jq -n --arg text ":x: *Starter smoke test failing: ${{ matrix.starter }}*\n<$URL|View run>\n\`\`\`$SUMMARY\`\`\`" \
-            '{text: $text}' > /tmp/slack-payload.json
+          JOB_URL="${URL}/job/${{ github.job }}"
+          # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
+          {
+            printf ':x: *Starter smoke test failing: %s*\n' "${{ matrix.starter }}"
+            printf '<%s|View run> · <%s|View job>\n' "$URL" "$JOB_URL"
+            printf '```\n%s\n```\n' "$SUMMARY"
+          } > /tmp/slack-message.txt
+          jq -n --rawfile text /tmp/slack-message.txt '{text: $text}' > /tmp/slack-payload.json
 
       - name: Alert Slack on failure
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')

--- a/.github/workflows/starter_deployed_smoke.yml
+++ b/.github/workflows/starter_deployed_smoke.yml
@@ -46,16 +46,101 @@ jobs:
 
       - name: Run starter deployed smoke tests
         working-directory: showcase/tests
-        run: npx playwright test e2e/integration-smoke.spec.ts --grep "@starter-health|@starter-agent|@starter-chat"
+        # Emit JSON report alongside the default reporter so the Slack step can enrich the alert.
+        run: npx playwright test e2e/integration-smoke.spec.ts --grep "@starter-health|@starter-agent|@starter-chat" --reporter=github,json
         env:
           STARTER_SLUG: ${{ inputs.starter_slug || '' }}
+          PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/results.json
+
+      - name: Extract failure details
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        id: failures
+        working-directory: showcase/tests
+        run: |
+          REPORT=test-results/results.json
+          if [ ! -f "$REPORT" ]; then
+            echo "No JSON report found at $REPORT; writing empty summary"
+            : > /tmp/failure-summary.txt
+            echo "failed_count=0" >> "$GITHUB_OUTPUT"
+            echo "starters=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Walk the playwright JSON suite tree, pull failed tests with: title, tags, first error line.
+          # Cap at 5 entries to avoid noisy Slack messages.
+          jq -r '
+            def walk_suites:
+              (.suites // [])[] | (., (.suites // [])[] | walk_suites), (.specs // [])[];
+            [ .. | objects | select(.tests? and .title?) ] as $specs
+            | $specs
+            | map(
+                . as $spec
+                | ($spec.tests[0] // {}) as $t
+                | ($t.results // [])[-1] as $r
+                | select($r.status == "failed" or $r.status == "timedOut")
+                | {
+                    title: $spec.title,
+                    tags: ($spec.title | [scan("@[a-zA-Z0-9_-]+")]),
+                    slug: ($spec.title | capture("\\[Starter\\] (?<s>[a-zA-Z0-9_-]+)"; "g").s // ""),
+                    error: (
+                      ($r.error.message // $r.errors[0].message // "no error message")
+                      | gsub("\u001b\\[[0-9;]*m"; "")
+                      | split("\n")[0]
+                      | .[0:240]
+                    )
+                  }
+              )
+          ' "$REPORT" > /tmp/failures.json || echo "[]" > /tmp/failures.json
+
+          TOTAL=$(jq 'length' /tmp/failures.json)
+          # Unique list of starter slugs for the header
+          STARTERS=$(jq -r '[.[].slug] | unique | map(select(. != "")) | join(", ")' /tmp/failures.json)
+
+          # Build a short human-readable summary (first 5 failures)
+          jq -r '
+            .[0:5][]
+            | "• *" + (.slug | if . == "" then "?" else . end) + "* "
+              + (if (.tags | length) > 0 then "(" + (.tags | join(" ")) + ") " else "" end)
+              + "— " + .error
+          ' /tmp/failures.json > /tmp/failure-summary.txt
+          if [ "$TOTAL" -gt 5 ]; then
+            echo "• …and $((TOTAL - 5)) more failure(s)" >> /tmp/failure-summary.txt
+          fi
+
+          echo "failed_count=${TOTAL}" >> "$GITHUB_OUTPUT"
+          {
+            echo "starters<<STARTERS_EOF"
+            echo "${STARTERS}"
+            echo "STARTERS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Slack payload
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
         run: |
-          URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          jq -n --arg text ":rotating_light: *Starter Deployed Smoke Test Failed*\n<$URL|View run>" \
-            '{text: $text}' > /tmp/slack-payload.json
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          JOB_URL="${RUN_URL}/job/${{ github.job }}"
+          STARTERS="${{ steps.failures.outputs.starters }}"
+          FAILED_COUNT="${{ steps.failures.outputs.failed_count || '0' }}"
+
+          # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
+          {
+            if [ "$FAILED_COUNT" = "0" ] || [ -z "$FAILED_COUNT" ]; then
+              # Fallback when JSON report wasn't produced (e.g. install step failed).
+              printf ':rotating_light: *Starter Deployed Smoke Test Failed*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
+            else
+              HEADER=":rotating_light: *Starter Deployed Smoke Test Failed*"
+              if [ -n "$STARTERS" ]; then
+                HEADER="${HEADER} — ${STARTERS}"
+              fi
+              printf '%s\n' "$HEADER"
+              printf '<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
+              printf '```\n'
+              cat /tmp/failure-summary.txt
+              printf '```\n'
+            fi
+          } > /tmp/slack-message.txt
+
+          jq -n --rawfile text /tmp/slack-message.txt '{text: $text}' > /tmp/slack-payload.json
 
       - name: Alert Slack on failure
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')

--- a/.github/workflows/starter_deployed_smoke.yml
+++ b/.github/workflows/starter_deployed_smoke.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run starter deployed smoke tests
         working-directory: showcase/tests
-        # Emit JSON report alongside the default reporter so the Slack step can enrich the alert.
+        # Use github reporter for Actions annotations plus json for programmatic parsing.
         run: npx playwright test e2e/integration-smoke.spec.ts --grep "@starter-health|@starter-agent|@starter-chat" --reporter=github,json
         env:
           STARTER_SLUG: ${{ inputs.starter_slug || '' }}
@@ -67,36 +67,39 @@ jobs:
           fi
 
           # Walk the playwright JSON suite tree, pull failed tests with: title, tags, first error line.
-          # Cap at 5 entries to avoid noisy Slack messages.
-          jq -r '
-            def walk_suites:
-              (.suites // [])[] | (., (.suites // [])[] | walk_suites), (.specs // [])[];
+          # Iterate all tests per spec so multi-project configs don't drop failures.
+          if ! jq -r '
             [ .. | objects | select(.tests? and .title?) ] as $specs
             | $specs
             | map(
                 . as $spec
-                | ($spec.tests[0] // {}) as $t
+                | ($spec.tests // [])[] as $t
                 | ($t.results // [])[-1] as $r
                 | select($r.status == "failed" or $r.status == "timedOut")
                 | {
                     title: $spec.title,
                     tags: ($spec.title | [scan("@[a-zA-Z0-9_-]+")]),
-                    slug: ($spec.title | capture("\\[Starter\\] (?<s>[a-zA-Z0-9_-]+)"; "g").s // ""),
+                    slug: ((try ($spec.title | capture("\\[Starter\\] (?<s>[a-zA-Z0-9_-]+)").s) catch "") // ""),
                     error: (
                       ($r.error.message // $r.errors[0].message // "no error message")
-                      | gsub("\u001b\\[[0-9;]*m"; "")
+                      | gsub("\u001b\\[[0-9;?]*[A-Za-z]"; "")
                       | split("\n")[0]
                       | .[0:240]
                     )
                   }
               )
-          ' "$REPORT" > /tmp/failures.json || echo "[]" > /tmp/failures.json
+          ' "$REPORT" > /tmp/failures.json 2> /tmp/jq-err.log; then
+            echo "::warning::jq failed to parse $REPORT"
+            echo "jq stderr:"; cat /tmp/jq-err.log
+            echo "[]" > /tmp/failures.json
+            echo "extraction_error=jq_parse_failed" >> "$GITHUB_OUTPUT"
+          fi
 
           TOTAL=$(jq 'length' /tmp/failures.json)
           # Unique list of starter slugs for the header
           STARTERS=$(jq -r '[.[].slug] | unique | map(select(. != "")) | join(", ")' /tmp/failures.json)
 
-          # Build a short human-readable summary (first 5 failures)
+          # Build a short human-readable summary — cap at 5 entries to avoid noisy Slack messages.
           jq -r '
             .[0:5][]
             | "• *" + (.slug | if . == "" then "?" else . end) + "* "
@@ -116,11 +119,15 @@ jobs:
 
       - name: Build Slack payload
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        id: slack-payload
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           JOB_URL="${RUN_URL}/job/${{ github.job }}"
           STARTERS="${{ steps.failures.outputs.starters }}"
           FAILED_COUNT="${{ steps.failures.outputs.failed_count || '0' }}"
+
+          SLACK_MSG=$(mktemp)
+          SLACK_PAYLOAD=$(mktemp)
 
           # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
           {
@@ -138,9 +145,11 @@ jobs:
               cat /tmp/failure-summary.txt
               printf '```\n'
             fi
-          } > /tmp/slack-message.txt
+          } > "$SLACK_MSG"
 
-          jq -n --rawfile text /tmp/slack-message.txt '{text: $text}' > /tmp/slack-payload.json
+          jq -n --rawfile text "$SLACK_MSG" '{text: $text}' > "$SLACK_PAYLOAD"
+          rm -f "$SLACK_MSG"
+          echo "payload_path=${SLACK_PAYLOAD}" >> "$GITHUB_OUTPUT"
 
       - name: Alert Slack on failure
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
@@ -149,7 +158,11 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload-file-path: /tmp/slack-payload.json
+          payload-file-path: ${{ steps.slack-payload.outputs.payload_path }}
+
+      - name: Clean up Slack payload tmpfile
+        if: always() && steps.slack-payload.outputs.payload_path
+        run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
 
       - name: Create GitHub issue on failure
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')

--- a/.github/workflows/starter_deployed_smoke.yml
+++ b/.github/workflows/starter_deployed_smoke.yml
@@ -63,6 +63,7 @@ jobs:
             : > /tmp/failure-summary.txt
             echo "failed_count=0" >> "$GITHUB_OUTPUT"
             echo "starters=" >> "$GITHUB_OUTPUT"
+            echo "extraction_error=missing_report" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -79,7 +80,7 @@ jobs:
                 | {
                     title: $spec.title,
                     tags: ($spec.title | [scan("@[a-zA-Z0-9_-]+")]),
-                    slug: ((try ($spec.title | capture("\\[Starter\\] (?<s>[a-zA-Z0-9_-]+)").s) catch "") // ""),
+                    slug: ((try ($spec.title | capture("\\[Starter\\] (?<s>[a-zA-Z0-9_-]+)").s) catch null) // ($spec.title | .[0:40]) // "unknown"),
                     error: (
                       ($r.error.message // $r.errors[0].message // "no error message")
                       | gsub("\u001b\\[[0-9;?]*[A-Za-z]"; "")
@@ -102,7 +103,7 @@ jobs:
           # Build a short human-readable summary — cap at 5 entries to avoid noisy Slack messages.
           jq -r '
             .[0:5][]
-            | "• *" + (.slug | if . == "" then "?" else . end) + "* "
+            | "• *" + (.slug | if . == "" then "unknown" else . end) + "* "
               + (if (.tags | length) > 0 then "(" + (.tags | join(" ")) + ") " else "" end)
               + "— " + .error
           ' /tmp/failures.json > /tmp/failure-summary.txt
@@ -125,15 +126,23 @@ jobs:
           JOB_URL="${RUN_URL}/job/${{ github.job }}"
           STARTERS="${{ steps.failures.outputs.starters }}"
           FAILED_COUNT="${{ steps.failures.outputs.failed_count || '0' }}"
+          EXTRACTION_ERROR="${{ steps.failures.outputs.extraction_error }}"
 
           SLACK_MSG=$(mktemp)
           SLACK_PAYLOAD=$(mktemp)
 
           # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
+          # Distinguish failure modes so on-call can tell install-failed from jq-failed from zero-hits from real test failures.
           {
-            if [ "$FAILED_COUNT" = "0" ] || [ -z "$FAILED_COUNT" ]; then
-              # Fallback when JSON report wasn't produced (e.g. install step failed).
-              printf ':rotating_light: *Starter Deployed Smoke Test Failed*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
+            if [ "$EXTRACTION_ERROR" = "jq_parse_failed" ]; then
+              # jq crashed trying to parse the report
+              printf ':rotating_light: *Starter Deployed Smoke Test Failed — jq parse of Playwright report failed*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
+            elif [ "$EXTRACTION_ERROR" = "missing_report" ]; then
+              # Report file never produced (pre-test stage: install, setup, playwright install, etc.)
+              printf ':rotating_light: *Starter Deployed Smoke Test Failed (pre-test stage — no JSON report produced)*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
+            elif [ "$FAILED_COUNT" = "0" ] || [ -z "$FAILED_COUNT" ]; then
+              # Report exists but jq matched zero failures — job-level error (e.g. non-zero exit without failed tests)
+              printf ':rotating_light: *Starter Deployed Smoke Test Failed (no test failures in report — check run for job-level error)*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
             else
               HEADER=":rotating_light: *Starter Deployed Smoke Test Failed*"
               if [ -n "$STARTERS" ]; then


### PR DESCRIPTION
## Summary

Fixes Slack alerts that rendered literal `\n` (backslash + n) instead of actual newlines — messages looked like `*Starter Deployed Smoke Test Failed*\nView run` in Slack.

Root cause: `jq -n --arg text "...\n..."` passes the two literal characters `\` and `n` to jq (bash doesn't interpret `\n` inside double quotes). `--arg` stores them verbatim; jq then JSON-escapes the backslash, producing `"\\n"` in the payload, which Slack parses back to the two-character string `\n` and renders as-is.

## Changes

Switched three alert builders from `jq --arg` with embedded `\n` to the safer pattern already used in `showcase_smoke-monitor.yml`: write a message file with real LF bytes via `printf`, then `jq -n --rawfile text …` for correct JSON escaping.

Affected workflows:
- `starter_deployed_smoke.yml` — Starter Deployed Smoke Test Failed (the alert from the screenshot)
- `starter-smoke.yml` — Starter smoke test failing: <starter>
- `showcase_drift-detection.yml` — Showcase E2E suite failed

## Enrichment (starter_deployed_smoke.yml)

The deployed-smoke failure alert was just `*Starter Deployed Smoke Test Failed* | View run`. Now emits a Playwright JSON report, extracts failures, and builds a richer payload:

- Failed starter slugs listed in the header (parsed from spec titles)
- Direct link to the failed job in addition to the workflow run
- Up to 5 failure entries, each with:
  - starter slug
  - test-level tags (`@starter-health` / `@starter-agent` / `@starter-chat` / `@starter-tools`)
  - first line of the error message (ANSI-stripped, 240-char cap)
- "…and N more failure(s)" footer when the count exceeds 5

Falls back to the minimal header when no JSON report exists (e.g. pre-test setup failed) so alerts still fire.

The other two alerts already had a summary but now also include a "View job" link for direct navigation.

## Test plan

- [ ] Trigger `starter_deployed_smoke.yml` via `workflow_dispatch` against a starter known to fail (or simulate) and confirm Slack renders real newlines plus the enriched payload
- [ ] Trigger `starter-smoke.yml` via `workflow_dispatch` (PR run skips the Slack step) and confirm alerting format when a starter is forced to fail
- [ ] Trigger `showcase_drift-detection.yml` via `workflow_dispatch` and confirm Slack renders real newlines and the fenced code block
- [ ] Grep `.github/workflows/` for `jq -n --arg text ".*\\n"` — should return zero matches

Supersedes #3912 (closed).