### PR TITLE
fix(crewai-crews): harden against LLM blocking calls at import time

### DIFF
--- a/showcase/packages/crewai-crews/requirements.txt
+++ b/showcase/packages/crewai-crews/requirements.txt
@@ -1,5 +1,5 @@
 crewai>=0.130.0
-ag-ui-crewai>=0.1.4
+ag-ui-crewai>=0.1.4,<0.1.6
 ag-ui-protocol>=0.1.5
 python-dotenv>=1.0.1
 uvicorn>=0.34.3

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -61,8 +61,18 @@ _crewai_crew_chat.generate_crew_description_with_ai = _static_crew_description
 
 # Verify the patch took effect (defense-in-depth against import-order weirdness
 # or re-imports that could shadow our module reference).
-assert _crewai_crew_chat.generate_input_description_with_ai is _static_input_description
-assert _crewai_crew_chat.generate_crew_description_with_ai is _static_crew_description
+if _crewai_crew_chat.generate_input_description_with_ai is not _static_input_description:
+    raise RuntimeError(
+        "crewai hardening shim: patch verification failed — "
+        "generate_input_description_with_ai was shadowed or re-imported after patching. "
+        "This would reintroduce the pre-bind LLM crash bug."
+    )
+if _crewai_crew_chat.generate_crew_description_with_ai is not _static_crew_description:
+    raise RuntimeError(
+        "crewai hardening shim: patch verification failed — "
+        "generate_crew_description_with_ai was shadowed or re-imported after patching. "
+        "This would reintroduce the pre-bind LLM crash bug."
+    )
 
 logging.getLogger(__name__).info(
     "Applied crewai.cli.crew_chat hardening shim (upstream issue #5510). "

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -5,6 +5,7 @@ FastAPI server that hosts the CrewAI crew backend.
 The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
 """
 
+import logging
 import os
 
 # HARDENING: CrewAI's ChatWithCrewFlow.__init__ (in ag_ui_crewai.crews) makes
@@ -20,9 +21,31 @@ import os
 # are only cosmetic for the CrewAI chat UI (which the CopilotKit runtime does
 # not use), so static defaults are functionally equivalent for our showcase.
 #
-# Upstream fix (deferred construction to first request) landed on ag-ui main
-# but is not yet released. Remove this shim once ag-ui-crewai > 0.1.5 ships.
+# Upstream issue: https://github.com/crewAIInc/crewAI/issues/5510
+# Upstream fix: ag-ui-crewai repo (deferred ChatWithCrewFlow construction
+# to first-request) — landed on main but not yet released as of 0.1.5.
+# Remove this shim once ag-ui-crewai > 0.1.5 ships and the requirements.txt
+# ceiling is lifted.
 from crewai.cli import crew_chat as _crewai_crew_chat
+
+# Fail loudly if upstream renames/removes these symbols. setattr() on a module
+# always succeeds regardless of prior attribute existence, so without this
+# guard an upstream rename would silently no-op the patch and reintroduce the
+# pre-bind LLM crash bug with a green PR.
+_REQUIRED_ATTRS = (
+    "generate_input_description_with_ai",
+    "generate_crew_description_with_ai",
+)
+for _attr in _REQUIRED_ATTRS:
+    if not hasattr(_crewai_crew_chat, _attr):
+        raise RuntimeError(
+            f"crewai upstream drift: crewai.cli.crew_chat.{_attr} no longer exists. "
+            f"The import-time hardening shim in agent_server.py would silently no-op, "
+            f"reintroducing the pre-bind LLM crash bug. Either update the shim to the "
+            f"new function name, or remove it if ag-ui-crewai > 0.1.5 (with deferred "
+            f"construction fix) has been adopted. See: "
+            f"https://github.com/crewAIInc/crewAI/issues/5510"
+        )
 
 
 def _static_input_description(input_name, *_args, **_kwargs):
@@ -35,6 +58,16 @@ def _static_crew_description(*_args, **_kwargs):
 
 _crewai_crew_chat.generate_input_description_with_ai = _static_input_description
 _crewai_crew_chat.generate_crew_description_with_ai = _static_crew_description
+
+# Verify the patch took effect (defense-in-depth against import-order weirdness
+# or re-imports that could shadow our module reference).
+assert _crewai_crew_chat.generate_input_description_with_ai is _static_input_description
+assert _crewai_crew_chat.generate_crew_description_with_ai is _static_crew_description
+
+logging.getLogger(__name__).info(
+    "Applied crewai.cli.crew_chat hardening shim (upstream issue #5510). "
+    "Remove this shim after ag-ui-crewai > 0.1.5 is adopted."
+)
 
 import uvicorn
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -6,6 +6,36 @@ The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
 """
 
 import os
+
+# HARDENING: CrewAI's ChatWithCrewFlow.__init__ (in ag_ui_crewai.crews) makes
+# blocking synchronous LLM calls via generate_crew_chat_inputs, which in turn
+# calls generate_input_description_with_ai and generate_crew_description_with_ai
+# from crewai.cli.crew_chat. In ag-ui-crewai <= 0.1.5 this happens at module
+# import time inside add_crewai_crew_fastapi_endpoint, BEFORE uvicorn binds its
+# port. Any LLM hiccup (aimock regression, OpenAI outage, network blip) will
+# crash the Python process before the HTTP server is listening, which causes
+# Railway/Kubernetes/ECS health checks to fail and deploys to roll back.
+#
+# Patch both functions to return static strings. The AI-generated descriptions
+# are only cosmetic for the CrewAI chat UI (which the CopilotKit runtime does
+# not use), so static defaults are functionally equivalent for our showcase.
+#
+# Upstream fix (deferred construction to first request) landed on ag-ui main
+# but is not yet released. Remove this shim once ag-ui-crewai > 0.1.5 ships.
+from crewai.cli import crew_chat as _crewai_crew_chat
+
+
+def _static_input_description(input_name, *_args, **_kwargs):
+    return f"Input value for '{input_name}'."
+
+
+def _static_crew_description(*_args, **_kwargs):
+    return "A CrewAI crew."
+
+
+_crewai_crew_chat.generate_input_description_with_ai = _static_input_description
+_crewai_crew_chat.generate_crew_description_with_ai = _static_crew_description
+
 import uvicorn
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
 from fastapi import FastAPI

--- a/showcase/starters/crewai-crews/agent/requirements.txt
+++ b/showcase/starters/crewai-crews/agent/requirements.txt
@@ -1,5 +1,5 @@
 crewai>=0.130.0
-ag-ui-crewai>=0.1.4
+ag-ui-crewai>=0.1.4,<0.1.6
 ag-ui-protocol>=0.1.5
 python-dotenv>=1.0.1
 uvicorn>=0.34.3

--- a/showcase/starters/crewai-crews/agent_server.py
+++ b/showcase/starters/crewai-crews/agent_server.py
@@ -61,8 +61,18 @@ _crewai_crew_chat.generate_crew_description_with_ai = _static_crew_description
 
 # Verify the patch took effect (defense-in-depth against import-order weirdness
 # or re-imports that could shadow our module reference).
-assert _crewai_crew_chat.generate_input_description_with_ai is _static_input_description
-assert _crewai_crew_chat.generate_crew_description_with_ai is _static_crew_description
+if _crewai_crew_chat.generate_input_description_with_ai is not _static_input_description:
+    raise RuntimeError(
+        "crewai hardening shim: patch verification failed — "
+        "generate_input_description_with_ai was shadowed or re-imported after patching. "
+        "This would reintroduce the pre-bind LLM crash bug."
+    )
+if _crewai_crew_chat.generate_crew_description_with_ai is not _static_crew_description:
+    raise RuntimeError(
+        "crewai hardening shim: patch verification failed — "
+        "generate_crew_description_with_ai was shadowed or re-imported after patching. "
+        "This would reintroduce the pre-bind LLM crash bug."
+    )
 
 logging.getLogger(__name__).info(
     "Applied crewai.cli.crew_chat hardening shim (upstream issue #5510). "

--- a/showcase/starters/crewai-crews/agent_server.py
+++ b/showcase/starters/crewai-crews/agent_server.py
@@ -5,7 +5,70 @@ FastAPI server that hosts the CrewAI crew backend.
 The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
 """
 
+import logging
 import os
+
+# HARDENING: CrewAI's ChatWithCrewFlow.__init__ (in ag_ui_crewai.crews) makes
+# blocking synchronous LLM calls via generate_crew_chat_inputs, which in turn
+# calls generate_input_description_with_ai and generate_crew_description_with_ai
+# from crewai.cli.crew_chat. In ag-ui-crewai <= 0.1.5 this happens at module
+# import time inside add_crewai_crew_fastapi_endpoint, BEFORE uvicorn binds its
+# port. Any LLM hiccup (aimock regression, OpenAI outage, network blip) will
+# crash the Python process before the HTTP server is listening, which causes
+# Railway/Kubernetes/ECS health checks to fail and deploys to roll back.
+#
+# Patch both functions to return static strings. The AI-generated descriptions
+# are only cosmetic for the CrewAI chat UI (which the CopilotKit runtime does
+# not use), so static defaults are functionally equivalent for our showcase.
+#
+# Upstream issue: https://github.com/crewAIInc/crewAI/issues/5510
+# Upstream fix: ag-ui-crewai repo (deferred ChatWithCrewFlow construction
+# to first-request) — landed on main but not yet released as of 0.1.5.
+# Remove this shim once ag-ui-crewai > 0.1.5 ships and the requirements.txt
+# ceiling is lifted.
+from crewai.cli import crew_chat as _crewai_crew_chat
+
+# Fail loudly if upstream renames/removes these symbols. setattr() on a module
+# always succeeds regardless of prior attribute existence, so without this
+# guard an upstream rename would silently no-op the patch and reintroduce the
+# pre-bind LLM crash bug with a green PR.
+_REQUIRED_ATTRS = (
+    "generate_input_description_with_ai",
+    "generate_crew_description_with_ai",
+)
+for _attr in _REQUIRED_ATTRS:
+    if not hasattr(_crewai_crew_chat, _attr):
+        raise RuntimeError(
+            f"crewai upstream drift: crewai.cli.crew_chat.{_attr} no longer exists. "
+            f"The import-time hardening shim in agent_server.py would silently no-op, "
+            f"reintroducing the pre-bind LLM crash bug. Either update the shim to the "
+            f"new function name, or remove it if ag-ui-crewai > 0.1.5 (with deferred "
+            f"construction fix) has been adopted. See: "
+            f"https://github.com/crewAIInc/crewAI/issues/5510"
+        )
+
+
+def _static_input_description(input_name, *_args, **_kwargs):
+    return f"Input value for '{input_name}'."
+
+
+def _static_crew_description(*_args, **_kwargs):
+    return "A CrewAI crew."
+
+
+_crewai_crew_chat.generate_input_description_with_ai = _static_input_description
+_crewai_crew_chat.generate_crew_description_with_ai = _static_crew_description
+
+# Verify the patch took effect (defense-in-depth against import-order weirdness
+# or re-imports that could shadow our module reference).
+assert _crewai_crew_chat.generate_input_description_with_ai is _static_input_description
+assert _crewai_crew_chat.generate_crew_description_with_ai is _static_crew_description
+
+logging.getLogger(__name__).info(
+    "Applied crewai.cli.crew_chat hardening shim (upstream issue #5510). "
+    "Remove this shim after ag-ui-crewai > 0.1.5 is adopted."
+)
+
 import uvicorn
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary

CrewAI's `ChatWithCrewFlow.__init__` (invoked from `ag_ui_crewai.endpoint.add_crewai_crew_fastapi_endpoint` at module import in `ag-ui-crewai <= 0.1.5`) makes synchronous blocking LLM calls via `crewai.cli.crew_chat.generate_input_description_with_ai` and `generate_crew_description_with_ai`. ANY LLM hiccup — aimock regression, OpenAI outage, network blip, DNS failure — crashes the Python process BEFORE uvicorn can bind its port, causing Railway/Kubernetes health checks to fail and deploys to roll back.

This was the direct cause of the crewai-crews Railway crash fixed server-side in #3971. That fix patched the aimock response schema, but the underlying fragility in upstream CrewAI / ag-ui-crewai remained — a future blip would crash us again.

This PR adds a defensive monkey-patch in `agent_server.py` that replaces both generator functions with static-string returns BEFORE `ag_ui_crewai` is imported. The AI-generated descriptions are only surfaced in the CrewAI chat UI (which the CopilotKit runtime does not use), so static defaults are functionally equivalent for our showcase.

Upstream issue filed: https://github.com/crewAIInc/crewAI/issues/5510

The long-term fix is deferred construction in `ag-ui-crewai`, which has landed on ag-ui `main` but is not yet released. Remove this shim once `ag-ui-crewai > 0.1.5` ships.

## Why a monkey-patch and not lazy-init

`add_crewai_crew_fastapi_endpoint` is the entry point and internally constructs `ChatWithCrewFlow(crew)` synchronously in `ag-ui-crewai <= 0.1.5`. Deferring that call would require either vendoring the endpoint function or reimplementing it. The monkey-patch is two lines and removes cleanly when the upstream fix ships.

## Test plan

Verified locally via Docker build + run with an intentionally broken LLM endpoint (`OPENAI_BASE_URL=http://invalid-host/v1`):

**Unhardened (negative control):**

```
File "/app/agent_server.py", line 27, in <module>
    add_crewai_crew_fastapi_endpoint(app, LatestAiDevelopment(), "/")
  File ".../ag_ui_crewai/endpoint.py", line 250, in add_crewai_crew_fastapi_endpoint
    add_crewai_flow_fastapi_endpoint(app, ChatWithCrewFlow(crew=crew), path)
  File ".../ag_ui_crewai/crews.py", line 56, in __init__
    self.crew_chat_inputs = crew_chat_generate_crew_chat_inputs(...)
  File ".../crewai/cli/crew_chat.py", line 387, in generate_crew_chat_inputs
    description = generate_input_description_with_ai(input_name, crew, chat_llm)
  File ".../crewai/cli/crew_chat.py", line 481, in generate_input_description_with_ai
    response = chat_llm.call(...)
APIError
```

Container exits with code 1, never binds a port.

**Hardened (this PR):**

```
INFO:     Started server process [7]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
```

`curl http://localhost:PORT/api/health` -> `{"status":"ok","integration":"crewai-crews","agent":"ok","timestamp":"..."}` (HTTP 200).

### Checklist

- [x] Docker build succeeds locally
- [x] Unhardened build crashes on import with broken LLM endpoint (negative control)
- [x] Hardened build starts cleanly with broken LLM endpoint and responds 200 on `/api/health`
- [x] Upstream issue filed on crewAIInc/crewAI