### PR TITLE
chore(ci): rename showcase_aimock-e2e → test_e2e-showcase-on-demand

### DIFF
--- a/.github/workflows/test_e2e-showcase-on-demand.yml
+++ b/.github/workflows/test_e2e-showcase-on-demand.yml
@@ -1,4 +1,4 @@
-name: "Showcase: Aimock E2E Tests"
+name: "test / e2e / showcase / on-demand"
 
 on:
   issue_comment:
@@ -163,5 +163,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `${status} **Aimock E2E Tests** (\`${slug}\`): ${{ job.status }}\n\n[View run](${runUrl})`
+              body: `${status} **Showcase E2E (on-demand)** (\`${slug}\`): ${{ job.status }}\n\n[View run](${runUrl})`
             });

--- a/showcase/QA-COVERAGE.md
+++ b/showcase/QA-COVERAGE.md
@@ -74,7 +74,7 @@ This matrix tracks what testing exists for each demo and the Sales Dashboard sta
 ### CI Workflows (`.github/workflows/showcase_*.yml`)
 
 - `showcase_validate.yml` -- runs `npx vitest run` on PR (unit tests only)
-- `showcase_aimock-e2e.yml` -- runs aimock-backed Playwright E2E, **manual trigger only** (`/test-aimock` comment or workflow_dispatch)
+- `test_e2e-showcase-on-demand.yml` -- runs aimock-backed Playwright E2E, **manual trigger only** (`/test-aimock` comment or workflow_dispatch)
 - `showcase_drift-detection.yml` -- template drift detection
 - `showcase_template-drift.yml` -- template synchronization
 - `showcase_deploy.yml` -- deployment pipeline


### PR DESCRIPTION
Bundle 6 workflow rename. This workflow runs only on /test-aimock <slug> PR comments, not as a PR gate — new name reflects that. Branch-protection audit confirmed drop-in safe ([Notion report](https://www.notion.so/3443aa38185281a3ad07e5ec63debd0f)). Consumer grep verified no remaining references to the old name.