### PR TITLE
feat(showcase/crewai-crews): QA markdown 9-for-all parity

### DIFF
--- a/showcase/packages/crewai-crews/qa/gen-ui-agent.md
+++ b/showcase/packages/crewai-crews/qa/gen-ui-agent.md
@@ -1,0 +1,64 @@
+# QA: Agentic Generative UI — CrewAI (Crews)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the gen-ui-agent demo page
+- [ ] Verify the chat interface loads in a centered full-height layout
+- [ ] Verify the chat input placeholder "Type a message" is visible
+- [ ] Verify the message list container renders (`data-testid="copilot-message-list"`)
+- [ ] Send a basic message (e.g. "Hello")
+- [ ] Verify the agent responds (assistant message appears via `[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Simple plan" suggestion button is visible (plan to go to mars in 5 steps)
+- [ ] Verify "Complex plan" suggestion button is visible (plan to make pizza in 10 steps)
+
+#### Task Progress Tracker (useAgent with state streaming)
+
+- [ ] Click "Simple plan" suggestion or type "Please build a plan to go to mars in 5 steps."
+- [ ] Verify the TaskProgress component renders (`data-testid="task-progress"`)
+- [ ] Verify the "Task Progress" heading is visible
+- [ ] Verify the progress bar appears with a gradient fill
+- [ ] Verify step items appear with descriptions (`data-testid="task-step-text"`)
+- [ ] Verify the "N/N Complete" counter updates as steps complete
+- [ ] Verify completed steps show:
+  - Green background gradient
+  - Check icon
+  - Green text color
+- [ ] Verify the current pending step shows:
+  - Blue/purple background gradient
+  - Spinner icon with "Processing..." text
+  - Pulsing animation
+- [ ] Verify future pending steps show:
+  - Gray background
+  - Clock icon
+  - Muted text color
+
+#### Complex Plan
+
+- [ ] Type "Please build a plan to make pizza in 10 steps."
+- [ ] Verify 10 steps appear in the progress tracker
+- [ ] Verify progress bar width increases as steps complete
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- Task progress tracker shows live step completion
+- Progress bar animates smoothly
+- No UI errors or broken layouts

--- a/showcase/packages/crewai-crews/qa/shared-state-read.md
+++ b/showcase/packages/crewai-crews/qa/shared-state-read.md
@@ -1,0 +1,75 @@
+# QA: Shared State (Reading) — CrewAI (Crews)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-read demo page
+- [ ] Verify the recipe card form loads (`data-testid="recipe-card"`)
+- [ ] Verify the CopilotSidebar opens by default with title "AI Recipe Assistant"
+- [ ] Send a message via the sidebar
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Initial Recipe State
+
+- [ ] Verify the recipe title input shows "Make Your Recipe"
+- [ ] Verify the cooking time dropdown defaults to "45 min"
+- [ ] Verify the skill level dropdown defaults to "Intermediate"
+- [ ] Verify the default ingredients are displayed:
+  - [ ] Carrots (3 large, grated) with carrot emoji
+  - [ ] All-Purpose Flour (2 cups) with wheat emoji
+- [ ] Verify the default instruction is displayed: "Preheat oven to 350°F (175°C)"
+
+#### Suggestions
+
+- [ ] Verify "Create Italian recipe" suggestion is visible
+- [ ] Verify "Make it healthier" suggestion is visible
+- [ ] Verify "Suggest variations" suggestion is visible
+
+#### Recipe Editing (Local State)
+
+- [ ] Edit the recipe title and verify it updates
+- [ ] Change the skill level dropdown and verify it updates
+- [ ] Change the cooking time dropdown and verify it updates
+- [ ] Toggle a dietary preference checkbox (e.g. "Vegetarian") and verify it's checked
+- [ ] Click "+ Add Ingredient" (`data-testid="add-ingredient-button"`) and verify a new empty row appears in the ingredients container (`data-testid="ingredients-container"`)
+- [ ] Edit an ingredient name and amount
+- [ ] Remove an ingredient by clicking the "x" button
+- [ ] Click "+ Add Step" and verify a new instruction row appears in the instructions container (`data-testid="instructions-container"`)
+- [ ] Edit an instruction and verify it saves
+- [ ] Remove an instruction by clicking the "x" button
+
+#### AI-Powered Recipe Updates (useAgent with shared state)
+
+- [ ] Click "Create Italian recipe" suggestion
+- [ ] Verify the agent updates the recipe title, ingredients, and instructions
+- [ ] Verify the ping indicator appears on changed sections
+- [ ] Verify the "Improve with AI" button (`data-testid="improve-button"`) changes to "Please Wait..." while loading
+- [ ] Click "Improve with AI" and verify the recipe is enhanced
+
+#### Agent Reads Frontend State
+
+- [ ] Edit the recipe (change title, add ingredients)
+- [ ] Ask the agent "What recipe am I making?"
+- [ ] Verify the agent's response references the current recipe state
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+- [ ] Verify the "Improve with AI" button is disabled while loading
+
+## Expected Results
+
+- Recipe card and sidebar load within 3 seconds
+- Agent responds within 10 seconds
+- Recipe state syncs bidirectionally between UI and agent
+- Ping indicators highlight changed sections
+- No UI errors or broken layouts

--- a/showcase/packages/crewai-crews/qa/shared-state-streaming.md
+++ b/showcase/packages/crewai-crews/qa/shared-state-streaming.md
@@ -1,0 +1,40 @@
+# QA: State Streaming — CrewAI (Crews)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-streaming demo page
+- [ ] Verify the chat interface loads with title "State Streaming"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/crewai-crews/qa/shared-state-write.md
+++ b/showcase/packages/crewai-crews/qa/shared-state-write.md
@@ -1,0 +1,40 @@
+# QA: Shared State (Writing) — CrewAI (Crews)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-write demo page
+- [ ] Verify the chat interface loads with title "Shared State (Writing)"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/crewai-crews/qa/subagents.md
+++ b/showcase/packages/crewai-crews/qa/subagents.md
@@ -1,0 +1,40 @@
+# QA: Sub-Agents — CrewAI (Crews)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the subagents demo page
+- [ ] Verify the chat interface loads with title "Sub-Agents"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts


### PR DESCRIPTION
## Summary

Brings `showcase/packages/crewai-crews/qa/` to 9-file parity with `showcase/packages/langgraph-python/qa/` by adding the 5 missing QA checklists. Part of **Bundle 0** showcase QA parity work.

## Files Added

- `qa/gen-ui-agent.md` — full checklist reflecting the implemented `TaskProgress` tracker, suggestions (Simple plan / Complex plan), `data-testid` selectors (`task-progress`, `task-step-text`, `copilot-message-list`), and step state styling (completed/current-pending/future-pending)
- `qa/shared-state-read.md` — full recipe-card checklist matching the implemented `CopilotSidebar` + Recipe form ("Make Your Recipe" title, 45 min / Intermediate defaults, ingredient/instruction CRUD with `add-ingredient-button` / `ingredients-container` / `instructions-container` testids, ping indicators, "Improve with AI" / "Please Wait..." states)
- `qa/shared-state-write.md` — stub-quality checklist (page is currently a `TODO: Implement` stub with CopilotChat + "Get started" suggestion only)
- `qa/shared-state-streaming.md` — stub-quality checklist (same stub pattern)
- `qa/subagents.md` — stub-quality checklist (same stub pattern)

## Rationale

Each QA file was adapted by reading the actual `src/app/demos/<demo-id>/page.tsx` and `tests/e2e/<demo-id>.spec.ts`:

- Where the page is a real implementation (gen-ui-agent, shared-state-read), the QA reflects the observable UI: specific data-testids, suggestion titles, default values, and feature-specific flows
- Where the page is a stub (shared-state-write, shared-state-streaming, subagents), the QA mirrors the LangGraph-Python stub pattern: basic chat loads, "Get started" suggestion, no custom UI expected
- Titles updated from "LangGraph (Python)" to "CrewAI (Crews)"
- Prerequisites / Test Steps / Error Handling / Expected Results structure preserved

## Test Plan

- [ ] Reviewer confirms all 5 new files render correctly as GitHub markdown
- [ ] QA engineer can follow gen-ui-agent.md steps against a running crewai-crews showcase and all checkboxes map to real UI behavior
- [ ] QA engineer can follow shared-state-read.md steps against the Recipe demo and all checkboxes map to real UI behavior
- [ ] Stub QA files (shared-state-write, shared-state-streaming, subagents) accurately describe current stub behavior (basic chat only)
- [ ] File count in `showcase/packages/crewai-crews/qa/` matches `showcase/packages/langgraph-python/qa/` (9 files each)

## Known Concerns

Some crewai-crews e2e test files reference aspirational UIs that don't match the current stub pages (e.g. `shared-state-write.spec.ts` expects a "Sales Pipeline" dashboard, `subagents.spec.ts` expects a "Travel Planning Assistant") — **this QA PR does not address that mismatch**, it just documents the *current* state of the pages. The QA files will need updating once the stub demos are actually implemented.