### PR TITLE
chore(ci): rename showcase_smoke-monitor workflow to test_smoke-showcase-deployed

### DIFF
--- a/.github/workflows/test_smoke-showcase-deployed.yml
+++ b/.github/workflows/test_smoke-showcase-deployed.yml
@@ -1,4 +1,4 @@
-name: "Showcase: Smoke Monitor"
+name: test / smoke / showcase-deployed
 
 on:
   schedule:


### PR DESCRIPTION
Part of workflow naming standardization Bundle 6. Internal name goes from 'Showcase: Smoke Monitor' to 'test / smoke / showcase-deployed' to match the test_<layer>-<target> convention. Branch-protection audit confirmed no required-status-check references this workflow — drop-in safe. Consumer grep found zero hits for the old name.