### PR TITLE
chore(ci): rename starter_deployed_smoke workflow to test_smoke-starter-deployed

### DIFF
--- a/.github/workflows/test_smoke-starter-deployed.yml
+++ b/.github/workflows/test_smoke-starter-deployed.yml
@@ -1,4 +1,4 @@
-name: Starter Deployed Smoke Tests
+name: test / smoke / starter-deployed
 
 on:
   schedule:


### PR DESCRIPTION
Part of workflow naming standardization Bundle 6. Internal name goes from 'Starter Deployed Smoke Tests' to 'test / smoke / starter-deployed'. Also fixes the dash/underscore inconsistency with its sibling starter-smoke.yml (renamed separately by N9). Branch-protection audit confirmed drop-in safe. Consumer grep found zero hits for the old name.