### PR TITLE
docs(showcase): INTEGRATION-CHECKLIST updates — examples/integrations relationship + prebuilt/node-based distinction

### DIFF
--- a/showcase/INTEGRATION-CHECKLIST.md
+++ b/showcase/INTEGRATION-CHECKLIST.md
@@ -61,6 +61,57 @@ One per declared feature. Each demo must:
 
 ---
 
+## Source of Truth: `examples/integrations/*` vs `showcase/packages/*`
+
+Two directories hold integration code, and they play different roles. Understanding the relationship is critical before adding or modifying a package.
+
+### Roles
+
+- **`examples/integrations/<name>/`** — the **Dojo example**. This is the dep-pinning source of truth: minimal, focused agent code used to prove a framework works against CopilotKit/AG-UI. The weekly drift-detection workflow and the "Always pin agent framework and SDK versions to exact versions from the working Dojo example" rule (see "Dependency Pinning" below) both treat this directory as canonical.
+- **`showcase/packages/<slug>/`** — the **full triple-duty integration**:
+  1. Partner-facing demo (lives on `showcase.copilotkit.dev`)
+  2. Cloneable starter source (composed into `showcase/starters/<slug>/` by `generate-starters.ts`)
+  3. Iframe-embedded experience inside the public showcase shell
+
+### Automation Direction (one-way)
+
+```
+examples/integrations/<name>/  ──(migrate-integration-examples.ts)──▶  showcase/packages/<slug>/src/agents/
+showcase/packages/<slug>/     ──(generate-starters.ts)────────────▶  showcase/starters/<slug>/
+```
+
+- `showcase/scripts/migrate-integration-examples.ts` copies agent code **from** `examples/integrations/<name>/` **into** `showcase/packages/<slug>/src/agents/`. It never runs in reverse.
+- `showcase/scripts/generate-starters.ts` composes a template frontend plus the showcase package into a self-contained starter under `showcase/starters/<slug>/`.
+- Do not hand-edit agent code inside `showcase/packages/<slug>/src/agents/` if the package has a Dojo counterpart — fix it upstream in `examples/integrations/<name>/` and re-run the migration script.
+
+### Born-in-Showcase Packages (no Dojo counterpart)
+
+Five packages exist only in showcase and have no `examples/integrations/<name>/` sibling:
+
+- `ag2`
+- `claude-sdk-python`
+- `claude-sdk-typescript`
+- `langroid`
+- `spring-ai`
+
+These are authored directly in `showcase/packages/<slug>/` and are **exempt from the pin-to-Dojo rule** — there is no Dojo to pin to. They still must pin exact versions (see "Dependency Pinning"), but the reference is whatever the framework's own examples or release notes recommend, not a sibling `examples/integrations/` directory.
+
+### Slug Aliasing
+
+Several packages have different names in `examples/integrations/` vs `showcase/packages/`. The aliasing is historical — showcase standardized on shorter, marketing-friendly slugs while the Dojo kept the original framework-canonical names.
+
+| `showcase/packages/` slug | `examples/integrations/` name | Why different                                             |
+| ------------------------- | ----------------------------- | --------------------------------------------------------- |
+| `google-adk`              | `adk`                         | Showcase prefixes with vendor for disambiguation          |
+| `langgraph-typescript`    | `langgraph-js`                | Showcase prefers full language name (`-typescript`)       |
+| `ms-agent-dotnet`         | `ms-agent-framework-dotnet`   | Showcase shortens `-framework-` out of the slug           |
+| `ms-agent-python`         | `ms-agent-framework-python`   | Same — shorter slug in showcase                           |
+| `strands`                 | `strands-python`              | Showcase drops the language suffix (no TS variant exists) |
+
+When running `migrate-integration-examples.ts` or reasoning about drift, remember that the script internally maps these aliases — don't "fix" them by renaming one side.
+
+---
+
 ## B. External Setup (after the package is ready)
 
 ### 1. Railway Service
@@ -127,6 +178,39 @@ One per declared feature. Each demo must:
 - Check the corresponding Dojo example at `examples/integrations/<slug>/`
 - Use exact versions from its `requirements.txt` / `pyproject.toml` / `package.json`
 - The weekly drift detection workflow will flag when pinned versions fall behind
+
+---
+
+## LangGraph: Prebuilt vs Node-Based
+
+LangGraph supports two agent authoring styles, and showcase uses both. When touching a LangGraph package — or adding a new one — decide the style explicitly and match the existing sibling's idioms.
+
+### The Two Styles
+
+- **Node-based** — hand-rolled `StateGraph` with `addNode(...)`, explicit edges, and custom routing logic. Maximum control; more code to maintain.
+- **Prebuilt** — `create_react_agent` / `create_agent` helpers that wrap the common ReAct pattern. Minimal code; less flexibility.
+
+### Current Showcase State
+
+| Package                                  | Style      | Evidence                                              |
+| ---------------------------------------- | ---------- | ----------------------------------------------------- |
+| `showcase/packages/langgraph-python`     | Prebuilt   | `create_react_agent` in `src/agents/main.py:53`       |
+| `showcase/packages/langgraph-fastapi`    | Prebuilt   | `create_react_agent` in `src/agents/src/agent.py:166` |
+| `showcase/packages/langgraph-typescript` | Node-based | `StateGraph` in `src/agent/graph.ts:271`              |
+
+### Dojo Coverage Gap
+
+The `ag-ui/apps/dojo/` e2e tests exclusively exercise **node-based** graphs. This means prebuilt-agent coverage is thin in the Dojo even though two of the three LangGraph packages users clone from showcase are prebuilt.
+
+Cross-reference the action inventory for the full breakdown of which AG-UI features are exercised where: <https://www.notion.so/3443aa38185281b5a1dfc6e0890264e1>.
+
+### Guidance
+
+- **When adding a new LangGraph-based package**, decide the authoring style explicitly and match the idioms of the corresponding showcase sibling (Python → prebuilt, TypeScript → node-based) unless you have a concrete reason to diverge.
+- If you do diverge, document why in the package's README and add an entry to the table above.
+- Do not silently convert a package between styles — it's a public API change for anyone who cloned the starter.
+
+This distinction only applies to LangGraph today. Other frameworks (CrewAI, Mastra, etc.) have their own framework-specific authoring idioms — out of scope for this section.
 
 ---
 


### PR DESCRIPTION
## Summary

Two new sections in `showcase/INTEGRATION-CHECKLIST.md` capturing tribal knowledge that has been causing confusion when onboarding new packages:

1. **Source of Truth: `examples/integrations/*` vs `showcase/packages/*`**
   - Documents the one-way automation flow: `examples/integrations/<name>/` → `showcase/packages/<slug>/src/agents/` (via `migrate-integration-examples.ts`) → `showcase/starters/<slug>/` (via `generate-starters.ts`).
   - Calls out the five "born-in-showcase" packages (`ag2`, `claude-sdk-python`, `claude-sdk-typescript`, `langroid`, `spring-ai`) that have no Dojo counterpart and are exempt from the pin-to-Dojo rule.
   - Documents the slug aliasing (`google-adk` ↔ `adk`, `langgraph-typescript` ↔ `langgraph-js`, `ms-agent-{dotnet,python}` ↔ `ms-agent-framework-{dotnet,python}`, `strands` ↔ `strands-python`) so nobody "fixes" it by renaming one side.

2. **LangGraph: Prebuilt vs Node-Based**
   - Documents the two agent authoring styles (`StateGraph` with `addNode(...)` vs `create_react_agent` / `create_agent`).
   - Records which showcase packages use which style today (Python → prebuilt, TypeScript → node-based) with file:line evidence.
   - Flags the Dojo coverage gap: `ag-ui/apps/dojo/` e2e tests only exercise node-based graphs, so prebuilt-agent coverage is thin in CI even though most LangGraph starters users clone are prebuilt.
   - Cross-references the action inventory: <https://www.notion.so/3443aa38185281b5a1dfc6e0890264e1>.

Both sections are inserted at logical structural homes (after section A / after Dependency Pinning) rather than appended to the end. Existing content is preserved verbatim.

## Test Plan

- [x] Pure markdown edit — no code changes
- [x] Pre-commit hooks pass (lint, tests, commitlint)
- [ ] Reviewer: skim both new sections for factual accuracy, especially the born-in-showcase list and the slug aliasing table

## Notes

No opportunistic fixes flagged — existing checklist content is accurate.