### PR TITLE
chore(ci): enforce >=9 e2e specs per showcase package

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -38,6 +38,30 @@ jobs:
       - name: Verify lockfile is up to date
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Enforce e2e spec count (min 9 per package)
+        run: |
+          set -euo pipefail
+          MIN=9
+          failed=0
+          found=0
+          for dir in showcase/packages/*/tests/e2e/; do
+            [ -d "$dir" ] || continue
+            found=$((found + 1))
+            count=$(find "$dir" -maxdepth 1 -name '*.spec.ts' | wc -l | tr -d ' ')
+            pkg=$(echo "$dir" | awk -F/ '{print $3}')
+            if [ "$count" -lt "$MIN" ]; then
+              echo "::error file=$dir::Package '$pkg' has $count e2e spec(s); minimum required is $MIN"
+              failed=1
+            else
+              echo "ok: $pkg has $count spec(s)"
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No showcase/packages/*/tests/e2e/ directories found — baseline check cannot run"
+            exit 1
+          fi
+          exit "$failed"
+
       - name: Run build pipeline tests
         working-directory: showcase/scripts
         run: npx vitest run


### PR DESCRIPTION
Locks in the current baseline: every `showcase/packages/<slug>/tests/e2e/` directory must have at least 9 spec files. Prevents future packages from shipping with an incomplete e2e surface.

## What

Adds an `Enforce e2e spec count (min 9 per package)` step to `.github/workflows/showcase_validate.yml`. The step iterates over every `showcase/packages/*/tests/e2e/` directory, counts `*.spec.ts` files, and fails with a GitHub `::error::` annotation pointing at any directory with fewer than 9 specs.

## Why

Current baseline (all 17 showcase packages):
- 16 packages at **9** specs
- `langgraph-python` at **10** specs

The check enforces `>= 9` so the existing baseline passes and new packages cannot regress it.

## Test plan

- [x] Logic dry-run locally over `showcase/packages/*/tests/e2e/`: 17 dirs found, 0 failures
- [ ] CI green on this PR
- [ ] Confirm annotation behavior by (future) test PR that removes a spec

References [Full Action Inventory](https://www.notion.so/3443aa38185281b5a1dfc6e0890264e1) item I4.