### PR TITLE
chore(ci): rename test_runtime-servers → test_integration-runtime

### DIFF
--- a/.github/workflows/test_integration-runtime.yml
+++ b/.github/workflows/test_integration-runtime.yml
@@ -1,16 +1,16 @@
-name: test / integration
+name: test / integration / runtime
 
 on:
   push:
     branches: [main]
     paths:
       - "packages/runtime/**"
-      - ".github/workflows/test_runtime-servers.yml"
+      - ".github/workflows/test_integration-runtime.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/runtime/**"
-      - ".github/workflows/test_runtime-servers.yml"
+      - ".github/workflows/test_integration-runtime.yml"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Bundle 6 workflow rename. BOTH filename AND internal name change: 'test / integration' → 'test / integration / runtime'. Consumer grep verified no remaining references to either old name. Branch-protection audit confirmed drop-in safe ([Notion](https://www.notion.so/3443aa38185281a3ad07e5ec63debd0f)).