### PR TITLE
chore(ci): rename e2e_examples → test_e2e-legacy-v1

### DIFF
--- a/.github/workflows/test_e2e-legacy-v1.yml
+++ b/.github/workflows/test_e2e-legacy-v1.yml
@@ -1,17 +1,17 @@
-name: test / e2e / examples
+name: test / e2e / legacy-v1
 
 on:
   push:
     branches: [main]
     paths:
       - "examples/**"
-      - ".github/workflows/e2e_examples.yml"
+      - ".github/workflows/test_e2e-legacy-v1.yml"
       - ".changeset"
   pull_request:
     branches: [main]
     paths:
       - "examples/**"
-      - ".github/workflows/e2e_examples.yml"
+      - ".github/workflows/test_e2e-legacy-v1.yml"
   workflow_dispatch:
     inputs:
       branch:

--- a/examples/e2e/AGENTS.md
+++ b/examples/e2e/AGENTS.md
@@ -119,7 +119,7 @@ If an example auto-opens Copilot UI / triggers calls, prefer adding a query para
 
 Workflow:
 
-- `.github/workflows/e2e_examples.yml`
+- `.github/workflows/test_e2e-legacy-v1.yml`
 
 It runs a matrix of:
 
@@ -153,4 +153,4 @@ Artifacts:
 3. Run locally:
    - `EXAMPLE=<example> pnpm test`
 4. Add the example name to the CI matrix in:
-   - `.github/workflows/e2e_examples.yml`
+   - `.github/workflows/test_e2e-legacy-v1.yml`


### PR DESCRIPTION
Bundle 6 workflow rename. New name reflects reality — this workflow exercises the half-abandoned examples/e2e/ harness against v1.x apps only. Clarifies legacy status. Branch-protection audit confirmed drop-in safe.