### PR TITLE
chore(ci): rename starter-smoke workflow to test_smoke-starter

### DIFF
--- a/.github/workflows/test_smoke-starter.yml
+++ b/.github/workflows/test_smoke-starter.yml
@@ -1,4 +1,4 @@
-name: Starter Smoke Tests
+name: test / smoke / starter
 
 on:
   schedule:
@@ -10,7 +10,7 @@ on:
   pull_request:
     paths:
       - "examples/integrations/**"
-      - ".github/workflows/starter-smoke.yml"
+      - ".github/workflows/test_smoke-starter.yml"
   workflow_dispatch: {}
 
 permissions:

--- a/showcase/scripts/create-integration/index.ts
+++ b/showcase/scripts/create-integration/index.ts
@@ -1529,8 +1529,8 @@ function updateWorkflows(args: CLIArgs) {
     }
   }
 
-  // 3. Update starter-smoke.yml — add to matrix (block sequence format)
-  const smokePath = path.join(workflowsDir, "starter-smoke.yml");
+  // 3. Update test_smoke-starter.yml — add to matrix (block sequence format)
+  const smokePath = path.join(workflowsDir, "test_smoke-starter.yml");
   if (fs.existsSync(smokePath)) {
     let smoke = fs.readFileSync(smokePath, "utf-8");
     const slug = args.slug;
@@ -1572,7 +1572,7 @@ function updateWorkflows(args: CLIArgs) {
       lines.splice(lastEntryIndex + 1, 0, `${entryIndent}${slug}`);
       smoke = lines.join("\n");
       fs.writeFileSync(smokePath, smoke);
-      console.log("  Updated starter-smoke.yml");
+      console.log("  Updated test_smoke-starter.yml");
     }
   }
 }


### PR DESCRIPTION
Bundle 6 workflow rename. Also fixes the dash-vs-underscore inconsistency with sibling starter_deployed_smoke.yml (renamed separately as test_smoke-starter-deployed in a parallel PR). Branch-protection audit confirmed drop-in safe.

## Changes

- Rename `.github/workflows/starter-smoke.yml` → `.github/workflows/test_smoke-starter.yml`
- Update internal `name:` field: `Starter Smoke Tests` → `test / smoke / starter`
- Update self-reference in `paths:` trigger (workflow re-runs on its own edits)
- Update `showcase/scripts/create-integration/index.ts` which programmatically edits this workflow when adding new integrations

## Preserved

- Job name `starter-smoke:` and artifact name `starter-smoke-${{ matrix.starter }}` preserved to avoid breaking any existing branch protection required status checks or monitoring.

## Not affected (separate artifact)

- `showcase/tests/e2e/starter-smoke.spec.ts` (Playwright spec file — invoked by `npx playwright test starter-smoke` across all docker-compose.test.yml files). This is a test artifact, not a workflow reference.