### PR TITLE
feat(showcase/langgraph-typescript): QA markdown 9-for-all parity

### DIFF
--- a/showcase/packages/langgraph-typescript/qa/gen-ui-agent.md
+++ b/showcase/packages/langgraph-typescript/qa/gen-ui-agent.md
@@ -1,0 +1,66 @@
+# QA: Agentic Generative UI — LangGraph (TypeScript)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the gen-ui-agent demo page
+- [ ] Verify the chat interface loads in a centered max-w-6xl container (md:w-4/5 md:h-4/5 rounded-lg wrapper)
+- [ ] Verify the chat input placeholder "Type a message" is visible
+- [ ] Send a basic message
+- [ ] Verify the agent responds
+- [ ] Verify the custom message list container is present (`data-testid="copilot-message-list"`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Simple plan" suggestion button is visible (plan to go to Mars in 5 steps)
+- [ ] Verify "Complex plan" suggestion button is visible (plan to make pizza in 10 steps)
+
+#### Task Progress Tracker (useAgent with OnStateChanged streaming)
+
+- [ ] Click "Simple plan" suggestion or type "Build a plan to go to Mars in 5 steps"
+- [ ] Verify the TaskProgress component renders (`data-testid="task-progress"`)
+- [ ] Verify the "Task Progress" heading is visible with blue-to-purple gradient text
+- [ ] Verify the progress bar appears with a gradient fill inside a rounded-full container
+- [ ] Verify step items appear with descriptions (`data-testid="task-step-text"`)
+- [ ] Verify the "N/N Complete" counter updates as steps complete
+- [ ] Verify completed steps show:
+  - Green-to-emerald background gradient
+  - Check icon in a green gradient circle
+  - Green text color (text-green-700)
+- [ ] Verify the current pending step shows:
+  - Blue-to-purple background gradient
+  - Spinner icon with "Processing..." text
+  - Pulsing animation overlay
+  - Larger text-base size
+- [ ] Verify future pending steps show:
+  - Gray background (bg-gray-50/50)
+  - Clock icon
+  - Muted text color (text-gray-500)
+
+#### Complex Plan
+
+- [ ] Type "Plan to make pizza in 10 steps"
+- [ ] Verify 10 steps appear in the progress tracker
+- [ ] Verify progress bar width increases as steps complete
+- [ ] Verify the LangGraph StateGraph node-based agent (chat_node, tool_node) streams partial state updates
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- Task progress tracker shows live step completion driven by LangGraph-JS state streaming
+- Progress bar animates smoothly
+- No UI errors or broken layouts

--- a/showcase/packages/langgraph-typescript/qa/shared-state-read.md
+++ b/showcase/packages/langgraph-typescript/qa/shared-state-read.md
@@ -1,0 +1,75 @@
+# QA: Shared State (Reading) — LangGraph (TypeScript)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-read demo page
+- [ ] Verify the recipe card form loads (`data-testid="recipe-card"`)
+- [ ] Verify the CopilotSidebar opens by default with title "AI Recipe Assistant"
+- [ ] Send a message via the sidebar
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Initial Recipe State
+
+- [ ] Verify the recipe title input shows "Make Your Recipe"
+- [ ] Verify the cooking time dropdown defaults to "45 min"
+- [ ] Verify the skill level dropdown defaults to "Intermediate"
+- [ ] Verify the default ingredients are displayed:
+  - [ ] Carrots (3 large, grated) with carrot emoji
+  - [ ] All-Purpose Flour (2 cups) with wheat emoji
+- [ ] Verify the default instruction is displayed: "Preheat oven to 350°F (175°C)"
+
+#### Suggestions
+
+- [ ] Verify "Create Italian recipe" suggestion is visible
+- [ ] Verify "Make it healthier" suggestion is visible
+- [ ] Verify "Suggest variations" suggestion is visible
+
+#### Recipe Editing (Local State)
+
+- [ ] Edit the recipe title and verify it updates
+- [ ] Change the skill level dropdown and verify it updates
+- [ ] Change the cooking time dropdown and verify it updates
+- [ ] Toggle a dietary preference checkbox (e.g. "Vegetarian") and verify it's checked
+- [ ] Click "+ Add Ingredient" (`data-testid="add-ingredient-button"`) and verify a new empty row appears in `data-testid="ingredients-container"`
+- [ ] Edit an ingredient name and amount inside an `data-testid="ingredient-card"` row
+- [ ] Remove an ingredient by clicking the "x" button
+- [ ] Click "+ Add Step" and verify a new instruction row appears in `data-testid="instructions-container"`
+- [ ] Edit an instruction and verify it saves
+- [ ] Remove an instruction by clicking the "x" button
+
+#### AI-Powered Recipe Updates (useAgent with OnStateChanged/OnRunStatusChanged)
+
+- [ ] Click "Create Italian recipe" suggestion
+- [ ] Verify the agent updates the recipe title, ingredients, and instructions
+- [ ] Verify the blue Ping indicator appears on changed sections (special_preferences, ingredients, instructions)
+- [ ] Verify the "Improve with AI" button (`data-testid="improve-button"`) changes to "Please Wait..." while loading
+- [ ] Click "Improve with AI" and verify the recipe is enhanced via `copilotkit.runAgent({ agent })`
+
+#### Agent Reads Frontend State
+
+- [ ] Edit the recipe (change title, add ingredients)
+- [ ] Ask the agent "What recipe am I making?"
+- [ ] Verify the agent's response references the current recipe state (pulled from shared agent.state via the LangGraph-JS StateGraph)
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+- [ ] Verify the "Improve with AI" button is disabled while loading
+
+## Expected Results
+
+- Recipe card and sidebar load within 3 seconds
+- Agent responds within 10 seconds
+- Recipe state syncs bidirectionally between UI and agent via node-based StateGraph
+- Ping indicators highlight changed sections
+- No UI errors or broken layouts

--- a/showcase/packages/langgraph-typescript/qa/shared-state-streaming.md
+++ b/showcase/packages/langgraph-typescript/qa/shared-state-streaming.md
@@ -1,0 +1,40 @@
+# QA: State Streaming — LangGraph (TypeScript)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-streaming demo page
+- [ ] Verify the chat interface loads with title "State Streaming"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages via the LangGraph-JS node-based StateGraph (agent="shared-state-streaming")
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/langgraph-typescript/qa/shared-state-write.md
+++ b/showcase/packages/langgraph-typescript/qa/shared-state-write.md
@@ -1,0 +1,40 @@
+# QA: Shared State (Writing) — LangGraph (TypeScript)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-write demo page
+- [ ] Verify the chat interface loads with title "Shared State (Writing)"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages via the LangGraph-JS node-based StateGraph (agent="shared-state-write")
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/langgraph-typescript/qa/subagents.md
+++ b/showcase/packages/langgraph-typescript/qa/subagents.md
@@ -1,0 +1,40 @@
+# QA: Sub-Agents — LangGraph (TypeScript)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the subagents demo page
+- [ ] Verify the chat interface loads with title "Sub-Agents"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages via the LangGraph-JS node-based StateGraph (agent="subagents")
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts


### PR DESCRIPTION
## Summary

- Adds 5 missing QA markdown files to `showcase/packages/langgraph-typescript/qa/` so the package has the full 9-file set (gen-ui-agent, shared-state-read, shared-state-write, shared-state-streaming, subagents)
- Content adapted for langgraph-typescript framework (TS + LangGraph-JS, node-based `StateGraph` per `src/agent/graph.ts:271`)
- Selectors and labels verified against `src/app/demos/<demo-id>/page.tsx` and `tests/e2e/<demo-id>.spec.ts`; stub-quality content where the demos themselves are stubs (shared-state-write/streaming, subagents)

## Test plan

- [ ] Verify `qa/` directory has 9 markdown files (was 4)
- [ ] Spot-check selectors in `gen-ui-agent.md` and `shared-state-read.md` match page.tsx `data-testid` attributes
- [ ] Confirm stub demo QA docs match stub demo page.tsx contents