### PR TITLE
chore(ci): rename test_doc-examples → test_integration-docs

### DIFF
--- a/.github/workflows/test_integration-docs.yml
+++ b/.github/workflows/test_integration-docs.yml
@@ -1,4 +1,4 @@
-name: test / doc-examples
+name: test / integration / docs
 on:
   pull_request:
     paths: ["docs/**"]


### PR DESCRIPTION
Bundle 6 workflow rename. Internal name 'test / doc-examples' → 'test / integration / docs' to match the test_<layer>-<target> convention. Branch-protection audit confirmed drop-in safe.