### PR TITLE
chore(ci): rename e2e_dojo.yml → test_e2e-dojo.yml (filename only)

### DIFF
--- a/.github/workflows/test_e2e-dojo.yml
+++ b/.github/workflows/test_e2e-dojo.yml
@@ -6,13 +6,13 @@ on:
     paths:
       - "packages/**"
       - "sdk-python/**"
-      - ".github/workflows/e2e_dojo.yml"
+      - ".github/workflows/test_e2e-dojo.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/**"
       - "sdk-python/**"
-      - ".github/workflows/e2e_dojo.yml"
+      - ".github/workflows/test_e2e-dojo.yml"
       - ".changeset"
   workflow_dispatch:
     inputs:
@@ -45,7 +45,7 @@ jobs:
           filters: |
             ts:
               - 'packages/**'
-              - '.github/workflows/e2e_dojo.yml'
+              - '.github/workflows/test_e2e-dojo.yml'
               - '.changeset'
             python:
               - 'sdk-python/**'


### PR DESCRIPTION
Bundle 6 workflow rename. Filename-only change — internal name 'test / e2e / dojo' unchanged. Lowest-risk rename since check-name is stable. Brings filename in line with test_<layer>-<target> convention.