### PR TITLE
feat(showcase/llamaindex): QA markdown 9-for-all parity

### DIFF
--- a/showcase/packages/llamaindex/qa/gen-ui-agent.md
+++ b/showcase/packages/llamaindex/qa/gen-ui-agent.md
@@ -1,0 +1,64 @@
+# QA: Agentic Generative UI — LlamaIndex
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the gen-ui-agent demo page
+- [ ] Verify the chat interface loads in a centered full-height layout
+- [ ] Verify the chat input placeholder "Type a message" is visible
+- [ ] Verify the custom message list container renders (`data-testid="copilot-message-list"`)
+- [ ] Send a basic message (e.g. "Hello")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Simple plan" suggestion button is visible (plan to go to mars in 5 steps)
+- [ ] Verify "Complex plan" suggestion button is visible (plan to make pizza in 10 steps)
+
+#### Task Progress Tracker (useAgent with state streaming)
+
+- [ ] Click "Simple plan" suggestion or type "Please build a plan to go to mars in 5 steps."
+- [ ] Verify the TaskProgress component renders (`data-testid="task-progress"`)
+- [ ] Verify the "Task Progress" heading is visible with gradient text styling
+- [ ] Verify the progress bar appears with a blue-to-purple gradient fill
+- [ ] Verify the "N/N Complete" counter is displayed and updates as steps complete
+- [ ] Verify step items appear with descriptions (`data-testid="task-step-text"`)
+- [ ] Verify completed steps show:
+  - Green gradient background (from-green-50 to-emerald-50)
+  - Check icon in a green gradient circle
+  - Green text color (text-green-700)
+- [ ] Verify the current pending step shows:
+  - Blue/purple gradient background (from-blue-50 to-purple-50)
+  - Spinner icon with "Processing..." text
+  - Pulsing animation overlay
+- [ ] Verify future pending steps show:
+  - Gray background (bg-gray-50/50)
+  - Clock icon
+  - Muted text color (text-gray-500)
+
+#### Complex Plan
+
+- [ ] Click "Complex plan" suggestion or type "Please build a plan to make pizza in 10 steps."
+- [ ] Verify 10 steps appear in the progress tracker
+- [ ] Verify progress bar width increases as steps complete
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- Task progress tracker shows live step completion
+- Progress bar animates smoothly
+- No UI errors or broken layouts

--- a/showcase/packages/llamaindex/qa/shared-state-read.md
+++ b/showcase/packages/llamaindex/qa/shared-state-read.md
@@ -1,0 +1,75 @@
+# QA: Shared State (Reading) — LlamaIndex
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-read demo page
+- [ ] Verify the recipe card form loads (`data-testid="recipe-card"`)
+- [ ] Verify the CopilotSidebar opens by default with title "AI Recipe Assistant"
+- [ ] Send a message via the sidebar
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Initial Recipe State
+
+- [ ] Verify the recipe title input shows "Make Your Recipe"
+- [ ] Verify the cooking time dropdown defaults to "45 min"
+- [ ] Verify the skill level dropdown defaults to "Intermediate"
+- [ ] Verify the default ingredients are displayed (`data-testid="ingredient-card"`):
+  - [ ] Carrots (3 large, grated) with carrot emoji
+  - [ ] All-Purpose Flour (2 cups) with wheat emoji
+- [ ] Verify the default instruction is displayed: "Preheat oven to 350°F (175°C)"
+
+#### Suggestions
+
+- [ ] Verify "Create Italian recipe" suggestion is visible
+- [ ] Verify "Make it healthier" suggestion is visible
+- [ ] Verify "Suggest variations" suggestion is visible
+
+#### Recipe Editing (Local State)
+
+- [ ] Edit the recipe title and verify it updates
+- [ ] Change the skill level dropdown and verify it updates
+- [ ] Change the cooking time dropdown and verify it updates
+- [ ] Toggle a dietary preference checkbox (e.g. "Vegetarian") and verify it's checked
+- [ ] Click "+ Add Ingredient" (`data-testid="add-ingredient-button"`) and verify a new empty row appears in the ingredients container (`data-testid="ingredients-container"`)
+- [ ] Edit an ingredient name and amount
+- [ ] Remove an ingredient by clicking the "x" button
+- [ ] Click "+ Add Step" and verify a new instruction row appears in the instructions container (`data-testid="instructions-container"`)
+- [ ] Edit an instruction and verify it saves
+- [ ] Remove an instruction by clicking the "x" button
+
+#### AI-Powered Recipe Updates (useAgent with shared state)
+
+- [ ] Click "Create Italian recipe" suggestion
+- [ ] Verify the agent updates the recipe title, ingredients, and instructions
+- [ ] Verify the Ping indicator appears on changed sections (dietary preferences, ingredients, and/or instructions)
+- [ ] Verify the "Improve with AI" button (`data-testid="improve-button"`) changes to "Please Wait..." while loading
+- [ ] Click "Improve with AI" and verify the recipe is enhanced
+
+#### Agent Reads Frontend State
+
+- [ ] Edit the recipe (change title, add ingredients)
+- [ ] Ask the agent "What recipe am I making?"
+- [ ] Verify the agent's response references the current recipe state
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+- [ ] Verify the "Improve with AI" button is disabled (gray styling) while loading
+
+## Expected Results
+
+- Recipe card and sidebar load within 3 seconds
+- Agent responds within 10 seconds
+- Recipe state syncs bidirectionally between UI and agent
+- Ping indicators highlight changed sections
+- No UI errors or broken layouts

--- a/showcase/packages/llamaindex/qa/shared-state-streaming.md
+++ b/showcase/packages/llamaindex/qa/shared-state-streaming.md
@@ -1,0 +1,40 @@
+# QA: State Streaming — LlamaIndex
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-streaming demo page
+- [ ] Verify the chat interface loads with title "State Streaming"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/llamaindex/qa/shared-state-write.md
+++ b/showcase/packages/llamaindex/qa/shared-state-write.md
@@ -1,0 +1,40 @@
+# QA: Shared State (Writing) — LlamaIndex
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-write demo page
+- [ ] Verify the chat interface loads with title "Shared State (Writing)"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/llamaindex/qa/subagents.md
+++ b/showcase/packages/llamaindex/qa/subagents.md
@@ -1,0 +1,40 @@
+# QA: Sub-Agents — LlamaIndex
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the subagents demo page
+- [ ] Verify the chat interface loads with title "Sub-Agents"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts


### PR DESCRIPTION
## Summary

- Adds 5 missing QA markdown files to `showcase/packages/llamaindex/qa/` to reach 9-for-all parity with `langgraph-python/qa/` (was 4, now 9).
- New files: `gen-ui-agent.md`, `shared-state-read.md`, `shared-state-write.md`, `shared-state-streaming.md`, `subagents.md`.
- Real-implementation demos (`gen-ui-agent`, `shared-state-read`) get full QA steps grounded in actual selectors/labels from `src/app/demos/<demo>/page.tsx`. Stub demos (`shared-state-write`, `shared-state-streaming`, `subagents`) get stub-quality QA matching the current TODO pages.

## Notes

- Titles use "LlamaIndex" per task spec.
- The 3 stub pages currently render only a CopilotChat with a "Get started" suggestion; when the demos are implemented, these QA files should be refreshed to match the new UI (same pattern as langgraph-python).
- Note: the e2e specs for `shared-state-read`, `shared-state-write`, `shared-state-streaming`, and `subagents` reference UI (Sales Pipeline, Travel Planner, Document Editor) that does not exist in the current `page.tsx` files — the QA checklists here intentionally follow the actual rendered pages, not the stale specs. Cleanup/sync of those e2e specs is out of scope.

## Test plan

- [ ] QA dir listing shows 9 files matching langgraph-python
- [ ] Selectors in real-implementation QA files (`gen-ui-agent.md`, `shared-state-read.md`) resolve against current `page.tsx`
- [ ] Stub QA files accurately describe current chat-only stub UI