### PR TITLE
feat(showcase/langroid): QA markdown 9-for-all parity

### DIFF
--- a/showcase/packages/langroid/qa/gen-ui-agent.md
+++ b/showcase/packages/langroid/qa/gen-ui-agent.md
@@ -1,0 +1,66 @@
+# QA: Agentic Generative UI — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the gen-ui-agent demo page
+- [ ] Verify the chat interface loads in a centered full-height layout (`h-full w-full md:w-4/5 md:h-4/5`)
+- [ ] Verify the chat input placeholder "Type a message" is visible
+- [ ] Verify the custom message list container is rendered (`data-testid="copilot-message-list"`)
+- [ ] Send a basic message (e.g. "Hello")
+- [ ] Verify the agent responds with an assistant role message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Simple plan" suggestion button is visible (triggers "Please build a plan to go to mars in 5 steps.")
+- [ ] Verify "Complex plan" suggestion button is visible (triggers "Please build a plan to make pizza in 10 steps.")
+
+#### Task Progress Tracker (useAgent with state streaming)
+
+- [ ] Click "Simple plan" suggestion or type "Please build a plan to go to mars in 5 steps."
+- [ ] Verify the TaskProgress component renders (`data-testid="task-progress"`)
+- [ ] Verify the "Task Progress" heading is visible with gradient text styling
+- [ ] Verify the "N/N Complete" counter is visible and matches the step count
+- [ ] Verify the progress bar appears (a `.rounded-full` element inside the tracker) with a gradient fill
+- [ ] Verify step items appear with descriptions (`data-testid="task-step-text"`)
+- [ ] Verify completed steps show:
+  - Green background gradient (`from-green-50 to-emerald-50`)
+  - Green check icon with gradient background (`from-green-500 to-emerald-600`)
+  - Green text color (`text-green-700`)
+- [ ] Verify the current pending step shows:
+  - Blue/purple background gradient (`from-blue-50 to-purple-50`)
+  - Spinner icon with "Processing..." text
+  - Pulsing animation overlay
+- [ ] Verify future pending steps show:
+  - Gray background (`bg-gray-50/50`)
+  - Clock icon
+  - Muted gray text (`text-gray-500`)
+
+#### Complex Plan
+
+- [ ] Type "Please build a plan to make pizza in 10 steps."
+- [ ] Verify 10 task-step-text items render in the TaskProgress tracker
+- [ ] Verify the progress bar width increases (`width: %`) as steps transition to completed
+- [ ] Verify the completion counter increments accordingly
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+- [ ] Send a very long message and verify no UI breakage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- Task progress tracker shows live step completion via streamed agent state
+- Progress bar animates smoothly (`transition-all duration-1000 ease-out`)
+- No UI errors or broken layouts

--- a/showcase/packages/langroid/qa/shared-state-read.md
+++ b/showcase/packages/langroid/qa/shared-state-read.md
@@ -1,0 +1,82 @@
+# QA: Shared State (Reading) — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-read demo page
+- [ ] Verify the recipe card form loads (`data-testid="recipe-card"`)
+- [ ] Verify the CopilotSidebar opens by default with title "AI Recipe Assistant"
+- [ ] Verify the chat input is visible inside the sidebar
+- [ ] Send a message via the sidebar (e.g. "Summarize the recipe")
+- [ ] Verify the agent responds with an assistant role message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Initial Recipe State
+
+- [ ] Verify the recipe title input shows "Make Your Recipe"
+- [ ] Verify the cooking time dropdown defaults to "45 min"
+- [ ] Verify the skill level dropdown defaults to "Intermediate"
+- [ ] Verify the default ingredients are displayed in the ingredients container (`data-testid="ingredients-container"`):
+  - [ ] Carrots (3 large, grated) with carrot emoji (🥕) — `data-testid="ingredient-card"`
+  - [ ] All-Purpose Flour (2 cups) with wheat emoji (🌾)
+- [ ] Verify the default instruction is displayed in the instructions container (`data-testid="instructions-container"`): "Preheat oven to 350°F (175°C)"
+
+#### Suggestions
+
+- [ ] Verify "Create Italian recipe" suggestion is visible
+- [ ] Verify "Make it healthier" suggestion is visible
+- [ ] Verify "Suggest variations" suggestion is visible
+
+#### Recipe Editing (Local State)
+
+- [ ] Edit the recipe title and verify it updates
+- [ ] Change the skill level dropdown (Beginner / Intermediate / Advanced) and verify it updates
+- [ ] Change the cooking time dropdown (5 min / 15 min / 30 min / 45 min / 60+ min) and verify it updates
+- [ ] Toggle a dietary preference checkbox (e.g. "Vegetarian") and verify it's checked
+- [ ] Verify all dietary options are present: High Protein, Low Carb, Spicy, Budget-Friendly, One-Pot Meal, Vegetarian, Vegan
+- [ ] Click "+ Add Ingredient" (`data-testid="add-ingredient-button"`) and verify a new empty ingredient-card row appears with the 🍴 icon
+- [ ] Edit an ingredient name and amount in the new row
+- [ ] Remove an ingredient by clicking its "x" button
+- [ ] Click "+ Add Step" and verify a new empty instruction row appears
+- [ ] Edit an instruction in the textarea and verify it saves
+- [ ] Remove an instruction by clicking its "x" button
+
+#### AI-Powered Recipe Updates (useAgent with shared state)
+
+- [ ] Click "Create Italian recipe" suggestion
+- [ ] Verify the agent updates the recipe title, ingredients, and instructions via shared state
+- [ ] Verify the Ping indicator (blue circle) appears on changed sections (ingredients / instructions / dietary preferences)
+- [ ] Verify the "Improve with AI" button (`data-testid="improve-button"`) changes to "Please Wait..." while loading
+- [ ] Verify the button is disabled (`cursor-not-allowed`, gray background) while loading
+- [ ] Click "Improve with AI" and verify the recipe is enhanced
+
+#### Agent Reads Frontend State
+
+- [ ] Edit the recipe (change title, add ingredients)
+- [ ] Ask the agent "What recipe am I making?"
+- [ ] Verify the agent's response references the current recipe state
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+- [ ] Verify the "Improve with AI" button is disabled while loading
+
+## Expected Results
+
+- Recipe card and sidebar load within 3 seconds
+- Agent responds within 10 seconds
+- Recipe state syncs bidirectionally between UI and agent
+- Ping indicators highlight changed sections
+- No UI errors or broken layouts
+
+## Notes
+
+- Stub-vs-test mismatch: the e2e spec `tests/e2e/shared-state-read.spec.ts` expects a "Sales Pipeline" dashboard and "Sales Pipeline Assistant" sidebar title, but the page implementation is a Recipe demo with "AI Recipe Assistant" sidebar title. Tests likely fail against this implementation.

--- a/showcase/packages/langroid/qa/shared-state-streaming.md
+++ b/showcase/packages/langroid/qa/shared-state-streaming.md
@@ -1,0 +1,46 @@
+# QA: State Streaming — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-streaming demo page
+- [ ] Verify the chat interface loads at full viewport height (`height: 100vh`)
+- [ ] Verify the chat title "State Streaming" is displayed
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds with an assistant role message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible (triggers "Hello! What can you do?")
+- [ ] Click the "Get started" suggestion and verify a message is sent / input populated
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement State Streaming)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts
+
+## Notes
+
+- Stub-vs-test mismatch: the e2e spec `tests/e2e/shared-state-streaming.spec.ts` expects a document editor with "AI Document Editor" sidebar title, "Write whatever you want here..." placeholder, a ConfirmChanges modal (`data-testid="confirm-changes-modal"`), reject/confirm buttons (`data-testid="reject-button"`, `data-testid="confirm-button"`), and a status display (`data-testid="status-display"`). The page is a stub CopilotChat with "State Streaming" title — none of those selectors exist. Tests will fail against this stub.

--- a/showcase/packages/langroid/qa/shared-state-write.md
+++ b/showcase/packages/langroid/qa/shared-state-write.md
@@ -1,0 +1,46 @@
+# QA: Shared State (Writing) — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-write demo page
+- [ ] Verify the chat interface loads at full viewport height (`height: 100vh`)
+- [ ] Verify the chat title "Shared State (Writing)" is displayed
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds with an assistant role message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible (triggers "Hello! What can you do?")
+- [ ] Click the "Get started" suggestion and verify a message is sent / input populated
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement Shared State (Writing))
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts
+
+## Notes
+
+- Stub-vs-test mismatch: the e2e spec `tests/e2e/shared-state-write.spec.ts` expects a "Sales Pipeline" dashboard, "Sales Pipeline Assistant" sidebar, "Add a deal" buttons, deal cards (`data-testid="todo-card"`), and completion toggles (`data-testid="toggle-completed"`). The page is a stub CopilotChat with a "Shared State (Writing)" title — none of those selectors exist. Tests will fail against this stub.

--- a/showcase/packages/langroid/qa/subagents.md
+++ b/showcase/packages/langroid/qa/subagents.md
@@ -1,0 +1,46 @@
+# QA: Sub-Agents — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the subagents demo page
+- [ ] Verify the chat interface loads at full viewport height (`height: 100vh`)
+- [ ] Verify the chat title "Sub-Agents" is displayed
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds with an assistant role message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible (triggers "Hello! What can you do?")
+- [ ] Click the "Get started" suggestion and verify a message is sent / input populated
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement Sub-Agents)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts
+
+## Notes
+
+- Stub-vs-test mismatch: the e2e spec `tests/e2e/subagents.spec.ts` expects a TravelPlanner dashboard with "Current Itinerary" section, "Travel Planning Assistant" sidebar, agent indicators (`data-testid="supervisor-indicator"`, `flights-indicator`, `hotels-indicator`, `experiences-indicator`), empty-state strings like "No items yet -- start planning!", "No flights found yet", "No hotels found yet", "No experiences planned yet", and section headings "Flight Options" / "Hotel Options" / "Experiences". The page is a stub CopilotChat with "Sub-Agents" title — none of those selectors exist. Tests will fail against this stub.


### PR DESCRIPTION
## Summary

- Adds 5 missing QA markdown files to `showcase/packages/langroid/qa/` to reach 9-for-all parity with `langgraph-python/qa/`.
- New files: `gen-ui-agent.md`, `shared-state-read.md`, `shared-state-write.md`, `shared-state-streaming.md`, `subagents.md`.
- Selectors and labels pulled from each demo's `src/app/demos/<demo-id>/page.tsx`; stub demos get stub-quality QA checklists.

## Stub-vs-test mismatches found (documented, not fixed)

- `shared-state-read.spec.ts` expects a Sales Pipeline dashboard; page is a Recipe demo.
- `shared-state-write.spec.ts` expects a Sales Pipeline dashboard with `todo-card`/`toggle-completed` selectors; page is a stub CopilotChat.
- `shared-state-streaming.spec.ts` expects a document editor with ConfirmChanges modal and status display; page is a stub CopilotChat.
- `subagents.spec.ts` expects a TravelPlanner with four agent indicators and empty-state strings; page is a stub CopilotChat.

Noted in each QA file under a `## Notes` section.

## Test plan

- [ ] Visual: open each new QA `.md` under `showcase/packages/langroid/qa/` and confirm checklist structure matches other QA files in the directory.
- [ ] Confirm `gen-ui-agent.md` and `shared-state-read.md` contain real selectors matching the page implementations.
- [ ] Confirm the 3 stub-quality QA files (`shared-state-write.md`, `shared-state-streaming.md`, `subagents.md`) each have a `## Notes` section calling out the mismatch.
- [ ] Directory listing of `showcase/packages/langroid/qa/` returns 9 files.