### PR TITLE
feat(showcase/ms-agent-dotnet): QA markdown 9-for-all parity

### DIFF
--- a/showcase/packages/ms-agent-dotnet/qa/gen-ui-agent.md
+++ b/showcase/packages/ms-agent-dotnet/qa/gen-ui-agent.md
@@ -1,0 +1,64 @@
+# QA: Agentic Generative UI — Microsoft Agent Framework (.NET)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the gen-ui-agent demo page
+- [ ] Verify the chat interface loads in a centered layout (`md:w-4/5 md:h-4/5` rounded container)
+- [ ] Verify the chat input placeholder "Type a message" is visible
+- [ ] Verify the custom message list container is present (`data-testid="copilot-message-list"`)
+- [ ] Send a basic message (e.g. "Hello")
+- [ ] Verify the agent responds with an assistant message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Simple plan" suggestion button is visible (plan to go to mars in 5 steps)
+- [ ] Verify "Complex plan" suggestion button is visible (plan to make pizza in 10 steps)
+
+#### Task Progress Tracker (useAgent with state streaming)
+
+- [ ] Click "Simple plan" suggestion or type "Please build a plan to go to mars in 5 steps."
+- [ ] Verify the TaskProgress component renders (`data-testid="task-progress"`)
+- [ ] Verify the "Task Progress" heading is visible with a gradient text style
+- [ ] Verify a progress bar appears with a blue-to-purple gradient fill
+- [ ] Verify the "N/N Complete" counter updates as steps complete
+- [ ] Verify step items appear with descriptions (`data-testid="task-step-text"`)
+- [ ] Verify completed steps show:
+  - Green gradient background (`from-green-50 to-emerald-50`)
+  - Check icon in a green circular badge
+  - Green text color (`text-green-700`)
+- [ ] Verify the current pending step shows:
+  - Blue/purple gradient background (`from-blue-50 to-purple-50`)
+  - Spinner icon with "Processing..." text
+  - Pulsing animation overlay
+- [ ] Verify future pending steps show:
+  - Gray background (`bg-gray-50/50`)
+  - Clock icon
+  - Muted gray text color
+
+#### Complex Plan
+
+- [ ] Click "Complex plan" suggestion or type "Please build a plan to make pizza in 10 steps."
+- [ ] Verify 10 steps appear in the progress tracker
+- [ ] Verify the progress bar width increases proportionally as steps complete
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- Task progress tracker shows live step completion driven by agent state updates
+- Progress bar animates smoothly with the blue-to-purple gradient
+- No UI errors or broken layouts

--- a/showcase/packages/ms-agent-dotnet/qa/shared-state-read.md
+++ b/showcase/packages/ms-agent-dotnet/qa/shared-state-read.md
@@ -1,0 +1,79 @@
+# QA: Shared State (Reading) — Microsoft Agent Framework (.NET)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-read demo page
+- [ ] Verify the recipe card form loads (`data-testid="recipe-card"`)
+- [ ] Verify the CopilotSidebar opens by default with title "AI Recipe Assistant"
+- [ ] Send a message via the sidebar
+- [ ] Verify the agent responds with an assistant message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Initial Recipe State
+
+- [ ] Verify the recipe title input shows "Make Your Recipe"
+- [ ] Verify the cooking time dropdown defaults to "45 min"
+- [ ] Verify the skill level dropdown defaults to "Intermediate"
+- [ ] Verify the default ingredients are displayed in the ingredients container
+      (`data-testid="ingredients-container"`):
+  - [ ] Carrots (3 large, grated) with carrot emoji
+  - [ ] All-Purpose Flour (2 cups) with wheat emoji
+- [ ] Verify the default instruction is displayed in the instructions container
+      (`data-testid="instructions-container"`): "Preheat oven to 350°F (175°C)"
+
+#### Suggestions
+
+- [ ] Verify "Create Italian recipe" suggestion is visible
+- [ ] Verify "Make it healthier" suggestion is visible
+- [ ] Verify "Suggest variations" suggestion is visible
+
+#### Recipe Editing (Local State)
+
+- [ ] Edit the recipe title and verify it updates
+- [ ] Change the skill level dropdown (Beginner/Intermediate/Advanced) and verify it updates
+- [ ] Change the cooking time dropdown (5/15/30/45/60+ min) and verify it updates
+- [ ] Toggle a dietary preference checkbox (e.g. "Vegetarian") and verify it's checked
+- [ ] Click "+ Add Ingredient" (`data-testid="add-ingredient-button"`) and verify a new
+      empty ingredient card (`data-testid="ingredient-card"`) appears
+- [ ] Edit an ingredient name and amount
+- [ ] Remove an ingredient by clicking the "x" button
+- [ ] Click "+ Add Step" and verify a new instruction row appears
+- [ ] Edit an instruction and verify it saves
+- [ ] Remove an instruction by clicking the "x" button
+
+#### AI-Powered Recipe Updates (useAgent with shared state)
+
+- [ ] Click "Create Italian recipe" suggestion
+- [ ] Verify the agent updates the recipe title, ingredients, and instructions
+- [ ] Verify the blue Ping indicator appears on changed sections (dietary, ingredients, or instructions)
+- [ ] Verify the "Improve with AI" button (`data-testid="improve-button"`) changes to
+      "Please Wait..." while loading and is disabled
+- [ ] Click "Improve with AI" and verify the recipe is enhanced after processing
+
+#### Agent Reads Frontend State
+
+- [ ] Edit the recipe (change title, add ingredients)
+- [ ] Ask the agent "What recipe am I making?"
+- [ ] Verify the agent's response references the current recipe state
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+- [ ] Verify the "Improve with AI" button is disabled while loading
+
+## Expected Results
+
+- Recipe card and sidebar load within 3 seconds
+- Agent responds within 10 seconds
+- Recipe state syncs bidirectionally between UI and agent
+- Ping indicators highlight changed sections
+- No UI errors or broken layouts

--- a/showcase/packages/ms-agent-dotnet/qa/shared-state-streaming.md
+++ b/showcase/packages/ms-agent-dotnet/qa/shared-state-streaming.md
@@ -1,0 +1,40 @@
+# QA: State Streaming — Microsoft Agent Framework (.NET)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-streaming demo page
+- [ ] Verify the chat interface loads with title "State Streaming"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds with an assistant message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible (sends "Hello! What can you do?")
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/ms-agent-dotnet/qa/shared-state-write.md
+++ b/showcase/packages/ms-agent-dotnet/qa/shared-state-write.md
@@ -1,0 +1,40 @@
+# QA: Shared State (Writing) — Microsoft Agent Framework (.NET)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the shared-state-write demo page
+- [ ] Verify the chat interface loads with title "Shared State (Writing)"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds with an assistant message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible (sends "Hello! What can you do?")
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts

--- a/showcase/packages/ms-agent-dotnet/qa/subagents.md
+++ b/showcase/packages/ms-agent-dotnet/qa/subagents.md
@@ -1,0 +1,40 @@
+# QA: Sub-Agents — Microsoft Agent Framework (.NET)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the subagents demo page
+- [ ] Verify the chat interface loads with title "Sub-Agents"
+- [ ] Verify the chat input placeholder "Type a message..." is visible
+- [ ] Send a basic message (e.g. "Hello! What can you do?")
+- [ ] Verify the agent responds with an assistant message (`[data-role="assistant"]`)
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify "Get started" suggestion button is visible (sends "Hello! What can you do?")
+
+#### Note: Stub Demo
+
+- [ ] This demo is currently a stub (TODO: implement)
+- [ ] Verify the basic CopilotChat loads and accepts messages
+- [ ] Verify the agent responds to messages
+- [ ] No custom UI components are expected beyond the chat interface
+
+### 3. Error Handling
+
+- [ ] Send an empty message (should be handled gracefully)
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 10 seconds
+- No UI errors or broken layouts


### PR DESCRIPTION
## Summary

Adds the 5 missing QA markdown files in `showcase/packages/ms-agent-dotnet/qa/` to reach 9-for-all parity with the `langgraph-python` reference.

New files:
- `gen-ui-agent.md` — grounded in `src/app/demos/gen-ui-agent/page.tsx` (TaskProgress tracker, `data-testid="task-progress"`, `task-step-text`, blue-to-purple gradient progress bar, pending/completed/current styling)
- `shared-state-read.md` — grounded in `src/app/demos/shared-state-read/page.tsx` (Recipe form with `data-testid="recipe-card"`, ingredients/instructions containers, `improve-button`, `add-ingredient-button`, `AI Recipe Assistant` sidebar)
- `shared-state-write.md` — stub-quality (demo is currently a `TODO: implement` stub wiring only CopilotChat with title "Shared State (Writing)" and "Get started" suggestion)
- `shared-state-streaming.md` — stub-quality (demo is currently a stub with title "State Streaming")
- `subagents.md` — stub-quality (demo is currently a stub with title "Sub-Agents")

Title convention: "Microsoft Agent Framework (.NET)" matches the package framing.

Selectors and labels were referenced directly from each demo's `page.tsx`, which is the current source of truth. Several `tests/e2e/*.spec.ts` files (`shared-state-read.spec.ts`, `shared-state-write.spec.ts`, `shared-state-streaming.spec.ts`, `subagents.spec.ts`) aspire to richer implementations (Sales Pipeline, document editor, travel planner) that don't yet exist in the stub `page.tsx` files — the QA docs reflect the current stubs, not the aspirational e2e tests. See Concerns below.

## Concerns

- `shared-state-read.spec.ts` checks for "Sales Pipeline" / "Sales Pipeline Assistant" while `page.tsx` renders the Recipe demo with "AI Recipe Assistant" — this e2e file is out of sync with the actual demo and will fail as-is.
- `shared-state-write.spec.ts` expects a Sales Pipeline dashboard with `todo-card` / `toggle-completed` testids; `page.tsx` is a stub with only `CopilotChat`.
- `shared-state-streaming.spec.ts` expects "AI Document Editor" + `confirm-changes-modal`; `page.tsx` is a stub.
- `subagents.spec.ts` expects a travel planner with `supervisor-indicator` and friends; `page.tsx` is a stub.

These pre-existing e2e/page mismatches are out of scope for this PR (QA docs) but should be tracked as follow-ups — either implement the demos to match the e2e tests, or prune the e2e tests to match the stubs.

## Test plan

- [ ] QA docs render as expected on GitHub
- [ ] File list under `showcase/packages/ms-agent-dotnet/qa/` contains 9 entries matching `langgraph-python/qa/`