### PR TITLE
chore(ci): workflow naming standardization (Bundle 6 consolidation)

### DIFF
--- a/.github/workflows/test_e2e-dojo.yml
+++ b/.github/workflows/test_e2e-dojo.yml
@@ -6,13 +6,13 @@ on:
     paths:
       - "packages/**"
       - "sdk-python/**"
-      - ".github/workflows/e2e_dojo.yml"
+      - ".github/workflows/test_e2e-dojo.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/**"
       - "sdk-python/**"
-      - ".github/workflows/e2e_dojo.yml"
+      - ".github/workflows/test_e2e-dojo.yml"
       - ".changeset"
   workflow_dispatch:
     inputs:
@@ -45,7 +45,7 @@ jobs:
           filters: |
             ts:
               - 'packages/**'
-              - '.github/workflows/e2e_dojo.yml'
+              - '.github/workflows/test_e2e-dojo.yml'
               - '.changeset'
             python:
               - 'sdk-python/**'

--- a/.github/workflows/test_e2e-legacy-v1.yml
+++ b/.github/workflows/test_e2e-legacy-v1.yml
@@ -1,17 +1,17 @@
-name: test / e2e / examples
+name: test / e2e / legacy-v1
 
 on:
   push:
     branches: [main]
     paths:
       - "examples/**"
-      - ".github/workflows/e2e_examples.yml"
+      - ".github/workflows/test_e2e-legacy-v1.yml"
       - ".changeset"
   pull_request:
     branches: [main]
     paths:
       - "examples/**"
-      - ".github/workflows/e2e_examples.yml"
+      - ".github/workflows/test_e2e-legacy-v1.yml"
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/test_e2e-showcase-on-demand.yml
+++ b/.github/workflows/test_e2e-showcase-on-demand.yml
@@ -1,4 +1,4 @@
-name: "Showcase: Aimock E2E Tests"
+name: "test / e2e / showcase / on-demand"
 
 on:
   issue_comment:
@@ -163,5 +163,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `${status} **Aimock E2E Tests** (\`${slug}\`): ${{ job.status }}\n\n[View run](${runUrl})`
+              body: `${status} **Showcase E2E (on-demand)** (\`${slug}\`): ${{ job.status }}\n\n[View run](${runUrl})`
             });

--- a/.github/workflows/test_integration-docs.yml
+++ b/.github/workflows/test_integration-docs.yml
@@ -1,4 +1,4 @@
-name: test / doc-examples
+name: test / integration / docs
 on:
   pull_request:
     paths: ["docs/**"]

--- a/.github/workflows/test_integration-runtime.yml
+++ b/.github/workflows/test_integration-runtime.yml
@@ -1,16 +1,16 @@
-name: test / integration
+name: test / integration / runtime
 
 on:
   push:
     branches: [main]
     paths:
       - "packages/runtime/**"
-      - ".github/workflows/test_runtime-servers.yml"
+      - ".github/workflows/test_integration-runtime.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/runtime/**"
-      - ".github/workflows/test_runtime-servers.yml"
+      - ".github/workflows/test_integration-runtime.yml"
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/test_smoke-showcase-deployed.yml
+++ b/.github/workflows/test_smoke-showcase-deployed.yml
@@ -1,4 +1,4 @@
-name: "Showcase: Smoke Monitor"
+name: test / smoke / showcase-deployed
 
 on:
   schedule:

--- a/.github/workflows/test_smoke-starter-deployed.yml
+++ b/.github/workflows/test_smoke-starter-deployed.yml
@@ -1,4 +1,4 @@
-name: Starter Deployed Smoke Tests
+name: test / smoke / starter-deployed
 
 on:
   schedule:

--- a/.github/workflows/test_smoke-starter.yml
+++ b/.github/workflows/test_smoke-starter.yml
@@ -1,4 +1,4 @@
-name: Starter Smoke Tests
+name: test / smoke / starter
 
 on:
   schedule:
@@ -10,7 +10,7 @@ on:
   pull_request:
     paths:
       - "examples/integrations/**"
-      - ".github/workflows/starter-smoke.yml"
+      - ".github/workflows/test_smoke-starter.yml"
   workflow_dispatch: {}
 
 permissions:

--- a/examples/e2e/AGENTS.md
+++ b/examples/e2e/AGENTS.md
@@ -119,7 +119,7 @@ If an example auto-opens Copilot UI / triggers calls, prefer adding a query para
 
 Workflow:
 
-- `.github/workflows/e2e_examples.yml`
+- `.github/workflows/test_e2e-legacy-v1.yml`
 
 It runs a matrix of:
 
@@ -153,4 +153,4 @@ Artifacts:
 3. Run locally:
    - `EXAMPLE=<example> pnpm test`
 4. Add the example name to the CI matrix in:
-   - `.github/workflows/e2e_examples.yml`
+   - `.github/workflows/test_e2e-legacy-v1.yml`

--- a/showcase/QA-COVERAGE.md
+++ b/showcase/QA-COVERAGE.md
@@ -74,7 +74,7 @@ This matrix tracks what testing exists for each demo and the Sales Dashboard sta
 ### CI Workflows (`.github/workflows/showcase_*.yml`)
 
 - `showcase_validate.yml` -- runs `npx vitest run` on PR (unit tests only)
-- `showcase_aimock-e2e.yml` -- runs aimock-backed Playwright E2E, **manual trigger only** (`/test-aimock` comment or workflow_dispatch)
+- `test_e2e-showcase-on-demand.yml` -- runs aimock-backed Playwright E2E, **manual trigger only** (`/test-aimock` comment or workflow_dispatch)
 - `showcase_drift-detection.yml` -- template drift detection
 - `showcase_template-drift.yml` -- template synchronization
 - `showcase_deploy.yml` -- deployment pipeline

--- a/showcase/scripts/create-integration/index.ts
+++ b/showcase/scripts/create-integration/index.ts
@@ -1529,8 +1529,8 @@ function updateWorkflows(args: CLIArgs) {
     }
   }
 
-  // 3. Update starter-smoke.yml — add to matrix (block sequence format)
-  const smokePath = path.join(workflowsDir, "starter-smoke.yml");
+  // 3. Update test_smoke-starter.yml — add to matrix (block sequence format)
+  const smokePath = path.join(workflowsDir, "test_smoke-starter.yml");
   if (fs.existsSync(smokePath)) {
     let smoke = fs.readFileSync(smokePath, "utf-8");
     const slug = args.slug;
@@ -1572,7 +1572,7 @@ function updateWorkflows(args: CLIArgs) {
       lines.splice(lastEntryIndex + 1, 0, `${entryIndent}${slug}`);
       smoke = lines.join("\n");
       fs.writeFileSync(smokePath, smoke);
-      console.log("  Updated starter-smoke.yml");
+      console.log("  Updated test_smoke-starter.yml");
     }
   }
 }


### PR DESCRIPTION
## Bundle 6 consolidation — workflow naming standardization

Consolidates 8 workflow renames into one PR. Adopts `test_<layer>-<target>[-<qualifier>].yml` convention with matching `test / <layer> / <target>[-<qualifier>]` internal names.

Branch-protection audit confirmed all 8 renames are drop-in safe — no required-status-checks reference any of these workflows ([audit report](https://www.notion.so/3443aa38185281a3ad07e5ec63debd0f)).

### Rename table

| Old → New | Internal name | Was PR |
|---|---|---|
| `test_runtime-servers` → `test_integration-runtime` | `test / integration` → `test / integration / runtime` | #3998 |
| `test_doc-examples` → `test_integration-docs` | `test / doc-examples` → `test / integration / docs` | #4003 |
| `e2e_dojo` → `test_e2e-dojo` | `test / e2e / dojo` (unchanged) | #4005 |
| `e2e_examples` → `test_e2e-legacy-v1` | `test / e2e / examples` → `test / e2e / legacy-v1` | #4000 |
| `showcase_aimock-e2e` → `test_e2e-showcase-on-demand` | `Showcase: Aimock E2E Tests` → `test / e2e / showcase / on-demand` | #3989 |
| `showcase_smoke-monitor` → `test_smoke-showcase-deployed` | `Showcase: Smoke Monitor` → `test / smoke / showcase-deployed` | #3991 |
| `starter-smoke` → `test_smoke-starter` | `Starter Smoke Tests` → `test / smoke / starter` | #4001 |
| `starter_deployed_smoke` → `test_smoke-starter-deployed` | `Starter Deployed Smoke Tests` → `test / smoke / starter-deployed` | #3992 |

### Consumer refs updated

Each rename included consumer grep + ref updates across the repo (README, QA-COVERAGE.md, create-integration script, AGENTS.md, workflow self-references). See individual child PRs for specifics.

Refs: [Full Action Inventory](https://www.notion.so/3443aa38185281b5a1dfc6e0890264e1)