### PR TITLE
fix(ci): drift rebuild gh workflow run requires --repo flag

### DIFF
--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -278,7 +278,7 @@ jobs:
           for SVC in ${{ steps.image_drift.outputs.stale_services }}; do
             echo "Triggering rebuild for ${SVC}..."
             RC=0
-            ERR_OUTPUT=$(gh workflow run showcase_deploy.yml -f service="${SVC}" 2>&1) || RC=$?
+            ERR_OUTPUT=$(gh workflow run showcase_deploy.yml --repo "${{ github.repository }}" -f service="${SVC}" 2>&1) || RC=$?
             if [ "$RC" -eq 0 ]; then
               COUNT=$((COUNT + 1))
             else


### PR DESCRIPTION
## Problem

All 18 stale-service rebuild triggers in [run 24534637524](https://github.com/CopilotKit/CopilotKit/actions/runs/24534637524) failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The image-drift workflow is completely broken — when it detects stale showcase images, the follow-up `gh workflow run showcase_deploy.yml` step 500-fails for every service, so no rebuilds actually happen.

## Root cause

The `smoke` job in `.github/workflows/showcase_smoke-monitor.yml` has **no `actions/checkout@v4` step**. `gh workflow run` (unlike `gh api` or `gh run list`) resolves the target repository by shelling out to `git` in the current directory to read the remote. With no checkout present, `git` aborts and the entire rebuild loop fails.

PR #3968 didn't introduce the missing-checkout problem — it was latent — but it was the first run to reach the rebuild path with a real stale list, exposing it.

## Fix

Pass `--repo "${{ github.repository }}"` to `gh workflow run` so the CLI skips the git-based repo lookup entirely. Minimal, one-line change; no checkout needed.

```diff
-ERR_OUTPUT=$(gh workflow run showcase_deploy.yml -f service="${SVC}" 2>&1) || RC=$?
+ERR_OUTPUT=$(gh workflow run showcase_deploy.yml --repo "${{ github.repository }}" -f service="${SVC}" 2>&1) || RC=$?
```

## Test plan

- [x] YAML parses
- [x] Local pre-commit (lint + test + check:packages) green
- [ ] Next scheduled smoke-monitor run (or manual `workflow_dispatch` with a stale service) triggers rebuilds without the `not a git repository` error