### PR TITLE
fix(ci): 4 hygiene fixes from QA/E2E blitz findings

### DIFF
--- a/.github/workflows/e2e_dojo.yml
+++ b/.github/workflows/e2e_dojo.yml
@@ -7,6 +7,7 @@ on:
       - "packages/**"
       - "sdk-python/**"
       - ".github/workflows/e2e_dojo.yml"
+      - ".changeset"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -19,7 +19,7 @@ permissions:
   issues: write
 
 jobs:
-  starter-smoke:
+  smoke-starter:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -109,7 +109,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: starter-smoke-${{ matrix.starter }}
+          name: smoke-starter-${{ matrix.starter }}
           path: showcase/tests/test-results/
           retention-days: 7
 

--- a/.github/workflows/test_doc-examples.yml
+++ b/.github/workflows/test_doc-examples.yml
@@ -1,6 +1,7 @@
 name: test / doc-examples
 on:
   pull_request:
+    branches: [main]
     paths: ["docs/**"]
   push:
     branches: [main]

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -7,12 +7,16 @@ on:
       - "docs/**"
       - "README.md"
       - "examples/**"
+      - "showcase/**"
+      - "sdk-python/**"
   pull_request:
     branches: [main]
     paths-ignore:
       - "docs/**"
       - "README.md"
       - "examples/**"
+      - "showcase/**"
+      - "sdk-python/**"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## CI hygiene fixes

Four direct-fix items surfaced during the 2026-04-16 QA/E2E blitz, bundled as one PR with one commit per fix:

1. **`test_unit.yml` paths-ignore** — add `showcase/**` + `sdk-python/**` (prevents spurious TS unit matrix runs on showcase-only or sdk-python-only PRs). `sdk-python-old/**` was mentioned in the plan but doesn't exist on main; only the two existing dirs are added.
2. **`test_doc-examples.yml`** — scope PR trigger to `branches: [main]` (matches convention of other workflows).
3. **`e2e_dojo.yml`** — symmetric `.changeset` path filter on push+PR (was asymmetric — already in the `dorny/paths-filter` step's `ts:` list, so this aligns the trigger).
4. **`starter-smoke.yml`** — rename internal job id (`starter-smoke` → `smoke-starter`) and artifact name pattern (cosmetic; matches the new `test_<layer>-<target>` / `smoke-<layer>` naming convention; no external consumers).

### Fix skipped

**`showcase_smoke-monitor.yml` slug normalization** (item #10 in the Notion page) — inspecting the file, it already uses the `showcase/packages/` slug convention (`ms-agent-python`, `ms-agent-dotnet`, `strands`). The apparent inconsistency is actually in `starter-smoke.yml`, whose matrix keys must stay as `ms-agent-framework-*` / `strands-python` because they are literal directory names in `examples/integrations/` (used as `working-directory: examples/integrations/${{ matrix.starter }}`). So there is no actionable change here — the two files use different slug conventions *by necessity*, because they target different directories (deployed `showcase/packages/*` vs. local `examples/integrations/*`). Flagging for the author of the blitz notes in case the actual concern was something else.

Refs: [Bugs Found During Blitz](https://www.notion.so/3443aa381852812fb595c5118dd68818) items #3, #8, #9, #12.