### PR TITLE
fix(showcase-deploy): narrow matrix on single-service dispatch + dispatch=all unconditional

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -169,11 +169,18 @@ jobs:
           CHANGES='${{ steps.filter.outputs.changes }}'
           CHANGES="${CHANGES:-[]}"
 
-          # Filter services: on workflow_dispatch with a specific service, narrow to that service ONLY (ignore paths-filter, which falls back to "all filters matched" when the workflow_dispatch event has no 'before' field). On push or when dispatch=="all"/"", use paths-filter results.
+          # Filter services based on three dispatch modes:
+          #   dispatch == "all": manual "deploy all" — include every service unconditionally
+          #     (paths-filter is unreliable on workflow_dispatch because there is no 'before' SHA,
+          #      so we must NOT consult $changes here — doing so silently produces an empty matrix).
+          #   dispatch == <specific service>: narrow to that service only (skips paths-filter so
+          #     drift-rebuild and manual single-service dispatches work regardless of $changes).
+          #   dispatch == "": push event — include services whose filter_key appears in paths-filter CHANGES.
           MATRIX=$(echo "$ALL_SERVICES" | jq -c --arg dispatch "$DISPATCH" --argjson changes "$CHANGES" '
             [.[] | (.filter_key as $fk | select(
+              $dispatch == "all" or
               ($dispatch != "" and $dispatch != "all" and $dispatch == .dispatch_name) or
-              (($dispatch == "" or $dispatch == "all") and ($changes | index($fk) != null))
+              ($dispatch == "" and ($changes | index($fk) != null))
             ))]
           ')
 

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -169,13 +169,12 @@ jobs:
           CHANGES='${{ steps.filter.outputs.changes }}'
           CHANGES="${CHANGES:-[]}"
 
-          # Filter services: on workflow_dispatch, include all (default) or specific service; on push, include only services whose paths changed
+          # Filter services: on workflow_dispatch with a specific service, narrow to that service ONLY (ignore paths-filter, which falls back to "all filters matched" when the workflow_dispatch event has no 'before' field). On push or when dispatch=="all"/"", use paths-filter results.
           MATRIX=$(echo "$ALL_SERVICES" | jq -c --arg dispatch "$DISPATCH" --argjson changes "$CHANGES" '
-            [.[] | select(
-              $dispatch == "all" or
-              $dispatch == .dispatch_name or
-              (.filter_key as $fk | $changes | index($fk) != null)
-            )]
+            [.[] | (.filter_key as $fk | select(
+              ($dispatch != "" and $dispatch != "all" and $dispatch == .dispatch_name) or
+              (($dispatch == "" or $dispatch == "all") and ($changes | index($fk) != null))
+            ))]
           ')
 
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fixes matrix fan-out bug in Showcase Build & Deploy: single-service workflow_dispatch was triggering all 37 matrix legs instead of 1
- Root cause: dorny/paths-filter@v3 on workflow_dispatch (no before SHA) falls back to "all filters matched", producing CHANGES=[all 37 filter_keys]. The old OR-branch `(.filter_key as $fk | $changes | index($fk) != null)` fired for every service regardless of $dispatch
- Also fixes regression: dispatch=all was routing through paths-filter (returned empty on dispatch) → manual "deploy all" produced 0-entry matrix
- New 3-mode filter:
  - `dispatch == "all"` → include every service unconditionally (manual "deploy all")
  - `dispatch == <specific>` → narrow to that one service (drift-rebuild, manual single-service)
  - `dispatch == ""` → push event, use paths-filter against CHANGES

## Impact
- Drift rebuild was amplifying CI ~37× per dispatch (19 drifted services × 37 matrix legs = 703 build jobs instead of 19)
- Manual single-service deploys via `gh workflow run` also fanning out to full matrix

## Test plan
- [ ] CI green on this branch
- [ ] Post-merge drift-rebuild run produces 1-leg matrix per dispatch, not 37
- [ ] Post-merge manual `service=all` dispatch deploys all services
- [ ] Post-merge push events continue to use paths-filter correctly