### PR TITLE
fix(ci): remove auto-issue creation from workflows (Slack alerts only)

### DIFF
--- a/.github/workflows/showcase_drift-detection.yml
+++ b/.github/workflows/showcase_drift-detection.yml
@@ -114,32 +114,6 @@ jobs:
         if: always() && steps.slack-payload.outputs.payload_path
         run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
 
-      - name: Create issue on failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = '[Drift] Showcase E2E suite failing';
-            const body = `## E2E Drift Detection Alert\n\n**Run**: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n**Schedule**: ${context.payload.schedule || 'manual'}\n\nThe centralized E2E smoke suite is failing. Please investigate.`;
-
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'showcase-drift',
-              state: 'open',
-            });
-
-            const existing = issues.find(i => i.title === title);
-            if (!existing) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels: ['showcase-drift'],
-              });
-            }
-
   version-drift:
     name: Version Drift Report
     runs-on: ubuntu-latest
@@ -221,59 +195,6 @@ jobs:
           echo -e "$report" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Create drift report issue
-        id: drift_issue
-        if: steps.python_drift.outputs.report != '' || steps.npm_drift.outputs.report != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pythonDrift = `${{ steps.python_drift.outputs.report }}`.trim();
-            const npmDrift = `${{ steps.npm_drift.outputs.report }}`.trim();
-
-            if (!pythonDrift && !npmDrift) return;
-
-            const title = `[Drift] Showcase packages have outdated pinned versions`;
-            const body = `## Weekly Version Drift Report
-
-            Showcase packages have pinned versions that differ from the latest releases.
-            Review each and update if the new version is compatible.
-
-            ${pythonDrift ? `### Python Packages\n| Package | Dep | Pinned | Latest |\n|---------|-----|--------|--------|\n${pythonDrift}` : ''}
-
-            ${npmDrift ? `### npm Packages\n| Package | Dep | Pinned | Latest |\n|---------|-----|--------|--------|\n${npmDrift}` : ''}
-
-            **Action**: For each outdated dep, check the Dojo example for the correct version.
-            Update \`requirements.txt\` / \`package.json\`, rebuild, and verify demos still work.
-            `;
-
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'showcase-drift,version-drift',
-              state: 'open',
-            });
-
-            let issueUrl;
-            if (issues.length === 0) {
-              const { data: created } = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels: ['showcase-drift', 'version-drift'],
-              });
-              issueUrl = created.html_url;
-            } else {
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues[0].number,
-                body,
-              });
-              issueUrl = issues[0].html_url;
-            }
-            core.setOutput('issue_url', issueUrl);
-
       - name: Notify Slack (version drift)
         if: steps.python_drift.outputs.report != '' || steps.npm_drift.outputs.report != ''
         uses: slackapi/slack-github-action@v2.1.0
@@ -281,7 +202,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload: |
-            { "text": ":warning: *Version drift*: dependency updates available | <${{ steps.drift_issue.outputs.issue_url }}|View issue>" }
+            { "text": ":warning: *Version drift*: dependency updates available | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>" }
 
       - name: Notify Slack (version drift failure)
         if: failure()

--- a/.github/workflows/starter-smoke.yml
+++ b/.github/workflows/starter-smoke.yml
@@ -16,7 +16,6 @@ on:
 permissions:
   contents: read
   packages: read
-  issues: write
 
 jobs:
   starter-smoke:
@@ -155,29 +154,3 @@ jobs:
       - name: Clean up Slack payload tmpfile
         if: always() && steps.slack-payload.outputs.payload_path
         run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
-
-      - name: Create GitHub issue on failure
-        if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v7
-        env:
-          FAILURE_SUMMARY: ${{ steps.failure-cause.outputs.summary }}
-        with:
-          script: |
-            const title = `[Drift] Starter smoke test failing: ${{ matrix.starter }}`;
-            const cause = (process.env.FAILURE_SUMMARY || 'Unknown').replace(/`/g, "'");
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'starter-drift',
-              state: 'open',
-            });
-            const existing = issues.find(i => i.title === title);
-            if (!existing) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                labels: ['starter-drift'],
-                body: `The scheduled starter smoke test for \`${{ matrix.starter }}\` is failing.\n\n**Cause:**\n\`\`\`\n${cause}\n\`\`\`\n\n**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nThis likely means a floating dependency update broke the starter.`,
-              });
-            }

--- a/.github/workflows/starter_deployed_smoke.yml
+++ b/.github/workflows/starter_deployed_smoke.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   contents: read
   packages: read
-  issues: write
 
 jobs:
   starter-deployed-smoke:
@@ -172,26 +171,3 @@ jobs:
       - name: Clean up Slack payload tmpfile
         if: always() && steps.slack-payload.outputs.payload_path
         run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
-
-      - name: Create GitHub issue on failure
-        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = `Starter deployed smoke test failure - ${new Date().toISOString().split('T')[0]}`;
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'starter-health',
-              state: 'open',
-            });
-            const existing = issues.find(i => i.title === title);
-            if (!existing) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                labels: ['starter-health'],
-                body: `Automated starter deployed smoke test failed.\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
-              });
-            }


### PR DESCRIPTION
## Summary
Removes all GitHub-issue-creation steps from 3 workflows. Slack alerts to #oss-alerts are the canonical (and now only) alert channel.

Workflows changed:
- **starter-smoke.yml** — dropped `Create GitHub issue on failure` step (github-script); removed `issues: write` permission. Slack step preserved with full FAILURE_SUMMARY context.
- **starter_deployed_smoke.yml** — dropped `Create GitHub issue on failure` step (github-script); removed `issues: write` permission. Slack step preserved.
- **showcase_drift-detection.yml** — dropped `Create issue on failure` (drift-detection job) and `Create drift report issue` (version-drift job). Slack payload updated to link to workflow run URL (previously linked to created issue). No `permissions:` block existed, so nothing to remove.

## Why
Auto-created issues became noise — 13 stale bot-created issues accumulated (all closed separately). Slack is the single source of truth going forward.

## Test plan
- [ ] CI green
- [ ] First post-merge failure of any of these workflows emits a Slack alert in #oss-alerts (no new GitHub issue)