### PR TITLE
ci: add workflow to update PR branches via qa:update-branch label

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -1,0 +1,40 @@
+name: Update PR branch
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-branch:
+    if: github.event.label.name == 'qa:update-branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PR branch with base
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            try {
+              await github.rest.pulls.updateBranch({ owner, repo, pull_number });
+              core.info(`Updated branch for PR #${pull_number}`);
+            } catch (error) {
+              core.setFailed(`Failed to update branch: ${error.message}`);
+              throw error;
+            } finally {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pull_number,
+                  name: 'qa:update-branch',
+                });
+              } catch (error) {
+                core.warning(`Could not remove label: ${error.message}`);
+              }
+            }

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -1,7 +1,7 @@
 name: Update PR branch
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 permissions:
@@ -24,8 +24,11 @@ jobs:
               await github.rest.pulls.updateBranch({ owner, repo, pull_number });
               core.info(`Updated branch for PR #${pull_number}`);
             } catch (error) {
-              core.setFailed(`Failed to update branch: ${error.message}`);
-              throw error;
+              if (error.status === 422) {
+                core.info(`Branch already up to date or cannot be updated: ${error.message}`);
+              } else {
+                core.setFailed(`Failed to update branch: ${error.message}`);
+              }
             } finally {
               try {
                 await github.rest.issues.removeLabel({


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/update-branch.yml` — a labeled-event workflow that updates a PR's branch with its base when the `qa:update-branch` label is applied.
- Removes the label after running so the bot can re-apply it on the next cycle.
- Infrastructure-only change; enables a QA bot to keep PRs current without human intervention.

## Behavior
1. Bot adds `qa:update-branch` label to any PR.
2. Workflow calls the GitHub `updateBranch` API (same as the "Update branch" button).
3. Workflow removes the label (in a `finally` block, so it clears even if the update fails).

Uses the namespaced `qa:` prefix to avoid collisions and leave room for future bot actions (`qa:triaged`, etc.).

## Test plan
- [ ] Merge this PR.
- [ ] On a separate out-of-date PR, apply the `qa:update-branch` label and confirm the workflow runs, updates the branch, and removes the label.
- [ ] Confirm the workflow does nothing when unrelated labels are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)