### PR TITLE
ci: add workflows: write permission to update-branch workflow

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   update-branch:


### PR DESCRIPTION
## Summary
- Adds `workflows: write` to the `.github/workflows/update-branch.yml` permissions block.
- Follow-up to #4036.

## Why
Without `workflows: write`, the labeled update-branch action fails on any PR whose base-merge would touch files under `.github/workflows/**` — GitHub rejects the merge with a "refusing to allow a GitHub App to create or update workflow" error. Adding the permission is harmless for PRs that don't touch workflow files and unblocks the QA bot for PRs that do.

## Test plan
- [ ] After merge: apply the \`qa:update-branch\` label to a PR that has workflow-file changes relative to base, confirm the workflow runs, updates the branch, and removes the label.
- [ ] Confirm unrelated PRs still get updated as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)