### PR TITLE
chore(langgraph-python-threads example): use published intelligence images in compose

### DIFF
--- a/examples/integrations/langgraph-python-threads/README.md
+++ b/examples/integrations/langgraph-python-threads/README.md
@@ -55,18 +55,11 @@ This authenticates you and issues a `COPILOTKIT_LICENSE_TOKEN`. Add it to your `
 
 5. **Start intelligence infrastructure** (for threads):
 
-First, build the local Docker images from the intelligence repo:
-
-```bash
-# From the intelligence repo root
-./scripts/build-local-images.sh
-```
-
-Then start the infrastructure:
-
 ```bash
 docker compose up -d --wait
 ```
+
+This pulls the published images from `public.ecr.aws/cpk/intelligence/*`.
 
 6. Start all services:
 

--- a/examples/integrations/langgraph-python-threads/docker-compose.yml
+++ b/examples/integrations/langgraph-python-threads/docker-compose.yml
@@ -3,9 +3,6 @@
 # Starts postgres, redis, runs DB migrations, and the intelligence
 # app-api + realtime-gateway services.
 #
-# Prerequisites:
-#   Build local images first — see intelligence/scripts/build-local-images.sh
-#
 # Usage:
 #   docker compose up -d --wait
 #
@@ -59,7 +56,7 @@ services:
   # ---------------------------------------------------------------------------
 
   db-migrations:
-    image: cpki/db-migrations:local
+    image: public.ecr.aws/cpk/intelligence/db-migrations:0.1.0-rc.5
     environment:
       DATABASE_URL: postgresql://intelligence:intelligence@postgres:5432/intelligence_app
     depends_on:
@@ -74,7 +71,7 @@ services:
   # ---------------------------------------------------------------------------
 
   app-api:
-    image: cpki/app-api:local
+    image: public.ecr.aws/cpk/intelligence/app-api:0.1.0-rc.5
     ports:
       - "${APP_API_HOST_PORT:-4201}:4201"
     environment:
@@ -100,7 +97,7 @@ services:
       - intelligence
 
   realtime-gateway:
-    image: cpki/realtime-gateway:local
+    image: public.ecr.aws/cpk/intelligence/realtime-gateway:0.1.0-rc.5
     ports:
       - "${REALTIME_GATEWAY_HOST_PORT:-4401}:4401"
     environment:


### PR DESCRIPTION
## Summary
- Point the `langgraph-python-threads` demo's `docker-compose.yml` at
  published images on ECR Public (`public.ecr.aws/cpk/intelligence/{app-api,db-migrations,realtime-gateway}:0.1.0-rc.5`)
  instead of `cpki/*:local` images that had to be built from the intelligence repo.
- Drop the "build local images first" prerequisite from the compose header
  and README step 5.

## Why
The demo previously required cloning the intelligence repo and running
`./scripts/build-local-images.sh` before `docker compose up` would work —
a non-starter for external users evaluating the template. The published
ECR Public images are anonymously pullable, so `docker compose up -d --wait`
now works out of the box.