### PR TITLE
fix(showcase-starters): health probes hit /health instead of /ok

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -633,6 +633,27 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
   copyDirSync(frontendSrc, frontendDest);
   processTemplateVarsInDir(frontendDest, vars);
 
+  // 1a. langgraph starters use langgraph_cli which exposes /ok (not /health).
+  // Rewrite the probe path in the copilotkit + health routes for these starters only.
+  if (fw.slug.startsWith("langgraph-")) {
+    const probeFiles = [
+      path.join(frontendDest, "app/api/copilotkit/route.ts"),
+      path.join(frontendDest, "app/api/health/route.ts"),
+    ];
+    for (const file of probeFiles) {
+      if (fs.existsSync(file)) {
+        const content = fs.readFileSync(file, "utf-8");
+        const updated = content.replace(
+          /\$\{AGENT_URL\}\/health/g,
+          "${AGENT_URL}/ok",
+        );
+        if (updated !== content) {
+          fs.writeFileSync(file, updated);
+        }
+      }
+    }
+  }
+
   // 2. Copy template config files
   const templateConfigs: Array<[string, string]> = [
     ["package.template.json", "package.json"],

--- a/showcase/starters/ag2/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/ag2/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/ag2/src/app/api/health/route.ts
+++ b/showcase/starters/ag2/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/agno/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/agno/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/agno/src/app/api/health/route.ts
+++ b/showcase/starters/agno/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/claude-sdk-python/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/claude-sdk-python/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/claude-sdk-python/src/app/api/health/route.ts
+++ b/showcase/starters/claude-sdk-python/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/claude-sdk-typescript/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/claude-sdk-typescript/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/claude-sdk-typescript/src/app/api/health/route.ts
+++ b/showcase/starters/claude-sdk-typescript/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/crewai-crews/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/crewai-crews/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/crewai-crews/src/app/api/health/route.ts
+++ b/showcase/starters/crewai-crews/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/google-adk/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/google-adk/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/google-adk/src/app/api/health/route.ts
+++ b/showcase/starters/google-adk/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/langroid/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/langroid/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/langroid/src/app/api/health/route.ts
+++ b/showcase/starters/langroid/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/llamaindex/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/llamaindex/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/llamaindex/src/app/api/health/route.ts
+++ b/showcase/starters/llamaindex/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/mastra/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/mastra/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/mastra/src/app/api/health/route.ts
+++ b/showcase/starters/mastra/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/ms-agent-dotnet/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/ms-agent-dotnet/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/ms-agent-dotnet/src/app/api/health/route.ts
+++ b/showcase/starters/ms-agent-dotnet/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/ms-agent-python/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/ms-agent-python/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/ms-agent-python/src/app/api/health/route.ts
+++ b/showcase/starters/ms-agent-python/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/pydantic-ai/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/pydantic-ai/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/pydantic-ai/src/app/api/health/route.ts
+++ b/showcase/starters/pydantic-ai/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/spring-ai/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/spring-ai/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/spring-ai/src/app/api/health/route.ts
+++ b/showcase/starters/spring-ai/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/strands/src/app/api/copilotkit/route.ts
+++ b/showcase/starters/strands/src/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/strands/src/app/api/health/route.ts
+++ b/showcase/starters/strands/src/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/starters/template/frontend/app/api/copilotkit/route.ts
+++ b/showcase/starters/template/frontend/app/api/copilotkit/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
 export const GET = async () => {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "reachable" : `error (${res.status})`;

--- a/showcase/starters/template/frontend/app/api/health/route.ts
+++ b/showcase/starters/template/frontend/app/api/health/route.ts
@@ -8,7 +8,7 @@ const AGENT_URL =
 export async function GET(req: NextRequest) {
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";


### PR DESCRIPTION
## Summary
All 17 `showcase-starter-*` Railway services were returning HTTP 503 on `/api/health` because both the starter's `/api/health` route AND `/api/copilotkit` route probed `${AGENT_URL}/ok`, but the in-container agent servers (FastAPI, .NET, Spring, Hono, etc.) expose `/health`, not `/ok`. Probe hit 404 → health route returned 503.

## Changes
- 14 starter `/api/health/route.ts` files — `/ok` → `/health`
- 15 starter `/api/copilotkit/route.ts` GET health probes — `/ok` → `/health`
- `showcase/starters/template/frontend/app/api/{copilotkit,health}/route.ts` — same fix (regeneration source)
- mastra `/api/health/route.ts` — same fix

## NOT changed (intentional)
- `langgraph-python`, `langgraph-fastapi`, `langgraph-typescript` starters — these run `langgraph_cli dev` which exposes `/ok` (not `/health`). Current probe is correct for them.

## Verification (per-starter `/health` endpoint confirmed)
- ag2: `agent_server.py:28 @app.get("/health")`
- agno: `agent_server.py:22`
- claude-sdk-python: `agent/agent.py:543`
- claude-sdk-typescript: `agent/index.ts:282`
- crewai-crews, google-adk, langroid, llamaindex, ms-agent-python, pydantic-ai, strands: all expose `@app.get("/health")`
- ms-agent-dotnet: `agent/Program.cs:23 MapGet("/health", ...)`
- spring-ai: `AgentController.java:34 @GetMapping("/health")` (also still has legacy `/ok`, safe either way)
- mastra: uses `npx mastra dev` — `/health` is the convention for Mastra's internal Hono server; may need a follow-up smoke-verify post-deploy

## Test plan
- [ ] CI green
- [ ] Post-merge: Railway rebuilds starters; `showcase-starter-*-production.up.railway.app/api/health` returns 200 with `status: healthy, agent: ok`
- [ ] Specifically verify mastra post-deploy — if still 503, iterate in follow-up