### PR TITLE
fix(langgraph-python-threads): load .env, bump runtime to latest

### DIFF
--- a/examples/integrations/langgraph-python-threads/apps/bff/package.json
+++ b/examples/integrations/langgraph-python-threads/apps/bff/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/server.ts",
+    "dev": "tsx watch --env-file=../../.env src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js"
   },
   "dependencies": {
-    "@copilotkit/runtime": "next",
+    "@copilotkit/runtime": "latest",
     "@hono/node-server": "^1.13.6",
     "hono": "^4.7.11",
     "zod": "^3.23.8"


### PR DESCRIPTION
The scaffolded BFF hits two bugs on first `pnpm dev`:

- `tsx` doesn't auto-load `.env` and the template's `.env` lives at the monorepo
  root, so `process.env.COPILOTKIT_LICENSE_TOKEN` is undefined and the runtime
  warns "No license token configured" even when `.env` is populated by the CLI.
- `@copilotkit/runtime: next` currently resolves to `1.55.0-next.9`, which
  predates the thread-naming UUID fix (v1.55.3). The BFF fails with
  `Invalid thread ID: must be a UUID` when LangGraph receives the compound
  `thread-name:<uuid>:<uuid>` string the runtime used to emit.