### PR TITLE
ci(docs-sync): auto-open needs-review PR on conflict + robustness hardening

### DIFF
--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -59,16 +59,13 @@ jobs:
           elif [ $EXIT_CODE -eq 3 ]; then
             echo "Has review items + clean transforms"
             echo "action=push_and_pr" >> "$GITHUB_OUTPUT"
-            if [ -f review-items.txt ]; then
-              REVIEW_ITEMS=$(cat review-items.txt)
-            else
+            # The sync script writes review-items.txt and emits
+            # review_items_file=<abs-path> directly to GITHUB_OUTPUT.
+            # Verify the file actually exists so downstream steps don't
+            # silently read an empty path.
+            if [ ! -f review-items.txt ]; then
               echo "::warning::review-items.txt not found despite exit code 3 — sync script may have a bug"
-              REVIEW_ITEMS="(review-items.txt not found — check sync script output)"
             fi
-            # Persist review items to a file for downstream jq-based payload building
-            # (avoids unsafe string interpolation of untrusted filenames into JSON).
-            printf '%s' "$REVIEW_ITEMS" > review-items-raw.txt
-            echo "review_items_file=review-items-raw.txt" >> "$GITHUB_OUTPUT"
           else
             echo "Sync failed with exit code $EXIT_CODE"
             exit 1
@@ -119,12 +116,29 @@ jobs:
             # GitHub's PR search syntax has no `head:` qualifier, so that
             # query always returns empty. Use jq on the full list instead
             # to filter by headRefName prefix client-side.
-            EXISTING_PR=$(gh pr list \
-              --state open \
-              --base "$SHOWCASE_BRANCH" \
-              --json number,url,headRefName \
-              --jq '[.[] | select(.headRefName | startswith("docs-sync/needs-review/"))] | .[0].url' \
-              2>/dev/null || echo "")
+            # Fail the step on gh API failure rather than swallowing it —
+            # `|| echo ""` would silently treat a transient 5xx as "no
+            # existing PR" and open a duplicate. Retry once with backoff
+            # to absorb blips; if both attempts fail, exit non-zero.
+            gh_pr_list_existing() {
+              gh pr list \
+                --state open \
+                --base "$SHOWCASE_BRANCH" \
+                --json number,url,headRefName \
+                --jq '[.[] | select(.headRefName | startswith("docs-sync/needs-review/"))] | .[0].url'
+            }
+            if ! EXISTING_PR=$(gh_pr_list_existing 2>gh-err.txt); then
+              echo "::warning::gh pr list failed on first attempt — retrying after 5s"
+              cat gh-err.txt || true
+              sleep 5
+              if ! EXISTING_PR=$(gh_pr_list_existing 2>gh-err.txt); then
+                echo "::error::gh pr list failed twice — aborting to avoid duplicate PR creation"
+                cat gh-err.txt || true
+                rm -f gh-err.txt
+                exit 1
+              fi
+            fi
+            rm -f gh-err.txt
             if [ -n "$EXISTING_PR" ]; then
               echo "Open needs-review PR already exists: $EXISTING_PR"
               echo "Skipping new PR — Slack alert will point at the existing one."
@@ -180,6 +194,15 @@ jobs:
             # Explicit signal: no PR opened, and this is the intended outcome
             # (not an error path). Downstream alerts key on this.
             echo "pr_opened=false" >> "$GITHUB_OUTPUT"
+            # Set needs_review explicitly so downstream `needs_review != 'true'`
+            # gates (notify-auto-sync) don't misfire on this deliberate
+            # no-op. Value depends on why we got here: push_and_pr path =
+            # review still pending; auto_push path = no review needed.
+            if [ "$ACTION" = "push_and_pr" ]; then
+              echo "needs_review=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "needs_review=false" >> "$GITHUB_OUTPUT"
+            fi
             exit 0
           fi
 

--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -97,11 +97,50 @@ jobs:
           ACTION: ${{ steps.sync.outputs.action }}
           REVIEW_ITEMS_FILE: ${{ steps.sync.outputs.review_items_file }}
         run: |
+          # Trap-based cleanup so temp files are removed even on signal kill.
+          CLEANUP_FILES=()
+          cleanup() {
+            for f in "${CLEANUP_FILES[@]}"; do
+              [ -n "$f" ] && [ -e "$f" ] && rm -f "$f" || true
+            done
+          }
+          trap cleanup EXIT INT TERM
+
           git config user.name "copilotkit-devops-bot[bot]"
           git config user.email "copilotkit-devops-bot[bot]@users.noreply.github.com"
 
           SHORT_SHA=$(git rev-parse --short origin/main)
           if [ "$ACTION" = "push_and_pr" ]; then
+            # Dedupe against open needs-review PRs. If one already exists,
+            # skip PR creation and let the Slack alert point at the existing
+            # one (simpler than re-pushing to its branch).
+            EXISTING_PR=$(gh pr list \
+              --state open \
+              --base "$SHOWCASE_BRANCH" \
+              --search "head:docs-sync/needs-review/ in:title [NEEDS REVIEW]" \
+              --json number,url,headRefName \
+              --jq '.[0].url' 2>/dev/null || echo "")
+            # Fallback: gh pr list with a plain head-prefix filter (--search
+            # may not honor head: prefix perfectly across gh versions).
+            if [ -z "$EXISTING_PR" ]; then
+              EXISTING_PR=$(gh pr list \
+                --state open \
+                --base "$SHOWCASE_BRANCH" \
+                --json number,url,headRefName \
+                --jq '[.[] | select(.headRefName | startswith("docs-sync/needs-review/"))] | .[0].url' \
+                2>/dev/null || echo "")
+            fi
+            if [ -n "$EXISTING_PR" ]; then
+              echo "Open needs-review PR already exists: $EXISTING_PR"
+              echo "Skipping new PR — Slack alert will point at the existing one."
+              echo "files_changed=0" >> "$GITHUB_OUTPUT"
+              echo "pr_url=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
+              echo "pr_opened=false" >> "$GITHUB_OUTPUT"
+              echo "needs_review=true" >> "$GITHUB_OUTPUT"
+              echo "existing_pr=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
             BRANCH="docs-sync/needs-review/${SHORT_SHA}-$(date +%s)"
             COMMIT_SUBJECT="chore: docs sync from main — needs review ($(date +%Y-%m-%d))"
           else
@@ -110,6 +149,26 @@ jobs:
           fi
 
           git checkout -b "$BRANCH"
+
+          # For push_and_pr: apply the conflict manifest now (upstream-wins
+          # content for conflicted files, written ONLY to the PR branch so
+          # the main branch worktree stays as-is and future sync runs still
+          # flag those files for review until this PR is merged).
+          if [ "$ACTION" = "push_and_pr" ] && [ -f conflict-manifest.json ]; then
+            CLEANUP_FILES+=("conflict-manifest.json")
+            node -e '
+              const fs = require("fs");
+              const path = require("path");
+              const manifest = JSON.parse(fs.readFileSync("conflict-manifest.json", "utf-8"));
+              for (const entry of manifest) {
+                const target = path.resolve(entry.showcasePath);
+                fs.mkdirSync(path.dirname(target), { recursive: true });
+                fs.writeFileSync(target, entry.content);
+                console.log("Applied upstream-wins to PR branch: " + entry.showcasePath);
+              }
+            '
+          fi
+
           git add showcase/shell/src/content/ showcase/shell/.docs-sync-sha
           CHANGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
 
@@ -135,32 +194,37 @@ jobs:
               REVIEW_ITEMS_CONTENT=$(cat "$REVIEW_ITEMS_FILE")
             fi
             PR_BODY_FILE=$(mktemp)
+            CLEANUP_FILES+=("$PR_BODY_FILE")
             {
-              echo ":warning: **Docs sync — MANUAL REVIEW REQUIRED**"
-              echo ""
-              echo "This PR was auto-opened because the docs-sync script detected"
-              echo "showcase-local modifications overlapping with upstream changes."
-              echo ""
-              echo "The script attempted a best-effort 3-way merge:"
-              echo ""
-              echo "- Where \`git merge-file\` produced a clean merge, the merged content was written."
-              echo "- Where \`git merge-file\` produced conflict markers, **upstream content was written as-is** and showcase-local modifications were overridden. **Manual review required.**"
-              echo ""
-              echo "### Review items"
-              echo ""
-              echo '```'
-              echo "$REVIEW_ITEMS_CONTENT"
-              echo '```'
-              echo ""
-              echo "### Source"
-              echo ""
-              echo "- Upstream ref: [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${SHORT_SHA})"
-              echo "- Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              echo ""
-              echo "**Review before merging.** Auto-merge is intentionally disabled"
-              echo "for \`needs-review\` PRs — confirm the upstream-wins sections"
-              echo "preserve any intentional showcase-local divergence you want to"
-              echo "keep, then merge manually."
+              printf '%s\n' ':warning: **Docs sync — MANUAL REVIEW REQUIRED**'
+              printf '\n'
+              printf '%s\n' 'This PR was auto-opened because the docs-sync script detected'
+              printf '%s\n' 'showcase-local modifications overlapping with upstream changes.'
+              printf '\n'
+              printf '%s\n' 'The script attempted a best-effort 3-way merge:'
+              printf '\n'
+              printf '%s\n' '- Where `git merge-file` produced a clean merge, the merged content was written.'
+              printf '%s\n' '- Where `git merge-file` produced conflict markers, **upstream content was written as-is** and showcase-local modifications were overridden. **Manual review required.**'
+              printf '\n'
+              printf '%s\n' '### Review items'
+              printf '\n'
+              printf '%s\n' '```'
+              # printf '%s\n' avoids running command substitution / backticks
+              # embedded in review-items content (cat "$REVIEW_ITEMS_FILE"
+              # would also work; printf is equivalent here since we already
+              # captured the content).
+              printf '%s\n' "$REVIEW_ITEMS_CONTENT"
+              printf '%s\n' '```'
+              printf '\n'
+              printf '%s\n' '### Source'
+              printf '\n'
+              printf '%s\n' "- Upstream ref: [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${SHORT_SHA})"
+              printf '%s\n' "- Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              printf '\n'
+              printf '%s\n' '**Review before merging.** Auto-merge is intentionally disabled'
+              printf '%s\n' 'for `needs-review` PRs — confirm the upstream-wins sections'
+              printf '%s\n' 'preserve any intentional showcase-local divergence you want to'
+              printf '%s\n' 'keep, then merge manually.'
             } > "$PR_BODY_FILE"
 
             PR_URL=$(gh pr create \
@@ -239,6 +303,16 @@ jobs:
             '{text: (":warning: *Docs sync*: auto-opened *NEEDS REVIEW* PR (best-effort 3-way merge; upstream-wins where conflicts) — human must review + merge\n```" + $items + "```\nReview: " + $pr_url + "\n<" + $run_url + "|View run>")}' \
             > slack-payloads/review-with-pr.json
 
+          # Collision path: new review items flagged but an existing open
+          # needs-review PR already covers the territory; we did NOT open a
+          # new PR. Point reviewers at the existing one.
+          jq -n \
+            --arg items "$REVIEW_ITEMS" \
+            --arg pr_url "${PR_URL:-}" \
+            --arg run_url "$RUN_URL" \
+            '{text: (":warning: *Docs sync*: new review items detected, but an open *NEEDS REVIEW* PR already exists — skipped new PR creation to avoid collision. Please resolve the existing PR.\n```" + $items + "```\nExisting PR: " + $pr_url + "\n<" + $run_url + "|View run>")}' \
+            > slack-payloads/review-existing-pr.json
+
           # Fallback path: review items flagged but no PR opened (e.g. 3-way
           # merge produced bit-for-bit identical content to what's already on
           # disk so nothing to commit). Keep an alert so it's visible.
@@ -288,7 +362,7 @@ jobs:
       # PR URL (not on any error path that leaves pr_url empty).
       - name: Notify Slack (review needed, with PR)
         id: notify-review-with-pr
-        if: always() && steps.sync.outputs.action == 'push_and_pr' && steps.push.outputs.pr_opened == 'true'
+        if: always() && steps.push.outputs.needs_review == 'true' && steps.push.outputs.pr_opened == 'true'
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
@@ -297,15 +371,27 @@ jobs:
 
       # Review items but the clean-transform portion was empty so no PR was
       # opened. Gated on pr_opened == 'false' (deliberate no-PR path) — not
-      # empty pr_url, which would also match error paths.
+      # empty pr_url, which would also match error paths. Explicitly excludes
+      # the existing-PR collision path, which gets its own step below.
       - name: Notify Slack (review needed, no PR)
         id: notify-review-no-pr
-        if: always() && steps.sync.outputs.action == 'push_and_pr' && steps.push.outputs.pr_opened == 'false'
+        if: always() && steps.sync.outputs.action == 'push_and_pr' && steps.push.outputs.pr_opened == 'false' && steps.push.outputs.existing_pr != 'true'
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload-file-path: slack-payloads/review-no-pr.json
+
+      # Collision path: new review items flagged but an existing open
+      # needs-review PR already exists — point reviewers at it.
+      - name: Notify Slack (review needed, existing PR)
+        id: notify-review-existing-pr
+        if: always() && steps.push.outputs.existing_pr == 'true'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload-file-path: slack-payloads/review-existing-pr.json
 
       - name: Notify Slack (failure)
         id: notify-failure
@@ -334,6 +420,7 @@ jobs:
             steps.notify-merge-failed.outcome == 'failure' ||
             steps.notify-review-with-pr.outcome == 'failure' ||
             steps.notify-review-no-pr.outcome == 'failure' ||
+            steps.notify-review-existing-pr.outcome == 'failure' ||
             steps.notify-failure.outcome == 'failure'
           )
         env:

--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -83,18 +83,31 @@ jobs:
           app-id: 1108748
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
 
-      # Create PR and auto-merge via devops bot (bypasses branch protection)
-      - name: Create and merge PR for clean transforms
+      # Create PR. For action=auto_push (no review items) the PR is
+      # auto-merged via the devops bot (bypasses branch protection). For
+      # action=push_and_pr the sync script has already written best-effort
+      # 3-way merged content to disk — this step commits it and opens a PR
+      # tagged [NEEDS REVIEW]. Auto-merge is DISABLED for needs-review PRs
+      # so a human reconciles any upstream-wins overrides.
+      - name: Create PR for docs sync
         id: push
         if: steps.sync.outputs.action == 'auto_push' || steps.sync.outputs.action == 'push_and_pr'
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          ACTION: ${{ steps.sync.outputs.action }}
+          REVIEW_ITEMS_FILE: ${{ steps.sync.outputs.review_items_file }}
         run: |
           git config user.name "copilotkit-devops-bot[bot]"
           git config user.email "copilotkit-devops-bot[bot]@users.noreply.github.com"
 
           SHORT_SHA=$(git rev-parse --short origin/main)
-          BRANCH="docs-sync/auto/${SHORT_SHA}-$(date +%s)"
+          if [ "$ACTION" = "push_and_pr" ]; then
+            BRANCH="docs-sync/needs-review/${SHORT_SHA}-$(date +%s)"
+            COMMIT_SUBJECT="chore: docs sync from main — needs review ($(date +%Y-%m-%d))"
+          else
+            BRANCH="docs-sync/auto/${SHORT_SHA}-$(date +%s)"
+            COMMIT_SUBJECT="chore: auto-sync docs from main ($(date +%Y-%m-%d))"
+          fi
 
           git checkout -b "$BRANCH"
           git add showcase/shell/src/content/ showcase/shell/.docs-sync-sha
@@ -109,27 +122,76 @@ jobs:
             exit 0
           fi
 
-          git commit --no-verify -m "chore: auto-sync docs from main ($(date +%Y-%m-%d))"
+          git commit --no-verify -m "$COMMIT_SUBJECT"
 
           # Override git credential to use bot token (checkout configured GITHUB_TOKEN)
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$BRANCH"
 
-          PR_URL=$(gh pr create \
-            --title "chore: auto-sync docs from main (${SHORT_SHA})" \
-            --body "Automated docs sync. Clean transforms only." \
-            --base "$SHOWCASE_BRANCH" \
-            --head "$BRANCH")
+          if [ "$ACTION" = "push_and_pr" ]; then
+            # Build the PR body from review-items.txt plus a clear callout.
+            REVIEW_ITEMS_CONTENT="(no review-items file produced)"
+            if [ -n "${REVIEW_ITEMS_FILE:-}" ] && [ -f "$REVIEW_ITEMS_FILE" ]; then
+              REVIEW_ITEMS_CONTENT=$(cat "$REVIEW_ITEMS_FILE")
+            fi
+            PR_BODY_FILE=$(mktemp)
+            {
+              echo ":warning: **Docs sync — MANUAL REVIEW REQUIRED**"
+              echo ""
+              echo "This PR was auto-opened because the docs-sync script detected"
+              echo "showcase-local modifications overlapping with upstream changes."
+              echo ""
+              echo "The script attempted a best-effort 3-way merge:"
+              echo ""
+              echo "- Where \`git merge-file\` produced a clean merge, the merged content was written."
+              echo "- Where \`git merge-file\` produced conflict markers, **upstream content was written as-is** and showcase-local modifications were overridden. **Manual review required.**"
+              echo ""
+              echo "### Review items"
+              echo ""
+              echo '```'
+              echo "$REVIEW_ITEMS_CONTENT"
+              echo '```'
+              echo ""
+              echo "### Source"
+              echo ""
+              echo "- Upstream ref: [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${SHORT_SHA})"
+              echo "- Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              echo ""
+              echo "**Review before merging.** Auto-merge is intentionally disabled"
+              echo "for \`needs-review\` PRs — confirm the upstream-wins sections"
+              echo "preserve any intentional showcase-local divergence you want to"
+              echo "keep, then merge manually."
+            } > "$PR_BODY_FILE"
 
-          echo "Created PR: $PR_URL"
-          echo "files_changed=${CHANGED}" >> "$GITHUB_OUTPUT"
-          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
-          # Only set pr_opened=true after the PR URL is captured. Any earlier
-          # failure (push, gh pr create) will leave this unset so downstream
-          # alerts fall through to failure() instead of a falsely-benign path.
-          echo "pr_opened=true" >> "$GITHUB_OUTPUT"
+            PR_URL=$(gh pr create \
+              --title "docs-sync(needs-review): sync from main (${SHORT_SHA}) [NEEDS REVIEW]" \
+              --body-file "$PR_BODY_FILE" \
+              --base "$SHOWCASE_BRANCH" \
+              --head "$BRANCH")
 
-          gh pr merge "$PR_URL" --merge
+            echo "Created NEEDS-REVIEW PR: $PR_URL"
+            echo "files_changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+            echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+            # Only set after URL captured — error paths leave this unset so
+            # downstream alerts fall through to failure().
+            echo "pr_opened=true" >> "$GITHUB_OUTPUT"
+            echo "needs_review=true" >> "$GITHUB_OUTPUT"
+            # Intentionally no `gh pr merge` — human must review & merge.
+          else
+            PR_URL=$(gh pr create \
+              --title "chore: auto-sync docs from main (${SHORT_SHA})" \
+              --body "Automated docs sync. Clean transforms / clean 3-way merges only." \
+              --base "$SHOWCASE_BRANCH" \
+              --head "$BRANCH")
+
+            echo "Created PR: $PR_URL"
+            echo "files_changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+            echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+            echo "pr_opened=true" >> "$GITHUB_OUTPUT"
+            echo "needs_review=false" >> "$GITHUB_OUTPUT"
+
+            gh pr merge "$PR_URL" --merge
+          fi
 
       # Build all Slack payloads via jq into tmpfiles. This guarantees any
       # review-item filename containing ", \, or control chars is safely
@@ -174,13 +236,16 @@ jobs:
             --arg items "$REVIEW_ITEMS" \
             --arg pr_url "${PR_URL:-}" \
             --arg run_url "$RUN_URL" \
-            '{text: (":warning: *Docs sync*: files needing manual review\n```" + $items + "```\nReview: " + $pr_url + "\n<" + $run_url + "|View run>")}' \
+            '{text: (":warning: *Docs sync*: auto-opened *NEEDS REVIEW* PR (best-effort 3-way merge; upstream-wins where conflicts) — human must review + merge\n```" + $items + "```\nReview: " + $pr_url + "\n<" + $run_url + "|View run>")}' \
             > slack-payloads/review-with-pr.json
 
+          # Fallback path: review items flagged but no PR opened (e.g. 3-way
+          # merge produced bit-for-bit identical content to what's already on
+          # disk so nothing to commit). Keep an alert so it's visible.
           jq -n \
             --arg items "$REVIEW_ITEMS" \
             --arg run_url "$RUN_URL" \
-            '{text: (":warning: *Docs sync*: files needing manual review (no auto-PR opened)\n```" + $items + "```\n<" + $run_url + "|View run>")}' \
+            '{text: (":warning: *Docs sync*: review items flagged but produced no diff (no PR opened)\n```" + $items + "```\n<" + $run_url + "|View run>")}' \
             > slack-payloads/review-no-pr.json
 
           # failure alert
@@ -200,7 +265,7 @@ jobs:
 
       - name: Notify Slack (auto-sync)
         id: notify-auto-sync
-        if: always() && steps.push.outcome == 'success' && steps.push.outputs.files_changed != '0'
+        if: always() && steps.push.outcome == 'success' && steps.push.outputs.files_changed != '0' && steps.push.outputs.needs_review != 'true'
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
@@ -209,7 +274,7 @@ jobs:
 
       - name: Notify Slack (merge failed)
         id: notify-merge-failed
-        if: failure() && steps.push.outputs.pr_opened == 'true'
+        if: failure() && steps.push.outputs.pr_opened == 'true' && steps.push.outputs.needs_review != 'true'
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}

--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -114,22 +114,17 @@ jobs:
             # Dedupe against open needs-review PRs. If one already exists,
             # skip PR creation and let the Slack alert point at the existing
             # one (simpler than re-pushing to its branch).
+            #
+            # NOTE: `gh pr list --search "head:..."` is NOT supported —
+            # GitHub's PR search syntax has no `head:` qualifier, so that
+            # query always returns empty. Use jq on the full list instead
+            # to filter by headRefName prefix client-side.
             EXISTING_PR=$(gh pr list \
               --state open \
               --base "$SHOWCASE_BRANCH" \
-              --search "head:docs-sync/needs-review/ in:title [NEEDS REVIEW]" \
               --json number,url,headRefName \
-              --jq '.[0].url' 2>/dev/null || echo "")
-            # Fallback: gh pr list with a plain head-prefix filter (--search
-            # may not honor head: prefix perfectly across gh versions).
-            if [ -z "$EXISTING_PR" ]; then
-              EXISTING_PR=$(gh pr list \
-                --state open \
-                --base "$SHOWCASE_BRANCH" \
-                --json number,url,headRefName \
-                --jq '[.[] | select(.headRefName | startswith("docs-sync/needs-review/"))] | .[0].url' \
-                2>/dev/null || echo "")
-            fi
+              --jq '[.[] | select(.headRefName | startswith("docs-sync/needs-review/"))] | .[0].url' \
+              2>/dev/null || echo "")
             if [ -n "$EXISTING_PR" ]; then
               echo "Open needs-review PR already exists: $EXISTING_PR"
               echo "Skipping new PR — Slack alert will point at the existing one."
@@ -150,10 +145,15 @@ jobs:
 
           git checkout -b "$BRANCH"
 
-          # For push_and_pr: apply the conflict manifest now (upstream-wins
+          # For push_and_pr: apply the conflict manifest FIRST (upstream-wins
           # content for conflicted files, written ONLY to the PR branch so
           # the main branch worktree stays as-is and future sync runs still
           # flag those files for review until this PR is merged).
+          #
+          # CRITICAL: This MUST run BEFORE `git add` below. `git add` stages
+          # the current working tree, so any manifest files written after
+          # that point would be left un-staged and never make it into the
+          # commit.
           if [ "$ACTION" = "push_and_pr" ] && [ -f conflict-manifest.json ]; then
             CLEANUP_FILES+=("conflict-manifest.json")
             node -e '
@@ -169,6 +169,8 @@ jobs:
             '
           fi
 
+          # Stage AFTER manifest has been applied so conflicted files land
+          # in the commit.
           git add showcase/shell/src/content/ showcase/shell/.docs-sync-sha
           CHANGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
 

--- a/showcase/scripts/sync-docs-from-main.ts
+++ b/showcase/scripts/sync-docs-from-main.ts
@@ -13,7 +13,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -35,6 +35,22 @@ const LANGCHAIN_EXCLUSIONS = [
   "langchain.agents",
   "langchain_core",
 ];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip only a single trailing newline (\n or \r\n). Preserves intentional
+ * leading/trailing whitespace inside the content — used for idempotency
+ * comparisons where trailing-EOL-only differences should be ignored but
+ * other whitespace differences are meaningful.
+ */
+function stripTrailingEol(s: string): string {
+  if (s.endsWith("\r\n")) return s.slice(0, -2);
+  if (s.endsWith("\n")) return s.slice(0, -1);
+  return s;
+}
 
 // ---------------------------------------------------------------------------
 // Transform pipeline
@@ -230,14 +246,15 @@ function hasShowcaseLocalModifications(
   // Get the main file content at the last sync point
   try {
     const mainRelative = path.relative(ROOT, mainPath);
-    const previousMainContent = execSync(
-      `git show ${lastSyncSha}:${mainRelative}`,
-      { encoding: "utf-8", cwd: ROOT },
+    const previousMainContent = execFileSync(
+      "git",
+      ["show", `${lastSyncSha}:${mainRelative}`],
+      { encoding: "utf-8", cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] },
     );
     const cleanTransform = transformContent(previousMainContent, showcasePath);
     const currentShowcase = fs.readFileSync(showcasePath, "utf-8");
 
-    return cleanTransform.trim() !== currentShowcase.trim();
+    return stripTrailingEol(cleanTransform) !== stripTrailingEol(currentShowcase);
   } catch (err: unknown) {
     // File didn't exist at last sync — safe to overwrite
     if (err instanceof Error && "status" in err) {
@@ -261,9 +278,10 @@ function getLastSyncSha(): string {
   }
   // No marker: use a reasonable default (100 commits ago)
   try {
-    return execSync("git rev-parse HEAD~100", {
+    return execFileSync("git", ["rev-parse", "HEAD~100"], {
       encoding: "utf-8",
       cwd: ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
     }).trim();
   } catch {
     throw new Error(
@@ -274,9 +292,17 @@ function getLastSyncSha(): string {
 }
 
 function getChangedFiles(sinceSha: string): string[] {
-  const output = execSync(
-    `git diff --name-only ${sinceSha}..HEAD -- docs/content/docs/ docs/snippets/`,
-    { encoding: "utf-8", cwd: ROOT },
+  const output = execFileSync(
+    "git",
+    [
+      "diff",
+      "--name-only",
+      `${sinceSha}..HEAD`,
+      "--",
+      "docs/content/docs/",
+      "docs/snippets/",
+    ],
+    { encoding: "utf-8", cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] },
   );
   return output.split("\n").filter((f) => f.trim() && f.endsWith(".mdx"));
 }
@@ -304,6 +330,12 @@ function getAllFiles(): string[] {
 // Main
 // ---------------------------------------------------------------------------
 
+interface ConflictEntry {
+  relPath: string;
+  showcasePath: string;
+  content: string;
+}
+
 interface SyncResult {
   copied: string[];
   transformed: string[];
@@ -312,6 +344,7 @@ interface SyncResult {
   mergeConflict: string[];
   skipped: string[];
   deleted: string[];
+  conflictManifest: ConflictEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -349,9 +382,10 @@ function attemptThreeWayMerge(
   let baseContent: string;
   try {
     const mainRelative = path.relative(ROOT, mainPath);
-    const previousMainContent = execSync(
-      `git show ${lastSyncSha}:${mainRelative}`,
-      { encoding: "utf-8", cwd: ROOT },
+    const previousMainContent = execFileSync(
+      "git",
+      ["show", `${lastSyncSha}:${mainRelative}`],
+      { encoding: "utf-8", cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] },
     );
     baseContent = transformContent(previousMainContent, showcasePath);
   } catch {
@@ -369,22 +403,42 @@ function attemptThreeWayMerge(
     fs.writeFileSync(remoteFile, upstreamTransformed);
 
     // `git merge-file` writes merged result in-place into `localFile`.
-    // Exit code 0 = clean merge; >0 = number of conflicts remaining.
-    let mergeExitCode = 0;
+    // Exit code 0 = clean merge; >0 = number of conflicts remaining; null =
+    // killed by signal (treat as failure).
+    let cleanMerge = false;
     try {
-      execSync(
-        `git merge-file -L showcase -L base -L upstream "${localFile}" "${baseFile}" "${remoteFile}"`,
+      execFileSync(
+        "git",
+        [
+          "merge-file",
+          "-L",
+          "showcase",
+          "-L",
+          "base",
+          "-L",
+          "upstream",
+          localFile,
+          baseFile,
+          remoteFile,
+        ],
         { stdio: "pipe" },
       );
+      cleanMerge = true;
     } catch (err: unknown) {
+      // status === null means killed by signal — treat as failure, not clean.
+      // status > 0 means N conflicts remaining — treat as failure.
       if (err instanceof Error && "status" in err) {
-        mergeExitCode = (err as { status: number }).status;
+        const status = (err as { status: number | null }).status;
+        if (status === null) {
+          return { success: false, content: upstreamTransformed };
+        }
+        // conflicts remain; fall through to upstream-wins
       } else {
         return { success: false, content: upstreamTransformed };
       }
     }
 
-    if (mergeExitCode === 0) {
+    if (cleanMerge) {
       const merged = fs.readFileSync(localFile, "utf-8");
       return { success: true, content: merged };
     }
@@ -408,9 +462,10 @@ function parseArgs(): { dryRun: boolean; all: boolean } {
 function main(): SyncResult {
   const { dryRun, all } = parseArgs();
   const lastSyncSha = getLastSyncSha();
-  const headSha = execSync("git rev-parse HEAD", {
+  const headSha = execFileSync("git", ["rev-parse", "HEAD"], {
     encoding: "utf-8",
     cwd: ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
   }).trim();
 
   console.log("=== Docs Sync ===");
@@ -430,7 +485,14 @@ function main(): SyncResult {
     mergeConflict: [],
     skipped: [],
     deleted: [],
+    conflictManifest: [],
   };
+
+  // Upstream-wins content for merge-conflict files. Not written to the
+  // current worktree — workflow applies these to the PR branch only so
+  // that future sync runs on main still detect local drift until the
+  // needs-review PR is merged by a human.
+  const conflictManifest: ConflictEntry[] = result.conflictManifest;
 
   for (const relPath of changedRelPaths) {
     const mainAbsolute = path.join(ROOT, relPath);
@@ -452,7 +514,9 @@ function main(): SyncResult {
 
     // Check for showcase-local modifications — attempt 3-way merge and
     // always produce file content. Clean merge = auto-applied; conflicting
-    // merge = upstream-wins, flagged for human review in PR body.
+    // merge = upstream-wins CONTENT captured but NOT written to the current
+    // worktree — workflow applies it to the PR branch only so that future
+    // sync runs on main still detect the local drift until a human merges.
     if (
       hasShowcaseLocalModifications(showcaseAbsolute, mainAbsolute, lastSyncSha)
     ) {
@@ -469,7 +533,7 @@ function main(): SyncResult {
         : null;
       if (
         existingContent !== null &&
-        existingContent.trim() === merge.content.trim()
+        stripTrailingEol(existingContent) === stripTrailingEol(merge.content)
       ) {
         result.skipped.push(relPath);
         if (merge.success) {
@@ -484,18 +548,29 @@ function main(): SyncResult {
         continue;
       }
 
-      if (!dryRun) {
-        fs.mkdirSync(path.dirname(showcaseAbsolute), { recursive: true });
-        fs.writeFileSync(showcaseAbsolute, merge.content);
-      }
-
       if (merge.success) {
+        // Clean 3-way merge: safe to write to the worktree; it reflects an
+        // auto-applied resolution of both local + upstream changes.
+        if (!dryRun) {
+          fs.mkdirSync(path.dirname(showcaseAbsolute), { recursive: true });
+          fs.writeFileSync(showcaseAbsolute, merge.content);
+        }
         result.autoMerged.push(relPath);
         console.log(`  [REVIEW/AUTO-MERGED] ${relPath} (3-way merge clean)`);
       } else {
+        // Conflict: DO NOT write upstream-wins to the current worktree.
+        // Record into a manifest — the workflow applies these files to the
+        // PR branch only. Leaving the worktree untouched preserves the
+        // invariant that future sync runs on main still flag this file for
+        // review until a human merges the needs-review PR.
+        conflictManifest.push({
+          relPath,
+          showcasePath: path.relative(ROOT, showcaseAbsolute),
+          content: merge.content,
+        });
         result.mergeConflict.push(relPath);
         console.log(
-          `  [REVIEW/CONFLICT] ${relPath} (3-way merge failed; upstream wins — manual review required)`,
+          `  [REVIEW/CONFLICT] ${relPath} (3-way merge failed; upstream-wins content staged to manifest — manual review required)`,
         );
       }
       continue;
@@ -511,7 +586,7 @@ function main(): SyncResult {
     // Check if showcase already has this content
     if (fs.existsSync(showcaseAbsolute)) {
       const existing = fs.readFileSync(showcaseAbsolute, "utf-8");
-      if (existing.trim() === transformed.trim()) {
+      if (stripTrailingEol(existing) === stripTrailingEol(transformed)) {
         result.skipped.push(relPath);
         continue; // Already up to date
       }
@@ -624,6 +699,15 @@ if (!hasAutoApplied && !hasReviewItems) {
     path.join(ROOT, "review-items.txt"),
     reviewLines.join("\n") + "\n",
   );
+  // Persist the conflict manifest so the workflow can apply upstream-wins
+  // content to the PR branch (NOT the current worktree — see
+  // conflictManifest comment above).
+  if (result.conflictManifest.length > 0) {
+    fs.writeFileSync(
+      path.join(ROOT, "conflict-manifest.json"),
+      JSON.stringify(result.conflictManifest, null, 2) + "\n",
+    );
+  }
   process.exit(3);
 } else {
   process.exit(0);

--- a/showcase/scripts/sync-docs-from-main.ts
+++ b/showcase/scripts/sync-docs-from-main.ts
@@ -41,15 +41,23 @@ const LANGCHAIN_EXCLUSIONS = [
 // ---------------------------------------------------------------------------
 
 /**
- * Strip only a single trailing newline (\n or \r\n). Preserves intentional
- * leading/trailing whitespace inside the content — used for idempotency
- * comparisons where trailing-EOL-only differences should be ignored but
- * other whitespace differences are meaningful.
+ * Normalize trailing-EOL + leading BOM for idempotency comparisons.
+ *
+ * - Strips a leading UTF-8 BOM (U+FEFF) that editors sometimes insert.
+ * - Strips ALL trailing whitespace (including \r\n, extra blank lines,
+ *   trailing spaces, tabs). Editors that re-save a file with an extra
+ *   trailing newline or BOM should not trigger spurious rewrites.
+ *
+ * Intentional internal whitespace (inside the file body) is preserved —
+ * only the edges are normalized.
  */
 function stripTrailingEol(s: string): string {
-  if (s.endsWith("\r\n")) return s.slice(0, -2);
-  if (s.endsWith("\n")) return s.slice(0, -1);
-  return s;
+  // Strip leading BOM if present.
+  if (s.charCodeAt(0) === 0xfeff) {
+    s = s.slice(1);
+  }
+  // Strip all trailing whitespace (newlines, spaces, tabs, \r).
+  return s.replace(/\s+$/, "");
 }
 
 // ---------------------------------------------------------------------------
@@ -254,7 +262,9 @@ function hasShowcaseLocalModifications(
     const cleanTransform = transformContent(previousMainContent, showcasePath);
     const currentShowcase = fs.readFileSync(showcasePath, "utf-8");
 
-    return stripTrailingEol(cleanTransform) !== stripTrailingEol(currentShowcase);
+    return (
+      stripTrailingEol(cleanTransform) !== stripTrailingEol(currentShowcase)
+    );
   } catch (err: unknown) {
     // File didn't exist at last sync — safe to overwrite
     if (err instanceof Error && "status" in err) {
@@ -607,11 +617,14 @@ function main(): SyncResult {
     }
   }
 
-  // Update sync marker only when the merge is clean (no manual-review
-  // conflicts left). If there are conflicts, keep the old sha so the next
-  // run re-attempts the merge once a human has reconciled the conflict PR.
+  // Update sync marker only when NOTHING had local modifications (no
+  // merge conflicts AND no auto-merged-with-local-mods files). If any file
+  // had local mods — even an auto-merged one — keep the old sha so the
+  // next run still has the correct base context for 3-way merging until
+  // a human has reviewed/merged the needs-review PR.
   if (
     !dryRun &&
+    result.needsReview.length === 0 &&
     result.mergeConflict.length === 0 &&
     (result.copied.length > 0 ||
       result.transformed.length > 0 ||
@@ -665,8 +678,14 @@ const hasAutoApplied =
   result.copied.length > 0 ||
   result.transformed.length > 0 ||
   result.autoMerged.length > 0;
+// Any file that had showcase-local modifications (needsReview) must route
+// through push_and_pr so a human can review — even if the 3-way merge was
+// clean (autoMerged). Silent auto-merging files with local mods would
+// clobber intentional showcase divergence.
 const hasReviewItems =
-  result.mergeConflict.length > 0 || result.deleted.length > 0;
+  result.mergeConflict.length > 0 ||
+  result.needsReview.length > 0 ||
+  result.deleted.length > 0;
 
 if (!hasAutoApplied && !hasReviewItems) {
   process.exit(2);
@@ -695,8 +714,14 @@ if (!hasAutoApplied && !hasReviewItems) {
     );
     for (const f of result.deleted) reviewLines.push(`  - ${f}`);
   }
+  // Write manifest + review items at the invocation cwd (the repo root
+  // when run from CI, matching the workflow's `[ -f conflict-manifest.json ]`
+  // and `cat review-items.txt` checks). Using process.cwd() rather than
+  // ROOT makes the contract explicit: whoever invokes the script picks
+  // where these artifacts land, and the workflow invokes from repo root.
+  const artifactDir = process.cwd();
   fs.writeFileSync(
-    path.join(ROOT, "review-items.txt"),
+    path.join(artifactDir, "review-items.txt"),
     reviewLines.join("\n") + "\n",
   );
   // Persist the conflict manifest so the workflow can apply upstream-wins
@@ -704,7 +729,7 @@ if (!hasAutoApplied && !hasReviewItems) {
   // conflictManifest comment above).
   if (result.conflictManifest.length > 0) {
     fs.writeFileSync(
-      path.join(ROOT, "conflict-manifest.json"),
+      path.join(artifactDir, "conflict-manifest.json"),
       JSON.stringify(result.conflictManifest, null, 2) + "\n",
     );
   }

--- a/showcase/scripts/sync-docs-from-main.ts
+++ b/showcase/scripts/sync-docs-from-main.ts
@@ -617,15 +617,17 @@ function main(): SyncResult {
     }
   }
 
-  // Update sync marker only when NOTHING had local modifications (no
-  // merge conflicts AND no auto-merged-with-local-mods files). If any file
-  // had local mods — even an auto-merged one — keep the old sha so the
-  // next run still has the correct base context for 3-way merging until
-  // a human has reviewed/merged the needs-review PR.
+  // Update sync marker whenever all files were successfully resolved:
+  // clean transforms, clean auto-merges, or no changes at all. A successful
+  // 3-way auto-merge means the file IS resolved — its content on disk
+  // reflects the merged state, so the next run should treat HEAD as the
+  // new base. Only outstanding merge conflicts (upstream-wins written to
+  // PR branch only) or deletions (not auto-applied) keep the old sha so
+  // future runs still flag them until a human merges the needs-review PR.
   if (
     !dryRun &&
-    result.needsReview.length === 0 &&
     result.mergeConflict.length === 0 &&
+    result.deleted.length === 0 &&
     (result.copied.length > 0 ||
       result.transformed.length > 0 ||
       result.autoMerged.length > 0)
@@ -678,14 +680,16 @@ const hasAutoApplied =
   result.copied.length > 0 ||
   result.transformed.length > 0 ||
   result.autoMerged.length > 0;
-// Any file that had showcase-local modifications (needsReview) must route
-// through push_and_pr so a human can review — even if the 3-way merge was
-// clean (autoMerged). Silent auto-merging files with local mods would
-// clobber intentional showcase divergence.
+// Only files that still need human attention force push_and_pr:
+// - mergeConflict: 3-way merge failed, upstream-wins content staged to PR
+//   branch, human must reconcile
+// - deleted: files gone on main, not auto-deleted in showcase, human decides
+// Auto-merged files (clean 3-way merge) are considered RESOLVED — they go
+// through the auto_push fast path and the marker advances. `needsReview`
+// is the superset tracker (local-mods detected pre-merge) and is NOT a
+// gating condition on its own.
 const hasReviewItems =
-  result.mergeConflict.length > 0 ||
-  result.needsReview.length > 0 ||
-  result.deleted.length > 0;
+  result.mergeConflict.length > 0 || result.deleted.length > 0;
 
 if (!hasAutoApplied && !hasReviewItems) {
   process.exit(2);
@@ -720,10 +724,18 @@ if (!hasAutoApplied && !hasReviewItems) {
   // ROOT makes the contract explicit: whoever invokes the script picks
   // where these artifacts land, and the workflow invokes from repo root.
   const artifactDir = process.cwd();
-  fs.writeFileSync(
-    path.join(artifactDir, "review-items.txt"),
-    reviewLines.join("\n") + "\n",
-  );
+  const reviewItemsPath = path.join(artifactDir, "review-items.txt");
+  fs.writeFileSync(reviewItemsPath, reviewLines.join("\n") + "\n");
+  // Emit the absolute path to GITHUB_OUTPUT so the workflow's PR-body and
+  // Slack payload steps can read the file without hardcoding a location.
+  // (Downstream steps use `steps.sync.outputs.review_items_file`.) Skipped
+  // outside CI — process.env.GITHUB_OUTPUT is unset for local runs.
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `review_items_file=${reviewItemsPath}\n`,
+    );
+  }
   // Persist the conflict manifest so the workflow can apply upstream-wins
   // content to the PR branch (NOT the current worktree — see
   // conflictManifest comment above).

--- a/showcase/scripts/sync-docs-from-main.ts
+++ b/showcase/scripts/sync-docs-from-main.ts
@@ -11,6 +11,7 @@
  */
 
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
@@ -307,8 +308,94 @@ interface SyncResult {
   copied: string[];
   transformed: string[];
   needsReview: string[];
+  autoMerged: string[];
+  mergeConflict: string[];
   skipped: string[];
   deleted: string[];
+}
+
+// ---------------------------------------------------------------------------
+// 3-way merge for showcase-local modifications
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt a 3-way merge for a file with showcase-local modifications.
+ *
+ * - base   = clean transform of main file at the last sync sha
+ * - local  = current showcase file on disk
+ * - remote = clean transform of main file at HEAD
+ *
+ * Returns { success: true, content } if `git merge-file` produced a clean
+ * merge (exit 0, no conflict markers).
+ *
+ * Returns { success: false, content: upstreamTransformed } if merge produced
+ * conflicts or failed to compute a base. Caller writes upstream-wins content
+ * and flags the file for manual review in the PR body.
+ */
+function attemptThreeWayMerge(
+  showcasePath: string,
+  mainPath: string,
+  lastSyncSha: string,
+): { success: boolean; content: string } {
+  const upstreamContent = fs.readFileSync(mainPath, "utf-8");
+  const upstreamTransformed = transformContent(upstreamContent, showcasePath);
+
+  if (!fs.existsSync(showcasePath)) {
+    return { success: true, content: upstreamTransformed };
+  }
+
+  const localContent = fs.readFileSync(showcasePath, "utf-8");
+
+  let baseContent: string;
+  try {
+    const mainRelative = path.relative(ROOT, mainPath);
+    const previousMainContent = execSync(
+      `git show ${lastSyncSha}:${mainRelative}`,
+      { encoding: "utf-8", cwd: ROOT },
+    );
+    baseContent = transformContent(previousMainContent, showcasePath);
+  } catch {
+    // No base available — cannot 3-way merge safely
+    return { success: false, content: upstreamTransformed };
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "docs-sync-"));
+  const localFile = path.join(tmpDir, "local");
+  const baseFile = path.join(tmpDir, "base");
+  const remoteFile = path.join(tmpDir, "remote");
+  try {
+    fs.writeFileSync(localFile, localContent);
+    fs.writeFileSync(baseFile, baseContent);
+    fs.writeFileSync(remoteFile, upstreamTransformed);
+
+    // `git merge-file` writes merged result in-place into `localFile`.
+    // Exit code 0 = clean merge; >0 = number of conflicts remaining.
+    let mergeExitCode = 0;
+    try {
+      execSync(
+        `git merge-file -L showcase -L base -L upstream "${localFile}" "${baseFile}" "${remoteFile}"`,
+        { stdio: "pipe" },
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && "status" in err) {
+        mergeExitCode = (err as { status: number }).status;
+      } else {
+        return { success: false, content: upstreamTransformed };
+      }
+    }
+
+    if (mergeExitCode === 0) {
+      const merged = fs.readFileSync(localFile, "utf-8");
+      return { success: true, content: merged };
+    }
+    return { success: false, content: upstreamTransformed };
+  } finally {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 function parseArgs(): { dryRun: boolean; all: boolean } {
@@ -339,6 +426,8 @@ function main(): SyncResult {
     copied: [],
     transformed: [],
     needsReview: [],
+    autoMerged: [],
+    mergeConflict: [],
     skipped: [],
     deleted: [],
   };
@@ -361,12 +450,54 @@ function main(): SyncResult {
       continue;
     }
 
-    // Check for showcase-local modifications
+    // Check for showcase-local modifications — attempt 3-way merge and
+    // always produce file content. Clean merge = auto-applied; conflicting
+    // merge = upstream-wins, flagged for human review in PR body.
     if (
       hasShowcaseLocalModifications(showcaseAbsolute, mainAbsolute, lastSyncSha)
     ) {
       result.needsReview.push(relPath);
-      console.log(`  [REVIEW] ${relPath} (showcase has local modifications)`);
+      const merge = attemptThreeWayMerge(
+        showcaseAbsolute,
+        mainAbsolute,
+        lastSyncSha,
+      );
+
+      // If the result is identical to what's already on disk, nothing to do.
+      const existingContent = fs.existsSync(showcaseAbsolute)
+        ? fs.readFileSync(showcaseAbsolute, "utf-8")
+        : null;
+      if (
+        existingContent !== null &&
+        existingContent.trim() === merge.content.trim()
+      ) {
+        result.skipped.push(relPath);
+        if (merge.success) {
+          console.log(
+            `  [REVIEW/NOOP] ${relPath} (merged content matches existing)`,
+          );
+        } else {
+          console.log(
+            `  [REVIEW/NOOP] ${relPath} (upstream-wins content matches existing)`,
+          );
+        }
+        continue;
+      }
+
+      if (!dryRun) {
+        fs.mkdirSync(path.dirname(showcaseAbsolute), { recursive: true });
+        fs.writeFileSync(showcaseAbsolute, merge.content);
+      }
+
+      if (merge.success) {
+        result.autoMerged.push(relPath);
+        console.log(`  [REVIEW/AUTO-MERGED] ${relPath} (3-way merge clean)`);
+      } else {
+        result.mergeConflict.push(relPath);
+        console.log(
+          `  [REVIEW/CONFLICT] ${relPath} (3-way merge failed; upstream wins — manual review required)`,
+        );
+      }
       continue;
     }
 
@@ -401,8 +532,16 @@ function main(): SyncResult {
     }
   }
 
-  // Update sync marker
-  if (!dryRun && (result.copied.length > 0 || result.transformed.length > 0)) {
+  // Update sync marker only when the merge is clean (no manual-review
+  // conflicts left). If there are conflicts, keep the old sha so the next
+  // run re-attempts the merge once a human has reconciled the conflict PR.
+  if (
+    !dryRun &&
+    result.mergeConflict.length === 0 &&
+    (result.copied.length > 0 ||
+      result.transformed.length > 0 ||
+      result.autoMerged.length > 0)
+  ) {
     fs.writeFileSync(SYNC_MARKER, headSha + "\n");
   }
 
@@ -410,15 +549,23 @@ function main(): SyncResult {
   console.log("\n=== Summary ===");
   console.log(`Copied (identical): ${result.copied.length}`);
   console.log(`Transformed: ${result.transformed.length}`);
-  console.log(`Needs review: ${result.needsReview.length}`);
+  console.log(`Auto-merged (3-way clean): ${result.autoMerged.length}`);
+  console.log(
+    `Merge conflict (upstream-wins, needs review): ${result.mergeConflict.length}`,
+  );
+  console.log(`Needs review (total): ${result.needsReview.length}`);
   console.log(`Skipped (up to date): ${result.skipped.length}`);
   console.log(`Deleted on main: ${result.deleted.length}`);
 
-  if (result.needsReview.length > 0) {
-    console.log("\nFiles needing manual review:");
-    for (const f of result.needsReview) {
-      console.log(`  ${f}`);
-    }
+  if (result.autoMerged.length > 0) {
+    console.log("\nFiles auto-merged (3-way clean):");
+    for (const f of result.autoMerged) console.log(`  ${f}`);
+  }
+  if (result.mergeConflict.length > 0) {
+    console.log(
+      "\nFiles written with upstream-wins (merge conflict — manual review):",
+    );
+    for (const f of result.mergeConflict) console.log(`  ${f}`);
   }
 
   if (result.deleted.length > 0) {
@@ -434,26 +581,40 @@ function main(): SyncResult {
 const result = main();
 
 // Exit codes for CI:
-//   0 = changes auto-applied (clean transforms only, safe to push directly)
-//   2 = nothing changed (CI does nothing)
-//   3 = has review items (CI should open a PR for the needsReview/deleted files)
+//   0 = changes auto-applied (clean transforms / clean 3-way merges); safe to
+//       push + auto-merge
+//   2 = nothing changed
+//   3 = has review items (either 3-way merge conflicts where upstream won,
+//       or files deleted on main); CI opens a PR but does NOT auto-merge
 const hasAutoApplied =
-  result.copied.length > 0 || result.transformed.length > 0;
+  result.copied.length > 0 ||
+  result.transformed.length > 0 ||
+  result.autoMerged.length > 0;
 const hasReviewItems =
-  result.needsReview.length > 0 || result.deleted.length > 0;
+  result.mergeConflict.length > 0 || result.deleted.length > 0;
 
 if (!hasAutoApplied && !hasReviewItems) {
   process.exit(2);
 } else if (hasReviewItems) {
-  // Write review items to a file for CI to include in PR body
+  // Write review items to a file for CI to include in PR body.
+  // These files are already written to disk — CI will commit them and open
+  // a PR flagged "needs review" (no auto-merge).
   const reviewLines: string[] = [];
-  if (result.needsReview.length > 0) {
+  if (result.mergeConflict.length > 0) {
     reviewLines.push(
-      "Files with showcase-local modifications (need manual merge):",
+      "Files where 3-way merge FAILED — upstream content written as-is, local modifications overridden. Manual review REQUIRED before merging this PR:",
     );
-    for (const f of result.needsReview) reviewLines.push(`  - ${f}`);
+    for (const f of result.mergeConflict) reviewLines.push(`  - ${f}`);
+  }
+  if (result.autoMerged.length > 0) {
+    reviewLines.push("");
+    reviewLines.push(
+      "Files auto-merged via 3-way merge (clean, no conflict markers — still worth a glance):",
+    );
+    for (const f of result.autoMerged) reviewLines.push(`  - ${f}`);
   }
   if (result.deleted.length > 0) {
+    reviewLines.push("");
     reviewLines.push(
       "Files deleted on main (review whether to delete in showcase):",
     );


### PR DESCRIPTION
## Summary
Makes the docs-sync workflow auto-open a PR on showcase-local conflicts instead of warn-and-skip. User asked for this after seeing drift accumulate because manual-review alerts got ignored.

## Behavior
- **Clean transforms / auto-merges**: unchanged fast path — commits to main via auto_push + auto-merge.
- **Showcase-local conflict**: best-effort 3-way merge via `git merge-file`. On conflict, upstream-wins content is applied only on the PR branch (main worktree untouched). Auto-opens a `docs-sync/needs-review/*` PR tagged `[NEEDS REVIEW]` with auto-merge disabled — human must review + merge. Slack posts a ":warning:" alert with PR link.
- **Dedupe**: if an open needs-review PR exists, skip creating a new one and post a ":information_source:" Slack alert pointing at the existing PR.
- **Sync SHA marker**: only advances when no conflicts (and no deletions) exist this run. Ensures the next run still detects the same drift until human merges.

## Hardening (addressed across 4 commits + 7-agent CR rounds)
- Shell injection: all `execSync` with template-literal interpolation → `execFileSync` with argv arrays.
- Missing Slack notify for needs-review PRs: added with correct gating.
- Silent re-resolution: upstream-wins content no longer leaks to main worktree; applied via `conflict-manifest.json` only on PR branch.
- PR collision on re-runs: explicit dedupe check with retry on transient `gh` API errors (fails the step rather than silently duplicating).
- Exit code / marker logic fixed so auto_push fast path works for clean merges.
- `stripTrailingEol` + BOM handling for whitespace idempotency.
- Emit `review_items_file` output to `$GITHUB_OUTPUT` so PR body correctly includes the review-items list.
- Explicit `needs_review=true/false` set on all exit paths including collision + early-exit, so `notify-auto-sync` doesn't misfire.
- Trap-based cleanup of temp artifacts on signal kill.

## Test plan
- [ ] CI green
- [ ] Post-merge: next docs-sync run with a local conflict opens a needs-review PR (instead of warn-and-skip)