### PR TITLE
fix(react-core): deduplicate tool calls in CopilotChatToolCallsView to prevent React key warning

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatToolCallsView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatToolCallsView.tsx
@@ -17,9 +17,18 @@ export function CopilotChatToolCallsView({
     return null;
   }
 
+  // Deduplicate tool calls by id. When connectAgent() replays historic
+  // TOOL_CALL_START events over a pre-populated messages state, the same
+  // toolCallId can appear more than once in the array, which causes React to
+  // emit a duplicate-key warning. Keep the last occurrence so that the most
+  // up-to-date arguments are used.
+  const uniqueToolCalls = [
+    ...new Map(message.toolCalls.map((tc) => [tc.id, tc])).values(),
+  ];
+
   return (
     <>
-      {message.toolCalls.map((toolCall) => {
+      {uniqueToolCalls.map((toolCall) => {
         const toolMessage = messages.find(
           (m) => m.role === "tool" && m.toolCallId === toolCall.id,
         ) as ToolMessage | undefined;


### PR DESCRIPTION
Fixes #3928

## Problem

When `connectAgent()` is called, `InMemoryAgentRunner.connect()` replays compacted historic events (including `TOOL_CALL_START` for completed tool calls) via `@ag-ui/client`'s `defaultApplyEvents`. However, at that point the agent's `messages` state already contains those tool calls from the prior run. Because `defaultApplyEvents` pushes to `message.toolCalls` unconditionally — with no duplicate guard — the same `toolCallId` ends up in the array twice.

`CopilotChatToolCallsView` then maps this array using `toolCall.id` as a React `key`, producing the duplicate-key warning:

```
Warning: Encountered two children with the same key, `call_uUF5OZtugHE6tyoC9PPtpAs6`.
```

## Solution

Deduplicate `message.toolCalls` by `id` before rendering in `CopilotChatToolCallsView`, keeping the last occurrence so the most up-to-date arguments are used:

```ts
const uniqueToolCalls = [
  ...new Map(message.toolCalls.map((tc) => [tc.id, tc])).values(),
];
```

This is a defensive fix at the view layer. The underlying idempotency issue in `@ag-ui/client`'s `defaultApplyEvents` has been separately reported upstream.

## Testing

- The fix eliminates the React duplicate-key console warning when `connectAgent()` is called on an agent whose `messages` state already contains completed tool calls.
- Existing tool call rendering behavior is preserved — only the deduplication step is added.