### PR TITLE
fix(react-core): merge toolCalls by id when deduplicating duplicate assistant messages

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -309,8 +309,8 @@ const MemoizedCustomMessage = React.memo(
  * Deduplicates messages by ID. For assistant messages, merges occurrences:
  * recovers non-empty content from any earlier occurrence if the latest wiped it
  * (empty string means the streaming update cleared the field, not blank text),
- * and similarly recovers toolCalls from earlier occurrences if the latest is
- * undefined (an empty array [] is treated as intentional and kept as-is).
+ * and merges toolCalls from all occurrences by id so that no tool call is lost
+ * (an explicit [] is treated as intentional and resets the set).
  * For all other roles, keeps the last entry.
  *
  * @internal Exported for unit testing only — not part of the public API.
@@ -328,9 +328,26 @@ export function deduplicateMessages(messages: Message[]): Message[] {
       // any non-empty content seen earlier. Use { ...existing, ...message } so
       // fields present only in an earlier occurrence are not silently dropped.
       const content = message.content || existing.content;
-      // undefined toolCalls means this chunk had no tool call activity — recover
-      // from earlier occurrences. An explicit [] means all tool calls completed.
-      const toolCalls = message.toolCalls ?? existing.toolCalls;
+      // Merge toolCalls from both occurrences by id so that tool calls from an
+      // earlier chunk are not lost when a later TOOL_CALL_START for the same
+      // parentMessageId creates a second entry (e.g. when a TOOL_CALL_RESULT
+      // was interleaved and the parent was no longer the last message).
+      // Precedence: later occurrence wins for any given id (most up-to-date args).
+      // undefined means no tool call activity in this chunk — fall back to existing.
+      // An explicit [] is intentional ("all tool calls finished") and resets the set.
+      let toolCalls: AssistantMessage["toolCalls"];
+      if (message.toolCalls === undefined) {
+        toolCalls = existing.toolCalls;
+      } else if (existing.toolCalls === undefined || message.toolCalls.length === 0) {
+        toolCalls = message.toolCalls;
+      } else {
+        // Both sides have non-empty toolCalls arrays — union by id, later wins.
+        const merged = new Map(existing.toolCalls.map((tc) => [tc.id, tc]));
+        for (const tc of message.toolCalls) {
+          merged.set(tc.id, tc);
+        }
+        toolCalls = [...merged.values()];
+      }
       acc.set(message.id, {
         ...existing,
         ...message,

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
@@ -251,6 +251,53 @@ describe("deduplicateMessages", () => {
     expect((result[0] as AssistantMessage).toolCalls).toEqual([]);
   });
 
+  it("merges toolCalls from both occurrences when a TOOL_CALL_START for the same parent follows a TOOL_CALL_RESULT", () => {
+    // Reproduces issue #3644: when a TOOL_CALL_RESULT is interleaved between two
+    // TOOL_CALL_START events for the same parentMessageId, @ag-ui/client creates
+    // a second assistant message with the same id instead of appending to the
+    // existing one (because the parent is no longer the last message).
+    // deduplicateMessages must merge both occurrences' toolCalls by id so no
+    // tool call is silently dropped.
+    const messages: Message[] = [
+      assistantMsg("msg-x", "Thinking...", [
+        toolCall("tool-a", "fetchData"),
+        toolCall("tool-b", "processData"),
+      ]),
+      // Simulates the duplicate entry created by TOOL_CALL_START(tool_c) after a TOOL_CALL_RESULT
+      assistantMsg("msg-x", "", [toolCall("tool-c", "saveData")]),
+    ];
+
+    const result = deduplicateMessages(messages);
+
+    expect(result).toHaveLength(1);
+    const merged = result[0] as AssistantMessage;
+    // Content recovered from the first occurrence
+    expect(merged.content).toBe("Thinking...");
+    // All three tool calls must be present — none dropped
+    expect(merged.toolCalls).toHaveLength(3);
+    expect(merged.toolCalls?.map((tc) => tc.id)).toEqual([
+      "tool-a",
+      "tool-b",
+      "tool-c",
+    ]);
+  });
+
+  it("later occurrence wins for overlapping tool call ids during merge", () => {
+    // When both occurrences share a tool call id, the later entry's arguments
+    // take precedence (most up-to-date data).
+    const messages: Message[] = [
+      assistantMsg("msg-x", "", [toolCall("tc-1", "doWork", '{"step":1}')]),
+      assistantMsg("msg-x", "", [toolCall("tc-1", "doWork", '{"step":2}')]),
+    ];
+
+    const result = deduplicateMessages(messages);
+
+    expect(result).toHaveLength(1);
+    const merged = result[0] as AssistantMessage;
+    expect(merged.toolCalls).toHaveLength(1);
+    expect(merged.toolCalls?.[0]?.function.arguments).toBe('{"step":2}');
+  });
+
   it("handles undefined content on both occurrences without error", () => {
     // assistantMsg with no content arg produces content: undefined.
     // undefined || undefined = undefined — should not throw or produce garbage.


### PR DESCRIPTION
Fixes #3644

## Problem

When a `TOOL_CALL_RESULT` is interleaved between `TOOL_CALL_START` events for the same `parentMessageId`, `@ag-ui/client` creates a second assistant message with the same id instead of appending to the existing one (because the parent is no longer the last message in the array).

This produces a sequence like:
1. `msg_x` created with `toolCalls: [tool_a, tool_b]`
2. A `TOOL_CALL_RESULT` for `tool_a` is inserted as a separate `"tool"` message
3. `TOOL_CALL_START(tool_c)` — parent `msg_x` is no longer last, so a **new** `msg_x` entry is created with `toolCalls: [tool_c]`

The previous `deduplicateMessages` logic:
```ts
const toolCalls = message.toolCalls ?? existing.toolCalls;
```
picks the later occurrence's `toolCalls` when it's defined — silently dropping `tool_a` and `tool_b`. The dev-mode warning fires but the data is already wrong.

## Solution

When both occurrences have non-empty `toolCalls` arrays, merge them by id (later occurrence wins for any given id):

```ts
const merged = new Map(existing.toolCalls.map((tc) => [tc.id, tc]));
for (const tc of message.toolCalls) {
  merged.set(tc.id, tc);
}
toolCalls = [...merged.values()];
```

Semantics preserved:
- `undefined` → fall back to existing (no tool call activity in this chunk)
- `[]` → intentional reset ("all tool calls finished"), resets the set
- Two non-empty arrays → union by id, later wins

## Testing

Two new unit tests added to the existing `deduplicateMessages` suite:
1. Verifies that toolCalls from both occurrences are merged correctly (reproduces the #3644 scenario)
2. Verifies that when the same tool call id appears in both, the later entry's arguments win