### PR TITLE
ci(showcase): grant id-token write for Depot OIDC auth

### DIFF
--- a/.github/workflows/showcase_drift-report.yml
+++ b/.github/workflows/showcase_drift-report.yml
@@ -18,8 +18,10 @@ on:
     - cron: "0 10 * * 1"
   workflow_dispatch:
 
+# id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   report:

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -20,8 +20,10 @@ on:
       - ".github/workflows/showcase_validate.yml"
 
 # Least-privilege by default. Individual jobs/steps can widen when needed.
+# id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
 permissions:
   contents: read
+  id-token: write
 
 # Split concurrency per event so main-branch push runs are never canceled
 # mid-execution (we need Slack failure alerts to fire reliably). PR runs


### PR DESCRIPTION
Hotfix for #4018.

The two workflows flipped to `runs-on: depot-ubuntu-24.04-4` in #4018 inherited the repo's default `contents: read` permissions, which blocks Depot's OIDC handshake. Jobs failed to spawn on the first main-branch push after merge.

Matches the pattern already used by `showcase_deploy.yml`'s Depot job.

## Test plan
- [x] Merging this should let `showcase_validate.yml` spawn a job on its next trigger (any PR touching `showcase/**` or this workflow itself)
- [x] `showcase_drift-report.yml` next scheduled Monday run will verify end-to-end