### PR TITLE
ci(showcase): fix secrets.* in step-level if: (post-#4018)

### DIFF
--- a/.github/workflows/showcase_drift-report.yml
+++ b/.github/workflows/showcase_drift-report.yml
@@ -26,6 +26,11 @@ permissions:
 jobs:
   report:
     name: Weekly Pin-Drift Report
+    # Hoist the Slack webhook into an env var so step-level `if:`
+    # expressions can reference it — `secrets.*` is not a valid
+    # named-value inside `if:` and causes a workflow startup failure.
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
     # Depot (Startup plan, unlimited minutes) for pnpm cache across
     # scheduled runs — keeps the weekly ratchet cheap.
     runs-on: depot-ubuntu-24.04-4
@@ -168,7 +173,7 @@ jobs:
       - name: Notify Slack (weekly drift report)
         # Skip cleanly when the webhook secret is unset (forks / pre-provision)
         # rather than failing the job. Counts still appear in the job log.
-        if: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS != '' }}
+        if: ${{ env.SLACK_WEBHOOK != '' }}
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
@@ -181,7 +186,7 @@ jobs:
             { "text": ${{ toJSON(format(':chart_with_downwards_trend: *Showcase pin-drift (weekly)*: FAIL={0} (baseline {1}) [{2}] | <https://github.com/{3}/actions/runs/{4}|View run>', steps.validate.outputs.actual, steps.baseline.outputs.count, steps.validate.outputs.set_status, github.repository, github.run_id)) }} }
 
       - name: Log result (no Slack)
-        if: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS == '' }}
+        if: ${{ env.SLACK_WEBHOOK == '' }}
         run: |
           echo "::warning::SLACK_WEBHOOK_OSS_ALERTS not set; weekly drift report not sent to Slack."
           echo "Weekly pin-drift report: FAIL=${{ steps.validate.outputs.actual }} baseline=${{ steps.baseline.outputs.count }} set_status=${{ steps.validate.outputs.set_status }} actual_hash=${{ steps.validate.outputs.actual_hash }} baseline_hash=${{ steps.baseline.outputs.hash }}"
@@ -189,7 +194,7 @@ jobs:
       - name: Notify Slack (job failure)
         # Surface silent crashes (baseline read, validate-pins internal error,
         # Slack post failure) so the weekly report doesn't fail invisibly.
-        if: ${{ failure() && secrets.SLACK_WEBHOOK_OSS_ALERTS != '' }}
+        if: ${{ failure() && env.SLACK_WEBHOOK != '' }}
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -35,6 +35,12 @@ concurrency:
 jobs:
   validate:
     name: Validate Showcase
+    # Hoist the Slack webhook into an env var so step-level `if:`
+    # expressions can reference it — `secrets.*` is not a valid
+    # named-value inside `if:` and causes a workflow startup failure
+    # on push events.
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
     # Depot (Startup plan, unlimited minutes) for persistent pnpm/npm
     # cache across runs — cold ubuntu-latest runs were ~18-20m; Depot
     # typically reduces to ~5-8m. 25m timeout retained as headroom.
@@ -356,7 +362,7 @@ jobs:
       # pinging the OSS alerts channel. Tradeoff: a broken PR that sneaks
       # past review won't alert Slack until after merge.
       - name: Notify Slack (failure)
-        if: failure() && github.event_name == 'push' && secrets.SLACK_WEBHOOK_OSS_ALERTS != ''
+        if: failure() && github.event_name == 'push' && env.SLACK_WEBHOOK != ''
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
@@ -372,6 +378,6 @@ jobs:
             { "text": ${{ toJSON(format(':x: *Showcase validate*: failed | <https://github.com/{0}/actions/runs/{1}|View run>', github.repository, github.run_id)) }} }
 
       - name: Log (no Slack — webhook unset)
-        if: failure() && github.event_name == 'push' && secrets.SLACK_WEBHOOK_OSS_ALERTS == ''
+        if: failure() && github.event_name == 'push' && env.SLACK_WEBHOOK == ''
         run: |
           echo "::warning::showcase_validate failed on push but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."


### PR DESCRIPTION
Second hotfix for #4018 — the Depot `id-token` addition in #4060 was needed for later but wasn't the actual blocker.

## Root cause

Both new workflows used `secrets.SLACK_WEBHOOK_OSS_ALERTS != ''` in step-level `if:` expressions. GitHub Actions rejects `secrets.*` as a named-value inside `if:` on push events with:

    Unrecognized named-value: 'secrets'

This aborted the workflow at parse time before any job could spawn (zero jobs in the API, conclusion=failure). PR CI passed because pull_request events validate `if:` expressions less strictly.

## Fix

Hoist the webhook into a job-level env var:
```yaml
env:
  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
```
Reference `env.SLACK_WEBHOOK` in every `if:`. `with: webhook:` keys keep using `secrets.*` (valid context).

## Test plan
- [ ] Merging this triggers showcase_validate.yml on main (workflow touches itself) — expect jobs to spawn and the Depot runner to start
- [ ] Weekly drift-report next Monday verifies the other workflow end-to-end