### PR TITLE
chore(showcase): quiet per-run success posts in #oss-alerts

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -468,12 +468,24 @@ jobs:
             exit 0
           fi
 
+          # Policy: #oss-alerts should only surface actionable state —
+          # failures and state transitions. Per-run success confirmations
+          # are noise, especially during bulk drift rebuilds which fan out
+          # one showcase_deploy.yml run per service (up to ~18). The
+          # top-line ":package: Image drift detected — N rebuilds triggered"
+          # posted by showcase_smoke-monitor.yml is the aggregate success
+          # signal for bulk rebuilds; ad-hoc single-service pushes/dispatches
+          # stay quiet on success (the Actions UI is the source of truth).
           if [ "$DETECT" = "failure" ] || [ "$LOCKFILE" = "failure" ]; then
             MSG=":x: *Showcase deploy*: FAILED (pre-build check)"
           elif [ "$BUILD" = "success" ]; then
-            MSG=":white_check_mark: *Showcase deploy*: ${COUNT} service(s) deployed to Railway (${SERVICES})"
+            echo "Build succeeded — suppressing per-run success notification (policy: actionable-only)"
+            echo "should_post=false" >> "$GITHUB_OUTPUT"
+            exit 0
           elif [ "$BUILD" = "skipped" ] && [ "$DETECT" = "success" ]; then
-            MSG=":white_check_mark: *Showcase deploy*: no changes detected, nothing to deploy"
+            echo "No changes detected — suppressing notification (policy: actionable-only)"
+            echo "should_post=false" >> "$GITHUB_OUTPUT"
+            exit 0
           else
             MSG=":x: *Showcase deploy*: FAILED — ${COUNT} service(s) targeted (${SERVICES})"
           fi
@@ -482,7 +494,9 @@ jobs:
           echo "should_post=true" >> "$GITHUB_OUTPUT"
 
       - name: Post to Slack
-        if: always() && steps.payload.outputs.should_post == 'true'
+        if: always() && steps.payload.outputs.should_post == 'true' && env.SLACK_WEBHOOK_OSS_ALERTS != ''
+        env:
+          SLACK_WEBHOOK_OSS_ALERTS: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}


### PR DESCRIPTION
## Summary

- Suppress per-run `:white_check_mark: *Showcase deploy*: N service(s) deployed to Railway` Slack posts from `showcase_deploy.yml`. During bulk drift rebuilds, the smoke-monitor fans out one `showcase_deploy.yml` run per stale service (up to ~18), producing ~18 noise messages in #oss-alerts per drift cycle. The top-line `:package: Image drift detected — N rebuilds triggered` in `showcase_smoke-monitor.yml` already covers the aggregate success case.
- Also suppress the `no changes detected, nothing to deploy` post — rare and uninformative.
- Preserve failure messages (pre-build failure, build failure) and the mid-matrix cancellation info message (state transition worth seeing).
- Harden the Post step with `env.SLACK_WEBHOOK_OSS_ALERTS != ''` guard so a missing secret fails closed rather than erroring the action.

Channel policy alignment: #oss-alerts surfaces only actionable state (failures + transitions). Ad-hoc single-service successes stay quiet — the Actions UI is the source of truth.

## Test plan

- [x] `actionlint .github/workflows/showcase_deploy.yml` — no new findings introduced by this diff (pre-existing SC2086 style infos unrelated to the edited region)
- [x] Local dry-run simulation of every branch in the payload step: success (bulk) → suppressed, no-changes → suppressed, build-failure → posted, detect/lockfile-failure → posted, mid-matrix cancel → posted, pre-build cancel → suppressed
- [ ] Observe in production: next drift rebuild cycle should post one top-line drift message and zero per-service greens; any failing leg still surfaces

## Out of scope

- Smoke monitor verbosity (already correct: red + recovery only)
- Drift detection logic (unchanged)
- `crewai-crews` 502 investigation (unrelated)