### PR TITLE
fix(showcase/crewai-crews): pin crewai<1.14 to avoid ag-ui-crewai 0.1.5 break

### DIFF
--- a/showcase/packages/crewai-crews/requirements.txt
+++ b/showcase/packages/crewai-crews/requirements.txt
@@ -1,4 +1,10 @@
-crewai>=0.130.0
+# crewai 1.14 changed the chat Flow method return type to a plain dict; this breaks
+# ag-ui-crewai 0.1.5's EventBus handler for MethodExecutionFinishedEvent, which calls
+# `.messages` on the result and raises AttributeError. The result is that STEP_FINISHED(chat)
+# never emits and RUN_FINISHED arrives with an open step, which Next.js rejects as
+# INCOMPLETE_STREAM on every /api/copilotkit call. Unpin when ag-ui-crewai ships a
+# compatible release or we bump to a compatible pair.
+crewai>=0.130.0,<1.14
 ag-ui-crewai>=0.1.4,<0.1.6
 ag-ui-protocol>=0.1.5
 python-dotenv>=1.0.1

--- a/showcase/starters/crewai-crews/agent/requirements.txt
+++ b/showcase/starters/crewai-crews/agent/requirements.txt
@@ -1,4 +1,10 @@
-crewai>=0.130.0
+# crewai 1.14 changed the chat Flow method return type to a plain dict; this breaks
+# ag-ui-crewai 0.1.5's EventBus handler for MethodExecutionFinishedEvent, which calls
+# `.messages` on the result and raises AttributeError. The result is that STEP_FINISHED(chat)
+# never emits and RUN_FINISHED arrives with an open step, which Next.js rejects as
+# INCOMPLETE_STREAM on every /api/copilotkit call. Unpin when ag-ui-crewai ships a
+# compatible release or we bump to a compatible pair.
+crewai>=0.130.0,<1.14
 ag-ui-crewai>=0.1.4,<0.1.6
 ag-ui-protocol>=0.1.5
 python-dotenv>=1.0.1


### PR DESCRIPTION
## Production is broken

Every `/api/copilotkit` call against the `showcase-crewai-crews` service currently fails with `INCOMPLETE_STREAM`. Fresh Docker builds from `main` are pulling `crewai 1.14.2` (shipped to PyPI 2026-04-17 14:09 UTC), which ships a breaking change incompatible with the `ag-ui-crewai<0.1.6` pin we already have.

## Root cause

`crewai 1.14.x` changed the chat Flow method to return a plain `dict` instead of an object with a `.messages` attribute. `ag-ui-crewai 0.1.5`'s `EventBus` handler for `MethodExecutionFinishedEvent` still calls `.messages` on that result. Result: `AttributeError`, `STEP_FINISHED(chat)` is never emitted, `RUN_FINISHED` arrives with an open step, and the Next.js runtime rejects the stream as `INCOMPLETE_STREAM`.

Verbatim log line from Railway (service `0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4`):

```
[EventBus Error] Handler '_' failed for event 'MethodExecutionFinishedEvent': 'dict' object has no attribute 'messages'
```

`ag-ui-crewai 0.1.5` is the latest release (2025-12-16) and is already ceiling-capped at `<0.1.6`. The missing piece was a ceiling on `crewai` itself.

## Fix

Cap `crewai` at `<1.14` in both the showcase package and the starter tree:

- `showcase/packages/crewai-crews/requirements.txt`
- `showcase/starters/crewai-crews/agent/requirements.txt`

Explanatory comment added to both files pointing at the exact incompatibility and flagging the unpin condition (ag-ui-crewai ships a 1.14-compatible release).

No other showcase Python starter depends on `crewai` or `ag-ui-crewai` — verified by grepping `showcase/packages/*/requirements.txt` and `showcase/starters/*/agent/requirements.txt`. Only the crewai-crews tree needed the pin.

## Verification

- `pip install --dry-run -r <path>` on Python 3.12 resolves cleanly against both files: `crewai-0.130.0`, `ag-ui-crewai-0.1.5`, `crewai-tools-0.76.0`, no conflicts.
- Standalone `pip install --dry-run "crewai>=0.130.0,<1.14"` resolves to `crewai-1.13.0` (last stable pre-1.14 line). The combined dependency graph with `crewai-tools` and `ag-ui-crewai` resolves to `crewai-0.130.0` — both satisfy the pin and both pre-date the 1.14 breaking change.
- Did not boot the Python agent locally end-to-end; the pin resolution is the entirety of the fix and CI/Railway will rebuild the image on merge.

## Deploy plan

On merge:
1. Showcase deploy workflow auto-rebuilds the `showcase-crewai-crews` image against the new pin.
2. Railway service auto-redeploys the new image via its `ghcr.io/copilotkit/showcase-crewai-crews:latest` tag.
3. Smoke monitor should show recovery within ~20 min.
4. Confirm via `gh pr checks` on this PR and a direct hit against the production URL once Railway redeploys.

## Follow-up (not in this PR)

When `ag-ui-crewai` ships a `crewai 1.14`-compatible release, bump both `ag-ui-crewai` and `crewai` ceilings together and remove the explanatory comment. The existing `hasattr()` shim guard in `agent_server.py` (added in `d5c86c1b3`) will surface any upstream drift on that transition.