### PR TITLE
docs(langgraph): add missing RunnableConfig imports to Python snippets

### DIFF
--- a/docs/content/docs/integrations/langgraph/advanced/disabling-state-streaming.mdx
+++ b/docs/content/docs/integrations/langgraph/advanced/disabling-state-streaming.mdx
@@ -23,6 +23,7 @@ You can disable all message streaming and tool call streaming by passing `emit_m
     <Tab value="Python">
         ```python
         from copilotkit.langgraph import copilotkit_customize_config
+        from langchain_core.runnables import RunnableConfig
 
         async def frontend_actions_node(state: AgentState, config: RunnableConfig):
 

--- a/docs/content/docs/integrations/langgraph/advanced/exit-agent.mdx
+++ b/docs/content/docs/integrations/langgraph/advanced/exit-agent.mdx
@@ -28,6 +28,7 @@ In this example from [our email-sending app](https://github.com/copilotkit/copil
             <Tab value="Python">
                 ```python
                 from copilotkit.langgraph import (copilotkit_exit)
+                from langchain_core.runnables import RunnableConfig
                 # ...
                 async def send_email_node(state: EmailAgentState, config: RunnableConfig):
                     """Send an email."""

--- a/docs/content/docs/integrations/langgraph/agent-app-context.mdx
+++ b/docs/content/docs/integrations/langgraph/agent-app-context.mdx
@@ -110,6 +110,7 @@ This context can then be shared with your LangChain agent.
                     <Tab value="Python">
                         ```python title="agent.py"
                         from langchain_core.messages import SystemMessage
+                        from langchain_core.runnables import RunnableConfig
                         from langchain_openai import ChatOpenAI
                         from copilotkit import CopilotKitState
 

--- a/docs/content/docs/integrations/langgraph/auth.mdx
+++ b/docs/content/docs/integrations/langgraph/auth.mdx
@@ -75,6 +75,8 @@ async def authenticate(authorization: str | None):
 ### Access User in Agent
 
 ```python
+from langchain_core.runnables import RunnableConfig
+
 async def my_agent_node(state: AgentState, config: RunnableConfig):
     # Access user from LangGraph Platform authentication
     user_info = config["configuration"]["langgraph_auth_user"]
@@ -116,6 +118,8 @@ sdk = CopilotKitRemoteEndpoint(
 ### Access User in Agent
 
 ```python
+from langchain_core.runnables import RunnableConfig
+
 async def my_agent_node(state: AgentState, config: RunnableConfig):
     # Handle authentication for self-hosted mode
     auth_token = config["configurable"].get("copilotkit_auth")
@@ -136,6 +140,8 @@ async def my_agent_node(state: AgentState, config: RunnableConfig):
 For agents that work in both environments, use this pattern:
 
 ```python
+from langchain_core.runnables import RunnableConfig
+
 async def my_agent_node(state: AgentState, config: RunnableConfig):
     user_id = "anonymous"
     user_role = None

--- a/docs/content/docs/integrations/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
+++ b/docs/content/docs/integrations/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
@@ -264,6 +264,7 @@ persisted at the end of a node.
             <Tab value="Python">
                 ```python
                 from copilotkit.langgraph import copilotkit_customize_config
+                from langchain_core.runnables import RunnableConfig
 
                 async def chat_node(state: AgentState, config: RunnableConfig):
                     # 1) Call the model with CopilotKit's modified config
@@ -302,6 +303,7 @@ persisted at the end of a node.
             <Tab value="Python">
                 ```python
                 from copilotkit.langgraph import copilotkit_customize_config
+                from langchain_core.runnables import RunnableConfig
 
                 async def chat_node(state: AgentState, config: RunnableConfig):
                     # 1) Configure CopilotKit not to emit messages

--- a/docs/content/docs/integrations/langgraph/coagent-troubleshooting/migrate-from-v0.2-to-v0.3.mdx
+++ b/docs/content/docs/integrations/langgraph/coagent-troubleshooting/migrate-from-v0.2-to-v0.3.mdx
@@ -10,6 +10,8 @@ Starting with `v0.3`, we changed how messages are synced between the agent (Lang
 This means that you need to return the messages you want to appear in CopilotKit chat from your LangGraph nodes, for example:
 
 ```python
+from langchain_core.runnables import RunnableConfig
+
 def my_node(state: State, config: RunnableConfig) -> State:
     response = # ... llm call ...
     return {

--- a/docs/content/docs/integrations/langgraph/configurable.mdx
+++ b/docs/content/docs/integrations/langgraph/configurable.mdx
@@ -66,6 +66,8 @@ Now you can simply pull the values from the provided config argument in any agen
 <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
     <Tab value="Python">
         ```python
+        from langchain_core.runnables import RunnableConfig
+
         async def agent_node(state: AgentState, config: RunnableConfig):
 
             auth_token = config['configurable'].get('authToken', None)

--- a/docs/content/docs/integrations/langgraph/generative-ui/tool-rendering.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/tool-rendering.mdx
@@ -46,6 +46,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
 <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
     <Tab value="Python">
         ```python title="agent.py"
+        from langchain_core.runnables import RunnableConfig
         from langchain_openai import ChatOpenAI
         from langchain.tools import tool
         # ...

--- a/docs/content/docs/integrations/langgraph/generative-ui/your-components/interrupt-based.mdx
+++ b/docs/content/docs/integrations/langgraph/generative-ui/your-components/interrupt-based.mdx
@@ -104,6 +104,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
             ```python title="agent.py"
             from langgraph.types import interrupt # [!code highlight]
             from langchain_core.messages import SystemMessage
+            from langchain_core.runnables import RunnableConfig
             from langchain_openai import ChatOpenAI
             from copilotkit import CopilotKitState
 
@@ -233,6 +234,7 @@ For this reason, the hook can take an `enabled` argument which will apply it con
                 ```python title="agent.py"
                 from langgraph.types import interrupt # [!code highlight]
                 from langchain_core.messages import SystemMessage
+                from langchain_core.runnables import RunnableConfig
                 from langchain_openai import ChatOpenAI
 
                 # ... your full state definition

--- a/docs/content/docs/integrations/langgraph/human-in-the-loop/interrupt-flow.mdx
+++ b/docs/content/docs/integrations/langgraph/human-in-the-loop/interrupt-flow.mdx
@@ -104,6 +104,7 @@ We're going to have the agent ask us to name it, so we'll need a state property 
             ```python title="agent.py"
             from langgraph.types import interrupt # [!code highlight]
             from langchain_core.messages import SystemMessage
+            from langchain_core.runnables import RunnableConfig
             from langchain_openai import ChatOpenAI
             from copilotkit import CopilotKitState
 
@@ -233,6 +234,7 @@ For this reason, the hook can take an `enabled` argument which will apply it con
                 ```python title="agent.py"
                 from langgraph.types import interrupt # [!code highlight]
                 from langchain_core.messages import SystemMessage
+                from langchain_core.runnables import RunnableConfig
                 from langchain_openai import ChatOpenAI
 
                 # ... your full state definition

--- a/docs/content/docs/integrations/langgraph/shared-state/in-app-agent-read.mdx
+++ b/docs/content/docs/integrations/langgraph/shared-state/in-app-agent-read.mdx
@@ -45,6 +45,7 @@ state updates, you can reflect these updates natively in your application.
       <Tab value="Python">
         ```python title="agent.py"
         from copilotkit import CopilotKitState
+        from langchain_core.runnables import RunnableConfig
         from typing import Literal
 
         class AgentState(CopilotKitState):

--- a/docs/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
+++ b/docs/content/docs/integrations/langgraph/shared-state/predictive-state-updates.mdx
@@ -113,6 +113,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                     <Tab value="Python">
                         ```python title="agent.py"
                         from copilotkit.langgraph import copilotkit_emit_state # [!code highlight]
+                        from langchain_core.runnables import RunnableConfig
                         # ...
                         async def chat_node(state: AgentState, config: RunnableConfig) -> Command[Literal["cpk_action_node", "tool_node", "__end__"]]:
                             # ...

--- a/docs/content/docs/integrations/langgraph/shared-state/state-inputs-outputs.mdx
+++ b/docs/content/docs/integrations/langgraph/shared-state/state-inputs-outputs.mdx
@@ -61,6 +61,7 @@ In addition, some state properties contain a lot of information. Syncing them ba
           <Tab value="Python">
           ```python title="agent.py"
           from copilotkit import CopilotKitState
+          from langchain_core.runnables import RunnableConfig
           from typing import Literal
 
           # Divide the state to 3 parts

--- a/docs/content/docs/integrations/langgraph/shared-state/workflow-execution.mdx
+++ b/docs/content/docs/integrations/langgraph/shared-state/workflow-execution.mdx
@@ -61,6 +61,7 @@ In addition, some state properties contain a lot of information. Syncing them ba
           <Tab value="Python">
           ```python title="agent.py"
           from copilotkit import CopilotKitState
+          from langchain_core.runnables import RunnableConfig
           from typing import Literal
 
           # Divide the state to 3 parts


### PR DESCRIPTION
## Summary

Several Python code examples across LangGraph integration docs used `RunnableConfig` as a type annotation without importing it. Copy-pasting these snippets would raise `NameError: name 'RunnableConfig' is not defined`.

Adds `from langchain_core.runnables import RunnableConfig` to 14 files across:
- `human-in-the-loop/interrupt-flow.mdx`
- `advanced/exit-agent.mdx`
- `advanced/disabling-state-streaming.mdx`
- `agent-app-context.mdx`
- `auth.mdx`
- `configurable.mdx`
- `coagent-troubleshooting/common-coagent-issues.mdx`
- `coagent-troubleshooting/migrate-from-v0.2-to-v0.3.mdx`
- `generative-ui/tool-rendering.mdx`
- `generative-ui/your-components/interrupt-based.mdx`
- `shared-state/in-app-agent-read.mdx`
- `shared-state/predictive-state-updates.mdx`
- `shared-state/state-inputs-outputs.mdx`
- `shared-state/workflow-execution.mdx`

Follows the same pattern as #3755 which fixed the same issue in `langgraph/generative-ui/state-rendering.mdx`.

## Test plan

- [x] Verified all Python blocks using `RunnableConfig` now include the import
- [x] No logic changes — import additions only