### PR TITLE
fix(showcase/test-integration): clean up test-integration-tmp between runs

### DIFF
--- a/showcase/scripts/__tests__/bundle-demo-content.test.ts
+++ b/showcase/scripts/__tests__/bundle-demo-content.test.ts
@@ -38,14 +38,11 @@ beforeAll(() => {
   }
   // NOTE: we intentionally do NOT pre-run the bundler here. Test 1 below
   // exercises the bundler AND asserts on stdout, so a pre-run in beforeAll
-  // was redundant (CR5 medium). Tests 2-5 call `runBundlerAndRead()` which
+  // was redundant. Tests 2-5 call `runBundlerAndRead()` which
   // runs the bundler themselves — afterEach restores to HEAD between tests
   // so they must re-invoke rather than read stale committed content.
 });
 afterEach(() => dataRestorer.restore());
-// afterAll is redundant on the happy path (afterEach already restored after
-// the final test) — kept as a belt-and-braces in case vitest ever changes
-// afterEach semantics, and symmetric with the other two suites.
 afterAll(() => dataRestorer.restore());
 
 /** Run the bundler and return the parsed demo-content.json. Tests 3-5 each

--- a/showcase/scripts/__tests__/bundle-demo-content.test.ts
+++ b/showcase/scripts/__tests__/bundle-demo-content.test.ts
@@ -1,58 +1,77 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
+import { execFileSync } from "child_process";
+import {
+  FileSnapshotRestorer,
+  execOptsFor,
+  restoreFromGitHead,
+} from "./test-cleanup";
+import { SCRIPTS_DIR, REPO_ROOT, SHELL_DATA_DIR } from "./paths";
+
+// `bundle-demo-content.ts` rewrites showcase/shell/src/data/demo-content.json
+// on every run, leaking changes into the working tree. Snapshot in beforeAll
+// and restore after each test. Assumes vitest's `fileParallelism: false`.
+const CONTENT_PATH = path.join(SHELL_DATA_DIR, "demo-content.json");
+const DATA_FILES = [CONTENT_PATH];
+const dataRestorer = new FileSnapshotRestorer(DATA_FILES);
+
+const EXEC_OPTS = execOptsFor(SCRIPTS_DIR);
+
+/** Invoke the bundler via argv form — argv-safe, no shell parser involvement.
+ *  Returns raw stdout so the call sites that need it (test 1) can assert
+ *  against it. */
+function runBundler(): string {
+  const out = execFileSync("npx", ["tsx", "bundle-demo-content.ts"], EXEC_OPTS);
+  return out.toString();
+}
+
+beforeAll(() => {
+  restoreFromGitHead(REPO_ROOT, DATA_FILES);
+  dataRestorer.snapshot();
+  if (dataRestorer.snapshotMap.size === 0) {
+    throw new Error(
+      `bundle-demo-content.test.ts: data snapshot is empty. Expected to find` +
+        ` tracked files at:\n` +
+        DATA_FILES.map((p) => `  ${p}`).join("\n"),
+    );
+  }
+  // NOTE: we intentionally do NOT pre-run the bundler here. Test 1 below
+  // exercises the bundler AND asserts on stdout, so a pre-run in beforeAll
+  // was redundant (CR5 medium). Tests 2-5 call `runBundlerAndRead()` which
+  // runs the bundler themselves — afterEach restores to HEAD between tests
+  // so they must re-invoke rather than read stale committed content.
+});
+afterEach(() => dataRestorer.restore());
+// afterAll is redundant on the happy path (afterEach already restored after
+// the final test) — kept as a belt-and-braces in case vitest ever changes
+// afterEach semantics, and symmetric with the other two suites.
+afterAll(() => dataRestorer.restore());
+
+/** Run the bundler and return the parsed demo-content.json. Tests 3-5 each
+ *  call this so they observe live bundler output (afterEach restores to HEAD
+ *  between tests, so without this step they'd read stale committed content). */
+function runBundlerAndRead(): any {
+  runBundler();
+  return JSON.parse(fs.readFileSync(CONTENT_PATH, "utf-8"));
+}
 
 describe("Content Bundler", () => {
-  it("generates demo-content.json from existing packages", async () => {
-    const { execSync } = await import("child_process");
-    const scriptsDir = path.resolve(__dirname, "..");
-
-    const stdout = execSync("npx tsx bundle-demo-content.ts", {
-      cwd: scriptsDir,
-      encoding: "utf-8",
-      timeout: 15000,
-    });
+  it("generates demo-content.json from existing packages", () => {
+    const stdout = runBundler();
 
     expect(stdout).toContain("Bundling demo content");
     expect(stdout).toContain("langgraph-python::agentic-chat");
 
-    const contentPath = path.resolve(
-      scriptsDir,
-      "..",
-      "shell",
-      "src",
-      "data",
-      "demo-content.json",
-    );
-    expect(fs.existsSync(contentPath)).toBe(true);
+    expect(fs.existsSync(CONTENT_PATH)).toBe(true);
 
-    const content = JSON.parse(fs.readFileSync(contentPath, "utf-8"));
+    const content = JSON.parse(fs.readFileSync(CONTENT_PATH, "utf-8"));
     expect(content.generated_at).toBeDefined();
     expect(Object.keys(content.demos).length).toBeGreaterThan(0);
   });
 
-  it("bundles correct files for each demo", async () => {
-    const contentPath = path.resolve(
-      __dirname,
-      "..",
-      "..",
-      "shell",
-      "src",
-      "data",
-      "demo-content.json",
-    );
-
-    if (!fs.existsSync(contentPath)) {
-      // Run bundler first
-      const { execSync } = await import("child_process");
-      execSync("npx tsx bundle-demo-content.ts", {
-        cwd: path.resolve(__dirname, ".."),
-        encoding: "utf-8",
-        timeout: 15000,
-      });
-    }
-
-    const content = JSON.parse(fs.readFileSync(contentPath, "utf-8"));
+  it("bundles correct files for each demo", () => {
+    const content = runBundlerAndRead();
 
     const agenticChat = content.demos["langgraph-python::agentic-chat"];
     expect(agenticChat).toBeDefined();
@@ -73,17 +92,8 @@ describe("Content Bundler", () => {
     expect(agentFile.language).toBe("python");
   });
 
-  it("detects correct language for each file type", async () => {
-    const contentPath = path.resolve(
-      __dirname,
-      "..",
-      "..",
-      "shell",
-      "src",
-      "data",
-      "demo-content.json",
-    );
-    const content = JSON.parse(fs.readFileSync(contentPath, "utf-8"));
+  it("detects correct language for each file type", () => {
+    const content = runBundlerAndRead();
 
     for (const [, demo] of Object.entries(content.demos) as any) {
       for (const file of demo.files) {
@@ -98,17 +108,8 @@ describe("Content Bundler", () => {
     }
   });
 
-  it("includes backend files for packages with agent code", async () => {
-    const contentPath = path.resolve(
-      __dirname,
-      "..",
-      "..",
-      "shell",
-      "src",
-      "data",
-      "demo-content.json",
-    );
-    const content = JSON.parse(fs.readFileSync(contentPath, "utf-8"));
+  it("includes backend files for packages with agent code", () => {
+    const content = runBundlerAndRead();
 
     // langgraph-python should have agent_server.py in backend files
     const lgDemo = content.demos["langgraph-python::agentic-chat"];
@@ -132,16 +133,7 @@ describe("Content Bundler", () => {
   });
 
   it("includes all 10 langgraph-python demos", () => {
-    const contentPath = path.resolve(
-      __dirname,
-      "..",
-      "..",
-      "shell",
-      "src",
-      "data",
-      "demo-content.json",
-    );
-    const content = JSON.parse(fs.readFileSync(contentPath, "utf-8"));
+    const content = runBundlerAndRead();
 
     const expectedDemos = [
       "agentic-chat",
@@ -161,6 +153,73 @@ describe("Content Bundler", () => {
       expect(content.demos[key]).toBeDefined();
       expect(content.demos[key].files.length).toBeGreaterThan(0);
       expect(content.demos[key].readme).toBeTruthy();
+    }
+  });
+
+  // Regression guard — verifies the snapshot/restore hooks defined at the
+  // top of this file actually heal drift that `bundle-demo-content.ts`
+  // produces in shell/src/data/demo-content.json.
+  //
+  // The sentinel append creates transient tracking drift on demo-content.json
+  // for the duration of the test; a developer with a git GUI / file watcher
+  // will see flicker while it runs. Restore heals it before the test returns.
+  it("restores shell/src/data/demo-content.json after the bundler mutates it", () => {
+    expect(dataRestorer.snapshotMap.size).toBeGreaterThan(0);
+
+    // Run the bundler (side-effect: overwrites demo-content.json).
+    runBundler();
+
+    // Capture pre-sentinel content so we can prove the append landed via a
+    // content check (stronger than byte-length: resistant to a hypothetical
+    // fs shim that updates stat but not bytes).
+    const preAppendContent = new Map<string, Buffer>();
+    for (const p of dataRestorer.snapshotMap.keys()) {
+      preAppendContent.set(p, fs.readFileSync(p));
+    }
+
+    // Force the file to differ from the snapshot regardless of generator
+    // output. Safe because we restore immediately below.
+    const SENTINEL = "\n/* regression-guard-sentinel */\n";
+    const sentinelBuf = Buffer.from(SENTINEL, "utf-8");
+    for (const p of dataRestorer.snapshotMap.keys()) {
+      fs.appendFileSync(p, SENTINEL);
+    }
+
+    // Verify the sentinel actually landed on disk — the file must be
+    // pre-append content followed by sentinel bytes, exactly.
+    for (const p of dataRestorer.snapshotMap.keys()) {
+      const before = preAppendContent.get(p)!;
+      const expected = Buffer.concat([before, sentinelBuf]);
+      const actual = fs.readFileSync(p);
+      expect(
+        actual.equals(expected),
+        `sentinel append did not land on ${p}`,
+      ).toBe(true);
+    }
+
+    // Restore and assert bit-for-bit against the in-memory snapshot (NOT
+    // against a re-read of disk, which would silently agree with a buggy
+    // restore()).
+    dataRestorer.restore();
+
+    for (const [p, baseline] of dataRestorer.snapshotMap) {
+      const current = fs.readFileSync(p);
+      expect(current.equals(baseline), `data drift not restored: ${p}`).toBe(
+        true,
+      );
+    }
+  });
+
+  // Safety net: every snapshotted data file must match its captured baseline
+  // bit-for-bit at the end of the suite. Mirrors the equivalent check in
+  // create-integration.test.ts and generate-registry.test.ts.
+  it("leaves every snapshotted data file byte-identical to its baseline", () => {
+    expect(dataRestorer.snapshotMap.size).toBeGreaterThan(0);
+    for (const [p, baseline] of dataRestorer.snapshotMap) {
+      const current = fs.readFileSync(p);
+      expect(current.equals(baseline), `data drift after suite: ${p}`).toBe(
+        true,
+      );
     }
   });
 });

--- a/showcase/scripts/__tests__/create-integration.test.ts
+++ b/showcase/scripts/__tests__/create-integration.test.ts
@@ -1,11 +1,31 @@
+// create-integration.test.ts — exercises the real generator end-to-end, then
+// restores every file it mutates so the working tree is byte-identical to
+// `git HEAD` when the suite exits.
+//
+// The generator mutates:
+//   - showcase/packages/test-integration-tmp/** (the scaffolded package)
+//   - .github/workflows/showcase_deploy.yml           (+47 lines per run)
+//   - .github/workflows/showcase_drift-detection.yml  (CI matrix row)
+//   - .github/workflows/starter-smoke.yml             (+1 line per run)
+//
+// This file depends on vitest's `fileParallelism: false` config (see
+// vitest.config.ts). The module-level `workflowRestorer` assumes no sibling
+// suite is concurrently writing to the same files.
+
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
+import { execFileSync } from "child_process";
 import yaml from "yaml";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
+import {
+  FileSnapshotRestorer,
+  execOptsFor,
+  restoreFromGitHead,
+} from "./test-cleanup";
+import { SCRIPTS_DIR, REPO_ROOT, WORKFLOWS_DIR } from "./paths";
 
-const SCRIPTS_DIR = path.resolve(__dirname, "..");
 const PACKAGES_DIR = path.resolve(SCRIPTS_DIR, "..", "packages");
 const SCHEMA_PATH = path.resolve(
   SCRIPTS_DIR,
@@ -21,28 +41,106 @@ const FEATURE_REGISTRY_PATH = path.resolve(
 );
 
 const TEST_SLUG = "test-integration-tmp";
+// Regression test uses its own slug so the generator always has fresh work to
+// do; the primary slug is already consumed by earlier tests in the file.
+const REGRESSION_SLUG = "test-integration-tmp-regression-guard";
+const TEST_SLUGS: readonly string[] = [TEST_SLUG, REGRESSION_SLUG];
 const TEST_DIR = path.join(PACKAGES_DIR, TEST_SLUG);
+const REGRESSION_DIR = path.join(PACKAGES_DIR, REGRESSION_SLUG);
+
+// Exactly the three workflow YAMLs the generator mutates. We deliberately do
+// NOT scan `.github/workflows/` — a wider scope would (a) make restoreFromGitHead
+// block a developer with uncommitted edits to ANY unrelated workflow from
+// running these tests, and (b) increase the chance of unrelated workflow
+// mutations being misattributed to this suite.
+const WORKFLOW_FILES: readonly string[] = [
+  path.join(WORKFLOWS_DIR, "showcase_deploy.yml"),
+  path.join(WORKFLOWS_DIR, "showcase_drift-detection.yml"),
+  path.join(WORKFLOWS_DIR, "starter-smoke.yml"),
+];
+
+// Shared restorer populated in beforeAll and drained by cleanup().
+const workflowRestorer = new FileSnapshotRestorer(WORKFLOW_FILES);
 
 function cleanup() {
-  if (fs.existsSync(TEST_DIR)) {
-    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  // Workflow restoration runs in a finally so a failed package-dir rmSync
+  // (EBUSY on Windows, EACCES on a stuck filehandle, …) can't leak workflow
+  // drift into the next test.
+  try {
+    for (const slug of TEST_SLUGS) {
+      const dir = path.join(PACKAGES_DIR, slug);
+      if (fs.existsSync(dir)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    workflowRestorer.restore();
   }
 }
 
-// Clean up before AND after — handles leftover dirs from killed CI runs
-beforeAll(cleanup);
+// beforeAll: (1) restore workflows from git so we snapshot a clean baseline
+// even if a previous run crashed between mutation and afterEach, (2) snapshot,
+// (3) remove any stale TEST_DIR / REGRESSION_DIR. Ordering matters — without
+// the git restore a crashed run would seed our snapshot with drifted content
+// and restore() would lock in the drift.
+beforeAll(() => {
+  restoreFromGitHead(REPO_ROOT, WORKFLOW_FILES);
+  workflowRestorer.snapshot();
+  if (workflowRestorer.snapshotMap.size === 0) {
+    throw new Error(
+      `create-integration.test.ts: workflow snapshot is empty. Expected to` +
+        ` find tracked files at:\n` +
+        WORKFLOW_FILES.map((p) => `  ${p}`).join("\n"),
+    );
+  }
+  for (const slug of TEST_SLUGS) {
+    const dir = path.join(PACKAGES_DIR, slug);
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+// `afterEach` + `afterAll` + per-test `cleanup()` at the top of each `it()` is
+// deliberate: `afterEach` is the primary failsafe, `afterAll` handles the last
+// test, and the top-of-body call makes each test independently re-entrant
+// (rerunning a single test in isolation starts from a known-clean state).
 afterEach(cleanup);
 afterAll(cleanup);
 
-describe("Template Generator", () => {
-  it("generates a valid package structure", async () => {
-    cleanup();
-    const { execSync } = await import("child_process");
+// Shared exec options (from test-cleanup.ts) plus cwd. See SAFE_EXEC_OPTS
+// docstring for the Node-20 stderr-race rationale.
+const EXEC_OPTS = execOptsFor(SCRIPTS_DIR);
 
-    execSync(
-      `npx tsx create-integration/index.ts --name "Test Integration" --slug ${TEST_SLUG} --category agent-framework --language python --features agentic-chat,hitl-in-chat`,
-      { cwd: SCRIPTS_DIR, encoding: "utf-8", timeout: 15000 },
-    );
+/** Invoke `npx tsx create-integration/index.ts` with argv-style args so none
+ *  of the slug / feature strings ever hit a shell parser. Previous revisions
+ *  used `execSync(string)` with interpolated slugs — safe today because the
+ *  slugs are constants, but a poor hygiene pattern worth stamping out. */
+function runGenerator(args: readonly string[]): { stdout: string } {
+  const stdout = execFileSync(
+    "npx",
+    ["tsx", "create-integration/index.ts", ...args],
+    EXEC_OPTS,
+  );
+  return { stdout: stdout.toString() };
+}
+
+describe("Template Generator", () => {
+  it("generates a valid package structure", () => {
+    cleanup();
+
+    runGenerator([
+      "--name",
+      "Test Integration",
+      "--slug",
+      TEST_SLUG,
+      "--category",
+      "agent-framework",
+      "--language",
+      "python",
+      "--features",
+      "agentic-chat,hitl-in-chat",
+    ]);
 
     // Check directory exists
     expect(fs.existsSync(TEST_DIR)).toBe(true);
@@ -72,14 +170,21 @@ describe("Template Generator", () => {
     }
   });
 
-  it("generates a manifest that passes schema validation", async () => {
+  it("generates a manifest that passes schema validation", () => {
     cleanup();
-    const { execSync } = await import("child_process");
 
-    execSync(
-      `npx tsx create-integration/index.ts --name "Test Integration" --slug ${TEST_SLUG} --category provider-sdk --language typescript --features agentic-chat,tool-rendering,mcp-apps`,
-      { cwd: SCRIPTS_DIR, encoding: "utf-8", timeout: 15000 },
-    );
+    runGenerator([
+      "--name",
+      "Test Integration",
+      "--slug",
+      TEST_SLUG,
+      "--category",
+      "provider-sdk",
+      "--language",
+      "typescript",
+      "--features",
+      "agentic-chat,tool-rendering,mcp-apps",
+    ]);
 
     const manifest = yaml.parse(
       fs.readFileSync(path.join(TEST_DIR, "manifest.yaml"), "utf-8"),
@@ -101,14 +206,21 @@ describe("Template Generator", () => {
     expect(manifest.interaction_modalities).toEqual(["chat"]);
   });
 
-  it("generates correct demo stubs for each feature", async () => {
+  it("generates correct demo stubs for each feature", () => {
     cleanup();
-    const { execSync } = await import("child_process");
 
-    execSync(
-      `npx tsx create-integration/index.ts --name "Test Integration" --slug ${TEST_SLUG} --category agent-framework --language python --features agentic-chat,hitl-in-chat,subagents`,
-      { cwd: SCRIPTS_DIR, encoding: "utf-8", timeout: 15000 },
-    );
+    runGenerator([
+      "--name",
+      "Test Integration",
+      "--slug",
+      TEST_SLUG,
+      "--category",
+      "agent-framework",
+      "--language",
+      "python",
+      "--features",
+      "agentic-chat,hitl-in-chat,subagents",
+    ]);
 
     const demoIds = ["agentic-chat", "hitl-in-chat", "subagents"];
 
@@ -140,14 +252,21 @@ describe("Template Generator", () => {
     }
   });
 
-  it("generates TypeScript agent files for TS integrations", async () => {
+  it("generates TypeScript agent files for TS integrations", () => {
     cleanup();
-    const { execSync } = await import("child_process");
 
-    execSync(
-      `npx tsx create-integration/index.ts --name "Test TS" --slug ${TEST_SLUG} --category agent-framework --language typescript --features agentic-chat`,
-      { cwd: SCRIPTS_DIR, encoding: "utf-8", timeout: 15000 },
-    );
+    runGenerator([
+      "--name",
+      "Test TS",
+      "--slug",
+      TEST_SLUG,
+      "--category",
+      "agent-framework",
+      "--language",
+      "typescript",
+      "--features",
+      "agentic-chat",
+    ]);
 
     const demoDir = path.join(TEST_DIR, "src", "app", "demos", "agentic-chat");
     expect(fs.existsSync(path.join(demoDir, "agent.ts"))).toBe(true);
@@ -157,9 +276,8 @@ describe("Template Generator", () => {
     expect(fs.existsSync(path.join(TEST_DIR, "requirements.txt"))).toBe(false);
   });
 
-  it("generates manifest with all declared features and demos", async () => {
+  it("generates manifest with all declared features and demos", () => {
     cleanup();
-    const { execSync } = await import("child_process");
 
     const features = [
       "agentic-chat",
@@ -168,10 +286,18 @@ describe("Template Generator", () => {
       "mcp-apps",
     ];
 
-    execSync(
-      `npx tsx create-integration/index.ts --name "Test" --slug ${TEST_SLUG} --category agent-framework --language python --features ${features.join(",")}`,
-      { cwd: SCRIPTS_DIR, encoding: "utf-8", timeout: 15000 },
-    );
+    runGenerator([
+      "--name",
+      "Test",
+      "--slug",
+      TEST_SLUG,
+      "--category",
+      "agent-framework",
+      "--language",
+      "python",
+      "--features",
+      features.join(","),
+    ]);
 
     const manifest = yaml.parse(
       fs.readFileSync(path.join(TEST_DIR, "manifest.yaml"), "utf-8"),
@@ -189,25 +315,42 @@ describe("Template Generator", () => {
     }
   });
 
-  it("refuses to create a package if directory already exists", async () => {
+  it("refuses to create a package if directory already exists", () => {
     cleanup();
-    const { execSync } = await import("child_process");
 
     // Create first
-    execSync(
-      `npx tsx create-integration/index.ts --name "Test" --slug ${TEST_SLUG} --category agent-framework --language python --features agentic-chat`,
-      { cwd: SCRIPTS_DIR, encoding: "utf-8", timeout: 15000 },
-    );
+    runGenerator([
+      "--name",
+      "Test",
+      "--slug",
+      TEST_SLUG,
+      "--category",
+      "agent-framework",
+      "--language",
+      "python",
+      "--features",
+      "agentic-chat",
+    ]);
 
-    // Try to create again
+    // Try to create again — the generator should refuse.
     try {
-      execSync(
-        `npx tsx create-integration/index.ts --name "Test" --slug ${TEST_SLUG} --category agent-framework --language python --features agentic-chat`,
-        { cwd: SCRIPTS_DIR, encoding: "utf-8", timeout: 15000 },
-      );
+      runGenerator([
+        "--name",
+        "Test",
+        "--slug",
+        TEST_SLUG,
+        "--category",
+        "agent-framework",
+        "--language",
+        "python",
+        "--features",
+        "agentic-chat",
+      ]);
       expect.fail("Should have thrown");
     } catch (e: any) {
-      expect(e.stderr || e.stdout).toContain("already exists");
+      const stream =
+        (e.stderr?.toString?.() ?? "") + (e.stdout?.toString?.() ?? "");
+      expect(stream).toContain("already exists");
     }
   });
 
@@ -215,7 +358,6 @@ describe("Template Generator", () => {
     const featureRegistry = JSON.parse(
       fs.readFileSync(FEATURE_REGISTRY_PATH, "utf-8"),
     );
-    const validIds = new Set(featureRegistry.features.map((f: any) => f.id));
 
     // All features in the registry should have valid IDs
     for (const feature of featureRegistry.features) {
@@ -235,5 +377,105 @@ describe("Template Generator", () => {
     expect(categories.has("interactivity")).toBe(true);
     expect(categories.has("multi-agent")).toBe(true);
     expect(categories.has("platform")).toBe(true);
+  });
+
+  // Regression guard — the test-integration-tmp leak.
+  //
+  // Before the cleanup fix, running the generator scaffolded a package into
+  // showcase/packages/ AND mutated three CI workflow YAMLs. cleanup() only
+  // removed the package dir; the workflow mutations leaked into the working
+  // tree and on Node 20 CI produced `Timeout calling "onTaskUpdate"` ->
+  // ELIFECYCLE on every PR.
+  //
+  // This test asserts `cleanup()` restores every workflow YAML bit-for-bit.
+  // The same `cleanup()` function runs in `afterEach`, so covering it here
+  // transitively covers the hook. The sentinel append below deliberately
+  // causes transient tracking drift on the workflow YAMLs for the duration
+  // of the test — a developer with a git GUI / file watcher will see flicker
+  // while this test runs; restore() heals it before the test returns.
+  it("cleanup restores workflow YAMLs after generator mutation (regression: test-integration-tmp leak)", () => {
+    cleanup();
+
+    // Verify we captured at least one workflow to test against.
+    expect(workflowRestorer.snapshotMap.size).toBeGreaterThan(0);
+
+    // Run the generator with a dedicated slug so it always has fresh work to
+    // do (the generator short-circuits once its slug is registered in any
+    // workflow file).
+    runGenerator([
+      "--name",
+      "Leak Guard",
+      "--slug",
+      REGRESSION_SLUG,
+      "--category",
+      "agent-framework",
+      "--language",
+      "python",
+      "--features",
+      "agentic-chat",
+    ]);
+
+    // Capture pre-sentinel content so we can prove the append was observed
+    // by the filesystem via a content check (stronger than byte-length:
+    // resistant to a hypothetical fs shim that updates stat but not bytes).
+    const preAppendContent = new Map<string, Buffer>();
+    for (const p of workflowRestorer.snapshotMap.keys()) {
+      preAppendContent.set(p, fs.readFileSync(p));
+    }
+
+    // Defense in depth: force every snapshotted file to differ from its
+    // baseline regardless of generator output. Safe because we restore
+    // immediately below via cleanup().
+    const SENTINEL = "\n# regression-guard-sentinel\n";
+    const sentinelBuf = Buffer.from(SENTINEL, "utf-8");
+    for (const p of workflowRestorer.snapshotMap.keys()) {
+      fs.appendFileSync(p, SENTINEL);
+    }
+
+    // Prove the sentinel actually landed on disk — the file must be
+    // pre-append content followed by sentinel bytes, exactly. Replaces the
+    // old tautological `anyMutated` check (which couldn't fail given the
+    // append ran unconditionally directly above it).
+    for (const p of workflowRestorer.snapshotMap.keys()) {
+      const before = preAppendContent.get(p)!;
+      const expected = Buffer.concat([before, sentinelBuf]);
+      const actual = fs.readFileSync(p);
+      expect(
+        actual.equals(expected),
+        `sentinel append did not land on ${p}`,
+      ).toBe(true);
+    }
+
+    // Run cleanup() and assert bit-for-bit restoration against the module
+    // snapshot (NOT a local re-read of disk — that would silently agree with
+    // a buggy workflowRestorer.restore()).
+    cleanup();
+
+    for (const [p, baseline] of workflowRestorer.snapshotMap) {
+      const current = fs.readFileSync(p);
+      expect(
+        current.equals(baseline),
+        `workflow drift not restored: ${p}`,
+      ).toBe(true);
+    }
+
+    // Both package dirs should be gone.
+    expect(fs.existsSync(TEST_DIR)).toBe(false);
+    expect(fs.existsSync(REGRESSION_DIR)).toBe(false);
+  });
+
+  // Safety net: every snapshotted workflow must match its captured baseline
+  // bit-for-bit at the end of the suite. Compares against the in-memory
+  // snapshot rather than `git diff`, so a developer editing an unrelated
+  // workflow locally doesn't get spurious failures — we only care about
+  // files the suite knows about.
+  it("leaves every snapshotted workflow byte-identical to its baseline", () => {
+    expect(workflowRestorer.snapshotMap.size).toBeGreaterThan(0);
+    for (const [p, baseline] of workflowRestorer.snapshotMap) {
+      const current = fs.readFileSync(p);
+      expect(current.equals(baseline), `workflow drift after suite: ${p}`).toBe(
+        true,
+      );
+    }
   });
 });

--- a/showcase/scripts/__tests__/generate-registry.test.ts
+++ b/showcase/scripts/__tests__/generate-registry.test.ts
@@ -45,9 +45,6 @@ beforeAll(() => {
   }
 });
 afterEach(() => dataRestorer.restore());
-// afterAll is redundant on the happy path (afterEach already restored after
-// the final test) — kept as a belt-and-braces in case vitest ever changes
-// afterEach semantics, and symmetric with the other two suites.
 afterAll(() => dataRestorer.restore());
 
 // The generator uses __dirname-relative paths, so we test it via the actual

--- a/showcase/scripts/__tests__/generate-registry.test.ts
+++ b/showcase/scripts/__tests__/generate-registry.test.ts
@@ -79,6 +79,12 @@ describe("Registry Generator", () => {
   });
 
   it("sorts integrations by sort_order", () => {
+    // Run the generator explicitly — afterEach restores shell/src/data JSONs
+    // to HEAD between tests, so we can't rely on test 1's side effect to
+    // leave registry.json populated. Mirrors the `runBundlerAndRead` pattern
+    // in bundle-demo-content.test.ts tests 2-5.
+    runGenerator();
+
     const registryPath = path.join(SHELL_DATA_DIR, "registry.json");
     const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
 

--- a/showcase/scripts/__tests__/generate-registry.test.ts
+++ b/showcase/scripts/__tests__/generate-registry.test.ts
@@ -1,94 +1,67 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
-import os from "os";
+import { execFileSync } from "child_process";
+import {
+  FileSnapshotRestorer,
+  execOptsFor,
+  restoreFromGitHead,
+} from "./test-cleanup";
+import { SCRIPTS_DIR, REPO_ROOT, SHELL_DATA_DIR } from "./paths";
 
-const SCRIPT_PATH = path.resolve(__dirname, "..", "generate-registry.ts");
+// `generate-registry.ts` writes to showcase/shell/src/data/registry.json AND
+// showcase/shell/src/data/constraints.json. Without this, every test run
+// leaks regenerated JSON into the working tree. Snapshot in beforeAll;
+// restore after each test and at the end of the suite. Assumes vitest's
+// `fileParallelism: false` config.
+const DATA_FILES = [
+  path.join(SHELL_DATA_DIR, "registry.json"),
+  path.join(SHELL_DATA_DIR, "constraints.json"),
+];
+const dataRestorer = new FileSnapshotRestorer(DATA_FILES);
 
-function createTempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "showcase-test-"));
+const EXEC_OPTS = execOptsFor(SCRIPTS_DIR);
+
+/** Invoke the generator via argv form — no shell parser involvement. Matches
+ *  the hygiene principle in create-integration.test.ts. A prior revision
+ *  used `execSync(\`npx tsx ${SCRIPT_PATH}\`)` with an interpolated path,
+ *  which is a landmine even when the constant is safe today. */
+function runGenerator(): string {
+  const out = execFileSync("npx", ["tsx", "generate-registry.ts"], EXEC_OPTS);
+  return out.toString();
 }
 
-function setupTestEnv(tmpDir: string) {
-  const packagesDir = path.join(tmpDir, "packages");
-  const sharedDir = path.join(tmpDir, "shared");
-  const shellDir = path.join(tmpDir, "shell", "src", "data");
-
-  fs.mkdirSync(packagesDir, { recursive: true });
-  fs.mkdirSync(sharedDir, { recursive: true });
-  fs.mkdirSync(shellDir, { recursive: true });
-
-  // Copy shared files
-  const realShared = path.resolve(__dirname, "..", "..", "shared");
-  fs.copyFileSync(
-    path.join(realShared, "feature-registry.json"),
-    path.join(sharedDir, "feature-registry.json"),
-  );
-  fs.copyFileSync(
-    path.join(realShared, "manifest.schema.json"),
-    path.join(sharedDir, "manifest.schema.json"),
-  );
-
-  return { packagesDir, sharedDir, shellDir };
-}
-
-function writeManifest(packagesDir: string, slug: string, manifest: string) {
-  const dir = path.join(packagesDir, slug);
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, "manifest.yaml"), manifest);
-}
-
-function runGenerator(tmpDir: string): {
-  code: number;
-  stdout: string;
-  stderr: string;
-} {
-  const { execSync } = require("child_process");
-  try {
-    const stdout = execSync(`npx tsx ${SCRIPT_PATH}`, {
-      cwd: path.join(tmpDir, "scripts-placeholder"),
-      env: {
-        ...process.env,
-        // Override the paths by running from the right context
-      },
-      encoding: "utf-8",
-      timeout: 15000,
-    });
-    return { code: 0, stdout, stderr: "" };
-  } catch (e: any) {
-    return {
-      code: e.status || 1,
-      stdout: e.stdout || "",
-      stderr: e.stderr || "",
-    };
+beforeAll(() => {
+  // Heal a working tree left dirty by a previously crashed run so our
+  // baseline snapshot matches git HEAD, not the leaked state.
+  restoreFromGitHead(REPO_ROOT, DATA_FILES);
+  dataRestorer.snapshot();
+  if (dataRestorer.snapshotMap.size === 0) {
+    throw new Error(
+      `generate-registry.test.ts: data snapshot is empty. Expected to find` +
+        ` tracked files at:\n` +
+        DATA_FILES.map((p) => `  ${p}`).join("\n"),
+    );
   }
-}
+});
+afterEach(() => dataRestorer.restore());
+// afterAll is redundant on the happy path (afterEach already restored after
+// the final test) — kept as a belt-and-braces in case vitest ever changes
+// afterEach semantics, and symmetric with the other two suites.
+afterAll(() => dataRestorer.restore());
 
-// Since the generator uses __dirname-relative paths, we test it via the actual script
-// against the real showcase directory, using the existing langgraph-python package.
+// The generator uses __dirname-relative paths, so we test it via the actual
+// script against the real showcase directory, using the existing
+// langgraph-python package.
 
 describe("Registry Generator", () => {
   it("generates registry.json from existing packages", async () => {
-    const { execSync } = await import("child_process");
-    const scriptsDir = path.resolve(__dirname, "..");
-
-    const stdout = execSync("npx tsx generate-registry.ts", {
-      cwd: scriptsDir,
-      encoding: "utf-8",
-      timeout: 15000,
-    });
+    const stdout = runGenerator();
 
     expect(stdout).toContain("Generating integration registry");
     expect(stdout).toContain("LangGraph (Python)");
 
-    const registryPath = path.resolve(
-      scriptsDir,
-      "..",
-      "shell",
-      "src",
-      "data",
-      "registry.json",
-    );
+    const registryPath = path.join(SHELL_DATA_DIR, "registry.json");
     expect(fs.existsSync(registryPath)).toBe(true);
 
     const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
@@ -109,15 +82,7 @@ describe("Registry Generator", () => {
   });
 
   it("sorts integrations by sort_order", () => {
-    const registryPath = path.resolve(
-      __dirname,
-      "..",
-      "..",
-      "shell",
-      "src",
-      "data",
-      "registry.json",
-    );
+    const registryPath = path.join(SHELL_DATA_DIR, "registry.json");
     const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
 
     // langgraph-python (sort_order: 10) should come before mastra (sort_order: 20)
@@ -139,8 +104,7 @@ describe("Registry Generator", () => {
 
   it("validates feature IDs against the registry", async () => {
     const featureRegistryPath = path.resolve(
-      __dirname,
-      "..",
+      SCRIPTS_DIR,
       "..",
       "shared",
       "feature-registry.json",
@@ -151,8 +115,7 @@ describe("Registry Generator", () => {
     const validIds = new Set(featureRegistry.features.map((f: any) => f.id));
 
     const manifestPath = path.resolve(
-      __dirname,
-      "..",
+      SCRIPTS_DIR,
       "..",
       "packages",
       "langgraph-python",
@@ -167,6 +130,78 @@ describe("Registry Generator", () => {
 
     for (const demo of manifest.demos) {
       expect(validIds.has(demo.id)).toBe(true);
+    }
+  });
+
+  // Regression guard — ensures the snapshot/restore hooks defined at the top
+  // of this file actually heal drift that `generate-registry.ts` produces in
+  // shell/src/data/. If these hooks regress we'll see data-file drift leak
+  // into the working tree (same failure mode as the workflow YAML leak
+  // fixed in create-integration.test.ts).
+  //
+  // The sentinel append below creates transient tracking drift on
+  // shell/src/data/*.json for the duration of the test; a developer with a
+  // git GUI / file watcher will see flicker while it runs. Restore heals it
+  // before the test returns.
+  it("restores shell/src/data JSONs after the generator mutates them", () => {
+    expect(dataRestorer.snapshotMap.size).toBeGreaterThan(0);
+
+    // Run the generator explicitly via the argv-safe helper.
+    runGenerator();
+
+    // Capture pre-sentinel content so we can prove the append landed on
+    // disk via a content check (stronger than byte-length comparison:
+    // resistant to a hypothetical fs shim that updates stat but not bytes).
+    const preAppendContent = new Map<string, Buffer>();
+    for (const p of dataRestorer.snapshotMap.keys()) {
+      preAppendContent.set(p, fs.readFileSync(p));
+    }
+
+    // Force each snapshotted file to differ from its snapshot — appending a
+    // byte the generator would never write. This makes the test independent
+    // of whether the generator's output was byte-identical to the snapshot.
+    const SENTINEL = "\n/* regression-guard-sentinel */\n";
+    const sentinelBuf = Buffer.from(SENTINEL, "utf-8");
+    for (const p of dataRestorer.snapshotMap.keys()) {
+      fs.appendFileSync(p, SENTINEL);
+    }
+
+    // Verify the sentinel actually landed — the file's bytes must now equal
+    // its pre-append content followed by the sentinel bytes, exactly.
+    // Fails red under a readonly-fs mock or a buggy appendFileSync shim.
+    for (const p of dataRestorer.snapshotMap.keys()) {
+      const before = preAppendContent.get(p)!;
+      const expected = Buffer.concat([before, sentinelBuf]);
+      const actual = fs.readFileSync(p);
+      expect(
+        actual.equals(expected),
+        `sentinel append did not land on ${p}`,
+      ).toBe(true);
+    }
+
+    // Restore and assert bit-for-bit against the in-memory snapshot (NOT
+    // against a re-read of disk, which would silently agree with a buggy
+    // restore()).
+    dataRestorer.restore();
+
+    for (const [p, baseline] of dataRestorer.snapshotMap) {
+      const current = fs.readFileSync(p);
+      expect(current.equals(baseline), `data drift not restored: ${p}`).toBe(
+        true,
+      );
+    }
+  });
+
+  // Safety net: every snapshotted data file must match its captured baseline
+  // bit-for-bit at the end of the suite. Mirrors the equivalent check in
+  // create-integration.test.ts.
+  it("leaves every snapshotted data file byte-identical to its baseline", () => {
+    expect(dataRestorer.snapshotMap.size).toBeGreaterThan(0);
+    for (const [p, baseline] of dataRestorer.snapshotMap) {
+      const current = fs.readFileSync(p);
+      expect(current.equals(baseline), `data drift after suite: ${p}`).toBe(
+        true,
+      );
     }
   });
 });

--- a/showcase/scripts/__tests__/paths.ts
+++ b/showcase/scripts/__tests__/paths.ts
@@ -1,0 +1,17 @@
+// Shared path constants for showcase/scripts test suites. Centralized here
+// so that repo-root / scripts-dir / data-dir drift in one place when the
+// directory layout changes — several suites previously recomputed these and
+// any future mismatch would be a silent bug.
+
+import path from "path";
+
+export const SCRIPTS_DIR = path.resolve(__dirname, "..");
+export const REPO_ROOT = path.resolve(SCRIPTS_DIR, "..", "..");
+export const SHELL_DATA_DIR = path.resolve(
+  SCRIPTS_DIR,
+  "..",
+  "shell",
+  "src",
+  "data",
+);
+export const WORKFLOWS_DIR = path.resolve(REPO_ROOT, ".github", "workflows");

--- a/showcase/scripts/__tests__/test-cleanup.test.ts
+++ b/showcase/scripts/__tests__/test-cleanup.test.ts
@@ -518,4 +518,132 @@ describe("restoreFromGitHead: drifted baseline guard", () => {
       console.warn = origWarn;
     }
   });
+
+  // --- Post-heal drift guard: the `git checkout HEAD --` above must leave the
+  //     tracked paths byte-identical to HEAD. We simulate a hostile layer by
+  //     stubbing execFileSync at the module level? No — simpler: we stub
+  //     `checkout` indirectly by preloading the file with drift AFTER checkout
+  //     would have run. We can't intercept the real checkout, so instead we
+  //     cover the guard by replacing the `git` binary with a wrapper that
+  //     rewrites the file to drifted content. Too invasive. Simplest direct
+  //     cover: make `git diff --quiet` exit non-zero by monkey-patching PATH
+  //     to a shim that reports drift. Skipped as over-engineered.
+  //
+  //     Instead, verify the structural invariant: on CI, after a successful
+  //     path-partition + checkout, a repo whose tracked file genuinely matches
+  //     HEAD must NOT trigger the guard. Red-green: an earlier revision of
+  //     this module lacked the post-heal diff and this test would have
+  //     silently passed; the drift-scenario coverage is exercised by the
+  //     integration test suites (create-integration, generate-registry,
+  //     bundle-demo-content) which all run under CI=true.
+  it("does not false-positive on a clean tracked path (CI)", () => {
+    const a = path.join(repo, "a.txt");
+    fs.writeFileSync(a, "baseline\n");
+    commitAll(repo, "baseline");
+    // Tree is clean; checkout is a no-op; post-heal diff must be clean.
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).not.toThrow();
+    // File still matches HEAD.
+    expect(fs.readFileSync(a, "utf-8")).toBe("baseline\n");
+  });
+
+  /** Build a shim `git` wrapper that fails the N-th `diff --quiet` invocation
+   *  (1-indexed). Earlier diff calls pass through to the real git. Used to
+   *  distinguish the off-CI pre-checkout dirty-tracked-file check (1st diff)
+   *  from the post-heal drift guard (2nd diff) without false positives.
+   *
+   *  State is persisted in a counter file in the shim dir so the same shim
+   *  can be used across multiple restoreFromGitHead calls in one test. */
+  function mkGitShim(failNthDiff: number): {
+    shimDir: string;
+    cleanup: () => void;
+    activate: () => string | undefined;
+    deactivate: (saved: string | undefined) => void;
+  } {
+    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "git-shim-"));
+    const counterFile = path.join(shimDir, "counter");
+    fs.writeFileSync(counterFile, "0");
+    const realGit = execFileSync("which", ["git"], {
+      encoding: "utf-8" as const,
+    })
+      .toString()
+      .trim();
+    const shim = path.join(shimDir, "git");
+    fs.writeFileSync(
+      shim,
+      `#!/usr/bin/env bash\n` +
+        `COUNTER_FILE=${JSON.stringify(counterFile)}\n` +
+        `FAIL_N=${failNthDiff}\n` +
+        `if [ "$1" = "diff" ] && [ "$2" = "--quiet" ]; then\n` +
+        `  n=$(cat "$COUNTER_FILE")\n` +
+        `  n=$((n+1))\n` +
+        `  echo "$n" > "$COUNTER_FILE"\n` +
+        `  if [ "$n" = "$FAIL_N" ]; then\n` +
+        `    exit 1\n` +
+        `  fi\n` +
+        `fi\n` +
+        `exec ${JSON.stringify(realGit)} "$@"\n`,
+      { mode: 0o755 },
+    );
+    return {
+      shimDir,
+      cleanup: () => fs.rmSync(shimDir, { recursive: true, force: true }),
+      activate: () => {
+        const saved = process.env.PATH;
+        process.env.PATH = `${shimDir}:${saved ?? ""}`;
+        return saved;
+      },
+      deactivate: (saved) => {
+        process.env.PATH = saved;
+      },
+    };
+  }
+
+  // Direct cover of the guard's throw path: use a git shim that makes the
+  // POST-HEAL diff (the 2nd `diff --quiet`) exit 1. On CI there's only one
+  // diff call (the post-heal) so `failNthDiff: 1` is correct.
+  it("throws on CI when a post-heal diff reports drift", () => {
+    const a = path.join(repo, "a.txt");
+    fs.writeFileSync(a, "baseline\n");
+    commitAll(repo, "baseline");
+
+    const shim = mkGitShim(1);
+    const saved = shim.activate();
+    try {
+      expect(() => restoreFromGitHead(repo, ["a.txt"])).toThrow(
+        /drifted-baseline guard: post-heal diff failed/,
+      );
+    } finally {
+      shim.deactivate(saved);
+      shim.cleanup();
+    }
+  });
+
+  it("warns (does not throw) off-CI when a post-heal diff reports drift", () => {
+    delete process.env.CI;
+    const a = path.join(repo, "a.txt");
+    fs.writeFileSync(a, "baseline\n");
+    commitAll(repo, "baseline");
+
+    // Off-CI there are TWO diff calls: (1) the pre-checkout dirty-tracked
+    // check, (2) the post-heal drift guard. We want to fail only the 2nd.
+    const shim = mkGitShim(2);
+    const saved = shim.activate();
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: unknown) => {
+      warnings.push(String(msg));
+    };
+    try {
+      expect(() => restoreFromGitHead(repo, ["a.txt"])).not.toThrow();
+      expect(
+        warnings.some((w) =>
+          /drifted-baseline guard: post-heal diff failed/.test(w),
+        ),
+      ).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      shim.deactivate(saved);
+      shim.cleanup();
+    }
+  });
 });

--- a/showcase/scripts/__tests__/test-cleanup.test.ts
+++ b/showcase/scripts/__tests__/test-cleanup.test.ts
@@ -268,7 +268,7 @@ describe("restoreFromGitHead", () => {
   });
 
   it("handles mixed tracked+untracked lists without masking dirty tracked files", () => {
-    // Regression for the CR4 HIGH finding: a mixed list caused
+    // Regression guard: a mixed tracked/untracked list previously caused
     // `git diff --quiet` to exit 128 (pathspec mismatch from untracked),
     // which the guard treated as "nothing to clobber" and silently
     // overwrote the dirty tracked file.
@@ -354,7 +354,7 @@ describe("execOptsFor", () => {
   });
 });
 
-// --- CR5 HIGH regression guards ---
+// --- Regression guards: narrow-catch + per-basename sweep + drift guard ---
 
 describe("restoreFromGitHead: narrow catch in partitionTrackedPaths", () => {
   let savedCI: string | undefined;
@@ -383,9 +383,10 @@ describe("restoreFromGitHead: narrow catch in partitionTrackedPaths", () => {
       execFileSync("git", ["commit", "-q", "-m", "init"], opts);
 
       // Force PATH to an empty dir so the spawned `git` fails with ENOENT.
-      // Before the CR5 fix, `partitionTrackedPaths` swallowed ENOENT and
-      // treated the path as "untracked", causing `restoreFromGitHead` to
-      // silently no-op and lock in the drifted baseline.
+      // Prior to the narrow-catch fix, `partitionTrackedPaths` swallowed
+      // ENOENT and treated the path as "untracked", causing
+      // `restoreFromGitHead` to silently no-op and lock in the drifted
+      // baseline.
       const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "fsr-empty-"));
       const savedPath = process.env.PATH;
       process.env.PATH = emptyDir;
@@ -417,9 +418,10 @@ describe("FileSnapshotRestorer: sweepTmpStragglers basename scope", () => {
   it("does NOT sweep same-shaped tmp files for unrelated basenames", () => {
     // Only `a.txt` is in the snapshot scope. A `.b.txt.<hex>.tmp` straggler
     // must survive the sweep — it belongs to a different snapshot target
-    // (possibly run by a different tool in the same directory). Before the
-    // CR5 HIGH tightening, the generic regex `/^\..+\.[0-9a-f]{16}\.tmp$/`
-    // matched and deleted any file of this shape.
+    // (possibly run by a different tool in the same directory). Prior to
+    // the per-basename tightening, the generic regex
+    // `/^\..+\.[0-9a-f]{16}\.tmp$/` matched and deleted any file of this
+    // shape.
     const a = path.join(tmp, "a.txt");
     fs.writeFileSync(a, "x");
 
@@ -449,9 +451,9 @@ describe("FileSnapshotRestorer: double-snapshot guard (flag-based)", () => {
   });
 
   it("throws on second snapshot() even when the path list matched nothing", () => {
-    // Before the CR5 MEDIUM fix, the guard was size-based (`snapshots.size
-    // > 0`); with zero matching paths the size stayed 0 forever and a
-    // second snapshot() would silently succeed.
+    // Prior to the flag-based guard, the check was size-based
+    // (`snapshots.size > 0`); with zero matching paths the size stayed 0
+    // forever and a second snapshot() would silently succeed.
     const r = new FileSnapshotRestorer([path.join(tmp, "never.txt")]);
     r.snapshot();
     expect(r.snapshotMap.size).toBe(0);
@@ -489,8 +491,8 @@ describe("restoreFromGitHead: drifted baseline guard", () => {
   });
 
   it("throws on CI when the input has paths but none are tracked", () => {
-    // Before the CR5 MEDIUM fix, this silently early-returned and the
-    // caller would snapshot whatever drifted content was on disk.
+    // Prior to the drifted-baseline guard, this silently early-returned
+    // and the caller would snapshot whatever drifted content was on disk.
     expect(() => restoreFromGitHead(repo, ["totally-untracked.txt"])).toThrow(
       /no input path is tracked by git/,
     );

--- a/showcase/scripts/__tests__/test-cleanup.test.ts
+++ b/showcase/scripts/__tests__/test-cleanup.test.ts
@@ -37,23 +37,29 @@ function cleanGitEnv(): NodeJS.ProcessEnv {
   return out;
 }
 
+/** Exec options shared by every `git` subprocess spawned from this test file.
+ *  Stdio is explicitly piped (not inherited) so child stdout/stderr can't
+ *  interleave with the vitest worker's stdio streams — inherited stdio on a
+ *  thread/fork vitest worker disrupts the worker→parent RPC channel on Node
+ *  20 and surfaces as "Timeout calling onTaskUpdate" during teardown. */
+const TEST_GIT_STDIO = ["ignore", "pipe", "pipe"] as const;
+
 function mkTmpRepo(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "test-cleanup-"));
   const env = cleanGitEnv();
-  execFileSync("git", ["init", "-q"], { cwd: dir, env });
-  execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir, env });
-  execFileSync("git", ["config", "user.name", "t"], { cwd: dir, env });
-  execFileSync("git", ["config", "commit.gpgsign", "false"], {
-    cwd: dir,
-    env,
-  });
+  const opts = { cwd: dir, env, stdio: TEST_GIT_STDIO } as const;
+  execFileSync("git", ["init", "-q"], opts);
+  execFileSync("git", ["config", "user.email", "t@t"], opts);
+  execFileSync("git", ["config", "user.name", "t"], opts);
+  execFileSync("git", ["config", "commit.gpgsign", "false"], opts);
   return dir;
 }
 
 function commitAll(repo: string, msg: string): void {
   const env = cleanGitEnv();
-  execFileSync("git", ["add", "-A"], { cwd: repo, env });
-  execFileSync("git", ["commit", "-q", "-m", msg], { cwd: repo, env });
+  const opts = { cwd: repo, env, stdio: TEST_GIT_STDIO } as const;
+  execFileSync("git", ["add", "-A"], opts);
+  execFileSync("git", ["commit", "-q", "-m", msg], opts);
 }
 
 describe("FileSnapshotRestorer", () => {
@@ -367,16 +373,14 @@ describe("restoreFromGitHead: narrow catch in partitionTrackedPaths", () => {
     const repo = fs.mkdtempSync(path.join(os.tmpdir(), "fsr-nogit-"));
     try {
       const env = cleanGitEnv();
-      execFileSync("git", ["init", "-q"], { cwd: repo, env });
+      const opts = { cwd: repo, env, stdio: TEST_GIT_STDIO } as const;
+      execFileSync("git", ["init", "-q"], opts);
       fs.writeFileSync(path.join(repo, "a.txt"), "x");
-      execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo, env });
-      execFileSync("git", ["config", "user.name", "t"], { cwd: repo, env });
-      execFileSync("git", ["config", "commit.gpgsign", "false"], {
-        cwd: repo,
-        env,
-      });
-      execFileSync("git", ["add", "-A"], { cwd: repo, env });
-      execFileSync("git", ["commit", "-q", "-m", "init"], { cwd: repo, env });
+      execFileSync("git", ["config", "user.email", "t@t"], opts);
+      execFileSync("git", ["config", "user.name", "t"], opts);
+      execFileSync("git", ["config", "commit.gpgsign", "false"], opts);
+      execFileSync("git", ["add", "-A"], opts);
+      execFileSync("git", ["commit", "-q", "-m", "init"], opts);
 
       // Force PATH to an empty dir so the spawned `git` fails with ENOENT.
       // Before the CR5 fix, `partitionTrackedPaths` swallowed ENOENT and

--- a/showcase/scripts/__tests__/test-cleanup.test.ts
+++ b/showcase/scripts/__tests__/test-cleanup.test.ts
@@ -1,0 +1,515 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import {
+  FileSnapshotRestorer,
+  SAFE_EXEC_OPTS,
+  execOptsFor,
+  restoreFromGitHead,
+} from "./test-cleanup";
+
+// Unit tests for the shared test-cleanup harness. Covers:
+//   - FileSnapshotRestorer round trip (mutate + restore)
+//   - FileSnapshotRestorer ENOENT read handling (file deleted after snapshot)
+//   - FileSnapshotRestorer ENOENT write handling (parent dir deleted)
+//   - FileSnapshotRestorer re-invocation guard (snapshot twice throws)
+//   - FileSnapshotRestorer byte-exact round trip (non-utf8 bytes)
+//   - FileSnapshotRestorer sweeps atomic-write tmp stragglers on snapshot()
+//   - restoreFromGitHead narrow catch (benign pathspec vs fatal errors)
+//   - restoreFromGitHead accepts the allowlisted truthy CI values
+//   - restoreFromGitHead tracked/untracked partitioning (mixed path list)
+//   - restoreFromGitHead off-CI guard propagates stderr on re-raise
+
+/** Env with all `GIT_*` vars stripped — pre-commit hooks (lefthook) run with
+ *  GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE set on process.env, which cause
+ *  child `git commit` calls to ignore `cwd` and write to the HOST repo. Every
+ *  test-owned subprocess must use this env so tmp-repo commits stay confined.
+ *  Without this scrub, a developer running `git commit` (which triggers
+ *  test-and-check-packages -> `pnpm run test` -> this file) would silently
+ *  accumulate "initial" / "init" commits on the real working-tree HEAD. */
+function cleanGitEnv(): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_")) out[k] = v;
+  }
+  return out;
+}
+
+function mkTmpRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "test-cleanup-"));
+  const env = cleanGitEnv();
+  execFileSync("git", ["init", "-q"], { cwd: dir, env });
+  execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir, env });
+  execFileSync("git", ["config", "user.name", "t"], { cwd: dir, env });
+  execFileSync("git", ["config", "commit.gpgsign", "false"], {
+    cwd: dir,
+    env,
+  });
+  return dir;
+}
+
+function commitAll(repo: string, msg: string): void {
+  const env = cleanGitEnv();
+  execFileSync("git", ["add", "-A"], { cwd: repo, env });
+  execFileSync("git", ["commit", "-q", "-m", msg], { cwd: repo, env });
+}
+
+describe("FileSnapshotRestorer", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fsr-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("round trip: mutate then restore returns original content", () => {
+    const f = path.join(tmp, "a.txt");
+    fs.writeFileSync(f, "original");
+    const r = new FileSnapshotRestorer([f]);
+    r.snapshot();
+
+    fs.writeFileSync(f, "mutated");
+    expect(fs.readFileSync(f, "utf-8")).toBe("mutated");
+
+    r.restore();
+    expect(fs.readFileSync(f, "utf-8")).toBe("original");
+  });
+
+  it("byte-exact round trip preserves non-utf8 bytes", () => {
+    const f = path.join(tmp, "bin");
+    // 0xC3 followed by 0x28 is an invalid utf-8 sequence. A utf-8 string
+    // round-trip would replace it with U+FFFD; Buffer round-trip preserves it.
+    const bytes = Buffer.from([0x00, 0xc3, 0x28, 0xff]);
+    fs.writeFileSync(f, bytes);
+    const r = new FileSnapshotRestorer([f]);
+    r.snapshot();
+
+    fs.writeFileSync(f, Buffer.from([0x01, 0x02]));
+    r.restore();
+
+    const got = fs.readFileSync(f);
+    expect(got.equals(bytes)).toBe(true);
+  });
+
+  it("is a no-op on a clean run (no mtime churn)", () => {
+    const f = path.join(tmp, "a.txt");
+    fs.writeFileSync(f, "unchanged");
+    const r = new FileSnapshotRestorer([f]);
+    r.snapshot();
+
+    const before = fs.statSync(f).mtimeMs;
+    r.restore();
+    const after = fs.statSync(f).mtimeMs;
+    expect(after).toBe(before);
+  });
+
+  it("re-creates a snapshotted file that was deleted after snapshot", () => {
+    const f = path.join(tmp, "a.txt");
+    fs.writeFileSync(f, "gone");
+    const r = new FileSnapshotRestorer([f]);
+    r.snapshot();
+
+    fs.rmSync(f);
+    expect(fs.existsSync(f)).toBe(false);
+
+    r.restore();
+    expect(fs.readFileSync(f, "utf-8")).toBe("gone");
+  });
+
+  it("re-creates parent directory on write ENOENT", () => {
+    const f = path.join(tmp, "sub", "a.txt");
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, "deep");
+    const r = new FileSnapshotRestorer([f]);
+    r.snapshot();
+
+    fs.rmSync(path.dirname(f), { recursive: true });
+    expect(fs.existsSync(f)).toBe(false);
+
+    r.restore();
+    expect(fs.readFileSync(f, "utf-8")).toBe("deep");
+  });
+
+  it("ignores paths that don't exist at snapshot time", () => {
+    const r = new FileSnapshotRestorer([path.join(tmp, "nonexistent.txt")]);
+    r.snapshot();
+    expect(r.snapshotMap.size).toBe(0);
+    r.restore(); // no-op, shouldn't throw
+  });
+
+  it("throws when snapshot() is called twice on the same instance", () => {
+    const f = path.join(tmp, "a.txt");
+    fs.writeFileSync(f, "first");
+    const r = new FileSnapshotRestorer([f]);
+    r.snapshot();
+    expect(() => r.snapshot()).toThrow(
+      /called on a restorer that already has a snapshot/,
+    );
+  });
+
+  it("sweeps leftover atomic-write tmp stragglers on snapshot()", () => {
+    const f = path.join(tmp, "a.txt");
+    fs.writeFileSync(f, "content");
+
+    // Simulate a straggler matching the atomic-write naming convention
+    // (`.{basename}.{16-hex}.tmp`). SIGKILL between writeFileSync +
+    // renameSync would leave one of these behind.
+    const straggler = path.join(tmp, ".a.txt.0123456789abcdef.tmp");
+    fs.writeFileSync(straggler, "leftover");
+    expect(fs.existsSync(straggler)).toBe(true);
+
+    // An unrelated dot-tmp file that MUST be preserved (not our pattern).
+    const unrelated = path.join(tmp, ".editor-swap.tmp");
+    fs.writeFileSync(unrelated, "keep me");
+
+    const r = new FileSnapshotRestorer([f]);
+    r.snapshot();
+
+    expect(fs.existsSync(straggler)).toBe(false);
+    expect(fs.existsSync(unrelated)).toBe(true);
+  });
+});
+
+describe("restoreFromGitHead", () => {
+  let repo: string;
+  let savedCI: string | undefined;
+
+  beforeEach(() => {
+    repo = mkTmpRepo();
+    savedCI = process.env.CI;
+    // Default to CI=true; individual tests that need the off-CI guard
+    // override this inside the test body.
+    process.env.CI = "true";
+  });
+
+  afterEach(() => {
+    if (savedCI === undefined) delete process.env.CI;
+    else process.env.CI = savedCI;
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("restores a tracked file from HEAD (on CI)", () => {
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+
+    fs.writeFileSync(path.join(repo, "a.txt"), "drift");
+    restoreFromGitHead(repo, ["a.txt"]);
+    expect(fs.readFileSync(path.join(repo, "a.txt"), "utf-8")).toBe(
+      "committed",
+    );
+  });
+
+  it("accepts CI=1 as truthy", () => {
+    process.env.CI = "1";
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+
+    fs.writeFileSync(path.join(repo, "a.txt"), "drift");
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).not.toThrow();
+    expect(fs.readFileSync(path.join(repo, "a.txt"), "utf-8")).toBe(
+      "committed",
+    );
+  });
+
+  it("accepts CI=yes as truthy (case-insensitive)", () => {
+    process.env.CI = "YES";
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+
+    fs.writeFileSync(path.join(repo, "a.txt"), "drift");
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).not.toThrow();
+  });
+
+  it("treats CI='false', CI='0', and arbitrary strings as off", () => {
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+    fs.writeFileSync(path.join(repo, "a.txt"), "wip");
+
+    process.env.CI = "false";
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).toThrow(
+      /refusing to overwrite/,
+    );
+
+    process.env.CI = "0";
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).toThrow(
+      /refusing to overwrite/,
+    );
+
+    // Allowlist strictness: a random value is off, not on.
+    process.env.CI = "on";
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).toThrow(
+      /refusing to overwrite/,
+    );
+  });
+
+  it("skips untracked paths when mixed with tracked peers (benign pathspec)", () => {
+    // Mixed lists must succeed: partitionTrackedPaths filters out the
+    // untracked entry and the tracked entry is healed normally. (An
+    // all-untracked call is a separate case — covered by the
+    // "drifted baseline guard" block.)
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+    fs.writeFileSync(path.join(repo, "a.txt"), "drift");
+    expect(() => restoreFromGitHead(repo, ["a.txt", "nope.txt"])).not.toThrow();
+    expect(fs.readFileSync(path.join(repo, "a.txt"), "utf-8")).toBe(
+      "committed",
+    );
+  });
+
+  it("handles mixed tracked+untracked lists without masking dirty tracked files", () => {
+    // Regression for the CR4 HIGH finding: a mixed list caused
+    // `git diff --quiet` to exit 128 (pathspec mismatch from untracked),
+    // which the guard treated as "nothing to clobber" and silently
+    // overwrote the dirty tracked file.
+    delete process.env.CI;
+
+    fs.writeFileSync(path.join(repo, "tracked.txt"), "committed");
+    commitAll(repo, "initial");
+
+    // Dirty tracked file + one untracked path in the same call.
+    fs.writeFileSync(path.join(repo, "tracked.txt"), "wip");
+
+    expect(() =>
+      restoreFromGitHead(repo, ["tracked.txt", "untracked.txt"]),
+    ).toThrow(/refusing to overwrite uncommitted changes/);
+
+    // Critically: the dirty tracked file must NOT have been clobbered.
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf-8")).toBe(
+      "wip",
+    );
+  });
+
+  it("off-CI, refuses to clobber uncommitted tracked-file changes", () => {
+    delete process.env.CI;
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+
+    // Create dev-style uncommitted edit
+    fs.writeFileSync(path.join(repo, "a.txt"), "wip");
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).toThrow(
+      /refusing to overwrite uncommitted changes/,
+    );
+    // File must remain unchanged
+    expect(fs.readFileSync(path.join(repo, "a.txt"), "utf-8")).toBe("wip");
+  });
+
+  it("off-CI error message mentions the discard alternative", () => {
+    delete process.env.CI;
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+    fs.writeFileSync(path.join(repo, "a.txt"), "wip");
+
+    try {
+      restoreFromGitHead(repo, ["a.txt"]);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as Error).message).toMatch(/git checkout HEAD --/);
+    }
+  });
+
+  it("off-CI, heals when tree is clean wrt the target paths", () => {
+    delete process.env.CI;
+    fs.writeFileSync(path.join(repo, "a.txt"), "committed");
+    commitAll(repo, "initial");
+
+    // clean tree -> heal is a no-op but must not throw
+    expect(() => restoreFromGitHead(repo, ["a.txt"])).not.toThrow();
+    expect(fs.readFileSync(path.join(repo, "a.txt"), "utf-8")).toBe(
+      "committed",
+    );
+  });
+});
+
+describe("SAFE_EXEC_OPTS", () => {
+  it("exposes stdio ignore/pipe/pipe and a bounded timeout", () => {
+    expect(SAFE_EXEC_OPTS.stdio).toEqual(["ignore", "pipe", "pipe"]);
+    expect(SAFE_EXEC_OPTS.timeout).toBe(30000);
+    expect(SAFE_EXEC_OPTS.maxBuffer).toBe(10 * 1024 * 1024);
+  });
+
+  it("freezes the inner stdio array (not just the outer object)", () => {
+    expect(Object.isFrozen(SAFE_EXEC_OPTS)).toBe(true);
+    expect(Object.isFrozen(SAFE_EXEC_OPTS.stdio)).toBe(true);
+  });
+});
+
+describe("execOptsFor", () => {
+  it("returns a frozen object with cwd and the SAFE_EXEC_OPTS defaults", () => {
+    const opts = execOptsFor("/some/path");
+    expect(opts.cwd).toBe("/some/path");
+    expect(opts.stdio).toEqual(["ignore", "pipe", "pipe"]);
+    expect(opts.timeout).toBe(30000);
+    expect(Object.isFrozen(opts)).toBe(true);
+  });
+});
+
+// --- CR5 HIGH regression guards ---
+
+describe("restoreFromGitHead: narrow catch in partitionTrackedPaths", () => {
+  let savedCI: string | undefined;
+
+  beforeEach(() => {
+    savedCI = process.env.CI;
+    process.env.CI = "true";
+  });
+
+  afterEach(() => {
+    if (savedCI === undefined) delete process.env.CI;
+    else process.env.CI = savedCI;
+  });
+
+  it("fails loudly when the git binary is missing (PATH empty)", () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), "fsr-nogit-"));
+    try {
+      const env = cleanGitEnv();
+      execFileSync("git", ["init", "-q"], { cwd: repo, env });
+      fs.writeFileSync(path.join(repo, "a.txt"), "x");
+      execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo, env });
+      execFileSync("git", ["config", "user.name", "t"], { cwd: repo, env });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], {
+        cwd: repo,
+        env,
+      });
+      execFileSync("git", ["add", "-A"], { cwd: repo, env });
+      execFileSync("git", ["commit", "-q", "-m", "init"], { cwd: repo, env });
+
+      // Force PATH to an empty dir so the spawned `git` fails with ENOENT.
+      // Before the CR5 fix, `partitionTrackedPaths` swallowed ENOENT and
+      // treated the path as "untracked", causing `restoreFromGitHead` to
+      // silently no-op and lock in the drifted baseline.
+      const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "fsr-empty-"));
+      const savedPath = process.env.PATH;
+      process.env.PATH = emptyDir;
+      try {
+        expect(() => restoreFromGitHead(repo, ["a.txt"])).toThrow(
+          /partitionTrackedPaths|git ls-files/,
+        );
+      } finally {
+        process.env.PATH = savedPath;
+        fs.rmSync(emptyDir, { recursive: true, force: true });
+      }
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("FileSnapshotRestorer: sweepTmpStragglers basename scope", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fsr-sweep-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("does NOT sweep same-shaped tmp files for unrelated basenames", () => {
+    // Only `a.txt` is in the snapshot scope. A `.b.txt.<hex>.tmp` straggler
+    // must survive the sweep — it belongs to a different snapshot target
+    // (possibly run by a different tool in the same directory). Before the
+    // CR5 HIGH tightening, the generic regex `/^\..+\.[0-9a-f]{16}\.tmp$/`
+    // matched and deleted any file of this shape.
+    const a = path.join(tmp, "a.txt");
+    fs.writeFileSync(a, "x");
+
+    const ourStraggler = path.join(tmp, ".a.txt.0123456789abcdef.tmp");
+    fs.writeFileSync(ourStraggler, "ours");
+
+    const foreignStraggler = path.join(tmp, ".b.txt.0123456789abcdef.tmp");
+    fs.writeFileSync(foreignStraggler, "foreign");
+
+    const r = new FileSnapshotRestorer([a]);
+    r.snapshot();
+
+    expect(fs.existsSync(ourStraggler)).toBe(false);
+    expect(fs.existsSync(foreignStraggler)).toBe(true);
+  });
+});
+
+describe("FileSnapshotRestorer: double-snapshot guard (flag-based)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fsr-dbl-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("throws on second snapshot() even when the path list matched nothing", () => {
+    // Before the CR5 MEDIUM fix, the guard was size-based (`snapshots.size
+    // > 0`); with zero matching paths the size stayed 0 forever and a
+    // second snapshot() would silently succeed.
+    const r = new FileSnapshotRestorer([path.join(tmp, "never.txt")]);
+    r.snapshot();
+    expect(r.snapshotMap.size).toBe(0);
+    expect(() => r.snapshot()).toThrow(
+      /called on a restorer that already has a snapshot/,
+    );
+  });
+});
+
+// Note: we intentionally do NOT test the `GIT_*` scrub by setting
+// `process.env.GIT_DIR` in the test body — a polluted process.env has
+// catastrophic blast-radius (any other git call in ANY parallel vitest
+// suite or pre-commit hook would misroute to our decoy repo, and if our
+// afterEach is skipped for any reason we'd silently corrupt the real
+// working tree). The unit under test is `gitEnv()`, which we cover via its
+// observable behavior: the existing "restores a tracked file from HEAD (on
+// CI)" / mixed-list tests exercise the git-subprocess path with a real
+// repo and would fail immediately if `gitEnv` stopped forwarding PATH,
+// HOME, etc. The scrub itself is a simple `!k.startsWith("GIT_")` loop.
+
+describe("restoreFromGitHead: drifted baseline guard", () => {
+  let repo: string;
+  let savedCI: string | undefined;
+
+  beforeEach(() => {
+    repo = mkTmpRepo();
+    savedCI = process.env.CI;
+    process.env.CI = "true";
+  });
+
+  afterEach(() => {
+    if (savedCI === undefined) delete process.env.CI;
+    else process.env.CI = savedCI;
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("throws on CI when the input has paths but none are tracked", () => {
+    // Before the CR5 MEDIUM fix, this silently early-returned and the
+    // caller would snapshot whatever drifted content was on disk.
+    expect(() => restoreFromGitHead(repo, ["totally-untracked.txt"])).toThrow(
+      /no input path is tracked by git/,
+    );
+  });
+
+  it("warns (does not throw) off-CI when nothing is tracked", () => {
+    delete process.env.CI;
+    // Off-CI we don't want to disrupt a developer running tests against a
+    // tree that may not yet have committed these files. Warn and return.
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: unknown) => {
+      warnings.push(String(msg));
+    };
+    try {
+      expect(() =>
+        restoreFromGitHead(repo, ["totally-untracked.txt"]),
+      ).not.toThrow();
+      expect(
+        warnings.some((w) => /no input path is tracked by git/.test(w)),
+      ).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+});

--- a/showcase/scripts/__tests__/test-cleanup.ts
+++ b/showcase/scripts/__tests__/test-cleanup.ts
@@ -26,11 +26,12 @@
 // parallel would race each other. If you enable file parallelism, you must
 // move to per-suite isolation (tmp cwd + env-var-parameterized scripts).
 //
-// WINDOWS: callers that invoke `npx` through `execFileSync` (see sibling
-// test files) are POSIX-only as written — on Windows `npx` is a `.cmd` and
-// `execFileSync("npx", ...)` without `shell: true` fails. Showcase tests
-// currently run on Ubuntu/macOS CI only; if we ever add Windows CI we'll
-// need a `process.platform === "win32"` gate at those call sites.
+// WINDOWS: callers in sibling test files (create-integration.test.ts,
+// generate-registry.test.ts, bundle-demo-content.test.ts) invoke `npx`
+// through `execFileSync` — these will fail on Windows because `npx` is a
+// `.cmd` there and `execFileSync("npx", ...)` without `shell: true` fails.
+// Showcase tests currently run on Ubuntu/macOS CI only; if we ever add
+// Windows CI those call sites need a `process.platform === "win32"` gate.
 
 import fs from "fs";
 import path from "path";
@@ -201,9 +202,12 @@ function partitionTrackedPaths(
  *     stash, commit, or discard (`git checkout HEAD -- <paths>`) first. If
  *     the tree is already clean wrt these paths, we heal.
  *
- * Untracked paths are skipped entirely. Anything else — EACCES, git missing,
- * corrupt worktree — is re-raised so the test suite fails loudly rather than
- * silently seeding a drifted baseline into the subsequent snapshot.
+ * Tracked paths are restored via `git checkout HEAD -- <paths>`; untracked
+ * paths are skipped (off-CI) or throw (on CI) per the drifted-baseline guard.
+ * An entirely-untracked input list throws on CI and logs a warning off-CI.
+ * Anything else — EACCES, git missing, corrupt worktree — is re-raised so the
+ * test suite fails loudly rather than silently seeding a drifted baseline into
+ * the subsequent snapshot.
  */
 export function restoreFromGitHead(
   repoRoot: string,
@@ -344,7 +348,8 @@ export class FileSnapshotRestorer {
     // revisions used a generic `/^\..+\.[0-9a-f]{16}\.tmp$/` regex which
     // would match any same-shaped tmp file in the directory — a landmine in
     // shared dirs like `.github/workflows/` where an unrelated tool could
-    // have created a similarly-named file. CR5 HIGH tightening.
+    // have created a similarly-named file. Tightened to per-basename scope
+    // to preserve unrelated tmp files in shared directories.
     const bucketed = new Map<string, Set<string>>();
     for (const p of this.paths) {
       const dir = path.dirname(p);

--- a/showcase/scripts/__tests__/test-cleanup.ts
+++ b/showcase/scripts/__tests__/test-cleanup.ts
@@ -280,11 +280,15 @@ export function restoreFromGitHead(
       stdio: ["ignore", "pipe", "pipe"],
     });
   } catch (err) {
-    // Narrow: pathspec-did-not-match on untracked files is benign. Git
-    // produces this as `error: pathspec '…' did not match any file(s) known
-    // to git` (exit 1) OR `fatal: … is outside repository` (exit 128).
-    // Anything else — EACCES, git missing, corrupt worktree — bubble up so
-    // the suite fails loudly instead of seeding a drifted baseline.
+    // Belt-and-braces: handles a race where a tracked file is removed
+    // between partitionTrackedPaths and this checkout (e.g. a parallel
+    // rm from another harness touching the same tree). Realistically
+    // unreachable in this suite — we run with fileParallelism: false and
+    // no concurrent harness — but cheap to tolerate. Git produces this as
+    // `error: pathspec '…' did not match any file(s) known to git`
+    // (exit 1). Anything else — EACCES, git missing, corrupt worktree —
+    // bubbles up so the suite fails loudly instead of seeding a drifted
+    // baseline.
     const stderr =
       // SAFE_EXEC_OPTS pins `encoding: "utf-8"`, so stderr is a string here.
       (err as { stderr?: string }).stderr ?? "";
@@ -298,6 +302,35 @@ export function restoreFromGitHead(
         { cause: err },
       );
     }
+  }
+
+  // Drifted-baseline guard (post-heal): after the `git checkout HEAD --`
+  // above, every tracked path we just healed MUST now be byte-identical
+  // to HEAD. If it isn't, something is mutating these files between our
+  // checkout and here — an external process, a filesystem layer, or
+  // (most likely in practice) a parallel test suite we haven't accounted
+  // for. That's a drifted baseline: our subsequent snapshot would bake
+  // in the drift and the restore loop would happily maintain it forever.
+  // On CI this is a hard error; off-CI we let the snapshot proceed but
+  // warn, since a developer may be iterating on a dirty tree.
+  try {
+    execFileSync("git", ["diff", "--quiet", "HEAD", "--", ...tracked], {
+      ...gitExecOpts(repoRoot),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    const code = (err as { status?: number }).status;
+    const stderr = (err as { stderr?: string }).stderr ?? "";
+    const msg =
+      `restoreFromGitHead: drifted-baseline guard: post-heal diff failed` +
+      ` (exit ${code ?? "?"}) for:\n` +
+      tracked.map((p) => `  ${p}`).join("\n") +
+      (stderr.trim() ? `\ngit stderr: ${stderr.trim()}` : "");
+    if (isCI()) {
+      throw new Error(msg, { cause: err });
+    }
+    // eslint-disable-next-line no-console
+    console.warn(`[test-cleanup] ${msg}`);
   }
 }
 

--- a/showcase/scripts/__tests__/test-cleanup.ts
+++ b/showcase/scripts/__tests__/test-cleanup.ts
@@ -1,0 +1,490 @@
+// Shared test helper: snapshot/restore working-tree files that test scripts
+// mutate as a side effect.
+//
+// Rationale:
+//
+// Several showcase test suites invoke real generator scripts (create-integration,
+// generate-registry, bundle-demo-content) that write to tracked files OUTSIDE
+// any tmp dir — workflow YAMLs in .github/workflows/ and data JSONs in
+// showcase/shell/src/data/. Without explicit restoration these writes leak
+// into the working tree on every `nx run-many -t test` and, on Node 20 CI with
+// vitest worker pools, the accumulated drift races the worker-RPC channel
+// (`Timeout calling "onTaskUpdate"` -> ELIFECYCLE).
+//
+// This module provides two pieces:
+//
+//   1. `restoreFromGitHead(repoRoot, paths)` — synchronously restore any file
+//      from the most recent git HEAD. Used in `beforeAll` to heal a working
+//      tree left dirty by a previously crashed test run before we snapshot.
+//
+//   2. `FileSnapshotRestorer` — captures content of a fixed file list at
+//      snapshot time and rewrites only the files that drift. Idempotent. Used
+//      in `afterEach` / `afterAll` as the inner loop.
+//
+// IMPORTANT: this depends on vitest's `fileParallelism: false` setting in
+// vitest.config.ts. Multiple suites snapshotting/restoring the SAME files in
+// parallel would race each other. If you enable file parallelism, you must
+// move to per-suite isolation (tmp cwd + env-var-parameterized scripts).
+//
+// WINDOWS: callers that invoke `npx` through `execFileSync` (see sibling
+// test files) are POSIX-only as written — on Windows `npx` is a `.cmd` and
+// `execFileSync("npx", ...)` without `shell: true` fails. Showcase tests
+// currently run on Ubuntu/macOS CI only; if we ever add Windows CI we'll
+// need a `process.platform === "win32"` gate at those call sites.
+
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { execFileSync } from "child_process";
+
+/** Escape a string for inclusion as a literal in a `RegExp`. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Shared exec options for all child_process calls in the test harness.
+ *
+ *  `stdio: ["ignore", "pipe", "pipe"]` — on Node 20 CI, inheriting stderr
+ *  into the parent vitest worker races the worker-RPC channel (observed as
+ *  `Timeout calling "onTaskUpdate"`). We capture instead; success-path stderr
+ *  is dropped by design — use the generator's stdout for test assertions.
+ *
+ *  `maxBuffer: 10MiB` — defensive; the default 1MiB can deadlock if the
+ *  generator logs verbose output.
+ *
+ *  `timeout: 30000` — generators shell out to npx/tsx which cold-boots on
+ *  first run; 15s produced flakes on slow CI runners.
+ */
+const SAFE_STDIO = Object.freeze([
+  "ignore",
+  "pipe",
+  "pipe",
+] as const) as readonly ["ignore", "pipe", "pipe"];
+
+export const SAFE_EXEC_OPTS = Object.freeze({
+  encoding: "utf-8" as const,
+  timeout: 30000,
+  maxBuffer: 10 * 1024 * 1024,
+  stdio: SAFE_STDIO,
+});
+
+/** Build exec options scoped to a specific cwd. Shared helper so suites don't
+ *  recompute the same frozen `{...SAFE_EXEC_OPTS, cwd}` shape. The freeze is
+ *  defensive — callers that accidentally mutate would corrupt subsequent
+ *  invocations. */
+export function execOptsFor(cwd: string) {
+  return Object.freeze({ ...SAFE_EXEC_OPTS, cwd });
+}
+
+/** Build the env forced for every `git` invocation in this module.
+ *
+ *  Computed lazily per call so a test that temporarily mutates `process.env`
+ *  (e.g. to toggle `CI`) observes the mutation instead of a module-load-time
+ *  snapshot.
+ *
+ *  Strips `GIT_*` environment overrides from the parent process
+ *  (`GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, ...). If the developer or
+ *  a wrapping tool has set any of these, git would silently redirect our
+ *  `ls-files` / `diff` / `checkout` calls to a different repository,
+ *  corrupting the snapshot baseline. We scrub ALL `GIT_*` vars (allowlist
+ *  is simpler and safer than enumerating the dozen+ recognized vars).
+ *
+ *  `LC_ALL=C` / `LANG=C` — git localizes its error strings; the benign
+ *  "pathspec did not match" detection is regex-based and must not depend on
+ *  the developer's locale. DO NOT remove LC_ALL — the `benign-pathspec`
+ *  regex below is English-only by design. */
+function gitEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("GIT_")) continue;
+    env[k] = v;
+  }
+  env.LC_ALL = "C";
+  env.LANG = "C";
+  return env;
+}
+
+/** Shared exec options for git invocations inside this module. Captures
+ *  stderr (we interrogate it for benign-pathspec detection) and applies the
+ *  SAFE_EXEC_OPTS timeout / buffer bounds — a hung git (corrupt worktree,
+ *  signing prompt, network filesystem) would otherwise wedge the suite.
+ *
+ *  Frozen for symmetry with `execOptsFor` — callers can't accidentally
+ *  mutate shared options. */
+function gitExecOpts(cwd: string) {
+  return Object.freeze({
+    ...SAFE_EXEC_OPTS,
+    cwd,
+    env: gitEnv(),
+  });
+}
+
+/** True when running under a recognized truthy CI env var. Accepts exactly
+ *  the common values — `"true"`, `"1"`, `"yes"` (case-insensitive). Anything
+ *  else (including unset, `""`, `"0"`, `"false"`, arbitrary strings) is off.
+ *  Allowlist over blocklist for strictness. */
+function isCI(): boolean {
+  const v = process.env.CI;
+  if (!v) return false;
+  const normalized = v.toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "yes";
+}
+
+/** Split input paths into tracked vs untracked relative to HEAD. Uses
+ *  `git ls-files --error-unmatch` per path; exit 0 = tracked, exit 1 =
+ *  untracked. Any OTHER failure (ENOENT git binary, EACCES, corrupt
+ *  worktree, signal kill, timeout) is re-raised — otherwise a broken
+ *  environment gets silently treated as "everything untracked" and the
+ *  caller skips its destructive healing, locking in any drifted baseline.
+ *
+ *  N complexity — we run one subprocess per path. Acceptable while the
+ *  snapshot scope is single-digit paths (3 workflow YAMLs / 2 data JSONs).
+ *  If scope grows materially, batch via a single `git ls-files -z -- <paths>`
+ *  and diff the output against the input.
+ */
+function partitionTrackedPaths(
+  repoRoot: string,
+  paths: readonly string[],
+): { tracked: string[]; untracked: string[] } {
+  const tracked: string[] = [];
+  const untracked: string[] = [];
+  for (const p of paths) {
+    try {
+      execFileSync("git", ["ls-files", "--error-unmatch", "--", p], {
+        ...gitExecOpts(repoRoot),
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      tracked.push(p);
+    } catch (err) {
+      const code = (err as { status?: number | null }).status;
+      const errno = (err as NodeJS.ErrnoException).code;
+      // SAFE_EXEC_OPTS pins `encoding: "utf-8"`, so stderr is a string here.
+      const stderr = (err as { stderr?: string }).stderr ?? "";
+      // Exit 1 == pathspec unmatched (git's documented "not tracked" code).
+      // Anything else (ENOENT = git missing, EACCES, ETIMEDOUT, SIGKILL with
+      // status=null, exit 128 for corrupt repo, ...) is an environment
+      // failure, not a tracked/untracked question.
+      if (code === 1 && typeof errno !== "string") {
+        untracked.push(p);
+        continue;
+      }
+      throw new Error(
+        `partitionTrackedPaths: unexpected git ls-files failure for ${p}` +
+          ` (exit ${code ?? "?"}, errno ${errno ?? "n/a"}): ${stderr.trim()}`,
+        { cause: err },
+      );
+    }
+  }
+  return { tracked, untracked };
+}
+
+/**
+ * Restore the given files from `git HEAD` (working tree refresh).
+ *
+ * @param repoRoot Absolute path to the git repository root. Used as `cwd` for
+ *                 all git invocations so resolution doesn't depend on the
+ *                 caller's current working directory.
+ * @param paths    Absolute or repo-relative paths to restore. Empty array is
+ *                 a no-op. Mixed tracked/untracked lists are supported: this
+ *                 function partitions them via `git ls-files --error-unmatch`
+ *                 and operates ONLY on tracked paths.
+ *
+ * This is destructive for tracked paths — it clobbers any uncommitted
+ * tracked-file edits. To prevent silently destroying a developer's in-progress
+ * work:
+ *
+ *   - On CI (`process.env.CI` set to a truthy value) we always heal, since
+ *     CI checkouts start clean and any drift is leaked state from a previous
+ *     test run.
+ *   - Off CI, we refuse to heal if the developer has uncommitted changes to
+ *     any of the tracked target paths, throwing an error that tells them to
+ *     stash, commit, or discard (`git checkout HEAD -- <paths>`) first. If
+ *     the tree is already clean wrt these paths, we heal.
+ *
+ * Untracked paths are skipped entirely. Anything else — EACCES, git missing,
+ * corrupt worktree — is re-raised so the test suite fails loudly rather than
+ * silently seeding a drifted baseline into the subsequent snapshot.
+ */
+export function restoreFromGitHead(
+  repoRoot: string,
+  paths: readonly string[],
+): void {
+  if (paths.length === 0) return;
+
+  // Partition BEFORE any destructive op. Mixing untracked paths into
+  // `git diff --quiet` would produce exit 128 (pathspec mismatch) and
+  // cause the off-CI guard to mis-treat a legitimate dirty-tracked case
+  // as "nothing to clobber", silently overwriting developer edits.
+  const { tracked } = partitionTrackedPaths(repoRoot, paths);
+  if (tracked.length === 0) {
+    // Silent early-return here used to lock in a drifted baseline: a
+    // previous run's generator output that was then committed (or a
+    // developer moved the paths out of tracking entirely) would leave
+    // `partitionTrackedPaths` returning an empty list and the caller
+    // would happily snapshot the already-drifted content. Surface it so
+    // the user investigates: on CI we throw outright; off-CI we warn
+    // (developers may legitimately be exercising the test harness against
+    // a tree that hasn't had those files committed yet).
+    const msg =
+      `restoreFromGitHead: no input path is tracked by git:\n` +
+      paths.map((p) => `  ${p}`).join("\n") +
+      `\nSnapshot baseline would be drifted — investigate before running tests.`;
+    if (isCI()) {
+      throw new Error(msg);
+    }
+    // eslint-disable-next-line no-console
+    console.warn(`[test-cleanup] ${msg}`);
+    return;
+  }
+
+  if (!isCI()) {
+    // Off-CI guard: bail before clobbering developer edits. Only runs
+    // against tracked paths so untracked path components can't mask a
+    // dirty tracked file.
+    try {
+      execFileSync("git", ["diff", "--quiet", "HEAD", "--", ...tracked], {
+        ...gitExecOpts(repoRoot),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      const code = (err as { status?: number }).status;
+      // SAFE_EXEC_OPTS pins `encoding: "utf-8"`, so stderr is a string here.
+      const stderr = (err as { stderr?: string }).stderr ?? "";
+      if (code === 1) {
+        // `git diff --quiet` exits 1 when there ARE differences.
+        throw new Error(
+          `restoreFromGitHead: refusing to overwrite uncommitted changes to:\n` +
+            tracked.map((p) => `  ${p}`).join("\n") +
+            `\nStash, commit, or discard these changes before running the test` +
+            ` suite (e.g. \`git checkout HEAD -- <paths>\`).`,
+          { cause: err },
+        );
+      }
+      // Any other failure is unexpected now that we've pre-filtered to
+      // tracked paths. Re-raise with stderr attached so the caller sees
+      // what git actually said.
+      throw new Error(
+        `restoreFromGitHead: unexpected git diff failure (exit ${code ?? "?"}): ${stderr.trim()}`,
+        { cause: err },
+      );
+    }
+  }
+
+  try {
+    execFileSync("git", ["checkout", "HEAD", "--", ...tracked], {
+      ...gitExecOpts(repoRoot),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // Narrow: pathspec-did-not-match on untracked files is benign. Git
+    // produces this as `error: pathspec '…' did not match any file(s) known
+    // to git` (exit 1) OR `fatal: … is outside repository` (exit 128).
+    // Anything else — EACCES, git missing, corrupt worktree — bubble up so
+    // the suite fails loudly instead of seeding a drifted baseline.
+    const stderr =
+      // SAFE_EXEC_OPTS pins `encoding: "utf-8"`, so stderr is a string here.
+      (err as { stderr?: string }).stderr ?? "";
+    const isBenignPathspec = /did not match any file\(s\) known to git/.test(
+      stderr,
+    );
+    if (!isBenignPathspec) {
+      const code = (err as { status?: number }).status;
+      throw new Error(
+        `restoreFromGitHead: git checkout failed (exit ${code ?? "?"}): ${stderr.trim()}`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+/**
+ * Snapshots file content in-memory and restores any file that drifts. Uses
+ * an atomic temp-file + rename only when the on-disk bytes differ from the
+ * snapshot, which avoids touching mtime on clean runs and guarantees readers
+ * never observe a truncated file.
+ *
+ * ASYMMETRY: `restore()` undoes drift to snapshotted files and re-creates
+ * snapshotted files that were deleted. It does NOT remove files that tests
+ * create which weren't in the snapshot — the test is responsible for cleaning
+ * up new files it creates (the create-integration suite does this explicitly
+ * via `fs.rmSync(TEST_DIR, {recursive: true, force: true})`).
+ */
+export class FileSnapshotRestorer {
+  private readonly snapshots = new Map<string, Buffer>();
+  // Tracks whether `snapshot()` has been invoked — set unconditionally
+  // before any throwing work so the double-snapshot guard fires even when
+  // the path list is empty or every path is missing (size-based guards
+  // would silently allow a second call in that case).
+  private snapshotted = false;
+
+  constructor(private readonly paths: readonly string[]) {}
+
+  /** Capture current content for every path that exists on disk.
+   *
+   *  Also sweeps any stragger atomic-write temp files in each path's parent
+   *  directory — `.<basename>.<hex>.tmp` — that a prior crashed run left
+   *  behind. Without the sweep, those tmp files accumulate in tracked
+   *  directories (`.github/workflows/`, `showcase/shell/src/data/`) and
+   *  reintroduce the exact pollution this harness exists to prevent.
+   *
+   *  Throws if called after a previous snapshot — snapshotting twice silently
+   *  discards the original baseline and is almost always a bug. Use a fresh
+   *  restorer instance per test suite. */
+  snapshot(): void {
+    if (this.snapshotted) {
+      throw new Error(
+        "FileSnapshotRestorer.snapshot() called on a restorer that already" +
+          " has a snapshot. Construct a new instance per suite.",
+      );
+    }
+    this.snapshotted = true;
+    // Sweep atomic-write temp stragglers BEFORE capturing. The sweep is
+    // scoped per-basename: for each snapshot target, we look ONLY for
+    // `.<basename>.<16hex>.tmp` stragglers of that specific target. Earlier
+    // revisions used a generic `/^\..+\.[0-9a-f]{16}\.tmp$/` regex which
+    // would match any same-shaped tmp file in the directory — a landmine in
+    // shared dirs like `.github/workflows/` where an unrelated tool could
+    // have created a similarly-named file. CR5 HIGH tightening.
+    const bucketed = new Map<string, Set<string>>();
+    for (const p of this.paths) {
+      const dir = path.dirname(p);
+      let bucket = bucketed.get(dir);
+      if (!bucket) {
+        bucket = new Set();
+        bucketed.set(dir, bucket);
+      }
+      bucket.add(path.basename(p));
+    }
+    for (const [dir, basenames] of bucketed) {
+      this.sweepTmpStragglers(dir, basenames);
+    }
+    for (const p of this.paths) {
+      if (fs.existsSync(p)) {
+        this.snapshots.set(p, fs.readFileSync(p));
+      }
+    }
+  }
+
+  /** Remove `.<basename>.<16hex>.tmp` stragglers in `dir`, where `basename`
+   *  is drawn from the snapshot target list for that directory. Tolerant of
+   *  a missing directory (parent dir may not exist yet in a fresh clone).
+   *
+   *  The pattern matches files produced by `atomicWrite` for the specific
+   *  targets we're about to snapshot, and ONLY those — stragglers for
+   *  unrelated files in the same directory are left alone. EACCES/EBUSY on
+   *  a specific unlink is debug-logged (`DEBUG_TEST_CLEANUP=1`) so hangs
+   *  are diagnosable, then swallowed per best-effort sweep semantics. */
+  private sweepTmpStragglers(
+    dir: string,
+    basenames: ReadonlySet<string>,
+  ): void {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+    // Escape each target basename for literal regex inclusion, then build
+    // an alternation. `crypto.randomBytes(8)` is 16 hex chars.
+    const escaped = Array.from(basenames, escapeRegExp);
+    const re = new RegExp(`^\\.(?:${escaped.join("|")})\\.[0-9a-f]{16}\\.tmp$`);
+    for (const name of entries) {
+      if (!re.test(name)) continue;
+      const target = path.join(dir, name);
+      try {
+        fs.unlinkSync(target);
+      } catch (err) {
+        if (process.env.DEBUG_TEST_CLEANUP) {
+          const code = (err as NodeJS.ErrnoException).code ?? "?";
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[test-cleanup] sweep: unlink ${target} failed (${code})`,
+          );
+        }
+        /* best effort */
+      }
+    }
+  }
+
+  /**
+   * Restore every snapshotted path. If the on-disk bytes match the snapshot,
+   * no write happens. Writes are atomic: we write the snapshot bytes to a
+   * sibling temp file and `fs.renameSync` it into place, so readers never
+   * observe a truncated intermediate state. Missing files are re-created
+   * from the snapshot (including re-creating parent directories if they
+   * were deleted). Any unexpected read error (EACCES, EISDIR, EBUSY, ...)
+   * propagates.
+   */
+  restore(): void {
+    for (const [p, content] of this.snapshots) {
+      let current: Buffer | null;
+      try {
+        current = fs.readFileSync(p);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          current = null;
+        } else {
+          throw err;
+        }
+      }
+      if (current === null || !current.equals(content)) {
+        this.atomicWrite(p, content);
+      }
+    }
+  }
+
+  /** Atomic write via temp file + rename. Creates parent dir if missing.
+   *
+   *  Temp filename uses `crypto.randomBytes(8).toString("hex")` so two
+   *  concurrent writes from the same process can't collide (they would with
+   *  `Date.now()` at ms resolution) and so the `snapshot()` sweep regex can
+   *  match stragglers unambiguously. */
+  private atomicWrite(target: string, content: Buffer): void {
+    const dir = path.dirname(target);
+    const ensureDir = () => {
+      try {
+        fs.mkdirSync(dir, { recursive: true });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      }
+    };
+
+    const write = () => {
+      // Temp file sits in the same directory so rename is atomic (same
+      // filesystem). `os.tmpdir()` could be a different mount.
+      const suffix = crypto.randomBytes(8).toString("hex");
+      const tmp = path.join(dir, `.${path.basename(target)}.${suffix}.tmp`);
+      fs.writeFileSync(tmp, content);
+      try {
+        fs.renameSync(tmp, target);
+      } catch (err) {
+        // Best effort — don't leak temp files on rename failure.
+        try {
+          fs.unlinkSync(tmp);
+        } catch {
+          /* swallow */
+        }
+        throw err;
+      }
+    };
+
+    try {
+      write();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // Parent directory was removed between snapshot and restore — create
+        // it and retry once.
+        ensureDir();
+        write();
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  /** Expose the snapshot map (read-only) so tests can assert against it. */
+  get snapshotMap(): ReadonlyMap<string, Buffer> {
+    return this.snapshots;
+  }
+}

--- a/showcase/scripts/vitest.config.ts
+++ b/showcase/scripts/vitest.config.ts
@@ -8,6 +8,22 @@ export default defineConfig({
     // for tmp dir reuse; validate-pins / validate-parity / audit subprocess tests for
     // VALIDATE_PINS_REPO_ROOT / VALIDATE_PARITY_REPO_ROOT / SHOWCASE_AUDIT_ROOT env vars.
     fileParallelism: false,
+    // Use process forks instead of the default thread pool. Under Node 20 the
+    // thread-based worker RPC channel times out ("Timeout calling
+    // onTaskUpdate") when a test file spawns many subprocesses
+    // (validate-pins.test.ts runs 134 tests each invoking a subprocess;
+    // create-integration / generate-registry / bundle-demo-content each
+    // spawn npx tsx). The stdio / signal traffic from these children
+    // contends with the vitest worker-thread RPC channel and surfaces as
+    // an unhandled timeout. Fork-based pools use node IPC (not worker
+    // threads) for the RPC, which is robust under the same load.
+    // Node 22/24 are unaffected either way.
+    //
+    // One fork per file (default) — combined with fileParallelism: false,
+    // files still run sequentially so shared-env mutations don't race, but
+    // each file gets a fresh process so one file's subprocess churn can't
+    // stall the RPC for subsequent files.
+    pool: "forks",
     // Exclude Playwright E2E tests — they use @playwright/test, not vitest.
     // Also exclude fixture *.spec.ts files under __tests__/fixtures/** —
     // these are inert data files consumed by validate-parity tests, not

--- a/showcase/scripts/vitest.config.ts
+++ b/showcase/scripts/vitest.config.ts
@@ -7,11 +7,12 @@ export default defineConfig({
     // Under Node 20, when a test file has spawned a large number of
     // subprocesses (validate-pins runs 134 subprocesses; create-integration /
     // generate-registry / bundle-demo-content each spawn `npx tsx`), vitest's
-    // worker-RPC channel ("Timeout calling 'onTaskUpdate'") times out during
-    // teardown under the combined load. Known upstream bug:
+    // per-hook timeouts can fire during slow teardown under the combined
+    // load. Bumping to 30s matches our testTimeout. Note: the vitest
+    // worker-RPC "onTaskUpdate" timeout is a SEPARATE, hardcoded 60s in
+    // birpc (DEFAULT_TIMEOUT = 6e4 in index.B521nVV-.js) — these knobs
+    // do NOT influence it. The RPC timeout is tracked upstream:
     //   https://github.com/vitest-dev/vitest/issues/6129
-    // The 30s budget matches our testTimeout so a slow teardown can't be the
-    // bottleneck that kills the run.
     teardownTimeout: 30000,
     hookTimeout: 30000,
     // Run test files sequentially — several suites mutate process env and temp dirs
@@ -30,21 +31,16 @@ export default defineConfig({
     // threads) for the RPC, which is robust under the same load.
     // Node 22/24 are unaffected either way.
     //
-    // `singleFork: true` — one fork shared across ALL test files (combined
-    // with fileParallelism: false, files still run sequentially). A
-    // previous revision used fork-per-file (the default under pool:
-    // "forks"), but unit (20.x) CI still emitted the onTaskUpdate timeout
-    // mid-run (see run 24602657301). With one long-lived fork, the
-    // parent↔child RPC channel stays warm instead of being torn down and
-    // re-established between every file — each teardown is one of the
-    // moments the Node-20 RPC race surfaces. This is the most conservative
-    // setting short of dropping to a single-thread pool entirely.
+    // ONE FORK PER FILE (the fork-pool default), combined with
+    // fileParallelism: false — files still run sequentially so shared-env
+    // mutations don't race, but each file gets a fresh process with a
+    // fresh RPC channel. A previous revision tried `singleFork: true` (one
+    // long-lived fork across all files) but observed run 24602985507 went
+    // STRICTLY WORSE: only 1/14 files completed before the RPC timeout
+    // fired, because validate-pins on its own takes 60s on Node 20 CI and
+    // blocks the fork's single RPC channel for that entire duration. With
+    // fork-per-file, each file gets its own fresh 60s RPC budget.
     pool: "forks",
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
     // Exclude Playwright E2E tests — they use @playwright/test, not vitest.
     // Also exclude fixture *.spec.ts files under __tests__/fixtures/** —
     // these are inert data files consumed by validate-parity tests, not

--- a/showcase/scripts/vitest.config.ts
+++ b/showcase/scripts/vitest.config.ts
@@ -3,6 +3,17 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     testTimeout: 30000,
+    // Teardown / setup hook timeouts bumped from the 10s vitest default.
+    // Under Node 20, when a test file has spawned a large number of
+    // subprocesses (validate-pins runs 134 subprocesses; create-integration /
+    // generate-registry / bundle-demo-content each spawn `npx tsx`), vitest's
+    // worker-RPC channel ("Timeout calling 'onTaskUpdate'") times out during
+    // teardown under the combined load. Known upstream bug:
+    //   https://github.com/vitest-dev/vitest/issues/6129
+    // The 30s budget matches our testTimeout so a slow teardown can't be the
+    // bottleneck that kills the run.
+    teardownTimeout: 30000,
+    hookTimeout: 30000,
     // Run test files sequentially — several suites mutate process env and temp dirs
     // that would race under parallel execution: create-integration vs generate-registry
     // for tmp dir reuse; validate-pins / validate-parity / audit subprocess tests for
@@ -19,11 +30,21 @@ export default defineConfig({
     // threads) for the RPC, which is robust under the same load.
     // Node 22/24 are unaffected either way.
     //
-    // One fork per file (default) — combined with fileParallelism: false,
-    // files still run sequentially so shared-env mutations don't race, but
-    // each file gets a fresh process so one file's subprocess churn can't
-    // stall the RPC for subsequent files.
+    // `singleFork: true` — one fork shared across ALL test files (combined
+    // with fileParallelism: false, files still run sequentially). A
+    // previous revision used fork-per-file (the default under pool:
+    // "forks"), but unit (20.x) CI still emitted the onTaskUpdate timeout
+    // mid-run (see run 24602657301). With one long-lived fork, the
+    // parent↔child RPC channel stays warm instead of being torn down and
+    // re-established between every file — each teardown is one of the
+    // moments the Node-20 RPC race surfaces. This is the most conservative
+    // setting short of dropping to a single-thread pool entirely.
     pool: "forks",
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
     // Exclude Playwright E2E tests — they use @playwright/test, not vitest.
     // Also exclude fixture *.spec.ts files under __tests__/fixtures/** —
     // these are inert data files consumed by validate-parity tests, not


### PR DESCRIPTION
## Summary

Three showcase test suites leak working-tree drift (workflow YAMLs + shell data JSONs) on every run. This fixes the leaks and adds a shared `FileSnapshotRestorer` + `restoreFromGitHead` harness so the suites are idempotent.

Also moves `showcase/scripts/vitest.config.ts` from the thread pool to the fork pool, which is required under Node 20 for the test subprocess churn in `validate-pins` + the three generator-invoking suites.

## What this PR does NOT fix — vitest 3.2.4 RPC timeout on Node 20 (upstream)

`unit (20.x)` still reports `Timeout calling "onTaskUpdate"` -> ELIFECYCLE **after** all 14/14 test files and 1011/1011 tests pass. Known upstream bug: https://github.com/vitest-dev/vitest/issues/6129. The birpc timeout is hardcoded at 60 s (`DEFAULT_TIMEOUT = 6e4` in vitest's bundled `index.B521nVV-.js`) and is NOT exposed to `vitest.config.ts`. No `poolOptions.forks.*` / `teardownTimeout` / `hookTimeout` knob influences it:

- `singleFork: true` made the run STRICTLY WORSE — only 1/14 files completed (validate-pins consumes the whole 60 s budget on its own, run 24602985507).
- `fork-per-file` (default) gives each file a fresh RPC channel, and every file passes — but the final pool-teardown RPC still races on Node 20 and surfaces as a process-level exit 1.

Under vitest 3.2.4 the fix requires either (a) upgrading to vitest 4.x (out of scope — monorepo-wide upgrade), or (b) a pnpm patch against the bundled `DEFAULT_TIMEOUT` constant (cross-cutting change; declined here). The observable reality: this PR makes the showcase-scripts suites idempotent and green; the remaining `unit (20.x)` redness is a known vitest flake orthogonal to what this PR is trying to fix.

## CI-killer error (verbatim)

```
Error: Package directory already exists: /home/runner/work/CopilotKit/CopilotKit/showcase/packages/test-integration-tmp
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯
Error: [vitest-worker]: Timeout calling "onTaskUpdate"
ELIFECYCLE  Test failed.
Failed tasks:
- @copilotkit/showcase-scripts:test
```

## Root cause (fixed here)

Three test suites invoke real generator scripts that write to tracked files OUTSIDE any tmp dir, leaking drift on every `nx run-many -t test`:
- `create-integration.test.ts` scaffolds `showcase/packages/test-integration-tmp/` AND mutates three CI workflow YAMLs (`showcase_deploy.yml`, `showcase_drift-detection.yml`, `starter-smoke.yml`).
- `generate-registry.test.ts` rewrites `showcase/shell/src/data/registry.json` + `constraints.json`.
- `bundle-demo-content.test.ts` rewrites `showcase/shell/src/data/demo-content.json`.

## Fix (9 commits, by area of concern)

1. **`test(showcase/scripts): add shared test-cleanup snapshot/restore helper`** — new `__tests__/test-cleanup.ts` + `__tests__/paths.ts` + direct unit coverage in `__tests__/test-cleanup.test.ts`:
   - `FileSnapshotRestorer` — snapshots file content as `Buffer` (byte-exact, preserves non-utf8), restores only files that drifted, writes atomically via temp-file + rename, recreates parent dirs on write ENOENT. Temp filenames use `crypto.randomBytes(8).toString("hex")` so concurrent writes can't collide and the `snapshot()` sweep can unambiguously identify stragglers. On `snapshot()`, sweeps `.<basename>.<16-hex>.tmp` stragglers **scoped to the snapshotted basenames only**.
   - `restoreFromGitHead(repoRoot, paths)` — partitions the input via `git ls-files --error-unmatch` BEFORE any destructive op. **Narrow catch**: only genuine exit-1 pathspec errors are treated as untracked; ENOENT / EACCES / non-exit-1 failures re-raise with captured stderr. Uses `execFileSync` (no shell), forces `LC_ALL=C` / `LANG=C`, scrubs all `GIT_*` environment overrides, frozen exec options.
   - `test-cleanup.test.ts` itself strips `GIT_*` from child env when it creates tmp repos — pre-commit hooks (lefthook) run with `GIT_DIR` / `GIT_INDEX_FILE` set, which would otherwise cause tmp-repo `git commit` calls to write to the HOST working-tree HEAD.

2. **`fix(showcase/test-integration): clean up test-integration-tmp between runs`** — `create-integration.test.ts` wires `FileSnapshotRestorer` + `restoreFromGitHead` into the suite, wraps `rmSync` in `try/finally` so workflow restoration always runs, and migrates `execSync(string)` -> `execFileSync("npx", [...args])` via a shared `runGenerator()` helper.

3. **`fix(showcase/test-integration): stop generate-registry + bundle-content leaks`** — same pattern applied to `generate-registry.test.ts` and `bundle-demo-content.test.ts`; drops a redundant bundler pre-run in the latter.

4. **`fix(showcase/scripts): switch vitest to forks pool for Node 20 stability`** — `vitest.config.ts`: thread -> fork pool.

5. **`docs(showcase/scripts): tidy test-cleanup comments and JSDoc`** — documentation cleanup.

6. **`fix(showcase/scripts): pin vitest to a single fork + bump teardown timeouts`** — SUPERSEDED by commit 9 below (left in history for auditability).

7. **`fix(showcase/scripts): add post-heal drifted-baseline guard`** — the PR had claimed a drifted-baseline guard on CI for `restoreFromGitHead`, but no post-heal `git diff --quiet` was actually running. Adds the missing check: on CI, any tracked path still drifted post-heal throws `drifted-baseline guard: post-heal diff failed`; off-CI warns. Red-green unit coverage via a counter-based git shim that selectively fails the N-th `diff --quiet` (so the post-heal diff is targeted independently of the off-CI pre-checkout diff).

8. **`fix(showcase/scripts): decouple generate-registry test 2 from test 1 output`** — `sorts integrations by sort_order` was reading `registry.json` without invoking the generator, so `afterEach(restore)` between tests meant it was exercising the committed baseline rather than live output. Adds a `runGenerator()` call at the top.

9. **`fix(showcase/scripts): revert singleFork — fork-per-file is strictly better`** — empirical data from run 24602985507 proved `singleFork: true` was worse than fork-per-file (1/14 vs 14/14 files completing before RPC timeout). Reverts the `poolOptions.forks.singleFork` change; keeps the 30 s `teardownTimeout` / `hookTimeout` bumps. Comments now accurately reflect that the RPC timeout is upstream-hardcoded in birpc and NOT tunable via vitest config.

## Proof of idempotence

```
pnpm nx run @copilotkit/showcase-scripts:test --skip-nx-cache
Run 1: Test Files 14 passed (14), Tests 1011 passed (1011)
Run 2: Test Files 14 passed (14), Tests 1011 passed (1011)
git status after each: only the intentional test file edits.
```

Red-green verified for the HIGH CR-findings:
- narrow `partitionTrackedPaths` catch: unit test with empty PATH reproduces ENOENT; pre-fix hid it as "untracked", post-fix throws.
- basename-scoped tmp sweep: unit test places both target-basename and unrelated `.something-else.<hex>.tmp`; pre-fix swept both, post-fix sweeps only target.
- post-heal drifted-baseline guard: counter-based git shim fails the 2nd `diff --quiet`; pre-fix tests pass (guard absent), post-fix tests throw on CI / warn off-CI with the advertised message.

## Test plan

- [x] `pnpm nx run @copilotkit/showcase-scripts:test` passes 1011/1011 twice in a row (locally, Node 25)
- [x] Red-green: disabling `restore()` fails the regression + safety-net tests
- [x] Red-green: disabling the post-heal drift guard fails the new guard tests
- [x] Working tree clean after full run
- [x] `prettier --check` + `oxlint` clean on touched files
- [x] `GIT_*` scrub in test harness prevents pre-commit-hook-induced pollution of real HEAD

## CI status

- **`unit (22.x)`**: pass
- **`unit (24.x)`**: pass
- **`unit (20.x)`**: all 14/14 files + 1011/1011 tests pass; post-suite `onTaskUpdate` RPC timeout emits exit 1. Upstream bug https://github.com/vitest-dev/vitest/issues/6129; not fixable at `vitest.config.ts` level on vitest 3.2.4.

## Caveats

- Local verification ran on Node v25.8.0. No Node 20 binary on this dev host; Node 20 CI was the final gate.
- The residual `unit (20.x)` failure is orthogonal to this PR. To resolve it we would need to upgrade vitest to 4.x (monorepo-wide change) or apply a pnpm patch to bump `DEFAULT_TIMEOUT` in vitest's bundled `birpc`. Both are tracked separately.
