### PR TITLE
fix: prevent multiple connectAgent calls in useCopilotChatInternal

### DIFF
--- a/packages/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/packages/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -393,8 +393,9 @@ export function useCopilotChatInternal({
       // Abort the HTTP request and detach the active run.
       // This is critical for React StrictMode which unmounts+remounts in dev,
       // preventing duplicate /connect requests from reaching the server.
-      // Reset the ref so remounts always trigger a fresh connect.
-      lastConnectedAgentRef.current = null;
+      // Note: we do NOT reset lastConnectedAgentRef.current here.
+      // If we did, the next render would see agent !== null (always true!)
+      // and trigger an unwanted re-connect for the SAME agent instance.
       detached = true;
       connectAbortController.abort();
       agent?.detachActiveRun();


### PR DESCRIPTION
## Summary

The cleanup function in the `useEffect` inside `useCopilotChatInternal` was setting `lastConnectedAgentRef.current = null`. This caused the effect to trigger `connect()` again on every render (especially in React Strict Mode) because `agent !== null` (always true!) would be true when the ref is null.

## Root Cause

In React Strict Mode, components mount → unmount → remount. The cleanup function was resetting the ref to null, causing the condition:

```javascript
agent !== lastConnectedAgentRef.current  // true when ref is null
``` 

to always be true, triggering duplicate `connectAgent` calls on every Strict Mode cycle.

## Fix

Remove `lastConnectedAgentRef.current = null` from the cleanup function. The ref now correctly prevents reconnection for the same agent instance across renders.

## Testing

The fix prevents the duplicate POST requests to `/api/copilotkit` that were occurring in Strict Mode and during re-renders.

Fixes CopilotKit/CopilotKit#4031