### PR TITLE
fix(showcase/validate-parity): resolve demo directory from demo.route

### DIFF
--- a/showcase/scripts/__tests__/validate-parity.test.ts
+++ b/showcase/scripts/__tests__/validate-parity.test.ts
@@ -36,6 +36,7 @@ import {
   HEADER_COLUMNS,
   formatRow,
   buildHeader,
+  routeToDirName,
   type PackageIssue,
 } from "../validate-parity.js";
 
@@ -469,6 +470,64 @@ describe("validate-parity", () => {
         });
         const report = auditPackage("route-split", tmp);
         // No missing-demo-dir MUST error: route-resolved dir "hitl" exists.
+        expect(
+          report.mustErrors.filter((e) => e.category === "missing-demo-dir"),
+        ).toEqual([]);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("reports missing-demo-dir whose expectedDir is route-derived (not demo.id) when route exists and dir is missing", () => {
+      // Negative-case regression for the route-based resolution: when the
+      // manifest specifies demo.route, the MUST error's expectedDir must be
+      // derived from the route (not from demo.id). Otherwise a rename where
+      // id and route diverge produces a misleading error pointing at a
+      // directory that was never the intended target.
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "parity-route-miss-"));
+      try {
+        writeFixturePackage(tmp, "route-missdir", {
+          manifest:
+            "slug: route-missdir\ndemos:\n  - id: hitl-in-chat\n    route: /demos/hitl\n",
+          // Intentionally create a directory that matches the catalog id but
+          // NOT the route. Without route-aware resolution, the walker would
+          // see "hitl-in-chat/" and pass; the fix makes it look for "hitl/"
+          // which is absent, surfacing the real drift.
+          demoDirs: ["hitl-in-chat"],
+          specFiles: ["hitl-in-chat.spec.ts"],
+          qaFiles: ["hitl-in-chat.md"],
+        });
+        const report = auditPackage("route-missdir", tmp);
+        const missing = report.mustErrors.filter(
+          (e) => e.category === "missing-demo-dir",
+        );
+        expect(missing.length).toBe(1);
+        // The issue carries the structured fields, not just a rendered line;
+        // assert the route-derived expectedDir is what we expect.
+        const issue = missing[0];
+        if (issue.category === "missing-demo-dir") {
+          expect(issue.demoId).toBe("hitl-in-chat");
+          expect(issue.expectedDir).toBe("hitl");
+        }
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("falls back to demo.id for directory resolution when route is omitted", () => {
+      // Fallback-path regression: without demo.route, the resolver must use
+      // demo.id as the expectedDir (pre-route-field behaviour). A demo whose
+      // id matches the on-disk dir must pass clean with no missing-demo-dir
+      // error even though no route field is declared.
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "parity-route-fall-"));
+      try {
+        writeFixturePackage(tmp, "route-fallback", {
+          manifest: "slug: route-fallback\ndemos:\n  - id: agentic-chat\n",
+          demoDirs: ["agentic-chat"],
+          specFiles: ["agentic-chat.spec.ts"],
+          qaFiles: ["agentic-chat.md"],
+        });
+        const report = auditPackage("route-fallback", tmp);
         expect(
           report.mustErrors.filter((e) => e.category === "missing-demo-dir"),
         ).toEqual([]);
@@ -2277,5 +2336,24 @@ Object.freeze = function(o) {
         fs.rmSync(root, { recursive: true, force: true });
       }
     });
+  });
+});
+
+describe("routeToDirName", () => {
+  // Minimal branch coverage for the exported helper. Paired with the
+  // fixture-based tests above that exercise it through auditPackage; these
+  // nail down the three input branches without the parity-walk overhead.
+
+  it("returns undefined when route is undefined", () => {
+    expect(routeToDirName(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for a bare /demos/ with no tail segment", () => {
+    expect(routeToDirName("/demos/")).toBeUndefined();
+  });
+
+  it("strips the /demos/ prefix and returns the tail segment", () => {
+    expect(routeToDirName("/demos/hitl")).toBe("hitl");
+    expect(routeToDirName("/demos/agentic-chat")).toBe("agentic-chat");
   });
 });

--- a/showcase/scripts/__tests__/validate-parity.test.ts
+++ b/showcase/scripts/__tests__/validate-parity.test.ts
@@ -449,6 +449,34 @@ describe("validate-parity", () => {
       ).toBe(true);
     });
 
+    it("resolves demo dir from demo.route (not demo.id) when the two differ", () => {
+      // Regression guard: demo.id is the CATALOG identifier (matched to
+      // qa/spec filenames + shell registry); demo.route is the URL +
+      // filesystem path under src/app/demos/. They are DELIBERATELY
+      // separate — e.g. manifest id: "hitl-in-chat" with route:
+      // "/demos/hitl" lives at src/app/demos/hitl/. validate-parity
+      // used to resolve the demo directory from demo.id, which produced
+      // a spurious missing-demo-dir MUST for every such mapping. Fix:
+      // resolve the directory from demo.route (strip the /demos/ prefix).
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "parity-route-"));
+      try {
+        writeFixturePackage(tmp, "route-split", {
+          manifest:
+            "slug: route-split\ndemos:\n  - id: hitl-in-chat\n    name: HITL\n    route: /demos/hitl\n",
+          demoDirs: ["hitl"],
+          specFiles: ["hitl-in-chat.spec.ts"],
+          qaFiles: ["hitl-in-chat.md"],
+        });
+        const report = auditPackage("route-split", tmp);
+        // No missing-demo-dir MUST error: route-resolved dir "hitl" exists.
+        expect(
+          report.mustErrors.filter((e) => e.category === "missing-demo-dir"),
+        ).toEqual([]);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
     it("flags a demo with no spec file as a WARNING, not a MUST error", () => {
       const report = auditPackage("missing-spec", FIXTURES_DIR);
       expect(report.mustErrors).toEqual([]);
@@ -2062,11 +2090,27 @@ Object.freeze = function(o) {
       ).toBe("unreadable manifest.yaml: EACCES: permission denied");
     });
 
-    it("renders missing-demo-dir including the demo id", () => {
+    it("renders missing-demo-dir including the demo id when id equals expectedDir", () => {
       expect(
-        deriveMessage({ category: "missing-demo-dir", demoId: "chat" }),
+        deriveMessage({
+          category: "missing-demo-dir",
+          demoId: "chat",
+          expectedDir: "chat",
+        }),
       ).toBe(
         "demo 'chat' declared in manifest but no src/app/demos/chat/ directory",
+      );
+    });
+
+    it("renders missing-demo-dir flagging the route-resolved dir when id and expectedDir differ", () => {
+      expect(
+        deriveMessage({
+          category: "missing-demo-dir",
+          demoId: "hitl-in-chat",
+          expectedDir: "hitl",
+        }),
+      ).toBe(
+        "demo 'hitl-in-chat' declared in manifest but no src/app/demos/hitl/ directory (resolved from route)",
       );
     });
 

--- a/showcase/scripts/lib/__tests__/manifest.test.ts
+++ b/showcase/scripts/lib/__tests__/manifest.test.ts
@@ -407,6 +407,104 @@ describe("parseManifest", () => {
     }
   });
 
+  // --- demo.route validation (added by R2 fix cycle) ---------------------
+  //
+  // `route` is optional on each demo. When present, it must be a non-empty
+  // string that begins with "/demos/". Downstream validators (validate-parity
+  // routeToDirName, bundle-demo-content) rely on the "/demos/" prefix to
+  // strip it uniformly; accepting a bare "/hitl" or a number silently
+  // produces the wrong on-disk directory lookup.
+
+  it("returns {kind:'malformed', subkind:'shape'} when demos[i].route is a number", () => {
+    const f = path.join(root, "manifest.yaml");
+    write(f, "slug: x\ndemos:\n  - id: foo\n    route: 42\n");
+    const r = parseManifest(f);
+    expect(r.kind).toBe("malformed");
+    if (r.kind === "malformed") {
+      expect(r.subkind).toBe("shape");
+      expect(r.error).toMatch(/route/i);
+    }
+  });
+
+  it("returns {kind:'malformed', subkind:'shape'} when demos[i].route is null", () => {
+    // YAML `route: ~` parses to null. hasOwnProp is true but the value is
+    // not a string, so the non-empty-string guard rejects it.
+    const f = path.join(root, "manifest.yaml");
+    write(f, "slug: x\ndemos:\n  - id: foo\n    route: ~\n");
+    const r = parseManifest(f);
+    expect(r.kind).toBe("malformed");
+    if (r.kind === "malformed") {
+      expect(r.subkind).toBe("shape");
+      expect(r.error).toMatch(/route/i);
+    }
+  });
+
+  it("returns {kind:'malformed', subkind:'shape'} when demos[i].route is an object", () => {
+    const f = path.join(root, "manifest.yaml");
+    write(f, "slug: x\ndemos:\n  - id: foo\n    route:\n      nested: true\n");
+    const r = parseManifest(f);
+    expect(r.kind).toBe("malformed");
+    if (r.kind === "malformed") {
+      expect(r.subkind).toBe("shape");
+      expect(r.error).toMatch(/route/i);
+    }
+  });
+
+  it("returns {kind:'malformed', subkind:'shape'} when demos[i].route is the empty string", () => {
+    const f = path.join(root, "manifest.yaml");
+    write(f, 'slug: x\ndemos:\n  - id: foo\n    route: ""\n');
+    const r = parseManifest(f);
+    expect(r.kind).toBe("malformed");
+    if (r.kind === "malformed") {
+      expect(r.subkind).toBe("shape");
+      expect(r.error).toMatch(/route/i);
+    }
+  });
+
+  it("returns {kind:'malformed', subkind:'shape'} when demos[i].route does not start with /demos/", () => {
+    // Catches the exact anti-pattern the prefix guard exists for: a bare
+    // "/hitl" looks route-shaped but routeToDirName's prefix strip would
+    // return the whole string unchanged, then miss a real directory match.
+    const f = path.join(root, "manifest.yaml");
+    write(f, "slug: x\ndemos:\n  - id: foo\n    route: /hitl\n");
+    const r = parseManifest(f);
+    expect(r.kind).toBe("malformed");
+    if (r.kind === "malformed") {
+      expect(r.subkind).toBe("shape");
+      expect(r.error).toMatch(/\/demos\//);
+    }
+  });
+
+  it("returns {kind:'ok'} and persists demo.route on the frozen entry when well-formed", () => {
+    const f = path.join(root, "manifest.yaml");
+    write(f, "slug: x\ndemos:\n  - id: foo\n    route: /demos/hitl-in-chat\n");
+    const r = parseManifest(f);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      const first = r.manifest.demos?.[0];
+      expect(first?.id).toBe("foo");
+      expect(first?.route).toBe("/demos/hitl-in-chat");
+      expect(Object.isFrozen(first)).toBe(true);
+    }
+  });
+
+  it("returns {kind:'ok'} with demo.route undefined when route is omitted (backward compat)", () => {
+    // Absence of `route` must not be treated as shape-malformed. Existing
+    // manifests predate this field; they must still parse cleanly and the
+    // frozen demo entry's .route must be undefined (not null, not a
+    // placeholder).
+    const f = path.join(root, "manifest.yaml");
+    write(f, "slug: x\ndemos:\n  - id: foo\n");
+    const r = parseManifest(f);
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      const first = r.manifest.demos?.[0];
+      expect(first?.id).toBe("foo");
+      expect(first?.route).toBeUndefined();
+      expect(Object.isFrozen(first)).toBe(true);
+    }
+  });
+
   it("sets demos to a frozen empty readonly array when demos is omitted", () => {
     // `demos` is non-optional in the public type: when absent, return an
     // empty readonly array so consumers can iterate without `?.` chains.

--- a/showcase/scripts/lib/manifest.ts
+++ b/showcase/scripts/lib/manifest.ts
@@ -57,6 +57,22 @@ export function createDemoId(s: unknown): DemoId | null {
 export interface ManifestDemo {
   readonly id: DemoId;
   readonly name?: string;
+  /**
+   * Relative URL path for the demo. `id` is the CATALOG identifier
+   * (stable; matched against spec/qa filenames and shell-side registry
+   * entries), whereas `route` is the deliberate URL / filesystem path
+   * (`/demos/<dir>` — resolved to `src/app/demos/<dir>/` by consumers
+   * that need the on-disk location, e.g. bundle-demo-content and
+   * validate-parity). The two are intentionally separate so renaming a
+   * catalog id does not mass-rewrite URLs (and vice versa).
+   *
+   * Optional at the type boundary for backward compatibility with test
+   * fixtures and historical manifests. When present, parseManifest
+   * validates it is a non-empty string starting with "/demos/".
+   * Consumers that need an on-disk demo directory should prefer
+   * `route` when present and fall back to `id`.
+   */
+  readonly route?: string;
 }
 
 /**
@@ -387,13 +403,36 @@ export function parseManifest(
         }
         demoName = d.name;
       }
-      validated.push(
-        Object.freeze(
-          demoName === undefined
-            ? { id: brandedId }
-            : { id: brandedId, name: demoName },
-        ),
-      );
+      // demo-level `route`: optional. When present, must be a non-empty
+      // string beginning with "/demos/" so downstream consumers
+      // (bundle-demo-content, validate-parity) can uniformly strip that
+      // prefix to derive the on-disk demo directory. The `/demos/` guard
+      // catches accidental absolute URLs or bare segments that would
+      // silently point to the wrong directory at runtime.
+      let demoRoute: string | undefined;
+      if (hasOwnProp(d, "route") && d.route !== undefined) {
+        if (typeof d.route !== "string" || d.route.length === 0) {
+          return {
+            kind: "malformed",
+            subkind: "shape",
+            error: `expected demos[${i}].route to be a non-empty string, got ${describeType(d.route)}`,
+          };
+        }
+        if (!d.route.startsWith("/demos/")) {
+          return {
+            kind: "malformed",
+            subkind: "shape",
+            error: `expected demos[${i}].route to start with "/demos/", got "${d.route}"`,
+          };
+        }
+        demoRoute = d.route;
+      }
+      const demoEntry: { id: DemoId; name?: string; route?: string } = {
+        id: brandedId,
+      };
+      if (demoName !== undefined) demoEntry.name = demoName;
+      if (demoRoute !== undefined) demoEntry.route = demoRoute;
+      validated.push(Object.freeze(demoEntry));
     }
     demos = Object.freeze(validated);
   }

--- a/showcase/scripts/validate-parity.ts
+++ b/showcase/scripts/validate-parity.ts
@@ -81,6 +81,24 @@ const EXIT_UNREADABLE = 3 as const;
 const EXIT_INTERNAL = 4 as const;
 
 /**
+ * Strip the leading "/demos/" prefix from a demo route and return the
+ * on-disk directory name (the segment under src/app/demos/). Returns
+ * `undefined` when the route is `undefined` OR when the resulting
+ * segment is empty (a route of exactly "/demos/" is malformed — but
+ * parseManifest already enforces a non-empty tail, so this fallback
+ * is a defence-in-depth guard, not a primary validation).
+ *
+ * Keep in sync with bundle-demo-content.ts, which applies the same
+ * route → dir transformation when copying per-demo READMEs into the
+ * bundled content payload.
+ */
+export function routeToDirName(route: string | undefined): string | undefined {
+  if (route === undefined) return undefined;
+  const stripped = route.replace(/^\/demos\//, "");
+  return stripped.length > 0 ? stripped : undefined;
+}
+
+/**
  * Literal union of every exit code `runParity` can return. Exposed so
  * in-process callers (tests, composed CLIs) can pattern-match against
  * the taxonomy without re-declaring magic numbers.
@@ -200,7 +218,7 @@ export type PackageIssue =
   | { category: "missing-manifest" }
   | { category: "unreadable-manifest"; error: string }
   | { category: "malformed-manifest"; error: string }
-  | { category: "missing-demo-dir"; demoId: string }
+  | { category: "missing-demo-dir"; demoId: string; expectedDir: string }
   | { category: "unreadable-demos-dir"; path: string; error: string }
   | { category: "unreadable-specs-dir"; path: string; error: string }
   | { category: "unreadable-qa-dir"; path: string; error: string }
@@ -234,7 +252,15 @@ export function deriveMessage(issue: PackageIssue): string {
     case "malformed-manifest":
       return `unparseable manifest.yaml: ${issue.error}`;
     case "missing-demo-dir":
-      return `demo '${issue.demoId}' declared in manifest but no src/app/demos/${issue.demoId}/ directory`;
+      // Include both the catalog id AND the expected on-disk directory
+      // because they can differ: `id` is the catalog key (matched
+      // against qa/spec filenames) while the on-disk directory comes
+      // from `demo.route` ("/demos/<dir>" → `src/app/demos/<dir>/`).
+      // Rendering only the id here hid route/id mismatches — operators
+      // saw the error but not the path the validator actually probed.
+      return issue.demoId === issue.expectedDir
+        ? `demo '${issue.demoId}' declared in manifest but no src/app/demos/${issue.expectedDir}/ directory`
+        : `demo '${issue.demoId}' declared in manifest but no src/app/demos/${issue.expectedDir}/ directory (resolved from route)`;
     case "unreadable-demos-dir":
       return `unreadable demos directory: failed to read directory ${issue.path}: ${issue.error}`;
     case "unreadable-specs-dir":
@@ -625,14 +651,25 @@ export function auditPackage(
   const specIdSet = new Set(specFiles.map((f) => f.replace(/\.spec\.ts$/, "")));
   const qaIdSet = new Set(qaFiles.map((f) => f.replace(/\.md$/, "")));
 
-  // MUST: every declared demo has a demos/<id>/ directory. Suppressed
-  // entirely when the demos/ dir itself is unreadable — a single
-  // unreadable-demos-dir MUST is clearer than N cascaded missing-demo-dir
-  // errors that all trace to the same EACCES root cause.
+  // MUST: every declared demo has a demos/<dir>/ directory. The
+  // expected directory is resolved from `demo.route` ("/demos/<dir>")
+  // when present, falling back to `demo.id` when absent. `id` is the
+  // CATALOG identifier (matched against qa/spec filenames); `route`
+  // is the URL + filesystem path. They are DELIBERATELY separate — a
+  // manifest with `id: hitl-in-chat` and `route: /demos/hitl` resolves
+  // to `src/app/demos/hitl/`. bundle-demo-content.ts uses the same
+  // idiom. Suppressed entirely when the demos/ dir itself is unreadable
+  // — a single unreadable-demos-dir MUST is clearer than N cascaded
+  // missing-demo-dir errors that all trace to the same EACCES root cause.
   if (!demosDirUnreadable) {
-    for (const id of demoIds) {
-      if (!demoDirSet.has(id)) {
-        mustErrors.push({ category: "missing-demo-dir", demoId: id });
+    for (const demo of demos) {
+      const expectedDir = routeToDirName(demo.route) ?? demo.id;
+      if (!demoDirSet.has(expectedDir)) {
+        mustErrors.push({
+          category: "missing-demo-dir",
+          demoId: demo.id,
+          expectedDir,
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary

Unblocks the `Validate Showcase` CI check which has been failing on `main` for all 17 packages (last 3 runs: 5b1a137a, eb13a8dc, bc35c2e8) with:

```
[FAIL] <pkg>: demo 'hitl-in-chat' declared in manifest but no src/app/demos/hitl-in-chat/ directory
```

Every package manifest declares `id: hitl-in-chat` with `route: /demos/hitl`, and every package has its demo files in `src/app/demos/hitl/`. The validator was using `demo.id` as the expected directory name, which is incorrect when `demo.route` deliberately points elsewhere.

## Fix

- Add optional `route` field to `ManifestDemo` (validated — must start with `/demos/` with a non-empty tail)
- Add `routeToDirName()` helper that extracts the tail segment from `demo.route`
- In `validate-parity.ts`, resolve `expectedDir = routeToDirName(demo.route) ?? demo.id` before probing `src/app/demos/<expectedDir>/`
- Expand the `missing-demo-dir` `PackageIssue` shape to carry `{ demoId, expectedDir }` for clearer error output
- Red-green regression tests in `validate-parity.test.ts` + `manifest.test.ts`

## Scope

Pure validator code — **no manifest changes, no demo directory renames, no package content changes**. 4 files changed (+314/−18) all under `showcase/scripts/`.

## Verification

- `pnpm test` in `showcase/scripts/`: 1027/1027 pass
- `pnpm tsx validate-parity.ts` against all 17 packages: **17 pass, 0 fail** (remaining 128 warnings are pre-existing and unrelated — missing QA/e2e files)

## Test plan

- [ ] CI `Validate Showcase` transitions to green
- [ ] No unrelated CI checks regress

## Not included

This PR is intentionally scoped to the validator fix only. It is cherry-picked off PR #4064 (showcase bundle-0/1 cleanup) so that `main` can unblock without waiting on that larger branch.