### PR TITLE
fix(showcase/langgraph-typescript): bind agent server to 0.0.0.0

### DIFF
--- a/showcase/packages/langgraph-typescript/entrypoint.sh
+++ b/showcase/packages/langgraph-typescript/entrypoint.sh
@@ -7,8 +7,12 @@ echo "[entrypoint] Starting LangGraph agent server on :8123..."
 echo "[entrypoint] Starting Next.js frontend..."
 echo "========================================="
 
-# Start LangGraph agent server in background
-cd /app/src/agent && npx @langchain/langgraph-cli dev --port 8123 --no-browser &
+# Start LangGraph agent server in background.
+# --host 0.0.0.0 binds IPv4 + IPv6 so the Next.js frontend can reach the agent
+# regardless of how `localhost` resolves in the container. Default is 'localhost'
+# which on modern Node resolves IPv6-first (::1), leaving the IPv4 loopback
+# unbound and causing 503s from the frontend's /api/health probe.
+cd /app/src/agent && npx @langchain/langgraph-cli dev --port 8123 --host 0.0.0.0 --no-browser &
 
 # Start Next.js frontend
 cd /app && exec npx next start --port "${PORT:-10000}"


### PR DESCRIPTION
## Summary

The `langgraph-typescript` container's agent server was binding to `localhost:8123` which resolves IPv6-first (`::1`) on modern Node. When the Next.js frontend's `/api/health` probe hit `localhost:8123`, it could resolve to IPv4 `127.0.0.1` (unbound), producing a 503 with `agent:"error"`.

## Fix

Pass `--host 0.0.0.0` to `@langchain/langgraph-cli dev` so the agent listens on both IPv4 and IPv6 loopback.

## Verification

Rebuilt and ran locally:

```
BEFORE: Server running at ::1:8123   → /api/health = 503 (agent:error)
AFTER:  Server running at 0.0.0.0:8123 → /api/health = 200 (agent:ok)
```

## Test plan

- [ ] `Validate Showcase` CI still green
- [ ] No unrelated CI regressions
- [ ] Once merged + deployed: `curl https://showcase-langgraph-typescript-production.up.railway.app/api/health` returns `agent:"ok"` consistently

## Not included

Scoped to the entrypoint fix only. Other packages' entrypoints were spot-checked and don't share this pattern (Python langgraph, mastra, ag2 etc all bind `0.0.0.0` or use frameworks that do by default).