### PR TITLE
feat(showcase): add local smoke target (aimock + 17 packages in Docker)

### DIFF
--- a/showcase/.env.example
+++ b/showcase/.env.example
@@ -5,3 +5,15 @@
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 LANGSMITH_API_KEY=
+
+# Optional: route LLM traffic through local aimock on the compose network.
+# Matches the Railway production setup where integrations hit showcase-aimock.
+# Leave unset to call real OpenAI/Anthropic directly.
+OPENAI_BASE_URL=http://aimock:4010/v1
+ANTHROPIC_BASE_URL=http://aimock:4010
+
+# Package-specific (only required for the packages that use them).
+# ms-agent-dotnet: GitHub model provider token.
+GitHubToken=
+# google-adk / gemini-based demos.
+GOOGLE_API_KEY=

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -3,6 +3,18 @@
 # Ports come from shared/local-ports.json; internal port is always 10000 (Railway convention).
 
 services:
+  aimock:
+    # Local aimock so the 17 integration containers can hit a stable LLM mock
+    # on the compose network at http://aimock:4010 instead of the prod Railway
+    # aimock (which can OOM) or direct-to-OpenAI (which costs).
+    build: ./aimock
+    image: showcase-aimock:local
+    container_name: showcase-aimock
+    env_file: .env
+    ports:
+      - "4010:4010"
+    restart: unless-stopped
+
   langgraph-python:
     build: ./packages/langgraph-python
     image: showcase-langgraph-python:local

--- a/showcase/scripts/smoke-local.sh
+++ b/showcase/scripts/smoke-local.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# End-to-end local smoke: bring up aimock + 17 showcase packages in Docker,
+# wait for health, run the integration-smoke Playwright suite against localhost,
+# print a pass/fail summary.
+#
+# Usage:
+#   scripts/smoke-local.sh                # L1-L4 all levels
+#   scripts/smoke-local.sh --level=L1     # single level (L1/L2/L3/L4)
+#   scripts/smoke-local.sh --keep         # leave containers running after
+#   scripts/smoke-local.sh --no-build     # assume images already built
+#
+# Prereqs: showcase/.env exists (copy from showcase/.env.example). Docker
+# daemon running. `pnpm install` in showcase/tests has been run once.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHOWCASE_DIR="$(dirname "$HERE")"
+
+LEVEL=""
+KEEP=0
+NO_BUILD=0
+for arg in "$@"; do
+  case "$arg" in
+    --level=L1) LEVEL="@health" ;;
+    --level=L2) LEVEL="@agent" ;;
+    --level=L3) LEVEL="@chat" ;;
+    --level=L4) LEVEL="@tools" ;;
+    --keep) KEEP=1 ;;
+    --no-build) NO_BUILD=1 ;;
+    -h|--help) sed -n '2,15p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -f "$SHOWCASE_DIR/.env" ]; then
+  echo "[smoke-local] Missing showcase/.env. Copy .env.example and fill in keys." >&2
+  exit 1
+fi
+
+if [ "$NO_BUILD" = "0" ]; then
+  echo "[smoke-local] Building + starting 18 containers (aimock + 17 packages)..."
+  "$HERE/dev-local.sh" up
+else
+  echo "[smoke-local] --no-build: assuming images present; starting containers..."
+  docker compose -f "$SHOWCASE_DIR/docker-compose.local.yml" up -d
+fi
+
+echo "[smoke-local] Waiting 20s for containers to warm..."
+sleep 20
+
+GREP_ARG=("--grep" "${LEVEL:-@health|@agent|@chat|@tools}")
+GREP_ARG+=("--grep-invert" "@starter")
+
+cd "$SHOWCASE_DIR/tests"
+EXIT=0
+LOCAL_PORTS=1 SMOKE_ALL=true npx playwright test integration-smoke \
+  "${GREP_ARG[@]}" --reporter=list || EXIT=$?
+
+if [ "$KEEP" = "0" ]; then
+  echo "[smoke-local] Tearing down..."
+  "$HERE/dev-local.sh" down
+else
+  echo "[smoke-local] --keep: containers left running."
+fi
+
+exit "$EXIT"

--- a/showcase/tests/e2e/integration-smoke.spec.ts
+++ b/showcase/tests/e2e/integration-smoke.spec.ts
@@ -17,6 +17,20 @@
 import { test, expect } from "@playwright/test";
 import { checkHealth, checkAgentEndpoint, sendChatMessage } from "./helpers";
 import registry from "../../shell/src/data/registry.json";
+import localPorts from "../../shared/local-ports.json";
+
+// LOCAL_PORTS=1 rewrites Railway backend URLs to http://localhost:<port>
+// using showcase/shared/local-ports.json. Lets smoke run against the
+// docker-compose.local.yml stack instead of Railway. Starters are skipped
+// because they're not represented in local-ports.json (local dev only
+// targets the 17 integration backends).
+const USE_LOCAL_PORTS = process.env.LOCAL_PORTS === "1";
+const rewriteBackendUrl = (slug: string, railwayUrl: string): string => {
+  if (!USE_LOCAL_PORTS) return railwayUrl;
+  const port = (localPorts as Record<string, number>)[slug];
+  if (!port) throw new Error(`LOCAL_PORTS=1 but no port for slug '${slug}'`);
+  return `http://localhost:${port}`;
+};
 
 // ---------------------------------------------------------------------------
 // Integration registry — source of truth: showcase/shell/src/data/registry.json
@@ -202,9 +216,9 @@ const INTEGRATIONS: Integration[] = [
 
 // Only test deployed integrations unless SMOKE_ALL=true
 const SMOKE_ALL = process.env.SMOKE_ALL === "true";
-const activeIntegrations = SMOKE_ALL
-  ? INTEGRATIONS
-  : INTEGRATIONS.filter((i) => i.deployed);
+const activeIntegrations = (
+  SMOKE_ALL ? INTEGRATIONS : INTEGRATIONS.filter((i) => i.deployed)
+).map((i) => ({ ...i, backendUrl: rewriteBackendUrl(i.slug, i.backendUrl) }));
 
 // ---------------------------------------------------------------------------
 // Level 1: Health checks (@health) — fast, API-only
@@ -389,6 +403,8 @@ const STARTERS: Starter[] = registry.integrations
   }));
 
 test.describe("Deployed Starters", () => {
+  // Starters don't have local-port mappings; skip them under LOCAL_PORTS=1.
+  test.skip(USE_LOCAL_PORTS, "LOCAL_PORTS=1: starters not mapped");
   for (const starter of STARTERS) {
     // Single test per starter so L2/L3 are naturally skipped when L1 fails.
     // (fullyParallel: true in playwright.config.ts overrides describe.configure serial mode)

--- a/showcase/tests/package.json
+++ b/showcase/tests/package.json
@@ -8,7 +8,11 @@
     "test:chat": "playwright test --grep @chat",
     "test:tools": "playwright test --grep @tools",
     "test:list": "playwright test --list",
-    "test:starter": "playwright test starter-smoke"
+    "test:starter": "playwright test starter-smoke",
+    "smoke:local": "../scripts/smoke-local.sh",
+    "smoke:local:L1": "../scripts/smoke-local.sh --level=L1",
+    "smoke:local:keep": "../scripts/smoke-local.sh --keep",
+    "smoke:local:nobuild": "../scripts/smoke-local.sh --no-build"
   },
   "devDependencies": {
     "@playwright/test": "1.52.0"


### PR DESCRIPTION
## Summary

Adds a one-command local smoke harness so the full 17-integration suite can be exercised against Docker on the dev machine instead of Railway. Useful when Railway is degraded (aimock OOM, rate limits, cold-start drift) or when validating changes that haven't been deployed yet.

## Usage

```bash
# one-time
cp showcase/.env.example showcase/.env   # fill in keys
pnpm --filter @showcase/e2e-smoke install

# full L1-L4 smoke
pnpm --filter @showcase/e2e-smoke smoke:local

# single level / keep containers up between runs
pnpm --filter @showcase/e2e-smoke smoke:local:L1
pnpm --filter @showcase/e2e-smoke smoke:local:keep
pnpm --filter @showcase/e2e-smoke smoke:local:nobuild
```

## What's in here

- **`docker-compose.local.yml`**: `aimock` added as 18th service → integration containers reach `http://aimock:4010` on the compose network, mirroring Railway's `showcase-aimock`.
- **`integration-smoke.spec.ts`**: `LOCAL_PORTS=1` env gates URL rewriting from `https://showcase-<slug>-production.up.railway.app` → `http://localhost:<port>` via `shared/local-ports.json`. Starters are skipped under the flag because they're not in `local-ports.json`.
- **`scripts/smoke-local.sh`**: thin orchestrator — `build → up → wait 20s → playwright → down`. Flags: `--level=L1|L2|L3|L4`, `--keep`, `--no-build`.
- **`tests/package.json`**: `pnpm smoke:local[:L1|:keep|:nobuild]` wrappers.
- **`.env.example`**: documents optional `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL` + `GitHubToken` (ms-agent-dotnet) and `GOOGLE_API_KEY` (google-adk).

## Verification

Run locally against a fresh checkout of this branch:

- `LOCAL_PORTS=1 SMOKE_ALL=true npx playwright test integration-smoke --grep @health` → **17/17 pass in 478ms**
- Full L1-L4 against the local stack → **42/51 pass** (9 failures in L3/L4 for mastra, google-adk, ms-agent-dotnet, strands, langroid, spring-ai — these are test-data / fixture gaps unrelated to this infrastructure and will be filed separately)
- `docker compose -f showcase/docker-compose.local.yml config` validates with 18 services

## Scope

Pure dev-ergonomics addition. No runtime behaviour changes in the shipped containers. `LOCAL_PORTS` is opt-in; unset = existing Railway-URL behaviour preserved.

## Test plan

- [ ] `Validate Showcase` CI still green (no package-source changes)
- [ ] No unrelated CI regressions
- [ ] Follow-up PR will investigate and fix the 9 L3/L4 failures surfaced by local smoke