### PR TITLE
chore(showcase): ratchet validate-pins baseline 111→109

### DIFF
--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
-  "validatePinsFailCount": 111,
-  "validatePinsFailHash": "77b586b74ed01f26a19814a9134f516e159c96529674eb2ba63748e60b474e03",
+  "validatePinsFailCount": 109,
+  "validatePinsFailHash": "d03716b5746ac43cd8d711fd51e866f92717e0c4abc5a99221f0c7f9f597e81d",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Why

`showcase/scripts/fail-baseline.json` drifted **below** the actual FAIL count: real pin-fix PRs have landed on `main` since the baseline was last refreshed, reducing the validate-pins FAIL set from 111 to 109 and invalidating the stored hash. The ratchet gate now rejects every PR (including ones that don't touch pins, like #4068) with a "ratchet down" instruction.

This is a pure **ratchet-down to match reality** — no policy change, no validator/workflow change, no actual pin fix.

## What

One-line update to `showcase/scripts/fail-baseline.json`:

| field | before | after |
|---|---|---|
| `validatePinsFailCount` | 111 | **109** |
| `validatePinsFailHash` | `77b586b7…b474e03` | **`d03716b5…f597e81d`** |

Values computed by running the canonical pipeline from `.github/workflows/showcase_validate.yml` ("Run validate-pins (ratchet)" step) against a clean `origin/main` worktree:

```bash
pnpm exec tsx showcase/scripts/validate-pins.ts 2> stderr
grep ^Summary stdout
# -> Summary: OK=0 SKIP=5 WARN=17 FAIL=109
grep '^\[FAIL\]' stderr | LC_ALL=C sort -u | shasum -a 256
# -> d03716b5746ac43cd8d711fd51e866f92717e0c4abc5a99221f0c7f9f597e81d
```

Matches CI run `24608764563` (PR #4068), which observed the same `FAIL=109` from a clean rebase onto `origin/main`.

## Unblocks

- #4068 (`chore/oss-alerts-validate-detail`) — currently failing `Validate Showcase` purely on this ratchet, despite only touching workflow files.
- Any other PR blocked on the same gate.

## Not in scope

- Fixing any of the 109 remaining pin-drift FAILs. That's a separate, larger effort (tracked under issue #4047).

## Test plan

- [ ] `Validate Showcase` check goes green on this PR on first run.