### PR TITLE
fix(ci): repair starter-deployed-smoke workflow (test discovery + Slack alert)

### DIFF
--- a/.github/workflows/starter_deployed_smoke.yml
+++ b/.github/workflows/starter_deployed_smoke.yml
@@ -21,6 +21,12 @@ permissions:
 jobs:
   starter-deployed-smoke:
     runs-on: ubuntu-latest
+    # Hoist the Slack webhook into an env var so step-level `if:`
+    # expressions can reference it — `secrets.*` is not a valid named
+    # value inside `if:` and causes a workflow startup failure on some
+    # event types. Matches the pattern used in showcase_validate.yml.
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
     if: >-
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
@@ -51,123 +57,120 @@ jobs:
           STARTER_SLUG: ${{ inputs.starter_slug || '' }}
           PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/results.json
 
+      # Extract the failed starters + first error line so the Slack
+      # payload is actionable at a glance rather than forcing a
+      # click-through to the workflow run. Bare "X failed" alerts bury
+      # the signal; red alerts must carry triage-ready detail per the
+      # oss-alerts policy.
+      #
+      # Writes `failed_count`, `starters`, `error_excerpt`, and
+      # `extraction_error` to $GITHUB_ENV so the Slack notify step below
+      # can reference them via `env.*` (which is valid inside
+      # `toJSON(format(...))` expressions). We deliberately do NOT fail
+      # this step on any error: all extraction branches fall back to
+      # sentinel values so the notify step still fires with best-effort
+      # content.
       - name: Extract failure details
-        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run') && env.SLACK_WEBHOOK != ''
         id: failures
         working-directory: showcase/tests
         run: |
+          set +e  # best-effort: never block the notify step below
           REPORT=test-results/results.json
+          EXTRACTION_ERROR=""
+          FAILED_COUNT=0
+          STARTERS=""
+          ERROR_EXCERPT="see workflow run for details"
+
           if [ ! -f "$REPORT" ]; then
-            echo "No JSON report found at $REPORT; writing empty summary"
-            : > /tmp/failure-summary.txt
-            echo "failed_count=0" >> "$GITHUB_OUTPUT"
-            echo "starters=" >> "$GITHUB_OUTPUT"
-            echo "extraction_error=missing_report" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Walk the playwright JSON suite tree, pull failed tests with: title, tags, first error line.
-          # Iterate all tests per spec so multi-project configs don't drop failures.
-          if ! jq -r '
-            [ .. | objects | select(.tests? and .title?) ] as $specs
-            | $specs
-            | map(
-                . as $spec
-                | ($spec.tests // [])[] as $t
-                | ($t.results // [])[-1] as $r
-                | select($r.status == "failed" or $r.status == "timedOut")
-                | {
-                    title: $spec.title,
-                    tags: ($spec.title | [scan("@[a-zA-Z0-9_-]+")]),
-                    slug: ((try ($spec.title | capture("\\[Starter\\] (?<s>[a-zA-Z0-9_-]+)").s) catch null) // ($spec.title | .[0:40]) // "unknown"),
-                    error: (
-                      ($r.error.message // $r.errors[0].message // "no error message")
-                      | gsub("\u001b\\[[0-9;?]*[A-Za-z]"; "")
-                      | split("\n")[0]
-                      | .[0:240]
-                    )
-                  }
-              )
-          ' "$REPORT" > /tmp/failures.json 2> /tmp/jq-err.log; then
-            echo "::warning::jq failed to parse $REPORT"
-            echo "jq stderr:"; cat /tmp/jq-err.log
-            echo "[]" > /tmp/failures.json
-            echo "extraction_error=jq_parse_failed" >> "$GITHUB_OUTPUT"
-          fi
-
-          TOTAL=$(jq 'length' /tmp/failures.json)
-          # Unique list of starter slugs for the header
-          STARTERS=$(jq -r '[.[].slug] | unique | map(select(. != "")) | join(", ")' /tmp/failures.json)
-
-          # Build a short human-readable summary — cap at 5 entries to avoid noisy Slack messages.
-          jq -r '
-            .[0:5][]
-            | "• *" + (.slug | if . == "" then "unknown" else . end) + "* "
-              + (if (.tags | length) > 0 then "(" + (.tags | join(" ")) + ") " else "" end)
-              + "— " + .error
-          ' /tmp/failures.json > /tmp/failure-summary.txt
-          if [ "$TOTAL" -gt 5 ]; then
-            echo "• …and $((TOTAL - 5)) more failure(s)" >> /tmp/failure-summary.txt
-          fi
-
-          echo "failed_count=${TOTAL}" >> "$GITHUB_OUTPUT"
-          {
-            echo "starters<<STARTERS_EOF"
-            echo "${STARTERS}"
-            echo "STARTERS_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build Slack payload
-        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
-        id: slack-payload
-        run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          JOB_URL="${RUN_URL}/job/${{ github.job }}"
-          STARTERS="${{ steps.failures.outputs.starters }}"
-          FAILED_COUNT="${{ steps.failures.outputs.failed_count || '0' }}"
-          EXTRACTION_ERROR="${{ steps.failures.outputs.extraction_error }}"
-
-          SLACK_MSG=$(mktemp)
-          SLACK_PAYLOAD=$(mktemp)
-
-          # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
-          # Distinguish failure modes so on-call can tell install-failed from jq-failed from zero-hits from real test failures.
-          {
-            if [ "$EXTRACTION_ERROR" = "jq_parse_failed" ]; then
-              # jq crashed trying to parse the report
-              printf ':rotating_light: *Starter Deployed Smoke Test Failed — jq parse of Playwright report failed*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
-            elif [ "$EXTRACTION_ERROR" = "missing_report" ]; then
-              # Report file never produced (pre-test stage: install, setup, playwright install, etc.)
-              printf ':rotating_light: *Starter Deployed Smoke Test Failed (pre-test stage — no JSON report produced)*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
-            elif [ "$FAILED_COUNT" = "0" ] || [ -z "$FAILED_COUNT" ]; then
-              # Report exists but jq matched zero failures — job-level error (e.g. non-zero exit without failed tests)
-              printf ':rotating_light: *Starter Deployed Smoke Test Failed (no test failures in report — check run for job-level error)*\n<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
+            # Report file never produced (pre-test stage: install,
+            # playwright install, test discovery, etc.).
+            EXTRACTION_ERROR="missing_report"
+            ERROR_EXCERPT="no JSON report produced — pre-test stage failure (install/setup/discovery)"
+          else
+            # Walk the playwright JSON suite tree, pull failed tests with:
+            # title, tags, first error line. Iterate all tests per spec
+            # so multi-project configs don't drop failures.
+            if ! jq -r '
+              [ .. | objects | select(.tests? and .title?) ] as $specs
+              | $specs
+              | map(
+                  . as $spec
+                  | ($spec.tests // [])[] as $t
+                  | ($t.results // [])[-1] as $r
+                  | select($r.status == "failed" or $r.status == "timedOut")
+                  | {
+                      title: $spec.title,
+                      tags: ($spec.title | [scan("@[a-zA-Z0-9_-]+")]),
+                      slug: ((try ($spec.title | capture("\\[Starter\\] (?<s>[a-zA-Z0-9_-]+)").s) catch null) // ($spec.title | .[0:40]) // "unknown"),
+                      error: (
+                        ($r.error.message // $r.errors[0].message // "no error message")
+                        | gsub("\u001b\\[[0-9;?]*[A-Za-z]"; "")
+                        | split("\n")[0]
+                        | .[0:240]
+                      )
+                    }
+                )
+            ' "$REPORT" > /tmp/failures.json 2> /tmp/jq-err.log; then
+              echo "::warning::jq failed to parse $REPORT"
+              echo "jq stderr:"; cat /tmp/jq-err.log
+              echo "[]" > /tmp/failures.json
+              EXTRACTION_ERROR="jq_parse_failed"
+              ERROR_EXCERPT="jq failed to parse Playwright report — check workflow log"
             else
-              HEADER=":rotating_light: *Starter Deployed Smoke Test Failed*"
-              if [ -n "$STARTERS" ]; then
-                HEADER="${HEADER} — ${STARTERS}"
+              FAILED_COUNT=$(jq 'length' /tmp/failures.json 2>/dev/null || echo 0)
+              STARTERS=$(jq -r '[.[].slug] | unique | map(select(. != "")) | join(", ")' /tmp/failures.json 2>/dev/null || echo "")
+              if [ "$FAILED_COUNT" = "0" ]; then
+                # Report exists but jq matched zero failures — job-level
+                # error (e.g. non-zero exit without failed tests).
+                EXTRACTION_ERROR="no_failures_in_report"
+                ERROR_EXCERPT="no test failures in report — job-level error, check run for details"
+              else
+                # Build first-failure excerpt: slug + first error line,
+                # capped at ~240 chars. Slack payload stays well under
+                # the budget even with JSON escaping overhead.
+                ERROR_EXCERPT=$(jq -r '
+                  .[0]
+                  | "\(.slug): \(.error)"
+                ' /tmp/failures.json 2>/dev/null | head -c 240)
+                [ -z "$ERROR_EXCERPT" ] && ERROR_EXCERPT="see workflow run for details"
               fi
-              printf '%s\n' "$HEADER"
-              printf '<%s|View run> · <%s|View job>\n' "$RUN_URL" "$JOB_URL"
-              printf '```\n'
-              cat /tmp/failure-summary.txt
-              printf '```\n'
             fi
-          } > "$SLACK_MSG"
+          fi
 
-          jq -n --rawfile text "$SLACK_MSG" '{text: $text}' > "$SLACK_PAYLOAD"
-          rm -f "$SLACK_MSG"
-          echo "payload_path=${SLACK_PAYLOAD}" >> "$GITHUB_OUTPUT"
+          # Emit to $GITHUB_ENV using heredoc delimiters so values
+          # containing `=`, quotes, or newlines don't break KEY=VALUE.
+          {
+            echo "failed_count=${FAILED_COUNT}"
+            echo "extraction_error=${EXTRACTION_ERROR}"
+            echo "starters<<EOF_STARTERS_b3f2"
+            printf '%s\n' "$STARTERS"
+            echo "EOF_STARTERS_b3f2"
+            echo "error_excerpt<<EOF_ERR_EXCERPT_b3f2"
+            printf '%s\n' "$ERROR_EXCERPT"
+            echo "EOF_ERR_EXCERPT_b3f2"
+          } >> "$GITHUB_ENV"
 
+          exit 0  # belt-and-suspenders: never propagate a failure
+
+      # Use inline `payload:` with `toJSON(format(...))` so dynamic
+      # values (starters list, error excerpt) are safely JSON-encoded —
+      # quotes/backslashes/newlines can't break the payload. This
+      # matches the pattern used in showcase_validate.yml (PR #4068) and
+      # replaces the previous `payload-file-path` approach which failed
+      # with `SlackError: Invalid input! Failed to parse file extension`
+      # because slackapi/slack-github-action@v2.1.0 requires `.json` /
+      # `.yaml` / `.yml` and `mktemp` produces extensionless files.
       - name: Alert Slack on failure
-        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run') && env.SLACK_WEBHOOK != ''
         uses: slackapi/slack-github-action@v2.1.0
-        continue-on-error: true
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload-file-path: ${{ steps.slack-payload.outputs.payload_path }}
+          payload: |
+            { "text": ${{ toJSON(format(':rotating_light: *Starter Deployed Smoke Test Failed* — {0} failure(s) in [{1}]: {2} | <https://github.com/{3}/actions/runs/{4}|View run>', env.failed_count, env.starters, env.error_excerpt, github.repository, github.run_id)) }} }
 
-      - name: Clean up Slack payload tmpfile
-        if: always() && steps.slack-payload.outputs.payload_path
-        run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
+      - name: Log (no Slack — webhook unset)
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run') && env.SLACK_WEBHOOK == ''
+        run: |
+          echo "::warning::starter_deployed_smoke failed but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."

--- a/showcase/tests/e2e/integration-smoke.spec.ts
+++ b/showcase/tests/e2e/integration-smoke.spec.ts
@@ -371,6 +371,15 @@ type RegistryIntegration = (typeof registry)["integrations"][number];
 
 const STARTER_SLUG = process.env.STARTER_SLUG;
 
+// Registry uses integration-level `deployed` as the single deployment flag.
+// An earlier iteration had `starter.deployed` as a per-starter override, but
+// the manifest→registry bundler (showcase/scripts/bundle-demo-content.ts +
+// generate-registry.ts) doesn't carry that field forward from the source YAML
+// manifests, so any value written there is dropped on regen. Gating on
+// `i.deployed === true` matches how the INTEGRATIONS array above filters
+// `activeIntegrations` and keeps both filters anchored to the same source of
+// truth. Without this, the Deployed Starters describe block yields zero tests
+// and Playwright's --grep fails with "No tests found."
 const STARTERS: Starter[] = registry.integrations
   .filter(
     (
@@ -380,7 +389,7 @@ const STARTERS: Starter[] = registry.integrations
     } =>
       Boolean(i.starter?.demo_url) &&
       (!STARTER_SLUG || i.slug === STARTER_SLUG) &&
-      (SMOKE_ALL || i.starter?.deployed === true),
+      (SMOKE_ALL || i.deployed === true),
   )
   .map((i) => ({
     slug: i.slug,


### PR DESCRIPTION
## Summary

The `Starter Deployed Smoke Tests` workflow has been red on every run since 2026-04-18 (>15 consecutive failures on main). Two independent bugs.

Failing run cited: https://github.com/CopilotKit/CopilotKit/actions/runs/24610503288

### Commit 1 — `fix(showcase): gate starter smoke tests on integration.deployed`

**Primary failure**: Playwright errored `No tests found.` against `--grep "@starter-health|@starter-agent|@starter-chat"`.

Root cause: `integration-smoke.spec.ts` filtered starters with `i.starter?.deployed === true`, but the manifest→registry bundler (`bundle-demo-content.ts` + `generate-registry.ts`) doesn't propagate that sub-field from the source YAML manifests. Commit `14537d8f3` regenerated the registry and silently dropped all `starter.deployed` values — so the filter matched zero entries, the `Deployed Starters` describe block generated zero tests, and Playwright's `--grep` had nothing to match.

Fix: gate on integration-level `i.deployed === true`, which is the single deployment flag the registry actually carries, and which the `INTEGRATIONS` array in the same file already uses. Both filters now anchor to the same source of truth.

Validated locally:
```
$ cd showcase/tests && npx playwright test e2e/integration-smoke.spec.ts \
    --grep "@starter-health|@starter-agent|@starter-chat" --list
Total: 17 tests in 1 file
```

### Commit 2 — `fix(ci): repair starter-deployed-smoke Slack alert payload`

**Secondary failure** (masked by `continue-on-error: true`): the Slack step failed with `SlackError: Invalid input! Failed to parse file extension /tmp/tmp.XXX`. `slackapi/slack-github-action@v2.1.0` rejects `payload-file-path` values without a `.json`/`.yaml`/`.yml` extension, and `mktemp` produces extensionless files. Result: smoke results never reached #oss-alerts.

Fix: switch to the inline `payload:` + `toJSON(format(...))` pattern from `showcase_validate.yml` (PR #4068, commit `d4e75958`). Same pattern; extracts failed starter slug + first error line and emits via `$GITHUB_ENV` so the notify step references them safely through `env.*`. Distinguishes four failure modes (missing_report, jq_parse_failed, no_failures_in_report, real failures) in the excerpt. `continue-on-error` and the tmp-file cleanup step are removed — no temp file to clean, and a genuine Slack failure should now surface in job status.

## Test plan

- [ ] CI on this PR goes green (checkout, npm ci, playwright install, test discovery)
- [ ] On the next failing smoke (scheduled or manual dispatch), verify:
  - [ ] #oss-alerts receives a single actionable message carrying failed-starter slug + first error line
  - [ ] No `Invalid input! Failed to parse...` error in the workflow log
- [ ] On a successful smoke, confirm no spurious Slack message is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)