### PR TITLE
ci: close showcase deploy automation gap for starters

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -402,7 +402,7 @@ jobs:
                 # Reset streak if we had a partial streak and then a non-200
                 HEALTHY_STREAK=0
               fi
-              # SUCCESS but not (yet) responding — may be sleep-on-idle waking up
+              # SUCCESS but not yet responding — app process still booting
             else
               HEALTHY_STREAK=0
             fi
@@ -418,6 +418,9 @@ jobs:
   notify:
     needs: [detect-changes, check-lockfile, build]
     if: always()
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -430,6 +433,83 @@ jobs:
           COUNT=$(echo "$MATRIX" | jq 'length')
           echo "services=$SERVICES" >> $GITHUB_OUTPUT
           echo "count=$COUNT" >> $GITHUB_OUTPUT
+
+      - name: Compute per-leg build results
+        id: legs
+        if: always() && needs.build.result == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          # The build job is a matrix with fail-fast: false, so
+          # `needs.build.result == 'failure'` can mean "ALL legs failed" or
+          # "one leg failed and N others succeeded". Without per-leg detail
+          # the notify step would say "FAILED — N service(s) targeted",
+          # falsely implying every leg failed when only one did.
+          #
+          # Query the Actions API to list every `build (<leg>)` job in this
+          # run and bucket by conclusion. Best-effort: if the API lookup
+          # fails (auth, transient 5xx), the notify step falls back to the
+          # softer "1+ of N failed" wording which doesn't lie either way.
+          set +e
+          jobs_json=$(gh api "/repos/${GH_REPO}/actions/runs/${RUN_ID}/jobs" --paginate 2>/dev/null)
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ] || [ -z "$jobs_json" ]; then
+            echo "::warning::Could not fetch per-leg job results (rc=$rc); notify will use softer wording"
+            echo "have_detail=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Matrix legs are named "build (<leg-name>)" by default. We extract
+          # the leg name from parentheses; anything that doesn't match is
+          # ignored. jq -r emits one SLUG<TAB>CONCLUSION pair per line so
+          # we can bucket in shell without re-parsing JSON.
+          pairs=$(printf '%s' "$jobs_json" | jq -r '
+            .jobs // []
+            | map(select(.name | test("^build \\(.+\\)$")))
+            | map({
+                slug: (.name | capture("^build \\((?<s>.+)\\)$").s),
+                conclusion: (.conclusion // "unknown")
+              })
+            | .[]
+            | "\(.slug)\t\(.conclusion)"
+          ' 2>/dev/null)
+          if [ -z "$pairs" ]; then
+            echo "::warning::No matrix-leg jobs found in run; notify will use softer wording"
+            echo "have_detail=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          succeeded=""
+          failed=""
+          while IFS=$'\t' read -r slug conclusion; do
+            [ -z "$slug" ] && continue
+            case "$conclusion" in
+              success) succeeded="$succeeded $slug" ;;
+              failure|cancelled|timed_out) failed="$failed $slug" ;;
+              *) ;;  # skipped/neutral/unknown — exclude from both lists
+            esac
+          done <<< "$pairs"
+
+          succeeded=$(echo "$succeeded" | xargs)
+          failed=$(echo "$failed" | xargs)
+          succeeded_count=$(echo "$succeeded" | wc -w | xargs)
+          failed_count=$(echo "$failed" | wc -w | xargs)
+
+          # Cap list length for Slack readability (same 200-char cap as
+          # services_list in the payload step).
+          succeeded_list=$(echo "$succeeded" | tr ' ' ',' | sed 's/,/, /g' | cut -c1-200)
+          failed_list=$(echo "$failed" | tr ' ' ',' | sed 's/,/, /g' | cut -c1-200)
+
+          {
+            echo "have_detail=true"
+            echo "succeeded_count=$succeeded_count"
+            echo "failed_count=$failed_count"
+            echo "succeeded_list=$succeeded_list"
+            echo "failed_list=$failed_list"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Slack payload
         id: payload
@@ -457,13 +537,12 @@ jobs:
 
           # Mid-build cancellation: the build job is a matrix over many
           # services with fail-fast: false. If ANY leg was cancelled while
-          # OTHERS completed (including the warn-not-fail health-probe
-          # timeout branch that exits 0), the aggregate rolls up to
-          # 'cancelled'. Silently skipping would hide those already-run
-          # legs. Additionally, a newer push's detect-changes is path-scoped
-          # and may not target the same services, so the cancelled leg may
-          # never be re-verified. Post a distinct muted message so humans
-          # can spot the anomaly instead of assuming green.
+          # OTHERS completed, the aggregate rolls up to 'cancelled'. Silently
+          # skipping would hide those already-run legs. Additionally, a newer
+          # push's detect-changes is path-scoped and may not target the same
+          # services, so the cancelled leg may never be re-verified. Post a
+          # distinct muted message so humans can spot the anomaly instead of
+          # assuming green.
           if [ "$BUILD" = "cancelled" ]; then
             MSG=":information_source: *Showcase deploy*: cancelled mid-matrix — newer run (or manual retrigger) continuing; inspect if issues persist"
             jq -n --arg text "$MSG | <$URL|View run>" '{text: $text}' > /tmp/slack-payload.json
@@ -490,7 +569,31 @@ jobs:
             echo "should_post=false" >> "$GITHUB_OUTPUT"
             exit 0
           else
-            MSG=":x: *Showcase deploy*: FAILED — ${COUNT} service(s) targeted (${SERVICES})"
+            # Build failed. Distinguish full failure (every leg failed) from
+            # partial failure (some legs passed, some failed). The previous
+            # wording said "FAILED — N service(s) targeted" which implied
+            # ALL N services failed when in fact only a subset did. Use the
+            # per-leg detail from steps.legs when available; fall back to a
+            # softer "1+ of N failed" phrasing if the API lookup didn't
+            # return detail (see the "Compute per-leg build results" step).
+            HAVE_DETAIL="${{ steps.legs.outputs.have_detail }}"
+            FAILED_COUNT="${{ steps.legs.outputs.failed_count }}"
+            SUCCEEDED_COUNT="${{ steps.legs.outputs.succeeded_count }}"
+            FAILED_LIST="${{ steps.legs.outputs.failed_list }}"
+            SUCCEEDED_LIST="${{ steps.legs.outputs.succeeded_list }}"
+            if [ "$HAVE_DETAIL" = "true" ] && [ -n "$FAILED_COUNT" ] && [ "$FAILED_COUNT" -gt 0 ]; then
+              if [ -n "$SUCCEEDED_COUNT" ] && [ "$SUCCEEDED_COUNT" -gt 0 ]; then
+                # Partial failure — some legs passed, some failed.
+                MSG=":x: *Showcase deploy*: ${FAILED_COUNT}/${COUNT} service(s) failed (${FAILED_LIST}) — ${SUCCEEDED_LIST} ok"
+              else
+                # All legs failed.
+                MSG=":x: *Showcase deploy*: FAILED — ${COUNT} service(s) targeted (${SERVICES})"
+              fi
+            else
+              # Softer fallback when per-leg detail isn't available — avoids
+              # the lie that "N of N failed" when we don't actually know.
+              MSG=":x: *Showcase deploy*: 1+ of ${COUNT} service(s) failed (${SERVICES} targeted)"
+            fi
           fi
 
           jq -n --arg text "$MSG | <$URL|View run>" '{text: $text}' > /tmp/slack-payload.json

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -516,9 +516,38 @@ jobs:
           failed_count=$(echo "$failed" | wc -w | xargs)
 
           # Cap list length for Slack readability (same 200-char cap as
-          # services_list in the payload step).
-          succeeded_list=$(echo "$succeeded" | tr ' ' ',' | sed 's/,/, /g' | cut -c1-200)
-          failed_list=$(echo "$failed" | tr ' ' ',' | sed 's/,/, /g' | cut -c1-200)
+          # services_list in the payload step). `cut -c1-200` used to
+          # truncate mid-slug, producing garbage like `starter-claude-sdk-pyth`;
+          # drop whole comma-separated entries instead and append a single
+          # ellipsis so truncation is legible to humans. Keeps the 200-char
+          # budget so Slack single-line formatting still fits.
+          truncate_csv() {
+            local budget=$1 input=$2 out="" item proposed
+            # Split on single space (entries come from shell word-split),
+            # then render as comma-separated.
+            for item in $input; do
+              if [ -z "$out" ]; then
+                proposed="$item"
+              else
+                proposed="$out, $item"
+              fi
+              if [ ${#proposed} -le "$budget" ]; then
+                out="$proposed"
+              else
+                if [ -z "$out" ]; then
+                  # First item already exceeds the budget — fall back to
+                  # a hard cut so we at least emit something.
+                  out=$(printf '%s' "$item" | cut -c1-"$budget")
+                else
+                  out="$out, …"
+                fi
+                break
+              fi
+            done
+            printf '%s' "$out"
+          }
+          succeeded_list=$(truncate_csv 200 "$succeeded")
+          failed_list=$(truncate_csv 200 "$failed")
 
           {
             echo "have_detail=true"
@@ -537,7 +566,35 @@ jobs:
           LOCKFILE="${{ needs.check-lockfile.result }}"
           BUILD="${{ needs.build.result }}"
           COUNT="${{ steps.summary.outputs.count }}"
-          SERVICES=$(echo "${{ steps.summary.outputs.services }}" | cut -c1-200)
+          # See truncate_csv in steps.legs for the truncation contract —
+          # drop whole entries, not mid-slug characters, then append `…`
+          # if the list exceeds the budget. Duplicate the helper inline
+          # because YAML run blocks don't share shell functions.
+          truncate_csv() {
+            local budget=$1 input=$2 out="" item proposed
+            # Input is comma-separated (jq join(", ")) — normalise to
+            # space separation for the shell word-split below.
+            local ws="${input//,/ }"
+            for item in $ws; do
+              if [ -z "$out" ]; then
+                proposed="$item"
+              else
+                proposed="$out, $item"
+              fi
+              if [ ${#proposed} -le "$budget" ]; then
+                out="$proposed"
+              else
+                if [ -z "$out" ]; then
+                  out=$(printf '%s' "$item" | cut -c1-"$budget")
+                else
+                  out="$out, …"
+                fi
+                break
+              fi
+            done
+            printf '%s' "$out"
+          }
+          SERVICES=$(truncate_csv 200 "${{ steps.summary.outputs.services }}")
 
           # Cancellations can come from concurrency group supersession (rapid
           # pushes), manual cancel via the UI, or an upstream-failure cascade.

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -483,15 +483,13 @@ jobs:
           # the leg name from parentheses; anything that doesn't match is
           # ignored. jq -r emits one SLUG<TAB>CONCLUSION pair per line so
           # we can bucket in shell without re-parsing JSON.
+          # Single-pass pipeline: iterate .jobs directly and emit on the
+          # matching branch — avoids the map-then-flatten indirection that
+          # made the previous version harder to read.
           pairs=$(printf '%s' "$jobs_json" | jq -r '
-            .jobs // []
-            | map(select(.name | test("^build \\(.+\\)$")))
-            | map({
-                slug: (.name | capture("^build \\((?<s>.+)\\)$").s),
-                conclusion: (.conclusion // "unknown")
-              })
-            | .[]
-            | "\(.slug)\t\(.conclusion)"
+            .jobs[]?
+            | select(.name | test("^build \\(.+\\)$"))
+            | "\(.name | capture("^build \\((?<s>.+)\\)$").s)\t\(.conclusion // "unknown")"
           ' 2>/dev/null)
           if [ -z "$pairs" ]; then
             echo "::warning::No matrix-leg jobs found in run; notify will use softer wording"

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -409,8 +409,11 @@ jobs:
 
             sleep 15
           done
-          echo "::warning::Service ${{ matrix.service.dispatch_name }} did not become healthy within 360s"
-          # Don't fail — sleep-on-idle services take time to wake
+          echo "::error::Service ${{ matrix.service.dispatch_name }} did not become healthy within 360s"
+          # Fail the job so Slack alerts fire — silent deploy failures
+          # should never report green. Railway is on the Pro tier and does
+          # not sleep on idle, so a persistent timeout is a real failure.
+          exit 1
 
   notify:
     needs: [detect-changes, check-lockfile, build]

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -390,7 +390,24 @@ jobs:
                 exit 1
               fi
               HEALTH_URL="https://${DOMAIN}${HEALTH_PATH}"
-              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$HEALTH_URL" 2>/dev/null || echo "000")
+              # Services like `shell` and `shell-dojolike` probe `/` (a Next.js
+              # homepage), which can transiently 5xx or bounce through a 301
+              # chain during cold starts — a single bad response would reset
+              # HEALTHY_STREAK and throw away progress. Retry the probe up to
+              # 3 times within this iteration before treating it as a genuine
+              # non-200; legitimate failures still fail because all 3 tries
+              # must return non-200.
+              HTTP_CODE="000"
+              for probe_try in 1 2 3; do
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$HEALTH_URL" 2>/dev/null || echo "000")
+                if [ "$HTTP_CODE" = "200" ]; then
+                  break
+                fi
+                if [ "$probe_try" -lt 3 ]; then
+                  echo "HTTP check: $HEALTH_URL → $HTTP_CODE (retry $probe_try/3)"
+                  sleep 2
+                fi
+              done
               echo "HTTP check: $HEALTH_URL → $HTTP_CODE"
               if [ "$HTTP_CODE" = "200" ]; then
                 HEALTHY_STREAK=$((HEALTHY_STREAK + 1))

--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -216,21 +216,66 @@ jobs:
 
           for SVC in "${SERVICES[@]}"; do
             PKG="showcase-${SVC}"
-            # Get tags for the latest version via GitHub Packages API
-            TAGS=$(gh api "/orgs/copilotkit/packages/container/${PKG}/versions?per_page=1" \
-              --jq '.[0].metadata.container.tags | join(" ")' 2>/dev/null) || true
+            # Query GHCR for the latest package version. The previous
+            # implementation used `gh api ... || true` + `[ -z "$TAGS" ]`
+            # to skip, which silently conflated three distinct cases:
+            #   - new service, not yet published (legitimate, expected)
+            #   - GHCR 404 (legitimate — same as above)
+            #   - GHCR 401/403/5xx (transient API error — NOT legitimate;
+            #     should surface so a broken drift run doesn't look clean)
+            # Split them: capture HTTP status from gh api -i, treat 200+empty
+            # and 404 as "no versions yet" (quiet continue), and warn on any
+            # other non-200 so the run log shows a ::warning:: without
+            # failing the whole drift detector over one flaky service.
+            set +e
+            API_RESPONSE=$(gh api -i "/orgs/copilotkit/packages/container/${PKG}/versions?per_page=1" 2>&1)
+            API_RC=$?
+            set -e
+            # gh api -i emits HTTP headers on stdout followed by a blank
+            # line then the body. Extract the status line (first line
+            # beginning with HTTP/) even if redirects prepended extras.
+            HTTP_STATUS=$(printf '%s\n' "$API_RESPONSE" | awk '/^HTTP\// { status=$2 } END { print status }')
+            # Body is everything after the first blank line.
+            API_BODY=$(printf '%s\n' "$API_RESPONSE" | awk 'blank { print; next } /^\r?$/ { blank=1 }')
 
-            if [ -z "$TAGS" ]; then
-              continue  # No package versions — new service, not yet built
+            if [ "$API_RC" -ne 0 ] && [ -z "$HTTP_STATUS" ]; then
+              # gh itself failed (network, missing binary) with no response
+              # at all — surface as a warning and move on. A brief outage
+              # shouldn't mark every service stale on the next clean run.
+              echo "::warning::${SVC}: gh api call failed (rc=$API_RC), skipping drift check"
+              continue
             fi
+
+            case "$HTTP_STATUS" in
+              200)
+                TAGS=$(printf '%s' "$API_BODY" | jq -r '.[0].metadata.container.tags | join(" ")' 2>/dev/null) || TAGS=""
+                if [ -z "$TAGS" ]; then
+                  echo "  ${SVC}: no package versions yet, skipping"
+                  continue
+                fi
+                ;;
+              404)
+                echo "  ${SVC}: no GHCR package yet (404), skipping"
+                continue
+                ;;
+              *)
+                # 401/403 (auth drift), 5xx (transient), any other surprise.
+                # Warn visibly but don't fail the whole drift run — one
+                # flaky service shouldn't break the monitor.
+                echo "::warning::${SVC}: GHCR returned HTTP ${HTTP_STATUS:-<no status>}, skipping"
+                continue
+                ;;
+            esac
 
             # Image is up to date if it matches EITHER the last showcase/ or
-            # examples/integrations/ commit (deploy triggers on both paths)
+            # examples/integrations/ commit (deploy triggers on both paths).
+            # Use `grep -w` (word boundary) instead of `grep` (substring)
+            # so one SHA isn't accidentally matched as a prefix of another.
             UP_TO_DATE=false
-            if [ -n "$SHOWCASE_SHA" ] && echo "$TAGS" | grep -q "$SHOWCASE_SHA"; then
+            if [ -n "$SHOWCASE_SHA" ] && echo "$TAGS" | grep -qw "$SHOWCASE_SHA"; then
               UP_TO_DATE=true
             fi
-            if [ -n "$EXAMPLES_SHA" ] && echo "$TAGS" | grep -q "$EXAMPLES_SHA"; then
+            if [ -n "$EXAMPLES_SHA" ] && echo "$TAGS" | grep -qw "$EXAMPLES_SHA"; then
               UP_TO_DATE=true
             fi
             if [ "$UP_TO_DATE" = true ]; then

--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -204,16 +204,29 @@ jobs:
           )
           # Starter slugs are derived from showcase/starters/*/ so adding a
           # new starter directory automatically extends drift detection.
-          # `template/` is scaffolding, not a deployed service.
+          # `template/` is scaffolding, not a deployed service — keep in sync
+          # with showcase/scripts/validate-workflow-starters.ts EXCLUDED_DIRS.
+          # nullglob guards against an empty showcase/starters/ tree expanding
+          # the literal "showcase/starters/*/" pattern into the iteration,
+          # which would corrupt SERVICES with a "starter-*" entry.
+          shopt -s nullglob
           for dir in showcase/starters/*/; do
             slug=$(basename "$dir")
             [ "$slug" = "template" ] && continue
             SERVICES+=("starter-$slug")
           done
-          if [ "${#SERVICES[@]}" -eq 19 ]; then
-            # 19 = non-starters only. Sparse checkout failed to populate
-            # showcase/starters/ — fail loudly instead of silently under-checking.
-            echo "::error::No starter directories found under showcase/starters/ — drift check would be incomplete"
+          shopt -u nullglob
+          # Count appended starter-* entries independently of the non-starter
+          # list size. Using a magic `-eq 19` sentinel tied us to a specific
+          # non-starter count; any add/remove there would have silently
+          # disabled this guard. `grep -c '^starter-'` stays correct under
+          # arbitrary churn to the literal non-starter list.
+          STARTER_COUNT=$(printf '%s\n' "${SERVICES[@]}" | grep -c '^starter-' || true)
+          if [ "$STARTER_COUNT" -eq 0 ]; then
+            # Sparse checkout failed to populate showcase/starters/, or every
+            # directory under it was `template/` — fail loudly instead of
+            # silently under-checking.
+            echo "::error::No starter directories found under showcase/starters/ — sparse checkout failed?"
             exit 1
           fi
           # Compare against the last commits that touched showcase-related paths,

--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -260,8 +260,15 @@ jobs:
             # and 404 as "no versions yet" (quiet continue), and warn on any
             # other non-200 so the run log shows a ::warning:: without
             # failing the whole drift detector over one flaky service.
+            # Capture stderr separately from stdout. Merging them with 2>&1
+            # can splice gh error lines (auth failures, rate limits, network
+            # errors) ahead of the HTTP header block, which then corrupts
+            # HTTP_STATUS and API_BODY parsing — a drift run can look "clean"
+            # while actually failing every call. Keep stderr in a temp file
+            # and surface it only when we need to diagnose a non-zero RC.
+            API_STDERR=$(mktemp)
             set +e
-            API_RESPONSE=$(gh api -i "/orgs/copilotkit/packages/container/${PKG}/versions?per_page=1" 2>&1)
+            API_RESPONSE=$(gh api -i "/orgs/copilotkit/packages/container/${PKG}/versions?per_page=1" 2>"$API_STDERR")
             API_RC=$?
             set -e
             # gh api -i emits HTTP headers on stdout followed by a blank
@@ -275,9 +282,12 @@ jobs:
               # gh itself failed (network, missing binary) with no response
               # at all — surface as a warning and move on. A brief outage
               # shouldn't mark every service stale on the next clean run.
-              echo "::warning::${SVC}: gh api call failed (rc=$API_RC), skipping drift check"
+              GH_ERR=$(tr '\n' ' ' < "$API_STDERR" | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
+              rm -f "$API_STDERR"
+              echo "::warning::${SVC}: gh api call failed (rc=$API_RC): ${GH_ERR:-no stderr captured}, skipping drift check"
               continue
             fi
+            rm -f "$API_STDERR"
 
             case "$HTTP_STATUS" in
               200)

--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -15,6 +15,17 @@ jobs:
       packages: read
       actions: write
     steps:
+      - name: Checkout (starters dir only)
+        # Sparse checkout of showcase/starters/ so the "Check image drift"
+        # step can enumerate starter slugs from the filesystem. This keeps
+        # the starter list a single source of truth (directory names under
+        # showcase/starters/) instead of a literal list duplicated in this
+        # workflow.
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: showcase/starters
+          sparse-checkout-cone-mode: false
+
       - name: Restore state from cache
         id: cache-restore
         uses: actions/cache/restore@v4
@@ -183,19 +194,28 @@ jobs:
 
           STALE=""
           STALE_LIST=""
+          # Non-starter services stay literal — they don't live under
+          # showcase/starters/ and each has bespoke provisioning elsewhere.
           SERVICES=(
             shell langgraph-python langgraph-typescript langgraph-fastapi
             mastra crewai-crews pydantic-ai google-adk ag2 agno llamaindex
             strands ms-agent-python ms-agent-dotnet claude-sdk-python
             claude-sdk-typescript langroid spring-ai aimock
-            starter-ag2 starter-agno starter-claude-sdk-python
-            starter-claude-sdk-typescript starter-crewai-crews
-            starter-google-adk starter-langgraph-fastapi
-            starter-langgraph-python starter-langgraph-typescript
-            starter-langroid starter-llamaindex starter-mastra
-            starter-ms-agent-dotnet starter-ms-agent-python
-            starter-pydantic-ai starter-spring-ai starter-strands
           )
+          # Starter slugs are derived from showcase/starters/*/ so adding a
+          # new starter directory automatically extends drift detection.
+          # `template/` is scaffolding, not a deployed service.
+          for dir in showcase/starters/*/; do
+            slug=$(basename "$dir")
+            [ "$slug" = "template" ] && continue
+            SERVICES+=("starter-$slug")
+          done
+          if [ "${#SERVICES[@]}" -eq 19 ]; then
+            # 19 = non-starters only. Sparse checkout failed to populate
+            # showcase/starters/ — fail loudly instead of silently under-checking.
+            echo "::error::No starter directories found under showcase/starters/ — drift check would be incomplete"
+            exit 1
+          fi
           # Compare against the last commits that touched showcase-related paths,
           # NOT main HEAD. Deploys only trigger on showcase/ and examples/integrations/
           # changes, so non-showcase commits shouldn't make images appear stale.

--- a/.github/workflows/showcase_smoke-monitor.yml
+++ b/.github/workflows/showcase_smoke-monitor.yml
@@ -188,6 +188,13 @@ jobs:
             mastra crewai-crews pydantic-ai google-adk ag2 agno llamaindex
             strands ms-agent-python ms-agent-dotnet claude-sdk-python
             claude-sdk-typescript langroid spring-ai aimock
+            starter-ag2 starter-agno starter-claude-sdk-python
+            starter-claude-sdk-typescript starter-crewai-crews
+            starter-google-adk starter-langgraph-fastapi
+            starter-langgraph-python starter-langgraph-typescript
+            starter-langroid starter-llamaindex starter-mastra
+            starter-ms-agent-dotnet starter-ms-agent-python
+            starter-pydantic-ai starter-spring-ai starter-strands
           )
           # Compare against the last commits that touched showcase-related paths,
           # NOT main HEAD. Deploys only trigger on showcase/ and examples/integrations/

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -9,6 +9,11 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".github/workflows/showcase_validate.yml"
+      # Also re-run when starter/workflow files change — the
+      # validate-workflow-starters step below verifies parity between
+      # showcase/starters/* and the SERVICES/options lists in these files.
+      - ".github/workflows/showcase_deploy.yml"
+      - ".github/workflows/showcase_smoke-monitor.yml"
   push:
     branches: [main]
     paths:
@@ -18,6 +23,8 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - ".github/workflows/showcase_validate.yml"
+      - ".github/workflows/showcase_deploy.yml"
+      - ".github/workflows/showcase_smoke-monitor.yml"
 
 # Least-privilege by default. Individual jobs/steps can widen when needed.
 # id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
@@ -174,6 +181,17 @@ jobs:
         # install; `npx tsx` could fetch a drifting version on a registry
         # cache miss.
         run: pnpm exec tsx validate-parity.ts
+
+      - name: Run validate-workflow-starters (parity with workflows)
+        working-directory: showcase/scripts
+        # Gate: for every directory under showcase/starters/ (excluding
+        # template/), verify `starter-<slug>` is registered in
+        # showcase_deploy.yml (workflow_dispatch options AND the
+        # ALL_SERVICES matrix) and in showcase_smoke-monitor.yml's
+        # SERVICES array. Catches the silent-drift failure mode where a
+        # new starter ships on disk but is invisible to deploy dispatch
+        # or drift detection.
+        run: pnpm exec tsx validate-workflow-starters.ts
 
       - name: Run validate-pins (ratchet)
         working-directory: showcase/scripts

--- a/showcase/scripts/__tests__/validate-workflow-starters.test.ts
+++ b/showcase/scripts/__tests__/validate-workflow-starters.test.ts
@@ -221,9 +221,7 @@ describe("validate-workflow-starters", () => {
         /missing from:\s+showcase_deploy\.yml workflow_dispatch/,
       );
       // Matrix source should NOT appear for mastra since it's present there
-      expect(r.stderr).not.toMatch(
-        /starter-mastra[\s\S]*ALL_SERVICES matrix/m,
-      );
+      expect(r.stderr).not.toMatch(/starter-mastra[\s\S]*ALL_SERVICES matrix/m);
     });
 
     it("exits 1 when a slug is only missing from the ALL_SERVICES matrix", () => {

--- a/showcase/scripts/__tests__/validate-workflow-starters.test.ts
+++ b/showcase/scripts/__tests__/validate-workflow-starters.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for the workflow starter-list validator.
+ *
+ * Strategy mirrors validate-parity.test.ts: build ephemeral fixture trees
+ * under per-suite tmpdirs, then invoke the validator with the
+ * VALIDATE_WORKFLOW_STARTERS_REPO_ROOT env var pointed at the fixture root.
+ * Committed fixtures aren't used because the whole point is to exercise
+ * drift scenarios (missing slugs, missing workflows) that can't safely
+ * live in the real repo tree.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+import { spawnSync } from "child_process";
+import {
+  listStarterSlugs,
+  isSlugInWorkflowDispatch,
+  isSlugInDeployMatrix,
+} from "../validate-workflow-starters.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SCRIPT = path.resolve(__dirname, "..", "validate-workflow-starters.ts");
+
+// Exit codes must stay in lockstep with the validator.
+const EXIT_OK = 0;
+const EXIT_DRIFT = 1;
+const EXIT_UNREADABLE = 3;
+
+// Minimum legal workflow_dispatch + ALL_SERVICES skeleton. Keep the shape
+// close to .github/workflows/showcase_deploy.yml so parser assumptions are
+// exercised against production-shaped YAML. Slugs are templated in per test.
+function buildDeployYaml(opts: {
+  dispatchOptions: string[];
+  matrixSlugs: string[];
+}): string {
+  const options = opts.dispatchOptions
+    .map((s) => `          - ${s}`)
+    .join("\n");
+  const matrix = opts.matrixSlugs
+    .map(
+      (s) =>
+        `            {"dispatch_name":"${s}","filter_key":"${s.replace(/-/g, "_")}","context":"showcase/starters/${s.replace(/^starter-/, "")}","image":"showcase-${s}","railway_id":"00000000-0000-0000-0000-000000000000","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},`,
+    )
+    .join("\n");
+  // The matrix is a heredoc-style embedded-JSON block inside a shell step.
+  // Preserve the trailing `]` on its own line to match the real workflow.
+  return `name: "Test Showcase Deploy"
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Service to deploy"
+        required: true
+        type: choice
+        options:
+          - all
+${options}
+      reason:
+        description: "Why"
+        type: string
+
+concurrency:
+  group: test
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build ALL_SERVICES
+        run: |
+          ALL_SERVICES='[
+${matrix}
+            {"dispatch_name":"sentinel","filter_key":"sentinel","context":".","image":"showcase-sentinel","railway_id":"x","timeout":1,"lfs":false,"build_args":"","dockerfile":"","health_path":"/"}
+          ]'
+`;
+}
+
+interface FixtureOpts {
+  starterSlugs?: readonly string[]; // directory names under showcase/starters/
+  extraDirs?: readonly string[]; // non-starter siblings (e.g. "template")
+  dispatchOptions?: readonly string[]; // list of `starter-<slug>` entries in options
+  matrixSlugs?: readonly string[]; // list of `starter-<slug>` entries in ALL_SERVICES
+  omitDeployWorkflow?: boolean; // skip writing showcase_deploy.yml entirely
+}
+
+/**
+ * Build a minimal repo-root fixture tree:
+ *   <root>/showcase/starters/<slug>/
+ *   <root>/.github/workflows/showcase_deploy.yml
+ * Returns the root so the caller can pass it via
+ * VALIDATE_WORKFLOW_STARTERS_REPO_ROOT.
+ */
+function makeFixtureRoot(opts: FixtureOpts): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vws-fixture-"));
+  const startersDir = path.join(root, "showcase", "starters");
+  fs.mkdirSync(startersDir, { recursive: true });
+  for (const slug of opts.starterSlugs ?? []) {
+    fs.mkdirSync(path.join(startersDir, slug), { recursive: true });
+  }
+  for (const extra of opts.extraDirs ?? []) {
+    fs.mkdirSync(path.join(startersDir, extra), { recursive: true });
+  }
+  if (!opts.omitDeployWorkflow) {
+    const workflowsDir = path.join(root, ".github", "workflows");
+    fs.mkdirSync(workflowsDir, { recursive: true });
+    const yaml = buildDeployYaml({
+      dispatchOptions: [...(opts.dispatchOptions ?? [])],
+      matrixSlugs: [...(opts.matrixSlugs ?? [])],
+    });
+    fs.writeFileSync(
+      path.join(workflowsDir, "showcase_deploy.yml"),
+      yaml,
+      "utf-8",
+    );
+  }
+  return root;
+}
+
+function runCli(root: string) {
+  return spawnSync("npx", ["tsx", SCRIPT], {
+    env: {
+      ...process.env,
+      VALIDATE_WORKFLOW_STARTERS_REPO_ROOT: root,
+    },
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+}
+
+describe("validate-workflow-starters", () => {
+  let roots: string[];
+
+  beforeEach(() => {
+    roots = [];
+  });
+
+  afterEach(() => {
+    for (const r of roots) {
+      fs.rmSync(r, { recursive: true, force: true });
+    }
+  });
+
+  function fixture(opts: FixtureOpts): string {
+    const r = makeFixtureRoot(opts);
+    roots.push(r);
+    return r;
+  }
+
+  describe("listStarterSlugs (pure helper)", () => {
+    it("excludes the template/ scaffolding directory", () => {
+      const root = fixture({
+        starterSlugs: ["ag2", "mastra"],
+        extraDirs: ["template"],
+      });
+      const slugs = listStarterSlugs(path.join(root, "showcase", "starters"));
+      expect(slugs).toEqual(["ag2", "mastra"]);
+      expect(slugs).not.toContain("template");
+    });
+
+    it("returns slugs sorted lexicographically for stable diff output", () => {
+      const root = fixture({
+        starterSlugs: ["zoo", "ag2", "mastra"],
+      });
+      const slugs = listStarterSlugs(path.join(root, "showcase", "starters"));
+      expect(slugs).toEqual(["ag2", "mastra", "zoo"]);
+    });
+  });
+
+  describe("isSlugInWorkflowDispatch (pure helper)", () => {
+    it("uses word-boundary matching so prefixes can't spoof presence", () => {
+      // `starter-ag2` must NOT match `starter-ag2-extended` — word-boundary
+      // anchoring is load-bearing: a regression here would let typos pass
+      // silently while the real starter stayed unregistered.
+      const yaml = buildDeployYaml({
+        dispatchOptions: ["starter-ag2-extended"],
+        matrixSlugs: ["starter-ag2-extended"],
+      });
+      expect(isSlugInWorkflowDispatch(yaml, "starter-ag2")).toBe(false);
+      expect(isSlugInWorkflowDispatch(yaml, "starter-ag2-extended")).toBe(true);
+    });
+  });
+
+  describe("isSlugInDeployMatrix (pure helper)", () => {
+    it("matches only the full dispatch_name, not substrings", () => {
+      const yaml = buildDeployYaml({
+        dispatchOptions: [],
+        matrixSlugs: ["starter-ag2-extended"],
+      });
+      expect(isSlugInDeployMatrix(yaml, "starter-ag2")).toBe(false);
+      expect(isSlugInDeployMatrix(yaml, "starter-ag2-extended")).toBe(true);
+    });
+  });
+
+  describe("CLI subprocess", () => {
+    it("exits 0 when every starter is present in both workflow locations", () => {
+      const root = fixture({
+        starterSlugs: ["ag2", "mastra"],
+        dispatchOptions: ["starter-ag2", "starter-mastra"],
+        matrixSlugs: ["starter-ag2", "starter-mastra"],
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(EXIT_OK);
+      expect(r.stdout).toMatch(/OK: all 2 starter\(s\) registered/);
+    });
+
+    it("exits 1 when a slug is only missing from workflow_dispatch options", () => {
+      const root = fixture({
+        starterSlugs: ["ag2", "mastra"],
+        dispatchOptions: ["starter-ag2"], // mastra missing here
+        matrixSlugs: ["starter-ag2", "starter-mastra"],
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(EXIT_DRIFT);
+      expect(r.stderr).toMatch(/starter-mastra/);
+      expect(r.stderr).toMatch(
+        /missing from:\s+showcase_deploy\.yml workflow_dispatch/,
+      );
+      // Matrix source should NOT appear for mastra since it's present there
+      expect(r.stderr).not.toMatch(
+        /starter-mastra[\s\S]*ALL_SERVICES matrix/m,
+      );
+    });
+
+    it("exits 1 when a slug is only missing from the ALL_SERVICES matrix", () => {
+      const root = fixture({
+        starterSlugs: ["ag2", "mastra"],
+        dispatchOptions: ["starter-ag2", "starter-mastra"],
+        matrixSlugs: ["starter-ag2"], // mastra missing here
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(EXIT_DRIFT);
+      expect(r.stderr).toMatch(/starter-mastra/);
+      expect(r.stderr).toMatch(
+        /missing from:\s+showcase_deploy\.yml ALL_SERVICES matrix/,
+      );
+    });
+
+    it("exits 1 and names both sources when a slug is missing from both", () => {
+      const root = fixture({
+        starterSlugs: ["ag2", "mastra"],
+        dispatchOptions: ["starter-ag2"],
+        matrixSlugs: ["starter-ag2"],
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(EXIT_DRIFT);
+      // Both sources should be listed for mastra
+      expect(r.stderr).toMatch(
+        /starter-mastra[\s\S]*workflow_dispatch[\s\S]*ALL_SERVICES matrix/m,
+      );
+    });
+
+    it("exits 3 when showcase/starters/ is empty (refuses trivial pass)", () => {
+      const root = fixture({
+        starterSlugs: [],
+        dispatchOptions: [],
+        matrixSlugs: [],
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(
+        EXIT_UNREADABLE,
+      );
+      expect(r.stderr).toMatch(/No starter directories found/);
+      expect(r.stderr).toMatch(/Refusing to pass trivially/);
+    });
+
+    it("ignores template/ scaffolding (doesn't flag it as missing)", () => {
+      const root = fixture({
+        starterSlugs: ["ag2"],
+        extraDirs: ["template"],
+        // Note: "starter-template" is NOT in either workflow location.
+        // A naive enumerator would flag it as drift; the validator must not.
+        dispatchOptions: ["starter-ag2"],
+        matrixSlugs: ["starter-ag2"],
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(EXIT_OK);
+      expect(r.stdout).not.toMatch(/starter-template/);
+      expect(r.stderr).not.toMatch(/starter-template/);
+    });
+
+    it("rejects substring-spoof: starter-ag2 missing while starter-ag2-extended is present", () => {
+      // Critical regression guard: if a typo gets registered as a different
+      // slug (starter-ag2-extended) the validator must NOT silently accept
+      // starter-ag2 as covered just because its characters appear inside
+      // the longer slug. Word-boundary anchoring keeps this honest.
+      const root = fixture({
+        starterSlugs: ["ag2"],
+        dispatchOptions: ["starter-ag2-extended"],
+        matrixSlugs: ["starter-ag2-extended"],
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(EXIT_DRIFT);
+      expect(r.stderr).toMatch(/starter-ag2\b/);
+    });
+
+    it("exits 3 when showcase_deploy.yml is missing entirely", () => {
+      const root = fixture({
+        starterSlugs: ["ag2"],
+        omitDeployWorkflow: true,
+      });
+      const r = runCli(root);
+      expect(r.status, (r.stdout ?? "") + (r.stderr ?? "")).toBe(
+        EXIT_UNREADABLE,
+      );
+      expect(r.stderr).toMatch(/Cannot read/);
+      expect(r.stderr).toMatch(/showcase_deploy\.yml/);
+    });
+  });
+});

--- a/showcase/scripts/tsconfig.json
+++ b/showcase/scripts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2022", "dom"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["*.ts", "create-integration/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules", "__tests__"]
+}

--- a/showcase/scripts/validate-workflow-starters.ts
+++ b/showcase/scripts/validate-workflow-starters.ts
@@ -34,12 +34,15 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // ROOT = showcase/ (NOT the repo root). This script lives at
 // showcase/scripts/validate-workflow-starters.ts.
-const SHOWCASE_ROOT = path.resolve(__dirname, "..");
 // Resolve the repo root so we can find .github/workflows/ even when
 // invoked from any cwd. Override via env var for tests / fixtures.
+// VALIDATE_WORKFLOW_STARTERS_REPO_ROOT overrides both STARTERS_DIR (via
+// showcase/) and DEPLOY_WORKFLOW (via .github/) so a single env var
+// re-homes every filesystem read.
 const REPO_ROOT =
   process.env.VALIDATE_WORKFLOW_STARTERS_REPO_ROOT ??
-  path.resolve(SHOWCASE_ROOT, "..");
+  path.resolve(__dirname, "..", "..");
+const SHOWCASE_ROOT = path.join(REPO_ROOT, "showcase");
 
 const STARTERS_DIR = path.join(SHOWCASE_ROOT, "starters");
 const DEPLOY_WORKFLOW = path.join(

--- a/showcase/scripts/validate-workflow-starters.ts
+++ b/showcase/scripts/validate-workflow-starters.ts
@@ -1,0 +1,262 @@
+/**
+ * Workflow Starter-List Validator
+ *
+ * The starter slug list is duplicated across multiple workflow sources
+ * (showcase_deploy.yml's workflow_dispatch options, its ALL_SERVICES matrix,
+ * the SERVICES array in showcase_smoke-monitor.yml, etc.). A silent drift
+ * — e.g. adding a new starter directory under `showcase/starters/` but
+ * forgetting to register it in a workflow — would mean the service is
+ * deployable in theory but invisible to drift detection or dispatch UI.
+ *
+ * This script is the parity gate: for every directory under
+ * `showcase/starters/` (excluding `template/`), it verifies that
+ * `starter-<slug>` appears in:
+ *   - .github/workflows/showcase_deploy.yml `workflow_dispatch.inputs.service.options`
+ *   - .github/workflows/showcase_deploy.yml ALL_SERVICES matrix (`dispatch_name`)
+ *   - .github/workflows/showcase_smoke-monitor.yml SERVICES array
+ *
+ * Any missing registration is reported with an explicit fix hint.
+ *
+ * Usage (from showcase/ or showcase/scripts/):
+ *   pnpm exec tsx validate-workflow-starters.ts
+ *   VALIDATE_WORKFLOW_STARTERS_REPO_ROOT=/tmp/fixture pnpm exec tsx validate-workflow-starters.ts
+ *
+ * Exit codes (aligned with the other validate-* scripts):
+ *   0 — parity OK
+ *   1 — drift detected (one or more starters missing from a workflow)
+ *   3 — unreadable (workflow file or starters dir missing)
+ *   4 — internal error
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// ROOT = showcase/ (NOT the repo root). This script lives at
+// showcase/scripts/validate-workflow-starters.ts.
+const SHOWCASE_ROOT = path.resolve(__dirname, "..");
+// Resolve the repo root so we can find .github/workflows/ even when
+// invoked from any cwd. Override via env var for tests / fixtures.
+const REPO_ROOT =
+  process.env.VALIDATE_WORKFLOW_STARTERS_REPO_ROOT ??
+  path.resolve(SHOWCASE_ROOT, "..");
+
+const STARTERS_DIR = path.join(SHOWCASE_ROOT, "starters");
+const DEPLOY_WORKFLOW = path.join(
+  REPO_ROOT,
+  ".github/workflows/showcase_deploy.yml",
+);
+const MONITOR_WORKFLOW = path.join(
+  REPO_ROOT,
+  ".github/workflows/showcase_smoke-monitor.yml",
+);
+
+// Directories under showcase/starters/ that are NOT starter services
+// (skeletons, scaffolding, docs). Add new non-service siblings here.
+const EXCLUDED_DIRS = new Set(["template"]);
+
+const EXIT_OK = 0 as const;
+const EXIT_DRIFT = 1 as const;
+const EXIT_UNREADABLE = 3 as const;
+const EXIT_INTERNAL = 4 as const;
+
+interface MissingEntry {
+  readonly slug: string;
+  readonly missingFrom: readonly string[];
+}
+
+/**
+ * Enumerate the set of starter slugs on disk. Each entry is the bare
+ * directory name (NOT prefixed with `starter-`) so callers can compose
+ * the workflow-registered name themselves.
+ */
+export function listStarterSlugs(startersDir: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(startersDir, { withFileTypes: true });
+  } catch (err) {
+    throw new Error(
+      `Cannot read starters directory ${startersDir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => !EXCLUDED_DIRS.has(name))
+    .sort();
+}
+
+/**
+ * Read a file and return its text. Throws with the source path on
+ * failure so operators don't have to hunt for which file was missing.
+ */
+function readTextFile(absPath: string): string {
+  try {
+    return fs.readFileSync(absPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Cannot read ${absPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+/**
+ * Regex-based presence checks — not a full YAML parse. The workflow
+ * files are authoritative for their own syntax (github actions parses
+ * them), so we only need to confirm the literal slug appears in the
+ * expected region(s). We use word-boundary (`\b`) anchoring so
+ * `starter-ag2` can't accidentally match `starter-ag2-extended`.
+ */
+export function isSlugInWorkflowDispatch(
+  deployYaml: string,
+  registeredName: string,
+): boolean {
+  // Match `- starter-<slug>` as a standalone list entry under
+  // `options:`. We locate the options block first so a stray mention
+  // elsewhere (comments, ALL_SERVICES) can't spoof the check.
+  const optionsMatch = deployYaml.match(
+    /inputs:\s*\n\s+service:[\s\S]*?options:\s*\n([\s\S]*?)(?:^\S|\n\s*\w+:\s*\n\s{6,}\w+:|\nconcurrency:)/m,
+  );
+  if (!optionsMatch) return false;
+  const optionsBlock = optionsMatch[1];
+  const entryPattern = new RegExp(
+    `^\\s*-\\s+${escapeRegex(registeredName)}\\s*$`,
+    "m",
+  );
+  return entryPattern.test(optionsBlock);
+}
+
+export function isSlugInDeployMatrix(
+  deployYaml: string,
+  registeredName: string,
+): boolean {
+  // ALL_SERVICES entries look like:
+  //   {"dispatch_name":"starter-foo","filter_key":"starter_foo",...}
+  const pattern = new RegExp(
+    `"dispatch_name"\\s*:\\s*"${escapeRegex(registeredName)}"`,
+  );
+  return pattern.test(deployYaml);
+}
+
+export function isSlugInSmokeMonitorServices(
+  monitorYaml: string,
+  registeredName: string,
+): boolean {
+  // The SERVICES=( ... ) bash array in the "Check image drift" step.
+  // Match as a word so `starter-ag2` does not match `starter-ag2-anything`.
+  const servicesMatch = monitorYaml.match(/SERVICES=\(([\s\S]*?)\)/);
+  if (!servicesMatch) return false;
+  const block = servicesMatch[1];
+  const pattern = new RegExp(`(?:^|\\s)${escapeRegex(registeredName)}(?=\\s|$)`);
+  return pattern.test(block);
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Main entry point. Returns an exit code — the CLI wrapper below calls
+ * process.exit with the return value. Kept pure to make testing easy.
+ */
+export function runValidation(): number {
+  let slugs: string[];
+  try {
+    slugs = listStarterSlugs(STARTERS_DIR);
+  } catch (err) {
+    console.error(
+      `[validate-workflow-starters] ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return EXIT_UNREADABLE;
+  }
+
+  if (slugs.length === 0) {
+    console.error(
+      `[validate-workflow-starters] No starter directories found under ${STARTERS_DIR} ` +
+        `(excluding ${[...EXCLUDED_DIRS].join(", ")}). Refusing to pass trivially.`,
+    );
+    return EXIT_UNREADABLE;
+  }
+
+  let deployYaml: string;
+  let monitorYaml: string;
+  try {
+    deployYaml = readTextFile(DEPLOY_WORKFLOW);
+    monitorYaml = readTextFile(MONITOR_WORKFLOW);
+  } catch (err) {
+    console.error(
+      `[validate-workflow-starters] ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return EXIT_UNREADABLE;
+  }
+
+  const missing: MissingEntry[] = [];
+  for (const slug of slugs) {
+    const registered = `starter-${slug}`;
+    const missingFrom: string[] = [];
+
+    if (!isSlugInWorkflowDispatch(deployYaml, registered)) {
+      missingFrom.push(
+        `showcase_deploy.yml workflow_dispatch.inputs.service.options`,
+      );
+    }
+    if (!isSlugInDeployMatrix(deployYaml, registered)) {
+      missingFrom.push(`showcase_deploy.yml ALL_SERVICES matrix`);
+    }
+    if (!isSlugInSmokeMonitorServices(monitorYaml, registered)) {
+      missingFrom.push(`showcase_smoke-monitor.yml SERVICES array`);
+    }
+
+    if (missingFrom.length > 0) {
+      missing.push({ slug: registered, missingFrom });
+    }
+  }
+
+  if (missing.length === 0) {
+    console.log(
+      `[validate-workflow-starters] OK: all ${slugs.length} starter(s) registered across workflows`,
+    );
+    return EXIT_OK;
+  }
+
+  console.error(
+    `[validate-workflow-starters] FAIL: ${missing.length} starter(s) missing workflow registration:`,
+  );
+  for (const entry of missing) {
+    console.error(`  - ${entry.slug}`);
+    for (const src of entry.missingFrom) {
+      console.error(`      missing from: ${src}`);
+    }
+  }
+  console.error(
+    `\nHint: add the slug to each location listed above. See existing starter entries for the shape.`,
+  );
+  return EXIT_DRIFT;
+}
+
+// CLI entry point — skipped when this module is imported by tests.
+// `import.meta.url` is a file:// URL; `process.argv[1]` is a plain path.
+if (
+  import.meta.url === `file://${process.argv[1]}` ||
+  fileURLToPath(import.meta.url) === process.argv[1]
+) {
+  try {
+    process.exit(runValidation());
+  } catch (err) {
+    console.error(
+      `[validate-workflow-starters] internal error: ${
+        err instanceof Error ? (err.stack ?? err.message) : String(err)
+      }`,
+    );
+    process.exit(EXIT_INTERNAL);
+  }
+}

--- a/showcase/scripts/validate-workflow-starters.ts
+++ b/showcase/scripts/validate-workflow-starters.ts
@@ -30,6 +30,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { parse as parseYaml } from "yaml";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // ROOT = showcase/ (NOT the repo root). This script lives at
@@ -52,6 +53,8 @@ const DEPLOY_WORKFLOW = path.join(
 
 // Directories under showcase/starters/ that are NOT starter services
 // (skeletons, scaffolding, docs). Add new non-service siblings here.
+// Keep in sync with `.github/workflows/showcase_smoke-monitor.yml` —
+// the drift detector applies the same exclusion at enumeration time.
 const EXCLUDED_DIRS = new Set(["template"]);
 
 const EXIT_OK = 0 as const;
@@ -104,45 +107,133 @@ function readTextFile(absPath: string): string {
 }
 
 /**
- * Regex-based presence checks — not a full YAML parse. The workflow
- * files are authoritative for their own syntax (github actions parses
- * them), so we only need to confirm the literal slug appears in the
- * expected region(s). We use word-boundary (`\b`) anchoring so
- * `starter-ag2` can't accidentally match `starter-ag2-extended`.
+ * Parse a workflow YAML string. Thrown errors carry the underlying
+ * parser message so CI logs identify the exact cause.
+ */
+function parseWorkflowYaml(deployYaml: string): unknown {
+  try {
+    return parseYaml(deployYaml);
+  } catch (err) {
+    throw new Error(
+      `Cannot parse showcase_deploy.yml as YAML: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+/**
+ * Navigate parsed YAML to `on.workflow_dispatch.inputs.service.options`
+ * and return the options array (as strings) or null if any hop is absent
+ * or mistyped. We accept either `on` or `true` at the top level because
+ * the YAML spec bool-coerces bare `on:` keys — the `yaml` package (like
+ * github's own parser) parses `on: { ... }` as key `true`. Real-world
+ * workflow files hit this in the wild.
+ */
+function getWorkflowDispatchOptions(parsed: unknown): string[] | null {
+  if (!parsed || typeof parsed !== "object") return null;
+  const root = parsed as Record<string, unknown>;
+  // `on:` gets YAML 1.1 bool-coerced to `true` by the `yaml` package.
+  // GitHub Actions' own parser treats the key as the literal string "on"
+  // because the workflow schema pre-binds it, but at the library level we
+  // have to look both places.
+  const onNode = (root["on"] ?? root[true as unknown as string]) as
+    | Record<string, unknown>
+    | undefined;
+  if (!onNode || typeof onNode !== "object") return null;
+  const dispatch = onNode["workflow_dispatch"];
+  if (!dispatch || typeof dispatch !== "object") return null;
+  const inputs = (dispatch as Record<string, unknown>)["inputs"];
+  if (!inputs || typeof inputs !== "object") return null;
+  const service = (inputs as Record<string, unknown>)["service"];
+  if (!service || typeof service !== "object") return null;
+  const options = (service as Record<string, unknown>)["options"];
+  if (!Array.isArray(options)) return null;
+  // options may contain non-string literals in a malformed workflow —
+  // coerce to string defensively so includes() is well-defined.
+  return options.map((v) => String(v));
+}
+
+/**
+ * Locate the shell step that builds ALL_SERVICES and return its run
+ * script body so we can extract the embedded JSON matrix. The matrix
+ * itself lives inside a bash heredoc-style single-quoted variable, so
+ * it is NOT a YAML sub-structure — we navigate to the step via YAML,
+ * then the JSON block is lifted out of the run body textually.
+ */
+function getDetectChangesRunBody(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== "object") return null;
+  const root = parsed as Record<string, unknown>;
+  const jobs = root["jobs"];
+  if (!jobs || typeof jobs !== "object") return null;
+  const detect = (jobs as Record<string, unknown>)["detect-changes"];
+  if (!detect || typeof detect !== "object") return null;
+  const steps = (detect as Record<string, unknown>)["steps"];
+  if (!Array.isArray(steps)) return null;
+  // Find any step whose run body references ALL_SERVICES — this is the
+  // step we care about. Keyed on the variable name rather than the step
+  // `name:` so renaming the step doesn't break validation.
+  for (const step of steps) {
+    if (!step || typeof step !== "object") continue;
+    const run = (step as Record<string, unknown>)["run"];
+    if (typeof run !== "string") continue;
+    if (run.includes("ALL_SERVICES")) return run;
+  }
+  return null;
+}
+
+/**
+ * Extract every `dispatch_name` value from the embedded ALL_SERVICES
+ * JSON array inside a run body. Regex scan because the JSON is
+ * interpolated inside a shell heredoc and can contain `${{ ... }}`
+ * Actions expressions that make JSON.parse unsafe — but the
+ * `"dispatch_name":"<value>"` shape is unambiguous.
+ */
+function extractDispatchNames(runBody: string): string[] {
+  const names: string[] = [];
+  const re = /"dispatch_name"\s*:\s*"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(runBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * YAML-aware presence check for workflow_dispatch options. Parses the
+ * workflow document and navigates to `on.workflow_dispatch.inputs.
+ * service.options`, then tests for exact membership. Immune to
+ * reformat / reorder / comment churn that would have defeated the
+ * previous regex-based implementation. Word-boundary semantics are
+ * preserved by `Array#includes`: "starter-ag2" is distinct from
+ * "starter-ag2-extended" at the array level.
  */
 export function isSlugInWorkflowDispatch(
   deployYaml: string,
   registeredName: string,
 ): boolean {
-  // Match `- starter-<slug>` as a standalone list entry under
-  // `options:`. We locate the options block first so a stray mention
-  // elsewhere (comments, ALL_SERVICES) can't spoof the check.
-  const optionsMatch = deployYaml.match(
-    /inputs:\s*\n\s+service:[\s\S]*?options:\s*\n([\s\S]*?)(?:^\S|\n\s*\w+:\s*\n\s{6,}\w+:|\nconcurrency:)/m,
-  );
-  if (!optionsMatch) return false;
-  const optionsBlock = optionsMatch[1];
-  const entryPattern = new RegExp(
-    `^\\s*-\\s+${escapeRegex(registeredName)}\\s*$`,
-    "m",
-  );
-  return entryPattern.test(optionsBlock);
+  const parsed = parseWorkflowYaml(deployYaml);
+  const options = getWorkflowDispatchOptions(parsed);
+  if (options === null) return false;
+  return options.includes(registeredName);
 }
 
+/**
+ * YAML-aware presence check for the ALL_SERVICES matrix. Parses the
+ * workflow, locates the `detect-changes` job's step that defines
+ * ALL_SERVICES, and extracts every `dispatch_name` from the embedded
+ * JSON via a targeted regex (full JSON.parse is unsafe because the
+ * matrix interpolates ${{ github.sha }} and similar expressions at
+ * workflow-execution time). Membership is then checked by equality.
+ */
 export function isSlugInDeployMatrix(
   deployYaml: string,
   registeredName: string,
 ): boolean {
-  // ALL_SERVICES entries look like:
-  //   {"dispatch_name":"starter-foo","filter_key":"starter_foo",...}
-  const pattern = new RegExp(
-    `"dispatch_name"\\s*:\\s*"${escapeRegex(registeredName)}"`,
-  );
-  return pattern.test(deployYaml);
-}
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parsed = parseWorkflowYaml(deployYaml);
+  const runBody = getDetectChangesRunBody(parsed);
+  if (runBody === null) return false;
+  return extractDispatchNames(runBody).includes(registeredName);
 }
 
 /**
@@ -224,11 +315,9 @@ export function runValidation(): number {
 }
 
 // CLI entry point — skipped when this module is imported by tests.
-// `import.meta.url` is a file:// URL; `process.argv[1]` is a plain path.
-if (
-  import.meta.url === `file://${process.argv[1]}` ||
-  fileURLToPath(import.meta.url) === process.argv[1]
-) {
+// `fileURLToPath(import.meta.url)` is the canonical path form on Node 20+;
+// compare directly with `process.argv[1]` which is the script path.
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
   try {
     process.exit(runValidation());
   } catch (err) {

--- a/showcase/scripts/validate-workflow-starters.ts
+++ b/showcase/scripts/validate-workflow-starters.ts
@@ -152,7 +152,9 @@ export function isSlugInSmokeMonitorServices(
   const servicesMatch = monitorYaml.match(/SERVICES=\(([\s\S]*?)\)/);
   if (!servicesMatch) return false;
   const block = servicesMatch[1];
-  const pattern = new RegExp(`(?:^|\\s)${escapeRegex(registeredName)}(?=\\s|$)`);
+  const pattern = new RegExp(
+    `(?:^|\\s)${escapeRegex(registeredName)}(?=\\s|$)`,
+  );
   return pattern.test(block);
 }
 

--- a/showcase/scripts/validate-workflow-starters.ts
+++ b/showcase/scripts/validate-workflow-starters.ts
@@ -1,21 +1,20 @@
 /**
  * Workflow Starter-List Validator
  *
- * The starter slug list is duplicated across multiple workflow sources
- * (showcase_deploy.yml's workflow_dispatch options, its ALL_SERVICES matrix,
- * the SERVICES array in showcase_smoke-monitor.yml, etc.). A silent drift
- * — e.g. adding a new starter directory under `showcase/starters/` but
- * forgetting to register it in a workflow — would mean the service is
- * deployable in theory but invisible to drift detection or dispatch UI.
+ * The starter slug list has two remaining literal copies that must stay
+ * in sync with `showcase/starters/*` on disk:
+ *   - showcase_deploy.yml workflow_dispatch.inputs.service.options
+ *     (GH Actions requires literal dropdown options; evaluated pre-checkout)
+ *   - showcase_deploy.yml ALL_SERVICES matrix (per-starter deploy metadata:
+ *     railway_id, dockerfile, health_path — can't be filesystem-derived)
  *
- * This script is the parity gate: for every directory under
- * `showcase/starters/` (excluding `template/`), it verifies that
- * `starter-<slug>` appears in:
- *   - .github/workflows/showcase_deploy.yml `workflow_dispatch.inputs.service.options`
- *   - .github/workflows/showcase_deploy.yml ALL_SERVICES matrix (`dispatch_name`)
- *   - .github/workflows/showcase_smoke-monitor.yml SERVICES array
+ * showcase_smoke-monitor.yml enumerates starters from `showcase/starters/*`
+ * at runtime (sparse checkout + bash glob), so drift there is impossible
+ * and no parity check is needed.
  *
- * Any missing registration is reported with an explicit fix hint.
+ * For every directory under `showcase/starters/` (excluding `template/`),
+ * this script verifies that `starter-<slug>` appears in both deploy.yml
+ * locations above. Missing entries are reported with explicit fix hints.
  *
  * Usage (from showcase/ or showcase/scripts/):
  *   pnpm exec tsx validate-workflow-starters.ts
@@ -46,10 +45,6 @@ const STARTERS_DIR = path.join(SHOWCASE_ROOT, "starters");
 const DEPLOY_WORKFLOW = path.join(
   REPO_ROOT,
   ".github/workflows/showcase_deploy.yml",
-);
-const MONITOR_WORKFLOW = path.join(
-  REPO_ROOT,
-  ".github/workflows/showcase_smoke-monitor.yml",
 );
 
 // Directories under showcase/starters/ that are NOT starter services
@@ -143,21 +138,6 @@ export function isSlugInDeployMatrix(
   return pattern.test(deployYaml);
 }
 
-export function isSlugInSmokeMonitorServices(
-  monitorYaml: string,
-  registeredName: string,
-): boolean {
-  // The SERVICES=( ... ) bash array in the "Check image drift" step.
-  // Match as a word so `starter-ag2` does not match `starter-ag2-anything`.
-  const servicesMatch = monitorYaml.match(/SERVICES=\(([\s\S]*?)\)/);
-  if (!servicesMatch) return false;
-  const block = servicesMatch[1];
-  const pattern = new RegExp(
-    `(?:^|\\s)${escapeRegex(registeredName)}(?=\\s|$)`,
-  );
-  return pattern.test(block);
-}
-
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -188,10 +168,8 @@ export function runValidation(): number {
   }
 
   let deployYaml: string;
-  let monitorYaml: string;
   try {
     deployYaml = readTextFile(DEPLOY_WORKFLOW);
-    monitorYaml = readTextFile(MONITOR_WORKFLOW);
   } catch (err) {
     console.error(
       `[validate-workflow-starters] ${
@@ -213,9 +191,6 @@ export function runValidation(): number {
     }
     if (!isSlugInDeployMatrix(deployYaml, registered)) {
       missingFrom.push(`showcase_deploy.yml ALL_SERVICES matrix`);
-    }
-    if (!isSlugInSmokeMonitorServices(monitorYaml, registered)) {
-      missingFrom.push(`showcase_smoke-monitor.yml SERVICES array`);
     }
 
     if (missingFrom.length > 0) {


### PR DESCRIPTION
## Summary

Two related defects in the showcase deploy pipeline let stale images sit live on Railway while Slack stayed green. This PR fixes both.

### Defect 1 — Drift detector skipped all starter services

`.github/workflows/showcase_smoke-monitor.yml` listed only 19 **package** slugs in its `SERVICES=(...)` array (ag2, mastra, llamaindex, ...). Zero **starter** slugs. As a result:

- GHCR `showcase-starter-<svc>` tags were never checked for drift.
- `gh workflow run showcase_deploy.yml -f service=starter-*` was never auto-dispatched.
- Starter services could run with weeks-old images and no alert would fire.

`showcase_deploy.yml` already supports `starter-*` dispatch names and already calls `serviceInstanceRedeploy` for any service with a `railway_id`, so no change is required there. The fix is extending `SERVICES=(...)` to include all 17 starter slugs via a sparse-checkout-driven filesystem enumeration (no more literal duplication between workflow and `showcase/starters/`).

### Defect 2 — Silent deploy failures reported green

`.github/workflows/showcase_deploy.yml` emitted `::warning::` and exited 0 when a service never returned 200 on its health path within 360s. The legacy justification (`# Don't fail — sleep-on-idle services take time to wake`) no longer applies: Railway is on the Pro tier with no sleep-on-idle, so a 6-minute failure to become healthy is a real failure. Changed to `::error::` + `exit 1`.

## Round 2 fixes

Round 2 CR raised six findings against the original smoke-monitor + validator changes. All fixed in this PR:

- **BLOCKING 1/2 — smoke-monitor guard.** Replaced the magic `-eq 19` sentinel with `grep -c '^starter-'` so adds/removes to the literal non-starter list can't silently disable the guard. Added `shopt -s nullglob` around the `showcase/starters/*/` loop so an empty starters tree no longer corrupts `SERVICES` with a `starter-*` literal.
- **BLOCKING 3 — GHCR stderr isolation.** Dropped `2>&1` on the `gh api -i` call; captured stderr to a temp file and surfaced it only when `gh` returns a non-zero RC with no HTTP status. Auth / rate-limit / network noise can no longer splice into the HTTP header block and poison `HTTP_STATUS` / `API_BODY` parsing.
- **BLOCKING 4 — validator tests.** Added `showcase/scripts/__tests__/validate-workflow-starters.test.ts` (12 specs): happy path, missing-from-options-only, missing-from-matrix-only, missing-from-both, empty starters dir (exit 3), template/ excluded, substring-spoof (starter-ag2 vs starter-ag2-extended), missing workflow file (exit 3). Also extended `VALIDATE_WORKFLOW_STARTERS_REPO_ROOT` to re-home the starters dir for testability.
- **MEDIUM 1 — YAML parsing.** Replaced the fragile regex-over-YAML options scanner with a real `yaml.parse()` + typed navigation down `on.workflow_dispatch.inputs.service.options`. ALL_SERVICES stays regex-scanned (embedded JSON in a bash heredoc, with `${{ ... }}` interpolations that aren't valid JSON pre-execution), but the surrounding step is now located via YAML.
- **MEDIUM 2 — Slack list truncation.** Replaced `cut -c1-200` with a `truncate_csv` helper that drops whole comma-separated entries until under budget and appends `…` when truncated. No more `starter-claude-sdk-pyth` mid-slug corruption.
- **MEDIUM 3 — template/ exclusion cross-references.** Both the TS validator's `EXCLUDED_DIRS` and `showcase_smoke-monitor.yml`'s `[ "$slug" = "template" ] && continue` now carry `# keep in sync with ...` comments pointing at each other.
- **NIT 2 — entry-check simplification.** Dropped the belt-and-suspenders `import.meta.url === \`file://${argv[1]}\`` branch; kept only the canonical `fileURLToPath(import.meta.url)` form.
- **NIT 3 — jq pipeline collapse.** Single-pass `.jobs[]? | select | "\(...)"` replaces the three-pass `map | map | .[]` chain in the notify step.

## Files changed

- `.github/workflows/showcase_deploy.yml` — warning → error + exit 1 on unhealthy deploy; `truncate_csv` replaces `cut -c1-200` (3 sites); single-pass jq pipeline in notify step.
- `.github/workflows/showcase_smoke-monitor.yml` — filesystem-driven `SERVICES=(...)`, starter-count guard, `nullglob` loop, stderr-isolated `gh api` call, cross-reference comment.
- `.github/workflows/showcase_validate.yml` — wires `validate-workflow-starters` into CI.
- `showcase/scripts/validate-workflow-starters.ts` — YAML-aware presence checks; env-var override homes both starters dir and workflow path.
- `showcase/scripts/tsconfig.json` — scripts-local tsconfig for LSP type resolution.
- `showcase/scripts/__tests__/validate-workflow-starters.test.ts` — 12 specs covering the full matrix of drift scenarios.

## Test plan

- [ ] Next scheduled `showcase_smoke-monitor` run includes starter services in its drift scan.
- [ ] A deliberately-unhealthy deploy (simulate by pointing health_path at a 404) fails the job and fires the Slack alert.
- [ ] `showcase_validate` CI job runs `validate-workflow-starters` and `npx vitest run scripts/__tests__/validate-workflow-starters.test.ts` green.