### PR TITLE
ci: migrate unit-test workflows to Depot runners

### DIFF
--- a/.github/workflows/e2e_examples.yml
+++ b/.github/workflows/e2e_examples.yml
@@ -25,6 +25,12 @@ env:
   NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
   NX_CI_EXECUTION_ENV: "E2E Examples"
 
+# Least-privilege by default. Individual jobs/steps can widen when needed.
+# id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -32,7 +38,7 @@ concurrency:
 jobs:
   examples:
     name: ${{ matrix.example }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/test_doc-examples.yml
+++ b/.github/workflows/test_doc-examples.yml
@@ -6,9 +6,15 @@ on:
     branches: [main]
     paths: ["docs/**"]
 
+# Least-privilege by default. Individual jobs/steps can widen when needed.
+# id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   validate-model-names:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +27,7 @@ jobs:
       - run: pnpm tsx scripts/validate-doc-model-names.ts
 
   doc-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     needs: validate-model-names
     steps:

--- a/.github/workflows/test_runtime-servers.yml
+++ b/.github/workflows/test_runtime-servers.yml
@@ -19,6 +19,12 @@ on:
         default: "main"
         type: string
 
+# Least-privilege by default. Individual jobs/steps can widen when needed.
+# id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,7 +32,7 @@ concurrency:
 jobs:
   node:
     name: "runtime / node"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -63,7 +69,7 @@ jobs:
 
   bun:
     name: "runtime / bun"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/test_unit-python-sdk.yml
+++ b/.github/workflows/test_unit-python-sdk.yml
@@ -12,13 +12,19 @@ on:
       - "sdk-python/**"
       - ".github/workflows/test_unit-python-sdk.yml"
 
+# Least-privilege by default. Individual jobs/steps can widen when needed.
+# id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -26,6 +26,12 @@ env:
   NX_CI_EXECUTION_ID: ${{ github.head_ref }}-${{ github.sha }}-${{ github.run_attempt }}
   NX_CI_EXECUTION_ENV: "Unit Tests"
 
+# Least-privilege by default. Individual jobs/steps can widen when needed.
+# id-token: write is required for Depot OIDC auth (runs-on: depot-ubuntu-*).
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -33,7 +39,7 @@ concurrency:
 jobs:
   unit:
     name: "unit"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why

CopilotKit has an unlimited Depot Startup plan, and standard GitHub runners
(`ubuntu-latest`) have been amplifying the vitest birpc `onTaskUpdate`
timeout bug on subprocess-heavy unit-test suites (see #4081). Depot runners
give us consistent runner quality and persistent caches for the test
workflows, matching what we already do on the showcase side.

## What

Flipped 5 workflows from `runs-on: ubuntu-latest` to
`runs-on: depot-ubuntu-24.04-4`, one commit per workflow:

- `.github/workflows/test_unit.yml`
- `.github/workflows/test_unit-python-sdk.yml`
- `.github/workflows/e2e_examples.yml`
- `.github/workflows/test_doc-examples.yml`
- `.github/workflows/test_runtime-servers.yml`

Each workflow also gets a top-level `permissions:` block with
`contents: read` + `id-token: write`, matching the pattern established in
`showcase_validate.yml`. `id-token: write` is required for Depot OIDC auth.

No test steps, timeouts, caching, or step order changed — the migration is
strictly a runner flip + permissions block addition.

4-core (`depot-ubuntu-24.04-4`) was chosen to match the existing precedent
in `showcase_validate.yml` / `showcase_drift-report.yml`. None of the
migrated jobs configure `--max-workers` or similar flags that would justify
an 8-core runner; the win here is runner quality, not raw core count.

## Reference

Extends the pattern established by #4018, which shipped
`showcase_validate.yml` and `showcase_drift-report.yml` on Depot runners
earlier today.

## Verification

- `actionlint` diff-clean: all warnings on touched files are pre-existing
  (shellcheck info on unrelated lines) or the expected "unknown label"
  warning on the Depot custom runner label — identical to the accepted
  state of `showcase_validate.yml` on main.
- Depot OIDC permission block matches the pattern used in
  `showcase_validate.yml`.

## Test plan

- [ ] CI green on this PR's own `unit (20.x / 22.x / 24.x)` matrix
- [ ] No new Depot OIDC errors in run logs
- [ ] `onTaskUpdate` timeout from #4081 no longer fires on the Depot runs