### PR TITLE
chore(showcase/scripts): bump vitest 3 → 4.1.3 to fix birpc onTaskUpdate timeout

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2893,8 +2893,8 @@ importers:
         specifier: ^2.4.9
         version: 2.4.9
       vitest:
-        specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@1.8.0))(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        specifier: ^4.1.3
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@3.2.4(vitest@4.1.3))(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -34029,6 +34029,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@18.19.130)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@vitest/mocker@4.1.3(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
@@ -47684,6 +47692,36 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 18.19.130
+      '@vitest/coverage-v8': 3.2.4(vitest@4.1.3)
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.3(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@3.2.4(vitest@4.1.3))(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.11
       '@vitest/coverage-v8': 3.2.4(vitest@4.1.3)
       jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:

--- a/showcase/scripts/package.json
+++ b/showcase/scripts/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/prompts": "^2.4.9",
-    "vitest": "^3.0.0"
+    "vitest": "^4.1.3"
   }
 }


### PR DESCRIPTION
## Problem

`showcase/scripts` test runs intermittently fail with birpc `onTaskUpdate` timeouts, caused by an upstream bug in vitest 3.x's subprocess reporter transport ([vitest-dev/vitest#8164](https://github.com/vitest-dev/vitest/issues/8164)). Fix landed upstream in [#8297](https://github.com/vitest-dev/vitest/pull/8297), shipped in v4.0.0-beta.4+.

## Why this is safe

- **Blast radius is this one package.** Root `package.json` already declares `"vitest": "^4.1.3"`. The only holdout was `showcase/scripts/package.json` at `"vitest": "^3.0.0"`. All 10 subprocess-spawning test files in the monorepo live in `showcase/scripts/__tests__/` — zero elsewhere — so this is the only package actually affected by the bug.
- **Zero vitest API breaks in the diff.** Spot-checked: no `vi.mock`, no `expect.extend`, no `.concurrent`, no snapshots, no coverage config, no custom reporters. Only `vi.spyOn` (unchanged in v4) and standard `describe`/`it`/`expect`.
- **Pool config unchanged.** `pool: 'forks'` + `fileParallelism` behave identically in v3 and v4.
- **Lockfile diff is minimal.** Only `showcase/scripts` import resolution changes + a new `@vitest/mocker@4.1.3` snapshot. No other package was edited; no other package's resolution changed. vitest 3.2.4 and 2.1.9 continue to resolve side-by-side for the packages that still pin them.

## Verification

3 consecutive `pnpm nx run @copilotkit/showcase-scripts:test --skip-nx-cache` runs on Node 20.20.2:

| Run | Result | Wall time | Tests |
|-----|--------|-----------|-------|
| 1 | green | 34.45s | 1061/1061 |
| 2 | green | 29.64s | 1061/1061 |
| 3 | green | 29.46s | 1061/1061 |

Zero `onTaskUpdate` errors, zero unhandled exceptions across all three runs.

## Test plan

- [ ] CI unit(20.x) green — this has been the red one on recent PRs due to this exact bug
- [ ] CI unit(22.x) green
- [ ] CI unit(24.x) green

## Relationship to #4081

Complementary, not overlapping. #4081 splits / isolates the showcase-scripts test suite as a workaround at the Nx/pool-config layer. This PR fixes the root cause in the test runner itself. Once this merges, the `onTaskUpdate` failures #4081 has been chasing should clear; #4081 can then rebase on a clean main and its remaining work (the split/isolation improvements) can be evaluated on its own merits rather than as a bug workaround.