### PR TITLE
ci: probe only /api/health in starter smoke test

### DIFF
--- a/showcase/tests/e2e/helpers.ts
+++ b/showcase/tests/e2e/helpers.ts
@@ -34,13 +34,24 @@ export interface ChatResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Try multiple health endpoint paths, return the first that responds 200.
+ * Probe the health endpoint(s) and return the first 200 response.
+ *
+ * Defaults to `/api/health` only — the standard Next.js convention used by
+ * all deployed showcase backends and starters. Historically this helper also
+ * fell back to `/health`, but every starter now mounts `/api/health` and the
+ * fallback masked legitimate 5xx responses (a 503 "agent degraded" on
+ * `/api/health` would be hidden behind the subsequent 404 from the non-
+ * existent `/health`, reporting the misleading `path=/health` in failures).
+ *
+ * Callers that need to probe a different path (e.g. local Docker starters
+ * with a custom health route) can pass an explicit `paths` array.
+ *
  * Supports retries with delay for cold-start scenarios (e.g. Railway starters).
  */
 export async function checkHealth(
   request: APIRequestContext,
   baseUrl: string,
-  paths: string[] = ["/api/health", "/health"],
+  paths: string[] = ["/api/health"],
   retries: number = 0,
   retryDelayMs: number = 15_000,
 ): Promise<HealthCheckResult> {


### PR DESCRIPTION
## Summary

The Deployed Starters smoke test is falsely reporting `status=404 path=/health` for every starter whose agent process is degraded. The reported path is misleading — it's just the last path probed before the test gave up. The real upstream is a 503 on `/api/health`.

## Root cause

`checkHealth()` in `showcase/tests/e2e/helpers.ts` defaulted to probing `[\"/api/health\", \"/health\"]` in sequence. All deployed starters and showcase backends serve their health endpoint at `/api/health` (standard Next.js convention). `/health` returns a Next.js 404 HTML page.

When `/api/health` returns a legitimate 5xx (e.g. 503 `\"agent degraded\"`), the helper's `res.ok()` check is false, so it falls through to probe `/health`, gets a 404, and reports that as `lastResult`. The Slack alert then reads `path=/health` and implies a route-missing bug, hiding the real 503.

Verified with live probes:
- Healthy starter `/api/health` → `200 {\"status\":\"ok\",...}`
- Degraded starter `/api/health` → `503 {\"status\":\"degraded\",\"agent\":\"error\",...}`
- Either starter `/health` → `404` (Next.js not-found page)

## Fix (Shape A — remove the fallback)

Change the default `paths` argument from `[\"/api/health\", \"/health\"]` to `[\"/api/health\"]`. No fallback. The reported status and body are the actual `/api/health` response.

- `starter-smoke.spec.ts` passes an explicit `paths` argument and is unaffected.
- `integration-smoke.spec.ts` L1 health check targets `/api/health` on all deployed backends (verified live on langgraph-python and mastra).

## Out of scope

15/17 starters currently return 503 because their agent processes are failing. That's a separate investigation — this PR is purely about making the smoke alert accurate so that investigation can proceed per-service.

## Evidence runs (all same failure mode tonight)

- https://github.com/CopilotKit/CopilotKit/actions/runs/24619147643
- https://github.com/CopilotKit/CopilotKit/actions/runs/24618944101
- https://github.com/CopilotKit/CopilotKit/actions/runs/24617315522

## Test plan

- [ ] Next scheduled smoke run surfaces `status=503 path=/api/health` for the 15 degraded starters (agent-down state, clearly attributable)
- [ ] Healthy starters (langgraph-python, one other) continue to pass L1
- [ ] `starter-smoke.spec.ts` (local Docker starters) unaffected — still uses explicit `starter.healthPaths`