### PR TITLE
fix(showcase): raise /api/smoke upstream timeout from 25s to 45s

### DIFF
--- a/showcase/packages/ag2/src/app/api/smoke/route.ts
+++ b/showcase/packages/ag2/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "ag2";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/agno/src/app/api/smoke/route.ts
+++ b/showcase/packages/agno/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "agno";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/claude-sdk-python/src/app/api/smoke/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "claude-sdk-python";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/claude-sdk-typescript/src/app/api/smoke/route.ts
+++ b/showcase/packages/claude-sdk-typescript/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "claude-sdk-typescript";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/crewai-crews/src/app/api/smoke/route.ts
+++ b/showcase/packages/crewai-crews/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "crewai-crews";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/google-adk/src/app/api/smoke/route.ts
+++ b/showcase/packages/google-adk/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "google-adk";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/langgraph-fastapi/src/app/api/smoke/route.ts
+++ b/showcase/packages/langgraph-fastapi/src/app/api/smoke/route.ts
@@ -4,7 +4,7 @@ const INTEGRATION_SLUG = "langgraph-fastapi";
 const LANGGRAPH_URL = process.env.AGENT_URL || "http://localhost:8123";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();

--- a/showcase/packages/langgraph-python/src/app/api/smoke/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/smoke/route.ts
@@ -5,7 +5,7 @@ const LANGGRAPH_URL =
   process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();

--- a/showcase/packages/langgraph-typescript/src/app/api/smoke/route.ts
+++ b/showcase/packages/langgraph-typescript/src/app/api/smoke/route.ts
@@ -5,7 +5,7 @@ const LANGGRAPH_URL =
   process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();

--- a/showcase/packages/langroid/src/app/api/smoke/route.ts
+++ b/showcase/packages/langroid/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "langroid";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/llamaindex/src/app/api/smoke/route.ts
+++ b/showcase/packages/llamaindex/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "llamaindex";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/mastra/src/app/api/smoke/route.ts
+++ b/showcase/packages/mastra/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "mastra";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/ms-agent-python/src/app/api/smoke/route.ts
+++ b/showcase/packages/ms-agent-python/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "ms-agent-python";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/pydantic-ai/src/app/api/smoke/route.ts
+++ b/showcase/packages/pydantic-ai/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "pydantic-ai";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/spring-ai/src/app/api/smoke/route.ts
+++ b/showcase/packages/spring-ai/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "spring-ai";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -34,7 +34,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/packages/strands/src/app/api/smoke/route.ts
+++ b/showcase/packages/strands/src/app/api/smoke/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 const INTEGRATION_SLUG = "strands";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(25000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;

--- a/showcase/scripts/create-integration/index.ts
+++ b/showcase/scripts/create-integration/index.ts
@@ -846,7 +846,7 @@ function generateSmokeRoute(args: CLIArgs): string {
 const INTEGRATION_SLUG = "${args.slug}";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export async function GET() {
     const start = Date.now();
@@ -877,7 +877,7 @@ export async function GET() {
                     forwardedProps: {},
                 },
             }),
-            signal: AbortSignal.timeout(25000),
+            signal: AbortSignal.timeout(45000),
         });
 
         const latency = Date.now() - start;


### PR DESCRIPTION
## Summary

Cold-start 502s on showcase package smoke probes (notably `agno`) consistently land just over the 25s upstream budget. The Next.js `/api/smoke` route uses `AbortSignal.timeout(25000)` to call its own `/api/copilotkit` which proxies to the Python agent which calls the LLM. On cold start, the end-to-end round-trip takes >25s and the probe aborts with `latency_ms: 25001, stage: "timeout"`, returning 502.

This PR raises the upstream budget from **25s -> 45s** across all showcase packages that exercise a full agent round-trip on smoke, and bumps Next.js `maxDuration` from 30s -> 60s so the route can actually run that long. The `create-integration` template is bumped too so new packages inherit the new budget.

The 3 `langgraph-*` routes have a different (lightweight health probe) pattern and `ms-agent-dotnet` is already at 50s — their `maxDuration` is bumped for consistency but their abort budgets are left alone.

**Evidence — agno 502 alerts tonight (PDT):**
- 18:40 PDT attempt 1 — HTTP 502 on `/api/smoke`, self-recovered
- 19:42 PDT attempt 2 — HTTP 502 on `/api/smoke`, `/api/health` already 200

Both probes had `latency_ms: 25001, stage: "timeout"` — a textbook cold-start boundary trip.

## Why 45s (not 60s or 90s)

The alert tells us the cold path lands **just over** 25s. 45s gives ~20s of headroom — enough to absorb cold starts without making slow failures look like slow successes. Tail latency beyond 45s would still alert, which is the intent. If we see tail probes >45s, we'll revisit with a post-deploy warmup ping.

## Files changed (17)

- 16 `showcase/packages/*/src/app/api/smoke/route.ts` (13 with both abort + maxDuration bumped, 3 langgraph-* with only maxDuration bumped, ms-agent-dotnet untouched)
- `showcase/scripts/create-integration/index.ts` template (new packages inherit the new budget)

## Test plan

- [ ] Deploy to Railway, observe agno `/api/smoke` no longer 502s on cold start
- [ ] Confirm other showcase services still smoke-pass
- [ ] If cold path drifts beyond 45s for any service, add a post-deploy warmup step (deferred)

Do not merge yet — pending user review.