### PR TITLE
fix(showcase): pin openai + httpx in google-adk/langroid/strands requirements

### DIFF
--- a/showcase/packages/google-adk/requirements.txt
+++ b/showcase/packages/google-adk/requirements.txt
@@ -5,3 +5,8 @@ pydantic
 google-adk
 google-genai
 ag-ui-adk
+# generate_a2ui tool uses the OpenAI SDK for a secondary LLM call (A2UI
+# planner) independent of the main google-adk agent. httpx is pulled in
+# by openai but listed here so CI + container both install it deterministically.
+openai>=1.0.0
+httpx>=0.27.0

--- a/showcase/packages/langroid/requirements.txt
+++ b/showcase/packages/langroid/requirements.txt
@@ -3,3 +3,8 @@ uvicorn>=0.34.0
 langroid>=0.53.0
 ag-ui-protocol==0.1.9
 python-dotenv>=1.0.0
+# agui_adapter narrows handle_run's except clause to (openai.APIError,
+# httpx.HTTPError, asyncio.TimeoutError, pydantic.ValidationError) — the
+# module-level imports of openai + httpx need to resolve at container start.
+openai>=1.0.0
+httpx>=0.27.0

--- a/showcase/packages/strands/requirements.txt
+++ b/showcase/packages/strands/requirements.txt
@@ -5,3 +5,8 @@ strands-agents-tools>=0.2.14
 fastapi>=0.115.0
 uvicorn>=0.34.0
 python-dotenv>=1.0.1
+# generate_a2ui tool and narrowed except clauses reference openai + httpx.
+# strands-agents[OpenAI] pulls openai transitively but we pin explicitly
+# so the import works even if strands-agents changes its extras.
+openai>=1.0.0
+httpx>=0.27.0


### PR DESCRIPTION
## Summary

Hotfix for #4083 post-merge: google-adk Railway deploy crashed at startup with `ModuleNotFoundError: No module named 'openai'`. Langroid would crash on next rebuild (same issue, module-level imports). Strands is lazy-imported so was unaffected but pinned for determinism.

## Root cause

#4083 narrowed exception handlers in:
- `showcase/packages/google-adk/src/agents/main.py` (top-level `import openai`)
- `showcase/packages/langroid/src/agents/agui_adapter.py` (top-level `import openai; import httpx`)
- `showcase/packages/strands/src/agents/agent.py` (lazy `import openai as _openai_mod`)

Imports resolved locally (dev venvs have openai) and in CI (workflow pip-installs openai explicitly for tests) but each package's Dockerfile only runs `pip install -r requirements.txt` which didn't list openai/httpx.

## Fix

Add `openai>=1.0.0` + `httpx>=0.27.0` to requirements.txt for all three packages.

## Verification

- google-adk: Railway deploy `77074a16` FAILED with the traceback above; will rebuild clean with this hotfix.
- Existing unit tests cover the exception-handling paths (google-adk 42, langroid 31, strands 40+ tests).

## Test plan

- [ ] Railway redeploy of showcase-google-adk returns to healthy
- [ ] Post-merge smoke tests pass on Railway for all three packages