### PR TITLE
perf(showcase): replace recursive chown in starter Dockerfiles with COPY --chown

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -612,7 +612,10 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     Object.keys(fw.extraFiles).some((dest) => !dest.includes("/"))
       ? Object.keys(fw.extraFiles)
           .filter((dest) => !dest.includes("/"))
-          .map((dest) => `\n# Framework config\nCOPY ${dest} ./`)
+          .map(
+            (dest) =>
+              `\n# Framework config\nCOPY --chown=app:app ${dest} ./`,
+          )
           .join("")
       : "";
 
@@ -636,15 +639,19 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     const copyTargets = hasAimockToggle
       ? "agent_server.py aimock_toggle.py"
       : "agent_server.py";
-    dockerExtraCopy += `\n# FastAPI agent server entrypoint\nCOPY ${copyTargets} ./`;
+    dockerExtraCopy += `\n# FastAPI agent server entrypoint\nCOPY --chown=app:app ${copyTargets} ./`;
   }
 
   // Only langgraph starters need `/app/.langgraph_api` (langgraph_cli writes
   // scratch state there). Non-langgraph Python starters (crewai, agno, etc.)
   // never touch that dir — creating it was copy-paste residue that burned a
   // layer per image for nothing. Gate the mkdir to langgraph starters only.
+  //
+  // Ownership is assigned in the same RUN so we never pay the cost of a
+  // recursive chown over `/app` (see Dockerfile templates — every other path
+  // under `/app` lands with `--chown=app:app` at COPY time).
   const langgraphMkdir = fw.slug.startsWith("langgraph-")
-    ? "RUN mkdir -p /app/.langgraph_api\n"
+    ? "RUN mkdir -p /app/.langgraph_api && chown app:app /app/.langgraph_api\n"
     : "";
 
   const vars: Record<string, string> = {

--- a/showcase/starters/ag2/Dockerfile
+++ b/showcase/starters/ag2/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/agno/Dockerfile
+++ b/showcase/starters/agno/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-python/Dockerfile
+++ b/showcase/starters/claude-sdk-python/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-typescript/Dockerfile
+++ b/showcase/starters/claude-sdk-typescript/Dockerfile
@@ -13,25 +13,27 @@ RUN npm run build
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 # Remove nested package.json to prevent a separate package boundary that
 # confuses ESM module resolution in tsx/node — deps are already in /app/node_modules/
 RUN rm -f agent/package.json agent/package-lock.json
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
- && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
- && mkdir -p /home/app && chown app:app /home/app \
- && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/crewai-crews/Dockerfile
+++ b/showcase/starters/crewai-crews/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py aimock_toggle.py ./
+COPY --chown=app:app agent_server.py aimock_toggle.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/google-adk/Dockerfile
+++ b/showcase/starters/google-adk/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-fastapi/Dockerfile
+++ b/showcase/starters/langgraph-fastapi/Dockerfile
@@ -17,29 +17,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY src/agents/requirements.txt ./src/agents/requirements.txt
+COPY --chown=app:app src/agents/requirements.txt ./src/agents/requirements.txt
 RUN pip install --no-cache-dir -r src/agents/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY src/agents/ ./src/agents/
+COPY --chown=app:app src/agents/ ./src/agents/
 
 # Framework config
-COPY langgraph.json ./
+COPY --chown=app:app langgraph.json ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN mkdir -p /app/.langgraph_api
-RUN chown -R app:app /app
+RUN mkdir -p /app/.langgraph_api && chown app:app /app/.langgraph_api
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-python/Dockerfile
+++ b/showcase/starters/langgraph-python/Dockerfile
@@ -17,29 +17,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY src/agents/requirements.txt ./src/agents/requirements.txt
+COPY --chown=app:app src/agents/requirements.txt ./src/agents/requirements.txt
 RUN pip install --no-cache-dir -r src/agents/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY src/agents/ ./src/agents/
+COPY --chown=app:app src/agents/ ./src/agents/
 
 # Framework config
-COPY langgraph.json ./
+COPY --chown=app:app langgraph.json ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN mkdir -p /app/.langgraph_api
-RUN chown -R app:app /app
+RUN mkdir -p /app/.langgraph_api && chown app:app /app/.langgraph_api
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-typescript/Dockerfile
+++ b/showcase/starters/langgraph-typescript/Dockerfile
@@ -13,25 +13,27 @@ RUN npm run build
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 # Remove nested package.json to prevent a separate package boundary that
 # confuses ESM module resolution in tsx/node — deps are already in /app/node_modules/
 RUN rm -f agent/package.json agent/package-lock.json
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
- && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
- && mkdir -p /home/app && chown app:app /home/app \
- && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langroid/Dockerfile
+++ b/showcase/starters/langroid/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/llamaindex/Dockerfile
+++ b/showcase/starters/llamaindex/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/mastra/Dockerfile
+++ b/showcase/starters/mastra/Dockerfile
@@ -13,25 +13,27 @@ RUN npm run build
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code
-COPY src/mastra/ ./src/mastra/
+COPY --chown=app:app src/mastra/ ./src/mastra/
 # Remove nested package.json to prevent a separate package boundary that
 # confuses ESM module resolution in tsx/node — deps are already in /app/node_modules/
 RUN rm -f src/mastra/package.json src/mastra/package-lock.json
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
- && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
- && mkdir -p /home/app && chown app:app /home/app \
- && chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-dotnet/Dockerfile
+++ b/showcase/starters/ms-agent-dotnet/Dockerfile
@@ -23,21 +23,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # .NET agent
-COPY --from=dotnet-builder /agent/publish ./agent/
+COPY --chown=app:app --from=dotnet-builder /agent/publish ./agent/
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-python/Dockerfile
+++ b/showcase/starters/ms-agent-python/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/pydantic-ai/Dockerfile
+++ b/showcase/starters/pydantic-ai/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/spring-ai/Dockerfile
+++ b/showcase/starters/spring-ai/Dockerfile
@@ -38,21 +38,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Java agent
-COPY --from=java-builder /agent/target/*.jar ./agent/app.jar
+COPY --chown=app:app --from=java-builder /agent/target/*.jar ./agent/app.jar
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/strands/Dockerfile
+++ b/showcase/starters/strands/Dockerfile
@@ -17,28 +17,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY agent/requirements.txt ./agent/requirements.txt
+COPY --chown=app:app agent/requirements.txt ./agent/requirements.txt
 RUN pip install --no-cache-dir -r agent/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY agent/ ./agent/
+COPY --chown=app:app agent/ ./agent/
 
 # FastAPI agent server entrypoint
-COPY agent_server.py ./
+COPY --chown=app:app agent_server.py ./
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.dotnet
+++ b/showcase/starters/template/dockerfiles/Dockerfile.dotnet
@@ -23,21 +23,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # .NET agent
-COPY --from=dotnet-builder /agent/publish ./agent/
+COPY --chown=app:app --from=dotnet-builder /agent/publish ./agent/
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.java
+++ b/showcase/starters/template/dockerfiles/Dockerfile.java
@@ -38,21 +38,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Java agent
-COPY --from=java-builder /agent/target/*.jar ./agent/app.jar
+COPY --chown=app:app --from=java-builder /agent/target/*.jar ./agent/app.jar
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-RUN chown -R app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.python
+++ b/showcase/starters/template/dockerfiles/Dockerfile.python
@@ -17,27 +17,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY {{AGENT_DIR}}/requirements.txt ./{{AGENT_DIR}}/requirements.txt
+COPY --chown=app:app {{AGENT_DIR}}/requirements.txt ./{{AGENT_DIR}}/requirements.txt
 RUN pip install --no-cache-dir -r {{AGENT_DIR}}/requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code (self-contained — tools + data bundled inside)
-COPY {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
+COPY --chown=app:app {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
 {{DOCKER_EXTRA_COPY}}
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true)
-RUN mkdir -p /home/app && chown app:app /home/app
-{{LANGGRAPH_MKDIR}}RUN chown -R app:app /app
-USER app
+{{LANGGRAPH_MKDIR}}USER app
 
 EXPOSE 10000
 # Intentionally NOT setting `ENV NODE_ENV=production` at the image level.

--- a/showcase/starters/template/dockerfiles/Dockerfile.typescript
+++ b/showcase/starters/template/dockerfiles/Dockerfile.typescript
@@ -13,25 +13,27 @@ RUN npm run build
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
 
 # Agent code
-COPY {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
+COPY --chown=app:app {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
 # Remove nested package.json to prevent a separate package boundary that
 # confuses ESM module resolution in tsx/node — deps are already in /app/node_modules/
 RUN rm -f {{AGENT_DIR}}/package.json {{AGENT_DIR}}/package-lock.json
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
-RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
- && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
- && mkdir -p /home/app && chown app:app /home/app \
- && chown -R app:app /app
 USER app
 
 EXPOSE 10000


### PR DESCRIPTION
## Summary

Replaces `RUN chown -R app:app /app` with `COPY --chown=app:app` across all 17 starter Dockerfiles + 4 shared templates.

Every starter ended with a recursive chown over `/app`, which walks ~50k files (Next.js `node_modules` dominates) to fix ownership after the fact. Under the 23-way Depot runner fan-out used by `.github/workflows/deploy-showcase-services.yml`, that step consistently ran 5+ minutes under I/O contention — busting the **15-minute GH Actions job budget** before images could finish pushing.

Failed run this fixes: https://github.com/CopilotKit/CopilotKit/actions/runs/24621469277 (22/23 showcase services cancelled mid-push).

## What changed

- Create the `app` user right after `WORKDIR /app` in every runner stage so `--chown=app:app` resolves by name.
- Add `--chown=app:app` to every runner-stage COPY (including multi-stage `COPY --from=frontend` and `COPY --from=<agent-builder>`).
- Drop the trailing `RUN chown -R app:app /app` (or the tail of the compound RUN in the TS starters).
- For langgraph starters, fold `chown app:app /app/.langgraph_api` into the same RUN as the `mkdir`, so `langgraph_cli`'s scratch dir remains writable by the runtime user.
- Update `showcase/scripts/generate-starters.ts` so the shared templates (`Dockerfile.python/typescript/dotnet/java`) emit the new pattern. Starters are regenerated from templates.

## Local timing (Docker Desktop, single starter, no contention)

| Starter | Pre-fix | Post-fix | `chown -R` step |
| --- | --- | --- | --- |
| ag2 (Python) | 3:03 | 1:39 | 50.1s → removed |
| langgraph-fastapi | n/a | 1:41 | replaced with 0.2s targeted chown on `.langgraph_api` |
| mastra (TS) | n/a | 2:16 | removed |

The real-world win on the 23-way Depot fan-out is substantially larger than the local 50s baseline — recursive chown degrades super-linearly with concurrent I/O pressure, which is exactly what the 5+ min Depot step demonstrated.

## Smoke tests

- ag2 image: container starts clean as `app` user, all files under `/app` owned by `app:app`, `/api/health` returns 200.
- langgraph-fastapi image: `/app/.langgraph_api` exists and is owned by `app:app`.
- mastra image: builds cleanly, ownership correct.

## Test plan

- [ ] CI green (existing showcase starter smoke suite covers startup)
- [ ] Watch the next showcase deploy workflow run — expect jobs to finish well under 15m

## Not touched

No workflow files, no `examples/` Dockerfiles (none matched the problem pattern), no `chmod -R` offenders (none found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)