### PR TITLE
fix(showcase/agno): mitigate SSE stream never terminating on /api/smoke

### DIFF
--- a/showcase/packages/agno/src/app/api/smoke/route.ts
+++ b/showcase/packages/agno/src/app/api/smoke/route.ts
@@ -55,16 +55,80 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // Response is SSE stream. The agno agent is known to drop the terminal
+    // event (TEXT_MESSAGE_END / RUN_FINISHED / RUN_ERROR), leaving the stream
+    // open until the client timeout fires — which surfaces as a 502 even
+    // though the agent produced valid output. Read the stream incrementally
+    // and bail as soon as we see TEXT_MESSAGE_CONTENT with "OK" in the delta,
+    // regardless of whether the agent ever closes the stream. See PR
+    // description for root-cause details.
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no response body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let gotOk = false;
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (
+          buffer.includes('"type":"TEXT_MESSAGE_CONTENT"') &&
+          buffer.includes('"OK"')
+        ) {
+          gotOk = true;
+          // Drop the connection; don't await a stream close that may never come.
+          await reader.cancel().catch(() => {});
+          break;
+        }
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        // reader may already be released via cancel(); ignore.
+      }
+    }
+
+    const finalLatency = Date.now() - start;
+
+    if (!gotOk && buffer.length === 0) {
       return NextResponse.json(
         {
           status: "error",
           integration: INTEGRATION_SLUG,
           stage: "response_empty",
           error: "Runtime returned empty response body",
-          latency_ms: latency,
+          latency_ms: finalLatency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    if (!gotOk) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_incomplete",
+          error:
+            "Stream ended without TEXT_MESSAGE_CONTENT 'OK': " +
+            buffer.slice(0, 200),
+          latency_ms: finalLatency,
           timestamp: new Date().toISOString(),
         },
         { status: 502 },
@@ -74,7 +138,7 @@ export async function GET() {
     return NextResponse.json({
       status: "ok",
       integration: INTEGRATION_SLUG,
-      latency_ms: latency,
+      latency_ms: finalLatency,
       timestamp: new Date().toISOString(),
     });
   } catch (e: unknown) {


### PR DESCRIPTION
## Root cause

The agno agent, when driven by our `/api/copilotkit` → `agent/run` smoke payload, emits valid AG-UI SSE events:

```
data: {"type":"RUN_STARTED",...}
data: {"type":"TEXT_MESSAGE_START",...}
data: {"type":"TEXT_MESSAGE_CONTENT","delta":"OK"}
```

...and then **hangs with the connection open indefinitely** — no `TEXT_MESSAGE_END`, no `RUN_FINISHED`, no `RUN_ERROR`. `/api/health` stays 200 because it's a trivial route that never touches the agent.

For comparison, spring-ai (identical payload) closes cleanly in ~500ms; langroid/llamaindex/pydantic-ai/mastra all close cleanly in under 1.5s.

Live repro against production (before this PR):

```
$ curl -m 35 -o /dev/null -w "http:%{http_code} time:%{time_total}s\n" \
    https://showcase-agno-production.up.railway.app/api/smoke
http:200 time:20.335709s           # hits whatever timeout we've set, or times out at 25/45s
```

Direct POST to `/api/copilotkit` confirms the stream hang (observed repeatedly this afternoon):
- status 200, `RUN_STARTED` + `TEXT_MESSAGE_START` + `TEXT_MESSAGE_CONTENT "OK"`, then stream hangs until client timeout.

## Why PR #4089 (25s → 45s timeout) does not cure this

Any *finite* client timeout still produces a 502 because the server never closes the stream. Raising the timeout only changes how long we wait before the inevitable `AbortError` fires and we emit `stage:"timeout"`. This PR fixes the actual mechanism rather than stretching the window.

## Phase A (this PR) — workaround in the smoke route

`showcase/packages/agno/src/app/api/smoke/route.ts` now:

1. Opens `/api/copilotkit` and reads `res.body` incrementally with the Web Streams `getReader()` API (not `await res.text()`, which only resolves when the server closes the stream).
2. On every chunk, checks if the accumulated buffer contains both `"type":"TEXT_MESSAGE_CONTENT"` and `"OK"`. Once seen, cancels the reader and returns 200 immediately — does not wait for the (possibly never-arriving) terminal event.
3. If the stream closes naturally without `TEXT_MESSAGE_CONTENT "OK"`, returns 502 with a new `stage:"response_incomplete"` so we can distinguish this failure mode from genuine timeouts or empty responses in future alerts.

Verified via a Node repro that mirrors the new route logic against the production agno agent:

```
=== attempt 1 === status=200 closedBy=cancel-on-OK latency=8642 ms  events: RUN_STARTED,TEXT_MESSAGE_START,TEXT_MESSAGE_CONTENT
=== attempt 2 === status=200 closedBy=cancel-on-OK latency=16400 ms events: RUN_STARTED,TEXT_MESSAGE_START,TEXT_MESSAGE_CONTENT
=== attempt 3 === status=200 closedBy=cancel-on-OK latency=7659 ms  events: RUN_STARTED,TEXT_MESSAGE_START,TEXT_MESSAGE_CONTENT
```

Before the fix all three of those would have hung until timeout and returned 502.

### Scope — other packages

All 17 showcase `/api/smoke/route.ts` files use the same `await res.text()` pattern, so in principle any of them could exhibit this class of bug. In practice only agno does today:

| package | production `/api/smoke` time | status |
|---|---|---|
| agno | ~20.3s (hangs until timeout) | 502 (intermittent) |
| spring-ai | ~1.0s | 200 |
| langroid | ~0.9s | 200 |
| llamaindex | ~1.6s | 200 |
| pydantic-ai | ~0.3s | 200 |
| mastra | ~0.3s | 200 |

Leaving the other packages untouched. If/when another integration starts dropping terminal SSE events, we can generalize this pattern across all 17 routes in one sweep.

## Phase B — agno agent_server investigation (not shipped)

Read `showcase/packages/agno/src/agent_server.py` and `src/agents/main.py`. Server is a thin wrapper:

```python
agent_os = AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)])
app = agent_os.get_app()
```

The terminal-event emission lives inside the agno SDK's `agno.os.interfaces.agui.AGUI` class — third-party code, not in our tree.

Findings from a short investigation:

- We pin `agno>=1.7.8` in `requirements.txt`. Current PyPI release is **2.5.17** (major version bump since we pinned). Recent versions include `2.5.5`..`2.5.17`. No cursory evidence that the 1.x → 2.x jump fixes this specific bug.
- A quick production probe also observed a separate failure mode: some runs emit only `RUN_STARTED` + `RUN_FINISHED` with *no* `TEXT_MESSAGE_*` events at all (agent silently produces no output). Distinct from the hang-on-content case, but same user-visible result (smoke reports 502). This PR's Phase A covers both via `stage:"response_incomplete"`.
- A concrete upstream fix (upgrade to 2.x + validate, or patch AGUI + PR upstream, or wrap with a terminal-event injecting middleware) is not landable in under 30 minutes: it requires agno major-version API validation across all our demos (agentic-chat, shared-state-*, subagents, hitl, tool-rendering, gen-ui-*, a2ui), which is a full project unto itself.

Phase B is intentionally deferred to a separate follow-up once Phase A stabilizes the alerts.

## Alert references from tonight

Recovery events from the `Showcase: Smoke Monitor` workflow (these ran after agno transient recoveries matching the PDT timestamps in the alerts):

- 20:56 PDT: https://github.com/CopilotKit/CopilotKit/actions/runs/24620460742
- 22:08 PDT: https://github.com/CopilotKit/CopilotKit/actions/runs/24621551281
- 00:36 PDT: https://github.com/CopilotKit/CopilotKit/actions/runs/24623940198
- 04:46 PDT: https://github.com/CopilotKit/CopilotKit/actions/runs/24628332422

## Test plan

- [x] Confirmed production `/api/smoke` hangs 20s+ (status quo 502 loop)
- [x] Confirmed production `/api/copilotkit` POST emits valid content then hangs (matches earlier diagnostic)
- [x] Verified other integration smoke endpoints close cleanly (<1.5s) — not affected
- [x] Ran route logic (Node simulation) against production: 7-16s happy-path, zero timeouts across 3 attempts
- [ ] Once deployed, monitor next 12 hours of `Showcase: Smoke Monitor` runs for agno stability