### PR TITLE
fix(showcase/google-adk): use Gemini for A2UI planner instead of OpenAI

### DIFF
--- a/showcase/packages/google-adk/entrypoint.sh
+++ b/showcase/packages/google-adk/entrypoint.sh
@@ -15,24 +15,24 @@ set -e
 # guard runs regardless. Both layers are intentional.
 export ADK_DISABLE_PROGRESSIVE_SSE_STREAMING=1
 
-# Warn (default) or fail-fast when OPENAI_API_KEY is missing. Only
-# `generate_a2ui` depends on it; other demos (weather, sales todos,
-# query_data, search_flights, schedule_meeting) in this container continue to
-# work without it. Default behavior is warn-and-continue so operators can
-# bring the container up for non-A2UI demos. generate_a2ui itself returns a
-# structured `a2ui_llm_error` dict at request time when the key is missing,
-# so callers see a clean error surface.
+# Warn (default) or fail-fast when GOOGLE_API_KEY is missing. This package is
+# Gemini end-to-end: the primary LlmAgent uses Gemini, and the secondary
+# generate_a2ui planner call also uses google.genai. Without the key, every
+# tool call in the container will fail. Default behavior is warn-and-continue
+# so operators can still bring the container up for inspection / smoke
+# testing; generate_a2ui itself returns a structured `a2ui_llm_error` dict at
+# request time when the key is missing, so callers see a clean error surface.
 #
 # For production deployments that MUST have the key, set
-# `REQUIRE_OPENAI_API_KEY=1` to escalate to fail-fast: the entrypoint exits
+# `REQUIRE_GOOGLE_API_KEY=1` to escalate to fail-fast: the entrypoint exits
 # non-zero immediately instead of surfacing the problem lazily at request
 # time. Railway / compose overrides should set this in prod environments.
-if [ -z "${OPENAI_API_KEY:-}" ]; then
-    if [ "${REQUIRE_OPENAI_API_KEY:-0}" = "1" ]; then
-        echo "[entrypoint] FATAL: OPENAI_API_KEY not set and REQUIRE_OPENAI_API_KEY=1 — refusing to start" >&2
+if [ -z "${GOOGLE_API_KEY:-}" ]; then
+    if [ "${REQUIRE_GOOGLE_API_KEY:-0}" = "1" ]; then
+        echo "[entrypoint] FATAL: GOOGLE_API_KEY not set and REQUIRE_GOOGLE_API_KEY=1 — refusing to start" >&2
         exit 1
     fi
-    echo "[entrypoint] WARN: OPENAI_API_KEY not set — generate_a2ui demo will return a structured error at request time (other demos unaffected)" >&2
+    echo "[entrypoint] WARN: GOOGLE_API_KEY not set — all Gemini-backed tools (chat + generate_a2ui) will return structured errors at request time" >&2
 fi
 
 # Start agent backend.

--- a/showcase/packages/google-adk/playwright.config.ts
+++ b/showcase/packages/google-adk/playwright.config.ts
@@ -25,8 +25,7 @@ export default defineConfig({
         reuseExistingServer: true,
         env: {
           ...process.env,
-          OPENAI_BASE_URL: process.env.OPENAI_BASE_URL || "",
-          OPENAI_API_KEY: process.env.OPENAI_API_KEY || "",
+          GOOGLE_API_KEY: process.env.GOOGLE_API_KEY || "",
         },
       },
 });

--- a/showcase/packages/google-adk/requirements.txt
+++ b/showcase/packages/google-adk/requirements.txt
@@ -3,5 +3,8 @@ uvicorn[standard]>=0.34.0
 python-dotenv
 pydantic
 google-adk
-google-genai
+# google-genai is required by both the primary LlmAgent (via google-adk) and
+# the secondary generate_a2ui planner call. Explicit pin keeps the version
+# floor independent of google-adk's transitive resolution.
+google-genai>=0.8.0
 ag-ui-adk

--- a/showcase/packages/google-adk/src/agents/main.py
+++ b/showcase/packages/google-adk/src/agents/main.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import os
 from typing import Any, Optional, TypedDict, Union
 
-import openai
 from dotenv import load_dotenv
+from google import genai
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.tools import ToolContext
+from google.genai import errors as genai_errors
 from google.genai import types
 
 import sys
@@ -37,29 +39,37 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-# Module-level OpenAI client — lazily constructed on first use. Rebuilding the
-# client on every generate_a2ui call wastes a few ms per request and, more
-# importantly, re-runs env/credential resolution which is unnecessary.
+# Model used for the secondary A2UI planner call. Overridable via A2UI_MODEL
+# env var. gemini-2.5-flash is cheap, fast, and supports forced tool-calling
+# via ToolConfig.function_calling_config.mode="ANY".
+_DEFAULT_A2UI_MODEL = "gemini-2.5-flash"
+
+
+def _a2ui_model() -> str:
+    """Return the Gemini model for the A2UI planner, overridable via env."""
+    return os.environ.get("A2UI_MODEL") or _DEFAULT_A2UI_MODEL
+
+
+# Module-level google.genai client — lazily constructed on first use.
+# Rebuilding the client on every generate_a2ui call re-runs env/credential
+# resolution unnecessarily.
 #
 # `functools.lru_cache(maxsize=1)` provides thread-safe cache bookkeeping
 # (the dict-lookup / insertion path is guarded), but it does NOT hold a lock
 # around execution of the wrapped function body. On a cold cache, two
-# concurrent callers CAN both enter `OpenAI()` — one result wins and is
+# concurrent callers CAN both enter `genai.Client()` — one result wins and is
 # retained; the other is garbage-collected. This is acceptable here because
-# `OpenAI()` is idempotent and cheap (just reads env/config and builds a
-# client object with no network I/O), so the worst case is a single wasted
-# object construction on a race that only happens during cold start.
+# `genai.Client()` is idempotent and cheap (just reads env/config), so the
+# worst case is a single wasted object construction on a cold-start race.
 @functools.lru_cache(maxsize=1)
-def _get_openai_client():
-    """Return a memoized OpenAI client, constructing it on first call.
+def _get_genai_client():
+    """Return a memoized google.genai client, constructing it on first call.
 
     Cache bookkeeping is thread-safe via `functools.lru_cache`; see the
     module-level comment above for the cold-cache race caveat. Call
     `.cache_clear()` in tests that need to reset the memoized instance.
     """
-    from openai import OpenAI
-
-    return OpenAI()
+    return genai.Client()
 
 
 class _A2uiError(TypedDict):
@@ -70,9 +80,13 @@ class _A2uiError(TypedDict):
 
     NOTE: Identical TypedDicts live in
     `showcase/packages/strands/src/agents/agent.py` and
-    `showcase/packages/langroid/src/agents/agent.py`. Keep all three in sync —
-    any key additions / removals must land in every sibling so the A2UI error
-    surface stays consistent across showcase adapters.
+    `showcase/packages/langroid/src/agents/agent.py`. Those siblings call
+    OpenAI directly; the google-adk sibling intentionally uses google.genai
+    (forced-function-call via ToolConfig) to avoid a cross-provider openai
+    dependency in a Gemini-primary package. The ERROR SHAPE still mirrors the
+    siblings — keep all three in sync. Any key additions / removals must land
+    in every sibling so the A2UI error surface stays consistent across
+    showcase adapters.
     """
 
     error: str
@@ -158,8 +172,18 @@ def search_flights(tool_context: ToolContext, flights: list[dict]) -> dict:
 def generate_a2ui(tool_context: ToolContext) -> Union[_A2uiError, dict[str, Any]]:
     """Generate dynamic A2UI components based on the conversation.
 
-    A secondary LLM designs the UI schema and data. The result is
-    returned as an a2ui_operations container for the middleware to detect.
+    A secondary LLM designs the UI schema and data. The result is returned as
+    an a2ui_operations container for the middleware to detect. The A2UI
+    planner is a structured-output tool call that is intentionally separate
+    from the primary chat turn — the primary agent decides WHEN to invoke a
+    UI, and this call decides WHAT UI to render.
+
+    Implementation: uses `google.genai.Client.models.generate_content` with a
+    forced tool call (`tool_config.function_calling_config.mode="ANY"` +
+    `allowed_function_names=["render_a2ui"]`). This keeps the google-adk
+    package on Gemini end-to-end; the sibling strands / langroid adapters
+    use OpenAI for the equivalent call but the ERROR SHAPE and user-facing
+    contract are identical.
 
     Returns either a successful `dict[str, Any]` (the a2ui_operations
     container from `build_a2ui_operations_from_tool_call`) or an `_A2uiError`
@@ -204,7 +228,11 @@ def generate_a2ui(tool_context: ToolContext) -> Union[_A2uiError, dict[str, Any]
     # also swallow typos and programmer errors inside the body), we look the
     # attribute up via `getattr` and only run the body when present. If ADK
     # renames / drops the attribute, we log-and-skip instead of crashing.
-    conversation_messages: list[dict] = []
+    #
+    # Gemini accepts `contents=` as a list of `types.Content` with role
+    # `"user"` or `"model"` (no "system" role — system prompt goes via
+    # `system_instruction` in the GenerateContentConfig).
+    conversation_contents: list[types.Content] = []
     invocation_context = getattr(tool_context, "_invocation_context", None)
     if invocation_context is None:
         logger.debug(
@@ -223,106 +251,166 @@ def generate_a2ui(tool_context: ToolContext) -> Union[_A2uiError, dict[str, Any]
                             if hasattr(part, "text") and part.text:
                                 text_parts.append(part.text)
                         if text_parts:
-                            oai_role = "assistant" if role_str == "model" else "user"
-                            conversation_messages.append({"role": oai_role, "content": "".join(text_parts)})
+                            conversation_contents.append(
+                                types.Content(
+                                    role=role_str,
+                                    parts=[types.Part(text="".join(text_parts))],
+                                )
+                            )
 
-    tool_schema = {
-        "type": "function",
-        "function": {
-            "name": "render_a2ui",
-            "description": "Render a dynamic A2UI v0.9 surface.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "surfaceId": {"type": "string"},
-                    "catalogId": {"type": "string"},
-                    "components": {"type": "array", "items": {"type": "object"}},
-                    "data": {"type": "object"},
-                },
-                "required": ["surfaceId", "catalogId", "components"],
+    # Build the render_a2ui function declaration. `parametersJsonSchema` lets
+    # us pass a raw JSON schema dict directly — google.genai converts it
+    # internally — instead of constructing a `types.Schema` object tree.
+    render_a2ui_declaration = types.FunctionDeclaration(
+        name="render_a2ui",
+        description="Render a dynamic A2UI v0.9 surface.",
+        parametersJsonSchema={
+            "type": "object",
+            "properties": {
+                "surfaceId": {"type": "string"},
+                "catalogId": {"type": "string"},
+                "components": {"type": "array", "items": {"type": "object"}},
+                "data": {"type": "object"},
             },
+            "required": ["surfaceId", "catalogId", "components"],
         },
-    }
+    )
+    render_a2ui_tool = types.Tool(function_declarations=[render_a2ui_declaration])
 
-    llm_messages: list[dict] = [
-        {"role": "system", "content": context_text or "Generate a useful dashboard UI."},
-    ]
-    llm_messages.extend(conversation_messages)
+    # Force the model to call render_a2ui. mode="ANY" + allowed_function_names
+    # constrains the model to exactly one of the listed tools; with a single
+    # entry that's equivalent to OpenAI's tool_choice={"type": "function",
+    # "function": {"name": "render_a2ui"}}.
+    tool_config = types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY",
+            allowed_function_names=["render_a2ui"],
+        ),
+    )
 
-    # Wrap the OpenAI call so expected transport / auth / rate-limit failures
+    generate_config = types.GenerateContentConfig(
+        tools=[render_a2ui_tool],
+        tool_config=tool_config,
+        system_instruction=context_text or "Generate a useful dashboard UI.",
+    )
+
+    # Wrap the Gemini call so expected transport / auth / rate-limit failures
     # do not bubble up through the ADK tool machinery as uncaught exceptions.
     # Return a structured error with remediation instead — the LLM can surface
-    # this to the user. We deliberately narrow the except to the openai
+    # this to the user. We deliberately narrow the except to the google.genai
     # exception hierarchy: programmer errors (AttributeError, TypeError from
-    # bad call shape, etc.) should propagate so they are caught in test and
+    # bad call shape, etc.) should propagate so they are caught in tests and
     # not silently masked as an LLM error.
     #
-    # `openai.OpenAIError` is the SDK's base class for ALL errors, including
-    # both `APIError` subclasses (RateLimitError, APIConnectionError,
-    # AuthenticationError, BadRequestError) AND config-time failures raised
-    # from `OpenAI()` construction when `OPENAI_API_KEY` is unset/malformed —
-    # which are NOT `APIError` subclasses. Catching only `APIError` would let
-    # the constructor's error escape. `_get_openai_client()` therefore sits
-    # inside the try block, and `openai.OpenAIError` is in the except tuple.
-    # Mirrors the strands sibling agent's exception scope.
+    # `genai_errors.APIError` is the base class for `ClientError` (4xx) and
+    # `ServerError` (5xx). Listing all three is belt-and-suspenders in case
+    # the hierarchy changes; `APIError` alone catches both today. Config-time
+    # failures from `genai.Client()` construction (e.g. missing
+    # `GOOGLE_API_KEY`) can raise either `ValueError` or `genai_errors.*`
+    # depending on the SDK path, so `_get_genai_client()` sits inside the try
+    # block and `ValueError` is also in the except tuple.
     try:
-        client = _get_openai_client()
-        response = client.chat.completions.create(
-            model="gpt-4.1",
-            messages=llm_messages,
-            tools=[tool_schema],
-            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
+        client = _get_genai_client()
+        response = client.models.generate_content(
+            model=_a2ui_model(),
+            contents=conversation_contents or None,
+            config=generate_config,
         )
     except (
-        openai.OpenAIError,
-        openai.APIError,
-        openai.APIConnectionError,
-        openai.AuthenticationError,
-        openai.RateLimitError,
+        genai_errors.APIError,
+        genai_errors.ClientError,
+        genai_errors.ServerError,
+        ValueError,
     ) as exc:
-        logger.exception("generate_a2ui: OpenAI API call failed")
+        logger.exception("generate_a2ui: Gemini API call failed")
         return _a2ui_error(
             error="a2ui_llm_error",
-            message=f"Secondary A2UI LLM call failed: {exc.__class__.__name__}",
+            message=f"Secondary A2UI LLM call failed: {exc.__class__.__name__}: {exc}",
             remediation=(
-                "Verify OPENAI_API_KEY is set and the OpenAI service is reachable. "
+                "Verify GOOGLE_API_KEY is set and the Gemini service is reachable. "
                 "See server logs for the full traceback."
             ),
         )
 
-    if not response.choices:
-        logger.warning("generate_a2ui: OpenAI response contained no choices")
+    # Read the function call back from the first candidate's first part.
+    # Gemini returns `candidates[].content.parts[].function_call` with `.args`
+    # already parsed into a dict (no JSON-decode step required). mode="ANY"
+    # with allowed_function_names should guarantee exactly one function_call,
+    # but we still defend against empty candidates / empty parts / non-
+    # function-call parts in case the model returns a refusal or the SDK
+    # shape drifts.
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        logger.warning("generate_a2ui: Gemini response contained no candidates")
         return _a2ui_error(
             error="a2ui_empty_response",
-            message="Secondary A2UI LLM returned no choices.",
-            remediation="Retry; if this persists, check OpenAI status.",
+            message="Secondary A2UI LLM returned no candidates.",
+            remediation="Retry; if this persists, check Gemini service status.",
         )
 
-    tool_calls = response.choices[0].message.tool_calls
-    if not tool_calls:
+    first_content = getattr(candidates[0], "content", None)
+    parts = getattr(first_content, "parts", None) or [] if first_content else []
+    if not parts:
+        logger.warning("generate_a2ui: Gemini response had no parts in first candidate")
+        return _a2ui_error(
+            error="a2ui_empty_response",
+            message="Secondary A2UI LLM returned no parts.",
+            remediation="Retry; if this persists, check Gemini service status.",
+        )
+
+    function_call = None
+    for part in parts:
+        fc = getattr(part, "function_call", None)
+        if fc is not None and getattr(fc, "name", None) == "render_a2ui":
+            function_call = fc
+            break
+
+    if function_call is None:
         logger.warning(
-            "generate_a2ui: OpenAI response had no tool_calls despite forced tool_choice"
+            "generate_a2ui: Gemini response had no render_a2ui function_call "
+            "despite forced tool_config mode=ANY"
         )
         return _a2ui_error(
             error="a2ui_no_tool_call",
             message="Secondary A2UI LLM did not call render_a2ui.",
             remediation=(
-                "Retry the request. If this persists, verify the tool_choice "
-                "schema matches the OpenAI API contract."
+                "Retry the request. If this persists, verify the tool_config "
+                "schema matches the google.genai API contract."
             ),
         )
 
-    tool_call = tool_calls[0]
-    try:
-        args = json.loads(tool_call.function.arguments)
-    except (ValueError, TypeError) as exc:
-        logger.exception(
-            "generate_a2ui: failed to parse render_a2ui tool arguments as JSON"
+    # `function_call.args` is a dict (google.genai parses the JSON for us).
+    # If the SDK ever returned a raw string we'd need to json.loads it — guard
+    # against that by coercing / reporting an invalid_arguments error.
+    args = getattr(function_call, "args", None)
+    if args is None:
+        logger.warning("generate_a2ui: render_a2ui function_call had no args")
+        return _a2ui_error(
+            error="a2ui_invalid_arguments",
+            message="render_a2ui function_call returned no arguments.",
+            remediation="Retry the request; the secondary LLM emitted an empty tool call.",
+        )
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except (ValueError, TypeError) as exc:
+            logger.exception(
+                "generate_a2ui: failed to parse render_a2ui args string as JSON"
+            )
+            return _a2ui_error(
+                error="a2ui_invalid_arguments",
+                message=f"Could not parse render_a2ui arguments: {exc}",
+                remediation="Retry the request; the secondary LLM emitted malformed JSON.",
+            )
+    if not isinstance(args, dict):
+        logger.warning(
+            "generate_a2ui: render_a2ui args was %s, expected dict",
+            type(args).__name__,
         )
         return _a2ui_error(
             error="a2ui_invalid_arguments",
-            message=f"Could not parse render_a2ui arguments: {exc}",
-            remediation="Retry the request; the secondary LLM emitted malformed JSON.",
+            message=f"render_a2ui arguments had unexpected type: {type(args).__name__}",
+            remediation="Retry the request; the secondary LLM emitted a non-dict payload.",
         )
     return build_a2ui_operations_from_tool_call(args)
 

--- a/showcase/packages/google-adk/src/app/api/debug/route.ts
+++ b/showcase/packages/google-adk/src/app/api/debug/route.ts
@@ -39,9 +39,7 @@ export async function GET(req: NextRequest) {
     },
     env: {
       NODE_ENV: process.env.NODE_ENV,
-      OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
-      LANGSMITH_API_KEY: process.env.LANGSMITH_API_KEY ? "set" : "NOT SET",
+      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY ? "set" : "NOT SET",
     },
     nodeVersion: process.version,
   });

--- a/showcase/packages/google-adk/src/app/api/health/route.ts
+++ b/showcase/packages/google-adk/src/app/api/health/route.ts
@@ -31,8 +31,7 @@ export async function GET(req: NextRequest) {
     publicResponse.diagnostics = {
       agent_url: AGENT_URL,
       env: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
+        GOOGLE_API_KEY: process.env.GOOGLE_API_KEY ? "set" : "NOT SET",
         NODE_ENV: process.env.NODE_ENV,
         PORT: process.env.PORT,
       },

--- a/showcase/packages/google-adk/tests/python/test_entrypoint_env_guards.py
+++ b/showcase/packages/google-adk/tests/python/test_entrypoint_env_guards.py
@@ -1,26 +1,27 @@
 """Subprocess tests for entrypoint.sh environment-variable guards.
 
-We exercise only the OPENAI_API_KEY branch at the top of the script. To avoid
+We exercise only the GOOGLE_API_KEY branch at the top of the script. To avoid
 actually starting uvicorn / next, we short-circuit the shell by arranging for
 the script to exit before reaching the background-process section:
 
-- When REQUIRE_OPENAI_API_KEY=1 and OPENAI_API_KEY is empty, the script must
+- When REQUIRE_GOOGLE_API_KEY=1 and GOOGLE_API_KEY is empty, the script must
   exit 1 IMMEDIATELY, before starting any subprocess. We assert exit=1 and
   the FATAL message on stderr.
-- When REQUIRE_OPENAI_API_KEY is unset / 0 and OPENAI_API_KEY is empty, the
+- When REQUIRE_GOOGLE_API_KEY is unset / 0 and GOOGLE_API_KEY is empty, the
   script must WARN and continue. We can't let it continue (it would try to
   launch the full stack), so we intercept by stubbing `python` and `npx` via
   a prepended PATH so they exit 0 immediately — the script then runs `wait
   -n` on already-exited children and exits 0 with the WARN message logged.
 
-Covers CR round 3 finding #7 (REQUIRE_OPENAI_API_KEY escalation).
+This package is Gemini end-to-end (primary LlmAgent + generate_a2ui both use
+google.genai), so the entrypoint guard was migrated from OPENAI_API_KEY to
+GOOGLE_API_KEY.
 """
 
 from __future__ import annotations
 
 import os
 import subprocess
-import textwrap
 from pathlib import Path
 
 import pytest
@@ -70,56 +71,56 @@ def _run_entrypoint(
 
 
 @pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
-def test_require_openai_api_key_fails_fast_when_missing():
-    """REQUIRE_OPENAI_API_KEY=1 + missing OPENAI_API_KEY → exit 1, FATAL log."""
+def test_require_google_api_key_fails_fast_when_missing():
+    """REQUIRE_GOOGLE_API_KEY=1 + missing GOOGLE_API_KEY → exit 1, FATAL log."""
     result = _run_entrypoint(
-        env={"REQUIRE_OPENAI_API_KEY": "1"},
+        env={"REQUIRE_GOOGLE_API_KEY": "1"},
     )
     assert result.returncode == 1, (
         f"expected exit 1, got {result.returncode}. stderr={result.stderr!r}"
     )
     assert "FATAL" in result.stderr
-    assert "OPENAI_API_KEY not set" in result.stderr
-    assert "REQUIRE_OPENAI_API_KEY=1" in result.stderr
+    assert "GOOGLE_API_KEY not set" in result.stderr
+    assert "REQUIRE_GOOGLE_API_KEY=1" in result.stderr
 
 
 @pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
 def test_default_missing_key_warns_but_does_not_fail_fast(tmp_path):
-    """Without REQUIRE_OPENAI_API_KEY, missing key only WARNs — script
+    """Without REQUIRE_GOOGLE_API_KEY, missing key only WARNs — script
     continues past the guard. With stubbed python/npx, the entrypoint
     completes and exits 0 (both children exited cleanly)."""
     result = _run_entrypoint(
-        env={},  # no REQUIRE_OPENAI_API_KEY, no OPENAI_API_KEY
+        env={},  # no REQUIRE_GOOGLE_API_KEY, no GOOGLE_API_KEY
         stub_subprocesses=True,
         tmp_path=tmp_path,
     )
     # Script must NOT fail fast on the guard. It continues; both stubbed
     # children exit 0 so the overall script exits 0.
     assert "FATAL" not in result.stderr, (
-        f"unexpected fail-fast when REQUIRE_OPENAI_API_KEY is unset: {result.stderr!r}"
+        f"unexpected fail-fast when REQUIRE_GOOGLE_API_KEY is unset: {result.stderr!r}"
     )
-    assert "WARN: OPENAI_API_KEY not set" in result.stderr
+    assert "WARN: GOOGLE_API_KEY not set" in result.stderr
 
 
 @pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
-def test_require_openai_api_key_zero_also_warns(tmp_path):
-    """REQUIRE_OPENAI_API_KEY=0 is equivalent to unset — WARN only."""
+def test_require_google_api_key_zero_also_warns(tmp_path):
+    """REQUIRE_GOOGLE_API_KEY=0 is equivalent to unset — WARN only."""
     result = _run_entrypoint(
-        env={"REQUIRE_OPENAI_API_KEY": "0"},
+        env={"REQUIRE_GOOGLE_API_KEY": "0"},
         stub_subprocesses=True,
         tmp_path=tmp_path,
     )
     assert "FATAL" not in result.stderr
-    assert "WARN: OPENAI_API_KEY not set" in result.stderr
+    assert "WARN: GOOGLE_API_KEY not set" in result.stderr
 
 
 @pytest.mark.skipif(not _ENTRYPOINT.exists(), reason="entrypoint.sh not found")
 def test_present_key_does_not_warn_or_fail(tmp_path):
-    """OPENAI_API_KEY present → no WARN, no FATAL, regardless of REQUIRE flag."""
+    """GOOGLE_API_KEY present → no WARN, no FATAL, regardless of REQUIRE flag."""
     result = _run_entrypoint(
-        env={"OPENAI_API_KEY": "sk-test-dummy", "REQUIRE_OPENAI_API_KEY": "1"},
+        env={"GOOGLE_API_KEY": "test-dummy", "REQUIRE_GOOGLE_API_KEY": "1"},
         stub_subprocesses=True,
         tmp_path=tmp_path,
     )
     assert "FATAL" not in result.stderr
-    assert "WARN: OPENAI_API_KEY not set" not in result.stderr
+    assert "WARN: GOOGLE_API_KEY not set" not in result.stderr

--- a/showcase/packages/google-adk/tests/python/test_generate_a2ui.py
+++ b/showcase/packages/google-adk/tests/python/test_generate_a2ui.py
@@ -1,11 +1,17 @@
 """Unit tests for generate_a2ui.
 
 Covers:
-- OpenAI client memoization via functools.lru_cache (thread-safe, no race).
+- google.genai client memoization via functools.lru_cache (thread-safe, no race).
 - Structured error shape consistency across all failure branches: each error
   return MUST have {error, message, remediation}.
 - Warning log when tool_context.state["copilotkit"] is a non-dict (schema
   drift signal).
+
+Rewritten from the OpenAI version: the google-adk package uses google.genai
+for the secondary A2UI planner call (forced function_call via ToolConfig
+mode="ANY") to avoid a cross-provider OpenAI dependency in a Gemini-primary
+package. The ERROR SHAPE and branch coverage are identical to the sibling
+strands / langroid adapters.
 """
 
 from __future__ import annotations
@@ -16,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agents.main import _a2ui_error, _get_openai_client, generate_a2ui
+from agents.main import _a2ui_error, _get_genai_client, generate_a2ui
 
 
 # ---------------------------------------------------------------------------
@@ -31,55 +37,65 @@ class FakeToolContext:
         self.state = {} if state is None else state
 
 
-def _openai_response(*, choices=None):
-    """Build a fake OpenAI ChatCompletion-like response."""
-    return SimpleNamespace(choices=choices or [])
+def _genai_response(*, candidates=None):
+    """Build a fake google.genai GenerateContentResponse-like object."""
+    return SimpleNamespace(candidates=candidates or [])
 
 
-def _choice(*, tool_calls=None):
-    return SimpleNamespace(message=SimpleNamespace(tool_calls=tool_calls))
+def _candidate(*, parts=None):
+    """Build a fake candidate with a .content.parts chain."""
+    return SimpleNamespace(content=SimpleNamespace(parts=parts or []))
 
 
-def _tool_call(*, arguments: str):
-    return SimpleNamespace(function=SimpleNamespace(arguments=arguments))
+def _function_call_part(*, name: str = "render_a2ui", args=None):
+    """Build a fake response Part carrying a function_call."""
+    return SimpleNamespace(
+        text=None,
+        function_call=SimpleNamespace(name=name, args=args),
+    )
+
+
+def _text_part(text: str):
+    """Build a fake response Part carrying plain text (no function_call)."""
+    return SimpleNamespace(text=text, function_call=None)
 
 
 @pytest.fixture(autouse=True)
 def _reset_client_cache():
-    """Clear the lru_cache on _get_openai_client between tests so each test
+    """Clear the lru_cache on _get_genai_client between tests so each test
     gets a fresh client instance (otherwise memoization leaks across tests)."""
-    _get_openai_client.cache_clear()
+    _get_genai_client.cache_clear()
     yield
-    _get_openai_client.cache_clear()
+    _get_genai_client.cache_clear()
 
 
 # ---------------------------------------------------------------------------
-# Memoization (finding #1)
+# Memoization
 # ---------------------------------------------------------------------------
 
 
-def test_openai_client_memoization_returns_same_instance():
+def test_genai_client_memoization_returns_same_instance():
     """Two calls must return the same instance (no re-construction)."""
     sentinel = object()
-    with patch("openai.OpenAI", return_value=sentinel) as mock_cls:
-        first = _get_openai_client()
-        second = _get_openai_client()
+    with patch("agents.main.genai.Client", return_value=sentinel) as mock_cls:
+        first = _get_genai_client()
+        second = _get_genai_client()
     assert first is second is sentinel
     assert mock_cls.call_count == 1
 
 
-def test_openai_client_memoization_cache_info():
+def test_genai_client_memoization_cache_info():
     """lru_cache reports 1 miss + 1 hit after two calls."""
-    with patch("openai.OpenAI", return_value=object()):
-        _get_openai_client()
-        _get_openai_client()
-    info = _get_openai_client.cache_info()
+    with patch("agents.main.genai.Client", return_value=object()):
+        _get_genai_client()
+        _get_genai_client()
+    info = _get_genai_client.cache_info()
     assert info.misses == 1
     assert info.hits == 1
 
 
 # ---------------------------------------------------------------------------
-# Error shape consistency (finding #2)
+# Error shape consistency
 # ---------------------------------------------------------------------------
 
 
@@ -93,99 +109,193 @@ def _assert_full_error_shape(result: dict) -> None:
         )
 
 
-def test_generate_a2ui_openai_exception_returns_full_error_shape():
-    """OpenAI client .create() raising an openai.APIError subclass →
-    a2ui_llm_error with all keys. We use APIConnectionError (a real
-    subclass) to exercise the narrowed except clause."""
-    import openai
+def test_generate_a2ui_genai_api_error_returns_full_error_shape():
+    """Gemini client .generate_content() raising a genai_errors.APIError →
+    a2ui_llm_error with all keys. We use ServerError (a real subclass) to
+    exercise the narrowed except tuple."""
+    from google.genai import errors as genai_errors
 
     fake_client = MagicMock()
-    # APIConnectionError requires a request kwarg; build a minimal stub.
-    fake_client.chat.completions.create.side_effect = openai.APIConnectionError(
-        request=MagicMock()
+    # ServerError/ClientError/APIError take (code, response_json, response).
+    # Build a minimal stub for construction: code, body, raw response.
+    fake_client.models.generate_content.side_effect = genai_errors.ServerError(
+        500, {"error": {"message": "boom"}}, MagicMock()
     )
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         result = generate_a2ui(FakeToolContext())
     _assert_full_error_shape(result)
     assert result["error"] == "a2ui_llm_error"
+    assert "GOOGLE_API_KEY" in result["remediation"]
 
 
-def test_generate_a2ui_empty_choices_returns_full_error_shape():
-    """Empty response.choices → a2ui_empty_response with all keys."""
+def test_generate_a2ui_empty_candidates_returns_full_error_shape():
+    """Empty response.candidates → a2ui_empty_response with all keys."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(choices=[])
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         result = generate_a2ui(FakeToolContext())
     _assert_full_error_shape(result)
     assert result["error"] == "a2ui_empty_response"
 
 
-def test_generate_a2ui_no_tool_calls_returns_full_error_shape():
-    """choices[0].message.tool_calls is None → a2ui_no_tool_call with all keys."""
+def test_generate_a2ui_no_parts_returns_full_error_shape():
+    """First candidate has no parts → a2ui_empty_response with all keys."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(
-        choices=[_choice(tool_calls=None)]
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[_candidate(parts=[])]
     )
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
+        result = generate_a2ui(FakeToolContext())
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_empty_response"
+
+
+def test_generate_a2ui_no_function_call_part_returns_full_error_shape():
+    """Parts contain only text (no function_call) → a2ui_no_tool_call."""
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[_candidate(parts=[_text_part("I refuse to render UI.")])]
+    )
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         result = generate_a2ui(FakeToolContext())
     _assert_full_error_shape(result)
     assert result["error"] == "a2ui_no_tool_call"
 
 
-def test_generate_a2ui_empty_tool_calls_returns_full_error_shape():
-    """choices[0].message.tool_calls is [] → a2ui_no_tool_call with all keys."""
+def test_generate_a2ui_wrong_function_name_returns_full_error_shape():
+    """function_call.name != 'render_a2ui' → a2ui_no_tool_call."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(
-        choices=[_choice(tool_calls=[])]
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[
+            _candidate(
+                parts=[_function_call_part(name="some_other_fn", args={"foo": "bar"})]
+            )
+        ]
     )
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         result = generate_a2ui(FakeToolContext())
     _assert_full_error_shape(result)
     assert result["error"] == "a2ui_no_tool_call"
 
 
-def test_generate_a2ui_unparseable_arguments_returns_full_error_shape():
-    """tool_call.function.arguments is not valid JSON → a2ui_invalid_arguments."""
+def test_generate_a2ui_none_args_returns_full_error_shape():
+    """function_call.args is None → a2ui_invalid_arguments with all keys."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(
-        choices=[_choice(tool_calls=[_tool_call(arguments="not-json {{{")])]
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[_candidate(parts=[_function_call_part(args=None)])]
     )
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         result = generate_a2ui(FakeToolContext())
     _assert_full_error_shape(result)
     assert result["error"] == "a2ui_invalid_arguments"
 
 
+def test_generate_a2ui_string_args_parseable_as_json_succeeds():
+    """If SDK ever returns args as a JSON string, we parse it and succeed."""
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[
+            _candidate(
+                parts=[
+                    _function_call_part(
+                        args='{"surfaceId": "s", "catalogId": "c", "components": []}'
+                    )
+                ]
+            )
+        ]
+    )
+    with patch("agents.main._get_genai_client", return_value=fake_client):
+        result = generate_a2ui(FakeToolContext())
+    # Happy-path: not an error shape — it's the a2ui_operations container.
+    assert "error" not in result or result.get("error") is None
+
+
+def test_generate_a2ui_unparseable_string_args_returns_full_error_shape():
+    """If SDK returns args as a malformed JSON string → a2ui_invalid_arguments."""
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[_candidate(parts=[_function_call_part(args="not-json {{{")])]
+    )
+    with patch("agents.main._get_genai_client", return_value=fake_client):
+        result = generate_a2ui(FakeToolContext())
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments"
+
+
+def test_generate_a2ui_non_dict_args_returns_full_error_shape():
+    """function_call.args is a list / number / str-that-parses-to-list →
+    a2ui_invalid_arguments (payload must be a dict)."""
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[_candidate(parts=[_function_call_part(args=[1, 2, 3])])]
+    )
+    with patch("agents.main._get_genai_client", return_value=fake_client):
+        result = generate_a2ui(FakeToolContext())
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments"
+
+
+def test_generate_a2ui_happy_path_returns_operations_container():
+    """function_call with a valid dict payload → build_a2ui_operations_from_tool_call
+    is invoked and its return value becomes generate_a2ui's return value."""
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = _genai_response(
+        candidates=[
+            _candidate(
+                parts=[
+                    _function_call_part(
+                        args={
+                            "surfaceId": "demo",
+                            "catalogId": "cat",
+                            "components": [{"type": "text"}],
+                        }
+                    )
+                ]
+            )
+        ]
+    )
+    sentinel = {"ok": True, "built": "operations"}
+    with patch("agents.main._get_genai_client", return_value=fake_client), patch(
+        "agents.main.build_a2ui_operations_from_tool_call", return_value=sentinel
+    ) as mock_builder:
+        result = generate_a2ui(FakeToolContext())
+    assert result is sentinel
+    mock_builder.assert_called_once_with(
+        {
+            "surfaceId": "demo",
+            "catalogId": "cat",
+            "components": [{"type": "text"}],
+        }
+    )
+
+
 def test_generate_a2ui_missing_invocation_context_still_completes_cleanly():
     """Tool context without _invocation_context must not crash — generate_a2ui
-    falls through to the OpenAI call with an empty conversation history. The
+    falls through to the Gemini call with an empty conversation history. The
     implementation uses `getattr(tool_context, '_invocation_context', None)`
     with an explicit `if value is None` guard (rather than a bare try/except
     AttributeError), so the missing attribute is detected and session-history
-    extraction is skipped. The OpenAI mock below then drives the normal
-    branch."""
+    extraction is skipped."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(choices=[])
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         # FakeToolContext intentionally has no _invocation_context.
         result = generate_a2ui(FakeToolContext())
-    # With no choices, we fall into the empty_response branch — still a full
-    # structured error shape.
     _assert_full_error_shape(result)
     assert result["error"] == "a2ui_empty_response"
 
 
 # ---------------------------------------------------------------------------
-# Schema drift warning (finding #4)
+# Schema drift warning
 # ---------------------------------------------------------------------------
 
 
 def test_non_dict_copilotkit_state_logs_warning(caplog):
     """When state['copilotkit'] is present but not a dict, emit a WARNING."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(choices=[])
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
     ctx = FakeToolContext(state={"copilotkit": "not-a-dict"})
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         with caplog.at_level(logging.WARNING, logger="agents.main"):
             generate_a2ui(ctx)
     warnings = [
@@ -204,9 +314,9 @@ def test_non_dict_copilotkit_state_logs_warning(caplog):
 def test_dict_copilotkit_state_does_not_log_warning(caplog):
     """When state['copilotkit'] IS a dict, no schema-drift warning."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(choices=[])
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
     ctx = FakeToolContext(state={"copilotkit": {"context": []}})
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         with caplog.at_level(logging.WARNING, logger="agents.main"):
             generate_a2ui(ctx)
     for rec in caplog.records:
@@ -218,9 +328,9 @@ def test_dict_copilotkit_state_does_not_log_warning(caplog):
 def test_missing_copilotkit_state_does_not_log_warning(caplog):
     """When state has no 'copilotkit' key at all, no warning (default {})."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(choices=[])
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
     ctx = FakeToolContext(state={})
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         with caplog.at_level(logging.WARNING, logger="agents.main"):
             generate_a2ui(ctx)
     for rec in caplog.records:
@@ -229,11 +339,11 @@ def test_missing_copilotkit_state_does_not_log_warning(caplog):
 
 def test_non_list_context_entries_logs_warning(caplog):
     """When state['copilotkit']['context'] is present but not a list, emit
-    a WARNING about the schema drift (CR round 3 finding #6)."""
+    a WARNING about the schema drift."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(choices=[])
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
     ctx = FakeToolContext(state={"copilotkit": {"context": "not-a-list"}})
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         with caplog.at_level(logging.WARNING, logger="agents.main"):
             generate_a2ui(ctx)
     warnings = [
@@ -252,9 +362,9 @@ def test_non_list_context_entries_logs_warning(caplog):
 def test_list_context_entries_does_not_log_warning(caplog):
     """When state['copilotkit']['context'] IS a list, no schema-drift warning."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.return_value = _openai_response(choices=[])
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
     ctx = FakeToolContext(state={"copilotkit": {"context": [{"value": "hi"}]}})
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         with caplog.at_level(logging.WARNING, logger="agents.main"):
             generate_a2ui(ctx)
     for rec in caplog.records:
@@ -264,7 +374,7 @@ def test_list_context_entries_does_not_log_warning(caplog):
 
 
 # ---------------------------------------------------------------------------
-# _a2ui_error contract check (CR round 3 finding #1)
+# _a2ui_error contract check
 # ---------------------------------------------------------------------------
 
 
@@ -285,44 +395,67 @@ def test_a2ui_error_rejects_empty_values():
 
 
 # ---------------------------------------------------------------------------
-# Narrowed except (CR round 3 finding #4): programmer errors must propagate.
+# Narrowed except: programmer errors must propagate.
 # ---------------------------------------------------------------------------
 
 
 def test_generate_a2ui_lets_programmer_errors_propagate():
-    """A bare RuntimeError from the OpenAI call is NOT in the narrowed
-    (openai.APIError, ...) hierarchy — it should propagate rather than be
-    silently converted to an a2ui_llm_error dict."""
+    """A bare RuntimeError from the Gemini call is NOT in the narrowed
+    (genai_errors.APIError, ValueError, ...) hierarchy — it should propagate
+    rather than be silently converted to an a2ui_llm_error dict."""
     fake_client = MagicMock()
-    fake_client.chat.completions.create.side_effect = RuntimeError("programmer bug")
-    with patch("agents.main._get_openai_client", return_value=fake_client):
+    fake_client.models.generate_content.side_effect = RuntimeError("programmer bug")
+    with patch("agents.main._get_genai_client", return_value=fake_client):
         with pytest.raises(RuntimeError, match="programmer bug"):
             generate_a2ui(FakeToolContext())
 
 
 # ---------------------------------------------------------------------------
-# OpenAIError base-class catch (parity with strands R4 fix).
+# Config-time failure: genai.Client() construction raising ValueError when
+# credentials are missing must become a structured a2ui_llm_error.
 # ---------------------------------------------------------------------------
 
 
-def test_generate_a2ui_openai_base_error_returns_structured():
-    """`openai.OpenAIError` is the base class raised from the `OpenAI()`
-    constructor when `OPENAI_API_KEY` is missing/malformed — it is NOT an
-    `APIError` subclass. The except clause must catch `OpenAIError` so
-    config-time failures become a structured tool result, not an uncaught
-    exception that bypasses the a2ui_error contract."""
-    import openai
-
-    # Clear lru_cache so the patched OpenAI constructor is actually called.
-    _get_openai_client.cache_clear()
+def test_generate_a2ui_client_construction_value_error_returns_structured():
+    """If genai.Client() construction raises ValueError (e.g. missing
+    GOOGLE_API_KEY in some SDK paths), we catch it and return a structured
+    error — not an uncaught exception bypassing the a2ui_error contract."""
+    # Clear lru_cache so the patched genai.Client constructor is actually called.
+    _get_genai_client.cache_clear()
 
     def _raise(*_a, **_kw):
-        raise openai.OpenAIError("missing key")
+        raise ValueError("missing GOOGLE_API_KEY")
 
-    with patch("openai.OpenAI", side_effect=_raise):
+    with patch("agents.main.genai.Client", side_effect=_raise):
         result = generate_a2ui(FakeToolContext())
 
     _assert_full_error_shape(result)
     assert result["error"] == "a2ui_llm_error"
-    assert "OpenAIError" in result["message"] or "missing key" in result["message"]
-    assert "OPENAI_API_KEY" in result["remediation"]
+    assert "GOOGLE_API_KEY" in result["remediation"]
+
+
+# ---------------------------------------------------------------------------
+# Model override via A2UI_MODEL env var.
+# ---------------------------------------------------------------------------
+
+
+def test_a2ui_model_env_override(monkeypatch):
+    """A2UI_MODEL env var overrides the default model passed to generate_content."""
+    from agents.main import _a2ui_model
+
+    monkeypatch.setenv("A2UI_MODEL", "gemini-pro-custom")
+    assert _a2ui_model() == "gemini-pro-custom"
+    monkeypatch.delenv("A2UI_MODEL", raising=False)
+    # Falls back to the hard-coded default.
+    assert _a2ui_model() == "gemini-2.5-flash"
+
+
+def test_generate_a2ui_passes_model_to_client(monkeypatch):
+    """generate_a2ui passes the resolved model name to client.models.generate_content."""
+    monkeypatch.setenv("A2UI_MODEL", "gemini-test-model")
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = _genai_response(candidates=[])
+    with patch("agents.main._get_genai_client", return_value=fake_client):
+        generate_a2ui(FakeToolContext())
+    _, kwargs = fake_client.models.generate_content.call_args
+    assert kwargs["model"] == "gemini-test-model"

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
-  "validatePinsFailCount": 109,
-  "validatePinsFailHash": "d03716b5746ac43cd8d711fd51e866f92717e0c4abc5a99221f0c7f9f597e81d",
+  "validatePinsFailCount": 110,
+  "validatePinsFailHash": "c87ecdd6cc0829f8ef93c6e3cc4bb30aa3a577f99c5c8e9349b7c2dc78a45560",
   "baselineDemoCount": 9
 }

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -613,8 +613,7 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
       ? Object.keys(fw.extraFiles)
           .filter((dest) => !dest.includes("/"))
           .map(
-            (dest) =>
-              `\n# Framework config\nCOPY --chown=app:app ${dest} ./`,
+            (dest) => `\n# Framework config\nCOPY --chown=app:app ${dest} ./`,
           )
           .join("")
       : "";

--- a/showcase/starters/google-adk/agent/main.py
+++ b/showcase/starters/google-adk/agent/main.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import os
 from typing import Any, Optional, TypedDict, Union
 
-import openai
 from dotenv import load_dotenv
+from google import genai
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.tools import ToolContext
+from google.genai import errors as genai_errors
 from google.genai import types
+
+import os
 
 from .tools import (
     get_weather_impl,
@@ -30,29 +34,35 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-# Module-level OpenAI client — lazily constructed on first use. Rebuilding the
-# client on every generate_a2ui call wastes a few ms per request and, more
-# importantly, re-runs env/credential resolution which is unnecessary.
+# Model used for the secondary A2UI planner call. Overridable via A2UI_MODEL
+# env var. gemini-2.5-flash is cheap, fast, and supports forced tool-calling
+# via ToolConfig.function_calling_config.mode="ANY".
+_DEFAULT_A2UI_MODEL = "gemini-2.5-flash"
+
+def _a2ui_model() -> str:
+    """Return the Gemini model for the A2UI planner, overridable via env."""
+    return os.environ.get("A2UI_MODEL") or _DEFAULT_A2UI_MODEL
+
+# Module-level google.genai client — lazily constructed on first use.
+# Rebuilding the client on every generate_a2ui call re-runs env/credential
+# resolution unnecessarily.
 #
 # `functools.lru_cache(maxsize=1)` provides thread-safe cache bookkeeping
 # (the dict-lookup / insertion path is guarded), but it does NOT hold a lock
 # around execution of the wrapped function body. On a cold cache, two
-# concurrent callers CAN both enter `OpenAI()` — one result wins and is
+# concurrent callers CAN both enter `genai.Client()` — one result wins and is
 # retained; the other is garbage-collected. This is acceptable here because
-# `OpenAI()` is idempotent and cheap (just reads env/config and builds a
-# client object with no network I/O), so the worst case is a single wasted
-# object construction on a race that only happens during cold start.
+# `genai.Client()` is idempotent and cheap (just reads env/config), so the
+# worst case is a single wasted object construction on a cold-start race.
 @functools.lru_cache(maxsize=1)
-def _get_openai_client():
-    """Return a memoized OpenAI client, constructing it on first call.
+def _get_genai_client():
+    """Return a memoized google.genai client, constructing it on first call.
 
     Cache bookkeeping is thread-safe via `functools.lru_cache`; see the
     module-level comment above for the cold-cache race caveat. Call
     `.cache_clear()` in tests that need to reset the memoized instance.
     """
-    from openai import OpenAI
-
-    return OpenAI()
+    return genai.Client()
 
 class _A2uiError(TypedDict):
     """Shape of the structured error dict returned by generate_a2ui branches.
@@ -62,9 +72,13 @@ class _A2uiError(TypedDict):
 
     NOTE: Identical TypedDicts live in
     `showcase/packages/strands/src/agents/agent.py` and
-    `showcase/packages/langroid/src/agents/agent.py`. Keep all three in sync —
-    any key additions / removals must land in every sibling so the A2UI error
-    surface stays consistent across showcase adapters.
+    `showcase/packages/langroid/src/agents/agent.py`. Those siblings call
+    OpenAI directly; the google-adk sibling intentionally uses google.genai
+    (forced-function-call via ToolConfig) to avoid a cross-provider openai
+    dependency in a Gemini-primary package. The ERROR SHAPE still mirrors the
+    siblings — keep all three in sync. Any key additions / removals must land
+    in every sibling so the A2UI error surface stays consistent across
+    showcase adapters.
     """
 
     error: str
@@ -142,8 +156,18 @@ def search_flights(tool_context: ToolContext, flights: list[dict]) -> dict:
 def generate_a2ui(tool_context: ToolContext) -> Union[_A2uiError, dict[str, Any]]:
     """Generate dynamic A2UI components based on the conversation.
 
-    A secondary LLM designs the UI schema and data. The result is
-    returned as an a2ui_operations container for the middleware to detect.
+    A secondary LLM designs the UI schema and data. The result is returned as
+    an a2ui_operations container for the middleware to detect. The A2UI
+    planner is a structured-output tool call that is intentionally separate
+    from the primary chat turn — the primary agent decides WHEN to invoke a
+    UI, and this call decides WHAT UI to render.
+
+    Implementation: uses `google.genai.Client.models.generate_content` with a
+    forced tool call (`tool_config.function_calling_config.mode="ANY"` +
+    `allowed_function_names=["render_a2ui"]`). This keeps the google-adk
+    package on Gemini end-to-end; the sibling strands / langroid adapters
+    use OpenAI for the equivalent call but the ERROR SHAPE and user-facing
+    contract are identical.
 
     Returns either a successful `dict[str, Any]` (the a2ui_operations
     container from `build_a2ui_operations_from_tool_call`) or an `_A2uiError`
@@ -188,7 +212,11 @@ def generate_a2ui(tool_context: ToolContext) -> Union[_A2uiError, dict[str, Any]
     # also swallow typos and programmer errors inside the body), we look the
     # attribute up via `getattr` and only run the body when present. If ADK
     # renames / drops the attribute, we log-and-skip instead of crashing.
-    conversation_messages: list[dict] = []
+    #
+    # Gemini accepts `contents=` as a list of `types.Content` with role
+    # `"user"` or `"model"` (no "system" role — system prompt goes via
+    # `system_instruction` in the GenerateContentConfig).
+    conversation_contents: list[types.Content] = []
     invocation_context = getattr(tool_context, "_invocation_context", None)
     if invocation_context is None:
         logger.debug(
@@ -207,106 +235,166 @@ def generate_a2ui(tool_context: ToolContext) -> Union[_A2uiError, dict[str, Any]
                             if hasattr(part, "text") and part.text:
                                 text_parts.append(part.text)
                         if text_parts:
-                            oai_role = "assistant" if role_str == "model" else "user"
-                            conversation_messages.append({"role": oai_role, "content": "".join(text_parts)})
+                            conversation_contents.append(
+                                types.Content(
+                                    role=role_str,
+                                    parts=[types.Part(text="".join(text_parts))],
+                                )
+                            )
 
-    tool_schema = {
-        "type": "function",
-        "function": {
-            "name": "render_a2ui",
-            "description": "Render a dynamic A2UI v0.9 surface.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "surfaceId": {"type": "string"},
-                    "catalogId": {"type": "string"},
-                    "components": {"type": "array", "items": {"type": "object"}},
-                    "data": {"type": "object"},
-                },
-                "required": ["surfaceId", "catalogId", "components"],
+    # Build the render_a2ui function declaration. `parametersJsonSchema` lets
+    # us pass a raw JSON schema dict directly — google.genai converts it
+    # internally — instead of constructing a `types.Schema` object tree.
+    render_a2ui_declaration = types.FunctionDeclaration(
+        name="render_a2ui",
+        description="Render a dynamic A2UI v0.9 surface.",
+        parametersJsonSchema={
+            "type": "object",
+            "properties": {
+                "surfaceId": {"type": "string"},
+                "catalogId": {"type": "string"},
+                "components": {"type": "array", "items": {"type": "object"}},
+                "data": {"type": "object"},
             },
+            "required": ["surfaceId", "catalogId", "components"],
         },
-    }
+    )
+    render_a2ui_tool = types.Tool(function_declarations=[render_a2ui_declaration])
 
-    llm_messages: list[dict] = [
-        {"role": "system", "content": context_text or "Generate a useful dashboard UI."},
-    ]
-    llm_messages.extend(conversation_messages)
+    # Force the model to call render_a2ui. mode="ANY" + allowed_function_names
+    # constrains the model to exactly one of the listed tools; with a single
+    # entry that's equivalent to OpenAI's tool_choice={"type": "function",
+    # "function": {"name": "render_a2ui"}}.
+    tool_config = types.ToolConfig(
+        function_calling_config=types.FunctionCallingConfig(
+            mode="ANY",
+            allowed_function_names=["render_a2ui"],
+        ),
+    )
 
-    # Wrap the OpenAI call so expected transport / auth / rate-limit failures
+    generate_config = types.GenerateContentConfig(
+        tools=[render_a2ui_tool],
+        tool_config=tool_config,
+        system_instruction=context_text or "Generate a useful dashboard UI.",
+    )
+
+    # Wrap the Gemini call so expected transport / auth / rate-limit failures
     # do not bubble up through the ADK tool machinery as uncaught exceptions.
     # Return a structured error with remediation instead — the LLM can surface
-    # this to the user. We deliberately narrow the except to the openai
+    # this to the user. We deliberately narrow the except to the google.genai
     # exception hierarchy: programmer errors (AttributeError, TypeError from
-    # bad call shape, etc.) should propagate so they are caught in test and
+    # bad call shape, etc.) should propagate so they are caught in tests and
     # not silently masked as an LLM error.
     #
-    # `openai.OpenAIError` is the SDK's base class for ALL errors, including
-    # both `APIError` subclasses (RateLimitError, APIConnectionError,
-    # AuthenticationError, BadRequestError) AND config-time failures raised
-    # from `OpenAI()` construction when `OPENAI_API_KEY` is unset/malformed —
-    # which are NOT `APIError` subclasses. Catching only `APIError` would let
-    # the constructor's error escape. `_get_openai_client()` therefore sits
-    # inside the try block, and `openai.OpenAIError` is in the except tuple.
-    # Mirrors the strands sibling agent's exception scope.
+    # `genai_errors.APIError` is the base class for `ClientError` (4xx) and
+    # `ServerError` (5xx). Listing all three is belt-and-suspenders in case
+    # the hierarchy changes; `APIError` alone catches both today. Config-time
+    # failures from `genai.Client()` construction (e.g. missing
+    # `GOOGLE_API_KEY`) can raise either `ValueError` or `genai_errors.*`
+    # depending on the SDK path, so `_get_genai_client()` sits inside the try
+    # block and `ValueError` is also in the except tuple.
     try:
-        client = _get_openai_client()
-        response = client.chat.completions.create(
-            model="gpt-4.1",
-            messages=llm_messages,
-            tools=[tool_schema],
-            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
+        client = _get_genai_client()
+        response = client.models.generate_content(
+            model=_a2ui_model(),
+            contents=conversation_contents or None,
+            config=generate_config,
         )
     except (
-        openai.OpenAIError,
-        openai.APIError,
-        openai.APIConnectionError,
-        openai.AuthenticationError,
-        openai.RateLimitError,
+        genai_errors.APIError,
+        genai_errors.ClientError,
+        genai_errors.ServerError,
+        ValueError,
     ) as exc:
-        logger.exception("generate_a2ui: OpenAI API call failed")
+        logger.exception("generate_a2ui: Gemini API call failed")
         return _a2ui_error(
             error="a2ui_llm_error",
-            message=f"Secondary A2UI LLM call failed: {exc.__class__.__name__}",
+            message=f"Secondary A2UI LLM call failed: {exc.__class__.__name__}: {exc}",
             remediation=(
-                "Verify OPENAI_API_KEY is set and the OpenAI service is reachable. "
+                "Verify GOOGLE_API_KEY is set and the Gemini service is reachable. "
                 "See server logs for the full traceback."
             ),
         )
 
-    if not response.choices:
-        logger.warning("generate_a2ui: OpenAI response contained no choices")
+    # Read the function call back from the first candidate's first part.
+    # Gemini returns `candidates[].content.parts[].function_call` with `.args`
+    # already parsed into a dict (no JSON-decode step required). mode="ANY"
+    # with allowed_function_names should guarantee exactly one function_call,
+    # but we still defend against empty candidates / empty parts / non-
+    # function-call parts in case the model returns a refusal or the SDK
+    # shape drifts.
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        logger.warning("generate_a2ui: Gemini response contained no candidates")
         return _a2ui_error(
             error="a2ui_empty_response",
-            message="Secondary A2UI LLM returned no choices.",
-            remediation="Retry; if this persists, check OpenAI status.",
+            message="Secondary A2UI LLM returned no candidates.",
+            remediation="Retry; if this persists, check Gemini service status.",
         )
 
-    tool_calls = response.choices[0].message.tool_calls
-    if not tool_calls:
+    first_content = getattr(candidates[0], "content", None)
+    parts = getattr(first_content, "parts", None) or [] if first_content else []
+    if not parts:
+        logger.warning("generate_a2ui: Gemini response had no parts in first candidate")
+        return _a2ui_error(
+            error="a2ui_empty_response",
+            message="Secondary A2UI LLM returned no parts.",
+            remediation="Retry; if this persists, check Gemini service status.",
+        )
+
+    function_call = None
+    for part in parts:
+        fc = getattr(part, "function_call", None)
+        if fc is not None and getattr(fc, "name", None) == "render_a2ui":
+            function_call = fc
+            break
+
+    if function_call is None:
         logger.warning(
-            "generate_a2ui: OpenAI response had no tool_calls despite forced tool_choice"
+            "generate_a2ui: Gemini response had no render_a2ui function_call "
+            "despite forced tool_config mode=ANY"
         )
         return _a2ui_error(
             error="a2ui_no_tool_call",
             message="Secondary A2UI LLM did not call render_a2ui.",
             remediation=(
-                "Retry the request. If this persists, verify the tool_choice "
-                "schema matches the OpenAI API contract."
+                "Retry the request. If this persists, verify the tool_config "
+                "schema matches the google.genai API contract."
             ),
         )
 
-    tool_call = tool_calls[0]
-    try:
-        args = json.loads(tool_call.function.arguments)
-    except (ValueError, TypeError) as exc:
-        logger.exception(
-            "generate_a2ui: failed to parse render_a2ui tool arguments as JSON"
+    # `function_call.args` is a dict (google.genai parses the JSON for us).
+    # If the SDK ever returned a raw string we'd need to json.loads it — guard
+    # against that by coercing / reporting an invalid_arguments error.
+    args = getattr(function_call, "args", None)
+    if args is None:
+        logger.warning("generate_a2ui: render_a2ui function_call had no args")
+        return _a2ui_error(
+            error="a2ui_invalid_arguments",
+            message="render_a2ui function_call returned no arguments.",
+            remediation="Retry the request; the secondary LLM emitted an empty tool call.",
+        )
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except (ValueError, TypeError) as exc:
+            logger.exception(
+                "generate_a2ui: failed to parse render_a2ui args string as JSON"
+            )
+            return _a2ui_error(
+                error="a2ui_invalid_arguments",
+                message=f"Could not parse render_a2ui arguments: {exc}",
+                remediation="Retry the request; the secondary LLM emitted malformed JSON.",
+            )
+    if not isinstance(args, dict):
+        logger.warning(
+            "generate_a2ui: render_a2ui args was %s, expected dict",
+            type(args).__name__,
         )
         return _a2ui_error(
             error="a2ui_invalid_arguments",
-            message=f"Could not parse render_a2ui arguments: {exc}",
-            remediation="Retry the request; the secondary LLM emitted malformed JSON.",
+            message=f"render_a2ui arguments had unexpected type: {type(args).__name__}",
+            remediation="Retry the request; the secondary LLM emitted a non-dict payload.",
         )
     return build_a2ui_operations_from_tool_call(args)
 

--- a/showcase/starters/google-adk/agent/requirements.txt
+++ b/showcase/starters/google-adk/agent/requirements.txt
@@ -3,5 +3,8 @@ uvicorn[standard]>=0.34.0
 python-dotenv
 pydantic
 google-adk
-google-genai
+# google-genai is required by both the primary LlmAgent (via google-adk) and
+# the secondary generate_a2ui planner call. Explicit pin keeps the version
+# floor independent of google-adk's transitive resolution.
+google-genai>=0.8.0
 ag-ui-adk


### PR DESCRIPTION
## Summary

The google-adk package's primary agent uses Gemini via `google-adk`'s `LlmAgent`, but the secondary `generate_a2ui` tool was calling OpenAI's `gpt-4.1` through `openai.OpenAI()`. Cross-provider dependency with no architectural justification — the A2UI planner's function-calling + forced tool-choice pattern works equally well via `google.genai`.

Rewrite to use `google.genai.Client.models.generate_content` with a `ToolConfig` forcing the `render_a2ui` function call (`mode="ANY"` + `allowed_function_names`). Drop the `openai` + `httpx` direct dependency entirely; `google-genai` is already pulled in transitively via `google-adk` and is now pinned explicitly at `>=0.8.0`.

Replaces short-term hotfix **PR #4090** (which pinned `openai` in `requirements.txt` after the post-merge Railway deploy of #4083 crashed with `ModuleNotFoundError: No module named 'openai'`). #4090 is already closed; this PR is the architectural correction that keeps the Gemini-primary package on Gemini end-to-end.

## Changes

- **`src/agents/main.py`** — `_get_openai_client` → `_get_genai_client` (`lru_cache`'d `google.genai.Client`). Rewrote `generate_a2ui` body to build a `types.Tool(function_declarations=[FunctionDeclaration])`, force the call via `types.ToolConfig(function_calling_config=FunctionCallingConfig(mode="ANY", allowed_function_names=["render_a2ui"]))`, and read the response from `candidates[0].content.parts[*].function_call.args`. Narrowed `except` clause to `genai_errors.APIError`/`ClientError`/`ServerError` + `ValueError` (for construction-time failures). `A2UI_MODEL` env var overrides the default `gemini-2.5-flash` model.
- **`entrypoint.sh`** — `OPENAI_API_KEY` guard → `GOOGLE_API_KEY` guard; `REQUIRE_OPENAI_API_KEY` → `REQUIRE_GOOGLE_API_KEY`. Warn / fail-fast semantics preserved.
- **`requirements.txt`** — explicit `google-genai>=0.8.0` pin; no `openai`, no `httpx`.
- **`src/app/api/health|debug/route.ts`** — report `GOOGLE_API_KEY` status instead of OpenAI/Anthropic/LangSmith (this is a Gemini-only package).
- **`playwright.config.ts`** — inject `GOOGLE_API_KEY` to the dev-server env, not `OPENAI_API_KEY` / `OPENAI_BASE_URL`.
- **`tests/python/test_generate_a2ui.py`** — rewrote 19 tests to mock `google.genai.Client` in place of `openai.OpenAI`. Preserves every error branch (`a2ui_llm_error`, `a2ui_empty_response`, `a2ui_no_tool_call`, `a2ui_invalid_arguments`) plus the happy path. Added `A2UI_MODEL` override coverage + string-args-parseable-as-JSON fallback.
- **`tests/python/test_entrypoint_env_guards.py`** — migrated to exercise the `GOOGLE_API_KEY` / `REQUIRE_GOOGLE_API_KEY` branch.

## Test plan

- [x] Unit tests: 53 passed locally (Python 3.12, `google-adk` + `google-genai` + all package deps installed)
- [x] `docker build` / `scripts/dev-local.sh build google-adk`: clean
- [x] `docker compose up -d google-adk` against latest image: container starts cleanly (no `ModuleNotFoundError`); uvicorn healthy; new WARN emitted when `GOOGLE_API_KEY` unset
- [x] `import agents.main` inside the container no longer pulls in any `openai.*` module
- [x] L1 (health) + L2 (agent) smoke via `LOCAL_PORTS=1 playwright test integration-smoke -g "google-adk"`: both pass
- [ ] L3 (chat) / L4 (tools) smoke: requires a live `GOOGLE_API_KEY`; left to CI / reviewer with secrets