### PR TITLE
fix(showcase/agno): upgrade agno SDK to 2.5.17

### DIFF
--- a/showcase/packages/agno/requirements.txt
+++ b/showcase/packages/agno/requirements.txt
@@ -1,4 +1,4 @@
-agno>=1.7.8
+agno>=2.5.17
 openai>=1.88.0
 fastapi>=0.115.13
 uvicorn[standard]>=0.34.3

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -613,8 +613,7 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
       ? Object.keys(fw.extraFiles)
           .filter((dest) => !dest.includes("/"))
           .map(
-            (dest) =>
-              `\n# Framework config\nCOPY --chown=app:app ${dest} ./`,
+            (dest) => `\n# Framework config\nCOPY --chown=app:app ${dest} ./`,
           )
           .join("")
       : "";


### PR DESCRIPTION
## Summary

Bumps the `agno` Python SDK pin from `>=1.7.8` to `>=2.5.17` (latest stable on PyPI) in `showcase/packages/agno/requirements.txt`.

## Why

The agno 1.x AGUI interface had a known bug where the terminal SSE event (`RUN_FINISHED` / `TEXT_MESSAGE_END`) was never emitted, causing consumers that block on stream close (such as `/api/smoke` calling `await res.text()`) to hang until AbortSignal fired (25-45s).

Agno 2.5.17 emits the terminal `RUN_FINISHED` frame and closes the stream cleanly, even when the underlying LLM call fails (dummy API key -> 401).

## Version

| | Before | After |
|---|---|---|
| Pin | `agno>=1.7.8` | `agno>=2.5.17` |
| Installed | 1.7.x | 2.5.17 |

## Breaking changes encountered

None in this package. All existing imports continue to resolve without change:

- `from agno.os import AgentOS`
- `from agno.os.interfaces.agui import AGUI`
- `from agno.agent.agent import Agent`
- `from agno.models.openai import OpenAIChat`
- `from agno.tools import tool`

No API adaptation was required.

## Relationship to PR #4093

PR #4093 works around the 1.x SSE bug in the consumer (`/api/smoke`) by reading the stream incrementally and bailing on `TEXT_MESSAGE_CONTENT "OK"`. With this upstream fix, that workaround becomes defense-in-depth rather than load-bearing.

**Recommendation:** leave #4093 in place after this merges. It's cheap, it's already written, and it protects against future agno regressions in stream termination.

## Local verification evidence

All tests ran against a local `docker build -t agno-test .` of this package (`agno==2.5.17`, Python 3.12.13).

### Imports
```
$ docker exec agno-test python -c "import agno; print(agno.__version__)"
2.5.17

$ docker exec agno-test python -c "from agno.os.interfaces.agui import AGUI; ..."
all imports OK
```

### /api/smoke timing (three consecutive runs)
```
run 1: time=0.256s code=200
run 2: time=0.157s code=200
run 3: time=0.151s code=200

{"status":"ok","integration":"agno","latency_ms":12,"timestamp":"2026-04-19T15:03:36.057Z"}
```
Previously: 25-45s hang ending in `AbortError`.

### Raw SSE stream inspection (dummy OpenAI key -> 401)
```
data: {"type":"RUN_STARTED","threadId":"test-thread","runId":"test-run",...}

data: {"type":"RUN_FINISHED","threadId":"test-thread","runId":"test-run"}
```
Stream closes immediately after `RUN_FINISHED`. Terminal event is present.

### Demos (homepage + 9 demo routes)
```
/                          200   0.008s
/demos/agentic-chat        200   0.010s
/demos/hitl                200   0.005s
/demos/tool-rendering      200   0.005s
/demos/gen-ui-tool-based   200   0.006s
/demos/subagents           200   0.004s
/demos/shared-state-read   200   0.005s
/demos/shared-state-write  200   0.006s
/demos/shared-state-streaming 200 0.005s
/demos/gen-ui-agent        200   0.005s
```

### Agent object
```
agent loaded: Agent
tool count: 8
model: gpt-4o
```

## Test plan

- [x] `docker build` succeeds with new pin
- [x] `import agno` reports 2.5.17
- [x] All existing `from agno...` imports resolve unchanged
- [x] `/api/health` returns 200
- [x] `/api/smoke` returns 200 in <1s (was 25-45s hang)
- [x] Raw SSE stream contains `RUN_FINISHED` terminal event
- [x] Homepage + all 9 demo routes return 200
- [x] Agent object loads with 8 tools
- [ ] CI green on PR