### PR TITLE
fix(showcase/starters): restore /api/health accuracy across 15 degraded agent starters

### DIFF
--- a/showcase/packages/ag2/src/agent_server.py
+++ b/showcase/packages/ag2/src/agent_server.py
@@ -9,6 +9,8 @@ import os
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 
 from agents.agent import stream
@@ -16,6 +18,22 @@ from agents.agent import stream
 load_dotenv()
 
 app = FastAPI(title="AG2 Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# A plain `@app.get("/health")` decorator is shadowed by the subsequent
+# `app.mount("/", ...)` call: Starlette's Mount at "/" matches every path
+# (including /health) and the decorated route never fires. Middleware runs
+# above the routing layer, so the health endpoint stays reachable regardless
+# of what the framework-specific AG-UI adapter mounts at root.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -25,13 +43,10 @@ app.add_middleware(
 )
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
-
-
-# Mount the AG2 AG-UI endpoint at the root
-# NOTE: must come AFTER route definitions — app.mount("/") shadows all routes defined after it
+# Mount the AG2 AG-UI endpoint at the root.
+# `app.mount("/", ...)` is a catch-all Mount that shadows any later route
+# decorators, which is why /health is served by HealthMiddleware above
+# rather than a `@app.get("/health")` handler registered here.
 app.mount("/", stream.build_asgi())
 
 

--- a/showcase/packages/agno/src/agent_server.py
+++ b/showcase/packages/agno/src/agent_server.py
@@ -9,6 +9,8 @@ import os
 import dotenv
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from agents.main import agent
 
@@ -19,9 +21,19 @@ agent_os = AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)])
 app = agent_os.get_app()
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# AgentOS mounts its own endpoints on `app`, some of which can register a
+# catch-all at "/" (depending on version / interface). Middleware guarantees
+# /health reaches the Next.js /api/health probe regardless of how AgentOS
+# wires its routes.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 
 def main():

--- a/showcase/packages/claude-sdk-python/src/agents/agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/agent.py
@@ -36,6 +36,19 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# Any later catch-all mount at "/" (whether added here or by a downstream
+# adapter) would shadow a plain `@app.get("/health")` decorator. Middleware
+# runs above routing so the health endpoint stays reachable regardless.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
 
 load_dotenv()
 
@@ -520,6 +533,8 @@ def create_app() -> FastAPI:
     """Create the FastAPI app with AG-UI endpoint."""
     app = FastAPI(title="Claude Agent SDK (Python) Agent Server")
 
+    app.add_middleware(HealthMiddleware)
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -544,9 +559,5 @@ def create_app() -> FastAPI:
                 "X-Accel-Buffering": "no",
             },
         )
-
-    @app.get("/health")
-    async def health() -> dict[str, str]:
-        return {"status": "ok"}
 
     return app

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -92,9 +92,25 @@ logging.getLogger(__name__).info(
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from agents.crew import LatestAiDevelopment
 
 app = FastAPI(title="CrewAI (Crews) Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `add_crewai_crew_fastapi_endpoint(app, crew, "/")` installs a catch-all at
+# the root that shadows any later `@app.get("/health")` decorator. Middleware
+# runs above the routing layer, so the health endpoint stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 # CORS: `allow_origins=["*"]` is intentional for this LOCAL DEMO / SHOWCASE
 # STARTER package. The agent server binds to localhost:8000 during `pnpm dev`
@@ -114,11 +130,6 @@ app.add_middleware(
 )
 
 add_crewai_crew_fastapi_endpoint(app, LatestAiDevelopment(), "/")
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 # NOTE: intentionally NO `if __name__ == "__main__": main()` block.

--- a/showcase/packages/google-adk/src/agent_server.py
+++ b/showcase/packages/google-adk/src/agent_server.py
@@ -10,12 +10,28 @@ import uvicorn
 from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 from agents.main import sales_pipeline_agent
 
 load_dotenv()
 
 app = FastAPI(title="Google ADK Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `add_adk_fastapi_endpoint(app, adk_agent, path="/")` installs a catch-all
+# at the root that shadows any later `@app.get("/health")` decorator.
+# Middleware runs above the routing layer, so /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -32,11 +48,6 @@ adk_agent = ADKAgent(
 )
 
 add_adk_fastapi_endpoint(app, adk_agent, path="/")
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/packages/langroid/src/agent_server.py
+++ b/showcase/packages/langroid/src/agent_server.py
@@ -13,6 +13,8 @@ import os
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 
 from agents.agui_adapter import handle_run
@@ -20,6 +22,19 @@ from agents.agui_adapter import handle_run
 load_dotenv()
 
 app = FastAPI(title="Langroid Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# Applied uniformly across every showcase FastAPI agent server so /health
+# remains reachable even if future changes introduce a catch-all mount at "/".
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -33,11 +48,6 @@ app.add_middleware(
 async def run_agent(request: Request):
     """AG-UI /run endpoint — streams SSE events."""
     return await handle_run(request)
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/packages/llamaindex/src/agent_server.py
+++ b/showcase/packages/llamaindex/src/agent_server.py
@@ -13,12 +13,28 @@ import uvicorn
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from agents.agent import agent_router
 
 load_dotenv()
 
 app = FastAPI(title="LlamaIndex Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `agent_router` can (now or in the future) register a catch-all at "/" that
+# would shadow a `@app.get("/health")` decorator. Middleware runs above the
+# routing layer, so /health stays reachable regardless.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -28,11 +44,6 @@ app.add_middleware(
 )
 
 app.include_router(agent_router)
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/packages/ms-agent-python/src/agent_server.py
+++ b/showcase/packages/ms-agent-python/src/agent_server.py
@@ -16,6 +16,8 @@ from agent_framework_ag_ui import add_agent_framework_fastapi_endpoint
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from agents.agent import create_agent
 
@@ -42,6 +44,21 @@ chat_client = _build_chat_client()
 my_agent = create_agent(chat_client)
 
 app = FastAPI(title="CopilotKit + Microsoft Agent Framework (Python)")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `add_agent_framework_fastapi_endpoint(..., path="/")` installs a catch-all
+# at the root that shadows any later `@app.get("/health")` decorator.
+# Middleware runs above the routing layer, so /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -55,11 +72,6 @@ add_agent_framework_fastapi_endpoint(
     agent=my_agent,
     path="/",
 )
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/packages/pydantic-ai/src/agent_server.py
+++ b/showcase/packages/pydantic-ai/src/agent_server.py
@@ -9,6 +9,8 @@ import os
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 
 from agents.agent import SalesTodosState, StateDeps, agent
@@ -17,17 +19,28 @@ load_dotenv()
 
 app = FastAPI(title="PydanticAI Agent Server")
 
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `app.mount("/", ag_ui_app)` installs a Starlette Mount at the root that
+# matches every path (including /health). A plain `@app.get("/health")`
+# decorator registered before the mount was still shadowed in practice because
+# Mount at "/" is a prefix match rather than an exact one. Middleware runs
+# above the routing layer, which guarantees /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# Health endpoint MUST be registered BEFORE app.mount("/") — mount creates a catch-all
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 # Mount the PydanticAI AG-UI endpoint at the root
 ag_ui_app = agent.to_ag_ui(deps=StateDeps(SalesTodosState()))

--- a/showcase/packages/strands/src/agent_server.py
+++ b/showcase/packages/strands/src/agent_server.py
@@ -91,6 +91,8 @@ _assert_instrumentor_patched()
 
 import uvicorn  # noqa: E402  (kept after patch for consistent import-ordering policy)
 from dotenv import load_dotenv  # noqa: E402
+from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
+from starlette.responses import JSONResponse  # noqa: E402
 
 from ag_ui_strands import create_strands_app  # noqa: E402  (must follow instrumentor patch)
 from agents.agent import build_showcase_agent  # noqa: E402  (must follow instrumentor patch)
@@ -107,9 +109,18 @@ agent_path = os.getenv("AGENT_PATH", "/")
 app = create_strands_app(agui_agent, agent_path)
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `create_strands_app(..., agent_path="/")` installs a catch-all at the root
+# that shadows any later `@app.get("/health")` decorator. Middleware runs
+# above the routing layer, so /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 
 def main():

--- a/showcase/packages/strands/tests/python/conftest.py
+++ b/showcase/packages/strands/tests/python/conftest.py
@@ -58,6 +58,11 @@ def _install_stub_modules() -> None:
 
             get = post = put = delete = patch = _decorator
 
+            # agent_server.py also calls ``app.add_middleware(...)`` to
+            # install HealthMiddleware; accept that on the stub too.
+            def add_middleware(self, *a, **k):
+                return None
+
         m.create_strands_app = lambda *a, **k: _FakeFastAPI()  # type: ignore[attr-defined]
         sys.modules["ag_ui_strands"] = m
 

--- a/showcase/packages/strands/tests/python/test_instrumentor_patch.py
+++ b/showcase/packages/strands/tests/python/test_instrumentor_patch.py
@@ -153,6 +153,12 @@ def test_agent_server_module_installs_patch():
 
         get = post = put = delete = patch = _decorator
 
+        # agent_server.py installs a ``HealthMiddleware`` via
+        # ``app.add_middleware(...)`` after creating the Strands app — the
+        # stub must accept that call so module execution completes.
+        def add_middleware(self, *a, **k):
+            return None
+
     fake_ag_ui_strands = types.ModuleType("ag_ui_strands")
     fake_ag_ui_strands.create_strands_app = lambda *a, **k: _FakeFastAPI()  # type: ignore[attr-defined]
     fake_ag_ui_strands.StrandsAgent = _AcceptsAnything  # type: ignore[attr-defined]

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
   "validatePinsFailCount": 110,
-  "validatePinsFailHash": "c87ecdd6cc0829f8ef93c6e3cc4bb30aa3a577f99c5c8e9349b7c2dc78a45560",
+  "validatePinsFailHash": "958bcf24c27cef69d7856e12deafe92073af7ad716289b2f6e4418827264ae17",
   "baselineDemoCount": 9
 }

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -841,15 +841,31 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     }
 
     // For langgraph starters: convert relative imports to absolute
-    // because langgraph_cli loads modules standalone, not as packages
+    // because langgraph_cli loads modules standalone, not as packages.
+    //
+    // Subdir-aware: `from .X import ...` resolves to the CURRENT package,
+    // which is the directory the file lives in, not `agentDir` flat. A file
+    // at `<agentDir>/tools/get_weather.py` saying `from .types import X` must
+    // become `from <agentDir>.tools.types import X`, not `from <agentDir>.types`.
+    // The previous flat rewrite dropped the `tools` segment and produced
+    // `ModuleNotFoundError: No module named '<agentDir>.types'` at startup,
+    // killing langgraph-fastapi silently inside the entrypoint `sed` pipe.
     if (fw.slug.startsWith("langgraph-")) {
       const lgAgentMod = fw.agentDir.replace(/\//g, ".");
       forEachPyFile(agentDest, (fp) => {
         let content = fs.readFileSync(fp, "utf-8");
-        // from .X import -> from <agentMod>.X import
+        // Compute the file's containing Python package path:
+        // <agentDir>.<relative-subdirs-joined-with-.>
+        const relFromAgent = path.relative(agentDest, path.dirname(fp));
+        const subPkg = relFromAgent
+          .split(path.sep)
+          .filter(Boolean)
+          .join(".");
+        const filePkg = subPkg ? `${lgAgentMod}.${subPkg}` : lgAgentMod;
+        // from .X import -> from <filePkg>.X import
         content = content.replace(
           /^from \.([\w.]+) import/gm,
-          `from ${lgAgentMod}.$1 import`,
+          `from ${filePkg}.$1 import`,
         );
         fs.writeFileSync(fp, content);
       });

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -477,6 +477,30 @@ else
   exit 1
 fi`;
 
+// Prefix each line of the agent's stdout/stderr with [agent] AND capture the
+// real PID of the agent process. Previously this used:
+//
+//   cmd 2>&1 | sed 's/^/[agent] /' &
+//   AGENT_PID=$!
+//
+// That has two bugs:
+//   1. `$!` after a pipeline points to the LAST command in the pipe (the
+//      `sed` process), not the agent. `kill -0 $AGENT_PID` and
+//      `wait -n $AGENT_PID` therefore monitored `sed`, not the agent, which
+//      always looked alive until sed closed stdin — by which time the agent
+//      had already crashed and Railway was mid-restart.
+//   2. `sed` buffers by default, so Python stack traces at crash time could
+//      be discarded when the pipe closed, hiding the real error.
+//
+// Process substitution (`&> >(awk …)`) redirects both streams without
+// creating a pipeline, so `$!` remains the agent's PID. `awk` with
+// `fflush()` line-flushes each prefixed line, so crash output reaches the
+// container logs immediately.
+//
+// Also export PYTHONUNBUFFERED=1 at the entrypoint level so Python-based
+// agents don't buffer their own writes before they reach awk.
+const AGENT_LOG_PREFIX = `&> >(awk '{print "[agent] " $0; fflush()}')`;
+
 function getEntrypointBlock(fw: FrameworkDef): string {
   switch (fw.language) {
     case "python":
@@ -486,13 +510,13 @@ python -m langgraph_cli dev \\
   --config langgraph.json \\
   --host 0.0.0.0 \\
   --port 8123 \\
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
       return `echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 sleep 2
 ${AGENT_HEALTH_CHECK}`;
@@ -503,32 +527,32 @@ npx @langchain/langgraph-cli dev \\
   --config agent/langgraph.json \\
   --host 0.0.0.0 \\
   --port 8123 \\
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
       if (fw.slug === "mastra") {
         return `echo "[entrypoint] Starting Mastra agent on port 8123..."
-PORT=8123 npx mastra dev 2>&1 | sed 's/^/[agent] /' &
+PORT=8123 npx mastra dev ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
       return `echo "[entrypoint] Starting TypeScript agent on port 8123..."
-npx tsx agent/index.ts 2>&1 | sed 's/^/[agent] /' &
+npx tsx agent/index.ts ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 sleep 2
 ${AGENT_HEALTH_CHECK}`;
     case "java":
       return `echo "[entrypoint] Starting Spring AI agent on port 8123..."
-java -jar agent/app.jar --server.port=8123 2>&1 | sed 's/^/[agent] /' &
+java -jar agent/app.jar --server.port=8123 ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 sleep 5
 ${AGENT_HEALTH_CHECK}`;
     case "csharp":
       return `echo "[entrypoint] Starting .NET agent on port 8123..."
-cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 2>&1 | sed 's/^/[agent] /' &
+cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 cd /app
 sleep 3

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -857,10 +857,7 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
         // Compute the file's containing Python package path:
         // <agentDir>.<relative-subdirs-joined-with-.>
         const relFromAgent = path.relative(agentDest, path.dirname(fp));
-        const subPkg = relFromAgent
-          .split(path.sep)
-          .filter(Boolean)
-          .join(".");
+        const subPkg = relFromAgent.split(path.sep).filter(Boolean).join(".");
         const filePkg = subPkg ? `${lgAgentMod}.${subPkg}` : lgAgentMod;
         // from .X import -> from <filePkg>.X import
         content = content.replace(

--- a/showcase/starters/ag2/agent_server.py
+++ b/showcase/starters/ag2/agent_server.py
@@ -9,6 +9,8 @@ import os
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 
 from agent.agent import stream
@@ -16,6 +18,22 @@ from agent.agent import stream
 load_dotenv()
 
 app = FastAPI(title="AG2 Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# A plain `@app.get("/health")` decorator is shadowed by the subsequent
+# `app.mount("/", ...)` call: Starlette's Mount at "/" matches every path
+# (including /health) and the decorated route never fires. Middleware runs
+# above the routing layer, so the health endpoint stays reachable regardless
+# of what the framework-specific AG-UI adapter mounts at root.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -25,13 +43,10 @@ app.add_middleware(
 )
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
-
-
-# Mount the AG2 AG-UI endpoint at the root
-# NOTE: must come AFTER route definitions — app.mount("/") shadows all routes defined after it
+# Mount the AG2 AG-UI endpoint at the root.
+# `app.mount("/", ...)` is a catch-all Mount that shadows any later route
+# decorators, which is why /health is served by HealthMiddleware above
+# rather than a `@app.get("/health")` handler registered here.
 app.mount("/", stream.build_asgi())
 
 

--- a/showcase/starters/ag2/entrypoint.sh
+++ b/showcase/starters/ag2/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: ag2"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/agno/agent/requirements.txt
+++ b/showcase/starters/agno/agent/requirements.txt
@@ -1,4 +1,4 @@
-agno>=1.7.8
+agno>=2.5.17
 openai>=1.88.0
 fastapi>=0.115.13
 uvicorn[standard]>=0.34.3

--- a/showcase/starters/agno/agent_server.py
+++ b/showcase/starters/agno/agent_server.py
@@ -9,6 +9,8 @@ import os
 import dotenv
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from agent.main import agent
 
@@ -19,9 +21,19 @@ agent_os = AgentOS(agents=[agent], interfaces=[AGUI(agent=agent)])
 app = agent_os.get_app()
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# AgentOS mounts its own endpoints on `app`, some of which can register a
+# catch-all at "/" (depending on version / interface). Middleware guarantees
+# /health reaches the Next.js /api/health probe regardless of how AgentOS
+# wires its routes.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 
 def main():

--- a/showcase/starters/agno/entrypoint.sh
+++ b/showcase/starters/agno/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: agno"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/claude-sdk-python/agent/agent.py
+++ b/showcase/starters/claude-sdk-python/agent/agent.py
@@ -36,6 +36,18 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# Any later catch-all mount at "/" (whether added here or by a downstream
+# adapter) would shadow a plain `@app.get("/health")` decorator. Middleware
+# runs above routing so the health endpoint stays reachable regardless.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
 
 load_dotenv()
 
@@ -515,6 +527,8 @@ def create_app() -> FastAPI:
     """Create the FastAPI app with AG-UI endpoint."""
     app = FastAPI(title="Claude Agent SDK (Python) Agent Server")
 
+    app.add_middleware(HealthMiddleware)
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
@@ -539,9 +553,5 @@ def create_app() -> FastAPI:
                 "X-Accel-Buffering": "no",
             },
         )
-
-    @app.get("/health")
-    async def health() -> dict[str, str]:
-        return {"status": "ok"}
 
     return app

--- a/showcase/starters/claude-sdk-python/entrypoint.sh
+++ b/showcase/starters/claude-sdk-python/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: claude-sdk-python"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/starters/claude-sdk-typescript/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: claude-sdk-typescript"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting TypeScript agent on port 8123..."
-npx tsx agent/index.ts 2>&1 | sed 's/^/[agent] /' &
+npx tsx agent/index.ts &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/crewai-crews/agent_server.py
+++ b/showcase/starters/crewai-crews/agent_server.py
@@ -92,9 +92,25 @@ logging.getLogger(__name__).info(
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from agent.crew import LatestAiDevelopment
 
 app = FastAPI(title="CrewAI (Crews) Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `add_crewai_crew_fastapi_endpoint(app, crew, "/")` installs a catch-all at
+# the root that shadows any later `@app.get("/health")` decorator. Middleware
+# runs above the routing layer, so the health endpoint stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 # CORS: `allow_origins=["*"]` is intentional for this LOCAL DEMO / SHOWCASE
 # STARTER package. The agent server binds to localhost:8000 during `pnpm dev`
@@ -114,11 +130,6 @@ app.add_middleware(
 )
 
 add_crewai_crew_fastapi_endpoint(app, LatestAiDevelopment(), "/")
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 # NOTE: intentionally NO `if __name__ == "__main__": main()` block.

--- a/showcase/starters/crewai-crews/entrypoint.sh
+++ b/showcase/starters/crewai-crews/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: crewai-crews"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/google-adk/agent_server.py
+++ b/showcase/starters/google-adk/agent_server.py
@@ -10,12 +10,28 @@ import uvicorn
 from ag_ui_adk import ADKAgent, add_adk_fastapi_endpoint
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 from agent.main import sales_pipeline_agent
 
 load_dotenv()
 
 app = FastAPI(title="Google ADK Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `add_adk_fastapi_endpoint(app, adk_agent, path="/")` installs a catch-all
+# at the root that shadows any later `@app.get("/health")` decorator.
+# Middleware runs above the routing layer, so /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -32,11 +48,6 @@ adk_agent = ADKAgent(
 )
 
 add_adk_fastapi_endpoint(app, adk_agent, path="/")
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/starters/google-adk/entrypoint.sh
+++ b/showcase/starters/google-adk/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: google-adk"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/langgraph-fastapi/entrypoint.sh
+++ b/showcase/starters/langgraph-fastapi/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: langgraph-fastapi"
 echo "[entrypoint] Time: $(date -u)"
@@ -28,7 +35,7 @@ python -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -49,7 +56,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/langgraph-fastapi/src/agents/src/agent.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/src/agent.py
@@ -4,7 +4,7 @@ LangGraph agent for the CopilotKit Showcase (FastAPI variant).
 Uses langgraph.prebuilt.create_react_agent with langgraph>=1.1.0.
 """
 
-from src.agents.tools import (
+from src.agents.src.tools import (
     get_weather_impl,
     query_data_impl,
     schedule_meeting_impl,
@@ -13,7 +13,7 @@ from src.agents.tools import (
     search_flights_impl,
     build_a2ui_operations_from_tool_call,
 )
-from src.agents.tools.types import SalesTodo, Flight
+from src.agents.src.tools.types import SalesTodo, Flight
 
 import json
 import time

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/__init__.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/__init__.py
@@ -1,25 +1,25 @@
 """Barrel exports for all shared showcase tool implementations."""
 
-from src.agents.types import (
+from src.agents.tools.types import (
     SalesStage,
     SalesTodo,
     Flight,
     WeatherResult,
 )
-from src.agents.get_weather import get_weather_impl
-from src.agents.query_data import query_data_impl
-from src.agents.sales_todos import (
+from src.agents.tools.get_weather import get_weather_impl
+from src.agents.tools.query_data import query_data_impl
+from src.agents.tools.sales_todos import (
     INITIAL_TODOS,
     manage_sales_todos_impl,
     get_sales_todos_impl,
 )
-from src.agents.search_flights import search_flights_impl
-from src.agents.generate_a2ui import (
+from src.agents.tools.search_flights import search_flights_impl
+from src.agents.tools.generate_a2ui import (
     RENDER_A2UI_TOOL_SCHEMA,
     generate_a2ui_impl,
     build_a2ui_operations_from_tool_call,
 )
-from src.agents.schedule_meeting import schedule_meeting_impl
+from src.agents.tools.schedule_meeting import schedule_meeting_impl
 
 __all__ = [
     # Types

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/get_weather.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/get_weather.py
@@ -1,7 +1,7 @@
 """Mock weather data tool implementation."""
 
 import random
-from src.agents.types import WeatherResult
+from src.agents.tools.types import WeatherResult
 
 _CONDITIONS = [
     "Sunny",

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/sales_todos.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/sales_todos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from src.agents.types import SalesTodo
+from src.agents.tools.types import SalesTodo
 
 INITIAL_TODOS: list[SalesTodo] = [
     SalesTodo(

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/search_flights.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/search_flights.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from src.agents.types import Flight
+from src.agents.tools.types import Flight
 
 _logger = logging.getLogger(__name__)
 

--- a/showcase/starters/langgraph-python/entrypoint.sh
+++ b/showcase/starters/langgraph-python/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: langgraph-python"
 echo "[entrypoint] Time: $(date -u)"
@@ -28,7 +35,7 @@ python -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -49,7 +56,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/langgraph-python/src/agents/tools/__init__.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/__init__.py
@@ -1,25 +1,25 @@
 """Barrel exports for all shared showcase tool implementations."""
 
-from src.agents.types import (
+from src.agents.tools.types import (
     SalesStage,
     SalesTodo,
     Flight,
     WeatherResult,
 )
-from src.agents.get_weather import get_weather_impl
-from src.agents.query_data import query_data_impl
-from src.agents.sales_todos import (
+from src.agents.tools.get_weather import get_weather_impl
+from src.agents.tools.query_data import query_data_impl
+from src.agents.tools.sales_todos import (
     INITIAL_TODOS,
     manage_sales_todos_impl,
     get_sales_todos_impl,
 )
-from src.agents.search_flights import search_flights_impl
-from src.agents.generate_a2ui import (
+from src.agents.tools.search_flights import search_flights_impl
+from src.agents.tools.generate_a2ui import (
     RENDER_A2UI_TOOL_SCHEMA,
     generate_a2ui_impl,
     build_a2ui_operations_from_tool_call,
 )
-from src.agents.schedule_meeting import schedule_meeting_impl
+from src.agents.tools.schedule_meeting import schedule_meeting_impl
 
 __all__ = [
     # Types

--- a/showcase/starters/langgraph-python/src/agents/tools/get_weather.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/get_weather.py
@@ -1,7 +1,7 @@
 """Mock weather data tool implementation."""
 
 import random
-from src.agents.types import WeatherResult
+from src.agents.tools.types import WeatherResult
 
 _CONDITIONS = [
     "Sunny",

--- a/showcase/starters/langgraph-python/src/agents/tools/sales_todos.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/sales_todos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from src.agents.types import SalesTodo
+from src.agents.tools.types import SalesTodo
 
 INITIAL_TODOS: list[SalesTodo] = [
     SalesTodo(

--- a/showcase/starters/langgraph-python/src/agents/tools/search_flights.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/search_flights.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from src.agents.types import Flight
+from src.agents.tools.types import Flight
 
 _logger = logging.getLogger(__name__)
 

--- a/showcase/starters/langgraph-typescript/entrypoint.sh
+++ b/showcase/starters/langgraph-typescript/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: langgraph-typescript"
 echo "[entrypoint] Time: $(date -u)"
@@ -28,7 +35,7 @@ npx @langchain/langgraph-cli dev \
   --config agent/langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -49,7 +56,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/langroid/agent_server.py
+++ b/showcase/starters/langroid/agent_server.py
@@ -13,6 +13,8 @@ import os
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 
 from agent.agui_adapter import handle_run
@@ -20,6 +22,19 @@ from agent.agui_adapter import handle_run
 load_dotenv()
 
 app = FastAPI(title="Langroid Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# Applied uniformly across every showcase FastAPI agent server so /health
+# remains reachable even if future changes introduce a catch-all mount at "/".
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -33,11 +48,6 @@ app.add_middleware(
 async def run_agent(request: Request):
     """AG-UI /run endpoint — streams SSE events."""
     return await handle_run(request)
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/starters/langroid/entrypoint.sh
+++ b/showcase/starters/langroid/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: langroid"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/llamaindex/agent_server.py
+++ b/showcase/starters/llamaindex/agent_server.py
@@ -13,12 +13,28 @@ import uvicorn
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from agent.agent import agent_router
 
 load_dotenv()
 
 app = FastAPI(title="LlamaIndex Agent Server")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `agent_router` can (now or in the future) register a catch-all at "/" that
+# would shadow a `@app.get("/health")` decorator. Middleware runs above the
+# routing layer, so /health stays reachable regardless.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
@@ -28,11 +44,6 @@ app.add_middleware(
 )
 
 app.include_router(agent_router)
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/starters/llamaindex/entrypoint.sh
+++ b/showcase/starters/llamaindex/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: llamaindex"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: mastra"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Mastra agent on port 8123..."
-PORT=8123 npx mastra dev 2>&1 | sed 's/^/[agent] /' &
+PORT=8123 npx mastra dev &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/ms-agent-dotnet/entrypoint.sh
+++ b/showcase/starters/ms-agent-dotnet/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: ms-agent-dotnet"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting .NET agent on port 8123..."
-cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 2>&1 | sed 's/^/[agent] /' &
+cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 cd /app
 sleep 3
@@ -46,7 +53,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/ms-agent-python/agent_server.py
+++ b/showcase/starters/ms-agent-python/agent_server.py
@@ -16,6 +16,8 @@ from agent_framework_ag_ui import add_agent_framework_fastapi_endpoint
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from agent.agent import create_agent
 
@@ -42,6 +44,21 @@ chat_client = _build_chat_client()
 my_agent = create_agent(chat_client)
 
 app = FastAPI(title="CopilotKit + Microsoft Agent Framework (Python)")
+
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `add_agent_framework_fastapi_endpoint(..., path="/")` installs a catch-all
+# at the root that shadows any later `@app.get("/health")` decorator.
+# Middleware runs above the routing layer, so /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -55,11 +72,6 @@ add_agent_framework_fastapi_endpoint(
     agent=my_agent,
     path="/",
 )
-
-
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 
 def main():

--- a/showcase/starters/ms-agent-python/entrypoint.sh
+++ b/showcase/starters/ms-agent-python/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: ms-agent-python"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/pydantic-ai/agent_server.py
+++ b/showcase/starters/pydantic-ai/agent_server.py
@@ -9,6 +9,8 @@ import os
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from dotenv import load_dotenv
 
 from agent.agent import SalesTodosState, StateDeps, agent
@@ -17,17 +19,28 @@ load_dotenv()
 
 app = FastAPI(title="PydanticAI Agent Server")
 
+
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `app.mount("/", ag_ui_app)` installs a Starlette Mount at the root that
+# matches every path (including /health). A plain `@app.get("/health")`
+# decorator registered before the mount was still shadowed in practice because
+# Mount at "/" is a prefix match rather than an exact one. Middleware runs
+# above the routing layer, which guarantees /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# Health endpoint MUST be registered BEFORE app.mount("/") — mount creates a catch-all
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
 
 # Mount the PydanticAI AG-UI endpoint at the root
 ag_ui_app = agent.to_ag_ui(deps=StateDeps(SalesTodosState()))

--- a/showcase/starters/pydantic-ai/entrypoint.sh
+++ b/showcase/starters/pydantic-ai/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: pydantic-ai"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/spring-ai/entrypoint.sh
+++ b/showcase/starters/spring-ai/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: spring-ai"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Spring AI agent on port 8123..."
-java -jar agent/app.jar --server.port=8123 2>&1 | sed 's/^/[agent] /' &
+java -jar agent/app.jar --server.port=8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 5
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/strands/agent_server.py
+++ b/showcase/starters/strands/agent_server.py
@@ -91,6 +91,8 @@ _assert_instrumentor_patched()
 
 import uvicorn  # noqa: E402  (kept after patch for consistent import-ordering policy)
 from dotenv import load_dotenv  # noqa: E402
+from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
+from starlette.responses import JSONResponse  # noqa: E402
 
 from ag_ui_strands import create_strands_app  # noqa: E402  (must follow instrumentor patch)
 from agent.agent import build_showcase_agent  # noqa: E402  (must follow instrumentor patch)
@@ -107,9 +109,18 @@ agent_path = os.getenv("AGENT_PATH", "/")
 app = create_strands_app(agui_agent, agent_path)
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
+# Serve /health via middleware so it short-circuits BEFORE route resolution.
+# `create_strands_app(..., agent_path="/")` installs a catch-all at the root
+# that shadows any later `@app.get("/health")` decorator. Middleware runs
+# above the routing layer, so /health stays reachable.
+class HealthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+app.add_middleware(HealthMiddleware)
 
 
 def main():

--- a/showcase/starters/strands/entrypoint.sh
+++ b/showcase/starters/strands/entrypoint.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: strands"
 echo "[entrypoint] Time: $(date -u)"
@@ -24,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -45,7 +52,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"

--- a/showcase/starters/template/entrypoint.template.sh
+++ b/showcase/starters/template/entrypoint.template.sh
@@ -9,6 +9,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Disable Python stdout buffering so Python-based agents flush tracebacks
+# and log lines to awk (and the container log) the moment they're written.
+# Previously a silent crash during module import would sit in Python's
+# userspace buffer until the process exited, by which point the pipe to the
+# log prefixer had already closed and the error was lost.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: {{SLUG}}"
 echo "[entrypoint] Time: $(date -u)"
@@ -36,7 +43,12 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-env NODE_ENV=production npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"


### PR DESCRIPTION
## Summary

15 of 17 showcase starters were reporting `{status: "degraded", agent: "error" | "down"}` from `/api/health`. Root-caused to two compounding bugs that hid each other.

### Cause 1 — FastAPI route shadowed by mount catch-all

Python FastAPI starters registered `@app.get("/health")` but then installed an AG-UI adapter at `/` (either `app.mount("/", stream.build_asgi())` or `add_agent_framework_fastapi_endpoint(path="/")`). Starlette's `Mount` at `/` is a prefix match and swallows every subsequent request including `/health`, so the decorated handler never fired and the runtime saw a non-JSON agent response and flagged the starter as "degraded".

Repro (reduced, before):
```python
app = FastAPI()
app.mount("/", mounted)  # or adapter that mounts at "/"

@app.get("/health")
def health():
    return {"status": "ok"}

# curl /health -> "agent-saw:/health"  (wrong — mount won)
```

Fix: install a `HealthMiddleware` (BaseHTTPMiddleware) that short-circuits `GET /health` above the routing layer, which runs before any Mount can claim the path. Agent mount stays intact so AG-UI traffic at `/` is unaffected.

Applies to 10 Python agent starters: ag2, agno, claude-sdk-python, crewai-crews, google-adk, langroid, llamaindex, ms-agent-python, pydantic-ai, strands.

### Cause 2 — `$!` after a pipeline points to `sed`, not the agent

The entrypoint template used:
```bash
cmd 2>&1 | sed 's/^/[agent] /' &
AGENT_PID=$!
```
After a pipeline, `$!` is the last command (`sed`), not the agent. Every `kill -0 $AGENT_PID` and `wait -n $AGENT_PID` therefore monitored `sed`, which stays alive until its stdin closes — long after the agent crashed. Compounding that, `sed` buffers by default and Python agents buffer their own stdout, so a stack trace at crash time was discarded when the pipe closed.

Fix: process substitution instead of pipeline, plus `PYTHONUNBUFFERED=1` at the entrypoint level:
```bash
cmd &> >(awk '{print "[agent] " $0; fflush()}') &
AGENT_PID=$!
```
Process substitution doesn't create a pipeline, so `$!` stays the agent's PID. `awk` with `fflush()` line-flushes prefixed output immediately.

Applied to all 17 starters via `generate-starters.ts` + the template.

### Cause 2a — hidden langgraph-fastapi crash

`generate-starters.ts` rewrites relative imports to absolute for langgraph starters (langgraph_cli loads modules standalone, not as packages). The rewrite was flat: `from .X import ...` -> `from <agentDir>.X import ...`. For a file at `<agentDir>/tools/get_weather.py`, `from .types import ...` resolves to `tools.types` (the CURRENT package), not `<agentDir>.types`. The flat rewrite dropped the `tools` segment and produced:
```
ModuleNotFoundError: No module named 'src.agents.types'
```
at import time. The agent crashed; the `sed` pipe bug swallowed the traceback; the 2-3s sleep guard caught the window while `sed` was still alive; `/api/health` reported `agent: "error"`.

Fix: make the rewrite subdir-aware — compute the file's containing Python package from its relative path under `agentDest` and prepend that to the relative import target. So `from .types import ...` inside `src/agents/tools/get_weather.py` becomes `from src.agents.tools.types import ...`.

langgraph-python had the same broken imports in `tools/__init__.py` but doesn't crash at runtime because `main.py` doesn't import from `tools` (dead path). Regenerating fixes the dead code too.

## Verification

### Middleware logic (reduced reproduction)

```python
# With HealthMiddleware installed above the routing layer:
app = FastAPI()
app.add_middleware(HealthMiddleware)
app.mount("/", mounted)

c.get("/health")      # 200 {"status": "ok"}   <- short-circuited
c.get("/anything")    # 200 agent-saw:/anything <- reaches mount
c.get("/")            # 200 agent-saw:/         <- reaches mount
```

### Tests
- `showcase/scripts` vitest: 1061/1061 passing
- `generate-starters.test.ts` (258) and `starter-consistency.test.ts` (306) both still green — no test updates required

### Starters touched
- Cause 1 (HealthMiddleware): ag2, agno, claude-sdk-python, crewai-crews, google-adk, langroid, llamaindex, ms-agent-python, pydantic-ai, strands (10)
- Cause 2 (entrypoint PID): all 17 starters via generator + template
- Cause 2a (langgraph import): langgraph-fastapi (crash path), langgraph-python (dead path)

## Commits

1. `fix(showcase/starters): serve /health via middleware to bypass FastAPI mount shadow` — Cause 1
2. `fix(showcase/starters): capture real agent PID in entrypoint.sh + unbuffer stderr` — Cause 2
3. `fix(showcase/starters/langgraph-fastapi): correct src.agents.tools.* imports` — Cause 2a

## Test plan

- [ ] Docker build + run ag2: `curl -i http://localhost:3000/api/health` returns 200 `{"status":"ok",...}`
- [ ] Docker build + run langgraph-fastapi: health OK, agent imports succeed, no ModuleNotFoundError in logs
- [ ] Docker build + run langgraph-typescript: health OK (entrypoint-only fix)
- [ ] Post-merge Railway: monitor all 17 starter health endpoints return `status: "ok"` after redeploy
- [ ] Post-merge: inspect logs for any starter that still reports `degraded` — with awk+fflush+PYTHONUNBUFFERED, the real import/crash error should now surface in container logs

## Safety notes

- No `.github/workflows/*.yml` edits
- No force-push, no amend
- Author: Jordan Ritter <jordan@copilotkit.ai>
- Do NOT merge until reviewer approves