### PR TITLE
fix(showcase/langroid): route A2UI planner through langroid LLM abstraction

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,12 @@
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.webm filter=lfs diff=lfs merge=lfs -text
 
+# Shell scripts must retain LF line endings. Windows contributors regenerating
+# showcase starters on a Windows checkout (or with autocrlf=true) would
+# otherwise silently ship CRLF ``entrypoint.sh`` files that bash in the
+# Docker runtime rejects (``bad interpreter: No such file or directory``).
+*.sh text eol=lf
+
 # Generated showcase starters — do not edit manually
 # Regenerate with: cd showcase/scripts && npx tsx generate-starters.ts
 showcase/starters/ag2/** linguist-generated=true

--- a/showcase/packages/langroid/.env.example
+++ b/showcase/packages/langroid/.env.example
@@ -5,8 +5,15 @@ ANTHROPIC_API_KEY=replace-with-your-key
 # Agent backend URL (for the CopilotKit runtime proxy)
 AGENT_URL=http://localhost:8000
 
-# Langroid model (defaults to openai/gpt-4.1)
-# LANGROID_MODEL=openai/gpt-4.1
+# Langroid model (defaults to the bare OpenAI name `gpt-4.1`).
+# NOTE: langroid does NOT strip the `openai/` prefix before passing the
+# model string to the OpenAI SDK — using `openai/gpt-4.1` here will produce
+# a "model not found" error at request time. Use bare names like `gpt-4.1`
+# for OpenAI; use provider prefixes (`litellm/anthropic/...`, `gemini/...`,
+# `openrouter/...`, `ollama/...`, etc.) for non-OpenAI providers.
+# LANGROID_MODEL=gpt-4.1
+# LANGROID_MODEL=litellm/anthropic/claude-opus-4
+# LANGROID_MODEL=gemini/gemini-2.5-flash
 
 # Showcase
 NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/showcase/packages/langroid/Dockerfile
+++ b/showcase/packages/langroid/Dockerfile
@@ -16,28 +16,45 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Create unprivileged runtime user BEFORE any COPY so --chown resolves
+# by name and so recursive chown over /app is never needed (fast builds).
+# Mirrors the starter Dockerfile pattern for parity — Railway / any
+# platform that enforces non-root by policy needs this from the package
+# image too, not just the generated starter.
+RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
+ && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
+ && mkdir -p /home/app && chown app:app /home/app
+
 # Python dependencies
-COPY requirements.txt ./
+COPY --chown=app:app requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Next.js build artifacts
-COPY --from=frontend /app/.next ./.next
-COPY --from=frontend /app/node_modules ./node_modules
-COPY --from=frontend /app/package.json ./
-COPY --from=frontend /app/public ./public
+COPY --chown=app:app --from=frontend /app/.next ./.next
+COPY --chown=app:app --from=frontend /app/node_modules ./node_modules
+COPY --chown=app:app --from=frontend /app/package.json ./
+COPY --chown=app:app --from=frontend /app/public ./public
 
 # Agent code
-COPY src/agent_server.py ./
-COPY src/agents/ ./agents/
+COPY --chown=app:app src/agent_server.py ./
+COPY --chown=app:app src/agents/ ./agents/
 
 # Shared Python tools (copied into build context by CI)
-COPY shared_python/ /app/shared/python/
+COPY --chown=app:app shared_python/ /app/shared/python/
 ENV PYTHONPATH=/app/shared/python
 
 # Entrypoint
-COPY entrypoint.sh ./
+COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+USER app
+
 EXPOSE 10000
-ENV NODE_ENV=production
+# Intentionally NOT setting `ENV NODE_ENV=production` at the image level.
+# NODE_ENV=production at the image level would leak into every child process
+# (Python agent, shell scripts, healthchecks) — most of which don't use it
+# the way Next.js does. entrypoint.sh scopes NODE_ENV=production to the
+# Next.js invocation only so non-Next children see the host's environment.
+ENV PORT=10000
+ENV HOSTNAME=0.0.0.0
 CMD ["./entrypoint.sh"]

--- a/showcase/packages/langroid/entrypoint.sh
+++ b/showcase/packages/langroid/entrypoint.sh
@@ -1,12 +1,379 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
+# Initialize PIDs up front so the cleanup trap below does not emit bare
+# ``kill`` usage errors when the script aborts before either child starts
+# (e.g. FATAL in ``_check_key``).
+AGENT_PID=""
+NEXT_PID=""
+
+cleanup() {
+    # Trap may fire from a FATAL ``exit 1`` path where ``set -e`` is still
+    # active. Any non-zero return from ``kill`` (e.g. process already gone)
+    # in a ``&&`` chain whose final command is ``kill`` is subject to
+    # errexit and would abort cleanup before the grace loop runs. Disable
+    # errexit for the duration of the trap — every kill/wait below
+    # explicitly expects and tolerates non-zero returns.
+    set +e
+    # Guard each pid: empty var -> skip (no operand), set var -> best-effort
+    # SIGTERM. ``2>/dev/null`` swallows normal "no such process" races after
+    # wait has already reaped the child.
+    #
+    # After SIGTERM, give each child up to 5s to exit cleanly before
+    # escalating to SIGKILL. Matches the survivor-termination grace window
+    # further down and the starter entrypoint's cleanup pattern — a
+    # runaway uvicorn / next.js process should not get wedged on trap-exit
+    # waiting for the container runtime to SIGKILL it.
+    [ -n "$AGENT_PID" ] && kill "$AGENT_PID" 2>/dev/null
+    [ -n "$NEXT_PID" ] && kill "$NEXT_PID" 2>/dev/null
+    for _ in 1 2 3 4 5; do
+        local any_alive=0
+        [ -n "$AGENT_PID" ] && kill -0 "$AGENT_PID" 2>/dev/null && any_alive=1
+        [ -n "$NEXT_PID" ] && kill -0 "$NEXT_PID" 2>/dev/null && any_alive=1
+        [ "$any_alive" = "0" ] && break
+        sleep 1
+    done
+    [ -n "$AGENT_PID" ] && kill -0 "$AGENT_PID" 2>/dev/null && kill -9 "$AGENT_PID" 2>/dev/null
+    [ -n "$NEXT_PID" ] && kill -0 "$NEXT_PID" 2>/dev/null && kill -9 "$NEXT_PID" 2>/dev/null
+    return 0
+}
+trap cleanup EXIT
+
+# Provider-agnostic startup diagnostic. langroid is multi-provider — the chat
+# model is selected via ``LANGROID_MODEL`` (e.g. ``gpt-4.1``,
+# ``litellm/anthropic/claude-opus-4``, ``gemini/gemini-2.5-flash``). Whichever
+# provider is picked, only THAT provider's API key is required.
+#
+# This block inspects ``LANGROID_MODEL`` (and the planner-only override
+# ``A2UI_MODEL`` if distinct) and warns when the expected credential env
+# var is missing. Default behavior is warn-and-continue so operators can
+# bring the container up for local dev; set ``REQUIRE_LANGROID_API_KEY=1``
+# in production to fail-fast.
+# Map a langroid model string like ``gpt-4.1`` (bare OpenAI name) or
+# ``gemini/gemini-2.5-flash`` to the env var that langroid's ``OpenAIGPT``
+# client actually reads at request time. Mappings verified against
+# langroid's installed ``language_models/openai_gpt.py`` — in particular:
+#   * Bare OpenAI names (``gpt-*``, ``o1*``, ``o3*``, ``o4*``, anything with
+#                        NO ``/`` separator)
+#                     -> ``OPENAI_API_KEY``. langroid strips no prefix from
+#                        ``openai/<model>`` — it passes the model string
+#                        LITERALLY to the OpenAI SDK, which then rejects
+#                        ``openai/gpt-4.1`` as "model not found". Use bare
+#                        OpenAI names.
+#   * ``openai/*``     -> WARN (fatal under REQUIRE_LANGROID_API_KEY=1):
+#                        ``openai/`` is NOT a langroid-native prefix;
+#                        langroid passes it literally to the OpenAI SDK
+#                        which will reject the model id.
+#   * ``gemini/*``     -> ``GEMINI_API_KEY`` (NOT ``GOOGLE_API_KEY``; that is
+#                        google-genai / google-adk's convention, not langroid's).
+#   * ``openrouter/*`` -> ``OPENROUTER_API_KEY``.
+#   * ``groq/*``       -> ``GROQ_API_KEY`` (native langroid prefix).
+#   * ``cerebras/*``   -> ``CEREBRAS_API_KEY`` (native langroid prefix).
+#   * ``glhf/*``       -> ``GLHF_API_KEY`` (native langroid prefix).
+#   * ``minimax/*``    -> ``MINIMAX_API_KEY`` (native langroid prefix).
+#   * ``portkey/*``    -> ``PORTKEY_API_KEY`` (native langroid prefix; note
+#                        langroid ALSO reads portkey provider-specific keys
+#                        at request time — a plain ``PORTKEY_API_KEY`` probe
+#                        is the best we can do at boot).
+#   * ``deepseek/*``   -> ``DEEPSEEK_API_KEY`` (native langroid prefix).
+#   * ``litellm/anthropic/*`` -> ``ANTHROPIC_API_KEY`` (langroid strips the
+#                        ``litellm/`` prefix and delegates to litellm, which
+#                        reads ``ANTHROPIC_API_KEY`` for the Anthropic provider).
+#   * Bare ``anthropic/*`` is NOT a langroid-native prefix — langroid has no
+#                        handling for it and falls through to the default
+#                        OpenAI client, which rejects the request. We still
+#                        map it to ``ANTHROPIC_API_KEY`` so the env-guard
+#                        doesn't falsely succeed in warn-mode, but _check_key
+#                        FATALs under ``REQUIRE_LANGROID_API_KEY=1`` so fail-
+#                        fast operators see this misconfig at boot rather than
+#                        at first request.
+#   * ``ollama/*``, ``local/*``, ``vllm/*``, ``llamacpp/*`` -> no API key
+#                        required (local-inference); ``_check_key`` returns
+#                        the ``NO_KEY_REQUIRED`` sentinel and logs INFO.
+_expected_key_for_model() {
+    local model="${1:-gpt-4.1}"
+    # ORDER MATTERS: ``litellm/anthropic/*`` must precede the bare
+    # ``anthropic/*`` arm below. Otherwise ``litellm/anthropic/...`` would
+    # never match — bash ``case`` uses first-match-wins, and an earlier bare
+    # ``anthropic/*`` arm would never fire for a ``litellm/`` prefix anyway,
+    # but keeping litellm first makes the routing intent explicit and is
+    # robust to future reorderings.
+    case "$model" in
+        # Local-inference prefixes: no API key required. Sentinel distinct
+        # from the empty string so _check_key can log an INFO and return 0
+        # even under REQUIRE_LANGROID_API_KEY=1 (fail-fast), rather than
+        # FATALing with "Cannot infer required credential".
+        ollama/*|local/*|vllm/*|llamacpp/*) echo "NO_KEY_REQUIRED" ;;
+        litellm/anthropic/*)  echo "ANTHROPIC_API_KEY" ;;
+        anthropic/*)          echo "ANTHROPIC_API_KEY" ;;
+        openai/*)             echo "OPENAI_API_KEY" ;;
+        openrouter/*)         echo "OPENROUTER_API_KEY" ;;
+        gemini/*)             echo "GEMINI_API_KEY" ;;
+        # ``google/`` is intentionally NOT mapped here. langroid has no
+        # native ``google/`` prefix handling — treating it as a gemini
+        # alias would let fail-fast mode "succeed" at boot (because
+        # GEMINI_API_KEY is set) only to blow up at request time when
+        # langroid falls through to the default OpenAI client. The
+        # dedicated ``google/*`` arm inside ``_check_key`` FATALs under
+        # REQUIRE_LANGROID_API_KEY=1 and WARNs otherwise, which is the
+        # correct signal.
+        groq/*)               echo "GROQ_API_KEY" ;;
+        cerebras/*)           echo "CEREBRAS_API_KEY" ;;
+        glhf/*)               echo "GLHF_API_KEY" ;;
+        minimax/*)            echo "MINIMAX_API_KEY" ;;
+        portkey/*)            echo "PORTKEY_API_KEY" ;;
+        deepseek/*)           echo "DEEPSEEK_API_KEY" ;;
+        # langdb/*: langroid's ``OpenAIGPT`` natively handles this prefix
+        # (sets ``is_langdb``) and resolves credentials via ``langdb_params``
+        # (a config object) rather than a single env var. There is no env var
+        # for us to probe at startup — emit a distinct NO_KEY_REQUIRED_*
+        # sentinel so ``_check_key`` logs INFO and returns 0 even under
+        # REQUIRE_LANGROID_API_KEY=1.
+        langdb/*)             echo "NO_KEY_REQUIRED_LANGDB" ;;
+        # litellm-proxy/*: langroid's ``OpenAIGPT`` natively handles this
+        # prefix (sets ``is_litellm_proxy``) and resolves credentials via
+        # ``LiteLLMProxyConfig`` (a config object) rather than a single env
+        # var. Same NO_KEY_REQUIRED_* treatment as langdb/.
+        litellm-proxy/*)      echo "NO_KEY_REQUIRED_LITELLM_PROXY" ;;
+        # Non-anthropic litellm variants (``litellm/openai/*``,
+        # ``litellm/azure/*``, ``litellm/bedrock/*``, etc.) — litellm resolves
+        # per-provider env vars internally (AZURE_API_KEY, AZURE_API_BASE,
+        # AWS_ACCESS_KEY_ID, ...) and we don't know which to probe at boot.
+        # Note: ``litellm/anthropic/*`` is handled by the SPECIFIC earlier
+        # arm (returns ANTHROPIC_API_KEY) and matches first by bash
+        # first-match-wins ordering — this catch-all only sees the non-
+        # anthropic variants.
+        litellm/*)            echo "NO_KEY_REQUIRED_LITELLM" ;;
+        # Bare model names with no ``/`` separator are treated as OpenAI
+        # (gpt-*, o1*, o3*, o4*, chatgpt-*, etc.). This matches langroid's
+        # canonical convention (``OpenAIChatModel.GPT4_1.value == "gpt-4.1"``)
+        # — and the OpenAI SDK accepts them directly.
+        */*)                  echo "" ;;
+        *)                    echo "OPENAI_API_KEY" ;;
+    esac
+}
+
+# Log when we're falling back to the default so operators understand why
+# the OpenAI-shaped env guard fires even though they "didn't pick OpenAI".
+if [ -z "${LANGROID_MODEL:-}" ]; then
+    echo "[entrypoint] INFO: LANGROID_MODEL not set — defaulting to 'gpt-4.1' (OPENAI_API_KEY will be required)" >&2
+fi
+LANGROID_MODEL_EFFECTIVE="${LANGROID_MODEL:-gpt-4.1}"
+A2UI_MODEL_EFFECTIVE="${A2UI_MODEL:-$LANGROID_MODEL_EFFECTIVE}"
+
+_check_key() {
+    local model="$1"; local role="$2"
+    # ``google/`` is a common typo for ``gemini/`` — handle it BEFORE we
+    # call ``_expected_key_for_model`` so a GEMINI_API_KEY that happens to
+    # be set can't silently pass the fail-fast guard for a prefix that has
+    # no langroid-native routing.
+    case "$model" in
+        google/*)
+            if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+                echo "[entrypoint] FATAL: $role model '$model' uses 'google/' prefix which is not a langroid-native prefix. Use 'gemini/<model>' instead (with GEMINI_API_KEY set); refusing to start under REQUIRE_LANGROID_API_KEY=1" >&2
+                exit 1
+            fi
+            echo "[entrypoint] WARN: $role model '$model' uses 'google/' prefix — langroid has no native google/ routing; use 'gemini/<model>' instead. Request-time calls will fail." >&2
+            return 0
+            ;;
+    esac
+    # ``openai/*`` is NOT langroid-native either: langroid passes the full
+    # string LITERALLY to the OpenAI SDK (verified empirically — the
+    # ``openai/`` prefix is not stripped inside ``lm.OpenAIGPT``), and the
+    # SDK rejects ``openai/gpt-4.1`` as "model not found". Emit a warning so
+    # operators see the boot-time remediation rather than a cryptic
+    # request-time failure.
+    case "$model" in
+        openai/*)
+            if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+                echo "[entrypoint] FATAL: $role model '$model' uses 'openai/' prefix which is not a langroid-native prefix — langroid passes it literally to the OpenAI SDK which will reject it. Use the bare model name (e.g. 'gpt-4.1') instead; refusing to start under REQUIRE_LANGROID_API_KEY=1" >&2
+                exit 1
+            fi
+            echo "[entrypoint] WARN: $role model '$model' uses 'openai/' prefix — langroid passes it LITERALLY to the OpenAI SDK (the prefix is NOT stripped) and the SDK will reject it as 'model not found'. Use the bare model name (e.g. 'gpt-4.1') instead. Falling through to OPENAI_API_KEY check so the operator sees both issues at boot." >&2
+            ;;
+    esac
+    local var
+    var=$(_expected_key_for_model "$model")
+    # NO_KEY_REQUIRED sentinels — two families:
+    #   * Plain ``NO_KEY_REQUIRED``: local-inference models (ollama/, local/,
+    #     vllm/, llamacpp/) — no credential at all.
+    #   * ``NO_KEY_REQUIRED_*`` variants: langroid-native prefixes where
+    #     credentials ARE required but resolved via a config object
+    #     (langdb_params, LiteLLMProxyConfig) or via per-provider env vars
+    #     internal to litellm (AZURE_*, AWS_*, etc.). We cannot name a
+    #     single env var to probe at startup — skip the env-key check and
+    #     let request-time surface any missing config.
+    # Both skip the env check and return 0 even under REQUIRE_LANGROID_API_KEY=1
+    # so the fail-fast contract doesn't reject a legitimately-configured
+    # langroid-native prefix.
+    case "$var" in
+        NO_KEY_REQUIRED)
+            echo "[entrypoint] INFO: local-inference model '$model' — no API key required for $role" >&2
+            return 0
+            ;;
+        NO_KEY_REQUIRED_*)
+            echo "[entrypoint] INFO: $role model '$model' uses a langroid-native prefix that resolves credentials via config (no single env var to probe) — skipping env-key check" >&2
+            return 0
+            ;;
+    esac
+    if [ -z "$var" ]; then
+        if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+            echo "[entrypoint] FATAL: Cannot infer required credential for $role model '$model'. Set a langroid-native prefix (bare OpenAI name e.g. 'gpt-4.1', litellm/anthropic/, gemini/, openrouter/, groq/, cerebras/, glhf/, minimax/, portkey/, deepseek/, ollama/, local/, vllm/, llamacpp/) or set REQUIRE_LANGROID_API_KEY=0 to downgrade to warn-mode." >&2
+            exit 1
+        fi
+        echo "[entrypoint] INFO: $role model '$model' does not match a known provider prefix — skipping env-key check (request-time calls will surface credentials)" >&2
+        return 0
+    fi
+    # Bash indirect expansion with default: ``${!var:-}`` resolves to the
+    # value of the env var NAMED by ``$var``, or "" if unset. The ``:-``
+    # default guarantees we evaluate to the empty string when the caller has
+    # not exported the credential, which is what the empty-check below
+    # expects. Note: this script runs under ``set -e`` but NOT ``set -u`` —
+    # every ``${FOO:-default}`` site in the file is load-bearing as-written
+    # because several env vars (REQUIRE_LANGROID_API_KEY, LANGROID_MODEL,
+    # A2UI_MODEL, PORT) are commonly unset in dev.
+    local val="${!var:-}"
+    if [ -z "$val" ]; then
+        if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+            echo "[entrypoint] FATAL: $var not set (required by $role model '$model') and REQUIRE_LANGROID_API_KEY=1 — refusing to start" >&2
+            exit 1
+        fi
+        echo "[entrypoint] WARN: $var not set — $role ('$model') calls will fail at request time (structured error returned to client)" >&2
+    fi
+    # Bare ``anthropic/<model>`` is not a langroid-native prefix; langroid
+    # only routes Anthropic via ``litellm/anthropic/...`` or
+    # ``openrouter/anthropic/...``. If an operator sets
+    # ``LANGROID_MODEL=anthropic/claude-opus-4`` the env-key check passes
+    # but the request will fail downstream because langroid falls back to
+    # the default OpenAI client and the OpenAI SDK rejects the model id.
+    #
+    # Under ``REQUIRE_LANGROID_API_KEY=1`` we FATAL (fail-fast contract) —
+    # silently booting and failing at first request contradicts the whole
+    # point of the guard. Under warn-mode we surface a WARN so local-dev
+    # operators can still bring the container up. The outer ``case``
+    # pattern already matched ``anthropic/*`` — no inner guard is needed
+    # (a string cannot simultaneously start with ``anthropic/`` and
+    # ``litellm/anthropic/``; the latter is handled by the earlier
+    # ``litellm/anthropic/*`` arm in ``_expected_key_for_model``).
+    # NOTE: this case intentionally tests only the bare ``anthropic/*``
+    # pattern. ``litellm/anthropic/...`` strings already matched the earlier
+    # ``litellm/anthropic/*`` arm in ``_expected_key_for_model`` (which runs
+    # first by design — see the ORDER MATTERS comment there) and are routed
+    # correctly via litellm; we must NOT warn on them here.
+    case "$model" in
+        anthropic/*)
+            if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+                echo "[entrypoint] FATAL: $role model '$model' uses bare 'anthropic/' prefix which is not routable through langroid (native langroid Anthropic support goes via 'litellm/anthropic/<model>' with ANTHROPIC_API_KEY set); refusing to start under REQUIRE_LANGROID_API_KEY=1" >&2
+                exit 1
+            fi
+            echo "[entrypoint] WARN: $role model '$model' uses bare 'anthropic/' prefix — langroid has no native Anthropic routing; requests will fail. Use 'litellm/anthropic/<model>' instead (drop-in replacement that reads ANTHROPIC_API_KEY)." >&2
+            ;;
+    esac
+}
+
+_check_key "$LANGROID_MODEL_EFFECTIVE" "primary agent"
+if [ "$A2UI_MODEL_EFFECTIVE" != "$LANGROID_MODEL_EFFECTIVE" ]; then
+    _check_key "$A2UI_MODEL_EFFECTIVE" "A2UI planner"
+fi
+
+# Start agent backend.
+# NOTE: `set -e` does not fire on backgrounded processes — if uvicorn crashes
+# immediately, the shell still proceeds to start Next.js. We capture PIDs and
+# probe them explicitly after `wait -n` so operators can tell which process
+# died with which exit code.
 python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+AGENT_PID=$!
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
+# Start Next.js frontend (PORT defaults to 10000 — Railway / local compose
+# override as needed).
 npx next start --port ${PORT:-10000} &
+NEXT_PID=$!
 
-# Wait for either process to exit
-wait -n
-exit $?
+# Wait for either process to exit; then figure out which one.
+# set +e for wait -n; exit code captured explicitly into EXIT_CODE. The
+# subsequent `kill -0` / `echo` calls run without errexit — that is fine
+# because the final `exit "$EXIT_CODE"` uses the captured value, so the
+# container exits with the dying child's status regardless.
+#
+# errexit (set -e) is INTENTIONALLY left off for the remainder of the
+# script: the diagnostic and cleanup blocks below use `kill`, `kill -0`,
+# and `wait` calls whose non-zero returns are expected (dead process,
+# already-reaped child, EPERM). Re-enabling errexit would cause the shell
+# to abort before the survivor-termination grace window runs.
+set +e
+# ``wait -n "$AGENT_PID" "$NEXT_PID"`` (positional pid list) narrows the wait
+# to just the two children we explicitly spawned, so an unrelated reaped
+# subshell (e.g. process-substitution helper) cannot spuriously satisfy
+# ``wait -n`` with its exit code. Requires bash 5.1+ — the base image ships
+# bash 5.2. For symmetry with the starter entrypoint.
+wait -n "$AGENT_PID" "$NEXT_PID"
+EXIT_CODE=$?
+
+# Interpret common POSIX / shell exit codes for operators reading the log
+# stream. These are the codes likely to show up from uvicorn/next.js/Node
+# under typical container-orchestration conditions (OOM kill, SIGTERM,
+# missing binary, uncaught-fatal, Ctrl-C during `docker run -it`, etc.).
+case "$EXIT_CODE" in
+    0)   EXIT_MEANING="clean exit (unexpected for a long-running server)" ;;
+    1)   EXIT_MEANING="generic error (uncaught exception / non-zero program exit)" ;;
+    2)   EXIT_MEANING="misuse of shell builtin / bad CLI args" ;;
+    126) EXIT_MEANING="command invoked but not executable (permission denied)" ;;
+    127) EXIT_MEANING="command not found (missing binary / bad PATH)" ;;
+    130) EXIT_MEANING="SIGINT (Ctrl-C / interactive interrupt)" ;;
+    137) EXIT_MEANING="SIGKILL (likely OOM-killed or force-stopped)" ;;
+    139) EXIT_MEANING="SIGSEGV (segmentation fault — native crash)" ;;
+    143) EXIT_MEANING="SIGTERM (orderly shutdown from platform)" ;;
+    255) EXIT_MEANING="exit -1 / catastrophic program failure" ;;
+    *)   EXIT_MEANING="(no common interpretation)" ;;
+esac
+
+SURVIVOR_PID=""
+if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+    echo "[entrypoint] agent backend (uvicorn, pid=$AGENT_PID) exited with code $EXIT_CODE — $EXIT_MEANING" >&2
+    if kill -0 "$NEXT_PID" 2>/dev/null; then
+        SURVIVOR_PID="$NEXT_PID"
+    fi
+elif ! kill -0 "$NEXT_PID" 2>/dev/null; then
+    echo "[entrypoint] next.js frontend (pid=$NEXT_PID) exited with code $EXIT_CODE — $EXIT_MEANING" >&2
+    if kill -0 "$AGENT_PID" 2>/dev/null; then
+        SURVIVOR_PID="$AGENT_PID"
+    fi
+else
+    # `wait -n` returned but both pids still resolve. This most commonly
+    # happens when a child was reaped before we ran `kill -0` (race), which
+    # means one IS actually dead — we just can't tell which. Escalate to
+    # ERROR + exit 1 so this path does not silently mask the real death.
+    # Under no-children-dead the shell would never reach this block.
+    echo "[entrypoint] ERROR: wait -n returned exit=$EXIT_CODE ($EXIT_MEANING) but both agent ($AGENT_PID) and next.js ($NEXT_PID) appear alive — treating as fatal race; the actual dying child's status has already been reaped" >&2
+    exit 1
+fi
+
+# Terminate the surviving sibling with a bounded grace window so it shuts
+# down cleanly rather than getting SIGKILL'd by the container runtime at
+# teardown.
+if [ -n "$SURVIVOR_PID" ]; then
+    echo "[entrypoint] Terminating surviving sibling (pid=${SURVIVOR_PID}) to avoid orphan-reparent" >&2
+    # Capture kill failure: if `kill` returns non-zero AND the process is
+    # still alive, that's a real signal-delivery failure (e.g. EPERM) —
+    # surface it rather than letting `2>/dev/null` swallow the diagnosis.
+    if ! kill "$SURVIVOR_PID" 2>/dev/null; then
+        if kill -0 "$SURVIVOR_PID" 2>/dev/null; then
+            echo "[entrypoint] WARN: kill(SIGTERM) failed for survivor pid=${SURVIVOR_PID} but process is still alive — signal delivery refused (EPERM?)" >&2
+        fi
+    fi
+    for _ in 1 2 3 4 5; do
+        kill -0 "$SURVIVOR_PID" 2>/dev/null || break
+        sleep 1
+    done
+    if kill -0 "$SURVIVOR_PID" 2>/dev/null; then
+        echo "[entrypoint] Survivor (pid=${SURVIVOR_PID}) did not exit within 5s — sending SIGKILL" >&2
+        if ! kill -9 "$SURVIVOR_PID" 2>/dev/null; then
+            if kill -0 "$SURVIVOR_PID" 2>/dev/null; then
+                echo "[entrypoint] WARN: kill(SIGKILL) failed for survivor pid=${SURVIVOR_PID} but process is still alive — cannot force-terminate (EPERM?)" >&2
+            fi
+        fi
+    fi
+    wait "$SURVIVOR_PID" 2>/dev/null || true
+fi
+
+exit "$EXIT_CODE"

--- a/showcase/packages/langroid/requirements.txt
+++ b/showcase/packages/langroid/requirements.txt
@@ -3,3 +3,10 @@ uvicorn>=0.34.0
 langroid>=0.53.0
 ag-ui-protocol==0.1.9
 python-dotenv>=1.0.0
+# Direct-dependency pins: agui_adapter.py imports httpx / openai / pydantic
+# explicitly. langroid already transitively pulls all three, but pinning
+# floors here keeps behavior reproducible if langroid ever narrows its
+# transitive requirements.
+httpx>=0.27.0
+openai>=1.40.0
+pydantic>=2.0.0

--- a/showcase/packages/langroid/src/agents/agent.py
+++ b/showcase/packages/langroid/src/agents/agent.py
@@ -7,24 +7,54 @@ protocol (SSE events) manually using the ag-ui-protocol types.
 
 The agent supports:
   - Agentic chat (streaming text responses)
-  - Backend tool execution (get_weather, query_data, manage_sales_todos, get_sales_todos)
+  - Backend tool execution (get_weather, query_data, manage_sales_todos,
+    get_sales_todos, search_flights, generate_a2ui)
   - Frontend tool calls (change_background, generate_haiku, schedule_meeting)
   - Human-in-the-loop via schedule_meeting (frontend-rendered meeting time picker)
+
+NOTE ON DRIFT: This module is the canonical source. The starter copy at
+``showcase/starters/langroid/agent/agent.py`` is regenerated from this file
+by ``showcase/scripts/generate-starters.ts``, which strips the shared-tools
+path-injection block below (together with any now-unused stdlib imports it
+relied on) and rewrites ``from tools import ...`` into ``from .tools
+import ...`` — a single relative import against the starter's bundled
+``agent/tools/`` package; no legacy fallback path is emitted. Any fix
+must land in BOTH files until the generator is re-run.
+Sibling provider-agnostic A2UI planner implementations live in
+``showcase/packages/google-adk/src/agents/main.py`` and
+``showcase/packages/strands/src/agents/agent.py`` — keep error shapes
+aligned.
 """
 
 from __future__ import annotations
 
+import functools
 import json
+import logging
 import os
 import sys
-from typing import Annotated
+from enum import Enum
+from typing import Annotated, Any, Literal, Protocol, TypedDict, cast
+
+# Module-local binding for json.dumps. Tests that need to inject
+# serialization failures (RecursionError / MemoryError / etc.) patch THIS
+# symbol instead of ``json.dumps``. Patching the stdlib attribute directly
+# mutates the globally-shared module object and can collide with pytest /
+# caplog internals that dispatch through ``json.dumps`` during the test
+# — producing false failures that look like test-code bugs but are
+# actually patch-leakage. The module-local binding is the only safe
+# patch target.
+_json_dumps = json.dumps
 
 import langroid as lr
 import langroid.language_models as lm
 from langroid.agent.tool_message import ToolMessage
+from pydantic import ValidationError
 from dotenv import load_dotenv
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 # =====================================================================
 # Shared tool implementations
@@ -46,33 +76,583 @@ from tools import (
 
 
 # =====================================================================
+# A2UI planner LLM — provider-agnostic
+# =====================================================================
+#
+# The secondary LLM that emits the A2UI schema is routed through langroid's
+# own LLM abstraction (``lm.OpenAIGPT``, which despite the historical name
+# handles OpenAI / Anthropic / Gemini / any ``provider/model`` chat-model
+# string). That way this package stays provider-agnostic: whatever
+# ``LANGROID_MODEL`` the operator picks for the primary chat agent, the A2UI
+# planner inherits by default. Operators can override only the planner via
+# ``A2UI_MODEL`` without touching the primary agent.
+#
+# Sibling implementations live in
+# ``showcase/packages/google-adk/src/agents/main.py`` (Gemini-native) and
+# ``showcase/packages/strands/src/agents/agent.py`` (OpenAI-only). Keep the
+# error-surface shape (_A2uiError) consistent across all three so the
+# frontend renderer treats them identically.
+
+
+class _A2uiErrorKind(str, Enum):
+    """Closed set of known A2UI planner error kinds.
+
+    Using an Enum (str-valued so JSON serialization stays stable) lets us
+    catch typos at static-analysis time and gives tests a single place to
+    enumerate the valid set. Kept as ``str``-subclass so the serialized
+    JSON shape is identical to the previous bare-string contract.
+    """
+
+    LLM_ERROR = "a2ui_llm_error"
+    NO_TOOL_CALL = "a2ui_no_tool_call"
+    INVALID_ARGUMENTS = "a2ui_invalid_arguments"
+
+
+class _A2uiError(TypedDict):
+    """Shape of the structured error dict returned by generate_a2ui branches.
+
+    Every error branch MUST populate all three keys so callers (and the LLM
+    summarizing the tool result) see a consistent surface.
+
+    NOTE: Identical TypedDicts live in
+    ``showcase/packages/google-adk/src/agents/main.py`` and
+    ``showcase/packages/strands/src/agents/agent.py``. Keep all three in
+    sync — any key additions / removals must land in every sibling so the
+    A2UI error surface stays consistent across showcase adapters.
+    """
+
+    # Synthesized from ``_A2uiErrorKind`` (Python 3.11+ ``Literal[*tuple(...)]``
+    # unpacking) so the Literal and the enum can never drift out of sync.
+    # Add/remove a kind in the enum above and the TypedDict follows automatically.
+    error: Literal[*tuple(k.value for k in _A2uiErrorKind)]  # type: ignore[misc]
+    message: str
+    remediation: str
+
+
+class _A2uiSuccess(TypedDict):
+    """Shape of the successful generate_a2ui return value.
+
+    Mirrors what ``build_a2ui_operations_from_tool_call`` produces: a single
+    key ``a2ui_operations`` mapping to a list of operation dicts. Defining
+    the shape here (rather than ``dict[str, Any]``) lets type-checkers flag
+    accidental key renames and keeps the public contract documented next to
+    the error surface.
+    """
+
+    a2ui_operations: list[dict[str, Any]]
+
+
+def _a2ui_error(
+    *, error: _A2uiErrorKind, message: str, remediation: str
+) -> _A2uiError:
+    """Construct and contract-check an ``_A2uiError``.
+
+    Centralizing construction lets us enforce at runtime that every error
+    return from the A2UI planner carries all three required keys with
+    non-empty string values. Typos ("remediaton") or accidental omissions
+    blow up here rather than silently produce a malformed error surface.
+
+    ``error`` is the ``_A2uiErrorKind`` enum (not a raw string) so call sites
+    cannot invent new error codes and bypass the closed set. The factory
+    extracts ``.value`` internally; callers pass the enum directly.
+
+    Raises ``ValueError`` (not ``assert``) so ``python -O`` can't strip the
+    validation in production. Also rejects non-string values for
+    ``message`` / ``remediation`` — the TypedDict annotation says ``str``
+    and runtime must match, otherwise callers can accidentally slip lists
+    or dicts through and break the frontend contract.
+    """
+    err: _A2uiError = {
+        "error": error.value,
+        "message": message,
+        "remediation": remediation,
+    }
+    missing = [k for k in ("error", "message", "remediation") if not err.get(k)]
+    if missing:
+        raise ValueError(
+            f"_a2ui_error missing required non-empty keys: {missing}; got {err!r}"
+        )
+    bad_types = [
+        k for k in ("error", "message", "remediation") if not isinstance(err[k], str)
+    ]
+    if bad_types:
+        raise ValueError(
+            f"_a2ui_error requires str values for keys {bad_types}; got {err!r}"
+        )
+    return err
+
+
+def _resolve_a2ui_model() -> str:
+    """Resolve the A2UI planner's chat_model string.
+
+    Resolution order:
+      1. ``A2UI_MODEL`` — planner-only override.
+      2. ``LANGROID_MODEL`` — inherits from the primary agent's model.
+      3. Default ``gpt-4.1`` (bare OpenAI name — matches ``create_agent``
+         below). NOTE: langroid does NOT strip the ``openai/`` prefix —
+         it passes the model string LITERALLY to the OpenAI SDK, which
+         rejects ``openai/gpt-4.1`` as "model not found". The canonical
+         langroid convention (and ``OpenAIChatModel.GPT4_1.value``) is
+         the bare name.
+    """
+    return (
+        os.getenv("A2UI_MODEL")
+        or os.getenv("LANGROID_MODEL")
+        or "gpt-4.1"
+    )
+
+
+# Memoize the A2UI planner LLM so we don't rebuild ``OpenAIGPT`` (and re-run
+# credential resolution) on every request. Keyed on the resolved model string
+# so env overrides produce distinct entries. ``maxsize=4`` is intentional: in
+# production the resolved model is effectively constant, so the cache only
+# needs to cover test churn — tests that patch across more distinct models
+# should call ``_get_a2ui_llm.cache_clear()`` rather than rely on identity.
+@functools.lru_cache(maxsize=4)
+def _get_a2ui_llm(model: str) -> lm.OpenAIGPT:
+    """Return a memoized langroid LLM bound to the given chat_model string.
+
+    Callers must resolve the model first (see ``_resolve_a2ui_model``) and
+    pass it in explicitly; the cache is keyed on ``model`` so env changes
+    produce distinct instances rather than silently returning a stale one.
+    ``maxsize=4`` — the 5th distinct model evicts the least-recently-used
+    entry (see block comment above for rationale). Call ``.cache_clear()``
+    in tests that need to reset memoization.
+    """
+    config = lm.OpenAIGPTConfig(
+        chat_model=model,
+        # Non-streaming for the planner: we need the full tool call before
+        # we can emit operations. Streaming here is wasted work.
+        stream=False,
+    )
+    return lm.OpenAIGPT(config)
+
+
+# The render_a2ui function the planner is forced to call. Kept here (not
+# imported from shared/) because the shape is OpenAI-compatible regardless
+# of which provider langroid's ``OpenAIGPT`` is talking to — langroid
+# normalizes the forced-function-call across providers.
+_RENDER_A2UI_FUNCTION_SPEC = lm.LLMFunctionSpec(
+    name="render_a2ui",
+    description="Render a dynamic A2UI v0.9 surface.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "surfaceId": {"type": "string"},
+            "catalogId": {"type": "string"},
+            "components": {"type": "array", "items": {"type": "object"}},
+            "data": {"type": "object"},
+        },
+        "required": ["surfaceId", "catalogId", "components"],
+    },
+)
+
+
+class _LLMResponseLike(Protocol):
+    """Structural type for the subset of ``LLMResponse`` we read.
+
+    Defined as a Protocol (rather than importing langroid's concrete type)
+    so the extractor is trivially unit-testable with a fake object and the
+    signature documents exactly which attributes matter.
+    """
+
+    oai_tool_calls: Any
+    function_call: Any
+
+
+# Sentinel: distinct from ``None`` so the caller can tell "no tool call at all"
+# (returned as ``None``) from "tool-call shape present but ``arguments`` field
+# was ``None``" (returned as this sentinel). The two cases have different
+# remediations — see ``generate_a2ui_via_llm``.
+_ARGS_MISSING: object = object()
+
+
+def _extract_tool_call_arguments(
+    response: _LLMResponseLike,
+) -> dict[str, Any] | str | None | object:
+    """Pull the planner's tool-call arguments out of an ``LLMResponse``.
+
+    Handles both shapes langroid exposes:
+      - ``oai_tool_calls[0].function.arguments`` — modern tool-calling path.
+      - ``function_call.arguments`` — legacy path used by some providers.
+
+    Returns:
+      - ``dict`` or ``str`` (JSON) — the raw arguments value to parse/use.
+      - ``None`` — no tool call was produced at all (→ ``a2ui_no_tool_call``).
+      - ``_ARGS_MISSING`` — a tool-call slot was present but its ``arguments``
+        field was missing/None (→ ``a2ui_invalid_arguments``; the planner
+        DID try to call but emitted a degraded shape, so "no tool call"
+        remediation would be misleading).
+
+    Logs a WARN for every shape-drift case so operators can diagnose
+    langroid / provider-SDK regressions without strace-ing tests.
+    """
+    tool_calls = getattr(response, "oai_tool_calls", None)
+    saw_modern_call = False
+    if tool_calls:
+        # Non-empty ``tool_calls`` list always counts as "planner attempted
+        # a modern-slot call" — even when ``.function`` is None (degraded
+        # shape). Without this, ``.function is None`` + no legacy
+        # ``function_call`` returns plain ``None``, which the caller maps
+        # to ``NO_TOOL_CALL``. But the planner DID try to call in the
+        # modern slot; the correct remediation is ``INVALID_ARGUMENTS``
+        # (symmetric with the ``.function.arguments is None`` case below).
+        saw_modern_call = True
+        if len(tool_calls) > 1:
+            # Forced function-call should produce exactly one tool call;
+            # multiple is unexpected and we pick index 0 silently today.
+            # Logging it makes the truncation visible rather than mysterious.
+            logger.warning(
+                "generate_a2ui_via_llm: planner returned %d tool calls; "
+                "using index 0 only",
+                len(tool_calls),
+            )
+        first = tool_calls[0]
+        func = getattr(first, "function", None)
+        if func is not None:
+            args = getattr(func, "arguments", None)
+            if args is not None:
+                return args
+            # Degraded shape: the modern slot has no arguments. Log and
+            # fall through to the legacy function_call path — providers
+            # occasionally put the forced call in the legacy slot even
+            # when the modern slot is present but empty.
+            logger.warning(
+                "generate_a2ui_via_llm: tool_call.function present but "
+                ".arguments is None (response-shape drift?)"
+            )
+        else:
+            # Degraded shape: tool_calls[0].function is None. Log and fall
+            # through to the legacy function_call path — some providers put
+            # the forced call in the legacy slot.
+            logger.warning(
+                "generate_a2ui_via_llm: tool_call present but .function is None "
+                "(response-shape drift?)"
+            )
+
+    function_call = getattr(response, "function_call", None)
+    if function_call is not None:
+        args = getattr(function_call, "arguments", None)
+        if args is None:
+            # Legacy slot is present but its ``arguments`` field is missing.
+            # Symmetric with the modern-slot warning above, and flagged as
+            # INVALID_ARGUMENTS (not NO_TOOL_CALL) via the sentinel so the
+            # caller emits the correct remediation.
+            logger.warning(
+                "generate_a2ui_via_llm: function_call present but .arguments "
+                "is None (response-shape drift?)"
+            )
+            return _ARGS_MISSING
+        return args
+
+    # No legacy slot. If we saw a modern tool-call structure but its
+    # arguments were empty, surface that as _ARGS_MISSING so the caller
+    # emits a2ui_invalid_arguments rather than a2ui_no_tool_call.
+    if saw_modern_call:
+        return _ARGS_MISSING
+
+    return None
+
+
+def generate_a2ui_via_llm(*, context: str) -> _A2uiError | _A2uiSuccess:
+    """Run the A2UI planner LLM and return either operations or a structured
+    error.
+
+    Provider-agnostic: routes through ``lm.OpenAIGPT`` (langroid's universal
+    LLM abstraction) so whatever provider the operator configured via
+    ``LANGROID_MODEL`` / ``A2UI_MODEL`` is used. No direct provider-SDK
+    imports live in this module.
+
+    Error surface is the shared ``_A2uiError`` TypedDict (see sibling
+    google-adk / strands implementations).
+    """
+    system_prompt = context or "Generate a useful dashboard UI."
+    messages = [
+        lm.LLMMessage(role=lm.Role.SYSTEM, content=system_prompt),
+        lm.LLMMessage(
+            role=lm.Role.USER,
+            content="Generate a dynamic A2UI dashboard based on the conversation.",
+        ),
+    ]
+
+    # Wrap the LLM call so expected transport / auth / rate-limit failures
+    # do not bubble up through langroid's tool machinery as uncaught
+    # exceptions.
+    #
+    # We explicitly re-raise the narrow class of structural / programmer
+    # bugs (AttributeError, TypeError, NameError, ImportError,
+    # ModuleNotFoundError, AssertionError, NotImplementedError,
+    # pydantic.ValidationError). Those indicate real bugs and must surface
+    # to tests and server logs rather than be reported as "verify provider
+    # credentials" — the remediation in ``a2ui_llm_error`` is wrong for
+    # those classes (e.g. a missing ``anthropic`` package is an install
+    # problem, not a credentials problem; a pydantic validation failure is
+    # a schema bug, not a transport failure).
+    #
+    # Intentionally NOT re-raised (so they flow into the transport-error
+    # path): KeyError, IndexError, LookupError, RecursionError, MemoryError.
+    # The SDK / adapter stack raises these as recoverable conditions on
+    # malformed provider payloads, and swallowing them into the structured
+    # error surface gives callers the correct "retry / check provider"
+    # remediation rather than an uncaught 500.
+    try:
+        llm = _get_a2ui_llm(_resolve_a2ui_model())
+        response = llm.chat(
+            messages=messages,
+            functions=[_RENDER_A2UI_FUNCTION_SPEC],
+            function_call={"name": "render_a2ui"},
+        )
+    except (
+        AttributeError,
+        TypeError,
+        NameError,
+        ImportError,
+        ModuleNotFoundError,
+        AssertionError,
+        NotImplementedError,
+        ValidationError,
+    ):
+        # Programmer / environment bugs — propagate so tests & server logs
+        # catch them instead of producing a misleading "verify credentials"
+        # remediation.
+        raise
+    except Exception as exc:  # noqa: BLE001 — see rationale above
+        logger.exception("generate_a2ui_via_llm: LLM call failed")
+        # Include a truncated str(exc) so ConnectionError("backend unreachable")
+        # and similar transport failures surface the actionable substring.
+        # We truncate regardless of provider SDK behavior — bounds the blast
+        # radius of any future regression where an SDK embeds credentials
+        # in exception messages.
+        exc_detail = str(exc)[:200] if str(exc) else ""
+        message = f"Secondary A2UI LLM call failed: {exc.__class__.__name__}"
+        if exc_detail:
+            message = f"{message}: {exc_detail}"
+        return _a2ui_error(
+            error=_A2uiErrorKind.LLM_ERROR,
+            message=message,
+            remediation=(
+                "Verify the provider credentials required by LANGROID_MODEL / "
+                "A2UI_MODEL are set and the provider is reachable. "
+                "See server logs for the full traceback."
+            ),
+        )
+
+    raw_args = _extract_tool_call_arguments(response)
+    if raw_args is None:
+        logger.warning(
+            "generate_a2ui_via_llm: planner did not emit a render_a2ui tool call"
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.NO_TOOL_CALL,
+            message="Secondary A2UI LLM did not call render_a2ui.",
+            remediation=(
+                "Retry the request. If this persists, verify the planner model "
+                "supports forced function-calling."
+            ),
+        )
+    if raw_args is _ARGS_MISSING:
+        # Distinct from NO_TOOL_CALL: the planner DID produce a tool-call
+        # shape but its ``arguments`` field was missing/None. "Supports
+        # forced function-calling" is the wrong remediation here — the
+        # actionable fix is to retry (transient) or investigate a
+        # response-shape regression in the provider SDK.
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message=(
+                "Secondary A2UI LLM emitted a tool-call with no arguments "
+                "payload."
+            ),
+            remediation=(
+                "Retry the request; if this persists, check server logs for a "
+                "response-shape drift warning from the provider SDK."
+            ),
+        )
+
+    # langroid usually pre-parses tool arguments into a dict, but some
+    # provider adapters surface them as a JSON string. Handle both shapes.
+    if isinstance(raw_args, str):
+        try:
+            args = json.loads(raw_args)
+        # MemoryError / RecursionError can fire on pathological payloads
+        # (multi-MB JSON, deeply-nested structures). Parity with
+        # ``GenerateA2UITool.handle``'s widened catch — we'd rather surface
+        # a structured INVALID_ARGUMENTS than let these bubble up as an
+        # uncaught 500.
+        except (ValueError, TypeError, MemoryError, RecursionError) as exc:
+            logger.exception(
+                "generate_a2ui_via_llm: failed to parse render_a2ui arguments as JSON"
+            )
+            # Truncate ``str(exc)`` — parity with the LLM-error path and
+            # defense against multi-KB raw LLM payloads leaking into the
+            # structured error surface.
+            return _a2ui_error(
+                error=_A2uiErrorKind.INVALID_ARGUMENTS,
+                message=f"Could not parse render_a2ui arguments: {str(exc)[:200]}",
+                remediation=(
+                    "Retry the request; the secondary LLM emitted malformed JSON."
+                ),
+            )
+    else:
+        args = raw_args
+
+    if not isinstance(args, dict):
+        logger.warning(
+            "generate_a2ui_via_llm: render_a2ui arguments parsed to %s (not dict)",
+            type(args).__name__,
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message=(
+                f"render_a2ui arguments must be a JSON object, got "
+                f"{type(args).__name__}."
+            ),
+            remediation="Retry the request; the secondary LLM emitted a non-object payload.",
+        )
+
+    # ``build_a2ui_operations_from_tool_call`` can raise if required keys
+    # are missing or values aren't serializable. Without this guard, an
+    # upstream schema change (planner LLM returns a slightly-wrong shape)
+    # produces a 500 and bypasses the structured-error contract the
+    # frontend relies on.
+    try:
+        result = build_a2ui_operations_from_tool_call(args)
+    # Widened to match the ``GenerateA2UITool.handle`` transport-path wrapper
+    # and the str-arg ``json.loads`` wrapper above: IndexError / AttributeError
+    # / LookupError can fire on malformed or partial payloads (planner emits a
+    # dict missing a list slot; provider SDK returns a sparse attribute) and
+    # must NOT escape into langroid's tool-handling stack. Narrow catches here
+    # produced a 500 that bypassed the structured-error contract the frontend
+    # relies on.
+    except (
+        KeyError,
+        ValueError,
+        TypeError,
+        IndexError,
+        AttributeError,
+        LookupError,
+    ) as exc:
+        logger.exception(
+            "generate_a2ui_via_llm: build_a2ui_operations_from_tool_call failed"
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message=f"Could not build A2UI operations: {exc.__class__.__name__}",
+            remediation=(
+                "Retry with a simpler A2UI design or check the LLM-emitted schema."
+            ),
+        )
+
+    # Defense-in-depth: the shared helper is contracted to return
+    # ``{"a2ui_operations": [...]}`` but a shape regression upstream
+    # (e.g. accidental ``None`` or dict without the key) would otherwise
+    # bypass ``_A2uiSuccess`` and break the frontend renderer silently.
+    if (
+        not isinstance(result, dict)
+        or "a2ui_operations" not in result
+        or not isinstance(result["a2ui_operations"], list)
+    ):
+        # Include the first-20 sorted keys when the result IS a dict so
+        # operators can tell "wrong key name" (e.g. planner emitted
+        # ``operations`` instead of ``a2ui_operations``) from "wrong type".
+        # The type name alone doesn't give enough signal to diagnose.
+        result_keys: list[str] | None = (
+            sorted(str(k) for k in result.keys())[:20]
+            if isinstance(result, dict)
+            else None
+        )
+        logger.error(
+            "build_a2ui_operations_from_tool_call returned unexpected shape: "
+            "type=%s keys=%r",
+            type(result).__name__,
+            result_keys,
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message="A2UI builder returned invalid shape.",
+            remediation=(
+                "Upstream `build_a2ui_operations_from_tool_call` returned an "
+                "unexpected result; check shared/python/tools."
+            ),
+        )
+    return cast(_A2uiSuccess, result)
+
+
+# =====================================================================
 # Langroid Tool Definitions
 # =====================================================================
 
+
+class _ToolErrorKind(str, Enum):
+    """Closed set of backend-tool error codes.
+
+    Using an Enum (str-valued so JSON serialization stays stable) keeps
+    call sites from inventing new codes and defends against typos like
+    ``"get_wether_failed"`` that ship silently through free-form strings.
+    Values match the historical bare-string codes so the serialized JSON
+    shape is identical to the previous contract.
+
+    Mirrors ``_A2uiErrorKind`` — both enums live in this module for the
+    same reason: closed-set typing for the error surface the outer LLM
+    consumes.
+    """
+
+    GET_WEATHER_FAILED = "get_weather_failed"
+    QUERY_DATA_FAILED = "query_data_failed"
+    MANAGE_SALES_TODOS_FAILED = "manage_sales_todos_failed"
+    GET_SALES_TODOS_FAILED = "get_sales_todos_failed"
+    SCHEDULE_MEETING_FAILED = "schedule_meeting_failed"
+    SEARCH_FLIGHTS_FAILED = "search_flights_failed"
+
+
+def _tool_error(*, error: _ToolErrorKind, message: str) -> str:
+    """Serialize a structured error that a tool ``handle()`` can return to
+    langroid. Keeps the surface consistent across all backend tools so the
+    outer LLM treats recoverable tool failures uniformly rather than seeing
+    unstructured exception tracebacks.
+
+    ``error`` is the ``_ToolErrorKind`` enum (not a raw string) so call
+    sites cannot invent new error codes and bypass the closed set. The
+    function extracts ``.value`` internally; callers pass the enum
+    directly.
+    """
+    return _json_dumps({"error": error.value, "message": message})
+
+
 class GetWeatherTool(ToolMessage):
-    """Get the weather for a given location."""
     request: str = "get_weather"
     purpose: str = "Get current weather for a location."
     location: str
 
     def handle(self) -> str:
-        result = get_weather_impl(self.location)
-        return json.dumps(result)
+        try:
+            result = get_weather_impl(self.location)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001 — tool errors must not escape
+            logger.exception("GetWeatherTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.GET_WEATHER_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 
 class QueryDataTool(ToolMessage):
-    """Query the database. Takes natural language."""
     request: str = "query_data"
     purpose: str = "Query the database. Always call before showing a chart or graph."
     query: str
 
     def handle(self) -> str:
-        result = query_data_impl(self.query)
-        return json.dumps(result)
+        try:
+            result = query_data_impl(self.query)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("QueryDataTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.QUERY_DATA_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 
 class ManageSalesTodosTool(ToolMessage):
-    """Replace the entire list of sales todos."""
     request: str = "manage_sales_todos"
     purpose: str = (
         "Replace the entire list of sales todos with the provided values. "
@@ -81,18 +661,31 @@ class ManageSalesTodosTool(ToolMessage):
     todos: list[dict]
 
     def handle(self) -> str:
-        result = manage_sales_todos_impl(self.todos)
-        return json.dumps(result)
+        try:
+            result = manage_sales_todos_impl(self.todos)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("ManageSalesTodosTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.MANAGE_SALES_TODOS_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 
 class GetSalesTodosTool(ToolMessage):
-    """Get the current list of sales todos."""
     request: str = "get_sales_todos"
     purpose: str = "Get the current list of sales todos."
 
     def handle(self) -> str:
-        result = get_sales_todos_impl()
-        return json.dumps(result)
+        try:
+            result = get_sales_todos_impl()
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("GetSalesTodosTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.GET_SALES_TODOS_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 
 # Frontend tools — the agent "calls" them but they execute client-side.
@@ -100,17 +693,25 @@ class GetSalesTodosTool(ToolMessage):
 # adapter intercepts the call and forwards it to the frontend.
 
 class ChangeBackgroundTool(ToolMessage):
-    """Change the background color/gradient of the chat area."""
     request: str = "change_background"
     purpose: str = "Change the background color/gradient of the chat area. ONLY call this when the user explicitly asks."
     background: Annotated[str, "CSS background value. Prefer gradients."]
 
     def handle(self) -> str:
+        # Frontend tool: the AG-UI adapter normally intercepts the call and
+        # routes it to the client before this handler runs. If we're here,
+        # the routing regressed and the agent is about to lie to the user
+        # about an action it never performed. Log loudly so the regression
+        # surfaces in server logs. We still return the benign string to
+        # preserve the existing non-breaking contract for starters.
+        logger.error(
+            "ChangeBackgroundTool.handle fired server-side — AG-UI adapter "
+            "dispatch regression; frontend tool was not intercepted"
+        )
         return f"Background changed to {self.background}"
 
 
 class GenerateHaikuTool(ToolMessage):
-    """Generate a haiku with Japanese text, English translation, and a background image."""
     request: str = "generate_haiku"
     purpose: str = "Generate a haiku with Japanese text, English translation, and a background image."
     japanese: list[str]
@@ -119,27 +720,34 @@ class GenerateHaikuTool(ToolMessage):
     gradient: str
 
     def handle(self) -> str:
+        # Frontend tool — see ChangeBackgroundTool.handle for rationale on
+        # logging vs raising.
+        logger.error(
+            "GenerateHaikuTool.handle fired server-side — AG-UI adapter "
+            "dispatch regression; frontend tool was not intercepted"
+        )
         return "Haiku generated!"
 
 
 class ScheduleMeetingTool(ToolMessage):
-    """Schedule a meeting. The user will be asked to pick a time via the UI."""
     request: str = "schedule_meeting"
     purpose: str = "Schedule a meeting. The user will be asked to pick a time via the meeting time picker UI."
     reason: str
     duration_minutes: int = 30
 
     def handle(self) -> str:
-        result = schedule_meeting_impl(self.reason, self.duration_minutes)
-        return json.dumps(result)
+        try:
+            result = schedule_meeting_impl(self.reason, self.duration_minutes)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("ScheduleMeetingTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.SCHEDULE_MEETING_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
-
-# =====================================================================
-# Agent factory
-# =====================================================================
 
 class SearchFlightsTool(ToolMessage):
-    """Search for flights and display the results as rich A2UI cards."""
     request: str = "search_flights"
     purpose: str = (
         "Search for flights and display the results as rich cards. Return exactly 2 flights. "
@@ -149,12 +757,18 @@ class SearchFlightsTool(ToolMessage):
     flights: list[dict]
 
     def handle(self) -> str:
-        result = search_flights_impl(self.flights)
-        return json.dumps(result)
+        try:
+            result = search_flights_impl(self.flights)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("SearchFlightsTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.SEARCH_FLIGHTS_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 
 class GenerateA2UITool(ToolMessage):
-    """Generate dynamic A2UI components based on the conversation."""
     request: str = "generate_a2ui"
     purpose: str = (
         "Generate dynamic A2UI components based on the conversation. "
@@ -163,66 +777,82 @@ class GenerateA2UITool(ToolMessage):
     context: str
 
     def handle(self) -> str:
-        from openai import OpenAI
-
-        client = OpenAI()
-        tool_schema = {
-            "type": "function",
-            "function": {
-                "name": "render_a2ui",
-                "description": "Render a dynamic A2UI v0.9 surface.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "surfaceId": {"type": "string"},
-                        "catalogId": {"type": "string"},
-                        "components": {"type": "array", "items": {"type": "object"}},
-                        "data": {"type": "object"},
-                    },
-                    "required": ["surfaceId", "catalogId", "components"],
-                },
-            },
-        }
-
-        response = client.chat.completions.create(
-            model="gpt-4.1",
-            messages=[
-                {"role": "system", "content": self.context or "Generate a useful dashboard UI."},
-                {"role": "user", "content": "Generate a dynamic A2UI dashboard based on the conversation."},
-            ],
-            tools=[tool_schema],
-            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
-        )
-
-        if not response.choices[0].message.tool_calls:
-            return json.dumps({"error": "LLM did not call render_a2ui"})
-
-        tool_call = response.choices[0].message.tool_calls[0]
-        args = json.loads(tool_call.function.arguments)
-        result = build_a2ui_operations_from_tool_call(args)
-        return json.dumps(result)
+        # Delegate to the provider-agnostic planner. `generate_a2ui_via_llm`
+        # returns either the successful `a2ui_operations` dict or a
+        # structured `_A2uiError` — both shapes are JSON-serializable and
+        # are surfaced verbatim to the outer langroid agent (and thereby
+        # the frontend A2UI renderer).
+        result = generate_a2ui_via_llm(context=self.context)
+        try:
+            return _json_dumps(result)
+        except (TypeError, ValueError, OverflowError, RecursionError) as exc:
+            # Defensive: generate_a2ui_via_llm returns dicts by contract,
+            # but if an upstream change ever returns a non-serializable
+            # value we want a structured error rather than an uncaught
+            # exception bubbling through langroid's tool machinery.
+            # OverflowError covers NaN/inf floats; RecursionError covers
+            # cyclic structures — both raised by ``json.dumps`` and not
+            # subclasses of ``TypeError`` / ``ValueError``.
+            logger.exception("GenerateA2UITool.handle: json.dumps failed")
+            # Use the stdlib json.dumps directly here (not _json_dumps) so
+            # the structured-error dump still succeeds when tests patch
+            # _json_dumps to simulate a RecursionError on the success path.
+            # Tests for this branch bind their side_effect to _json_dumps
+            # only; the raw ``json.dumps`` remains callable and produces a
+            # parseable error envelope for the frontend.
+            return json.dumps(
+                _a2ui_error(
+                    error=_A2uiErrorKind.INVALID_ARGUMENTS,
+                    message=(
+                        f"Could not serialize A2UI result: "
+                        f"{exc.__class__.__name__}"
+                    ),
+                    remediation=(
+                        "This indicates an upstream planner contract bug; "
+                        "see server logs."
+                    ),
+                )
+            )
 
 
 # Tools that execute server-side (Langroid handles them directly)
-BACKEND_TOOLS = [
+BACKEND_TOOLS: tuple[type[ToolMessage], ...] = (
     GetWeatherTool,
     QueryDataTool,
     ManageSalesTodosTool,
     GetSalesTodosTool,
     SearchFlightsTool,
     GenerateA2UITool,
-]
+)
 
 # Tools that execute client-side (AG-UI adapter forwards to frontend)
-FRONTEND_TOOLS = [
+FRONTEND_TOOLS: tuple[type[ToolMessage], ...] = (
     ChangeBackgroundTool,
     GenerateHaikuTool,
     ScheduleMeetingTool,
-]
+)
 
-ALL_TOOLS = BACKEND_TOOLS + FRONTEND_TOOLS
+ALL_TOOLS: tuple[type[ToolMessage], ...] = BACKEND_TOOLS + FRONTEND_TOOLS
 
-FRONTEND_TOOL_NAMES = {t.default_value("request") for t in FRONTEND_TOOLS}
+FRONTEND_TOOL_NAMES: frozenset[str] = frozenset(
+    t.default_value("request") for t in FRONTEND_TOOLS
+)
+
+# Canary: the set of frontend tool names is part of the contract with the
+# AG-UI adapter (which looks them up to route execution to the client).
+# If a tool is added/removed/renamed without updating the adapter, this
+# raises at import time rather than at request time.
+#
+# Uses ``raise RuntimeError`` (not ``assert``) so ``python -O`` can't strip
+# the check in production — same reasoning as ``_a2ui_error`` above.
+_EXPECTED_FRONTEND_TOOL_NAMES = frozenset(
+    {"change_background", "generate_haiku", "schedule_meeting"}
+)
+if FRONTEND_TOOL_NAMES != _EXPECTED_FRONTEND_TOOL_NAMES:
+    raise RuntimeError(
+        f"FRONTEND_TOOL_NAMES drifted: {FRONTEND_TOOL_NAMES!r} "
+        f"(expected {_EXPECTED_FRONTEND_TOOL_NAMES!r})"
+    )
 
 SYSTEM_PROMPT = (
     "You are a polished, professional demo assistant for CopilotKit. "
@@ -242,9 +872,21 @@ SYSTEM_PROMPT = (
 )
 
 
+# =====================================================================
+# Agent factory
+# =====================================================================
+
+
 def create_agent() -> lr.ChatAgent:
-    """Create a Langroid ChatAgent configured with all showcase tools."""
-    model = os.getenv("LANGROID_MODEL", "openai/gpt-4.1")
+    """Create a Langroid ChatAgent configured with all showcase tools.
+
+    Default model is the bare ``gpt-4.1`` (not ``openai/gpt-4.1``): langroid
+    does NOT strip the ``openai/`` prefix before passing the string to the
+    OpenAI SDK, and the SDK rejects ``openai/gpt-4.1`` as "model not found".
+    See ``_resolve_a2ui_model`` for the same reasoning on the planner
+    default.
+    """
+    model = os.getenv("LANGROID_MODEL", "gpt-4.1")
 
     llm_config = lm.OpenAIGPTConfig(
         chat_model=model,
@@ -257,5 +899,5 @@ def create_agent() -> lr.ChatAgent:
     )
 
     agent = lr.ChatAgent(agent_config)
-    agent.enable_message(ALL_TOOLS)
+    agent.enable_message(list(ALL_TOOLS))
     return agent

--- a/showcase/packages/langroid/tests/python/test_generate_a2ui.py
+++ b/showcase/packages/langroid/tests/python/test_generate_a2ui.py
@@ -1,0 +1,1862 @@
+"""Unit tests for langroid's A2UI planner.
+
+Sibling tests to ``showcase/packages/google-adk/tests/python/test_generate_a2ui.py``
+and ``showcase/packages/strands/tests/python/test_generate_a2ui.py``. Covers:
+
+- Provider-agnostic LLM routing through langroid's ``OpenAIGPT`` abstraction
+  (which despite the name handles OpenAI / Anthropic / Gemini / any
+  ``provider/model`` chat-model string).
+- ``A2UI_MODEL`` env override takes precedence over ``LANGROID_MODEL``.
+- Structured error surface (``_A2uiError``) for every failure branch:
+    - LLM call raises (transport / auth / rate-limit)
+    - response contains no tool call
+    - response tool-call arguments are malformed JSON
+- Happy path: valid tool call args → ``build_a2ui_operations_from_tool_call``
+- Programmer errors (``AttributeError``, ``TypeError``, ``ImportError``,
+  ``NameError``, ``AssertionError``, ``NotImplementedError``,
+  ``ModuleNotFoundError``, ``pydantic.ValidationError``) propagate — not
+  silently masked as LLM errors. Conversely ``KeyError`` / ``IndexError`` /
+  ``RecursionError`` / ``MemoryError`` / ``LookupError`` are NO LONGER
+  re-raised; they wrap into the structured ``a2ui_llm_error`` surface.
+- Construction must not require OpenAI-specific env when a non-OpenAI
+  ``LANGROID_MODEL`` is configured (provider-agnostic routing).
+- Memoization: the A2UI planner LLM is built once per resolved model string.
+- Structured warning / error log output on the module logger for every
+  degraded / drift path (with message substring assertions).
+
+Mocks live at the langroid-LLM layer (``lm.OpenAIGPT``) rather than at any
+provider SDK layer — the whole point of the provider-agnostic fix is that
+the A2UI planner no longer speaks to any provider SDK directly.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.agent import (
+    _A2uiError,
+    _A2uiErrorKind,
+    _RENDER_A2UI_FUNCTION_SPEC,
+    _a2ui_error,
+    _get_a2ui_llm,
+    _resolve_a2ui_model,
+    _ToolErrorKind,
+    generate_a2ui_via_llm,
+    create_agent,
+    ALL_TOOLS,
+    BACKEND_TOOLS,
+    FRONTEND_TOOLS,
+    ChangeBackgroundTool,
+    GenerateA2UITool,
+    GenerateHaikuTool,
+    GetSalesTodosTool,
+    GetWeatherTool,
+    ManageSalesTodosTool,
+    QueryDataTool,
+    ScheduleMeetingTool,
+    SearchFlightsTool,
+)
+from langroid.agent.tool_message import ToolMessage
+
+
+# ---------------------------------------------------------------------------
+# Fakes / helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFunction:
+    """Typo-safe stand-in for a langroid tool-call ``function`` attribute.
+
+    Dataclass (rather than ``SimpleNamespace``) so typos in field names blow
+    up at construction rather than silently producing a shape that looks
+    right but with a missing attribute.
+    """
+
+    name: str = "render_a2ui"
+    arguments: Any = None
+
+
+@dataclass
+class _FakeOaiToolCall:
+    """Typo-safe stand-in for a langroid ``OaiToolCall``."""
+
+    id: str = "call-1"
+    function: _FakeFunction | None = None
+
+
+@dataclass
+class _FakeFunctionCall:
+    """Typo-safe stand-in for a legacy ``LLMFunctionCall``."""
+
+    name: str = "render_a2ui"
+    arguments: Any = None
+
+
+@dataclass
+class _FakeLLMResponse:
+    """Typo-safe stand-in for langroid's ``LLMResponse``.
+
+    The planner only reads ``.oai_tool_calls`` and ``.function_call`` so those
+    are the only fields we model. Using a dataclass guards against silently
+    adding unused attrs via typo.
+    """
+
+    message: str = ""
+    oai_tool_calls: list | None = None
+    function_call: _FakeFunctionCall | None = None
+
+
+def _llm_response(*, tool_calls=None, function_call=None) -> _FakeLLMResponse:
+    """Build a fake langroid ``LLMResponse``-shaped object."""
+    return _FakeLLMResponse(
+        message="",
+        oai_tool_calls=tool_calls,
+        function_call=function_call,
+    )
+
+
+def _oai_tool_call(*, arguments, call_id: str = "call-1") -> _FakeOaiToolCall:
+    """Build a fake ``OpenAIToolCall``.
+
+    Helper passes the ``arguments`` value through unchanged; callers may
+    supply a dict or a JSON string — both paths are exercised by the tests
+    below.
+    """
+    return _FakeOaiToolCall(
+        id=call_id,
+        function=_FakeFunction(name="render_a2ui", arguments=arguments),
+    )
+
+
+def _function_call(*, arguments) -> _FakeFunctionCall:
+    """Build a fake legacy ``LLMFunctionCall``."""
+    return _FakeFunctionCall(name="render_a2ui", arguments=arguments)
+
+
+@pytest.fixture(autouse=True)
+def _reset_llm_cache():
+    """Clear the memoized A2UI LLM between tests so patched factories are
+    honored freshly each test."""
+    _get_a2ui_llm.cache_clear()
+    yield
+    _get_a2ui_llm.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Unset A2UI_MODEL / LANGROID_MODEL / OPENAI_* / every provider key
+    between tests so tests don't leak one another's env setup. The provider
+    key set matches what ``_expected_key_for_model`` handles across sibling
+    adapters — keeping them all unset here means a regression in provider
+    routing can't be silently masked by a stray key in the developer's env.
+    """
+    for var in (
+        "A2UI_MODEL",
+        "LANGROID_MODEL",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GROQ_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "CEREBRAS_API_KEY",
+        "GLHF_API_KEY",
+        "MINIMAX_API_KEY",
+        "PORTKEY_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# _A2uiErrorKind enum identity — pins the error-code contract
+# ---------------------------------------------------------------------------
+
+
+def test_a2ui_error_kind_values_pinned():
+    """The enum ``.value``s are the string contract shared with the
+    frontend renderer and the sibling ``google-adk`` / ``strands`` adapters.
+    Renaming any of these is a cross-sibling breaking change; pin the set
+    here so a regression is caught at unit-test time rather than by an
+    alert from the renderer in production."""
+    assert _A2uiErrorKind.LLM_ERROR.value == "a2ui_llm_error"
+    assert _A2uiErrorKind.NO_TOOL_CALL.value == "a2ui_no_tool_call"
+    assert _A2uiErrorKind.INVALID_ARGUMENTS.value == "a2ui_invalid_arguments"
+    assert {m.value for m in _A2uiErrorKind} == {
+        "a2ui_llm_error",
+        "a2ui_no_tool_call",
+        "a2ui_invalid_arguments",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _ToolErrorKind enum identity — pins the backend-tool error-code contract
+# ---------------------------------------------------------------------------
+
+
+def test_tool_error_kind_values_pinned():
+    """The enum ``.value``s are the ``{"error": "<tool>_failed"}`` strings
+    the outer LLM consumes when a backend tool handler wraps an impl
+    exception. The values match the historical bare-string codes, so a
+    rename here is a cross-language breaking change (the strings show up
+    in prompt-engineered retry logic elsewhere in the product). Pin the
+    complete set so a typo regression (``"get_wether_failed"``) or an
+    accidental addition / removal is caught at unit-test time."""
+    assert _ToolErrorKind.GET_WEATHER_FAILED.value == "get_weather_failed"
+    assert _ToolErrorKind.QUERY_DATA_FAILED.value == "query_data_failed"
+    assert (
+        _ToolErrorKind.MANAGE_SALES_TODOS_FAILED.value
+        == "manage_sales_todos_failed"
+    )
+    assert (
+        _ToolErrorKind.GET_SALES_TODOS_FAILED.value == "get_sales_todos_failed"
+    )
+    assert (
+        _ToolErrorKind.SCHEDULE_MEETING_FAILED.value
+        == "schedule_meeting_failed"
+    )
+    assert (
+        _ToolErrorKind.SEARCH_FLIGHTS_FAILED.value == "search_flights_failed"
+    )
+    assert {m.value for m in _ToolErrorKind} == {
+        "get_weather_failed",
+        "query_data_failed",
+        "manage_sales_todos_failed",
+        "get_sales_todos_failed",
+        "schedule_meeting_failed",
+        "search_flights_failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _a2ui_error contract
+# ---------------------------------------------------------------------------
+
+
+def test_a2ui_error_accepts_full_shape():
+    err = _a2ui_error(
+        error=_A2uiErrorKind.LLM_ERROR, message="m", remediation="r"
+    )
+    assert err == {
+        "error": "a2ui_llm_error",
+        "message": "m",
+        "remediation": "r",
+    }
+
+
+def test_a2ui_error_rejects_empty_values():
+    """Empty-string values for message/remediation must blow up at
+    construction time, not silently produce a malformed error surface.
+    ``error`` is the enum now, so the only way to get an empty ``error``
+    value would be to subvert the enum — not a supported use case."""
+    with pytest.raises(ValueError):
+        _a2ui_error(error=_A2uiErrorKind.LLM_ERROR, message="", remediation="r")
+    with pytest.raises(ValueError):
+        _a2ui_error(error=_A2uiErrorKind.LLM_ERROR, message="m", remediation="")
+
+
+def test_a2ui_error_rejects_non_string_message():
+    """The TypedDict annotation says ``str``; the factory must enforce that
+    at runtime. A caller accidentally slipping a list/dict/int into
+    ``message`` would break the frontend's error renderer."""
+    with pytest.raises(ValueError):
+        _a2ui_error(
+            error=_A2uiErrorKind.LLM_ERROR, message=123, remediation="r"  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError):
+        _a2ui_error(
+            error=_A2uiErrorKind.LLM_ERROR,
+            message="m",
+            remediation=["r"],  # type: ignore[arg-type]
+        )
+
+
+def _assert_full_error_shape(result: dict) -> None:
+    """Every generate_a2ui error branch must include these three keys and
+    ONLY these three keys (no traceback / stderr / secret leakage)."""
+    assert isinstance(result, dict), f"expected dict, got {type(result).__name__}"
+    # Exactly the three required keys — no extras (catches regressions that
+    # leak tracebacks, stderr, or secret material into error dicts).
+    assert set(result.keys()) == {"error", "message", "remediation"}, (
+        f"unexpected keys in error result: {sorted(result.keys())}"
+    )
+    for key in ("error", "message", "remediation"):
+        assert isinstance(result[key], str) and result[key], (
+            f"'{key}' must be non-empty str; got {result.get(key)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_generate_a2ui_happy_path_returns_operations():
+    """A valid ``oai_tool_calls`` response should be routed through
+    ``build_a2ui_operations_from_tool_call`` and return the operations dict.
+
+    Pins the full op shape — surfaceId / catalogId / components / data —
+    so a regression that swaps args or drops the data-update op is caught.
+    Also asserts the LLM was called with the forced-function-call kwargs
+    so the "the planner forces render_a2ui" contract is pinned.
+    """
+    fake_llm = MagicMock()
+    args = {
+        "surfaceId": "dynamic-surface",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+        "data": {"greeting": "hi"},
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[_oai_tool_call(arguments=args)]
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="test context")
+
+    # LLM forced-function-call wiring
+    fake_llm.chat.assert_called_once()
+    call_kwargs = fake_llm.chat.call_args.kwargs
+    assert call_kwargs["functions"] == [_RENDER_A2UI_FUNCTION_SPEC]
+    assert call_kwargs["function_call"] == {"name": "render_a2ui"}
+
+    # Message wiring: system prompt from caller's ``context``, plus a user
+    # message instructing the planner to emit a dashboard. Both must be
+    # present (langroid uses two-message system+user priming) — a regression
+    # that drops one would still forward kwargs but emit a broken prompt.
+    messages = call_kwargs["messages"]
+    assert len(messages) == 2, f"expected system+user messages, got {len(messages)}"
+    assert messages[0].content == "test context", (
+        f"system message must carry caller's context verbatim; got "
+        f"{messages[0].content!r}"
+    )
+
+    # Op shape
+    assert "a2ui_operations" in result, f"unexpected shape: {result!r}"
+    ops = result["a2ui_operations"]
+    assert len(ops) == 3
+
+    assert ops[0]["type"] == "create_surface"
+    assert ops[0]["surfaceId"] == "dynamic-surface"
+    assert ops[0]["catalogId"] == "copilotkit://app-dashboard-catalog"
+
+    assert ops[1]["type"] == "update_components"
+    assert ops[1]["components"] == [{"id": "root", "type": "Container"}]
+
+    assert ops[2]["type"] == "update_data_model"
+    assert ops[2]["data"] == {"greeting": "hi"}
+
+
+def test_generate_a2ui_happy_path_json_string_arguments_also_work():
+    """If a provider adapter returns ``arguments`` as a JSON string (not a
+    pre-parsed dict — some langroid backends do this), the function must
+    still parse and succeed. Assert the round-trip — ``surfaceId`` from the
+    JSON string makes it into ``a2ui_operations[0].surfaceId`` — so that a
+    regression where the parsed dict was dropped on the floor gets caught."""
+    fake_llm = MagicMock()
+    args_json = json.dumps({
+        "surfaceId": "s1",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    })
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[_oai_tool_call(arguments=args_json)]
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    assert "a2ui_operations" in result
+    assert result["a2ui_operations"][0]["surfaceId"] == "s1"
+    # No ``data`` in args → no update_data_model op → exactly 2 ops.
+    assert len(result["a2ui_operations"]) == 2, (
+        f"expected 2 ops when args has no 'data' key; got "
+        f"{len(result['a2ui_operations'])}"
+    )
+    # Default system prompt must kick in when context is empty.
+    call_kwargs = fake_llm.chat.call_args.kwargs
+    messages = call_kwargs["messages"]
+    assert messages[0].content == "Generate a useful dashboard UI.", (
+        f"empty context must trigger the default system prompt; got "
+        f"{messages[0].content!r}"
+    )
+
+
+def test_generate_a2ui_legacy_function_call_path():
+    """Older / alternate providers surface the forced tool call via
+    ``function_call`` rather than ``oai_tool_calls``. Both shapes must work.
+    Pin ``surfaceId`` so we know the LEGACY slot's args were consumed (a
+    regression that reads from the empty modern slot would fall through to
+    ``a2ui_no_tool_call`` — but an even subtler regression could read the
+    wrong slot's args)."""
+    fake_llm = MagicMock()
+    args = {
+        "surfaceId": "legacy-surface",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=None,
+        function_call=_function_call(arguments=args),
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    assert "a2ui_operations" in result
+    assert result["a2ui_operations"][0]["surfaceId"] == "legacy-surface"
+
+
+# ---------------------------------------------------------------------------
+# Error branches
+# ---------------------------------------------------------------------------
+
+
+def test_generate_a2ui_llm_exception_returns_full_error_shape(caplog):
+    """Runtime exception from ``llm.chat(...)`` → structured ``a2ui_llm_error``
+    with all keys populated, and an ERROR-level log on the module logger.
+
+    Also pin the remediation content — the entire point of the
+    provider-agnostic fix is that the remediation points at
+    ``LANGROID_MODEL`` / ``A2UI_MODEL`` rather than OpenAI-specific env
+    variables."""
+    fake_llm = MagicMock()
+    fake_llm.chat.side_effect = ConnectionError("backend unreachable")
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with caplog.at_level(logging.ERROR, logger="agents.agent"):
+            result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_llm_error"
+    # Source formats the message as "...: ClassName: detail" — BOTH parts
+    # must be present. Previously used `or`; that weakened the assertion
+    # and would pass if the class name alone leaked through.
+    assert "ConnectionError" in result["message"]
+    assert "backend unreachable" in result["message"]
+    # Remediation must reference the provider-agnostic env vars — catches a
+    # regression that reintroduces "set OPENAI_API_KEY" phrasing.
+    assert "LANGROID_MODEL" in result["remediation"]
+    assert "A2UI_MODEL" in result["remediation"]
+    # And the module logger must have emitted an ERROR record whose message
+    # pins the substring from the source's ``logger.exception(...)`` call.
+    assert any(
+        rec.levelno >= logging.ERROR
+        and rec.name == "agents.agent"
+        and "LLM call failed" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected ERROR-level log mentioning 'LLM call failed'; got "
+        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_generate_a2ui_llm_exception_message_is_truncated_to_200_chars():
+    """The source truncates ``str(exc)`` to 200 chars to bound the blast
+    radius if a future provider SDK regression embeds credentials /
+    huge stack state in exception text. Regression-guard the truncation."""
+    fake_llm = MagicMock()
+    huge = "X" * 5000
+    fake_llm.chat.side_effect = ConnectionError(huge)
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    # Message format: "Secondary A2UI LLM call failed: ConnectionError: <detail>"
+    # The <detail> portion must be at most 200 chars (truncated from 5000).
+    prefix = "Secondary A2UI LLM call failed: ConnectionError: "
+    assert result["message"].startswith(prefix)
+    detail = result["message"][len(prefix):]
+    # Pin the exact truncation: source slices ``str(exc)[:200]`` with a huge
+    # input, so the detail must be EXACTLY the first 200 chars of the
+    # stressor string, not merely <=200 (which would accept a regression
+    # that truncated to e.g. 50 chars).
+    assert detail == "X" * 200, (
+        f"detail must be exactly 200 'X's from str(exc)[:200]; got {len(detail)} chars"
+    )
+    # And the total must not be anywhere near the original 5000.
+    assert len(result["message"]) < 500
+
+
+def test_generate_a2ui_llm_construction_failure_returns_full_error_shape():
+    """Failure inside ``_get_a2ui_llm`` (e.g. missing provider-specific API
+    key at construction time) must surface as a structured tool result
+    rather than propagate as an uncaught exception."""
+    def _raise(*_a, **_kw):
+        raise ValueError("no API key for provider X")
+
+    with patch("agents.agent._get_a2ui_llm", side_effect=_raise):
+        result = generate_a2ui_via_llm(context="")
+
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_llm_error"
+    # Message must carry both the exception class name (``ValueError``) and
+    # the original detail substring (``no API key``) — a regression that
+    # dropped ``str(exc)`` and left only the class name is caught.
+    assert "ValueError" in result["message"]
+    assert "no API key" in result["message"]
+
+
+def test_generate_a2ui_no_tool_call_returns_full_error_shape():
+    """LLM responded but emitted no tool call → a2ui_no_tool_call."""
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = _llm_response(tool_calls=None, function_call=None)
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_no_tool_call"
+
+
+def test_generate_a2ui_empty_tool_calls_returns_full_error_shape():
+    """``oai_tool_calls`` was an empty list → a2ui_no_tool_call."""
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = _llm_response(tool_calls=[], function_call=None)
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_no_tool_call"
+
+
+def test_generate_a2ui_invalid_arguments_returns_full_error_shape():
+    """Arguments that are a str but NOT valid JSON → a2ui_invalid_arguments."""
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[_oai_tool_call(arguments="not json {{{")]
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments"
+
+
+def test_generate_a2ui_non_dict_arguments_returns_full_error_shape():
+    """Arguments valid JSON but not a dict (e.g. a list) →
+    a2ui_invalid_arguments (build_a2ui_operations_from_tool_call expects
+    a dict and we must not let the TypeError escape)."""
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[_oai_tool_call(arguments=[1, 2, 3])]
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments"
+
+
+@pytest.mark.parametrize(
+    "exc_cls,exc_args",
+    [
+        (KeyError, ("missing surfaceId",)),
+        (TypeError, ("nope",)),
+        (ValueError, ("bad value",)),
+    ],
+)
+def test_build_a2ui_operations_wrapper_catches_expected_errors(exc_cls, exc_args):
+    """``build_a2ui_operations_from_tool_call`` raising any of the three
+    expected classes (``KeyError`` / ``TypeError`` / ``ValueError``) on
+    malformed args must wrap into ``a2ui_invalid_arguments`` rather than
+    propagate. Parametrized so the three near-identical bodies don't drift
+    (previously copy-pasted, which is exactly how one of the branches would
+    silently fall out of sync on a refactor).
+    """
+    fake_llm = MagicMock()
+    args = {
+        "surfaceId": "s",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[_oai_tool_call(arguments=args)]
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm), patch(
+        "agents.agent.build_a2ui_operations_from_tool_call",
+        side_effect=exc_cls(*exc_args),
+    ):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments"
+
+
+def test_build_a2ui_operations_boundary_validates_return_shape():
+    """Even on the happy path, ``build_a2ui_operations_from_tool_call`` can
+    theoretically drift and return a dict missing the ``a2ui_operations``
+    key (e.g. upstream schema change). The planner MUST boundary-validate
+    the return shape and surface a structured ``a2ui_invalid_arguments``
+    rather than propagate the malformed dict to the frontend."""
+    fake_llm = MagicMock()
+    args = {
+        "surfaceId": "s",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[_oai_tool_call(arguments=args)]
+    )
+    # Patch the builder to return a malformed dict lacking "a2ui_operations".
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm), patch(
+        "agents.agent.build_a2ui_operations_from_tool_call",
+        return_value={"unexpected_key": "foo"},
+    ):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments"
+
+
+# ---------------------------------------------------------------------------
+# Programmer errors MUST propagate — not be silently swallowed.
+# The narrow re-raise tuple is (AttributeError, TypeError, NameError,
+# ImportError, ModuleNotFoundError, AssertionError, NotImplementedError,
+# pydantic.ValidationError).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc_cls,exc_args",
+    [
+        (AttributeError, ("typo",)),
+        (TypeError, ("bad kwargs",)),
+        (NameError, ("unknown name",)),
+        (ImportError, ("bad import",)),
+        (ModuleNotFoundError, ("no module",)),
+        (AssertionError, ("assertion",)),
+        (NotImplementedError, ("todo",)),
+    ],
+)
+def test_generate_a2ui_lets_programmer_errors_propagate(exc_cls, exc_args):
+    """Programmer-error exception classes must propagate uncaught rather
+    than being wrapped as ``a2ui_llm_error``. Keeps genuine bugs visible
+    in tests and server logs instead of silently masked."""
+    fake_llm = MagicMock()
+    fake_llm.chat.side_effect = exc_cls(*exc_args)
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with pytest.raises(exc_cls):
+            generate_a2ui_via_llm(context="")
+
+
+def test_generate_a2ui_propagates_pydantic_validation_error():
+    """``pydantic.ValidationError`` indicates a schema bug (the planner's
+    response could not be validated against the expected model), not a
+    transport failure. It must propagate rather than be wrapped as
+    ``a2ui_llm_error`` — the remediation for a schema bug is not "verify
+    provider credentials"."""
+    from pydantic import BaseModel, ValidationError
+
+    class _Dummy(BaseModel):
+        x: int
+
+    # Trigger a real ValidationError so we have a legitimate instance to
+    # raise — constructing ValidationError directly is tricky across
+    # pydantic versions.
+    try:
+        _Dummy(x="not-an-int")  # type: ignore[arg-type]
+    except ValidationError as ve:
+        real_ve = ve
+    else:  # pragma: no cover - defensive
+        pytest.fail("expected pydantic to raise ValidationError")
+
+    fake_llm = MagicMock()
+    fake_llm.chat.side_effect = real_ve
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with pytest.raises(ValidationError):
+            generate_a2ui_via_llm(context="")
+
+
+@pytest.mark.parametrize(
+    "exc_cls,exc_args",
+    [
+        (KeyError, ("missing",)),
+        (IndexError, ("out of range",)),
+        (RecursionError, ("too deep",)),
+        (MemoryError, ()),
+        (LookupError, ("lookup",)),
+    ],
+)
+def test_generate_a2ui_wraps_recoverable_errors_into_llm_error(exc_cls, exc_args):
+    """``KeyError`` / ``IndexError`` / ``LookupError`` / ``RecursionError`` /
+    ``MemoryError`` are raised by SDK/adapter code as recoverable conditions
+    on malformed provider payloads. They used to propagate, but the narrowed
+    re-raise tuple now lets them fall through into the transport-error path
+    so callers get the structured ``a2ui_llm_error`` surface with the
+    correct "retry / verify provider" remediation rather than an uncaught
+    500."""
+    fake_llm = MagicMock()
+    fake_llm.chat.side_effect = exc_cls(*exc_args)
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_llm_error"
+
+
+def test_generate_a2ui_memory_error_without_args_produces_classname_only_message():
+    """``MemoryError()`` carries no args, so ``str(exc) == ""``. The source's
+    ``exc_detail = str(exc)[:200] if str(exc) else ""`` branch drops the
+    trailing ``: <detail>`` segment, so the message must be exactly
+    ``"Secondary A2UI LLM call failed: MemoryError"`` with no trailing
+    colon. Pinning this catches a regression that always appends ``:`` even
+    when detail is empty (which would produce ``"...: MemoryError: "`` and
+    look subtly broken in the frontend)."""
+    fake_llm = MagicMock()
+    fake_llm.chat.side_effect = MemoryError()
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_llm_error"
+    assert result["message"] == "Secondary A2UI LLM call failed: MemoryError", (
+        f"empty-detail path must produce classname-only message (no trailing "
+        f"': '); got {result['message']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _get_a2ui_llm: model resolution + keyed memoization + provider-agnostic
+# ---------------------------------------------------------------------------
+
+
+def test_a2ui_model_env_overrides_langroid_model(monkeypatch):
+    """When ``A2UI_MODEL`` is set, the planner LLM must use it regardless
+    of ``LANGROID_MODEL``."""
+    monkeypatch.setenv("LANGROID_MODEL", "gpt-4.1")
+    monkeypatch.setenv("A2UI_MODEL", "anthropic/claude-opus-4")
+
+    captured_models: list[str] = []
+
+    class _FakeLLM:
+        def __init__(self, config):
+            captured_models.append(config.chat_model)
+
+        def chat(self, *_a, **_kw):
+            return _llm_response(tool_calls=None)
+
+    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
+        # Drive through the public path so model resolution runs.
+        generate_a2ui_via_llm(context="")
+
+    assert captured_models == ["anthropic/claude-opus-4"], (
+        f"A2UI_MODEL should win; got {captured_models!r}"
+    )
+
+
+def test_langroid_model_used_when_a2ui_model_unset(monkeypatch):
+    """When only ``LANGROID_MODEL`` is set, the planner LLM should inherit
+    it — same provider as the primary chat agent."""
+    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
+
+    captured_models: list[str] = []
+
+    class _FakeLLM:
+        def __init__(self, config):
+            captured_models.append(config.chat_model)
+
+        def chat(self, *_a, **_kw):
+            return _llm_response(tool_calls=None)
+
+    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
+        generate_a2ui_via_llm(context="")
+
+    assert captured_models == ["anthropic/claude-opus-4"]
+
+
+def test_default_model_when_no_env_set(monkeypatch):
+    """With neither ``A2UI_MODEL`` nor ``LANGROID_MODEL`` set, the default
+    chat_model must match the primary agent's default (``gpt-4.1``
+    as documented in ``create_agent``). Pinning the string here catches a
+    silent drift between the planner default and the primary default.
+
+    Explicit ``monkeypatch.delenv`` on both vars (belt-and-suspenders
+    alongside the autouse ``_clean_env`` fixture) so a future refactor of
+    the fixture can't accidentally leak a stray env var into this test.
+    """
+    monkeypatch.delenv("A2UI_MODEL", raising=False)
+    monkeypatch.delenv("LANGROID_MODEL", raising=False)
+    captured_models: list[str] = []
+
+    class _FakeLLM:
+        def __init__(self, config):
+            captured_models.append(config.chat_model)
+
+        def chat(self, *_a, **_kw):
+            return _llm_response(tool_calls=None)
+
+    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
+        generate_a2ui_via_llm(context="")
+
+    assert captured_models == ["gpt-4.1"]
+
+
+def test_llm_memoization_returns_same_instance_for_same_model():
+    """Two calls with the same resolved model must return the same LLM
+    instance — rebuilding is wasted work and re-runs credential resolution."""
+    sentinel = MagicMock()
+    with patch("agents.agent.lm.OpenAIGPT", return_value=sentinel) as mock_cls:
+        first = _get_a2ui_llm("gpt-4.1")
+        second = _get_a2ui_llm("gpt-4.1")
+    assert first is second is sentinel
+    assert mock_cls.call_count == 1
+
+
+def test_llm_memoization_is_keyed_per_model():
+    """Different model strings must produce different instances, and each
+    call must construct ``OpenAIGPT`` with the exact model string passed."""
+    instances: list[MagicMock] = []
+    captured_models: list[str] = []
+
+    class _FakeLLM:
+        def __init__(self, config):
+            captured_models.append(config.chat_model)
+            instances.append(self)  # type: ignore[arg-type]
+
+        def chat(self, *_a, **_kw):  # pragma: no cover - not used here
+            return _llm_response(tool_calls=None)
+
+    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
+        a = _get_a2ui_llm("gpt-4.1")
+        b = _get_a2ui_llm("anthropic/claude-opus-4")
+        a2 = _get_a2ui_llm("gpt-4.1")
+
+    assert a is not b, "different models must produce different instances"
+    assert a is a2, "repeated calls for same model must hit the cache"
+    assert captured_models == ["gpt-4.1", "anthropic/claude-opus-4"]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("LANGROID_INTEGRATION_TESTS"),
+    reason=(
+        "Integration test: constructs real lm.OpenAIGPT. Set "
+        "LANGROID_INTEGRATION_TESTS=1 to enable."
+    ),
+)
+def test_construction_succeeds_without_openai_env_real_openaigpt(monkeypatch):
+    """Regression guard (strong form): with ``LANGROID_MODEL=anthropic/...``
+    set and NO ``OPENAI_*`` env variables, constructing the REAL
+    ``lm.OpenAIGPT`` must not raise.
+
+    This is the whole point of the provider-agnostic fix. langroid's
+    ``OpenAIGPT`` class dispatches to the right provider based on the
+    ``provider/model`` prefix; only that provider's credentials are
+    required at construction time. Construction should be pure (config +
+    env reads, no network), so calling it against an Anthropic-prefixed
+    model with only ``ANTHROPIC_API_KEY`` set should succeed without
+    requiring any OpenAI-specific env.
+
+    Opt-in (``LANGROID_INTEGRATION_TESTS=1``) because langroid's
+    ``OpenAIGPT.__init__`` has historically flirted with network / provider
+    init; we keep the weaker model-string routing test (below) as the
+    always-on unit-level line of defense.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    import langroid.language_models as lm  # noqa: WPS433 — local import by design
+
+    # Construct directly — this is the regression we're actually guarding.
+    try:
+        config = lm.OpenAIGPTConfig(
+            chat_model="anthropic/claude-opus-4",
+            stream=False,
+        )
+        llm = lm.OpenAIGPT(config)
+    except Exception as exc:  # pragma: no cover - explicit failure path
+        pytest.fail(
+            f"OpenAIGPT construction must not require OpenAI env when model is "
+            f"non-OpenAI; got {type(exc).__name__}: {exc}"
+        )
+    assert llm is not None
+
+
+def test_construction_uses_correct_model_string_for_non_openai(monkeypatch):
+    """Supplementary model-string routing test: with a non-OpenAI
+    ``LANGROID_MODEL``, the planner constructs an ``OpenAIGPT`` with the
+    exact model string. This is the weaker cousin of the strong-form
+    regression guard above — it confirms the routing path even if the real
+    constructor becomes impossible to unit-test (e.g. adds network I/O)."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    captured_models: list[str] = []
+
+    class _FakeLLM:
+        def __init__(self, config):
+            captured_models.append(config.chat_model)
+
+        def chat(self, *_a, **_kw):
+            return _llm_response(tool_calls=None)
+
+    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
+        generate_a2ui_via_llm(context="")
+
+    assert captured_models == ["anthropic/claude-opus-4"]
+
+
+def test_agent_module_imports_cleanly_without_openai_env(tmp_path):
+    """Honest import-time regression guard: importing ``agents.agent`` with
+    no OpenAI-specific env must succeed. This catches any top-level
+    ``openai.OpenAI()`` / ``openai.Client()`` call that would re-introduce
+    a hard provider dependency.
+
+    Runs in a SUBPROCESS so module-level state (specifically the
+    ``_get_a2ui_llm`` ``lru_cache`` and any other module-scope singletons)
+    in the parent interpreter is not perturbed by a reload. Previously we
+    used ``importlib.reload`` which rebinds module-level function
+    identities — downstream tests patching by name would then silently see
+    a stale reference and leak state across tests. Subprocess isolation
+    makes this test order-independent.
+    """
+    # Strip any OPENAI_* / LANGROID_* / A2UI_* env vars the child would
+    # otherwise inherit, but keep everything else (PATH, HOME, etc.) so the
+    # interpreter can actually start.
+    env = {
+        k: v for k, v in os.environ.items()
+        if not k.startswith(("OPENAI_", "LANGROID_", "A2UI_"))
+    }
+    # Ensure the child can import ``agents.agent`` via the package's src/
+    # directory — mirrors what conftest.py does for the parent.
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{src_dir}{os.pathsep}{existing_pp}" if existing_pp else str(src_dir)
+    )
+
+    # Run the import from ``tmp_path`` so any stray ``.env`` file in the
+    # project root isn't auto-loaded by ``dotenv.load_dotenv`` (which would
+    # reintroduce OPENAI_* silently and mask a regression).
+    result = subprocess.run(
+        [sys.executable, "-c", "import agents.agent"],
+        env=env,
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import agents.agent failed in clean subprocess:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GenerateA2UITool.handle delegates to generate_a2ui_via_llm
+# ---------------------------------------------------------------------------
+
+
+def test_generate_a2ui_tool_handle_returns_json_str_of_operations():
+    """``GenerateA2UITool.handle`` is what langroid invokes server-side. It
+    must return a JSON string of whatever ``generate_a2ui_via_llm`` returned
+    (a2ui_operations dict on success, or an error dict on failure)."""
+    happy_result = {"a2ui_operations": [{"type": "create_surface"}]}
+    with patch(
+        "agents.agent.generate_a2ui_via_llm", return_value=happy_result
+    ) as stub:
+        tool = GenerateA2UITool(context="whatever")
+        out = tool.handle()
+    stub.assert_called_once_with(context="whatever")
+    assert isinstance(out, str), (
+        f"handle() must return str for langroid's tool framework; got "
+        f"{type(out).__name__}"
+    )
+    parsed = json.loads(out)
+    assert parsed == happy_result
+
+
+def test_generate_a2ui_tool_handle_surfaces_error_dicts_verbatim():
+    """Errors from generate_a2ui_via_llm must be serialized to JSON verbatim
+    so the frontend / outer LLM can show the structured error."""
+    err = {"error": "a2ui_llm_error", "message": "x", "remediation": "y"}
+    with patch("agents.agent.generate_a2ui_via_llm", return_value=err):
+        tool = GenerateA2UITool(context="")
+        out = tool.handle()
+    assert isinstance(out, str)
+    parsed = json.loads(out)
+    assert parsed == err
+
+
+def test_generate_a2ui_tool_handle_wraps_json_dumps_failure():
+    """If ``generate_a2ui_via_llm`` returns something with a non-JSON-serializable
+    value (e.g. a ``set`` leaked in from an upstream bug), ``handle()``
+    must NOT propagate the ``TypeError`` to the langroid tool framework.
+    Instead it emits a JSON-encoded structured error string so the outer
+    agent sees a recognizable failure shape.
+
+    Uses ``{1, 2, 3}`` (a set) because it is unambiguously non-JSON-
+    serializable and — unlike ``datetime.utcnow()`` — does not depend on a
+    deprecated stdlib API.
+    """
+    unserializable = {"a2ui_operations": [{"payload": {1, 2, 3}}]}
+    with patch("agents.agent.generate_a2ui_via_llm", return_value=unserializable):
+        tool = GenerateA2UITool(context="")
+        out = tool.handle()
+    # Must still be a str that json.loads accepts.
+    parsed = json.loads(out)
+    _assert_full_error_shape(parsed)
+
+
+# ---------------------------------------------------------------------------
+# Module hygiene: no top-level openai import (including inside top-level
+# try/except blocks, conditional imports, etc. — anywhere that runs at
+# module load time).
+# ---------------------------------------------------------------------------
+
+
+def _module_level_ancestors(tree: ast.Module) -> dict[int, bool]:
+    """Return a map ``id(node) -> is_module_level``.
+
+    A node is module-level iff the chain of containing nodes from the
+    module root never passes through a ``FunctionDef`` / ``AsyncFunctionDef``.
+    Top-level ``Try`` / ``If`` / ``With`` / ``ClassDef`` blocks DO count as
+    module-level — their bodies execute at import time. A regression that
+    drops an ``import openai`` into a class body (e.g. default-factory
+    attribute, metaclass setup) must be caught here too.
+    """
+    is_module_level: dict[int, bool] = {}
+
+    def _walk(node: ast.AST, inside_func: bool) -> None:
+        # Any import statement encountered here gets tagged. We don't need
+        # every node, just the imports — but walking uniformly keeps the
+        # logic simple.
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            is_module_level[id(node)] = not inside_func
+        # Recurse, flipping the flag only when we enter a function body
+        # (its code runs on call, not at import time). Class bodies execute
+        # at module load, so we intentionally do NOT flip the flag for
+        # ``ClassDef``.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.iter_child_nodes(node):
+                _walk(child, inside_func=True)
+        else:
+            for child in ast.iter_child_nodes(node):
+                _walk(child, inside_func=inside_func)
+
+    _walk(tree, inside_func=False)
+    return is_module_level
+
+
+def test_agent_module_does_not_import_openai_at_module_load_time():
+    """The provider-agnostic fix requires that importing ``agents.agent``
+    does not pull in the ``openai`` SDK. A module-load-time ``import openai``
+    — whether at the top of the file, inside a top-level ``try/except``, or
+    inside a top-level ``if``/``with``/etc — would reintroduce the
+    hard-coded provider dependency we just removed.
+
+    The previous walker only inspected ``tree.body``, missing imports
+    nested inside a ``try: import openai; except: pass`` pattern (which
+    still runs at module import). This version walks the full AST and
+    flags any import whose execution path is NOT guarded by a
+    ``FunctionDef`` / ``AsyncFunctionDef`` / ``ClassDef`` body.
+    """
+    import agents.agent as mod
+
+    source = inspect.getsource(mod)
+    tree = ast.parse(source)
+    is_module_level = _module_level_ancestors(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
+        if not is_module_level.get(id(node), False):
+            continue  # inside a function / class body → fine, lazy
+        if isinstance(node, ast.ImportFrom):
+            if node.module and node.module.startswith("openai"):
+                raise AssertionError(
+                    f"agents.agent must not `from openai ...` at module load "
+                    f"time (line {node.lineno}); found: from {node.module} import ..."
+                )
+        else:  # ast.Import
+            for alias in node.names:
+                if alias.name.startswith("openai"):
+                    raise AssertionError(
+                        f"agents.agent must not `import openai` at module load "
+                        f"time (line {node.lineno}); found: {alias.name}"
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Logger assertions — every logger.exception / logger.warning call in source
+# should have a corresponding caplog assertion here. Message substrings are
+# pinned so an unrelated future WARN doesn't silently satisfy the assertion.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_tool_call_picks_first_and_warns(caplog):
+    """When the planner returns more than one tool call (some providers do
+    this under certain conditions), the code must pick ``[0]`` and emit a
+    WARN log about dropping the tail. Never silently consume N>1.
+
+    Pin the message substring (``"2 tool calls"`` — source formats the
+    count via ``%d``) so an unrelated future WARN can't satisfy this
+    assertion.
+    """
+    fake_llm = MagicMock()
+    args_first = {
+        "surfaceId": "first",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    args_second = {
+        "surfaceId": "second",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[
+            _oai_tool_call(arguments=args_first, call_id="c1"),
+            _oai_tool_call(arguments=args_second, call_id="c2"),
+        ]
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with caplog.at_level(logging.WARNING, logger="agents.agent"):
+            result = generate_a2ui_via_llm(context="")
+
+    assert "a2ui_operations" in result
+    assert result["a2ui_operations"][0]["surfaceId"] == "first", (
+        "must pick tool_calls[0] when multiple are present"
+    )
+    # The FIRST call's args lack ``data``, so the op list should be exactly
+    # 2 (surface + components) — NOT 4 (which would indicate both calls
+    # were processed and concatenated). Pinning the count catches a
+    # regression that silently processes all calls.
+    assert len(result["a2ui_operations"]) == 2, (
+        f"expected 2 ops from first tool_call's args only; got "
+        f"{len(result['a2ui_operations'])}"
+    )
+    assert any(
+        rec.levelno == logging.WARNING
+        and rec.name == "agents.agent"
+        and "2 tool calls" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected WARN mentioning '2 tool calls'; got "
+        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_tool_call_missing_function_attr_falls_through_to_legacy_path(caplog):
+    """Degraded-shape: ``tool_calls=[call]`` where ``call.function`` is
+    ``None``. The code must fall through to the legacy ``function_call``
+    path rather than raising ``AttributeError``, and emit a WARN pinpointing
+    the drift so operators see it in logs.
+
+    Pin the message substring (``".function is None"``) so the caplog
+    assertion can't silently pass on an unrelated future WARN.
+    """
+    fake_llm = MagicMock()
+    degraded = _FakeOaiToolCall(id="c1", function=None)
+    args = {
+        "surfaceId": "legacy-via-fallthrough",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[degraded],
+        function_call=_function_call(arguments=args),
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with caplog.at_level(logging.WARNING, logger="agents.agent"):
+            result = generate_a2ui_via_llm(context="")
+    assert "a2ui_operations" in result
+    assert result["a2ui_operations"][0]["surfaceId"] == "legacy-via-fallthrough"
+    assert any(
+        rec.levelno == logging.WARNING
+        and rec.name == "agents.agent"
+        and ".function is None" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected WARN mentioning '.function is None'; got "
+        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_tool_call_with_function_arguments_none_falls_through_to_legacy_path(caplog):
+    """Symmetric fallthrough: ``tool_calls[0].function`` is present but its
+    ``arguments`` is ``None``. The modern slot has no args, so the code
+    must fall through to the legacy ``function_call`` path (some providers
+    put the forced call in the legacy slot even when the modern slot is
+    half-populated).
+
+    This is symmetric with the ``function is None`` fallthrough above —
+    before the source fix, the modern slot returned ``None`` eagerly and
+    this case was misclassified as ``a2ui_no_tool_call``.
+
+    Pin the WARN substring (``".arguments is None"``) so the assertion
+    doesn't silently pass on an unrelated future WARN.
+    """
+    fake_llm = MagicMock()
+    # Modern slot: function present, but arguments is None (degraded shape).
+    modern_no_args = _FakeOaiToolCall(
+        id="c1",
+        function=_FakeFunction(name="render_a2ui", arguments=None),
+    )
+    legacy_args = {
+        "surfaceId": "legacy-surface",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[modern_no_args],
+        function_call=_function_call(arguments=legacy_args),
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with caplog.at_level(logging.WARNING, logger="agents.agent"):
+            result = generate_a2ui_via_llm(context="")
+    assert "a2ui_operations" in result
+    assert result["a2ui_operations"][0]["surfaceId"] == "legacy-surface"
+    # Tight substring: pin the MODERN-slot warning specifically. The legacy-
+    # slot warning ("function_call present but .arguments is None") also
+    # contains ".arguments is None" — a regression that swaps which warning
+    # fires would pass with the looser substring.
+    assert any(
+        rec.levelno == logging.WARNING
+        and rec.name == "agents.agent"
+        and "tool_call.function present but .arguments is None" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected WARN mentioning 'tool_call.function present but .arguments is None'; got "
+        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_tool_call_with_function_missing_arguments_returns_invalid_arguments(caplog):
+    """Degraded-shape: ``tool_calls[0].function`` exists but has no
+    ``arguments`` attr AND there is no legacy ``function_call`` fallback.
+
+    The updated source distinguishes this case from "no tool call at all":
+    the planner DID produce a tool-call shape, just with no args payload,
+    so the ``_extract_tool_call_arguments`` helper surfaces ``_ARGS_MISSING``
+    and the caller emits ``a2ui_invalid_arguments`` (not
+    ``a2ui_no_tool_call``) — "supports forced function-calling" would be
+    the wrong remediation since the planner clearly did try.
+
+    Pin the full MODERN-slot WARN substring (``"tool_call.function present
+    but .arguments is None"``) instead of the loose ``".arguments is None"``
+    — the legacy-slot WARN (``"function_call present but .arguments is
+    None"``) also contains ``.arguments is None``, and a regression that
+    swaps which WARN fires would pass the loose assertion.
+    """
+    fake_llm = MagicMock()
+    # SimpleNamespace with no `arguments` attr — getattr returns None.
+    degraded_func = SimpleNamespace(name="render_a2ui")
+    degraded_call = _FakeOaiToolCall(id="c1", function=degraded_func)
+    fake_llm.chat.return_value = _llm_response(tool_calls=[degraded_call])
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with caplog.at_level(logging.WARNING, logger="agents.agent"):
+            result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments", (
+        f"modern slot present with arguments=None and no legacy fallback "
+        f"must surface a2ui_invalid_arguments (via _ARGS_MISSING sentinel); "
+        f"got {result['error']!r}"
+    )
+    assert any(
+        rec.levelno == logging.WARNING
+        and rec.name == "agents.agent"
+        and "tool_call.function present but .arguments is None" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected WARN mentioning 'tool_call.function present but .arguments is None'; got "
+        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_no_tool_call_warn_log(caplog):
+    """``a2ui_no_tool_call`` branch must log a WARNING so operators see the
+    planner drift in logs. Pin the substring ``"did not emit"`` from the
+    source's WARN message."""
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = _llm_response(tool_calls=None, function_call=None)
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with caplog.at_level(logging.WARNING, logger="agents.agent"):
+            result = generate_a2ui_via_llm(context="")
+    assert result["error"] == "a2ui_no_tool_call"
+    assert any(
+        rec.levelno == logging.WARNING
+        and rec.name == "agents.agent"
+        and "did not emit" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected WARN mentioning 'did not emit'; got "
+        f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_legacy_function_call_with_none_arguments_warns_and_returns_invalid_arguments(caplog):
+    """Legacy-slot fallthrough: ``function_call`` is present but its
+    ``arguments`` attr is ``None``. The updated source emits a WARN and
+    surfaces ``_ARGS_MISSING`` → ``a2ui_invalid_arguments`` (symmetric with
+    the modern slot's degraded-shape path). Distinct from
+    ``a2ui_no_tool_call``: the planner DID emit a tool-call shape, just
+    with no args payload.
+
+    Pin the WARN substring (``"function_call present but .arguments is
+    None"``) so an unrelated future WARN can't silently satisfy the
+    assertion.
+    """
+    fake_llm = MagicMock()
+    # Modern slot absent; legacy slot present with arguments=None.
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=None,
+        function_call=_function_call(arguments=None),
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm):
+        with caplog.at_level(logging.WARNING, logger="agents.agent"):
+            result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments", (
+        f"legacy slot with arguments=None must surface a2ui_invalid_arguments "
+        f"(via _ARGS_MISSING sentinel); got {result['error']!r}"
+    )
+    assert any(
+        rec.levelno == logging.WARNING
+        and rec.name == "agents.agent"
+        and "function_call present but .arguments is None" in rec.getMessage()
+        for rec in caplog.records
+    ), (
+        f"expected WARN mentioning 'function_call present but .arguments is None'; "
+        f"got {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_a2ui_model: env-var precedence contract
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_a2ui_precedence(monkeypatch):
+    """``A2UI_MODEL`` must win over ``LANGROID_MODEL`` — the planner-only
+    override is the whole point of that env var."""
+    monkeypatch.setenv("A2UI_MODEL", "anthropic/claude-opus-4")
+    monkeypatch.setenv("LANGROID_MODEL", "gpt-4.1")
+    assert _resolve_a2ui_model() == "anthropic/claude-opus-4"
+
+
+def test_resolve_a2ui_empty_a2ui_falls_through(monkeypatch):
+    """Empty-string ``A2UI_MODEL`` (e.g. operator typed ``A2UI_MODEL=``
+    without a value) must fall through to ``LANGROID_MODEL`` rather than
+    freezing the planner into the empty string. ``os.getenv`` returns ``""``
+    (not ``None``) in this case, and the source relies on ``or``'s
+    falsy-fallthrough semantics for the empty-string case.
+    """
+    monkeypatch.setenv("A2UI_MODEL", "")
+    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
+    assert _resolve_a2ui_model() == "anthropic/claude-opus-4"
+
+
+def test_resolve_a2ui_default(monkeypatch):
+    """With no env vars set at all, the resolver returns the documented
+    default ``gpt-4.1``. Pinning the string here catches a silent
+    drift between the planner default and ``create_agent``'s default.
+    """
+    monkeypatch.delenv("A2UI_MODEL", raising=False)
+    monkeypatch.delenv("LANGROID_MODEL", raising=False)
+    assert _resolve_a2ui_model() == "gpt-4.1"
+
+
+# ---------------------------------------------------------------------------
+# _get_a2ui_llm LRU eviction: maxsize=4 must evict LRU entry on 5th distinct
+# model. Documented behavior in the source block comment — unpinned until now.
+# ---------------------------------------------------------------------------
+
+
+def test_llm_cache_evicts_after_maxsize():
+    """After ``maxsize=4`` was made explicit, the 5th distinct model evicts
+    the least-recently-used entry. The first-inserted model's second call
+    must reconstruct a fresh ``OpenAIGPT`` (not hit the cache), observable
+    as a second ``__init__`` invocation with the same model string.
+
+    Without this guard, a silent bump of ``maxsize`` to a larger number
+    (or to ``None`` / unbounded) wouldn't fail any existing test but would
+    change memory semantics in production.
+    """
+    instances: list[str] = []
+
+    class _FakeLLM:
+        def __init__(self, config):
+            instances.append(config.chat_model)
+
+    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
+        # Fill the cache (4 distinct models).
+        for i in range(4):
+            _get_a2ui_llm(f"provider/m{i}")
+        # Insert a 5th — evicts provider/m0 (LRU).
+        _get_a2ui_llm("provider/m4")
+        # Re-fetching provider/m0 must reconstruct.
+        _get_a2ui_llm("provider/m0")
+
+    # provider/m0 appears twice in the construction log: once on initial
+    # insert, once after eviction + reconstruct.
+    assert instances.count("provider/m0") == 2, (
+        f"provider/m0 should have been constructed twice (initial + after "
+        f"eviction); got instances={instances!r}"
+    )
+    # Others constructed exactly once.
+    for m in ("provider/m1", "provider/m2", "provider/m3", "provider/m4"):
+        assert instances.count(m) == 1, (
+            f"{m} should have been constructed once; got instances={instances!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Planner LLM must construct with stream=False — load-bearing per source
+# block comment (streaming wastes work; we need the full tool call before
+# emitting operations). Previously untested.
+# ---------------------------------------------------------------------------
+
+
+def test_planner_llm_constructs_with_stream_false():
+    """Capture the ``OpenAIGPTConfig`` passed to the planner LLM and assert
+    ``stream is False``. Load-bearing per the source comment; distinct from
+    the primary chat agent's config which uses ``stream=True`` for SSE
+    streaming to the frontend.
+    """
+    captured_configs: list[Any] = []
+
+    class _FakeLLM:
+        def __init__(self, config):
+            captured_configs.append(config)
+
+        def chat(self, *_a, **_kw):
+            return _llm_response(tool_calls=None)
+
+    with patch("agents.agent.lm.OpenAIGPT", _FakeLLM):
+        generate_a2ui_via_llm(context="")
+
+    assert len(captured_configs) == 1, (
+        f"expected one OpenAIGPTConfig construction; got {len(captured_configs)}"
+    )
+    cfg = captured_configs[0]
+    assert cfg.stream is False, (
+        f"planner must construct with stream=False (full tool call before "
+        f"emitting ops); got stream={cfg.stream!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _RENDER_A2UI_FUNCTION_SPEC: pin the schema shape. This is the contract
+# between the planner LLM and the frontend renderer; a silent rename of
+# required fields would break every downstream consumer.
+# ---------------------------------------------------------------------------
+
+
+def test_render_a2ui_function_spec_required_fields():
+    """Pin the forced-function-call spec's name and required-field set.
+    These are the contract the planner LLM is forced to obey — renaming
+    ``surfaceId`` / ``catalogId`` / ``components`` is a frontend-breaking
+    change and must be caught at unit-test time.
+    """
+    assert _RENDER_A2UI_FUNCTION_SPEC.name == "render_a2ui"
+    assert _RENDER_A2UI_FUNCTION_SPEC.parameters["required"] == [
+        "surfaceId",
+        "catalogId",
+        "components",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tuple annotations: BACKEND_TOOLS / FRONTEND_TOOLS / ALL_TOOLS
+# ---------------------------------------------------------------------------
+
+
+def test_tool_tuples_contain_only_tool_message_subclasses():
+    """All entries in ``BACKEND_TOOLS`` / ``FRONTEND_TOOLS`` / ``ALL_TOOLS``
+    must be ``ToolMessage`` subclasses (not instances, not random strings).
+    Pins the ``tuple[type[ToolMessage], ...]`` annotation shape at runtime —
+    a regression that slipped a stringified tool name into the tuple would
+    pass mypy on some configurations but fail at langroid registration.
+    """
+    for tools_tuple, label in (
+        (BACKEND_TOOLS, "BACKEND_TOOLS"),
+        (FRONTEND_TOOLS, "FRONTEND_TOOLS"),
+        (ALL_TOOLS, "ALL_TOOLS"),
+    ):
+        assert isinstance(tools_tuple, tuple), f"{label} must be a tuple"
+        for entry in tools_tuple:
+            assert isinstance(entry, type) and issubclass(entry, ToolMessage), (
+                f"{label} must contain only ToolMessage subclasses; got {entry!r}"
+            )
+
+    # ALL_TOOLS = BACKEND_TOOLS + FRONTEND_TOOLS — count pin so a new tool
+    # not wired into ALL_TOOLS gets caught here too.
+    assert len(ALL_TOOLS) == len(BACKEND_TOOLS) + len(FRONTEND_TOOLS)
+    assert len(ALL_TOOLS) == 9, (
+        f"ALL_TOOLS should have 9 entries (6 backend + 3 frontend); got "
+        f"{len(ALL_TOOLS)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend tool handle() try/except wrappers — each of the 6 backend tools
+# wraps its ``*_impl()`` call. Parametrized happy + error paths.
+# ---------------------------------------------------------------------------
+
+
+# (tool_cls, impl_symbol_on_agent_module, tool_ctor_kwargs, error_code)
+_BACKEND_TOOL_CASES = [
+    (GetWeatherTool, "get_weather_impl", {"location": "Seattle"}, "get_weather_failed"),
+    (QueryDataTool, "query_data_impl", {"query": "show sales"}, "query_data_failed"),
+    (
+        ManageSalesTodosTool,
+        "manage_sales_todos_impl",
+        {"todos": []},
+        "manage_sales_todos_failed",
+    ),
+    (
+        GetSalesTodosTool,
+        "get_sales_todos_impl",
+        {},
+        "get_sales_todos_failed",
+    ),
+    (
+        ScheduleMeetingTool,
+        "schedule_meeting_impl",
+        {"reason": "demo", "duration_minutes": 30},
+        "schedule_meeting_failed",
+    ),
+    (
+        SearchFlightsTool,
+        "search_flights_impl",
+        {"flights": []},
+        "search_flights_failed",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "tool_cls,impl_name,kwargs,_error_code",
+    _BACKEND_TOOL_CASES,
+    ids=[c[0].__name__ for c in _BACKEND_TOOL_CASES],
+)
+def test_backend_tool_handle_happy_path(tool_cls, impl_name, kwargs, _error_code):
+    """Happy-path: each backend tool's ``handle()`` serializes the result of
+    its wrapped ``*_impl()`` to a JSON string. Patches the impl symbol on
+    ``agents.agent`` (where it's bound at import time) so we control the
+    return value without depending on shared/python's actual implementation.
+    """
+    sentinel_result = {"ok": True, "tool": tool_cls.__name__}
+    with patch(f"agents.agent.{impl_name}", return_value=sentinel_result):
+        tool = tool_cls(**kwargs)
+        out = tool.handle()
+    assert isinstance(out, str)
+    assert json.loads(out) == sentinel_result
+
+
+@pytest.mark.parametrize(
+    "tool_cls,impl_name,kwargs,error_code",
+    _BACKEND_TOOL_CASES,
+    ids=[c[0].__name__ for c in _BACKEND_TOOL_CASES],
+)
+def test_backend_tool_handle_error_path_returns_structured_error(
+    tool_cls, impl_name, kwargs, error_code, caplog
+):
+    """Error-path: each backend tool must wrap an impl exception into the
+    structured ``_tool_error`` JSON shape (``{"error": "<tool>_failed",
+    "message": "ValueError: simulated"}``). The exception must NOT escape
+    into langroid's tool-handling stack.
+
+    Also asserts the module logger emits an ERROR record (from
+    ``logger.exception(...)`` in the handler).
+    """
+    with patch(f"agents.agent.{impl_name}", side_effect=ValueError("simulated")):
+        tool = tool_cls(**kwargs)
+        with caplog.at_level(logging.ERROR, logger="agents.agent"):
+            out = tool.handle()
+    assert isinstance(out, str)
+    parsed = json.loads(out)
+    assert parsed["error"] == error_code
+    # Message includes the class name AND the detail substring — both halves
+    # are load-bearing for operator diagnosis.
+    assert "ValueError" in parsed["message"]
+    assert "simulated" in parsed["message"]
+    # Error record logged on agents.agent.
+    assert any(
+        rec.levelno >= logging.ERROR and rec.name == "agents.agent"
+        for rec in caplog.records
+    ), (
+        f"expected ERROR log on agents.agent from {tool_cls.__name__}.handle; "
+        f"got {[(r.name, r.levelname) for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GenerateA2UITool.handle: json.dumps wrapper must catch every exception
+# class raised by ``json.dumps`` on pathological inputs. Source catches
+# ``(TypeError, ValueError, OverflowError, RecursionError)`` — each branch
+# gets its own test so a regression that narrows the tuple is caught.
+# ---------------------------------------------------------------------------
+
+
+def test_tool_handle_wraps_value_error_on_circular_reference():
+    """A cyclic dict makes ``json.dumps`` raise ``ValueError("Circular
+    reference detected")`` — NOT ``RecursionError``. CPython's ``json``
+    encoder detects the cycle via its ``markers`` dict and raises
+    ``ValueError`` long before the recursion limit is hit.
+    ``GenerateA2UITool.handle`` must catch it and emit a structured-error
+    JSON string rather than propagate the exception to langroid's
+    tool-handling stack. Pins the ``ValueError`` branch of the source's
+    widened ``except (TypeError, ValueError, OverflowError,
+    RecursionError)`` tuple.
+    """
+    cyclic: dict = {}
+    cyclic["self"] = cyclic
+    with patch(
+        "agents.agent.generate_a2ui_via_llm",
+        return_value={"a2ui_operations": [cyclic]},
+    ):
+        tool = GenerateA2UITool(context="")
+        out = tool.handle()
+    assert isinstance(out, str)
+    parsed = json.loads(out)
+    _assert_full_error_shape(parsed)
+    assert parsed["error"] == "a2ui_invalid_arguments"
+
+
+def test_tool_handle_wraps_recursion_error_on_deep_nesting():
+    """The ``RecursionError`` branch of the source's widened ``json.dumps``
+    catch must actually be exercised. Patches the module-local
+    ``_json_dumps`` binding (NOT the stdlib ``json.dumps``) to raise
+    ``RecursionError`` — ``json.dumps`` on truly pathological inputs
+    (e.g. deeply-nested but acyclic structures) can hit ``RecursionError``
+    under sufficient nesting, and we also want the source to stay
+    resilient against any future regression that introduces it via a
+    different path.
+
+    NOTE on patching discipline: earlier test revisions patched
+    ``agents.agent.json.dumps`` directly, which mutates the shared stdlib
+    module object and can collide with pytest / caplog internals that
+    dispatch through ``json.dumps`` while the patch is active. The source
+    introduces a module-local ``_json_dumps = json.dumps`` binding so
+    tests can patch ONLY the agent's success-path serialization without
+    leaking into unrelated stdlib consumers. The exception-branch
+    structured-error dump uses the raw ``json.dumps`` so the error
+    envelope still serializes even when ``_json_dumps`` is patched.
+    """
+    with patch(
+        "agents.agent.generate_a2ui_via_llm",
+        return_value={"a2ui_operations": [{"deep": "stub"}]},
+    ), patch(
+        "agents.agent._json_dumps", side_effect=RecursionError("max depth")
+    ):
+        tool = GenerateA2UITool(context="")
+        out = tool.handle()
+    assert isinstance(out, str)
+    parsed = json.loads(out)
+    _assert_full_error_shape(parsed)
+    assert parsed["error"] == "a2ui_invalid_arguments"
+    # Message must mention the class name so operators can diagnose the
+    # branch that fired.
+    assert "RecursionError" in parsed["message"]
+
+
+# ---------------------------------------------------------------------------
+# Additional _A2uiSuccess boundary validation — parametrized coverage for
+# non-dict / None / wrong-shape returns from build_a2ui_operations_from_tool_call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "builder_return,case",
+    [
+        (None, "returns None"),
+        (["not", "a", "dict"], "returns list"),
+        ({"a2ui_operations": None}, "operations key None"),
+        ({"a2ui_operations": "not a list"}, "operations key str"),
+    ],
+)
+def test_build_a2ui_boundary_rejects_malformed_shapes(builder_return, case):
+    """The planner's boundary-validation layer must reject every shape that
+    doesn't match ``_A2uiSuccess`` contract (``{"a2ui_operations": [...]}``
+    with a list value). Parametrized so all four failure modes are exercised
+    — a regression that loosens the ``isinstance(..., list)`` check to
+    ``is not None`` would be caught by the 'operations key str' case.
+    """
+    fake_llm = MagicMock()
+    args = {
+        "surfaceId": "s",
+        "catalogId": "copilotkit://app-dashboard-catalog",
+        "components": [{"id": "root", "type": "Container"}],
+    }
+    fake_llm.chat.return_value = _llm_response(
+        tool_calls=[_oai_tool_call(arguments=args)]
+    )
+    with patch("agents.agent._get_a2ui_llm", return_value=fake_llm), patch(
+        "agents.agent.build_a2ui_operations_from_tool_call",
+        return_value=builder_return,
+    ):
+        result = generate_a2ui_via_llm(context="")
+    _assert_full_error_shape(result)
+    assert result["error"] == "a2ui_invalid_arguments", f"case: {case}"
+
+
+# ---------------------------------------------------------------------------
+# create_agent factory — wiring contract with langroid
+# ---------------------------------------------------------------------------
+
+
+def test_create_agent_wires_all_tools_with_stream_true(monkeypatch):
+    """``create_agent`` must:
+      - construct ``OpenAIGPTConfig`` with ``chat_model=$LANGROID_MODEL`` and
+        ``stream=True`` (primary agent streams to SSE; distinct from the
+        planner's ``stream=False``).
+      - construct ``ChatAgent`` and call ``enable_message(list(ALL_TOOLS))``
+        with every tool.
+
+    Pins the full wiring contract so a regression that drops a tool from
+    ``ALL_TOOLS`` or flips the primary agent to ``stream=False`` is caught.
+
+    Captures via ``lm.OpenAIGPTConfig`` (not ``lm.OpenAIGPT``) because
+    langroid's ``ChatAgent`` lazily constructs the LLM from the config —
+    ``create_agent`` itself only instantiates the config, not the LLM.
+    """
+    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
+
+    captured_config_kwargs: list[dict] = []
+    enable_message_calls: list[Any] = []
+
+    # Import the real config / agent types so isinstance checks (and
+    # attribute access) still work downstream; we only intercept
+    # construction kwargs for assertion.
+    import agents.agent as agent_mod
+    real_config_cls = agent_mod.lm.OpenAIGPTConfig
+
+    def _spy_config(**kwargs):
+        captured_config_kwargs.append(kwargs)
+        # Return a real instance so subsequent code paths (including any
+        # model-string validation inside langroid) keep working.
+        return real_config_cls(**kwargs)
+
+    class _FakeAgent:
+        def __init__(self, config):
+            self.config = config
+
+        def enable_message(self, tools):
+            enable_message_calls.append(tools)
+
+    with patch("agents.agent.lm.OpenAIGPTConfig", side_effect=_spy_config), patch(
+        "agents.agent.lr.ChatAgent", _FakeAgent
+    ):
+        agent = create_agent()
+
+    # Config kwargs: model from env, stream=True.
+    assert len(captured_config_kwargs) == 1
+    kwargs = captured_config_kwargs[0]
+    assert kwargs["chat_model"] == "anthropic/claude-opus-4"
+    assert kwargs["stream"] is True, (
+        f"create_agent must construct primary LLM config with stream=True; "
+        f"got stream={kwargs.get('stream')!r}"
+    )
+
+    # enable_message called once with a list equal to list(ALL_TOOLS).
+    assert len(enable_message_calls) == 1
+    enabled = enable_message_calls[0]
+    assert enabled == list(ALL_TOOLS), (
+        f"enable_message must receive list(ALL_TOOLS); got {enabled!r}"
+    )
+
+    # Returned value is the fake agent instance.
+    assert isinstance(agent, _FakeAgent)
+
+
+def test_create_agent_default_model_when_langroid_model_unset(monkeypatch):
+    """When ``LANGROID_MODEL`` is unset, ``create_agent`` falls back to the
+    documented default ``gpt-4.1``. Pins the default string in a
+    second test site (the other is ``_resolve_a2ui_model``) so a silent
+    drift between the two defaults is caught."""
+    monkeypatch.delenv("LANGROID_MODEL", raising=False)
+
+    captured_config_kwargs: list[dict] = []
+
+    import agents.agent as agent_mod
+    real_config_cls = agent_mod.lm.OpenAIGPTConfig
+
+    def _spy_config(**kwargs):
+        captured_config_kwargs.append(kwargs)
+        return real_config_cls(**kwargs)
+
+    class _FakeAgent:
+        def __init__(self, config):
+            pass
+
+        def enable_message(self, tools):
+            pass
+
+    with patch("agents.agent.lm.OpenAIGPTConfig", side_effect=_spy_config), patch(
+        "agents.agent.lr.ChatAgent", _FakeAgent
+    ):
+        create_agent()
+
+    assert captured_config_kwargs[0]["chat_model"] == "gpt-4.1"
+
+
+# ---------------------------------------------------------------------------
+# Complementary module-hygiene regression: subprocess-import warnings check.
+# The AST walker only catches static imports. This test catches dynamic
+# imports (e.g. a function-scope ``import openai`` that fires on module load
+# via side-effect) AND provider-SDK-emitted warnings that would leak to
+# stderr at import time.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_module_import_does_not_warn_about_openai_on_stderr(tmp_path):
+    """Complement to the AST walker: run ``import agents.agent`` in a clean
+    subprocess and assert neither stdout nor stderr mentions ``openai``.
+    Catches:
+      - dynamic imports (function-scope ``import openai`` triggered at
+        module load via side-effect) that the AST walker misses.
+      - provider-SDK-emitted deprecation / initialization warnings that
+        leak the provider name to stderr.
+
+    A regression that reintroduces a lazy ``import openai`` inside a
+    module-level ``try``-block whose body runs at import time would be
+    caught here even if the AST walker's scoping missed it.
+    """
+    env = {
+        k: v for k, v in os.environ.items()
+        if not k.startswith(("OPENAI_", "LANGROID_", "A2UI_"))
+    }
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{src_dir}{os.pathsep}{existing_pp}" if existing_pp else str(src_dir)
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import agents.agent"],
+        env=env,
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import agents.agent failed: stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    # Tight regex: an unconditional ``"openai" not in ...`` check is
+    # fragile — langroid's own ``OpenAIGPTConfig`` (imported at module
+    # load) emits benign messages that can contain "OpenAIGPT" / "openai"
+    # without actually importing the ``openai`` SDK. We look specifically
+    # for the regressions that matter: an actual ``import openai`` (or
+    # ``from openai import``) succeeding or warning, OR a direct SDK
+    # instantiation (``openai.OpenAI(`` / ``openai.Client(``).
+    import re
+
+    regression_patterns = [
+        r"\bimport openai\b",
+        r"\bfrom openai\b",
+        r"\bopenai\.OpenAI\s*\(",
+        r"\bopenai\.Client\s*\(",
+    ]
+    for stream_name, stream_val in (
+        ("stderr", result.stderr),
+        ("stdout", result.stdout),
+    ):
+        for pat in regression_patterns:
+            assert not re.search(pat, stream_val), (
+                f"{stream_name} matched regression pattern {pat!r}: "
+                f"{stream_val!r}"
+            )

--- a/showcase/scripts/__tests__/generate-starters.test.ts
+++ b/showcase/scripts/__tests__/generate-starters.test.ts
@@ -12,6 +12,7 @@ import {
   forEachPyFile,
   extractUvicornModule,
   getEntrypointBlock,
+  generateStarterToDir,
   FRAMEWORKS,
   PIN_OVERRIDES,
 } from "../generate-starters";
@@ -634,6 +635,98 @@ describe("generate-starters", () => {
       const fw = FRAMEWORKS.find((f) => f.slug === "ms-agent-dotnet")!;
       const block = getEntrypointBlock(fw);
       expect(block).toContain("dotnet ProverbsAgent.dll");
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // entrypointOverride regression guard.
+  //
+  // Rationale: ``generateStarterImpl`` has an ``entrypointOverride`` branch
+  // that preserves the committed starter ``entrypoint.sh`` across regen
+  // (vs. the shared OpenAI-hardcoded template). langroid uses this — a
+  // future refactor that silently removes or short-circuits that branch
+  // would quietly revert the provider-agnostic entrypoint on the next
+  // regen and all existing tests would still pass (the template picks up
+  // the default ``entrypoint.sh`` for non-override slugs).
+  //
+  // Import ``generateStarterToDir`` at the suite level so the test fixture
+  // can regenerate a single starter into a tmp directory and byte-diff
+  // against the committed canonical file.
+  // ---------------------------------------------------------------------
+  describe("entrypointOverride: committed entrypoint.sh is preserved verbatim", () => {
+    it("langroid: generator-emitted entrypoint.sh equals the committed canonical file", async () => {
+      const fw = FRAMEWORKS.find((f) => f.slug === "langroid");
+      expect(fw, "langroid framework must exist in FRAMEWORKS").toBeDefined();
+      expect(fw!.entrypointOverride).toBe(true);
+
+      const canonical = fs.readFileSync(
+        path.join(STARTERS_DIR, "langroid", "entrypoint.sh"),
+        "utf-8",
+      );
+
+      const tmp = fs.mkdtempSync(
+        path.join(os.tmpdir(), "gen-starters-override-"),
+      );
+      try {
+        generateStarterToDir(fw!, tmp);
+        const generated = fs.readFileSync(
+          path.join(tmp, "langroid", "entrypoint.sh"),
+          "utf-8",
+        );
+        expect(generated).toBe(canonical);
+        // Also assert the file is executable — the override branch
+        // force-writes 0o755. Windows checkouts or archive round-trips
+        // strip +x, so pin it explicitly.
+        const stat = fs.statSync(path.join(tmp, "langroid", "entrypoint.sh"));
+        // Check the user-execute bit — platform-agnostic (works on both
+        // POSIX and Windows-simulated checkouts).
+        expect((stat.mode & 0o100) !== 0).toBe(true);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("non-override slug: generator-emitted entrypoint.sh differs from langroid's canonical (uses template)", async () => {
+      // Pick a non-override Python slug so we actually hit the shared
+      // template codepath (not the override branch). google-adk is python
+      // and does NOT set entrypointOverride — it will regenerate from the
+      // template on every call.
+      const nonOverrideFw = FRAMEWORKS.find(
+        (f) => f.slug === "google-adk" && !f.entrypointOverride,
+      );
+      expect(
+        nonOverrideFw,
+        "expected a non-override python slug (google-adk) in FRAMEWORKS",
+      ).toBeDefined();
+
+      const langroidCanonical = fs.readFileSync(
+        path.join(STARTERS_DIR, "langroid", "entrypoint.sh"),
+        "utf-8",
+      );
+
+      const tmp = fs.mkdtempSync(
+        path.join(os.tmpdir(), "gen-starters-template-"),
+      );
+      try {
+        generateStarterToDir(nonOverrideFw!, tmp);
+        const generated = fs.readFileSync(
+          path.join(tmp, nonOverrideFw!.slug, "entrypoint.sh"),
+          "utf-8",
+        );
+        // Distinct content: the non-override slug uses the shared template
+        // which does NOT contain the provider-agnostic
+        // ``_expected_key_for_model`` function that the langroid override
+        // carries. If this assertion starts passing by equality, something
+        // has gone wrong in the generator wiring (e.g. template got the
+        // override block pasted in, or langroid's override leaked cross-
+        // slug).
+        expect(generated).not.toBe(langroidCanonical);
+        // Stronger signal: the langroid-only override guard function
+        // must NOT appear in the template-generated entrypoint.
+        expect(generated).not.toContain("_expected_key_for_model");
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -63,6 +63,13 @@ interface FrameworkDef {
   devScript: string;
   extraFiles?: Record<string, string>; // destPath -> sourcePath (relative to package dir)
   extraDependencies?: Record<string, string>; // Additional npm dependencies to merge into package.json
+  // When true, the generator preserves the slug's existing
+  // ``showcase/starters/<slug>/entrypoint.sh`` verbatim across regeneration
+  // instead of overwriting it with the shared ``entrypoint.template.sh``
+  // output. Used by multi-provider starters (e.g. langroid) whose boot
+  // sequence diverges from the OpenAI-hardcoded template UX. The existing
+  // file IS the source of truth — editing it is how you change behavior.
+  entrypointOverride?: boolean;
 }
 
 const FRAMEWORKS: FrameworkDef[] = [
@@ -148,6 +155,10 @@ const FRAMEWORKS: FrameworkDef[] = [
     agentDir: "agent",
     devScript:
       'concurrently "next dev --turbopack" "python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 --reload"',
+    // langroid is multi-provider: the starter entrypoint selects the
+    // credential env var from LANGROID_MODEL rather than hard-coding
+    // OPENAI_API_KEY. Keep the committed file as the source of truth.
+    entrypointOverride: true,
   },
   {
     slug: "llamaindex",
@@ -298,6 +309,14 @@ function substituteVars(content: string, vars: Record<string, string>): string {
   }
   const remaining = result.match(/\{\{[A-Z_]+\}\}/g);
   if (remaining) {
+    // NOTE: warn-and-pass-through rather than throw. Callers of
+    // substituteVars include partial-vars callers (tests,
+    // processTemplateVarsInDir scanning JSON/CSS/HTML that may contain
+    // ``{{literal}}`` tokens unrelated to our template vars). The
+    // callers that REQUIRE full replacement — e.g. the Dockerfile and
+    // entrypoint.template.sh writes in generateStarterImpl — already
+    // feed a complete ``vars`` map; unreplaced tokens there surface in
+    // integration tests or the ``diff -r`` drift check.
     console.warn(
       `  [warn] Unreplaced template variables: ${remaining.join(", ")}`,
     );
@@ -364,6 +383,33 @@ function rewritePythonImports(filePath: string): void {
       // Keep import os lines — don't skip them
       for (const idx of osImportIndices) {
         skipIndices.delete(idx);
+      }
+    }
+  }
+
+  // After stripping the sys.path.insert block, any remaining top-level
+  // `import sys` becomes unused — the shared-tools bootstrap was the ONLY
+  // use of `sys` in these generated files. Mirror the `osUsed` logic:
+  // scan non-skipped lines for a reference to ``sys`` and, if none exists,
+  // mark every standalone ``import sys`` line for removal too. This keeps
+  // the regenerated starter import block tidy (no dead ``import sys``
+  // lingering once generate-starters is re-run).
+  const sysImportIndices: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (skipIndices.has(i)) continue;
+    if (lines[i].trim() === "import sys") {
+      sysImportIndices.push(i);
+    }
+  }
+  if (sysImportIndices.length > 0) {
+    const sysImportSet = new Set(sysImportIndices);
+    const sysUsed = lines.some(
+      (line, i) =>
+        !skipIndices.has(i) && !sysImportSet.has(i) && /\bsys\b/.test(line),
+    );
+    if (!sysUsed) {
+      for (const idx of sysImportIndices) {
+        skipIndices.add(idx);
       }
     }
   }
@@ -463,6 +509,12 @@ function rewriteTypeScriptSharedImports(
 function extractUvicornModule(fw: FrameworkDef): string {
   const match = fw.devScript.match(/uvicorn\s+([\w.:]+)/);
   if (!match) {
+    // Non-uvicorn devScripts (e.g. langgraph-python uses langgraph_cli)
+    // legitimately have no uvicorn module — fall back to the conventional
+    // default. This helper is currently called only by tests; the real
+    // entrypoint block is built by getEntrypointBlock with a hardcoded
+    // module path per language. If future callers require strict
+    // extraction, gate that at the call site rather than here.
     console.warn(
       `  [warn] Could not extract uvicorn module from devScript for ${fw.slug}, using default "agent.main:app"`,
     );
@@ -477,30 +529,6 @@ else
   exit 1
 fi`;
 
-// Prefix each line of the agent's stdout/stderr with [agent] AND capture the
-// real PID of the agent process. Previously this used:
-//
-//   cmd 2>&1 | sed 's/^/[agent] /' &
-//   AGENT_PID=$!
-//
-// That has two bugs:
-//   1. `$!` after a pipeline points to the LAST command in the pipe (the
-//      `sed` process), not the agent. `kill -0 $AGENT_PID` and
-//      `wait -n $AGENT_PID` therefore monitored `sed`, not the agent, which
-//      always looked alive until sed closed stdin — by which time the agent
-//      had already crashed and Railway was mid-restart.
-//   2. `sed` buffers by default, so Python stack traces at crash time could
-//      be discarded when the pipe closed, hiding the real error.
-//
-// Process substitution (`&> >(awk …)`) redirects both streams without
-// creating a pipeline, so `$!` remains the agent's PID. `awk` with
-// `fflush()` line-flushes each prefixed line, so crash output reaches the
-// container logs immediately.
-//
-// Also export PYTHONUNBUFFERED=1 at the entrypoint level so Python-based
-// agents don't buffer their own writes before they reach awk.
-const AGENT_LOG_PREFIX = `&> >(awk '{print "[agent] " $0; fflush()}')`;
-
 function getEntrypointBlock(fw: FrameworkDef): string {
   switch (fw.language) {
     case "python":
@@ -510,13 +538,13 @@ python -m langgraph_cli dev \\
   --config langgraph.json \\
   --host 0.0.0.0 \\
   --port 8123 \\
-  --no-browser ${AGENT_LOG_PREFIX} &
+  --no-browser 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
       return `echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 ${AGENT_LOG_PREFIX} &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 ${AGENT_HEALTH_CHECK}`;
@@ -527,32 +555,32 @@ npx @langchain/langgraph-cli dev \\
   --config agent/langgraph.json \\
   --host 0.0.0.0 \\
   --port 8123 \\
-  --no-browser ${AGENT_LOG_PREFIX} &
+  --no-browser 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
       if (fw.slug === "mastra") {
         return `echo "[entrypoint] Starting Mastra agent on port 8123..."
-PORT=8123 npx mastra dev ${AGENT_LOG_PREFIX} &
+PORT=8123 npx mastra dev 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
       return `echo "[entrypoint] Starting TypeScript agent on port 8123..."
-npx tsx agent/index.ts ${AGENT_LOG_PREFIX} &
+npx tsx agent/index.ts 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 2
 ${AGENT_HEALTH_CHECK}`;
     case "java":
       return `echo "[entrypoint] Starting Spring AI agent on port 8123..."
-java -jar agent/app.jar --server.port=8123 ${AGENT_LOG_PREFIX} &
+java -jar agent/app.jar --server.port=8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 sleep 5
 ${AGENT_HEALTH_CHECK}`;
     case "csharp":
       return `echo "[entrypoint] Starting .NET agent on port 8123..."
-cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 ${AGENT_LOG_PREFIX} &
+cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 2>&1 | sed 's/^/[agent] /' &
 AGENT_PID=$!
 cd /app
 sleep 3
@@ -625,6 +653,43 @@ function copySharedTypeScriptTools(agentDestDir: string): void {
  * Writes a fully self-contained starter into `outDir`.
  */
 function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
+  // Preserve the per-slug entrypoint.sh override (if any) across the
+  // rmSync+regen cycle. ``entrypointOverride: true`` declares that the
+  // slug's committed ``entrypoint.sh`` is canonical; snapshot it from the
+  // canonical committed location (``STARTERS_DIR/<slug>/entrypoint.sh``)
+  // before wiping outDir and restore it after the template-based
+  // entrypoint write step below.
+  //
+  // Reading from the canonical committed path (NOT ``outDir``) matters for
+  // --check mode: runCheckMode writes each starter to a *fresh* temp
+  // directory, so ``path.join(outDir, "entrypoint.sh")`` doesn't exist
+  // there. Sourcing from STARTERS_DIR means --check reads the same
+  // canonical override that a normal regen does, which is exactly what the
+  // drift test needs. Without this, every --check would regenerate langroid
+  // against the generic OpenAI-hardcoded template and falsely flag drift.
+  let preservedEntrypoint: { content: Buffer; mode: number } | null = null;
+  if (fw.entrypointOverride) {
+    const canonicalEntrypoint = path.join(
+      STARTERS_DIR,
+      fw.slug,
+      "entrypoint.sh",
+    );
+    if (fs.existsSync(canonicalEntrypoint)) {
+      preservedEntrypoint = {
+        content: fs.readFileSync(canonicalEntrypoint),
+        mode: fs.statSync(canonicalEntrypoint).mode,
+      };
+    } else {
+      // A declared override with no committed file is a repo-integrity
+      // failure, not a degradable warning — silently falling back to the
+      // shared template would reintroduce the OpenAI-hardcoded entrypoint
+      // on the next regen and quietly revert provider-agnostic behavior.
+      throw new Error(
+        `${fw.slug} declares entrypointOverride=true but the canonical override file ${canonicalEntrypoint} does not exist. Commit the override file before regenerating.`,
+      );
+    }
+  }
+
   if (fs.existsSync(outDir)) {
     fs.rmSync(outDir, { recursive: true });
   }
@@ -765,8 +830,14 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
           if (pkg.dependencies[dep]) {
             pkg.dependencies[dep] = version;
           } else {
-            console.warn(
-              `  [warn] PIN_OVERRIDES: ${dep} not found in ${fw.slug} dependencies — pin ignored`,
+            // A PIN_OVERRIDES entry for a dep that isn't in the package's
+            // dependencies is stale config — the package was updated and
+            // the pin wasn't cleaned up, OR the pin targets the wrong
+            // package. Silently warning means the dep keeps floating (the
+            // whole point of PIN_OVERRIDES is reproducibility) without any
+            // CI signal. Fail loudly so the pin gets removed or corrected.
+            throw new Error(
+              `PIN_OVERRIDES: ${dep} not found in ${fw.slug} dependencies — pin is stale, remove or correct the entry in PIN_OVERRIDES`,
             );
           }
         }
@@ -841,28 +912,15 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     }
 
     // For langgraph starters: convert relative imports to absolute
-    // because langgraph_cli loads modules standalone, not as packages.
-    //
-    // Subdir-aware: `from .X import ...` resolves to the CURRENT package,
-    // which is the directory the file lives in, not `agentDir` flat. A file
-    // at `<agentDir>/tools/get_weather.py` saying `from .types import X` must
-    // become `from <agentDir>.tools.types import X`, not `from <agentDir>.types`.
-    // The previous flat rewrite dropped the `tools` segment and produced
-    // `ModuleNotFoundError: No module named '<agentDir>.types'` at startup,
-    // killing langgraph-fastapi silently inside the entrypoint `sed` pipe.
+    // because langgraph_cli loads modules standalone, not as packages
     if (fw.slug.startsWith("langgraph-")) {
       const lgAgentMod = fw.agentDir.replace(/\//g, ".");
       forEachPyFile(agentDest, (fp) => {
         let content = fs.readFileSync(fp, "utf-8");
-        // Compute the file's containing Python package path:
-        // <agentDir>.<relative-subdirs-joined-with-.>
-        const relFromAgent = path.relative(agentDest, path.dirname(fp));
-        const subPkg = relFromAgent.split(path.sep).filter(Boolean).join(".");
-        const filePkg = subPkg ? `${lgAgentMod}.${subPkg}` : lgAgentMod;
-        // from .X import -> from <filePkg>.X import
+        // from .X import -> from <agentMod>.X import
         content = content.replace(
           /^from \.([\w.]+) import/gm,
-          `from ${filePkg}.$1 import`,
+          `from ${lgAgentMod}.$1 import`,
         );
         fs.writeFileSync(fp, content);
       });
@@ -890,8 +948,15 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
         );
         fs.writeFileSync(path.join(outDir, "agent_server.py"), serverContent);
       } else {
-        console.warn(
-          `  [warn] agent_server.py missing for ${fw.slug}: ${agentServerSrc} — skipping`,
+        // Non-langgraph Python starters all depend on ``agent_server.py``
+        // being present at the starter root — the Dockerfile COPYs it in
+        // and the generated entrypoint execs ``uvicorn agent_server:app``.
+        // A missing source file is a repo-integrity failure (either the
+        // package was deleted or FRAMEWORKS needs to add this slug to the
+        // langgraph-exempt allowlist); silently skipping produces a
+        // starter that won't boot.
+        throw new Error(
+          `agent_server.py missing for ${fw.slug}: expected ${agentServerSrc} to exist. Add the file or extend the langgraph-exempt slug list if this starter does not need a FastAPI shim.`,
         );
       }
 
@@ -935,10 +1000,13 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
       const srcPath = path.join(pkgDir, src);
       const destPath = path.join(outDir, dest);
       if (!fs.existsSync(srcPath)) {
-        console.warn(
-          `  [warn] Extra file missing for ${fw.slug}: ${srcPath} — skipping`,
+        // ``fw.extraFiles`` is an explicit declaration that this file is
+        // required by the starter (e.g. langgraph.json for langgraph-*).
+        // A missing source is a repo-integrity failure — silently skipping
+        // produces a generator-good but runtime-broken starter.
+        throw new Error(
+          `Extra file missing for ${fw.slug}: ${srcPath} was declared in fw.extraFiles but does not exist. Add the source file or remove the extraFiles entry.`,
         );
-        continue;
       }
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
       fs.copyFileSync(srcPath, destPath);
@@ -974,14 +1042,34 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
   fs.writeFileSync(path.join(outDir, "Dockerfile"), dockerfileContent);
 
   // 6. Generate entrypoint.sh
-  const entrypointTemplate = fs.readFileSync(
-    path.join(TEMPLATE_DIR, "entrypoint.template.sh"),
-    "utf-8",
-  );
-  const entrypoint = substituteVars(entrypointTemplate, vars);
-  fs.writeFileSync(path.join(outDir, "entrypoint.sh"), entrypoint, {
-    mode: 0o755,
-  });
+  //
+  // Slugs with ``entrypointOverride: true`` opt out of the shared template
+  // and carry their own ``entrypoint.sh`` in the committed starter tree.
+  // For those slugs, restore the pre-rmSync snapshot (captured above) and
+  // skip the template substitution entirely — otherwise every regeneration
+  // would silently overwrite the provider-aware entrypoint with the
+  // generic OpenAI-hardcoded template.
+  if (preservedEntrypoint) {
+    // Force executable mode on the restored override regardless of the
+    // source mode. Editors, filesystem copies across platforms, and
+    // archive round-trips can strip the +x bit — trusting the source mode
+    // would ship a non-executable entrypoint.sh into the starter output
+    // and break container startup with a permission-denied at exec time.
+    fs.writeFileSync(
+      path.join(outDir, "entrypoint.sh"),
+      preservedEntrypoint.content,
+      { mode: 0o755 },
+    );
+  } else {
+    const entrypointTemplate = fs.readFileSync(
+      path.join(TEMPLATE_DIR, "entrypoint.template.sh"),
+      "utf-8",
+    );
+    const entrypoint = substituteVars(entrypointTemplate, vars);
+    fs.writeFileSync(path.join(outDir, "entrypoint.sh"), entrypoint, {
+      mode: 0o755,
+    });
+  }
 
   // 7. Generate showcase.json
   const showcaseJson = {
@@ -1231,6 +1319,10 @@ export {
   FRAMEWORKS,
   PIN_OVERRIDES,
   generateStarter,
+  // Exported so tests can regenerate a single starter into a temp directory
+  // and diff against the committed canonical tree — specifically used to
+  // regression-guard the ``entrypointOverride`` branch of generateStarterImpl.
+  generateStarterToDir,
   substituteVars,
   rewritePythonImports,
   forEachPyFile,

--- a/showcase/starters/langroid/.env.example
+++ b/showcase/starters/langroid/.env.example
@@ -5,8 +5,15 @@ ANTHROPIC_API_KEY=replace-with-your-key
 # Agent backend URL (for the CopilotKit runtime proxy)
 AGENT_URL=http://localhost:8123
 
-# Langroid model (defaults to openai/gpt-4.1)
-# LANGROID_MODEL=openai/gpt-4.1
+# Langroid model (defaults to the bare OpenAI name `gpt-4.1`).
+# NOTE: langroid does NOT strip the `openai/` prefix before passing the
+# model string to the OpenAI SDK — using `openai/gpt-4.1` here will produce
+# a "model not found" error at request time. Use bare names like `gpt-4.1`
+# for OpenAI; use provider prefixes (`litellm/anthropic/...`, `gemini/...`,
+# `openrouter/...`, `ollama/...`, etc.) for non-OpenAI providers.
+# LANGROID_MODEL=gpt-4.1
+# LANGROID_MODEL=litellm/anthropic/claude-opus-4
+# LANGROID_MODEL=gemini/gemini-2.5-flash
 
 # Showcase
 NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/showcase/starters/langroid/agent/agent.py
+++ b/showcase/starters/langroid/agent/agent.py
@@ -7,24 +7,53 @@ protocol (SSE events) manually using the ag-ui-protocol types.
 
 The agent supports:
   - Agentic chat (streaming text responses)
-  - Backend tool execution (get_weather, query_data, manage_sales_todos, get_sales_todos)
+  - Backend tool execution (get_weather, query_data, manage_sales_todos,
+    get_sales_todos, search_flights, generate_a2ui)
   - Frontend tool calls (change_background, generate_haiku, schedule_meeting)
   - Human-in-the-loop via schedule_meeting (frontend-rendered meeting time picker)
+
+NOTE ON DRIFT: This module is the canonical source. The starter copy at
+``showcase/starters/langroid/agent/agent.py`` is regenerated from this file
+by ``showcase/scripts/generate-starters.ts``, which strips the shared-tools
+path-injection block below (together with any now-unused stdlib imports it
+relied on) and rewrites ``from tools import ...`` into ``from .tools
+import ...`` — a single relative import against the starter's bundled
+``agent/tools/`` package; no legacy fallback path is emitted. Any fix
+must land in BOTH files until the generator is re-run.
+Sibling provider-agnostic A2UI planner implementations live in
+``showcase/packages/google-adk/src/agents/main.py`` and
+``showcase/packages/strands/src/agents/agent.py`` — keep error shapes
+aligned.
 """
 
 from __future__ import annotations
 
+import functools
 import json
+import logging
 import os
-import sys
-from typing import Annotated
+from enum import Enum
+from typing import Annotated, Any, Literal, Protocol, TypedDict, cast
+
+# Module-local binding for json.dumps. Tests that need to inject
+# serialization failures (RecursionError / MemoryError / etc.) patch THIS
+# symbol instead of ``json.dumps``. Patching the stdlib attribute directly
+# mutates the globally-shared module object and can collide with pytest /
+# caplog internals that dispatch through ``json.dumps`` during the test
+# — producing false failures that look like test-code bugs but are
+# actually patch-leakage. The module-local binding is the only safe
+# patch target.
+_json_dumps = json.dumps
 
 import langroid as lr
 import langroid.language_models as lm
 from langroid.agent.tool_message import ToolMessage
+from pydantic import ValidationError
 from dotenv import load_dotenv
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 # =====================================================================
 # Shared tool implementations
@@ -41,31 +70,566 @@ from .tools import (
 )
 
 # =====================================================================
+# A2UI planner LLM — provider-agnostic
+# =====================================================================
+#
+# The secondary LLM that emits the A2UI schema is routed through langroid's
+# own LLM abstraction (``lm.OpenAIGPT``, which despite the historical name
+# handles OpenAI / Anthropic / Gemini / any ``provider/model`` chat-model
+# string). That way this package stays provider-agnostic: whatever
+# ``LANGROID_MODEL`` the operator picks for the primary chat agent, the A2UI
+# planner inherits by default. Operators can override only the planner via
+# ``A2UI_MODEL`` without touching the primary agent.
+#
+# Sibling implementations live in
+# ``showcase/packages/google-adk/src/agents/main.py`` (Gemini-native) and
+# ``showcase/packages/strands/src/agents/agent.py`` (OpenAI-only). Keep the
+# error-surface shape (_A2uiError) consistent across all three so the
+# frontend renderer treats them identically.
+
+class _A2uiErrorKind(str, Enum):
+    """Closed set of known A2UI planner error kinds.
+
+    Using an Enum (str-valued so JSON serialization stays stable) lets us
+    catch typos at static-analysis time and gives tests a single place to
+    enumerate the valid set. Kept as ``str``-subclass so the serialized
+    JSON shape is identical to the previous bare-string contract.
+    """
+
+    LLM_ERROR = "a2ui_llm_error"
+    NO_TOOL_CALL = "a2ui_no_tool_call"
+    INVALID_ARGUMENTS = "a2ui_invalid_arguments"
+
+class _A2uiError(TypedDict):
+    """Shape of the structured error dict returned by generate_a2ui branches.
+
+    Every error branch MUST populate all three keys so callers (and the LLM
+    summarizing the tool result) see a consistent surface.
+
+    NOTE: Identical TypedDicts live in
+    ``showcase/packages/google-adk/src/agents/main.py`` and
+    ``showcase/packages/strands/src/agents/agent.py``. Keep all three in
+    sync — any key additions / removals must land in every sibling so the
+    A2UI error surface stays consistent across showcase adapters.
+    """
+
+    # Synthesized from ``_A2uiErrorKind`` (Python 3.11+ ``Literal[*tuple(...)]``
+    # unpacking) so the Literal and the enum can never drift out of sync.
+    # Add/remove a kind in the enum above and the TypedDict follows automatically.
+    error: Literal[*tuple(k.value for k in _A2uiErrorKind)]  # type: ignore[misc]
+    message: str
+    remediation: str
+
+class _A2uiSuccess(TypedDict):
+    """Shape of the successful generate_a2ui return value.
+
+    Mirrors what ``build_a2ui_operations_from_tool_call`` produces: a single
+    key ``a2ui_operations`` mapping to a list of operation dicts. Defining
+    the shape here (rather than ``dict[str, Any]``) lets type-checkers flag
+    accidental key renames and keeps the public contract documented next to
+    the error surface.
+    """
+
+    a2ui_operations: list[dict[str, Any]]
+
+def _a2ui_error(
+    *, error: _A2uiErrorKind, message: str, remediation: str
+) -> _A2uiError:
+    """Construct and contract-check an ``_A2uiError``.
+
+    Centralizing construction lets us enforce at runtime that every error
+    return from the A2UI planner carries all three required keys with
+    non-empty string values. Typos ("remediaton") or accidental omissions
+    blow up here rather than silently produce a malformed error surface.
+
+    ``error`` is the ``_A2uiErrorKind`` enum (not a raw string) so call sites
+    cannot invent new error codes and bypass the closed set. The factory
+    extracts ``.value`` internally; callers pass the enum directly.
+
+    Raises ``ValueError`` (not ``assert``) so ``python -O`` can't strip the
+    validation in production. Also rejects non-string values for
+    ``message`` / ``remediation`` — the TypedDict annotation says ``str``
+    and runtime must match, otherwise callers can accidentally slip lists
+    or dicts through and break the frontend contract.
+    """
+    err: _A2uiError = {
+        "error": error.value,
+        "message": message,
+        "remediation": remediation,
+    }
+    missing = [k for k in ("error", "message", "remediation") if not err.get(k)]
+    if missing:
+        raise ValueError(
+            f"_a2ui_error missing required non-empty keys: {missing}; got {err!r}"
+        )
+    bad_types = [
+        k for k in ("error", "message", "remediation") if not isinstance(err[k], str)
+    ]
+    if bad_types:
+        raise ValueError(
+            f"_a2ui_error requires str values for keys {bad_types}; got {err!r}"
+        )
+    return err
+
+def _resolve_a2ui_model() -> str:
+    """Resolve the A2UI planner's chat_model string.
+
+    Resolution order:
+      1. ``A2UI_MODEL`` — planner-only override.
+      2. ``LANGROID_MODEL`` — inherits from the primary agent's model.
+      3. Default ``gpt-4.1`` (bare OpenAI name — matches ``create_agent``
+         below). NOTE: langroid does NOT strip the ``openai/`` prefix —
+         it passes the model string LITERALLY to the OpenAI SDK, which
+         rejects ``openai/gpt-4.1`` as "model not found". The canonical
+         langroid convention (and ``OpenAIChatModel.GPT4_1.value``) is
+         the bare name.
+    """
+    return (
+        os.getenv("A2UI_MODEL")
+        or os.getenv("LANGROID_MODEL")
+        or "gpt-4.1"
+    )
+
+# Memoize the A2UI planner LLM so we don't rebuild ``OpenAIGPT`` (and re-run
+# credential resolution) on every request. Keyed on the resolved model string
+# so env overrides produce distinct entries. ``maxsize=4`` is intentional: in
+# production the resolved model is effectively constant, so the cache only
+# needs to cover test churn — tests that patch across more distinct models
+# should call ``_get_a2ui_llm.cache_clear()`` rather than rely on identity.
+@functools.lru_cache(maxsize=4)
+def _get_a2ui_llm(model: str) -> lm.OpenAIGPT:
+    """Return a memoized langroid LLM bound to the given chat_model string.
+
+    Callers must resolve the model first (see ``_resolve_a2ui_model``) and
+    pass it in explicitly; the cache is keyed on ``model`` so env changes
+    produce distinct instances rather than silently returning a stale one.
+    ``maxsize=4`` — the 5th distinct model evicts the least-recently-used
+    entry (see block comment above for rationale). Call ``.cache_clear()``
+    in tests that need to reset memoization.
+    """
+    config = lm.OpenAIGPTConfig(
+        chat_model=model,
+        # Non-streaming for the planner: we need the full tool call before
+        # we can emit operations. Streaming here is wasted work.
+        stream=False,
+    )
+    return lm.OpenAIGPT(config)
+
+# The render_a2ui function the planner is forced to call. Kept here (not
+# imported from shared/) because the shape is OpenAI-compatible regardless
+# of which provider langroid's ``OpenAIGPT`` is talking to — langroid
+# normalizes the forced-function-call across providers.
+_RENDER_A2UI_FUNCTION_SPEC = lm.LLMFunctionSpec(
+    name="render_a2ui",
+    description="Render a dynamic A2UI v0.9 surface.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "surfaceId": {"type": "string"},
+            "catalogId": {"type": "string"},
+            "components": {"type": "array", "items": {"type": "object"}},
+            "data": {"type": "object"},
+        },
+        "required": ["surfaceId", "catalogId", "components"],
+    },
+)
+
+class _LLMResponseLike(Protocol):
+    """Structural type for the subset of ``LLMResponse`` we read.
+
+    Defined as a Protocol (rather than importing langroid's concrete type)
+    so the extractor is trivially unit-testable with a fake object and the
+    signature documents exactly which attributes matter.
+    """
+
+    oai_tool_calls: Any
+    function_call: Any
+
+# Sentinel: distinct from ``None`` so the caller can tell "no tool call at all"
+# (returned as ``None``) from "tool-call shape present but ``arguments`` field
+# was ``None``" (returned as this sentinel). The two cases have different
+# remediations — see ``generate_a2ui_via_llm``.
+_ARGS_MISSING: object = object()
+
+def _extract_tool_call_arguments(
+    response: _LLMResponseLike,
+) -> dict[str, Any] | str | None | object:
+    """Pull the planner's tool-call arguments out of an ``LLMResponse``.
+
+    Handles both shapes langroid exposes:
+      - ``oai_tool_calls[0].function.arguments`` — modern tool-calling path.
+      - ``function_call.arguments`` — legacy path used by some providers.
+
+    Returns:
+      - ``dict`` or ``str`` (JSON) — the raw arguments value to parse/use.
+      - ``None`` — no tool call was produced at all (→ ``a2ui_no_tool_call``).
+      - ``_ARGS_MISSING`` — a tool-call slot was present but its ``arguments``
+        field was missing/None (→ ``a2ui_invalid_arguments``; the planner
+        DID try to call but emitted a degraded shape, so "no tool call"
+        remediation would be misleading).
+
+    Logs a WARN for every shape-drift case so operators can diagnose
+    langroid / provider-SDK regressions without strace-ing tests.
+    """
+    tool_calls = getattr(response, "oai_tool_calls", None)
+    saw_modern_call = False
+    if tool_calls:
+        # Non-empty ``tool_calls`` list always counts as "planner attempted
+        # a modern-slot call" — even when ``.function`` is None (degraded
+        # shape). Without this, ``.function is None`` + no legacy
+        # ``function_call`` returns plain ``None``, which the caller maps
+        # to ``NO_TOOL_CALL``. But the planner DID try to call in the
+        # modern slot; the correct remediation is ``INVALID_ARGUMENTS``
+        # (symmetric with the ``.function.arguments is None`` case below).
+        saw_modern_call = True
+        if len(tool_calls) > 1:
+            # Forced function-call should produce exactly one tool call;
+            # multiple is unexpected and we pick index 0 silently today.
+            # Logging it makes the truncation visible rather than mysterious.
+            logger.warning(
+                "generate_a2ui_via_llm: planner returned %d tool calls; "
+                "using index 0 only",
+                len(tool_calls),
+            )
+        first = tool_calls[0]
+        func = getattr(first, "function", None)
+        if func is not None:
+            args = getattr(func, "arguments", None)
+            if args is not None:
+                return args
+            # Degraded shape: the modern slot has no arguments. Log and
+            # fall through to the legacy function_call path — providers
+            # occasionally put the forced call in the legacy slot even
+            # when the modern slot is present but empty.
+            logger.warning(
+                "generate_a2ui_via_llm: tool_call.function present but "
+                ".arguments is None (response-shape drift?)"
+            )
+        else:
+            # Degraded shape: tool_calls[0].function is None. Log and fall
+            # through to the legacy function_call path — some providers put
+            # the forced call in the legacy slot.
+            logger.warning(
+                "generate_a2ui_via_llm: tool_call present but .function is None "
+                "(response-shape drift?)"
+            )
+
+    function_call = getattr(response, "function_call", None)
+    if function_call is not None:
+        args = getattr(function_call, "arguments", None)
+        if args is None:
+            # Legacy slot is present but its ``arguments`` field is missing.
+            # Symmetric with the modern-slot warning above, and flagged as
+            # INVALID_ARGUMENTS (not NO_TOOL_CALL) via the sentinel so the
+            # caller emits the correct remediation.
+            logger.warning(
+                "generate_a2ui_via_llm: function_call present but .arguments "
+                "is None (response-shape drift?)"
+            )
+            return _ARGS_MISSING
+        return args
+
+    # No legacy slot. If we saw a modern tool-call structure but its
+    # arguments were empty, surface that as _ARGS_MISSING so the caller
+    # emits a2ui_invalid_arguments rather than a2ui_no_tool_call.
+    if saw_modern_call:
+        return _ARGS_MISSING
+
+    return None
+
+def generate_a2ui_via_llm(*, context: str) -> _A2uiError | _A2uiSuccess:
+    """Run the A2UI planner LLM and return either operations or a structured
+    error.
+
+    Provider-agnostic: routes through ``lm.OpenAIGPT`` (langroid's universal
+    LLM abstraction) so whatever provider the operator configured via
+    ``LANGROID_MODEL`` / ``A2UI_MODEL`` is used. No direct provider-SDK
+    imports live in this module.
+
+    Error surface is the shared ``_A2uiError`` TypedDict (see sibling
+    google-adk / strands implementations).
+    """
+    system_prompt = context or "Generate a useful dashboard UI."
+    messages = [
+        lm.LLMMessage(role=lm.Role.SYSTEM, content=system_prompt),
+        lm.LLMMessage(
+            role=lm.Role.USER,
+            content="Generate a dynamic A2UI dashboard based on the conversation.",
+        ),
+    ]
+
+    # Wrap the LLM call so expected transport / auth / rate-limit failures
+    # do not bubble up through langroid's tool machinery as uncaught
+    # exceptions.
+    #
+    # We explicitly re-raise the narrow class of structural / programmer
+    # bugs (AttributeError, TypeError, NameError, ImportError,
+    # ModuleNotFoundError, AssertionError, NotImplementedError,
+    # pydantic.ValidationError). Those indicate real bugs and must surface
+    # to tests and server logs rather than be reported as "verify provider
+    # credentials" — the remediation in ``a2ui_llm_error`` is wrong for
+    # those classes (e.g. a missing ``anthropic`` package is an install
+    # problem, not a credentials problem; a pydantic validation failure is
+    # a schema bug, not a transport failure).
+    #
+    # Intentionally NOT re-raised (so they flow into the transport-error
+    # path): KeyError, IndexError, LookupError, RecursionError, MemoryError.
+    # The SDK / adapter stack raises these as recoverable conditions on
+    # malformed provider payloads, and swallowing them into the structured
+    # error surface gives callers the correct "retry / check provider"
+    # remediation rather than an uncaught 500.
+    try:
+        llm = _get_a2ui_llm(_resolve_a2ui_model())
+        response = llm.chat(
+            messages=messages,
+            functions=[_RENDER_A2UI_FUNCTION_SPEC],
+            function_call={"name": "render_a2ui"},
+        )
+    except (
+        AttributeError,
+        TypeError,
+        NameError,
+        ImportError,
+        ModuleNotFoundError,
+        AssertionError,
+        NotImplementedError,
+        ValidationError,
+    ):
+        # Programmer / environment bugs — propagate so tests & server logs
+        # catch them instead of producing a misleading "verify credentials"
+        # remediation.
+        raise
+    except Exception as exc:  # noqa: BLE001 — see rationale above
+        logger.exception("generate_a2ui_via_llm: LLM call failed")
+        # Include a truncated str(exc) so ConnectionError("backend unreachable")
+        # and similar transport failures surface the actionable substring.
+        # We truncate regardless of provider SDK behavior — bounds the blast
+        # radius of any future regression where an SDK embeds credentials
+        # in exception messages.
+        exc_detail = str(exc)[:200] if str(exc) else ""
+        message = f"Secondary A2UI LLM call failed: {exc.__class__.__name__}"
+        if exc_detail:
+            message = f"{message}: {exc_detail}"
+        return _a2ui_error(
+            error=_A2uiErrorKind.LLM_ERROR,
+            message=message,
+            remediation=(
+                "Verify the provider credentials required by LANGROID_MODEL / "
+                "A2UI_MODEL are set and the provider is reachable. "
+                "See server logs for the full traceback."
+            ),
+        )
+
+    raw_args = _extract_tool_call_arguments(response)
+    if raw_args is None:
+        logger.warning(
+            "generate_a2ui_via_llm: planner did not emit a render_a2ui tool call"
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.NO_TOOL_CALL,
+            message="Secondary A2UI LLM did not call render_a2ui.",
+            remediation=(
+                "Retry the request. If this persists, verify the planner model "
+                "supports forced function-calling."
+            ),
+        )
+    if raw_args is _ARGS_MISSING:
+        # Distinct from NO_TOOL_CALL: the planner DID produce a tool-call
+        # shape but its ``arguments`` field was missing/None. "Supports
+        # forced function-calling" is the wrong remediation here — the
+        # actionable fix is to retry (transient) or investigate a
+        # response-shape regression in the provider SDK.
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message=(
+                "Secondary A2UI LLM emitted a tool-call with no arguments "
+                "payload."
+            ),
+            remediation=(
+                "Retry the request; if this persists, check server logs for a "
+                "response-shape drift warning from the provider SDK."
+            ),
+        )
+
+    # langroid usually pre-parses tool arguments into a dict, but some
+    # provider adapters surface them as a JSON string. Handle both shapes.
+    if isinstance(raw_args, str):
+        try:
+            args = json.loads(raw_args)
+        # MemoryError / RecursionError can fire on pathological payloads
+        # (multi-MB JSON, deeply-nested structures). Parity with
+        # ``GenerateA2UITool.handle``'s widened catch — we'd rather surface
+        # a structured INVALID_ARGUMENTS than let these bubble up as an
+        # uncaught 500.
+        except (ValueError, TypeError, MemoryError, RecursionError) as exc:
+            logger.exception(
+                "generate_a2ui_via_llm: failed to parse render_a2ui arguments as JSON"
+            )
+            # Truncate ``str(exc)`` — parity with the LLM-error path and
+            # defense against multi-KB raw LLM payloads leaking into the
+            # structured error surface.
+            return _a2ui_error(
+                error=_A2uiErrorKind.INVALID_ARGUMENTS,
+                message=f"Could not parse render_a2ui arguments: {str(exc)[:200]}",
+                remediation=(
+                    "Retry the request; the secondary LLM emitted malformed JSON."
+                ),
+            )
+    else:
+        args = raw_args
+
+    if not isinstance(args, dict):
+        logger.warning(
+            "generate_a2ui_via_llm: render_a2ui arguments parsed to %s (not dict)",
+            type(args).__name__,
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message=(
+                f"render_a2ui arguments must be a JSON object, got "
+                f"{type(args).__name__}."
+            ),
+            remediation="Retry the request; the secondary LLM emitted a non-object payload.",
+        )
+
+    # ``build_a2ui_operations_from_tool_call`` can raise if required keys
+    # are missing or values aren't serializable. Without this guard, an
+    # upstream schema change (planner LLM returns a slightly-wrong shape)
+    # produces a 500 and bypasses the structured-error contract the
+    # frontend relies on.
+    try:
+        result = build_a2ui_operations_from_tool_call(args)
+    # Widened to match the ``GenerateA2UITool.handle`` transport-path wrapper
+    # and the str-arg ``json.loads`` wrapper above: IndexError / AttributeError
+    # / LookupError can fire on malformed or partial payloads (planner emits a
+    # dict missing a list slot; provider SDK returns a sparse attribute) and
+    # must NOT escape into langroid's tool-handling stack. Narrow catches here
+    # produced a 500 that bypassed the structured-error contract the frontend
+    # relies on.
+    except (
+        KeyError,
+        ValueError,
+        TypeError,
+        IndexError,
+        AttributeError,
+        LookupError,
+    ) as exc:
+        logger.exception(
+            "generate_a2ui_via_llm: build_a2ui_operations_from_tool_call failed"
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message=f"Could not build A2UI operations: {exc.__class__.__name__}",
+            remediation=(
+                "Retry with a simpler A2UI design or check the LLM-emitted schema."
+            ),
+        )
+
+    # Defense-in-depth: the shared helper is contracted to return
+    # ``{"a2ui_operations": [...]}`` but a shape regression upstream
+    # (e.g. accidental ``None`` or dict without the key) would otherwise
+    # bypass ``_A2uiSuccess`` and break the frontend renderer silently.
+    if (
+        not isinstance(result, dict)
+        or "a2ui_operations" not in result
+        or not isinstance(result["a2ui_operations"], list)
+    ):
+        # Include the first-20 sorted keys when the result IS a dict so
+        # operators can tell "wrong key name" (e.g. planner emitted
+        # ``operations`` instead of ``a2ui_operations``) from "wrong type".
+        # The type name alone doesn't give enough signal to diagnose.
+        result_keys: list[str] | None = (
+            sorted(str(k) for k in result.keys())[:20]
+            if isinstance(result, dict)
+            else None
+        )
+        logger.error(
+            "build_a2ui_operations_from_tool_call returned unexpected shape: "
+            "type=%s keys=%r",
+            type(result).__name__,
+            result_keys,
+        )
+        return _a2ui_error(
+            error=_A2uiErrorKind.INVALID_ARGUMENTS,
+            message="A2UI builder returned invalid shape.",
+            remediation=(
+                "Upstream `build_a2ui_operations_from_tool_call` returned an "
+                "unexpected result; check shared/python/tools."
+            ),
+        )
+    return cast(_A2uiSuccess, result)
+
+# =====================================================================
 # Langroid Tool Definitions
 # =====================================================================
 
+class _ToolErrorKind(str, Enum):
+    """Closed set of backend-tool error codes.
+
+    Using an Enum (str-valued so JSON serialization stays stable) keeps
+    call sites from inventing new codes and defends against typos like
+    ``"get_wether_failed"`` that ship silently through free-form strings.
+    Values match the historical bare-string codes so the serialized JSON
+    shape is identical to the previous contract.
+
+    Mirrors ``_A2uiErrorKind`` — both enums live in this module for the
+    same reason: closed-set typing for the error surface the outer LLM
+    consumes.
+    """
+
+    GET_WEATHER_FAILED = "get_weather_failed"
+    QUERY_DATA_FAILED = "query_data_failed"
+    MANAGE_SALES_TODOS_FAILED = "manage_sales_todos_failed"
+    GET_SALES_TODOS_FAILED = "get_sales_todos_failed"
+    SCHEDULE_MEETING_FAILED = "schedule_meeting_failed"
+    SEARCH_FLIGHTS_FAILED = "search_flights_failed"
+
+def _tool_error(*, error: _ToolErrorKind, message: str) -> str:
+    """Serialize a structured error that a tool ``handle()`` can return to
+    langroid. Keeps the surface consistent across all backend tools so the
+    outer LLM treats recoverable tool failures uniformly rather than seeing
+    unstructured exception tracebacks.
+
+    ``error`` is the ``_ToolErrorKind`` enum (not a raw string) so call
+    sites cannot invent new error codes and bypass the closed set. The
+    function extracts ``.value`` internally; callers pass the enum
+    directly.
+    """
+    return _json_dumps({"error": error.value, "message": message})
+
 class GetWeatherTool(ToolMessage):
-    """Get the weather for a given location."""
     request: str = "get_weather"
     purpose: str = "Get current weather for a location."
     location: str
 
     def handle(self) -> str:
-        result = get_weather_impl(self.location)
-        return json.dumps(result)
+        try:
+            result = get_weather_impl(self.location)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001 — tool errors must not escape
+            logger.exception("GetWeatherTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.GET_WEATHER_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 class QueryDataTool(ToolMessage):
-    """Query the database. Takes natural language."""
     request: str = "query_data"
     purpose: str = "Query the database. Always call before showing a chart or graph."
     query: str
 
     def handle(self) -> str:
-        result = query_data_impl(self.query)
-        return json.dumps(result)
+        try:
+            result = query_data_impl(self.query)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("QueryDataTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.QUERY_DATA_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 class ManageSalesTodosTool(ToolMessage):
-    """Replace the entire list of sales todos."""
     request: str = "manage_sales_todos"
     purpose: str = (
         "Replace the entire list of sales todos with the provided values. "
@@ -74,33 +638,54 @@ class ManageSalesTodosTool(ToolMessage):
     todos: list[dict]
 
     def handle(self) -> str:
-        result = manage_sales_todos_impl(self.todos)
-        return json.dumps(result)
+        try:
+            result = manage_sales_todos_impl(self.todos)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("ManageSalesTodosTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.MANAGE_SALES_TODOS_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 class GetSalesTodosTool(ToolMessage):
-    """Get the current list of sales todos."""
     request: str = "get_sales_todos"
     purpose: str = "Get the current list of sales todos."
 
     def handle(self) -> str:
-        result = get_sales_todos_impl()
-        return json.dumps(result)
+        try:
+            result = get_sales_todos_impl()
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("GetSalesTodosTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.GET_SALES_TODOS_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 # Frontend tools — the agent "calls" them but they execute client-side.
 # We define them so Langroid's LLM knows the tool schemas; the AG-UI
 # adapter intercepts the call and forwards it to the frontend.
 
 class ChangeBackgroundTool(ToolMessage):
-    """Change the background color/gradient of the chat area."""
     request: str = "change_background"
     purpose: str = "Change the background color/gradient of the chat area. ONLY call this when the user explicitly asks."
     background: Annotated[str, "CSS background value. Prefer gradients."]
 
     def handle(self) -> str:
+        # Frontend tool: the AG-UI adapter normally intercepts the call and
+        # routes it to the client before this handler runs. If we're here,
+        # the routing regressed and the agent is about to lie to the user
+        # about an action it never performed. Log loudly so the regression
+        # surfaces in server logs. We still return the benign string to
+        # preserve the existing non-breaking contract for starters.
+        logger.error(
+            "ChangeBackgroundTool.handle fired server-side — AG-UI adapter "
+            "dispatch regression; frontend tool was not intercepted"
+        )
         return f"Background changed to {self.background}"
 
 class GenerateHaikuTool(ToolMessage):
-    """Generate a haiku with Japanese text, English translation, and a background image."""
     request: str = "generate_haiku"
     purpose: str = "Generate a haiku with Japanese text, English translation, and a background image."
     japanese: list[str]
@@ -109,25 +694,32 @@ class GenerateHaikuTool(ToolMessage):
     gradient: str
 
     def handle(self) -> str:
+        # Frontend tool — see ChangeBackgroundTool.handle for rationale on
+        # logging vs raising.
+        logger.error(
+            "GenerateHaikuTool.handle fired server-side — AG-UI adapter "
+            "dispatch regression; frontend tool was not intercepted"
+        )
         return "Haiku generated!"
 
 class ScheduleMeetingTool(ToolMessage):
-    """Schedule a meeting. The user will be asked to pick a time via the UI."""
     request: str = "schedule_meeting"
     purpose: str = "Schedule a meeting. The user will be asked to pick a time via the meeting time picker UI."
     reason: str
     duration_minutes: int = 30
 
     def handle(self) -> str:
-        result = schedule_meeting_impl(self.reason, self.duration_minutes)
-        return json.dumps(result)
-
-# =====================================================================
-# Agent factory
-# =====================================================================
+        try:
+            result = schedule_meeting_impl(self.reason, self.duration_minutes)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("ScheduleMeetingTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.SCHEDULE_MEETING_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 class SearchFlightsTool(ToolMessage):
-    """Search for flights and display the results as rich A2UI cards."""
     request: str = "search_flights"
     purpose: str = (
         "Search for flights and display the results as rich cards. Return exactly 2 flights. "
@@ -137,11 +729,17 @@ class SearchFlightsTool(ToolMessage):
     flights: list[dict]
 
     def handle(self) -> str:
-        result = search_flights_impl(self.flights)
-        return json.dumps(result)
+        try:
+            result = search_flights_impl(self.flights)
+            return _json_dumps(result)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("SearchFlightsTool.handle failed")
+            return _tool_error(
+                error=_ToolErrorKind.SEARCH_FLIGHTS_FAILED,
+                message=f"{exc.__class__.__name__}: {str(exc)[:200]}",
+            )
 
 class GenerateA2UITool(ToolMessage):
-    """Generate dynamic A2UI components based on the conversation."""
     request: str = "generate_a2ui"
     purpose: str = (
         "Generate dynamic A2UI components based on the conversation. "
@@ -150,65 +748,81 @@ class GenerateA2UITool(ToolMessage):
     context: str
 
     def handle(self) -> str:
-        from openai import OpenAI
-
-        client = OpenAI()
-        tool_schema = {
-            "type": "function",
-            "function": {
-                "name": "render_a2ui",
-                "description": "Render a dynamic A2UI v0.9 surface.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "surfaceId": {"type": "string"},
-                        "catalogId": {"type": "string"},
-                        "components": {"type": "array", "items": {"type": "object"}},
-                        "data": {"type": "object"},
-                    },
-                    "required": ["surfaceId", "catalogId", "components"],
-                },
-            },
-        }
-
-        response = client.chat.completions.create(
-            model="gpt-4.1",
-            messages=[
-                {"role": "system", "content": self.context or "Generate a useful dashboard UI."},
-                {"role": "user", "content": "Generate a dynamic A2UI dashboard based on the conversation."},
-            ],
-            tools=[tool_schema],
-            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
-        )
-
-        if not response.choices[0].message.tool_calls:
-            return json.dumps({"error": "LLM did not call render_a2ui"})
-
-        tool_call = response.choices[0].message.tool_calls[0]
-        args = json.loads(tool_call.function.arguments)
-        result = build_a2ui_operations_from_tool_call(args)
-        return json.dumps(result)
+        # Delegate to the provider-agnostic planner. `generate_a2ui_via_llm`
+        # returns either the successful `a2ui_operations` dict or a
+        # structured `_A2uiError` — both shapes are JSON-serializable and
+        # are surfaced verbatim to the outer langroid agent (and thereby
+        # the frontend A2UI renderer).
+        result = generate_a2ui_via_llm(context=self.context)
+        try:
+            return _json_dumps(result)
+        except (TypeError, ValueError, OverflowError, RecursionError) as exc:
+            # Defensive: generate_a2ui_via_llm returns dicts by contract,
+            # but if an upstream change ever returns a non-serializable
+            # value we want a structured error rather than an uncaught
+            # exception bubbling through langroid's tool machinery.
+            # OverflowError covers NaN/inf floats; RecursionError covers
+            # cyclic structures — both raised by ``json.dumps`` and not
+            # subclasses of ``TypeError`` / ``ValueError``.
+            logger.exception("GenerateA2UITool.handle: json.dumps failed")
+            # Use the stdlib json.dumps directly here (not _json_dumps) so
+            # the structured-error dump still succeeds when tests patch
+            # _json_dumps to simulate a RecursionError on the success path.
+            # Tests for this branch bind their side_effect to _json_dumps
+            # only; the raw ``json.dumps`` remains callable and produces a
+            # parseable error envelope for the frontend.
+            return json.dumps(
+                _a2ui_error(
+                    error=_A2uiErrorKind.INVALID_ARGUMENTS,
+                    message=(
+                        f"Could not serialize A2UI result: "
+                        f"{exc.__class__.__name__}"
+                    ),
+                    remediation=(
+                        "This indicates an upstream planner contract bug; "
+                        "see server logs."
+                    ),
+                )
+            )
 
 # Tools that execute server-side (Langroid handles them directly)
-BACKEND_TOOLS = [
+BACKEND_TOOLS: tuple[type[ToolMessage], ...] = (
     GetWeatherTool,
     QueryDataTool,
     ManageSalesTodosTool,
     GetSalesTodosTool,
     SearchFlightsTool,
     GenerateA2UITool,
-]
+)
 
 # Tools that execute client-side (AG-UI adapter forwards to frontend)
-FRONTEND_TOOLS = [
+FRONTEND_TOOLS: tuple[type[ToolMessage], ...] = (
     ChangeBackgroundTool,
     GenerateHaikuTool,
     ScheduleMeetingTool,
-]
+)
 
-ALL_TOOLS = BACKEND_TOOLS + FRONTEND_TOOLS
+ALL_TOOLS: tuple[type[ToolMessage], ...] = BACKEND_TOOLS + FRONTEND_TOOLS
 
-FRONTEND_TOOL_NAMES = {t.default_value("request") for t in FRONTEND_TOOLS}
+FRONTEND_TOOL_NAMES: frozenset[str] = frozenset(
+    t.default_value("request") for t in FRONTEND_TOOLS
+)
+
+# Canary: the set of frontend tool names is part of the contract with the
+# AG-UI adapter (which looks them up to route execution to the client).
+# If a tool is added/removed/renamed without updating the adapter, this
+# raises at import time rather than at request time.
+#
+# Uses ``raise RuntimeError`` (not ``assert``) so ``python -O`` can't strip
+# the check in production — same reasoning as ``_a2ui_error`` above.
+_EXPECTED_FRONTEND_TOOL_NAMES = frozenset(
+    {"change_background", "generate_haiku", "schedule_meeting"}
+)
+if FRONTEND_TOOL_NAMES != _EXPECTED_FRONTEND_TOOL_NAMES:
+    raise RuntimeError(
+        f"FRONTEND_TOOL_NAMES drifted: {FRONTEND_TOOL_NAMES!r} "
+        f"(expected {_EXPECTED_FRONTEND_TOOL_NAMES!r})"
+    )
 
 SYSTEM_PROMPT = (
     "You are a polished, professional demo assistant for CopilotKit. "
@@ -227,9 +841,20 @@ SYSTEM_PROMPT = (
     "When asked about data, charts, or graphs, use the query_data tool first."
 )
 
+# =====================================================================
+# Agent factory
+# =====================================================================
+
 def create_agent() -> lr.ChatAgent:
-    """Create a Langroid ChatAgent configured with all showcase tools."""
-    model = os.getenv("LANGROID_MODEL", "openai/gpt-4.1")
+    """Create a Langroid ChatAgent configured with all showcase tools.
+
+    Default model is the bare ``gpt-4.1`` (not ``openai/gpt-4.1``): langroid
+    does NOT strip the ``openai/`` prefix before passing the string to the
+    OpenAI SDK, and the SDK rejects ``openai/gpt-4.1`` as "model not found".
+    See ``_resolve_a2ui_model`` for the same reasoning on the planner
+    default.
+    """
+    model = os.getenv("LANGROID_MODEL", "gpt-4.1")
 
     llm_config = lm.OpenAIGPTConfig(
         chat_model=model,
@@ -242,5 +867,5 @@ def create_agent() -> lr.ChatAgent:
     )
 
     agent = lr.ChatAgent(agent_config)
-    agent.enable_message(ALL_TOOLS)
+    agent.enable_message(list(ALL_TOOLS))
     return agent

--- a/showcase/starters/langroid/agent/requirements.txt
+++ b/showcase/starters/langroid/agent/requirements.txt
@@ -3,3 +3,10 @@ uvicorn>=0.34.0
 langroid>=0.53.0
 ag-ui-protocol==0.1.9
 python-dotenv>=1.0.0
+# Direct-dependency pins: agui_adapter.py imports httpx / openai / pydantic
+# explicitly. langroid already transitively pulls all three, but pinning
+# floors here keeps behavior reproducible if langroid ever narrows its
+# transitive requirements.
+httpx>=0.27.0
+openai>=1.40.0
+pydantic>=2.0.0

--- a/showcase/starters/langroid/entrypoint.sh
+++ b/showcase/starters/langroid/entrypoint.sh
@@ -1,20 +1,60 @@
 #!/bin/bash
-# Template variables (substituted by generate-starters.ts):
-#   SLUG             — framework slug (e.g. "langgraph-python")
-#   DEV_SCRIPT_BLOCK — language-specific agent startup block
+# NOTE: adapted from ``showcase/packages/langroid/entrypoint.sh`` — the
+# provider-aware credential guard matches (same ``_expected_key_for_model``
+# mappings, same ``_check_key`` contract, same bare-anthropic fail-fast
+# behavior), but the surrounding process orchestration differs from the
+# package entrypoint: this starter runs the agent on port 8123 (not 8000),
+# splits stdout with ``[agent] ``/``[nextjs] `` prefixes for readability in
+# starter compose logs, and scopes ``NODE_ENV=production`` to the Next.js
+# exec only. When editing the credential guard, mirror changes in both
+# files; when editing process orchestration, each file stands alone.
+#
+# Because the showcase template system now supports per-slug entrypoint
+# overrides (see ``showcase/scripts/generate-starters.ts``:
+# ``entrypointOverride``), this file is the canonical source for the
+# langroid starter entrypoint. ``generate-starters.ts`` preserves it
+# verbatim across regeneration instead of overwriting it with the
+# OpenAI-hardcoded shared template.
 set -e
 
+# Initialize PIDs so the cleanup trap does not emit ``kill`` usage errors
+# when the script aborts before either child is started (e.g. FATAL in
+# ``_check_key``). Without this, ``trap cleanup EXIT`` expands to bare
+# ``kill`` with no operand and prints a usage line to stderr.
+AGENT_PID=""
+NEXTJS_PID=""
+
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  # Trap may fire from a FATAL ``exit 1`` path where ``set -e`` is still
+  # active. Any non-zero return from ``kill`` (e.g. process already gone)
+  # in a ``&&`` chain whose final command is ``kill`` is subject to
+  # errexit and would abort cleanup before the grace loop runs. Disable
+  # errexit for the duration of the trap — every kill/wait below
+  # explicitly expects and tolerates non-zero returns.
+  set +e
+  # Guard each pid: empty var -> skip (no operand), set var -> best-effort
+  # SIGTERM. ``2>/dev/null`` is still used to swallow normal "no such
+  # process" races after wait has already reaped the child.
+  #
+  # After SIGTERM, give each child up to 5s to exit cleanly before
+  # escalating to SIGKILL — matches the survivor-termination grace window
+  # further down and the package entrypoint's cleanup pattern. A runaway
+  # uvicorn / next.js process should not get wedged on trap-exit waiting
+  # for the container runtime to SIGKILL it.
+  [ -n "$AGENT_PID" ] && kill "$AGENT_PID" 2>/dev/null
+  [ -n "$NEXTJS_PID" ] && kill "$NEXTJS_PID" 2>/dev/null
+  for _ in 1 2 3 4 5; do
+      local any_alive=0
+      [ -n "$AGENT_PID" ] && kill -0 "$AGENT_PID" 2>/dev/null && any_alive=1
+      [ -n "$NEXTJS_PID" ] && kill -0 "$NEXTJS_PID" 2>/dev/null && any_alive=1
+      [ "$any_alive" = "0" ] && break
+      sleep 1
+  done
+  [ -n "$AGENT_PID" ] && kill -0 "$AGENT_PID" 2>/dev/null && kill -9 "$AGENT_PID" 2>/dev/null
+  [ -n "$NEXTJS_PID" ] && kill -0 "$NEXTJS_PID" 2>/dev/null && kill -9 "$NEXTJS_PID" 2>/dev/null
+  return 0
 }
 trap cleanup EXIT
-
-# Disable Python stdout buffering so Python-based agents flush tracebacks
-# and log lines to awk (and the container log) the moment they're written.
-# Previously a silent crash during module import would sit in Python's
-# userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
-export PYTHONUNBUFFERED=1
 
 echo "========================================="
 echo "[entrypoint] Starting showcase: langroid"
@@ -23,18 +63,231 @@ echo "[entrypoint] PORT=${PORT:-not set}"
 echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
 echo "========================================="
 
-# Check critical env vars
-if [ -z "$OPENAI_API_KEY" ]; then
-  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
-else
-  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+# --- Provider-aware env-key guard (mirrors showcase/packages/langroid/entrypoint.sh) ---
+#
+# Map a langroid model string to the env var that langroid's ``OpenAIGPT``
+# client reads at request time. Verified against langroid's
+# ``language_models/openai_gpt.py``:
+#   * Bare OpenAI names (``gpt-*``, ``o1*``, ``o3*``, ``o4*``, no ``/``)
+#                             -> ``OPENAI_API_KEY``. langroid does NOT strip
+#                                the ``openai/`` prefix — it passes the model
+#                                string LITERALLY to the OpenAI SDK, which
+#                                rejects ``openai/gpt-4.1`` as "model not
+#                                found". Use bare names like ``gpt-4.1``.
+#   * ``openai/*``            -> WARN (fatal under REQUIRE_LANGROID_API_KEY=1):
+#                                not a langroid-native prefix.
+#   * ``gemini/*``            -> ``GEMINI_API_KEY`` (NOT ``GOOGLE_API_KEY``)
+#   * ``openrouter/*``        -> ``OPENROUTER_API_KEY``
+#   * ``groq/*``              -> ``GROQ_API_KEY``
+#   * ``cerebras/*``          -> ``CEREBRAS_API_KEY``
+#   * ``glhf/*``              -> ``GLHF_API_KEY``
+#   * ``minimax/*``           -> ``MINIMAX_API_KEY``
+#   * ``portkey/*``           -> ``PORTKEY_API_KEY``
+#   * ``deepseek/*``          -> ``DEEPSEEK_API_KEY``
+#   * ``litellm/anthropic/*`` -> ``ANTHROPIC_API_KEY``
+#   * Bare ``anthropic/*`` is not langroid-native — FATAL under
+#                                ``REQUIRE_LANGROID_API_KEY=1``, WARN otherwise.
+#   * ``ollama/*``, ``local/*``, ``vllm/*``, ``llamacpp/*`` -> no API key
+#                                required (local-inference; sentinel
+#                                ``NO_KEY_REQUIRED`` returned and _check_key
+#                                logs INFO and returns 0 even under
+#                                REQUIRE_LANGROID_API_KEY=1).
+_expected_key_for_model() {
+    local model="${1:-gpt-4.1}"
+    # ORDER MATTERS: ``litellm/anthropic/*`` must precede the bare
+    # ``anthropic/*`` arm. bash ``case`` is first-match-wins; keeping
+    # litellm first makes the routing intent explicit and is robust to
+    # future reorderings.
+    case "$model" in
+        # Local-inference prefixes: no API key required. Sentinel is
+        # distinct from the empty string so _check_key can log INFO and
+        # return 0 even under REQUIRE_LANGROID_API_KEY=1 rather than FATAL
+        # with "Cannot infer required credential".
+        ollama/*|local/*|vllm/*|llamacpp/*) echo "NO_KEY_REQUIRED" ;;
+        litellm/anthropic/*)  echo "ANTHROPIC_API_KEY" ;;
+        anthropic/*)          echo "ANTHROPIC_API_KEY" ;;
+        openai/*)             echo "OPENAI_API_KEY" ;;
+        openrouter/*)         echo "OPENROUTER_API_KEY" ;;
+        gemini/*)             echo "GEMINI_API_KEY" ;;
+        # ``google/`` intentionally NOT mapped: langroid has no native
+        # ``google/`` prefix handling. Treating it as a gemini alias would
+        # let fail-fast mode "succeed" at boot (GEMINI_API_KEY set) only
+        # to fail at request time. Dedicated arm in ``_check_key`` FATALs
+        # under REQUIRE_LANGROID_API_KEY=1 and WARNs otherwise.
+        groq/*)               echo "GROQ_API_KEY" ;;
+        cerebras/*)           echo "CEREBRAS_API_KEY" ;;
+        glhf/*)               echo "GLHF_API_KEY" ;;
+        minimax/*)            echo "MINIMAX_API_KEY" ;;
+        portkey/*)            echo "PORTKEY_API_KEY" ;;
+        deepseek/*)           echo "DEEPSEEK_API_KEY" ;;
+        # langdb/*: langroid's ``OpenAIGPT`` natively handles this prefix
+        # (sets ``is_langdb``) and resolves credentials via ``langdb_params``
+        # (a config object) rather than a single env var. There is no env var
+        # for us to probe at startup — emit a distinct NO_KEY_REQUIRED_*
+        # sentinel so ``_check_key`` logs INFO and returns 0 even under
+        # REQUIRE_LANGROID_API_KEY=1.
+        langdb/*)             echo "NO_KEY_REQUIRED_LANGDB" ;;
+        # litellm-proxy/*: langroid's ``OpenAIGPT`` natively handles this
+        # prefix (sets ``is_litellm_proxy``) and resolves credentials via
+        # ``LiteLLMProxyConfig`` (a config object) rather than a single env
+        # var. Same NO_KEY_REQUIRED_* treatment as langdb/.
+        litellm-proxy/*)      echo "NO_KEY_REQUIRED_LITELLM_PROXY" ;;
+        # Non-anthropic litellm variants (``litellm/openai/*``,
+        # ``litellm/azure/*``, ``litellm/bedrock/*``, etc.) — litellm resolves
+        # per-provider env vars internally (AZURE_API_KEY, AZURE_API_BASE,
+        # AWS_ACCESS_KEY_ID, ...) and we don't know which to probe at boot.
+        # Note: ``litellm/anthropic/*`` is handled by the SPECIFIC earlier
+        # arm (returns ANTHROPIC_API_KEY) and matches first by bash
+        # first-match-wins ordering — this catch-all only sees the non-
+        # anthropic variants.
+        litellm/*)            echo "NO_KEY_REQUIRED_LITELLM" ;;
+        # Bare model names (no ``/`` separator) map to OpenAI. Matches
+        # langroid's canonical convention
+        # (``OpenAIChatModel.GPT4_1.value == "gpt-4.1"``) and is accepted
+        # directly by the OpenAI SDK.
+        */*)                  echo "" ;;
+        *)                    echo "OPENAI_API_KEY" ;;
+    esac
+}
+
+if [ -z "${LANGROID_MODEL:-}" ]; then
+    echo "[entrypoint] INFO: LANGROID_MODEL not set — defaulting to 'gpt-4.1' (OPENAI_API_KEY will be required)"
 fi
+LANGROID_MODEL_EFFECTIVE="${LANGROID_MODEL:-gpt-4.1}"
+A2UI_MODEL_EFFECTIVE="${A2UI_MODEL:-$LANGROID_MODEL_EFFECTIVE}"
+
+# Bucketize key length into short/medium/long instead of printing the exact
+# character count. Leaking an exact length is a weak but unnecessary
+# fingerprint — bucket gives operators enough signal ("something is set,
+# looks roughly right") without handing a length oracle to logs.
+_key_length_bucket() {
+    local n="$1"
+    if [ "$n" -lt 20 ]; then
+        echo "short"
+    elif [ "$n" -lt 60 ]; then
+        echo "medium"
+    else
+        echo "long"
+    fi
+}
+
+_check_key() {
+    local model="$1"; local role="$2"
+    # ``google/`` is a common typo for ``gemini/``. Check BEFORE calling
+    # ``_expected_key_for_model`` so a GEMINI_API_KEY that happens to be
+    # set can't silently pass the fail-fast guard for a non-langroid-native
+    # prefix.
+    case "$model" in
+        google/*)
+            if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+                echo "[entrypoint] FATAL: $role model '$model' uses 'google/' prefix which is not a langroid-native prefix. Use 'gemini/<model>' instead (with GEMINI_API_KEY set); refusing to start under REQUIRE_LANGROID_API_KEY=1"
+                exit 1
+            fi
+            echo "[entrypoint] WARNING: $role model '$model' uses 'google/' prefix — langroid has no native google/ routing; use 'gemini/<model>' instead. Request-time calls will fail."
+            return 0
+            ;;
+    esac
+    # ``openai/*`` is NOT langroid-native either: langroid passes the full
+    # string LITERALLY to the OpenAI SDK (verified empirically — the
+    # ``openai/`` prefix is not stripped inside ``lm.OpenAIGPT``), and the
+    # SDK rejects ``openai/gpt-4.1`` as "model not found". Emit a warning so
+    # operators see the boot-time remediation rather than a cryptic
+    # request-time failure.
+    case "$model" in
+        openai/*)
+            if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+                echo "[entrypoint] FATAL: $role model '$model' uses 'openai/' prefix which is not a langroid-native prefix — langroid passes it literally to the OpenAI SDK which will reject it. Use the bare model name (e.g. 'gpt-4.1') instead; refusing to start under REQUIRE_LANGROID_API_KEY=1"
+                exit 1
+            fi
+            echo "[entrypoint] WARNING: $role model '$model' uses 'openai/' prefix — langroid passes it LITERALLY to the OpenAI SDK (the prefix is NOT stripped) and the SDK will reject it as 'model not found'. Use the bare model name (e.g. 'gpt-4.1') instead. Falling through to OPENAI_API_KEY check so the operator sees both issues at boot."
+            ;;
+    esac
+    local var
+    var=$(_expected_key_for_model "$model")
+    # NO_KEY_REQUIRED sentinels — two families:
+    #   * Plain ``NO_KEY_REQUIRED``: local-inference models (ollama/, local/,
+    #     vllm/, llamacpp/) — no credential at all.
+    #   * ``NO_KEY_REQUIRED_*`` variants: langroid-native prefixes where
+    #     credentials ARE required but resolved via a config object
+    #     (langdb_params, LiteLLMProxyConfig) or via per-provider env vars
+    #     internal to litellm (AZURE_*, AWS_*, etc.). We cannot name a
+    #     single env var to probe at startup — skip the env-key check and
+    #     let request-time surface any missing config.
+    # Both skip the env check and return 0 even under REQUIRE_LANGROID_API_KEY=1
+    # so the fail-fast contract doesn't reject a legitimately-configured
+    # langroid-native prefix.
+    case "$var" in
+        NO_KEY_REQUIRED)
+            echo "[entrypoint] INFO: local-inference model '$model' — no API key required for $role"
+            return 0
+            ;;
+        NO_KEY_REQUIRED_*)
+            echo "[entrypoint] INFO: $role model '$model' uses a langroid-native prefix that resolves credentials via config (no single env var to probe) — skipping env-key check"
+            return 0
+            ;;
+    esac
+    if [ -z "$var" ]; then
+        if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+            echo "[entrypoint] FATAL: Cannot infer required credential for $role model '$model'. Set a langroid-native prefix (bare OpenAI name e.g. 'gpt-4.1', litellm/anthropic/, gemini/, openrouter/, groq/, cerebras/, glhf/, minimax/, portkey/, deepseek/, ollama/, local/, vllm/, llamacpp/) or set REQUIRE_LANGROID_API_KEY=0 to downgrade to warn-mode."
+            exit 1
+        fi
+        echo "[entrypoint] INFO: $role model '$model' does not match a known provider prefix — skipping env-key check (request-time calls will surface credentials)"
+        return 0
+    fi
+    # Bash indirect expansion with default — evaluates to the empty string
+    # when the named env var is unset, which is what the empty-check below
+    # expects. Note: this script runs under ``set -e`` but NOT ``set -u``;
+    # every ``${FOO:-default}`` site in the file is load-bearing as-written
+    # because several env vars (REQUIRE_LANGROID_API_KEY, LANGROID_MODEL,
+    # A2UI_MODEL, PORT, NODE_ENV) are commonly unset in dev.
+    local val="${!var:-}"
+    if [ -z "$val" ]; then
+        if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+            echo "[entrypoint] FATAL: $var not set (required by $role model '$model') and REQUIRE_LANGROID_API_KEY=1 — refusing to start"
+            exit 1
+        fi
+        echo "[entrypoint] WARNING: $var is not set — $role ('$model') calls will fail at request time."
+    else
+        echo "[entrypoint] $var: set ($(_key_length_bucket "${#val}")) — $role ('$model')"
+    fi
+    # Bare ``anthropic/<model>`` is not a langroid-native prefix. This
+    # case intentionally tests only ``anthropic/*`` — ``litellm/anthropic/...``
+    # strings already matched the earlier ``litellm/anthropic/*`` arm in
+    # ``_expected_key_for_model`` (which runs first by design — see the
+    # ORDER MATTERS comment there) and are routed correctly via litellm; we
+    # must NOT warn on them here. Under REQUIRE_LANGROID_API_KEY=1 we FATAL
+    # so fail-fast operators see the misconfig at boot; otherwise WARN and
+    # continue.
+    case "$model" in
+        anthropic/*)
+            if [ "${REQUIRE_LANGROID_API_KEY:-0}" = "1" ]; then
+                echo "[entrypoint] FATAL: $role model '$model' uses bare 'anthropic/' prefix which is not routable through langroid (use 'litellm/anthropic/<model>' with ANTHROPIC_API_KEY set); refusing to start under REQUIRE_LANGROID_API_KEY=1"
+                exit 1
+            fi
+            echo "[entrypoint] WARNING: $role model '$model' uses bare 'anthropic/' prefix — langroid has no native Anthropic routing; requests will fail. Use 'litellm/anthropic/<model>' instead (drop-in replacement that reads ANTHROPIC_API_KEY)."
+            ;;
+    esac
+}
+
+_check_key "$LANGROID_MODEL_EFFECTIVE" "primary agent"
+if [ "$A2UI_MODEL_EFFECTIVE" != "$LANGROID_MODEL_EFFECTIVE" ]; then
+    _check_key "$A2UI_MODEL_EFFECTIVE" "A2UI planner"
+fi
+# --- end provider-aware guard ---
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+# Use process substitution so ``$!`` captures the uvicorn PID, NOT the sed
+# PID. A plain ``uvicorn ... | sed ... &`` bug is insidious: if uvicorn
+# crashes immediately, sed stays alive reading a closed pipe; the liveness
+# probe below passes ("kill -0 $AGENT_PID" succeeds because sed is the
+# PID), Next.js then starts against a dead agent, and when sed eventually
+# exits 0 ``wait -n`` reports EXIT_CODE=0 "clean exit" masking the real
+# failure. Process substitution feeds sed on stdout+stderr without pipeline
+# semantics, so ``$!`` here is the actual python PID.
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 > >(sed 's/^/[agent] /') 2>&1 &
 AGENT_PID=$!
 sleep 2
-if kill -0 $AGENT_PID 2>/dev/null; then
+if kill -0 "$AGENT_PID" 2>/dev/null; then
   echo "[entrypoint] Agent server started (PID: $AGENT_PID)"
 else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
@@ -52,27 +305,93 @@ PORT=${PORT:-10000}
 # of which don't interpret NODE_ENV the way Next.js does. `env` prefix binds
 # the value to this single exec so the agent spawned above keeps the host
 # environment intact.
-#
-# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
-# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
-# Next.js process, so `wait -n $NEXTJS_PID` monitors the right thing.
-# `awk` with `fflush()` line-flushes each prefixed line to the container log.
-env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+# Same process-substitution pattern as the agent launch above — ``$!`` must
+# capture the Next.js PID, not the sed PID, or the survivor-kill logic and
+# ``wait -n`` exit-code interpretation below silently misdiagnose which
+# child died.
+env NODE_ENV=production npx next start --port $PORT > >(sed 's/^/[nextjs] /') 2>&1 &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 echo "[entrypoint] Both processes running. Waiting..."
 
-wait -n $AGENT_PID $NEXTJS_PID
+# `set -e` must NOT be active across `wait -n`: the first non-zero child
+# exit status would otherwise kill the shell before the diagnostic
+# interpretation block below can identify which child died. Disable errexit
+# for the wait/diagnose/cleanup section; we exit explicitly with the
+# captured status at the end. errexit is INTENTIONALLY left off for the
+# remainder of the script — the kill / kill -0 / wait calls below expect
+# to see non-zero returns for dead processes and already-reaped children.
+#
+# NOTE: ``wait -n <pid1> <pid2>`` (positional pid list) requires bash 5.1+.
+# The base image (debian-slim / python:3.12-slim / node:22-slim) ships bash
+# 5.2, so this is safe. If the base image ever drops below 5.1, change to
+# bare ``wait -n``.
+set +e
+wait -n "$AGENT_PID" "$NEXTJS_PID"
 EXIT_CODE=$?
-if ! kill -0 $AGENT_PID 2>/dev/null; then
-  echo "[entrypoint] Agent process (PID: $AGENT_PID) exited with code $EXIT_CODE"
-elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
-  echo "[entrypoint] Next.js process (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+
+# Interpret common POSIX / shell exit codes for operators reading the log
+# stream.
+case "$EXIT_CODE" in
+    0)   EXIT_MEANING="clean exit (unexpected for a long-running server)" ;;
+    1)   EXIT_MEANING="generic error (uncaught exception / non-zero program exit)" ;;
+    2)   EXIT_MEANING="misuse of shell builtin / bad CLI args" ;;
+    126) EXIT_MEANING="command invoked but not executable (permission denied)" ;;
+    127) EXIT_MEANING="command not found (missing binary / bad PATH)" ;;
+    130) EXIT_MEANING="SIGINT (Ctrl-C / interactive interrupt)" ;;
+    137) EXIT_MEANING="SIGKILL (likely OOM-killed or force-stopped)" ;;
+    139) EXIT_MEANING="SIGSEGV (segmentation fault — native crash)" ;;
+    143) EXIT_MEANING="SIGTERM (orderly shutdown from platform)" ;;
+    255) EXIT_MEANING="exit -1 / catastrophic program failure" ;;
+    *)   EXIT_MEANING="(no common interpretation)" ;;
+esac
+
+SURVIVOR_PID=""
+if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+  echo "[entrypoint] Agent process (PID: $AGENT_PID) exited with code $EXIT_CODE — $EXIT_MEANING"
+  if kill -0 "$NEXTJS_PID" 2>/dev/null; then
+    SURVIVOR_PID="$NEXTJS_PID"
+  fi
+elif ! kill -0 "$NEXTJS_PID" 2>/dev/null; then
+  echo "[entrypoint] Next.js process (PID: $NEXTJS_PID) exited with code $EXIT_CODE — $EXIT_MEANING"
+  if kill -0 "$AGENT_PID" 2>/dev/null; then
+    SURVIVOR_PID="$AGENT_PID"
+  fi
 else
-  echo "[entrypoint] A process exited with code $EXIT_CODE"
+  # wait -n returned but both pids still resolve; one was reaped before we
+  # could probe it. Escalate so the dying child's status is not masked.
+  echo "[entrypoint] ERROR: wait -n returned exit=$EXIT_CODE ($EXIT_MEANING) but both agent ($AGENT_PID) and next.js ($NEXTJS_PID) appear alive — treating as fatal race"
+  exit 1
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Terminate the surviving sibling only. Iterating both PIDs would kill the
+# already-dead child again (no-op) but — more importantly — would send
+# SIGTERM/SIGKILL to the one that just died and is mid-reap, which is
+# pointless noise. Grace-window up to 5s, escalate to SIGKILL, then reap.
+if [ -n "$SURVIVOR_PID" ]; then
+    echo "[entrypoint] Terminating surviving sibling (pid=${SURVIVOR_PID}) to avoid orphan-reparent"
+    # Capture kill failure: if `kill` returns non-zero AND the process is
+    # still alive, that's a real signal-delivery failure (e.g. EPERM) —
+    # surface it rather than letting `2>/dev/null` swallow the diagnosis.
+    if ! kill "$SURVIVOR_PID" 2>/dev/null; then
+        if kill -0 "$SURVIVOR_PID" 2>/dev/null; then
+            echo "[entrypoint] WARN: kill(SIGTERM) failed for survivor pid=${SURVIVOR_PID} but process is still alive — signal delivery refused (EPERM?)"
+        fi
+    fi
+    for _ in 1 2 3 4 5; do
+        kill -0 "$SURVIVOR_PID" 2>/dev/null || break
+        sleep 1
+    done
+    if kill -0 "$SURVIVOR_PID" 2>/dev/null; then
+        echo "[entrypoint] Survivor (pid=${SURVIVOR_PID}) did not exit within 5s — sending SIGKILL"
+        if ! kill -9 "$SURVIVOR_PID" 2>/dev/null; then
+            if kill -0 "$SURVIVOR_PID" 2>/dev/null; then
+                echo "[entrypoint] WARN: kill(SIGKILL) failed for survivor pid=${SURVIVOR_PID} but process is still alive — cannot force-terminate (EPERM?)"
+            fi
+        fi
+    fi
+    wait "$SURVIVOR_PID" 2>/dev/null || true
+fi
+
 exit $EXIT_CODE


### PR DESCRIPTION
## Summary

langroid is provider-agnostic by design — operators pick a chat model via `LANGROID_MODEL`. But `GenerateA2UITool` hardcoded `openai.OpenAI()` + `gpt-4.1`, forcing non-OpenAI users to keep an `OPENAI_API_KEY` around just for the A2UI dashboard demo.

This PR routes the A2UI planner through `lm.OpenAIGPT` (langroid's universal LLM abstraction) and hardens the deploy/boot path around it.

## Core fix

- **Provider-agnostic A2UI planner.** `GenerateA2UITool` now uses `lm.OpenAIGPT` keyed on `A2UI_MODEL` (override) → `LANGROID_MODEL` (inherit) → `gpt-4.1` (default, bare name — `openai/` prefix is NOT langroid-native and silently breaks at request time).
- **Structured error surface.** `_A2uiError` TypedDict with `_A2uiErrorKind` enum (values pinned to sibling adapters), `_a2ui_error` factory with non-empty-string validation at construction, runtime `ValueError` (not `assert`) so `python -O` can't strip it.
- **`_ARGS_MISSING` sentinel** distinguishes "no tool call" from "tool call with degraded shape" — different remediations for the frontend.
- **Narrow re-raise tuple** propagates programmer errors (`AttributeError`, `TypeError`, `NameError`, `ImportError`, `ModuleNotFoundError`, `AssertionError`, `NotImplementedError`, `pydantic.ValidationError`) while wrapping recoverable SDK errors into `a2ui_llm_error`.
- **Backend tool handlers** now wrap impls in try/except → `_tool_error(kind: _ToolErrorKind, ...)` JSON surfaces, preventing unhandled exceptions from escaping to langroid's tool machinery.
- **Boundary validation** after `build_a2ui_operations_from_tool_call` return.

## Deploy / entrypoint hardening

- **Provider-aware credential guard.** Detects `LANGROID_MODEL` prefix (`openai/` → warns it's not routable, `gemini/` → `GEMINI_API_KEY`, `litellm/anthropic/` → `ANTHROPIC_API_KEY`, `ollama/`/`local/`/`vllm/`/`llamacpp/` → no-key-required, `langdb/`/`litellm-proxy/`/`litellm/<other>/` → config-resolved) and fails fast under `REQUIRE_LANGROID_API_KEY=1` only when credentials are genuinely missing.
- **Real PID capture** for uvicorn + Next.js via process substitution (prior `| sed` pattern captured the sed PID, masking crash diagnostics).
- **Graceful shutdown:** trap cleanup with `set +e` safety + 5s SIGTERM→SIGKILL grace window, survivor-kill with EPERM diagnostics.
- **Package Dockerfile** now runs as non-root with `ENV PORT=10000` / `ENV HOSTNAME=0.0.0.0` parity with starter.

## Generator + CI

- **`entrypointOverride`** mechanism in `generate-starters.ts` so the langroid starter's provider-aware entrypoint survives regeneration. Reads canonical from `STARTERS_DIR/<slug>/` (not `outDir`) so `--check` mode doesn't false-flag drift.
- **Fail-loud** on missing required inputs (agent_server.py, extraFiles, PIN_OVERRIDES stale deps, missing override file) instead of silent warn+skip.
- **Regression test** pins the `entrypointOverride` preservation behavior.
- **`.gitattributes`** enforces LF on `.sh` for Windows contributor safety.

## Review

5 full CR rounds (7 agents each) + 6 fix rounds. Load-bearing bugs converged:
- Round 1: R1 → 47 findings, most resolved
- Round 2: R2 → 30+ findings, critical (lru_cache keying, build_a2ui wrapper, starter parity, `_A2uiError` hardening)
- Round 3: R3 → sed-PID bug (production-blocking), `--check` drift, file mode, `entrypointOverride` hard-error, `saw_modern_call` logic gap
- Round 4: R4 → `google/*` FATAL, bare-prefix FATAL, RecursionError test naming, caplog ambiguity, ClassDef walker, `_ToolErrorKind` enum
- Round 5: R5 → **`openai/gpt-4.1` default empirically broken** (langroid doesn't strip the prefix → OpenAI SDK rejects), fail-fast refusing ollama/local/vllm/llamacpp, missing regression test for entrypointOverride, rootful package Dockerfile
- Round 6: R6 → `langdb/`/`litellm-proxy/`/`litellm/<non-anthropic>/` refused under fail-fast, starter `wait -n` pid quoting, cleanup trap `set -e` safety

Deferred as design-scope follow-ups (not load-bearing, current code is correct):
- `_A2uiError` TypedDict → frozen dataclass / pydantic model (stronger encapsulation, cross-sibling alignment required)
- `_ARGS_MISSING: object` → named sentinel class (cleaner narrowing)
- `list[dict]` tool fields → TypedDict / pydantic models for schema enforcement at ingestion
- Comment rot around "Identical TypedDicts live in siblings" (sibling adapters diverged on the Literal)
- Frontend-tool `handle()` server-side regression path returns benign string (explicit UX tradeoff)

## Tests

- 109 passed, 1 skipped (integration test gated by `LANGROID_INTEGRATION_TESTS=1`)
- Module-import hygiene via subprocess isolation (no more stale `importlib.reload` state)
- AST walker catches top-level + `try/except` `import openai` (including ClassDef bodies)
- LRU eviction pinned at `maxsize=4`
- Forced-function-call kwargs + `stream=False` planner assertion
- Parametrized error propagation (both re-raise and wrap tuples)
- Backend tool handle happy + error paths across all 6 tools
- `create_agent` factory: stream=True + enable_message(ALL_TOOLS)

## Test plan
- [x] `pytest showcase/packages/langroid/tests/python/` — 109 pass, 1 skipped
- [x] `npx tsx showcase/scripts/generate-starters.ts --check` — no langroid drift
- [x] `bash -n` clean on both entrypoints
- [x] Manual: `REQUIRE_LANGROID_API_KEY=1` + various `LANGROID_MODEL` values — bare anthropic/ FATALs, langdb/litellm-proxy/litellm-non-anthropic INFO-pass, ollama/local no-key-required INFO-pass
- [ ] CI green (watching)
- [ ] Railway deploy of showcase-langroid once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)