### PR TITLE
fix(showcase/starters): chown /app to app user to prevent CLI cache-dir crashes

### DIFF
--- a/showcase/starters/ag2/Dockerfile
+++ b/showcase/starters/ag2/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/agno/Dockerfile
+++ b/showcase/starters/agno/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-python/Dockerfile
+++ b/showcase/starters/claude-sdk-python/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/claude-sdk-typescript/Dockerfile
+++ b/showcase/starters/claude-sdk-typescript/Dockerfile
@@ -34,6 +34,13 @@ RUN rm -f agent/package.json agent/package-lock.json
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `mastra dev` -> /app/.mastra,
+# `langgraph-cli dev` -> /app/.langgraph_api, Next.js build caches, etc.)
+# hits EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/crewai-crews/Dockerfile
+++ b/showcase/starters/crewai-crews/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py aimock_toggle.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/google-adk/Dockerfile
+++ b/showcase/starters/google-adk/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langgraph-fastapi/Dockerfile
+++ b/showcase/starters/langgraph-fastapi/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app langgraph.json ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 RUN mkdir -p /app/.langgraph_api && chown app:app /app/.langgraph_api
 USER app
 

--- a/showcase/starters/langgraph-python/Dockerfile
+++ b/showcase/starters/langgraph-python/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app langgraph.json ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 RUN mkdir -p /app/.langgraph_api && chown app:app /app/.langgraph_api
 USER app
 

--- a/showcase/starters/langgraph-typescript/Dockerfile
+++ b/showcase/starters/langgraph-typescript/Dockerfile
@@ -34,6 +34,13 @@ RUN rm -f agent/package.json agent/package-lock.json
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `mastra dev` -> /app/.mastra,
+# `langgraph-cli dev` -> /app/.langgraph_api, Next.js build caches, etc.)
+# hits EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/langroid/Dockerfile
+++ b/showcase/starters/langroid/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/llamaindex/Dockerfile
+++ b/showcase/starters/llamaindex/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/mastra/Dockerfile
+++ b/showcase/starters/mastra/Dockerfile
@@ -34,6 +34,13 @@ RUN rm -f src/mastra/package.json src/mastra/package-lock.json
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `mastra dev` -> /app/.mastra,
+# `langgraph-cli dev` -> /app/.langgraph_api, Next.js build caches, etc.)
+# hits EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-dotnet/Dockerfile
+++ b/showcase/starters/ms-agent-dotnet/Dockerfile
@@ -41,6 +41,12 @@ COPY --chown=app:app --from=dotnet-builder /agent/publish ./agent/
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any subprocess that tries
+# to mkdir under /app at runtime (Next.js build caches, .NET tooling caches,
+# etc.) hits EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/ms-agent-python/Dockerfile
+++ b/showcase/starters/ms-agent-python/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/pydantic-ai/Dockerfile
+++ b/showcase/starters/pydantic-ai/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/spring-ai/Dockerfile
+++ b/showcase/starters/spring-ai/Dockerfile
@@ -56,6 +56,12 @@ COPY --chown=app:app --from=java-builder /agent/target/*.jar ./agent/app.jar
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any subprocess that tries
+# to mkdir under /app at runtime (Next.js build caches, JVM tmp, etc.) hits
+# EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/strands/Dockerfile
+++ b/showcase/starters/strands/Dockerfile
@@ -42,6 +42,13 @@ COPY --chown=app:app agent_server.py ./
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.dotnet
+++ b/showcase/starters/template/dockerfiles/Dockerfile.dotnet
@@ -41,6 +41,12 @@ COPY --chown=app:app --from=dotnet-builder /agent/publish ./agent/
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any subprocess that tries
+# to mkdir under /app at runtime (Next.js build caches, .NET tooling caches,
+# etc.) hits EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.java
+++ b/showcase/starters/template/dockerfiles/Dockerfile.java
@@ -56,6 +56,12 @@ COPY --chown=app:app --from=java-builder /agent/target/*.jar ./agent/app.jar
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any subprocess that tries
+# to mkdir under /app at runtime (Next.js build caches, JVM tmp, etc.) hits
+# EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.python
+++ b/showcase/starters/template/dockerfiles/Dockerfile.python
@@ -40,6 +40,13 @@ COPY --chown=app:app {{AGENT_DIR}}/ ./{{AGENT_DIR}}/
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `langgraph-cli dev` -> /app/.langgraph_api,
+# Next.js build caches, Python tooling caches, etc.) hits EACCES under the
+# unprivileged user and crashes the container.
+RUN chown app:app /app
 {{LANGGRAPH_MKDIR}}USER app
 
 EXPOSE 10000

--- a/showcase/starters/template/dockerfiles/Dockerfile.typescript
+++ b/showcase/starters/template/dockerfiles/Dockerfile.typescript
@@ -34,6 +34,13 @@ RUN rm -f {{AGENT_DIR}}/package.json {{AGENT_DIR}}/package-lock.json
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Ensure WORKDIR itself is owned by `app` — `WORKDIR /app` at the top of the
+# stage creates /app as root, and `COPY --chown=app:app` only reassigns the
+# copied files, NOT the parent dir. Without this, any CLI that tries to
+# mkdir under /app at runtime (e.g. `mastra dev` -> /app/.mastra,
+# `langgraph-cli dev` -> /app/.langgraph_api, Next.js build caches, etc.)
+# hits EACCES under the unprivileged user and crashes the container.
+RUN chown app:app /app
 USER app
 
 EXPOSE 10000


### PR DESCRIPTION
## Summary

**Root cause:** PR #4092 replaced a blanket `RUN chown -R app:app /app` with per-COPY `COPY --chown=app:app` lines. That covers the copied files, but `WORKDIR /app` at the top of the runner stage creates `/app` as root BEFORE the `app` user exists, and `COPY --chown=` only reassigns the copied files — not the parent dir. Result: `/app` stays owned by root.

**Symptom:** `starter-mastra` deploy CRASHED on Railway with:

```
Error: EACCES: permission denied, mkdir '/app/.mastra'
```

`npx mastra dev` tries to create its cache dir under CWD at runtime as user `app`, and fails.

**Likely co-victims:** any starter whose runtime invokes a Node CLI that writes to CWD. `starter-langgraph-typescript` (uses `@langchain/langgraph-cli dev`) fits the exact same signature — same class of bug, would have hit the same wall once traffic forced a cache write.

**Fix:** add `RUN chown app:app /app` immediately before `USER app` in all four Dockerfile templates (typescript, python, dotnet, java), applied uniformly to all 17 generated starters via `showcase/scripts/generate-starters.ts`. Surgical, cheap, idempotent.

## Evidence — local docker build + run

**starter-mastra:**

```
$ docker exec starter-mastra-test ls -la /app | head
drwxr-xr-x 1 app  app  4096 .          ← WORKDIR now owned by app
drwxr-xr-x 1 root root 4096 ..
drwxr-xr-x 4 app  app  4096 .mastra    ← created successfully by mastra dev
...
$ curl http://localhost:13010/api/health
{"status":"ok","integration":"mastra","agent":"ok",...}  ← HTTP 200
```

**starter-langgraph-typescript:**

```
$ docker ps --filter name=starter-langgraph-ts-test
starter-langgraph-ts-test Up 8 minutes             ← stable, not crashlooping
$ docker exec starter-langgraph-ts-test touch /app/test-write && echo OK
OK
$ curl http://localhost:13020/api/health
{"status":"degraded","integration":"langgraph-typescript","agent":"down",...}
                                                    ← HTTP 503 (dummy key) — NOT a crash
```

## Scope

- 17 starter Dockerfiles regenerated
- 4 template Dockerfiles updated (the source of truth)
- Generator TS untouched — the fix is purely in the Dockerfile templates that the generator copies verbatim
- `showcase/scripts` vitest: 1073/1073 green

## Test plan

- [x] `pnpm run generate-starters` regenerates without errors
- [x] `pnpm test` in `showcase/scripts` — 1073 tests green
- [x] `docker build` + `docker run` starter-mastra — container stays up, `/api/health` 200
- [x] `docker build` + `docker run` starter-langgraph-typescript — container stays up 8+ min, `/api/health` 503 degraded (expected on dummy key)
- [ ] Railway redeploy of starter-mastra after merge — expect container to boot and reach `running`
- [ ] Railway redeploy of starter-langgraph-typescript after merge — expect container to boot and reach `running`

Independent of #4096 — branched from `origin/main`, no dependency.