### PR TITLE
chore(showcase/starters): regenerate to pick up #4101 fixes for langgraph + entrypoint

### DIFF
--- a/showcase/starters/ag2/entrypoint.sh
+++ b/showcase/starters/ag2/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/agno/entrypoint.sh
+++ b/showcase/starters/agno/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/claude-sdk-python/entrypoint.sh
+++ b/showcase/starters/claude-sdk-python/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/starters/claude-sdk-typescript/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting TypeScript agent on port 8123..."
-npx tsx agent/index.ts 2>&1 | sed 's/^/[agent] /' &
+npx tsx agent/index.ts &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/crewai-crews/entrypoint.sh
+++ b/showcase/starters/crewai-crews/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/google-adk/entrypoint.sh
+++ b/showcase/starters/google-adk/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/langgraph-fastapi/entrypoint.sh
+++ b/showcase/starters/langgraph-fastapi/entrypoint.sh
@@ -35,7 +35,7 @@ python -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/__init__.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/__init__.py
@@ -1,25 +1,25 @@
 """Barrel exports for all shared showcase tool implementations."""
 
-from src.agents.types import (
+from src.agents.tools.types import (
     SalesStage,
     SalesTodo,
     Flight,
     WeatherResult,
 )
-from src.agents.get_weather import get_weather_impl
-from src.agents.query_data import query_data_impl
-from src.agents.sales_todos import (
+from src.agents.tools.get_weather import get_weather_impl
+from src.agents.tools.query_data import query_data_impl
+from src.agents.tools.sales_todos import (
     INITIAL_TODOS,
     manage_sales_todos_impl,
     get_sales_todos_impl,
 )
-from src.agents.search_flights import search_flights_impl
-from src.agents.generate_a2ui import (
+from src.agents.tools.search_flights import search_flights_impl
+from src.agents.tools.generate_a2ui import (
     RENDER_A2UI_TOOL_SCHEMA,
     generate_a2ui_impl,
     build_a2ui_operations_from_tool_call,
 )
-from src.agents.schedule_meeting import schedule_meeting_impl
+from src.agents.tools.schedule_meeting import schedule_meeting_impl
 
 __all__ = [
     # Types

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/get_weather.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/get_weather.py
@@ -1,7 +1,7 @@
 """Mock weather data tool implementation."""
 
 import random
-from src.agents.types import WeatherResult
+from src.agents.tools.types import WeatherResult
 
 _CONDITIONS = [
     "Sunny",

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/sales_todos.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/sales_todos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from src.agents.types import SalesTodo
+from src.agents.tools.types import SalesTodo
 
 INITIAL_TODOS: list[SalesTodo] = [
     SalesTodo(

--- a/showcase/starters/langgraph-fastapi/src/agents/tools/search_flights.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/tools/search_flights.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from src.agents.types import Flight
+from src.agents.tools.types import Flight
 
 _logger = logging.getLogger(__name__)
 

--- a/showcase/starters/langgraph-python/entrypoint.sh
+++ b/showcase/starters/langgraph-python/entrypoint.sh
@@ -35,7 +35,7 @@ python -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/langgraph-python/src/agents/tools/__init__.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/__init__.py
@@ -1,25 +1,25 @@
 """Barrel exports for all shared showcase tool implementations."""
 
-from src.agents.types import (
+from src.agents.tools.types import (
     SalesStage,
     SalesTodo,
     Flight,
     WeatherResult,
 )
-from src.agents.get_weather import get_weather_impl
-from src.agents.query_data import query_data_impl
-from src.agents.sales_todos import (
+from src.agents.tools.get_weather import get_weather_impl
+from src.agents.tools.query_data import query_data_impl
+from src.agents.tools.sales_todos import (
     INITIAL_TODOS,
     manage_sales_todos_impl,
     get_sales_todos_impl,
 )
-from src.agents.search_flights import search_flights_impl
-from src.agents.generate_a2ui import (
+from src.agents.tools.search_flights import search_flights_impl
+from src.agents.tools.generate_a2ui import (
     RENDER_A2UI_TOOL_SCHEMA,
     generate_a2ui_impl,
     build_a2ui_operations_from_tool_call,
 )
-from src.agents.schedule_meeting import schedule_meeting_impl
+from src.agents.tools.schedule_meeting import schedule_meeting_impl
 
 __all__ = [
     # Types

--- a/showcase/starters/langgraph-python/src/agents/tools/get_weather.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/get_weather.py
@@ -1,7 +1,7 @@
 """Mock weather data tool implementation."""
 
 import random
-from src.agents.types import WeatherResult
+from src.agents.tools.types import WeatherResult
 
 _CONDITIONS = [
     "Sunny",

--- a/showcase/starters/langgraph-python/src/agents/tools/sales_todos.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/sales_todos.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from src.agents.types import SalesTodo
+from src.agents.tools.types import SalesTodo
 
 INITIAL_TODOS: list[SalesTodo] = [
     SalesTodo(

--- a/showcase/starters/langgraph-python/src/agents/tools/search_flights.py
+++ b/showcase/starters/langgraph-python/src/agents/tools/search_flights.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from src.agents.types import Flight
+from src.agents.tools.types import Flight
 
 _logger = logging.getLogger(__name__)
 

--- a/showcase/starters/langgraph-typescript/entrypoint.sh
+++ b/showcase/starters/langgraph-typescript/entrypoint.sh
@@ -35,7 +35,7 @@ npx @langchain/langgraph-cli dev \
   --config agent/langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 | sed 's/^/[agent] /' &
+  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/llamaindex/entrypoint.sh
+++ b/showcase/starters/llamaindex/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Mastra agent on port 8123..."
-PORT=8123 npx mastra dev 2>&1 | sed 's/^/[agent] /' &
+PORT=8123 npx mastra dev &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 3
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/ms-agent-dotnet/entrypoint.sh
+++ b/showcase/starters/ms-agent-dotnet/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting .NET agent on port 8123..."
-cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 2>&1 | sed 's/^/[agent] /' &
+cd agent && dotnet ProverbsAgent.dll --urls http://0.0.0.0:8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 cd /app
 sleep 3

--- a/showcase/starters/ms-agent-python/entrypoint.sh
+++ b/showcase/starters/ms-agent-python/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/pydantic-ai/entrypoint.sh
+++ b/showcase/starters/pydantic-ai/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/spring-ai/entrypoint.sh
+++ b/showcase/starters/spring-ai/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Spring AI agent on port 8123..."
-java -jar agent/app.jar --server.port=8123 2>&1 | sed 's/^/[agent] /' &
+java -jar agent/app.jar --server.port=8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 5
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/starters/strands/entrypoint.sh
+++ b/showcase/starters/strands/entrypoint.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 2>&1 | sed 's/^/[agent] /' &
+cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then


### PR DESCRIPTION
## Summary

PR #4101 updated the resolution-aware import rewriter and the entrypoint `$!` -> agent PID fix, but the regeneration in that merge didn't include all affected files. After merge, `origin/main` at `2087950ee` still had stale output — and `showcase-starter-langgraph-fastapi-production` has been returning `503 {"agent":"down"}` on `/api/health` as a result.

Root cause:
- `showcase/starters/langgraph-fastapi/src/agents/tools/*.py` still imported `from src.agents.types` / `src.agents.get_weather` / etc. (old flat-rewrite output). `src/agents/src/agent.py` imports `src.agents.tools`, which loads `tools/__init__.py`, which fails with `ModuleNotFoundError: No module named 'src.agents.types'`. The agent subprocess crashes during langgraph_cli's graph import step; `/api/health` flips to 503.
- langgraph-python has the same broken imports in its tools/ barrel.
- All 15 generated `entrypoint.sh` files still used `2>&1 | sed 's/^/[agent] /' &`, so `$!` (used for `kill -0 $AGENT_PID` and `wait -n`) tracked `sed`, not the agent. Stack traces also got line-buffered inside the pipe and never reached the container log.

Fix: rerun `pnpm -C showcase/scripts generate-starters` (the script already on main from #4101). Pure regeneration — no source changes.

Verified locally:
- `tools/__init__.py` now emits `from src.agents.tools.types import ...` (resolution-aware rewrite finds `<agentDest>/tools/types.py` one parent away).
- `entrypoint.sh` now emits `&> >(awk '{print "[agent] " $0; fflush()}')`.

Once merged, the Railway drift rebuild will pick up the new image for langgraph-fastapi and `/api/health` should return green within one redeploy cycle.

## Test plan
- [ ] CI green
- [ ] After merge + drift rebuild, `curl https://showcase-starter-langgraph-fastapi-production-c7d2.up.railway.app/api/health` returns `200 {"agent":"up"}`
- [ ] langgraph-python health stays green (same tools/ fix applied, same container architecture)