### PR TITLE
ci(showcase): emit red→green transition alerts for deploy + smoke workflows

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -451,6 +451,30 @@ jobs:
           echo "services=$SERVICES" >> $GITHUB_OUTPUT
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
+      # Restore previous run's pass/fail status from cache so we can emit
+      # a red→green transition alert on recovery. Mirrors the per-service
+      # transition pattern in showcase_smoke-monitor.yml. The restore-keys
+      # prefix gives us the most recently saved state regardless of which
+      # run_id wrote it. Cache TTL is ~7 days, which is fine — deploys run
+      # more frequently than that.
+      - name: Restore deploy state from cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: showcase-deploy-state.json
+          key: showcase-deploy-state-impossible-match
+          restore-keys: |
+            showcase-deploy-state-
+
+      - name: Initialize state if missing
+        run: |
+          # First-ever run (or cache eviction): assume "ok" so we don't
+          # emit a false recovery alert on the first green run after
+          # deploying this workflow change.
+          if [ ! -f showcase-deploy-state.json ]; then
+            echo '{"lastStatus":"ok","lastFailureAt":""}' > showcase-deploy-state.json
+          fi
+
       - name: Compute per-leg build results
         id: legs
         if: always() && needs.build.result == 'failure'
@@ -564,6 +588,14 @@ jobs:
           LOCKFILE="${{ needs.check-lockfile.result }}"
           BUILD="${{ needs.build.result }}"
           COUNT="${{ steps.summary.outputs.count }}"
+          NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          # Read previous run's status (restored from cache). Mirrors the
+          # smoke-monitor transition pattern: on red→green we post a
+          # recovery message; green→green stays silent.
+          PREV_STATUS=$(jq -r '.lastStatus // "ok"' showcase-deploy-state.json)
+          PREV_FAILURE_AT=$(jq -r '.lastFailureAt // ""' showcase-deploy-state.json)
+
           # See truncate_csv in steps.legs for the truncation contract —
           # drop whole entries, not mid-slug characters, then append `…`
           # if the list exceeds the budget. Duplicate the helper inline
@@ -594,16 +626,25 @@ jobs:
           }
           SERVICES=$(truncate_csv 200 "${{ steps.summary.outputs.services }}")
 
+          # Classify the run outcome into one of:
+          #   failure  → update state→failure, post red alert
+          #   success  → update state→ok, post recovery iff PREV_STATUS=failure
+          #   skip     → no state change, no post (indeterminate)
+          OUTCOME=""
+          MSG=""
+
           # Cancellations can come from concurrency group supersession (rapid
           # pushes), manual cancel via the UI, or an upstream-failure cascade.
           # We handle pre-build and mid-build cancellations differently:
           #
           # Pre-build stages (detect-changes, check-lockfile): no build work
           # has happened yet. Safe to stay silent — any newer run (or the
-          # manual re-trigger) will redo all work from scratch.
+          # manual re-trigger) will redo all work from scratch. Don't touch
+          # state either way — indeterminate outcome.
           if [ "$DETECT" = "cancelled" ] || [ "$LOCKFILE" = "cancelled" ]; then
             echo "Pre-build stage cancelled — newer run will redo all work, skipping Slack notification"
             echo "should_post=false" >> "$GITHUB_OUTPUT"
+            echo "update_state=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -614,33 +655,26 @@ jobs:
           # push's detect-changes is path-scoped and may not target the same
           # services, so the cancelled leg may never be re-verified. Post a
           # distinct muted message so humans can spot the anomaly instead of
-          # assuming green.
+          # assuming green. Don't touch state — indeterminate outcome.
           if [ "$BUILD" = "cancelled" ]; then
             MSG=":information_source: *Showcase deploy*: cancelled mid-matrix — newer run (or manual retrigger) continuing; inspect if issues persist"
             jq -n --arg text "$MSG | <$URL|View run>" '{text: $text}' > /tmp/slack-payload.json
             echo "should_post=true" >> "$GITHUB_OUTPUT"
+            echo "update_state=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Policy: #oss-alerts should only surface actionable state —
-          # failures and state transitions. Per-run success confirmations
-          # are noise, especially during bulk drift rebuilds which fan out
-          # one showcase_deploy.yml run per service (up to ~18). The
-          # top-line ":package: Image drift detected — N rebuilds triggered"
-          # posted by showcase_smoke-monitor.yml is the aggregate success
-          # signal for bulk rebuilds; ad-hoc single-service pushes/dispatches
-          # stay quiet on success (the Actions UI is the source of truth).
+          # Classify the terminal outcome.
           if [ "$DETECT" = "failure" ] || [ "$LOCKFILE" = "failure" ]; then
+            OUTCOME="failure"
             MSG=":x: *Showcase deploy*: FAILED (pre-build check)"
           elif [ "$BUILD" = "success" ]; then
-            echo "Build succeeded — suppressing per-run success notification (policy: actionable-only)"
-            echo "should_post=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            OUTCOME="success"
           elif [ "$BUILD" = "skipped" ] && [ "$DETECT" = "success" ]; then
-            echo "No changes detected — suppressing notification (policy: actionable-only)"
-            echo "should_post=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          else
+            # No service changes matched the paths filter — run proved
+            # nothing either way. Don't flip state.
+            OUTCOME="skip"
+          elif [ "$BUILD" = "failure" ] || [ -n "$BUILD" ]; then
             # Build failed. Distinguish full failure (every leg failed) from
             # partial failure (some legs passed, some failed). The previous
             # wording said "FAILED — N service(s) targeted" which implied
@@ -648,6 +682,7 @@ jobs:
             # per-leg detail from steps.legs when available; fall back to a
             # softer "1+ of N failed" phrasing if the API lookup didn't
             # return detail (see the "Compute per-leg build results" step).
+            OUTCOME="failure"
             HAVE_DETAIL="${{ steps.legs.outputs.have_detail }}"
             FAILED_COUNT="${{ steps.legs.outputs.failed_count }}"
             SUCCEEDED_COUNT="${{ steps.legs.outputs.succeeded_count }}"
@@ -666,10 +701,48 @@ jobs:
               # the lie that "N of N failed" when we don't actually know.
               MSG=":x: *Showcase deploy*: 1+ of ${COUNT} service(s) failed (${SERVICES} targeted)"
             fi
+          else
+            # BUILD is empty/unknown + no other signal — no-op.
+            OUTCOME="skip"
           fi
 
-          jq -n --arg text "$MSG | <$URL|View run>" '{text: $text}' > /tmp/slack-payload.json
-          echo "should_post=true" >> "$GITHUB_OUTPUT"
+          # Policy: #oss-alerts should only surface actionable state —
+          # failures and red→green transitions. green→green is silent
+          # (suppresses per-run success noise, especially during bulk drift
+          # rebuilds which fan out one showcase_deploy.yml run per service
+          # up to ~18). The top-line ":package: Image drift detected — N
+          # rebuilds triggered" posted by showcase_smoke-monitor.yml is the
+          # aggregate success signal for bulk rebuilds; ad-hoc single-service
+          # pushes/dispatches stay quiet on success.
+          case "$OUTCOME" in
+            failure)
+              jq -n --arg text "$MSG | <$URL|View run>" '{text: $text}' > /tmp/slack-payload.json
+              echo "should_post=true" >> "$GITHUB_OUTPUT"
+              echo "update_state=true" >> "$GITHUB_OUTPUT"
+              echo "new_status=failure" >> "$GITHUB_OUTPUT"
+              echo "new_failure_at=$NOW" >> "$GITHUB_OUTPUT"
+              ;;
+            success)
+              if [ "$PREV_STATUS" = "failure" ]; then
+                # Red→green transition — emit recovery. Wording mirrors
+                # the smoke-monitor per-service format.
+                RECOVERY_MSG=":white_check_mark: *Showcase deploy*: recovered (was down since ${PREV_FAILURE_AT})"
+                jq -n --arg text "$RECOVERY_MSG | <$URL|View run>" '{text: $text}' > /tmp/slack-payload.json
+                echo "should_post=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "Build succeeded (green→green) — suppressing per-run success notification (policy: actionable-only)"
+                echo "should_post=false" >> "$GITHUB_OUTPUT"
+              fi
+              echo "update_state=true" >> "$GITHUB_OUTPUT"
+              echo "new_status=ok" >> "$GITHUB_OUTPUT"
+              echo "new_failure_at=" >> "$GITHUB_OUTPUT"
+              ;;
+            skip)
+              echo "Indeterminate / no-changes run — suppressing notification (policy: actionable-only)"
+              echo "should_post=false" >> "$GITHUB_OUTPUT"
+              echo "update_state=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
       - name: Post to Slack
         if: always() && steps.payload.outputs.should_post == 'true' && env.SLACK_WEBHOOK_OSS_ALERTS != ''
@@ -680,3 +753,25 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
           payload-file-path: /tmp/slack-payload.json
+
+      # Persist the transition state for the NEXT run to read. We save
+      # iff the payload step classified this run as a terminal outcome
+      # (failure or success); indeterminate runs (cancelled, no-changes)
+      # leave the prior state untouched so streaks aren't broken.
+      - name: Update deploy state file
+        if: always() && steps.payload.outputs.update_state == 'true'
+        run: |
+          NEW_STATUS='${{ steps.payload.outputs.new_status }}'
+          NEW_FAILURE_AT='${{ steps.payload.outputs.new_failure_at }}'
+          jq -n \
+            --arg status "$NEW_STATUS" \
+            --arg failureAt "$NEW_FAILURE_AT" \
+            '{lastStatus: $status, lastFailureAt: $failureAt}' \
+            > showcase-deploy-state.json
+
+      - name: Save deploy state to cache
+        if: always() && steps.payload.outputs.update_state == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: showcase-deploy-state.json
+          key: showcase-deploy-state-${{ github.run_id }}

--- a/.github/workflows/starter_deployed_smoke.yml
+++ b/.github/workflows/starter_deployed_smoke.yml
@@ -41,6 +41,30 @@ jobs:
         with:
           node-version: "20"
 
+      # Restore previous run's pass/fail status from cache so we can emit
+      # a red→green transition alert on recovery. Mirrors the per-service
+      # transition pattern in showcase_smoke-monitor.yml. The restore-keys
+      # prefix gives us the most recently saved state regardless of which
+      # run_id wrote it. Cache TTL is ~7 days; scheduled runs every 6h
+      # plus workflow_run triggers refresh it well within that window.
+      - name: Restore smoke state from cache
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: starter-smoke-state.json
+          key: starter-smoke-state-impossible-match
+          restore-keys: |
+            starter-smoke-state-
+
+      - name: Initialize state if missing
+        run: |
+          # First-ever run (or cache eviction): assume "ok" so we don't
+          # emit a false recovery alert on the first green run after
+          # deploying this workflow change.
+          if [ ! -f starter-smoke-state.json ]; then
+            echo '{"lastStatus":"ok","lastFailureAt":""}' > starter-smoke-state.json
+          fi
+
       - name: Install test dependencies
         run: npm ci
         working-directory: showcase/tests
@@ -50,6 +74,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Run starter deployed smoke tests
+        id: playwright
         working-directory: showcase/tests
         # Use github reporter for Actions annotations plus json for programmatic parsing.
         run: npx playwright test e2e/integration-smoke.spec.ts --grep "@starter-health|@starter-agent|@starter-chat" --reporter=github,json
@@ -174,3 +199,86 @@ jobs:
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run') && env.SLACK_WEBHOOK == ''
         run: |
           echo "::warning::starter_deployed_smoke failed but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
+
+      # Compute outcome + state transition for the next run. Runs on
+      # success and failure alike (but not when the job is cancelled —
+      # that's indeterminate). Policy: post recovery message on
+      # red→green transition only. green→green is silent.
+      #
+      # This step also decides whether to save state. We save iff the
+      # run had a terminal outcome (passed or failed tests); cancelled
+      # runs leave the prior state untouched so streaks aren't broken.
+      - name: Compute transition + recovery payload
+        id: transition
+        if: always() && !cancelled() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
+        run: |
+          set +e
+          NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [ ! -f starter-smoke-state.json ]; then
+            # Shouldn't happen — "Initialize state if missing" runs before
+            # the tests. Belt-and-suspenders fallback so this step never
+            # crashes and leaves state unwritten.
+            echo '{"lastStatus":"ok","lastFailureAt":""}' > starter-smoke-state.json
+          fi
+          PREV_STATUS=$(jq -r '.lastStatus // "ok"' starter-smoke-state.json)
+          PREV_FAILURE_AT=$(jq -r '.lastFailureAt // ""' starter-smoke-state.json)
+
+          # The Playwright step is the only thing that can fail this job.
+          # We infer success vs failure from job.status, which is exposed
+          # by Actions via the `job` context — but step-level `if:` can't
+          # read it directly. Instead, we use the playwright step's
+          # outcome which is reliably set by the preceding step.
+          PLAYWRIGHT_OUTCOME='${{ steps.playwright.outcome }}'
+          case "$PLAYWRIGHT_OUTCOME" in
+            success)
+              NEW_STATUS="ok"
+              NEW_FAILURE_AT=""
+              if [ "$PREV_STATUS" = "failure" ]; then
+                # Red→green transition — emit recovery. Wording mirrors
+                # the smoke-monitor per-service format.
+                RECOVERY_MSG=":white_check_mark: *Starter Deployed Smoke Tests*: recovered (was down since ${PREV_FAILURE_AT})"
+                jq -n --arg text "$RECOVERY_MSG | <$URL|View run>" '{text: $text}' > /tmp/starter-smoke-recovery.json
+                echo "should_post_recovery=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "should_post_recovery=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            failure|*)
+              # Any non-success outcome is treated as failure for state
+              # tracking. The existing "Alert Slack on failure" step
+              # handles the red alert — we only touch state here.
+              NEW_STATUS="failure"
+              NEW_FAILURE_AT="$NOW"
+              echo "should_post_recovery=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+          jq -n \
+            --arg status "$NEW_STATUS" \
+            --arg failureAt "$NEW_FAILURE_AT" \
+            '{lastStatus: $status, lastFailureAt: $failureAt}' \
+            > starter-smoke-state.json
+
+          echo "update_state=true" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Alert Slack on recovery
+        if: >-
+          always() && !cancelled() &&
+          steps.transition.outputs.should_post_recovery == 'true' &&
+          (github.event_name == 'schedule' || github.event_name == 'workflow_run') &&
+          env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          payload-file-path: /tmp/starter-smoke-recovery.json
+
+      - name: Save smoke state to cache
+        if: always() && steps.transition.outputs.update_state == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: starter-smoke-state.json
+          key: starter-smoke-state-${{ github.run_id }}


### PR DESCRIPTION
## Why

#oss-alerts currently fires red alerts on failure but never posts a recovery message when `Showcase: Build & Deploy` or `Starter Deployed Smoke Tests` flip back to passing. Team reported this gap — there's no positive signal when the pipeline is healthy again after an outage. Per the oss-alerts verbosity policy, we want red→green transitions (but not green→green spam).

## What

Mirrors the per-service transition pattern already shipped in `showcase_smoke-monitor.yml` (`:white_check_mark: agno recovered (was down since <iso8601>)`), applied at the workflow level for these two pipelines.

### `showcase_deploy.yml` (notify job)

- Restore previous run's status from `actions/cache` (same key/restore-keys pattern the smoke monitor uses: `showcase-deploy-state-<run_id>` save key, prefix-based restore)
- Classify outcome as `failure | success | skip`
  - `failure` → post existing red alert (unchanged wording) + set state to `failure`
  - `success` AND `PREV=failure` → post recovery message + clear state to `ok`
  - `success` AND `PREV=ok` → silent (green→green — matches prior behavior for bulk drift rebuilds)
  - `skip` (no-changes push, cancellation, indeterminate) → no state change, no post

### `starter_deployed_smoke.yml`

- Restore state before tests run
- After the test step, classify via `steps.playwright.outcome`
- On red→green, post recovery message alongside the existing failure-alert path
- On any terminal outcome (passed or failed tests), save state; cancelled runs leave state untouched so streaks aren't broken

## Design choices

- **State storage: `actions/cache`** — not a committed JSON file. Avoids commit-loop concerns entirely. TTL is ~7 days, far longer than the run cadence of either workflow (showcase deploy fires on every main push + manual dispatch; starter smoke runs every 6h + on every deploy). Same pattern as the smoke monitor, which has been stable.
- **First-ever run**: initialize state to `ok` so we don't emit a false recovery alert on the first green run after this ships.
- **Recovery wording** (matches smoke-monitor convention):
  - `:white_check_mark: *Showcase deploy*: recovered (was down since <iso8601>) | <url|View run>`
  - `:white_check_mark: *Starter Deployed Smoke Tests*: recovered (was down since <iso8601>) | <url|View run>`
- **Existing red-alert wording is unchanged.**

## Edge cases considered

- First-ever run with no prior state: initializes to `ok` — no spurious recovery alert
- Cancelled / mid-matrix cancellation / no-changes push: no state change, prior red state survives into next run
- Cache eviction beyond TTL: same as first-ever run (assume `ok`)
- `workflow_dispatch` with single service: doesn't post Slack today, doesn't update state (unchanged behavior)

## Note for reviewer

This PR touches `.github/workflows/*.yml` so **please merge via the UI** — my `gh` token can't admin-merge workflow-touching PRs.

## Test plan

- [ ] CI passes
- [ ] Merge → next failing deploy run writes `lastStatus=failure` to cache
- [ ] Next green run after a failure posts `:white_check_mark: *Showcase deploy*: recovered ...` in #oss-alerts
- [ ] Subsequent green runs stay silent
- [ ] Same verification for starter smoke tests