### PR TITLE
fix(showcase/agno): read SSE incrementally in smoke route to work around agno SDK success-path hang

### DIFF
--- a/showcase/packages/agno/src/app/api/smoke/route.ts
+++ b/showcase/packages/agno/src/app/api/smoke/route.ts
@@ -55,16 +55,82 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // Response is SSE stream. The agno SDK does not reliably emit the
+    // terminal events (TEXT_MESSAGE_END / RUN_FINISHED) on the success path,
+    // so `await res.text()` can hang until the client timeout fires even
+    // though the agent has already produced valid output. Workaround: read
+    // the stream incrementally and short-circuit as soon as we observe
+    // TEXT_MESSAGE_CONTENT with "OK" in the delta, canceling the reader
+    // rather than awaiting a stream close that may never come. This is a
+    // client-side mitigation — the real fix belongs upstream in the agno
+    // SDK's AG-UI interface.
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no response body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let gotOk = false;
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (
+          buffer.includes('"type":"TEXT_MESSAGE_CONTENT"') &&
+          buffer.includes('"OK"')
+        ) {
+          gotOk = true;
+          // Drop the connection; don't await a stream close that may never come.
+          await reader.cancel().catch(() => {});
+          break;
+        }
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        // reader may already be released via cancel(); ignore.
+      }
+    }
+
+    const finalLatency = Date.now() - start;
+
+    if (!gotOk && buffer.length === 0) {
       return NextResponse.json(
         {
           status: "error",
           integration: INTEGRATION_SLUG,
           stage: "response_empty",
           error: "Runtime returned empty response body",
-          latency_ms: latency,
+          latency_ms: finalLatency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    if (!gotOk) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_incomplete",
+          error:
+            "Stream ended without TEXT_MESSAGE_CONTENT 'OK': " +
+            buffer.slice(0, 200),
+          latency_ms: finalLatency,
           timestamp: new Date().toISOString(),
         },
         { status: 502 },
@@ -74,7 +140,7 @@ export async function GET() {
     return NextResponse.json({
       status: "ok",
       integration: INTEGRATION_SLUG,
-      latency_ms: latency,
+      latency_ms: finalLatency,
       timestamp: new Date().toISOString(),
     });
   } catch (e: unknown) {


### PR DESCRIPTION
## Summary

Reimplements the SSE incremental reader workaround from the now-closed PR #4093 on a fresh branch off `main`.

## Background

PR #4093 was closed under the assumption that PR #4095 (agno SDK upgrade to 2.5.17) had fixed the underlying SSE stream termination bug at the source. Follow-up diagnostics on 2026-04-19 revealed that the SDK upgrade only addressed the **error path**; production `/api/smoke` with real API keys still hangs because the agno SDK does not reliably emit `TEXT_MESSAGE_END` / `RUN_FINISHED` on the **success path**.

Documented in Notion page `3473aa38-1852-815b-9765-fd28fa53275a`, item #5.

## Change

`showcase/packages/agno/src/app/api/smoke/route.ts` — swap `await res.text()` for an incremental reader:

- Read `res.body` via `getReader()` + `TextDecoder` + string buffer accumulator.
- On each chunk, check whether the accumulated buffer contains `"type":"TEXT_MESSAGE_CONTENT"` along with `"OK"` in the delta. Once seen, cancel the reader and return a 200 success envelope — do not await a terminal event that the SDK may never send on the success path.
- If the stream closes cleanly without ever producing the confirmation payload, return a 502 with `stage:"response_incomplete"` so regressions surface clearly in the smoke monitor.
- Keep `AbortSignal.timeout(45000)` as the final safety net.
- Response envelope shape preserved for the smoke monitor parser.

## Scope

Only the agno `/api/smoke/route.ts` is touched. The other 16 showcase starters use the same `await res.text()` pattern but none have exhibited the hang in production — no speculative fixes.

## Caveat — this is a mitigation, not a fix

The real fix belongs upstream in the agno SDK's AG-UI interface. **Do not merge-and-forget.** Keep this PR open until upstream is addressed and the fix is verified in production with real API keys, then revisit whether this client-side workaround can be removed.

## Test plan

- [x] Visual inspection of the diff matches the pattern from PR #4093
- [x] Standalone `tsc --noEmit` against `route.ts` with DOM + ES2017 libs — clean (only missing `@types/node` for `process`, expected in dry-run; code compiles cleanly otherwise)
- [ ] Production curl sanity check against `https://showcase-agno-production.up.railway.app/api/smoke` once deployed
- [ ] Monitor next 12h of `Showcase: Smoke Monitor` runs for agno stability

Closes/replaces the approach from #4093.