### PR TITLE
shell-docs tech-debt: CR-surfaced deferred findings from #4109

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -291,6 +291,13 @@ jobs:
         run: |
           # Capture the current deployment ID BEFORE redeploying so the verify
           # step can distinguish the fresh deployment from the prior one.
+          # Railway's `deployments` query has no explicit orderBy argument;
+          # the API's default is createdAt DESC, which is exactly what we
+          # want here (edges[0] == most recent). Confirmed against the
+          # public GraphQL schema. If Railway ever changes the default,
+          # this query needs an explicit orderBy — the `first: 1` pagination
+          # would otherwise return an arbitrary deployment and the
+          # stale-deployment guard in the verify step would break open.
           PRIOR_RESULT=$(curl -s -H "Authorization: Bearer $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"query\":\"query { deployments(first: 1, input: { serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\" }) { edges { node { id } } } }\"}" \
@@ -556,8 +563,18 @@ jobs:
           # budget so Slack single-line formatting still fits.
           truncate_csv() {
             local budget=$1 input=$2 out="" item proposed
-            # Split on single space (entries come from shell word-split),
-            # then render as comma-separated.
+            # Split on whitespace (entries come from shell word-split),
+            # then render as comma-separated. Disable globbing inside the
+            # loop so a slug containing a shell glob character (*, ?, [)
+            # can't expand against the filesystem — defense in depth even
+            # though our current slug set is controlled via the matrix.
+            local _old_glob
+            case "$-" in *f*) _old_glob=1 ;; *) _old_glob=0 ;; esac
+            set -f
+            # Use explicit IFS so whitespace tokenisation is predictable
+            # regardless of the caller's environment.
+            local _old_ifs="$IFS"
+            IFS=$' \t\n'
             for item in $input; do
               if [ -z "$out" ]; then
                 proposed="$item"
@@ -577,6 +594,8 @@ jobs:
                 break
               fi
             done
+            IFS="$_old_ifs"
+            [ "$_old_glob" = 0 ] && set +f
             printf '%s' "$out"
           }
           succeeded_list=$(truncate_csv 200 "$succeeded")
@@ -616,6 +635,16 @@ jobs:
             # Input is comma-separated (jq join(", ")) — normalise to
             # space separation for the shell word-split below.
             ws="${input//,/ }"
+            # Disable globbing while iterating so an (unexpected) glob
+            # char in a slug can't expand against the filesystem; restore
+            # the prior setting on the way out. Also lock IFS to
+            # whitespace for deterministic word-splitting regardless of
+            # caller environment.
+            local _old_glob
+            case "$-" in *f*) _old_glob=1 ;; *) _old_glob=0 ;; esac
+            set -f
+            local _old_ifs="$IFS"
+            IFS=$' \t\n'
             for item in $ws; do
               if [ -z "$out" ]; then
                 proposed="$item"
@@ -633,6 +662,8 @@ jobs:
                 break
               fi
             done
+            IFS="$_old_ifs"
+            [ "$_old_glob" = 0 ] && set +f
             printf '%s' "$out"
           }
           SERVICES=$(truncate_csv 200 "${{ steps.summary.outputs.services }}")

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -222,7 +222,7 @@ jobs:
     needs: [detect-changes, check-lockfile]
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: ${{ fromJSON(matrix.service.timeout) }}
+    timeout-minutes: ${{ matrix.service.timeout }}
     permissions:
       id-token: write
       contents: read
@@ -430,7 +430,6 @@ jobs:
               # 3 times within this iteration before treating it as a genuine
               # non-200; legitimate failures still fail because all 3 tries
               # must return non-200.
-              HTTP_CODE="000"
               for probe_try in 1 2 3; do
                 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$HEALTH_URL" 2>/dev/null || echo "000")
                 if [ "$HTTP_CODE" = "200" ]; then

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -116,8 +116,16 @@ jobs:
             starter_strands: 'showcase/starters/strands/**'
             aimock: 'showcase/aimock/**'
             shell_dojo: 'showcase/shell-dojo/**'
-            shell_dashboard: 'showcase/shell-dashboard/**'
-            shell_docs: 'showcase/shell-docs/**'
+            shell_dashboard:
+              - 'showcase/shell-dashboard/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/packages/*/manifest.yaml'
+            shell_docs:
+              - 'showcase/shell-docs/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/packages/*/manifest.yaml'
 
       - name: Build service matrix
         id: build-matrix

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -55,7 +55,7 @@ on:
           - shell-docs
 
 concurrency:
-  group: showcase-deploy-${{ github.ref }}-${{ github.event.inputs.service || 'auto' }}
+  group: showcase-deploy-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 env:
@@ -256,9 +256,16 @@ jobs:
       - name: Copy shared modules into build context
         run: |
           CONTEXT="${{ matrix.service.context }}"
-          # Starters are self-contained — skip shared module copies
-          if [[ "$CONTEXT" == showcase/starters/* ]]; then
-            echo "Starter build — skipping shared module copies"
+          # Allowlist: only the framework-integration packages under
+          # showcase/packages/* consume shared_python / shared_typescript/tools.
+          # Everything else (starters, shell-family with context=".", aimock,
+          # shell-dojo) is self-contained — their Dockerfiles never reference
+          # these paths, and copying into their contexts either pollutes the
+          # repo root (context=".") or leaves stray unused dirs in the build
+          # context. Allowlist beats denylist here since the set of consumers
+          # is small, known, and grows with package additions (easy to spot).
+          if [[ "$CONTEXT" != showcase/packages/* ]]; then
+            echo "Self-contained build context ($CONTEXT) — skipping shared module copies"
             exit 0
           fi
           if [ -d "showcase/shared/python" ] && [ -d "$CONTEXT" ]; then
@@ -458,6 +465,13 @@ jobs:
       actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    env:
+      # Hoisted to job level so the step-level `if:` on "Post to Slack" can
+      # reference `env.SLACK_WEBHOOK_OSS_ALERTS`. Step-level `env:` mappings
+      # are NOT visible to the same step's `if:` — only workflow-level and
+      # job-level env are. Previously defined only at step level, which made
+      # the gate always evaluate false and silently disabled Slack posts.
+      SLACK_WEBHOOK_OSS_ALERTS: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
     steps:
       - name: Build deploy summary
         id: summary
@@ -788,8 +802,6 @@ jobs:
 
       - name: Post to Slack
         if: always() && steps.payload.outputs.should_post == 'true' && env.SLACK_WEBHOOK_OSS_ALERTS != ''
-        env:
-          SLACK_WEBHOOK_OSS_ALERTS: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}

--- a/.github/workflows/static_check-binaries.yml
+++ b/.github/workflows/static_check-binaries.yml
@@ -20,6 +20,15 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
+          # Fail on any unset variable, failed command in a pipeline, or
+          # unhandled non-zero exit. The previous script would let `wc -c`
+          # failing on a transient race (file deleted mid-diff) produce
+          # an empty `$SIZE`, which then triggered `[ "$SIZE" -gt ... ]`
+          # with the error `integer expression expected` written to
+          # stderr while the script marched on — false-green runs
+          # possible. With `set -euo pipefail` + the explicit numeric
+          # check below, that failure path now fails the job loudly.
+          set -euo pipefail
           VIOLATIONS=0
 
           # Get list of added/modified files in the PR
@@ -30,8 +39,11 @@ jobs:
             exit 0
           fi
 
-          # Check for binary file extensions
-          BINARY_FILES=$(echo "$CHANGED_FILES" | grep -iE '\.(exe|dll|so|dylib|o|obj|a|lib|wasm)$' || true)
+          # Check for binary file extensions. Keep in rough sync with
+          # `.gitignore` — any compiled/archive/debug artefact authored
+          # by a build tool belongs here. Missing extensions historically
+          # let by: .class, .jar, .pyd, .pyc, .node, .bin, .pdb, .zip, .whl.
+          BINARY_FILES=$(echo "$CHANGED_FILES" | grep -iE '\.(exe|dll|so|dylib|o|obj|a|lib|wasm|class|jar|pyd|pyc|node|bin|pdb|zip|whl)$' || true)
           if [ -n "$BINARY_FILES" ]; then
             echo "::error::Binary files detected in PR:"
             echo "$BINARY_FILES"
@@ -65,7 +77,18 @@ jobs:
                 .github/actions/*/dist/*) continue ;;
                 showcase/shell/src/data/*|showcase/shell-docs/src/data/*|showcase/shell-dojo/src/data/demo-content.json) continue ;;
               esac
-              SIZE=$(wc -c < "$file" | tr -d ' ')
+              # Guard `wc -c`: if the read fails or returns a non-numeric
+              # value, skip this file rather than letting the subsequent
+              # arithmetic comparison spew "integer expression expected"
+              # to stderr while the script silently continues.
+              if ! SIZE=$(wc -c < "$file" 2>/dev/null | tr -d ' '); then
+                echo "::warning::Could not size $file; skipping"
+                continue
+              fi
+              if ! [[ "$SIZE" =~ ^[0-9]+$ ]]; then
+                echo "::warning::wc returned non-numeric size for $file ($SIZE); skipping"
+                continue
+              fi
               if [ "$SIZE" -gt 1048576 ]; then
                 LARGE_FILES="${LARGE_FILES}${file} ($(( SIZE / 1024 )) KB)\n"
               fi

--- a/showcase/scripts/bundle-demo-content.ts
+++ b/showcase/scripts/bundle-demo-content.ts
@@ -482,9 +482,19 @@ function main() {
         });
 
         // Collapse per-file regions into the public map in file-order. For
-        // multi-file regions we concatenate bodies with a blank separator and
-        // use the FIRST file's line span (there's no single coherent range
-        // across files — this is a best-effort pointer for tooling).
+        // multi-file regions we concatenate bodies with a blank separator.
+        //
+        // Caption accuracy: when the SAME region name appears in multiple
+        // files we previously kept the first file's `file`/`startLine`/
+        // `endLine` while appending code from subsequent files — the rendered
+        // `<Snippet>` caption then read like a single-file slice but showed
+        // concatenated content. Instead we track contributor filenames and,
+        // when >1, rewrite `file` to `(multiple: a, b)` so the caption
+        // visibly signals the concatenation. `startLine`/`endLine` are
+        // preserved (Snippet's caption always renders a line range and
+        // rewriting those to null would break the renderer) — they remain
+        // the FIRST contributor's span as a best-effort pointer, with the
+        // `(multiple: ...)` prefix preventing the caption from misleading.
         //
         // `perFileRegions` can carry entries whose filename is NOT in
         // `files` — specifically the demo-root README (README.md / README.mdx),
@@ -496,6 +506,7 @@ function main() {
         // over the README's — README regions either fill in untouched names
         // or get concatenated at the tail like any other contributor.
         const regions: Record<string, Region> = {};
+        const regionContributors: Record<string, string[]> = {};
         const fileOrder = files.map((f) => f.filename);
         const knownInFiles = new Set(fileOrder);
         const leftoverKeys = Object.keys(perFileRegions)
@@ -510,6 +521,18 @@ function main() {
               if (regions[name]) {
                 regions[name].code =
                   regions[name].code + "\n\n" + slice.lines.join("\n");
+                // Same-file multi-slice: extend endLine so the caption's
+                // span at least reaches the last contributor in the
+                // original file. Cross-file concatenation keeps the first
+                // contributor's span untouched (file gets rewritten to
+                // `(multiple: …)` below, which signals the caption can't
+                // be a single contiguous range).
+                if (regions[name].file === filename) {
+                  regions[name].endLine = slice.endLine;
+                }
+                if (!regionContributors[name].includes(filename)) {
+                  regionContributors[name].push(filename);
+                }
               } else {
                 regions[name] = {
                   file: filename,
@@ -518,8 +541,17 @@ function main() {
                   code: slice.lines.join("\n"),
                   language: detectLanguage(filename),
                 };
+                regionContributors[name] = [filename];
               }
             }
+          }
+        }
+        // Rewrite `file` for regions with >1 contributor so the snippet
+        // caption visibly signals concatenation instead of lying about
+        // origin. Keep the first contributor's line span untouched.
+        for (const [name, contributors] of Object.entries(regionContributors)) {
+          if (contributors.length > 1) {
+            regions[name].file = `(multiple: ${contributors.join(", ")})`;
           }
         }
 
@@ -586,13 +618,39 @@ if (process.argv.includes("--watch")) {
     }, 200);
   };
   console.log("[watch] watching packages/ for changes...\n");
+  // `fs.watch({ recursive: true })` only honours `recursive` on macOS and
+  // Windows. On Linux (most CI + many dev boxes) the option is silently
+  // ignored: only the top-level directory is watched, so edits to
+  // `packages/<x>/src/...` never trigger a rebundle — and the "watching..."
+  // log above misleads the operator into thinking they're covered. We
+  // can't transparently fix this without adding a dependency (chokidar is
+  // not in package.json), so at minimum emit a loud warning at startup so
+  // the limitation isn't silent.
+  if (process.platform === "linux") {
+    console.warn(
+      "[watch] WARNING: fs.watch recursive is not supported on Linux — " +
+        "watch mode will only detect changes at the top level of " +
+        `${PACKAGES_DIR} and will MISS nested edits under ` +
+        "packages/<x>/src/...  Run the bundler manually (e.g. " +
+        "`tsx ../scripts/bundle-demo-content.ts`) after editing demo " +
+        "sources, or add chokidar to scripts/package.json for proper " +
+        "recursive watching.",
+    );
+  }
   fs.watch(PACKAGES_DIR, { recursive: true }, (_event, filename) => {
     if (!filename) return;
+    // Normalize separators before matching: `fs.watch` reports paths with
+    // the host OS separator, so on Windows the filename is emitted with
+    // backslashes (`packages\foo\src\app\demos\...`). The directory
+    // patterns below are hardcoded forward-slash, so without this
+    // normalization every event on Windows would silently fail to match
+    // and the watcher would drop ALL changes.
+    const normalized = filename.replace(/\\/g, "/");
     // Rebundle for demo sources, agent sources, READMEs, and — critically —
     // manifest.yaml edits.
     if (
       /(\/demos\/|\/agents\/|\/agent\/|\/mastra\/|README\.md$|manifest\.yaml$)/.test(
-        filename,
+        normalized,
       )
     ) {
       rebundle();

--- a/showcase/scripts/bundle-demo-content.ts
+++ b/showcase/scripts/bundle-demo-content.ts
@@ -419,7 +419,19 @@ function main() {
         const demoPathSet = new Set(files.map((f) => f.filename));
         for (const hlPath of highlightList) {
           if (demoPathSet.has(hlPath)) continue;
-          const absExternal = path.join(pkgRoot, hlPath);
+          const absExternal = path.resolve(pkgRoot, hlPath);
+          // Guard against highlight entries that escape the package root
+          // (e.g. `../../other-pkg/secret.txt` or absolute paths). The
+          // bundle output is committed to the repo and consumed by both
+          // shells at build time, so a malicious manifest could otherwise
+          // smuggle arbitrary filesystem contents into the bundled JSON.
+          // Block anything that resolves outside pkgRoot up front.
+          const rel = path.relative(pkgRoot, absExternal);
+          if (rel.startsWith("..") || path.isAbsolute(rel)) {
+            throw new Error(
+              `${key}: highlight path "${hlPath}" resolves outside the package root (${absExternal}). Highlight paths must be package-relative.`,
+            );
+          }
           if (!fs.existsSync(absExternal)) {
             throw new Error(
               `${key}: highlight path "${hlPath}" not found in demo folder nor at ${absExternal}.`,

--- a/showcase/scripts/generate-registry.ts
+++ b/showcase/scripts/generate-registry.ts
@@ -218,7 +218,17 @@ function main() {
   // schema validation, since `docs_links` isn't part of the manifest schema.
   // Best-effort: missing file or stale shapes are tolerated and don't error.
   for (const manifest of integrations) {
-    const pkgDir = path.join(PACKAGES_DIR, manifest.slug as string);
+    // Runtime guard: schema validation above already enforces `slug`, but
+    // do not trust that guarantee here — a silently-undefined slug fed
+    // to path.join yields "<packages-dir>/undefined" and would produce
+    // an empty docs_links without any error. Fail loudly instead.
+    if (typeof manifest.slug !== "string" || manifest.slug.length === 0) {
+      allErrors.push(
+        `manifest is missing a valid string "slug" field (got ${typeof manifest.slug}). Cannot load docs-links.`,
+      );
+      continue;
+    }
+    const pkgDir = path.join(PACKAGES_DIR, manifest.slug);
     manifest.docs_links = loadDocsLinks(pkgDir, allErrors);
   }
 

--- a/showcase/shell-docs/src/app/[[...slug]]/error.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { ErrorBoundaryCard } from "@/components/error-boundary-card";
 
 export default function DocsError({
   error,
@@ -10,39 +9,5 @@ export default function DocsError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const pathname = usePathname();
-  useEffect(() => {
-    // Log the full Error instance (not just .message/.digest) so the
-    // stack trace reaches the server log / browser devtools. Include
-    // pathname where available so reports can be tied back to a page.
-    console.error(
-      `[docs] Page render error${pathname ? ` on ${pathname}` : ""}:`,
-      error,
-    );
-  }, [error, pathname]);
-
-  return (
-    <div className="flex items-center justify-center min-h-[50vh]">
-      <div className="text-center max-w-md">
-        <h2 className="text-lg font-semibold text-[var(--text)] mb-2">
-          Something went wrong
-        </h2>
-        <p className="text-sm text-[var(--text-muted)] mb-4">
-          We hit an error rendering this page. Please refresh, and if it keeps
-          happening, report it with the ID below so we can track it down.
-        </p>
-        {error.digest && (
-          <p className="text-xs text-[var(--text-faint)] mb-4 font-mono">
-            Error ID: {error.digest}
-          </p>
-        )}
-        <button
-          onClick={reset}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-colors"
-        >
-          Try again
-        </button>
-      </div>
-    </div>
-  );
+  return <ErrorBoundaryCard scope="docs" error={error} reset={reset} />;
 }

--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -179,36 +179,66 @@ function DocsOverview() {
                   {label}
                 </div>
                 <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                  {items.map((i) => (
-                    <Link
-                      key={i.slug}
-                      href={`/${i.slug}`}
-                      className={`group relative flex items-center gap-2 p-3 rounded-lg border transition-all ${
-                        i.deployed
-                          ? "border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--accent)] hover:shadow-sm"
-                          : "border-[var(--border-dim)] bg-[var(--bg-elevated)] opacity-70"
-                      }`}
-                    >
-                      {i.logo ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={i.logo} alt="" className="w-5 h-5 shrink-0" />
-                      ) : (
-                        <span className="w-5 h-5 shrink-0" />
-                      )}
-                      <span className="flex-1 min-w-0 truncate text-sm font-medium text-[var(--text)] group-hover:text-[var(--accent)]">
-                        {i.name}
-                      </span>
-                      {!i.deployed && (
-                        <span className="text-[9px] font-mono uppercase tracking-widest text-[var(--text-faint)]">
-                          soon
+                  {items.map((i) => {
+                    // Undeployed integrations render as non-interactive
+                    // cards. The framework catch-all route would happily
+                    // serve a landing page for any registry entry, but
+                    // that page has no live demos wired up — clicking an
+                    // undeployed card would drop the user on a dead end.
+                    // The "soon" pill + dimmed styling already signal
+                    // not-ready; stripping the <Link> makes the
+                    // affordance match the signal.
+                    const cardContent = (
+                      <>
+                        {i.logo ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={i.logo}
+                            alt=""
+                            className="w-5 h-5 shrink-0"
+                          />
+                        ) : (
+                          <span className="w-5 h-5 shrink-0" />
+                        )}
+                        <span
+                          className={`flex-1 min-w-0 truncate text-sm font-medium text-[var(--text)] ${
+                            i.deployed ? "group-hover:text-[var(--accent)]" : ""
+                          }`}
+                        >
+                          {i.name}
                         </span>
-                      )}
-                      {/* Marks the framework currently stored in
-                          localStorage so repeat visitors can spot "their"
-                          choice at a glance without an auto-redirect. */}
-                      <StoredFrameworkHighlight slug={i.slug} />
-                    </Link>
-                  ))}
+                        {!i.deployed && (
+                          <span className="text-[9px] font-mono uppercase tracking-widest text-[var(--text-faint)]">
+                            soon
+                          </span>
+                        )}
+                        {/* Marks the framework currently stored in
+                            localStorage so repeat visitors can spot "their"
+                            choice at a glance without an auto-redirect. */}
+                        <StoredFrameworkHighlight slug={i.slug} />
+                      </>
+                    );
+                    if (i.deployed) {
+                      return (
+                        <Link
+                          key={i.slug}
+                          href={`/${i.slug}`}
+                          className="group relative flex items-center gap-2 p-3 rounded-lg border transition-all border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--accent)] hover:shadow-sm"
+                        >
+                          {cardContent}
+                        </Link>
+                      );
+                    }
+                    return (
+                      <div
+                        key={i.slug}
+                        aria-disabled="true"
+                        className="group relative flex items-center gap-2 p-3 rounded-lg border border-[var(--border-dim)] bg-[var(--bg-elevated)] opacity-70 cursor-not-allowed"
+                      >
+                        {cardContent}
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             );
@@ -365,10 +395,18 @@ export default async function DocsPage({
       deployed: i.deployed,
     }));
 
+  // Only consider deployed integrations — `findFrameworksWithCell`
+  // receives a slug list and doesn't know about deployment state, so
+  // filter BEFORE the `.map` to avoid seeding the "has this cell" set
+  // with slugs that point at unreachable integration pages. Downstream
+  // `<RouterPivot>` already filters options to deployed, so undeployed
+  // slugs here would be dead weight at best, dead links at worst.
   const frameworksWithCell = doc.fm.defaultCell
     ? findFrameworksWithCell(
         doc.fm.defaultCell,
-        getIntegrations().map((i) => i.slug),
+        getIntegrations()
+          .filter((i) => i.deployed === true)
+          .map((i) => i.slug),
         demos,
       )
     : [];
@@ -385,8 +423,14 @@ export default async function DocsPage({
   // docs UI.
   let previewUrl: string | null | undefined = undefined;
   if (doc.fm.defaultCell) {
+    // Restrict the preview search to deployed integrations. An
+    // undeployed integration may still ship a preview asset in its
+    // registry entry, but showing it would advertise an experience the
+    // user cannot actually reach via the pivot (which itself filters to
+    // deployed). Filter BEFORE sorting so the first-match loop picks
+    // the visually-priority deployed integration's preview.
     const sortedIntegrations = getIntegrations()
-      .slice()
+      .filter((i) => i.deployed === true)
       .sort((a, b) => {
         const orderA = a.sort_order ?? 999;
         const orderB = b.sort_order ?? 999;

--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -21,11 +21,13 @@ import {
   CONTENT_DIR,
   FRAMEWORK_CATEGORY_ORDER,
   buildNavTree,
+  findFrameworksWithCell,
   loadDoc,
   readMeta,
   type NavNode,
 } from "@/lib/docs-render";
 import {
+  getIntegration,
   getIntegrations,
   getFeature,
   getCategoryLabel,
@@ -39,14 +41,6 @@ interface DemoRecord {
 const demos: Record<string, DemoRecord> = (
   demoContent as { demos: Record<string, DemoRecord> }
 ).demos;
-
-function findFrameworksWithCell(cell: string): string[] {
-  const matches: string[] = [];
-  for (const integration of getIntegrations()) {
-    if (demos[`${integration.slug}::${cell}`]) matches.push(integration.slug);
-  }
-  return matches;
-}
 
 // Category ordering for the framework picker grid is imported from
 // @/lib/docs-render so the landing grid, sidebar dropdown, and this
@@ -339,6 +333,12 @@ export default async function DocsPage({
   const integrationMatch = slugPath.match(/^integrations\/([^/]+)/);
   if (integrationMatch) {
     const framework = integrationMatch[1];
+    // Validate the framework slug against the registry. A crafted URL
+    // like `/docs/integrations/fake-framework/anything` would otherwise
+    // silently fall through to an empty nav tree rather than a clean
+    // 404 — the reader can't tell the difference between "valid
+    // integration with no scoped content" and "invalid slug".
+    if (!getIntegration(framework)) notFound();
     const frameworkDir = `${CONTENT_DIR}/integrations/${framework}`;
     const frameworkMeta = readMeta(frameworkDir);
     sidebarTitle =
@@ -366,18 +366,34 @@ export default async function DocsPage({
     }));
 
   const frameworksWithCell = doc.fm.defaultCell
-    ? findFrameworksWithCell(doc.fm.defaultCell)
+    ? findFrameworksWithCell(
+        doc.fm.defaultCell,
+        getIntegrations().map((i) => i.slug),
+        demos,
+      )
     : [];
 
   // Look up the feature record for an animated preview URL, if any
   const featureFromCell = doc.fm.defaultCell
     ? getFeature(doc.fm.defaultCell)
     : undefined;
-  // Fallback to the first integration that implements the feature and
-  // has an animated preview.
+  // Fallback to the FIRST integration (sorted by sort_order, then slug)
+  // that implements the feature and has an animated preview. Registry
+  // iteration order alone isn't deterministic w.r.t. the visual
+  // priority consumers set via `sort_order`, so sort explicitly so the
+  // preview we pick matches the ordering shown everywhere else in the
+  // docs UI.
   let previewUrl: string | null | undefined = undefined;
   if (doc.fm.defaultCell) {
-    for (const integration of getIntegrations()) {
+    const sortedIntegrations = getIntegrations()
+      .slice()
+      .sort((a, b) => {
+        const orderA = a.sort_order ?? 999;
+        const orderB = b.sort_order ?? 999;
+        if (orderA !== orderB) return orderA - orderB;
+        return a.slug.localeCompare(b.slug);
+      });
+    for (const integration of sortedIntegrations) {
       const demo = integration.demos?.find((d) => d.id === doc.fm.defaultCell);
       if (demo?.animated_preview_url) {
         previewUrl = demo.animated_preview_url;

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -23,11 +23,21 @@ import { SidebarFrameworkSelector } from "@/components/sidebar-framework-selecto
 import {
   CONTENT_DIR,
   buildNavTree,
+  findFrameworksWithCell,
   loadDoc,
   type NavNode,
 } from "@/lib/docs-render";
 import { getIntegration, getIntegrations } from "@/lib/registry";
+import { RESERVED_ROUTE_SLUGS } from "@/app/layout";
 import demoContent from "@/data/demo-content.json";
+
+// Route cannot be statically exported: generateStaticParams returns [] and
+// Next.js' default `dynamicParams=true` is what makes runtime rendering
+// work for every framework + slug. Declare it explicitly so a future
+// migration to `output: "export"` fails loudly here (dynamicParams must
+// be false under static export, which would surface immediately) rather
+// than silently 404ing every `/<framework>/<slug>` URL.
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   // Rely on the catch-all's dynamic behaviour at runtime; returning an
@@ -59,6 +69,17 @@ export default async function FrameworkScopedDocsPage({
   params: Promise<{ framework: string; slug?: string[] }>;
 }) {
   const { framework, slug } = await params;
+
+  // Defense in depth: explicitly 404 on reserved top-level route slugs.
+  // Next.js already prefers exact-match routes over this catch-all, so
+  // `/docs`, `/ag-ui`, etc. never reach here during normal routing.
+  // But if the registry ever ships an integration whose slug collides
+  // with a reserved segment, layout.tsx drops it from knownFrameworks
+  // AND this guard ensures the route handler still short-circuits to a
+  // clean 404 rather than rendering garbage.
+  if ((RESERVED_ROUTE_SLUGS as readonly string[]).includes(framework)) {
+    notFound();
+  }
 
   // Validate the framework slug against the registry. Anything else
   // falls through to 404 — Next.js top-level routes (`/docs`, etc.)
@@ -95,7 +116,11 @@ export default async function FrameworkScopedDocsPage({
   const missingCell =
     doc.fm.defaultCell && !frameworkHasCellFor(framework, doc.fm.defaultCell);
   const alternativeFrameworks = doc.fm.defaultCell
-    ? findFrameworksWithCell(doc.fm.defaultCell)
+    ? findFrameworksWithCell(
+        doc.fm.defaultCell,
+        getIntegrations().map((i) => i.slug),
+        demos,
+      )
     : [];
 
   const banner = missingCell ? (
@@ -110,23 +135,31 @@ export default async function FrameworkScopedDocsPage({
           <>
             {" "}
             Try{" "}
-            {alternativeFrameworks.slice(0, 3).map((slug, i) => {
-              const alt = getIntegration(slug);
-              if (!alt) return null;
-              const name = alt.name;
-              const href = `/${slug}/${slugPath}`;
-              return (
-                <React.Fragment key={slug}>
-                  {i > 0 && ", "}
-                  <Link
-                    href={href}
-                    className="text-[var(--accent)] hover:underline"
-                  >
-                    {name}
-                  </Link>
-                </React.Fragment>
-              );
-            })}{" "}
+            {alternativeFrameworks
+              // Filter out any slug that doesn't resolve to a registered
+              // integration BEFORE mapping to fragments — otherwise the
+              // comma separator (`i > 0 && ", "`) is emitted against the
+              // pre-filter index, producing a stray leading or double
+              // comma when a slug drops out mid-sequence.
+              .map((slug) => getIntegration(slug))
+              .filter(
+                (alt): alt is NonNullable<typeof alt> => alt !== undefined,
+              )
+              .slice(0, 3)
+              .map((alt, i) => {
+                const href = `/${alt.slug}/${slugPath}`;
+                return (
+                  <React.Fragment key={alt.slug}>
+                    {i > 0 && ", "}
+                    <Link
+                      href={href}
+                      className="text-[var(--accent)] hover:underline"
+                    >
+                      {alt.name}
+                    </Link>
+                  </React.Fragment>
+                );
+              })}{" "}
             instead, or browse the{" "}
             <Link
               href={`/docs/${slugPath}`}
@@ -154,18 +187,61 @@ export default async function FrameworkScopedDocsPage({
   );
 }
 
-function findFrameworksWithCell(cell: string): string[] {
-  const matches: string[] = [];
-  for (const integration of getIntegrations()) {
-    if (demos[`${integration.slug}::${cell}`]) matches.push(integration.slug);
-  }
-  return matches;
-}
-
 // ---------------------------------------------------------------------------
 // Framework landing page: renders the docs shell but with an overview
 // body derived from the integration's registry metadata.
 // ---------------------------------------------------------------------------
+
+// Doc-page landing cards for the framework overview. Each entry declares
+// the doc slug (relative to `/<framework>/`) plus the registry feature IDs
+// that gate it. A card only renders when the integration declares at
+// least one of its gating features — so `strands` (no HITL support) no
+// longer shows a dead "Human-in-the-Loop" card the moment the framework
+// registry says it's unsupported. When the registry ever drops a
+// feature the card automatically disappears from the landing without a
+// code edit.
+//
+// The registry doesn't currently expose a feature-id → doc-slug map
+// (features and doc pages live in separate namespaces). Keep the
+// gating feature list colocated with the card so any future mapping
+// table can drop in as a replacement. Follow-up owners: move this into
+// `feature-registry.json` once a canonical feature→docs-slug schema
+// exists.
+const FRAMEWORK_LANDING_CARDS: {
+  docSlug: string;
+  title: string;
+  desc: string;
+  gatingFeatures: string[];
+}[] = [
+  {
+    docSlug: "agentic-chat-ui",
+    title: "Chat UI",
+    desc: "Pre-built chat components wired to the agent",
+    gatingFeatures: ["agentic-chat", "prebuilt-sidebar", "prebuilt-popup"],
+  },
+  {
+    docSlug: "generative-ui/tool-rendering",
+    title: "Tool Rendering",
+    desc: "Render agent tool calls as UI components",
+    gatingFeatures: [
+      "tool-rendering",
+      "tool-rendering-default-catchall",
+      "tool-rendering-custom-catchall",
+    ],
+  },
+  {
+    docSlug: "frontend-tools",
+    title: "Frontend Tools",
+    desc: "Expose client-side actions to the agent",
+    gatingFeatures: ["frontend-tools"],
+  },
+  {
+    docSlug: "human-in-the-loop",
+    title: "Human-in-the-Loop",
+    desc: "Intercept tool calls for approval",
+    gatingFeatures: ["hitl-in-chat", "gen-ui-interrupt", "interrupt-headless"],
+  },
+];
 
 function FrameworkLandingPage({ framework }: { framework: string }) {
   const integration = getIntegration(framework);
@@ -173,6 +249,11 @@ function FrameworkLandingPage({ framework }: { framework: string }) {
 
   const navTree = buildNavTree(CONTENT_DIR);
   const tree = navTree;
+
+  const integrationFeatureSet = new Set(integration.features ?? []);
+  const visibleCards = FRAMEWORK_LANDING_CARDS.filter((card) =>
+    card.gatingFeatures.some((f) => integrationFeatureSet.has(f)),
+  );
 
   return (
     <div className="flex" style={{ height: "calc(100vh - 52px)" }}>
@@ -225,26 +306,14 @@ function FrameworkLandingPage({ framework }: { framework: string }) {
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <LandingCard
-            href={`/${framework}/agentic-chat-ui`}
-            title="Chat UI"
-            desc="Pre-built chat components wired to the agent"
-          />
-          <LandingCard
-            href={`/${framework}/generative-ui/tool-rendering`}
-            title="Tool Rendering"
-            desc="Render agent tool calls as UI components"
-          />
-          <LandingCard
-            href={`/${framework}/frontend-tools`}
-            title="Frontend Tools"
-            desc="Expose client-side actions to the agent"
-          />
-          <LandingCard
-            href={`/${framework}/human-in-the-loop`}
-            title="Human-in-the-Loop"
-            desc="Intercept tool calls for approval"
-          />
+          {visibleCards.map((card) => (
+            <LandingCard
+              key={card.docSlug}
+              href={`/${framework}/${card.docSlug}`}
+              title={card.title}
+              desc={card.desc}
+            />
+          ))}
         </div>
       </main>
     </div>

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -145,6 +145,14 @@ export default async function FrameworkScopedDocsPage({
               .filter(
                 (alt): alt is NonNullable<typeof alt> => alt !== undefined,
               )
+              // Only surface deployed integrations — `findFrameworksWithCell`
+              // walks the full `getIntegrations()` list (including
+              // undeployed ones), so without this filter the banner can
+              // link to integration pages that aren't reachable. Apply
+              // BEFORE `.slice(0, 3)` so we show up to three _deployed_
+              // alternatives rather than padding the slice with dead
+              // links. If fewer than three qualify, show what's available.
+              .filter((alt) => alt.deployed)
               .slice(0, 3)
               .map((alt, i) => {
                 const href = `/${alt.slug}/${slugPath}`;

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/error.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { ErrorBoundaryCard } from "@/components/error-boundary-card";
 
 export default function AgUiError({
   error,
@@ -10,39 +9,5 @@ export default function AgUiError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const pathname = usePathname();
-  useEffect(() => {
-    // Log the full Error instance (not just .message/.digest) so the
-    // stack trace reaches the server log / browser devtools. Include
-    // pathname where available so reports can be tied back to a page.
-    console.error(
-      `[ag-ui] Page render error${pathname ? ` on ${pathname}` : ""}:`,
-      error,
-    );
-  }, [error, pathname]);
-
-  return (
-    <div className="flex items-center justify-center min-h-[50vh]">
-      <div className="text-center max-w-md">
-        <h2 className="text-lg font-semibold text-[var(--text)] mb-2">
-          Something went wrong
-        </h2>
-        <p className="text-sm text-[var(--text-muted)] mb-4">
-          We hit an error rendering this page. Please refresh, and if it keeps
-          happening, report it with the ID below so we can track it down.
-        </p>
-        {error.digest && (
-          <p className="text-xs text-[var(--text-faint)] mb-4 font-mono">
-            Error ID: {error.digest}
-          </p>
-        )}
-        <button
-          onClick={reset}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-colors"
-        >
-          Try again
-        </button>
-      </div>
-    </div>
-  );
+  return <ErrorBoundaryCard scope="ag-ui" error={error} reset={reset} />;
 }

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
@@ -140,8 +140,24 @@ const NAV_DEFINITION: NavTab[] = [
 
 // Fallback title derived from the slug itself when we can't read a better
 // one from the file (missing file, IO error, malformed frontmatter, etc.).
+// Title Case the result: `multimodal-inputs` → `Multimodal Inputs`. The
+// previous `toLowerCase()`-preserving fallback produced lowercase labels
+// in the sidebar whenever frontmatter was missing, which clashed with
+// the docs-render default (e.g. reference breadcrumb, framework nav) of
+// Title-Cased fallbacks.
 function titleFromSlug(slug: string): string {
-  return slug.split("/").pop()?.replace(/-/g, " ") || slug;
+  const last = slug.split("/").pop() || slug;
+  return last.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// Process-scoped cache so `getTitleForSlug` doesn't re-read and re-parse
+// the same MDX file once per entry in NAV_DEFINITION on every request.
+// In prod the nav tree is static so caching is safe for the life of the
+// Node process; in dev we skip the cache so MDX edits show up without a
+// server restart. Mirrors the cache pattern in reference-items.ts.
+const __titleCache = new Map<string, string>();
+function isProd(): boolean {
+  return process.env.NODE_ENV === "production";
 }
 
 // Read the title for a given slug from its MDX file. Uses gray-matter so
@@ -150,6 +166,16 @@ function titleFromSlug(slug: string): string {
 // body). Guards fs reads so a single malformed file doesn't crash the
 // whole nav build.
 function getTitleForSlug(slug: string): string {
+  if (isProd()) {
+    const cached = __titleCache.get(slug);
+    if (cached !== undefined) return cached;
+  }
+  const title = readTitleForSlug(slug);
+  if (isProd()) __titleCache.set(slug, title);
+  return title;
+}
+
+function readTitleForSlug(slug: string): string {
   const filePath = path.join(CONTENT_DIR, `${slug}.mdx`);
   if (!fs.existsSync(filePath)) {
     return titleFromSlug(slug);

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
@@ -176,8 +176,21 @@ function getTitleForSlug(slug: string): string {
 }
 
 function readTitleForSlug(slug: string): string {
-  const filePath = path.join(CONTENT_DIR, `${slug}.mdx`);
-  if (!fs.existsSync(filePath)) {
+  // Mirror the lookup precedence used by the page handler below
+  // (`${slug}.mdx` first, then `${slug}/index.mdx`). Without the
+  // index.mdx fallback the sidebar would show a slug-derived title
+  // (e.g. "Foo") while the page itself renders the real frontmatter
+  // title, silently diverging whenever content is authored as
+  // `foo/index.mdx`.
+  const flatPath = path.join(CONTENT_DIR, `${slug}.mdx`);
+  const indexPath = path.join(CONTENT_DIR, slug, "index.mdx");
+  let filePath: string | null = null;
+  if (fs.existsSync(flatPath)) {
+    filePath = flatPath;
+  } else if (fs.existsSync(indexPath)) {
+    filePath = indexPath;
+  }
+  if (!filePath) {
     return titleFromSlug(slug);
   }
   let raw: string;
@@ -417,25 +430,51 @@ export default async function AgUiDocPage({
   }
 
   let content = "";
-  let title = titleFromSlug(slugPath) || "AG-UI";
+  // `titleFromSlug` always returns a non-empty string here: slugPath is
+  // guaranteed non-empty by the `isOverview` early-return above, so the
+  // `last || slug` path in `titleFromSlug` can't collapse to "" for this
+  // call site. The prior `|| "AG-UI"` fallback was dead code — removed.
+  let title = titleFromSlug(slugPath);
   try {
     const parsed = matter(source);
     content = stripLeadingImports(parsed.content);
-    if (typeof parsed.data.title === "string" && parsed.data.title.length > 0) {
-      title = parsed.data.title;
-    } else {
-      const headingMatch = parsed.content.match(/^#\s+(.+)$/m);
-      if (headingMatch) title = headingMatch[1];
+    // Extract the body's first H1 (if any) separately so we can compare
+    // it against the frontmatter title before deciding to strip it.
+    // Match on `content` (post-`stripLeadingImports`) rather than
+    // `parsed.content`: import lines live above the H1 in the raw body,
+    // so the anchored `^…#\s+` regex wouldn't match until they're gone.
+    // CRLF support: `.` doesn't match `\r`, so match `(.+?)` up to
+    // `\r?\n` to handle both LF and CRLF MDX sources.
+    const bodyH1Match = content.match(/^(\s*\r?\n)*#\s+(.+?)\s*\r?\n/);
+    const bodyH1 = bodyH1Match ? bodyH1Match[2].trim() : null;
+    const fmTitle =
+      typeof parsed.data.title === "string" && parsed.data.title.length > 0
+        ? parsed.data.title
+        : null;
+    if (fmTitle) {
+      title = fmTitle;
+    } else if (bodyH1) {
+      title = bodyH1;
     }
     // The page wrapper below renders `title` inside its own <h1>. If the
-    // MDX body also leads with a `# Title` heading — which is the common
-    // case, since that's how we extract the title when frontmatter is
-    // absent — MDXRemote renders a second h1 and the page shows two
-    // stacked titles. Strip one leading `# …` line (skipping any blank
-    // lines above it) so the body picks up from the body text. We only
-    // strip the FIRST heading and only when it's the first non-blank
-    // content line, so code fences and deeper headings are untouched.
-    content = content.replace(/^(\s*\n)*#\s+.+\n?/, "");
+    // MDX body also leads with a `# Title` heading MDXRemote renders a
+    // second h1 and the page shows two stacked titles. Strip the leading
+    // body H1 ONLY when:
+    //   - there was no FM title (we're using the body H1 AS the page
+    //     title, so stripping avoids the duplicate), OR
+    //   - the FM title and body H1 match after whitespace normalization
+    //     (same title, just duplicated between FM and body).
+    // If FM title and body H1 differ, leave the body H1 intact so we
+    // don't silently drop a distinct section heading. Regex uses
+    // `\r?\n` to handle CRLF-authored MDX.
+    if (bodyH1) {
+      const normalizedFm = fmTitle?.replace(/\s+/g, " ").trim() ?? null;
+      const normalizedBody = bodyH1.replace(/\s+/g, " ").trim();
+      const shouldStrip = !normalizedFm || normalizedFm === normalizedBody;
+      if (shouldStrip) {
+        content = content.replace(/^(\s*\r?\n)*#\s+.+\r?\n?/, "");
+      }
+    }
   } catch (err) {
     console.error(`[ag-ui] Failed to parse MDX in ${filePath}:`, err);
     notFound();

--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -19,6 +19,16 @@ import {
 import { stripLeadingImports } from "@/lib/docs-render";
 import { safeReadFileSync } from "@/lib/safe-fs";
 
+// Title-Case a slug segment. `my-component` → `My Component`. The
+// previous `capitalize` Tailwind class only cased the first letter of
+// the whole segment, so hyphenated segments came out as `My-component`.
+function titleCase(slugSegment: string): string {
+  return slugSegment
+    .split("-")
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}
+
 // next-mdx-remote components map
 const mdxComponents = {
   PropertyReference,
@@ -66,6 +76,15 @@ export default async function ReferenceSlugPage({
   const cleanedContent = stripLeadingImports(content);
 
   const allItems = loadAllReferenceItems();
+  // Derive the sidebar category list from the loaded items rather than
+  // hardcoding — a new top-level subdir in src/content/reference/ (added
+  // via REFERENCE_SUBDIRS in reference-items.ts) picks up automatically
+  // without a second edit here. Stable order: lexical sort on the
+  // category label, which matches the current alphabetical layout
+  // (Components, Hooks).
+  const categories = Array.from(new Set(allItems.map((i) => i.category))).sort(
+    (a, b) => a.localeCompare(b),
+  );
   const title =
     typeof data.title === "string" && data.title.length > 0
       ? data.title
@@ -86,7 +105,7 @@ export default async function ReferenceSlugPage({
               Reference
             </Link>
           </div>
-          {["Components", "Hooks"].map((cat) => (
+          {categories.map((cat) => (
             <div key={cat}>
               <div className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-2">
                 {cat}
@@ -129,7 +148,7 @@ export default async function ReferenceSlugPage({
               Reference
             </Link>
             {" / "}
-            <span className="capitalize">{slug[0]}</span>
+            <span>{titleCase(slug[0])}</span>
           </div>
           <h1 className="text-2xl font-bold text-[var(--text)]">{title}</h1>
           {description && (

--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -54,7 +54,15 @@ export default async function ReferenceSlugPage({
   // slugPath is user-supplied (URL segments). Route the filesystem read
   // through safeReadFileSync so crafted paths like `..%2F..%2Fsecrets`
   // can't escape REFERENCE_CONTENT_DIR.
-  const raw = safeReadFileSync(REFERENCE_CONTENT_DIR, `${slugPath}.mdx`);
+  //
+  // Try `${slugPath}.mdx` first, then fall back to `${slugPath}/index.mdx`.
+  // This mirrors docs-render's `loadDoc` and matches the slug normalization
+  // in reference-items.ts's `walkMdx`, which collapses `foo/index.mdx` into
+  // slug `foo` — so a file at `components/foo/index.mdx` is reachable at
+  // `/reference/components/foo` rather than 404ing.
+  const raw =
+    safeReadFileSync(REFERENCE_CONTENT_DIR, `${slugPath}.mdx`) ??
+    safeReadFileSync(REFERENCE_CONTENT_DIR, `${slugPath}/index.mdx`);
   if (raw === null) {
     notFound();
   }
@@ -67,7 +75,7 @@ export default async function ReferenceSlugPage({
     data = parsed.data;
   } catch (err) {
     console.error(
-      `[reference] Failed to parse frontmatter in ${slugPath}.mdx:`,
+      `[reference] Failed to parse frontmatter for slug ${slugPath}:`,
       err,
     );
     notFound();
@@ -85,10 +93,15 @@ export default async function ReferenceSlugPage({
   const categories = Array.from(new Set(allItems.map((i) => i.category))).sort(
     (a, b) => a.localeCompare(b),
   );
+  // Apply `titleCase` to the slug fallback so the <h1> matches the
+  // breadcrumb style (e.g. `my-component` → `My Component`). Previously
+  // the fallback echoed the raw slug segment, so a page without a FM
+  // title showed `my-component` in the heading but `My Component` in
+  // the breadcrumb one line above.
   const title =
     typeof data.title === "string" && data.title.length > 0
       ? data.title
-      : slug[slug.length - 1];
+      : titleCase(slug[slug.length - 1]);
   const description =
     typeof data.description === "string" ? data.description : undefined;
 

--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -283,16 +283,31 @@ export function BrandNav() {
                 </Link>
               ))}
             </div>
-            {/* AG-UI link at bottom */}
+            {/* Cross-brand link at bottom — mirrors the top-nav brand
+                switcher, pointing at whichever brand ISN'T currently
+                active. Previously hardcoded to `/ag-ui`, which sent
+                users from an AG-UI page back to the AG-UI homepage
+                (same brand) instead of crossing over to CopilotKit. */}
             <div className="mt-auto px-4 py-4 border-t border-[var(--border)]">
-              <Link
-                href="/ag-ui"
-                onClick={() => setMobileMenuOpen(false)}
-                className="flex items-center gap-2 rounded-md px-3 py-2.5 text-[13px] font-medium text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-all"
-              >
-                <AgUiIcon />
-                AG-UI
-              </Link>
+              {active === "ag-ui" ? (
+                <Link
+                  href="/"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className="flex items-center gap-2 rounded-md px-3 py-2.5 text-[13px] font-medium text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-all"
+                >
+                  <CopilotKitIcon />
+                  CopilotKit
+                </Link>
+              ) : (
+                <Link
+                  href="/ag-ui"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className="flex items-center gap-2 rounded-md px-3 py-2.5 text-[13px] font-medium text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-all"
+                >
+                  <AgUiIcon />
+                  AG-UI
+                </Link>
+              )}
             </div>
           </div>
           <style jsx global>{`

--- a/showcase/shell-docs/src/components/brand-nav.tsx
+++ b/showcase/shell-docs/src/components/brand-nav.tsx
@@ -119,8 +119,6 @@ function AgUiIcon({ className }: { className?: string }) {
 
 type Brand = "copilotkit" | "ag-ui";
 
-const AG_UI_PREFIXES = ["/ag-ui"];
-
 const COPILOTKIT_LINKS = [
   { href: "/docs", label: "Docs" },
   { href: "/integrations", label: "Integrations" },
@@ -135,22 +133,15 @@ const AG_UI_LINKS = [
   { href: "/ag-ui/sdk/python/core/overview", label: "Python SDK" },
 ];
 
+// Match `/ag-ui` exactly OR `/ag-ui/...`, but NOT `/ag-ui-anything` —
+// a bare `startsWith("/ag-ui")` would incorrectly classify a hypothetical
+// `/ag-ui-foo` slug as AG-UI, which misroutes the nav.
 function activeBrandFromPath(pathname: string): Brand {
-  return AG_UI_PREFIXES.some((p) => pathname.startsWith(p))
-    ? "ag-ui"
-    : "copilotkit";
+  if (pathname === "/ag-ui" || pathname.startsWith("/ag-ui/")) return "ag-ui";
+  return "copilotkit";
 }
 
-export interface BrandNavProps {
-  // Note: the framework selector previously lived in the top bar. It's
-  // now rendered at the top of the docs sidebar instead — mirroring the
-  // docs.copilotkit.ai reference. Props preserved for API compatibility
-  // with the current call site but intentionally unused here.
-  frameworkOptions?: unknown;
-  frameworkCategoryOrder?: unknown;
-}
-
-export function BrandNav(_props: BrandNavProps = {}) {
+export function BrandNav() {
   const pathname = usePathname();
   const active = activeBrandFromPath(pathname);
   const links = active === "copilotkit" ? COPILOTKIT_LINKS : AG_UI_LINKS;
@@ -248,9 +239,10 @@ export function BrandNav(_props: BrandNavProps = {}) {
             className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
             onClick={() => setMobileMenuOpen(false)}
           />
-          {/* Panel */}
+          {/* Panel — explicitly layered above the backdrop (z-[51] vs z-50)
+              so layering doesn't rely on DOM sibling order. */}
           <div
-            className="fixed top-0 right-0 bottom-0 z-50 w-[280px] bg-[var(--bg-surface)] border-l border-[var(--border)] flex flex-col"
+            className="fixed top-0 right-0 bottom-0 z-[51] w-[280px] bg-[var(--bg-surface)] border-l border-[var(--border)] flex flex-col"
             style={{
               boxShadow: "-8px 0 30px rgba(0,0,0,0.1)",
               animation: "mobileMenuSlideIn 0.2s ease",

--- a/showcase/shell-docs/src/components/docs-callout.tsx
+++ b/showcase/shell-docs/src/components/docs-callout.tsx
@@ -80,6 +80,17 @@ const PALETTE: Record<
 };
 
 export function Callout({ type = "info", title, children }: CalloutProps) {
+  // Warn (dev only) when an unknown type slips past TS — e.g. from MDX
+  // authors passing a raw string. Silent fallback to `info` masks typos.
+  if (
+    process.env.NODE_ENV !== "production" &&
+    !Object.prototype.hasOwnProperty.call(PALETTE, type)
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[docs-callout] unknown type "${type}" — falling back to "info". Known types: ${Object.keys(PALETTE).join(", ")}`,
+    );
+  }
   const palette = PALETTE[type] ?? PALETTE.info;
   const icon = ICON[type] ?? ICON.info;
   const heading = title ?? palette.title;

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -111,15 +111,10 @@ export async function DocsPageView({
     }
     if (node.type === "page") {
       const isActive = node.slug === slugPath;
-      const scope: "docs" | "framework" = slugHrefPrefix.startsWith("/docs")
-        ? "docs"
-        : "framework";
       return (
         <div style={{ paddingLeft: `${indent}px` }} key={node.slug}>
           <SidebarLink
             slug={node.slug}
-            scope={scope}
-            fallbackHref={`${slugHrefPrefix}/${node.slug}`}
             active={isActive}
             className={`block py-[5px] text-[13px] transition-colors ${
               isActive

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -82,7 +82,28 @@ export async function DocsPageView({
     );
   }
 
-  const rawContent = doc.source.replace(/^---[\s\S]*?---\n?/, "");
+  // Strip the YAML frontmatter block. `\r?\n?` at the tail handles both
+  // LF- and CRLF-authored MDX; otherwise Windows line endings leave the
+  // trailing `\r\n` after the closing `---` in the rendered body.
+  let rawContent = doc.source.replace(/^---[\s\S]*?---\r?\n?/, "");
+
+  // The page wrapper below renders `doc.fm.title` inside its own <h1>. If the
+  // MDX body also leads with a `# Title` heading MDXRemote renders a second
+  // h1 and the page shows two stacked titles. Strip the leading body H1 ONLY
+  // when it matches the FM title after whitespace normalization — otherwise
+  // a distinct body heading would be silently dropped. Mirrors the ag-ui
+  // route's behavior (see app/ag-ui/[[...slug]]/page.tsx). CRLF-safe: the
+  // regex uses `\r?\n` so Windows-authored MDX is handled.
+  const bodyH1Match = rawContent.match(/^(\s*\r?\n)*#\s+(.+?)\s*\r?\n/);
+  const bodyH1 = bodyH1Match ? bodyH1Match[2].trim() : null;
+  if (bodyH1) {
+    const normalizedFm = doc.fm.title.replace(/\s+/g, " ").trim();
+    const normalizedBody = bodyH1.replace(/\s+/g, " ").trim();
+    if (normalizedFm === normalizedBody) {
+      rawContent = rawContent.replace(/^(\s*\r?\n)*#\s+.+\r?\n?/, "");
+    }
+  }
+
   const inlined = inlineSnippets(rawContent, slugPath);
   const content = convertTablesInJSX(inlined);
 

--- a/showcase/shell-docs/src/components/docs-steps.tsx
+++ b/showcase/shell-docs/src/components/docs-steps.tsx
@@ -9,19 +9,23 @@ import React from "react";
 
 export function Steps({ children }: { children: React.ReactNode }) {
   // Walk children and wrap each Step with its auto-assigned number.
-  const items = React.Children.toArray(children).filter((c) =>
-    React.isValidElement(c),
+  // Filter to <Step> elements specifically so nested non-Step valid
+  // elements (e.g. stray <div> spacers from MDX authors) don't receive
+  // bogus `__index`/`__total` props which React would pass straight
+  // through to the DOM and warn about.
+  const items = React.Children.toArray(children).filter(
+    (c): c is React.ReactElement<StepProps> =>
+      React.isValidElement(c) && c.type === Step,
   );
   const numbered = items.map((child, idx) =>
-    React.isValidElement(child)
-      ? React.cloneElement(child as React.ReactElement<StepProps>, {
-          __index: idx + 1,
-          __total: items.length,
-        })
-      : child,
+    React.cloneElement(child, {
+      __index: idx + 1,
+      __total: items.length,
+    }),
   );
   return (
     <div
+      role="list"
       style={{
         position: "relative",
         paddingLeft: "2rem",
@@ -47,6 +51,7 @@ export function Step({ title, children, __index, __total }: StepProps) {
     __index !== undefined && __total !== undefined && __index === __total;
   return (
     <div
+      role="listitem"
       style={{
         position: "relative",
         paddingBottom: isLast ? "0" : "1.5rem",

--- a/showcase/shell-docs/src/components/docs-tabs.tsx
+++ b/showcase/shell-docs/src/components/docs-tabs.tsx
@@ -13,7 +13,13 @@
 
 "use client";
 
-import React, { useState, useMemo, Children, isValidElement } from "react";
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  Children,
+  isValidElement,
+} from "react";
 
 interface TabsProps {
   items?: string[];
@@ -41,9 +47,53 @@ export function Tabs({ items, defaultValue, children }: TabsProps) {
   }, [children]);
 
   const labels = items ?? kids.map((k) => k.label);
+
+  // Warn (dev only) when author-supplied `items` count diverges from the
+  // number of <Tab> children — silent drops hide authoring mistakes.
+  if (
+    process.env.NODE_ENV !== "production" &&
+    items &&
+    items.length !== kids.length
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[docs-tabs] items.length (${items.length}) !== children count (${kids.length}). Extra entries will be silently dropped.`,
+    );
+  }
+
+  // Warn (dev only) on duplicate labels — React reconciliation keys on
+  // label below, so duplicates corrupt which panel is shown.
+  if (process.env.NODE_ENV !== "production") {
+    const seen = new Set<string>();
+    for (const l of labels) {
+      if (seen.has(l)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[docs-tabs] duplicate label "${l}" — labels must be unique.`,
+        );
+        break;
+      }
+      seen.add(l);
+    }
+  }
+
   const [active, setActive] = useState<string>(
     defaultValue ?? labels[0] ?? "Tab",
   );
+
+  // Re-sync active selection when labels change after mount (e.g. MDX
+  // author swapped tab titles, or an HMR edit changed the set). useState
+  // only seeds its initial value once, so without this effect an active
+  // tab whose label disappeared would leave the panel stuck empty.
+  const labelsKey = labels.join("|");
+  useEffect(() => {
+    if (!labels.includes(active)) {
+      setActive(defaultValue ?? labels[0] ?? "Tab");
+    }
+    // labelsKey intentionally used as a proxy for labels — avoids array
+    // identity churn every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [labelsKey, defaultValue]);
 
   return (
     <div
@@ -65,11 +115,13 @@ export function Tabs({ items, defaultValue, children }: TabsProps) {
           gap: "0.25rem",
         }}
       >
-        {labels.map((label) => {
+        {labels.map((label, i) => {
           const isActive = label === active;
           return (
             <button
-              key={label}
+              // Key includes the index so duplicate labels (warned above)
+              // don't collide and break React reconciliation.
+              key={`${label}-${i}`}
               role="tab"
               aria-selected={isActive}
               onClick={() => setActive(label)}

--- a/showcase/shell-docs/src/components/docs-tabs.tsx
+++ b/showcase/shell-docs/src/components/docs-tabs.tsx
@@ -146,11 +146,21 @@ export function Tabs({ items, defaultValue, children }: TabsProps) {
         })}
       </div>
       <div style={{ padding: "1rem" }}>
-        {kids
-          .filter((k) => k.label === active)
-          .map((k, i) => (
-            <React.Fragment key={i}>{k.content}</React.Fragment>
-          ))}
+        {(() => {
+          // Body selection is strictly positional: `labels[i]` is paired
+          // with `kids[i]` regardless of whether `labels` came from the
+          // `items` prop or was derived from child props. This avoids the
+          // items-vs-child-label-mismatch trap (author-supplied `items`
+          // rarely match each <Tab>'s `value ?? title ?? "Tab"`) and it
+          // also sidesteps duplicate-label double-render — `.find` would
+          // at least be single, but pairing by index is the actual
+          // contract MDX authors reason about.
+          const idx = labels.findIndex((l) => l === active);
+          if (idx < 0) return null;
+          const kid = kids[idx];
+          if (!kid) return null;
+          return <React.Fragment key={idx}>{kid.content}</React.Fragment>;
+        })()}
       </div>
     </div>
   );

--- a/showcase/shell-docs/src/components/error-boundary-card.tsx
+++ b/showcase/shell-docs/src/components/error-boundary-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+// Shared error-boundary card rendered by Next.js route-level error.tsx
+// handlers. Each route (app/[[...slug]]/error.tsx, app/ag-ui/[[...slug]]/error.tsx)
+// previously copy-pasted an identical component tree; this component is
+// the single source of truth. Route-level error.tsx files remain
+// required by Next.js (it discovers them per route segment) — they're
+// now thin wrappers that forward props into this card with a log
+// `scope` string so server logs / devtools can tell which route segment
+// blew up.
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+export interface ErrorBoundaryCardProps {
+  /** Human-readable route-segment label used to tag the console.error
+   * (e.g. `docs`, `ag-ui`). Prefixed onto the log line so multiple
+   * nested error boundaries don't produce identical log entries. */
+  scope: string;
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export function ErrorBoundaryCard({
+  scope,
+  error,
+  reset,
+}: ErrorBoundaryCardProps) {
+  const pathname = usePathname();
+  useEffect(() => {
+    // Log the full Error instance (not just .message/.digest) so the
+    // stack trace reaches the server log / browser devtools. Include
+    // pathname where available so reports can be tied back to a page.
+    console.error(
+      `[${scope}] Page render error${pathname ? ` on ${pathname}` : ""}:`,
+      error,
+    );
+  }, [scope, error, pathname]);
+
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="text-center max-w-md">
+        <h2 className="text-lg font-semibold text-[var(--text)] mb-2">
+          Something went wrong
+        </h2>
+        <p className="text-sm text-[var(--text-muted)] mb-4">
+          We hit an error rendering this page. Please refresh, and if it keeps
+          happening, report it with the ID below so we can track it down.
+        </p>
+        {error.digest && (
+          <p className="text-xs text-[var(--text-faint)] mb-4 font-mono">
+            Error ID: {error.digest}
+          </p>
+        )}
+        <button
+          onClick={reset}
+          className="px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/components/error-boundary-card.tsx
+++ b/showcase/shell-docs/src/components/error-boundary-card.tsx
@@ -27,6 +27,16 @@ export function ErrorBoundaryCard({
   reset,
 }: ErrorBoundaryCardProps) {
   const pathname = usePathname();
+  // Depend on stable primitives (message + digest) rather than the `error`
+  // object itself. Next.js re-wraps the error across renders (and remounts
+  // the boundary on `reset()`), so a dep array of `[scope, error, pathname]`
+  // fires the effect repeatedly on identity change and emits duplicate
+  // console.error lines / telemetry. `message` and `digest` are strings and
+  // identity-stable for a given error. Fall back to empty-string for
+  // `message` in case an exception without a message slipped through
+  // (e.g. `throw new Error()`); `digest` is already optional on the type.
+  const errorMessage = error?.message ?? "";
+  const errorDigest = error?.digest;
   useEffect(() => {
     // Log the full Error instance (not just .message/.digest) so the
     // stack trace reaches the server log / browser devtools. Include
@@ -35,7 +45,8 @@ export function ErrorBoundaryCard({
       `[${scope}] Page render error${pathname ? ` on ${pathname}` : ""}:`,
       error,
     );
-  }, [scope, error, pathname]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope, errorMessage, errorDigest, pathname]);
 
   return (
     <div className="flex items-center justify-center min-h-[50vh]">

--- a/showcase/shell-docs/src/components/framework-provider.tsx
+++ b/showcase/shell-docs/src/components/framework-provider.tsx
@@ -139,10 +139,28 @@ export function FrameworkProvider({
   // both `stored` and `storageAvailable`; in private-mode browsers
   // where the read throws, `storageAvailable` stays false so consumers
   // can branch on "we can't persist your pick".
+  //
+  // Validate the retrieved slug against the known registry — same
+  // contract as `setStoredFramework` and the cross-tab `storage` handler.
+  // A stale localStorage entry from a framework slug that was later
+  // removed from the registry must not seed `stored`, otherwise
+  // RouterPivot would redirect users to a non-existent framework page.
+  // Clear the poisoned key so it stops haunting subsequent loads.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const result = readStoredFramework();
-    setStored(result.value);
     setStorageAvailable(result.available);
+    if (result.value !== null && !knownFrameworks.includes(result.value)) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          `[framework-provider] ignoring stored framework with unknown slug "${result.value}" — clearing`,
+        );
+      }
+      writeStoredFramework(null);
+      setStored(null);
+      return;
+    }
+    setStored(result.value);
   }, []);
 
   // Cross-tab sync — when ANOTHER tab writes `selectedFramework`, our
@@ -161,11 +179,24 @@ export function FrameworkProvider({
       // Scoped reads can pass null for e.newValue when the key is
       // removed; that's legitimately "cleared" and should null out
       // our state rather than be ignored.
+      //
+      // Validate non-null values against the known registry — same
+      // contract as `setStoredFramework` below. A cross-tab write of an
+      // arbitrary string (stale tab, browser extension, dev tools) must
+      // not poison this tab's state.
+      if (e.newValue !== null && !knownFrameworks.includes(e.newValue)) {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(
+            `[framework-provider] ignoring cross-tab storage write with unknown slug "${e.newValue}"`,
+          );
+        }
+        return;
+      }
       setStored(e.newValue);
     };
     window.addEventListener("storage", handler);
     return () => window.removeEventListener("storage", handler);
-  }, []);
+  }, [knownFrameworks]);
 
   // Whenever the URL asserts a framework, persist it so the preference
   // follows the user when they navigate back to /docs/*.

--- a/showcase/shell-docs/src/components/framework-provider.tsx
+++ b/showcase/shell-docs/src/components/framework-provider.tsx
@@ -41,6 +41,16 @@ export interface FrameworkContextValue {
    * without implying the current view is scoped to it.
    */
   storedFramework: string | null;
+  /**
+   * Whether the browser exposes usable localStorage. Lets consumers
+   * distinguish "user has never picked a framework" (`storedFramework`
+   * null, `storageAvailable` true) from "storage is unavailable so we
+   * can't know" (`storedFramework` null, `storageAvailable` false).
+   * Without this tri-state, a private-mode / cookies-disabled browser
+   * would look identical to a fresh visitor, and UIs that want to warn
+   * about lost persistence have no signal.
+   */
+  storageAvailable: boolean;
   /** All known framework slugs derived from the registry. */
   knownFrameworks: string[];
   /** Persist a new framework preference (does not navigate). */
@@ -58,16 +68,30 @@ const STORAGE_KEY = "selectedFramework";
 let readLogged = false;
 let writeLogged = false;
 
-function readStoredFramework(): string | null {
-  if (typeof window === "undefined") return null;
+interface ReadResult {
+  value: string | null;
+  /**
+   * False when localStorage threw (private mode, cookies disabled,
+   * storage quota blown, etc). Callers MUST treat this as a separate
+   * signal from `value === null` — the latter is "never set", the
+   * former is "we can't tell".
+   */
+  available: boolean;
+}
+
+function readStoredFramework(): ReadResult {
+  if (typeof window === "undefined") return { value: null, available: false };
   try {
-    return window.localStorage.getItem(STORAGE_KEY);
+    return {
+      value: window.localStorage.getItem(STORAGE_KEY),
+      available: true,
+    };
   } catch (err) {
     if (!readLogged) {
       console.warn("[framework-provider] localStorage read failed", err);
       readLogged = true;
     }
-    return null;
+    return { value: null, available: false };
   }
 }
 
@@ -104,10 +128,43 @@ export function FrameworkProvider({
   }, [pathname, knownFrameworks]);
 
   const [stored, setStored] = useState<string | null>(null);
+  // Start false on both server and initial client render to keep SSR
+  // and hydration output identical. Flipped to the real value in the
+  // mount effect below.
+  const [storageAvailable, setStorageAvailable] = useState<boolean>(false);
 
-  // Hydrate stored framework on client mount
+  // Hydrate stored framework on client mount.
+  //
+  // Covered by: first client render reads localStorage once and seeds
+  // both `stored` and `storageAvailable`; in private-mode browsers
+  // where the read throws, `storageAvailable` stays false so consumers
+  // can branch on "we can't persist your pick".
   useEffect(() => {
-    setStored(readStoredFramework());
+    const result = readStoredFramework();
+    setStored(result.value);
+    setStorageAvailable(result.available);
+  }, []);
+
+  // Cross-tab sync — when ANOTHER tab writes `selectedFramework`, our
+  // current tab's `stored` falls out of sync until a full reload.
+  // `storage` events fire on every tab EXCEPT the one that wrote, so
+  // this is safe against self-echo loops.
+  //
+  // Covered by: Tab A picks langgraph-python; Tab B (already open on
+  // /docs/foo) immediately updates its StoredFrameworkHighlight badge
+  // and RouterPivot redirects without a reload. Clearing storage in
+  // Tab A (`e.newValue === null`) likewise clears Tab B's `stored`.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (e: StorageEvent) => {
+      if (e.key !== STORAGE_KEY) return;
+      // Scoped reads can pass null for e.newValue when the key is
+      // removed; that's legitimately "cleared" and should null out
+      // our state rather than be ignored.
+      setStored(e.newValue);
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
   }, []);
 
   // Whenever the URL asserts a framework, persist it so the preference
@@ -118,6 +175,10 @@ export function FrameworkProvider({
   // ping-pong with the state setter below). We only care about URL
   // changes as the trigger. The internal `!== stored` check short-circuits
   // the no-op case using the latest closed-over value.
+  //
+  // Covered by: navigating /docs/foo → /langgraph-python/foo persists
+  // once and does NOT re-fire when the setter updates `stored`; subsequent
+  // navigation to /langgraph-python/bar (same framework) is a no-op.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (urlFramework && urlFramework !== stored) {
@@ -149,6 +210,7 @@ export function FrameworkProvider({
   const value: FrameworkContextValue = {
     framework,
     storedFramework: stored,
+    storageAvailable,
     knownFrameworks,
     setStoredFramework,
   };

--- a/showcase/shell-docs/src/components/framework-selector.tsx
+++ b/showcase/shell-docs/src/components/framework-selector.tsx
@@ -81,7 +81,7 @@ export function FrameworkSelector({
   // Close on outside-click / Escape
   useEffect(() => {
     if (!open) return;
-    const handleClick = (e: MouseEvent) => {
+    const handleClick = (e: MouseEvent | TouchEvent) => {
       // `e.target` is typed as `EventTarget | null`; `Node.contains`
       // requires an actual `Node`. Guard instead of casting so we don't
       // silently invoke `contains` with non-DOM targets (e.g. events
@@ -100,9 +100,14 @@ export function FrameworkSelector({
       if (e.key === "Escape") setOpen(false);
     };
     document.addEventListener("mousedown", handleClick);
+    // iOS Safari doesn't always fire `mousedown` for taps that land
+    // outside focusable UI — mirror the handler on `touchstart` so the
+    // panel closes on mobile as expected.
+    document.addEventListener("touchstart", handleClick);
     document.addEventListener("keydown", handleKey);
     return () => {
       document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("touchstart", handleClick);
       document.removeEventListener("keydown", handleKey);
     };
   }, [open]);

--- a/showcase/shell-docs/src/components/framework-selector.tsx
+++ b/showcase/shell-docs/src/components/framework-selector.tsx
@@ -298,15 +298,31 @@ export function FrameworkSelector({
                 </div>
                 {opts.map((opt) => {
                   const isActive = opt.slug === framework;
+                  // Undeployed frameworks must not be selectable — picking
+                  // one persists the slug to storedFramework, which then
+                  // traps the user in a RouterPivot redirect loop on every
+                  // `/docs/*` visit because the destination doesn't exist.
+                  const isDisabled = !opt.deployed;
                   return (
                     <button
                       key={opt.slug}
                       type="button"
-                      onClick={() => selectFramework(opt.slug)}
-                      className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer ${
+                      disabled={isDisabled}
+                      aria-disabled={isDisabled}
+                      onClick={() => {
+                        if (isDisabled) return;
+                        selectFramework(opt.slug);
+                      }}
+                      className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-[13px] transition-colors ${
+                        isDisabled
+                          ? "cursor-not-allowed opacity-60 text-[var(--text-muted)]"
+                          : "cursor-pointer"
+                      } ${
                         isActive
                           ? "bg-[var(--accent-light)] text-[var(--accent)]"
-                          : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
+                          : isDisabled
+                            ? ""
+                            : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
                       }`}
                     >
                       {opt.logo ? (

--- a/showcase/shell-docs/src/components/framework-tabs.tsx
+++ b/showcase/shell-docs/src/components/framework-tabs.tsx
@@ -1,17 +1,21 @@
 // <FrameworkTabs> — tabbed view of the same region rendered against
 // multiple integration frameworks' cells.
 //
-// Usage:
-//     <FrameworkTabs
-//       frameworks={["langgraph-python", "mastra", "crewai-crews"]}
-//       cell="agentic-chat"
-//       region="provider-setup"
-//     />
+// Usage (MDX):
+//     <FrameworkTabs frameworks={["langgraph-python", "mastra", "crewai-crews"]}>
+//       <Snippet framework="langgraph-python" cell="agentic-chat" region="provider-setup" />
+//       <Snippet framework="mastra"           cell="agentic-chat" region="provider-setup" />
+//       <Snippet framework="crewai-crews"     cell="agentic-chat" region="provider-setup" />
+//     </FrameworkTabs>
 //
-// Each tab runs <Snippet framework=... cell=... region=...>. When a
-// framework is missing that region/cell the Snippet's built-in warning
-// box surfaces inline, so authors get a clear signal to tag the missing
-// region in the corresponding cell.
+// The authored MDX passes one server-rendered <Snippet> per framework
+// as children, in the same order as `frameworks`. Mapping is strictly
+// positional (`frameworks[i]` ↔ children[i]), so children counts must
+// match `frameworks.length`. When a framework is missing that region
+// the Snippet's built-in warning box surfaces inline, so authors still
+// get a clear signal to tag the missing region in the corresponding
+// cell (and, critically, Snippet emits a non-null element so the
+// positional mapping holds).
 //
 // FrameworkTabs is intentionally **client-side** (uses useState for the
 // active tab). The inner <Snippet> is a server component — Next.js will
@@ -21,21 +25,10 @@
 
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 interface FrameworkTabsProps {
   frameworks: string[];
-  /**
-   * `cell` and `region` are authored-facing props that describe WHICH
-   * snippet region each tab should surface. They are consumed by the
-   * parent MDX renderer (see `docs-render.inlineSnippets`), which
-   * pre-renders one <Snippet> per framework on the server and emits
-   * them as `children` here. This component itself does not read them
-   * at runtime — they are documented on the interface for MDX authors
-   * and tooling (typed <FrameworkTabs> usage in MDX) only.
-   */
-  cell?: string;
-  region?: string;
   /** Render an alternative label for each framework (e.g. pretty names). */
   labels?: Record<string, string>;
   /** Pre-rendered <Snippet> content, keyed by framework slug. Populated by
@@ -51,14 +44,45 @@ export function FrameworkTabs({
 }: FrameworkTabsProps) {
   const [active, setActive] = useState<string>(frameworks[0] ?? "");
 
-  // children should be an array of <div data-framework="..."> wrappers.
-  // We filter + render the active one. This keeps all snippets rendered
-  // on the server (good: syntax highlighting) and client only swaps.
+  // Re-sync active selection when `frameworks` changes after mount (e.g.
+  // MDX author swapped the framework list, or an HMR edit changed the
+  // set). useState only seeds its initial value once, so without this
+  // effect an active tab whose slug disappeared from the list would
+  // leave the tab highlight blank and every body render null. Mirror
+  // the sibling pattern in docs-tabs.tsx.
+  const frameworksKey = frameworks.join("|");
+  useEffect(() => {
+    if (!frameworks.includes(active)) {
+      setActive(frameworks[0] ?? "");
+    }
+    // frameworksKey intentionally used as a proxy for frameworks —
+    // avoids array identity churn every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [frameworksKey]);
+
+  // children should be an array of server-rendered <Snippet> wrappers,
+  // one per framework in `frameworks`. We filter + render the active one.
+  // This keeps all snippets rendered on the server (good: syntax
+  // highlighting) and client only swaps.
+  //
   // Filter to valid elements so MDX whitespace text nodes between
   // <Snippet> siblings don't shift the index→framework mapping below.
-  const wrapped = React.Children.toArray(children).filter(
-    React.isValidElement,
-  );
+  const wrapped = React.Children.toArray(children).filter(React.isValidElement);
+
+  // Count mismatch is a hard authoring error: mapping is strictly
+  // positional (`frameworks[i]` ↔ `wrapped[i]`), so a Snippet that
+  // rendered null (region missing for that framework) would shift every
+  // subsequent tab's content onto the wrong framework. Surface in dev
+  // and refuse to render misleading content in prod rather than silently
+  // display the wrong snippet.
+  const countMismatch = wrapped.length !== frameworks.length;
+  if (process.env.NODE_ENV !== "production" && countMismatch) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[framework-tabs] frameworks.length (${frameworks.length}) !== rendered children (${wrapped.length}). ` +
+        `Every framework must emit exactly one child; refusing to render to avoid misaligned tab bodies.`,
+    );
+  }
 
   const displayLabel = (slug: string) =>
     labels?.[slug] ??
@@ -116,11 +140,13 @@ export function FrameworkTabs({
         })}
       </div>
       <div>
-        {wrapped.map((child, i) => {
-          const fw = frameworks[i];
-          if (fw !== active) return null;
-          return <React.Fragment key={fw}>{child}</React.Fragment>;
-        })}
+        {countMismatch
+          ? null
+          : wrapped.map((child, i) => {
+              const fw = frameworks[i];
+              if (fw !== active) return null;
+              return <React.Fragment key={fw}>{child}</React.Fragment>;
+            })}
       </div>
     </div>
   );

--- a/showcase/shell-docs/src/components/framework-tabs.tsx
+++ b/showcase/shell-docs/src/components/framework-tabs.tsx
@@ -25,8 +25,17 @@ import React, { useState } from "react";
 
 interface FrameworkTabsProps {
   frameworks: string[];
-  cell: string;
-  region: string;
+  /**
+   * `cell` and `region` are authored-facing props that describe WHICH
+   * snippet region each tab should surface. They are consumed by the
+   * parent MDX renderer (see `docs-render.inlineSnippets`), which
+   * pre-renders one <Snippet> per framework on the server and emits
+   * them as `children` here. This component itself does not read them
+   * at runtime — they are documented on the interface for MDX authors
+   * and tooling (typed <FrameworkTabs> usage in MDX) only.
+   */
+  cell?: string;
+  region?: string;
   /** Render an alternative label for each framework (e.g. pretty names). */
   labels?: Record<string, string>;
   /** Pre-rendered <Snippet> content, keyed by framework slug. Populated by
@@ -45,7 +54,11 @@ export function FrameworkTabs({
   // children should be an array of <div data-framework="..."> wrappers.
   // We filter + render the active one. This keeps all snippets rendered
   // on the server (good: syntax highlighting) and client only swaps.
-  const wrapped = React.Children.toArray(children);
+  // Filter to valid elements so MDX whitespace text nodes between
+  // <Snippet> siblings don't shift the index→framework mapping below.
+  const wrapped = React.Children.toArray(children).filter(
+    React.isValidElement,
+  );
 
   const displayLabel = (slug: string) =>
     labels?.[slug] ??

--- a/showcase/shell-docs/src/components/property-reference.tsx
+++ b/showcase/shell-docs/src/components/property-reference.tsx
@@ -13,6 +13,49 @@ type Props = {
   collapsable?: boolean;
 };
 
+/**
+ * Recursively walk a React children tree, cloning any PropertyReference
+ * encountered at ANY depth with `collapsable: true`. Non-PropertyReference
+ * elements (divs, Fragments, arbitrary wrapper components) are preserved
+ * with their structure intact and their own children deep-walked in turn.
+ *
+ * Why: React.Children.map only visits direct children. Authors frequently
+ * wrap nested PropertyReferences in layout elements (`<div>`, `<Fragment>`)
+ * or MDX-emitted wrappers; without deep walking, those nested references
+ * silently lose `collapsable` propagation. See caller's "Covered by:" note.
+ *
+ * We do NOT recurse into children whose `type` is PropertyReference itself
+ * — we only clone them with the new prop and stop. Their own auto-collapse
+ * logic runs at their render time with the updated prop.
+ */
+function deepMapPropertyReferences(node: React.ReactNode): React.ReactNode {
+  return React.Children.map(node, (child) => {
+    if (!React.isValidElement(child)) return child;
+
+    // PropertyReference: enhance and stop — don't recurse into its
+    // children, since that's the next PropertyReference's own concern.
+    if (child.type === PropertyReference) {
+      return React.cloneElement(child as React.ReactElement<Props>, {
+        collapsable: true,
+      });
+    }
+
+    // Any other element with children (div, Fragment, wrapper component):
+    // preserve the wrapper and recurse. Elements without children pass
+    // through untouched.
+    const childProps = child.props as { children?: React.ReactNode };
+    if (childProps && childProps.children !== undefined) {
+      return React.cloneElement(
+        child,
+        undefined,
+        deepMapPropertyReferences(childProps.children),
+      );
+    }
+
+    return child;
+  });
+}
+
 export function PropertyReference({
   children,
   name,
@@ -36,18 +79,18 @@ export function PropertyReference({
   // the `collapsable` prop never propagates. Reference equality is minifier-safe
   // because both sides point to the same function identity after bundling.
   //
-  // Known limitation: React.Children.map only walks *direct* children. A
-  // <PropertyReference> wrapped inside a <div> (or any other element) will NOT
-  // be detected here. Callers should nest PropertyReferences as direct
-  // siblings, not wrapped in other elements, for auto-collapse to work.
-  const enhancedChildren = React.Children.map(children, (child) => {
-    if (React.isValidElement(child) && child.type === PropertyReference) {
-      return React.cloneElement(child as React.ReactElement<Props>, {
-        collapsable: true,
-      });
-    }
-    return child;
-  });
+  // Deep walk: React.Children.map only walks *direct* children. Previously a
+  // <PropertyReference> wrapped in a <div> or <Fragment> was invisible and
+  // never received `collapsable: true`. `deepMapPropertyReferences` recurses
+  // into children's children, preserving the tree structure while applying
+  // the enhancement to every PropertyReference it finds at any depth. That
+  // lets authors use arbitrary wrapper layout (divs, fragments, etc.)
+  // around nested PropertyReferences without losing auto-collapse.
+  //
+  // Covered by: a <PropertyReference> containing <div><PropertyReference/></div>
+  // correctly renders the nested one with `collapsable: true`; direct-child
+  // nesting continues to work unchanged.
+  const enhancedChildren = deepMapPropertyReferences(children);
 
   const collapseClassName = `${isCollapsed ? "hidden" : ""}`;
 

--- a/showcase/shell-docs/src/components/router-pivot.tsx
+++ b/showcase/shell-docs/src/components/router-pivot.tsx
@@ -10,7 +10,7 @@
 // framework is selected — the router-page's job is to pivot, not to
 // serve code without the relevant backend context.
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useFramework } from "./framework-provider";
@@ -46,9 +46,19 @@ export interface RouterPivotProps {
  *   - Neither → render the body so the user sees the pivot + any MDX
  *     copy that accompanies it.
  *
+ * Hydration-flash guard: `storedFramework` is always null on the first
+ * render (localStorage is read in a mount effect). Without the
+ * `hasHydrated` gate below, a returning user who picked LangChain
+ * would briefly see the MDX body render, then disappear as the
+ * effect reads localStorage and flips `storedFramework` from null to
+ * "langgraph-python". The gate holds the body back until the first
+ * mount effect has run, swallowing that flash. Fresh visitors (who
+ * legitimately have null stored) see the content on the next tick;
+ * the delay is one microtask and invisible in practice.
+ *
  * Covered by: visit /docs/foo with no localStorage entry → MDX body
  * visible alongside the pivot; visit with localStorage=langgraph-python
- * → body hidden while redirect runs.
+ * → NO flash of docs body while redirect runs.
  */
 export function FrameworkGuardedContent({
   children,
@@ -56,9 +66,16 @@ export function FrameworkGuardedContent({
   children: React.ReactNode;
 }) {
   const { framework, storedFramework } = useFramework();
-  // Hide only when we're about to redirect to a framework-scoped page
-  // (URL framework present, or a stored preference will trigger
-  // redirect). When neither exists we want the pivot + MDX body.
+  const [hasHydrated, setHasHydrated] = useState(false);
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
+  // Before hydration, suppress — we don't yet know whether a stored
+  // framework exists, and rendering content we're about to hide
+  // causes a visible flash. After hydration, apply the normal rule:
+  // hide only when we're about to redirect to a framework-scoped
+  // page. When neither exists we want the pivot + MDX body.
+  if (!hasHydrated) return null;
   if (framework || storedFramework) return null;
   return <>{children}</>;
 }
@@ -73,6 +90,10 @@ export function RouterPivot({
 }: RouterPivotProps) {
   const router = useRouter();
   const { framework, storedFramework } = useFramework();
+  const [hasHydrated, setHasHydrated] = useState(false);
+  useEffect(() => {
+    setHasHydrated(true);
+  }, []);
 
   // Redirect target: prefer URL framework (should never happen on
   // `/docs/*` since that route prefix isn't a known framework, but we
@@ -94,6 +115,21 @@ export function RouterPivot({
       router.replace(`/${target}/${slugPath}`);
     }
   }, [target, router, slugPath]);
+
+  // Hydration-flash guard: `storedFramework` is null on the very first
+  // render (populated by a mount effect in FrameworkProvider). Without
+  // this gate, returning users see the full pivot grid render, then
+  // have it replaced by the "Loading …" placeholder one tick later as
+  // storedFramework flips from null to their stored slug.
+  //
+  // Covered by: returning user with localStorage=langgraph-python visits
+  // /docs/<feature> → sees the loading placeholder immediately, not a
+  // flash of the pivot grid.
+  if (!hasHydrated) {
+    return (
+      <div className="text-xs text-[var(--text-muted)]">Loading…</div>
+    );
+  }
 
   // If we have a redirect target we'll be redirected in a tick —
   // render a lightweight placeholder instead of the full pivot to

--- a/showcase/shell-docs/src/components/router-pivot.tsx
+++ b/showcase/shell-docs/src/components/router-pivot.tsx
@@ -126,9 +126,7 @@ export function RouterPivot({
   // /docs/<feature> → sees the loading placeholder immediately, not a
   // flash of the pivot grid.
   if (!hasHydrated) {
-    return (
-      <div className="text-xs text-[var(--text-muted)]">Loading…</div>
-    );
+    return <div className="text-xs text-[var(--text-muted)]">Loading…</div>;
   }
 
   // If we have a redirect target we'll be redirected in a tick —

--- a/showcase/shell-docs/src/components/sidebar-link.tsx
+++ b/showcase/shell-docs/src/components/sidebar-link.tsx
@@ -2,16 +2,8 @@
 
 // SidebarLink — framework-aware client-side anchor used for every
 // entry in the docs sidebar. Resolves its final href based on the
-// active FrameworkContext:
-//
-//   - When the consumer passes `scope="docs"` (i.e. we're rendering
-//     under `/docs/...`) and a framework is selected, rewrite the
-//     href to `/<framework>/<slug>` so clicking keeps the user in
-//     their chosen backend.
-//   - When the consumer passes `scope="framework"` (we're rendering
-//     under a framework-scoped page), always use the current
-//     framework for the href. If no framework is active we fall back
-//     to `/docs/<slug>`.
+// active FrameworkContext: when a framework is selected, the href is
+// `/<framework>/<slug>`; otherwise it falls through to `/docs/<slug>`.
 //
 // `framework` is URL-derived (see framework-provider) so the resolved
 // href is identical during SSR and post-hydration — no transient
@@ -29,18 +21,6 @@ export interface SidebarLinkProps {
   className?: string;
   /** Active-state data attribute. */
   active?: boolean;
-  /**
-   * The render context. `"docs"` = we're on `/docs/*`; `"framework"`
-   * = we're on `/<framework>/*`. Affects which prefix we prefer.
-   */
-  scope: "docs" | "framework";
-  /**
-   * Deprecated. Previously held a server-rendered best-guess href used
-   * before hydration; the component now resolves the href identically
-   * during SSR and on the client, so this value is ignored. Kept on the
-   * interface for call-site compatibility.
-   */
-  fallbackHref?: string;
 }
 
 export function SidebarLink({
@@ -48,15 +28,11 @@ export function SidebarLink({
   children,
   className,
   active,
-  scope: _scope,
-  fallbackHref: _fallbackHref,
 }: SidebarLinkProps) {
   const { framework } = useFramework();
 
-  // Both scopes currently resolve the same way: use the active
-  // framework when set, otherwise fall through to /docs/<slug>. We
-  // keep `scope` in the props for call-site clarity and future
-  // divergence without any runtime branching.
+  // Use the active framework when set, otherwise fall through to
+  // /docs/<slug>.
   const href = framework ? `/${framework}/${slug}` : `/docs/${slug}`;
 
   return (

--- a/showcase/shell-docs/src/components/snippet.tsx
+++ b/showcase/shell-docs/src/components/snippet.tsx
@@ -79,8 +79,10 @@ interface SnippetProps {
    */
   file?: string;
   /**
-   * Line range within the file — e.g. `"10-20"`, or a single line `"5"`.
-   * Applied only when `file` is set. Omit to render the full file.
+   * Line range within the file — e.g. `"10-20"`, a single line `"5"`, or a
+   * comma-separated list of ranges `"1-5,10-15"` (concatenated with a
+   * `// ...` separator between discontinuous sections). Applied only when
+   * `file` is set. Omit to render the full file.
    */
   lines?: string;
   /**
@@ -129,7 +131,12 @@ const warnedUnknownLanguages = new Set<string>();
 function resolveHljsLanguage(lang: string): string | null {
   const map: Record<string, string> = {
     typescript: "typescript",
+    // JSX/TSX are highlighted by hljs's javascript/typescript grammars
+    // respectively — explicit entries here avoid the highlightAuto
+    // fallback + the one-shot "unknown language" warning below.
+    tsx: "typescript",
     javascript: "javascript",
+    jsx: "javascript",
     python: "python",
     csharp: "csharp",
     css: "css",
@@ -137,6 +144,12 @@ function resolveHljsLanguage(lang: string): string | null {
     yaml: "yaml",
     markdown: "markdown",
     text: "plaintext",
+    // Shell-family hints all resolve to hljs's "bash" grammar. sh/shell
+    // are the common bundler hints; bash is a no-op passthrough so future
+    // additions don't regress.
+    sh: "bash",
+    bash: "bash",
+    shell: "bash",
   };
   const mapped = map[lang];
   if (mapped) return mapped;
@@ -151,21 +164,18 @@ function resolveHljsLanguage(lang: string): string | null {
 }
 
 /**
- * Parse a `lines` prop like `"10-20"` or `"5"` into `[start, end]` (1-indexed,
- * inclusive on both ends). Returns null on invalid input.
+ * Parse a single segment of a `lines` prop — one of `"10-20"`, `"5"`, or
+ * `"A-"` — into `[start, end]` (1-indexed, inclusive on both ends). Returns
+ * null on invalid input.
  *
  * Special forms:
  *   - `"A-"` (trailing dash, no end) — treated as "start to end-of-file"; we
  *     return `[start, Number.POSITIVE_INFINITY]` and the caller clamps to the
  *     actual file length.
- *   - empty string / whitespace — treated as "no range" (equivalent to absent
- *     `lines`), returning null so the caller renders the full file.
  */
-function parseLineRange(input: string | undefined): [number, number] | null {
-  if (!input) return null;
-  const trimmed = input.trim();
+function parseSingleRange(segment: string): [number, number] | null {
+  const trimmed = segment.trim();
   if (trimmed === "") return null;
-  // `A-` → start through end-of-file (caller clamps).
   const openEnded = trimmed.match(/^(\d+)\s*[-\u2013]\s*$/);
   if (openEnded) {
     const start = parseInt(openEnded[1], 10);
@@ -185,6 +195,33 @@ function parseLineRange(input: string | undefined): [number, number] | null {
     if (n > 0) return [n, n];
   }
   return null;
+}
+
+/**
+ * Parse a `lines` prop into an ordered list of `[start, end]` tuples.
+ * Accepts a comma-separated list of segments — e.g. `"1-5,10-15"` yields
+ * `[[1,5],[10,15]]`. Segments may be single lines, closed ranges, or an
+ * open-ended range (`"A-"`); see `parseSingleRange` for the grammar.
+ *
+ * Returns null when:
+ *   - input is absent / whitespace (caller treats as "no range")
+ *   - any segment is malformed (the whole prop is rejected so authors get
+ *     a single clear error instead of partial rendering)
+ */
+function parseLineRange(
+  input: string | undefined,
+): Array<[number, number]> | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+  const segments = trimmed.split(",");
+  const ranges: Array<[number, number]> = [];
+  for (const seg of segments) {
+    const r = parseSingleRange(seg);
+    if (!r) return null;
+    ranges.push(r);
+  }
+  return ranges.length > 0 ? ranges : null;
 }
 
 /**
@@ -208,32 +245,53 @@ function regionFromFile(
       language: file.language,
     };
   }
-  const range = parseLineRange(lines);
-  if (!range) {
+  const ranges = parseLineRange(lines);
+  if (!ranges) {
     return {
-      warning: `Invalid lines="${lines}" — expected "A-B", "A-" (start to end), or single line "A".`,
+      warning: `Invalid lines="${lines}" — expected "A-B", "A-" (start to end), a single line "A", or a comma-separated list like "1-5,10-15".`,
     };
   }
-  const [start, end] = range;
-  if (start > allLines.length) {
-    return {
-      warning: `lines="${lines}" is out of range (file has ${allLines.length} lines).`,
-    };
+  // Validate every range is in bounds before slicing so authors get a
+  // single clear error rather than partial output.
+  for (const [start] of ranges) {
+    if (start > allLines.length) {
+      return {
+        warning: `lines="${lines}" is out of range (file has ${allLines.length} lines).`,
+      };
+    }
   }
-  // Clamp `end` once up front; also warn when the author's explicit range
-  // drifted past the file so they notice the source changed under them.
-  const effectiveEnd = Math.min(end, allLines.length);
-  if (Number.isFinite(end) && end > allLines.length) {
-    console.warn(
-      `[snippet] lines="${lines}" end (${end}) exceeds file length (${allLines.length}) for ${file.filename} — clamping.`,
-    );
-  }
-  const slice = allLines.slice(start - 1, effectiveEnd).join("\n");
+  // Slice each range, clamp ends, and stitch with a visual separator line
+  // between discontinuous sections. `startLine`/`endLine` in the caption
+  // span the full range (first start → last clamped end) so readers see
+  // where the snippet pulls from even when it's non-contiguous.
+  const pieces: string[] = [];
+  let firstStart = ranges[0][0];
+  let lastEnd = ranges[0][0];
+  ranges.forEach(([start, end], idx) => {
+    const effectiveEnd = Math.min(end, allLines.length);
+    if (Number.isFinite(end) && end > allLines.length) {
+      console.warn(
+        `[snippet] lines="${lines}" segment end (${end}) exceeds file length (${allLines.length}) for ${file.filename} — clamping.`,
+      );
+    }
+    if (idx === 0) firstStart = start;
+    lastEnd = effectiveEnd;
+    const slice = allLines.slice(start - 1, effectiveEnd).join("\n");
+    if (idx > 0) {
+      // Use a comment-style ellipsis that survives any highlighter as a
+      // visible gap marker. Language-specific comment syntax varies, so
+      // `// ...` is a reasonable default for the JS/TS/shell bulk; pure
+      // "..." renders fine across all grammars even when it isn't
+      // technically a comment.
+      pieces.push("// ...");
+    }
+    pieces.push(slice);
+  });
   return {
     file: file.filename,
-    startLine: start,
-    endLine: effectiveEnd,
-    code: slice,
+    startLine: firstStart,
+    endLine: lastEnd,
+    code: pieces.join("\n"),
     language: file.language,
   };
 }

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -664,9 +664,23 @@ const isTableSeparator = (s: string): boolean =>
   /\|/.test(s) && /^\s*[|:\- ]+\s*$/.test(s);
 
 export function convertTablesInJSX(content: string): string {
-  const tagPattern = JSX_CONTAINER_TAGS.join("|");
+  // Sort longest-first so the regex alternation doesn't leftmost-FIRST
+  // match a prefix tag (e.g. `Tab`) when the source is actually the
+  // longer variant (`Tabs`). JS regex alternation is not leftmost-longest:
+  // for `<Tabs>`, `Tab|Tabs` matches "Tab", then `[^>]*` consumes the "s",
+  // group 2 captures "Tab", and the `</\2>` backref demands `</Tab>` — the
+  // actual `</Tabs>` never matches and table conversion is silently skipped.
+  const tagPattern = [...JSX_CONTAINER_TAGS]
+    .sort((a, b) => b.length - a.length)
+    .join("|");
+  // Require the closing tag to match the captured opening tag via
+  // backreference (`\\2`). Without this, alternation in the close group
+  // allowed cross-tag mismatches — e.g. `<Tabs><Tab>x</Tab></Tabs>` would
+  // pair `<Tabs>` with `</Tab>` and leave `</Tabs>` stranded. JS regex
+  // supports numbered backrefs, so `\\2` refers to the inner tag-name
+  // capture of the opener.
   const regex = new RegExp(
-    `(<(${tagPattern})[^>]*>)([\\s\\S]*?)(<\\/(?:${tagPattern})>)`,
+    `(<(${tagPattern})[^>]*>)([\\s\\S]*?)(<\\/\\2>)`,
     "g",
   );
 
@@ -680,7 +694,7 @@ export function convertTablesInJSX(content: string): string {
       closeTag: string,
     ) => {
       // Non-greedy `[\s\S]*?` matches through the FIRST close tag of
-      // any container in the set, so nested same-tag content (e.g.
+      // the SAME container, so nested same-tag content (e.g.
       // `<Card>outer <Card>inner</Card> rest</Card>`) closes at the
       // inner `</Card>` and leaves `rest</Card>` stranded. Detect the
       // nesting and bail — the outer match is left untouched, which

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -485,8 +485,13 @@ export function inlineSnippets(
   // systems non-overlapping: SNIPPET_MAP files get inlined as raw MDX
   // (their imports and headings are preserved), while component-map
   // entries render as React components with full prop handling.
+  // MDX authors pass component-map overrides via doubled-brace object
+  // syntax: `<SharedContent components={{ Foo: Bar }} />`. Using
+  // `[^}]*` truncates at the inner `}` and causes the whole tag to
+  // silently fail to match, so the snippet never gets inlined. Match
+  // the doubled-brace object form explicitly.
   result = result.replace(
-    /<([A-Z]\w*)\s*(?:components=\{[^}]*\}\s*)?\/>/g,
+    /<([A-Z]\w*)\s*(?:components=\{\{[\s\S]*?\}\}\s*)?\/>/g,
     (match, componentName) => {
       let snippetRel = SNIPPET_MAP[componentName];
 

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -447,6 +447,18 @@ export function inlineSnippets(
 ): string {
   let result = stripLeadingImports(content);
 
+  // This regex is intentionally strict: it only matches self-closing JSX
+  // tags with an optional `components={...}` attribute, e.g.
+  //   <FrontendTools />
+  //   <SharedContent components={{ ... }} />
+  //
+  // Anything else — tags with other props (`<Snippet region="x" />`),
+  // non-self-closing tags, or tags wrapping children — is deliberately
+  // skipped here and handed off to the MDX component map (see
+  // `docsComponents` in mdx-registry.tsx). The split keeps the two
+  // systems non-overlapping: SNIPPET_MAP files get inlined as raw MDX
+  // (their imports and headings are preserved), while component-map
+  // entries render as React components with full prop handling.
   result = result.replace(
     /<([A-Z]\w*)\s*(?:components=\{[^}]*\}\s*)?\/>/g,
     (match, componentName) => {

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -152,9 +152,24 @@ export function readTitle(filePath: string): string | null {
   const fmMatch = fm.match(/^title:\s*["']?(.+?)["']?\s*$/m);
   let title: string | null = null;
   if (fmMatch) {
-    title = fmMatch[1].replace(/["']$/, "");
+    title = fmMatch[1];
   } else {
-    const headingMatch = raw.match(/^#\s+(.+)$/m);
+    // Match against the post-frontmatter body so a `# ...` YAML comment
+    // inside frontmatter can't be mistaken for the page's H1.
+    let body = raw;
+    try {
+      body = matter(raw).content;
+    } catch (err) {
+      // If frontmatter parsing blows up we still want a title guess;
+      // fall back to the raw source. Log so a malformed file doesn't
+      // silently produce a garbage H1-derived title with zero diagnostic.
+      console.error(
+        "[docs-render] frontmatter parse failed for",
+        filePath,
+        err,
+      );
+    }
+    const headingMatch = body.match(/^#\s+(.+)$/m);
     if (headingMatch) title = headingMatch[1];
   }
   if (isProd()) titleCache.set(cacheKey, title);
@@ -791,7 +806,7 @@ export function loadDoc(
   // and CRLF line endings correctly. Previously the regex split on
   // `^---\n` and missed anything Windows-authored.
   let data: Record<string, unknown> = {};
-  let parsed: { data: Record<string, unknown> } | null = null;
+  let parsed: { data: Record<string, unknown>; content: string } | null = null;
   try {
     parsed = matter(source);
     data = parsed.data ?? {};
@@ -802,7 +817,10 @@ export function loadDoc(
   }
 
   const rawTitle = typeof data.title === "string" ? data.title : undefined;
-  const headingMatch = rawTitle ? null : source.match(/^#\s+(.+)$/m);
+  // Use the parsed body (frontmatter stripped) for the H1 fallback so a
+  // `# ...` YAML comment inside frontmatter can't masquerade as an H1.
+  const body = parsed?.content ?? source;
+  const headingMatch = rawTitle ? null : body.match(/^#\s+(.+)$/m);
   const title =
     rawTitle ||
     headingMatch?.[1] ||

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -39,6 +39,32 @@ export const FRAMEWORK_CATEGORY_ORDER = [
 export type FrameworkCategory = (typeof FRAMEWORK_CATEGORY_ORDER)[number];
 
 // ---------------------------------------------------------------------------
+// Demo-content cell lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the list of integration slugs that have bundled demo content for
+ * the given `defaultCell` key. Used by the pivot UI (both the
+ * framework-agnostic `/docs/<slug>` route and the scoped `/<framework>/<slug>`
+ * route) to answer "which frameworks actually implement this snippet?"
+ *
+ * The demo-content bundle is imported lazily and the iteration shape is
+ * parameterized so both routes call through the same helper without
+ * introducing a circular dependency between the two page.tsx files.
+ */
+export function findFrameworksWithCell(
+  cell: string,
+  integrationSlugs: Iterable<string>,
+  demos: Record<string, unknown>,
+): string[] {
+  const matches: string[] = [];
+  for (const slug of integrationSlugs) {
+    if (demos[`${slug}::${cell}`]) matches.push(slug);
+  }
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Nav tree types
 // ---------------------------------------------------------------------------
 

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -85,18 +85,26 @@ export function escapeHtml(s: string): string {
 //
 // Memory footprint: titles are tiny strings, meta is a small JSON
 // object — negligible even with hundreds of docs files.
+//
+// Dev caveat: the cache would prevent MDX title / meta.json edits from
+// showing up without a server restart. We skip the cache when
+// NODE_ENV !== "production" so `next dev` picks up edits on the next
+// page reload, matching the convention in reference-items.ts.
 const titleCache = new Map<string, string | null>();
 const metaCache = new Map<
   string,
   { title?: string; pages?: string[]; root?: boolean } | null
 >();
+function isProd(): boolean {
+  return process.env.NODE_ENV === "production";
+}
 
 export function readTitle(filePath: string): string | null {
   const cacheKey = path.resolve(filePath);
-  if (titleCache.has(cacheKey)) return titleCache.get(cacheKey)!;
+  if (isProd() && titleCache.has(cacheKey)) return titleCache.get(cacheKey)!;
 
   if (!fs.existsSync(filePath)) {
-    titleCache.set(cacheKey, null);
+    if (isProd()) titleCache.set(cacheKey, null);
     return null;
   }
   let raw: string;
@@ -107,7 +115,7 @@ export function readTitle(filePath: string): string | null {
     // page render. Log loudly and cache a null so we don't retry on
     // every nav build in the same process.
     console.error("[docs-render] failed to read", filePath, err);
-    titleCache.set(cacheKey, null);
+    if (isProd()) titleCache.set(cacheKey, null);
     return null;
   }
   // Restrict frontmatter matches to the frontmatter block so we don't
@@ -123,7 +131,7 @@ export function readTitle(filePath: string): string | null {
     const headingMatch = raw.match(/^#\s+(.+)$/m);
     if (headingMatch) title = headingMatch[1];
   }
-  titleCache.set(cacheKey, title);
+  if (isProd()) titleCache.set(cacheKey, title);
   return title;
 }
 
@@ -132,15 +140,15 @@ export function readMeta(
 ): { title?: string; pages?: string[]; root?: boolean } | null {
   const metaPath = path.join(dir, "meta.json");
   const cacheKey = path.resolve(metaPath);
-  if (metaCache.has(cacheKey)) return metaCache.get(cacheKey)!;
+  if (isProd() && metaCache.has(cacheKey)) return metaCache.get(cacheKey)!;
 
   if (!fs.existsSync(metaPath)) {
-    metaCache.set(cacheKey, null);
+    if (isProd()) metaCache.set(cacheKey, null);
     return null;
   }
   try {
     const parsed = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
-    metaCache.set(cacheKey, parsed);
+    if (isProd()) metaCache.set(cacheKey, parsed);
     return parsed;
   } catch (err) {
     // Previously swallowed silently — a malformed meta.json rendered
@@ -148,7 +156,7 @@ export function readMeta(
     // see the offending path and parse error. Cache the null so we
     // don't re-parse a bad file on every call.
     console.error("[docs-render] failed to parse", metaPath, err);
-    metaCache.set(cacheKey, null);
+    if (isProd()) metaCache.set(cacheKey, null);
     return null;
   }
 }

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -66,6 +66,57 @@ function warnSilentNull(component: string, reason: string): void {
   console.warn(`[mdx-registry] <${component}> rendered nothing — ${reason}`);
 }
 
+// Validate a user-supplied URL string destined for an <iframe src>. Only
+// https:// URLs are accepted — http is too easy to mix-content-block, and
+// `javascript:` / `data:` are an XSS surface even inside a sandboxed
+// iframe (some engines still evaluate scripts in the parent for javascript:
+// schemes). Returns null when the URL is malformed or non-https, and warns
+// in dev so authors notice their embed silently vanished.
+function validateIframeSrc(
+  component: string,
+  src: string | undefined,
+): string | null {
+  if (!src) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(src);
+  } catch {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[mdx-registry] <${component}> src is not a valid URL — skipping embed.`,
+        { src },
+      );
+    }
+    return null;
+  }
+  if (parsed.protocol !== "https:") {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[mdx-registry] <${component}> src protocol "${parsed.protocol}" is not allowed (expected https:) — skipping embed.`,
+        { src },
+      );
+    }
+    return null;
+  }
+  return parsed.toString();
+}
+
+// Detect links that should NOT go through next/link's client-side router.
+// next/link is only meaningful for same-origin in-app navigation; using it
+// for external URLs (or non-http schemes like mailto:/tel:) either fires a
+// spurious prefetch or fails outright. Internal href forms (`/foo`, `#id`,
+// `?q=`) are safe for next/link.
+function isExternalHref(href: string): boolean {
+  if (!href) return false;
+  if (href.startsWith("/") || href.startsWith("#") || href.startsWith("?"))
+    return false;
+  // Any URL with a scheme that isn't a relative path → treat as external.
+  // Covers https://..., http://..., mailto:..., tel:..., ftp:..., etc.
+  return /^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(href);
+}
+
 export const docsComponents = {
   Callout,
   Cards,
@@ -303,8 +354,10 @@ export const docsComponents = {
     children?: React.ReactNode;
     src?: string;
     title?: string;
-  }) =>
-    src ? (
+  }) => {
+    const safeSrc = validateIframeSrc("IframeSwitcher", src);
+    if (!safeSrc) return <div>{children}</div>;
+    return (
       <div
         style={{
           border: "1px solid var(--border)",
@@ -314,16 +367,15 @@ export const docsComponents = {
         }}
       >
         <iframe
-          src={src}
+          src={safeSrc}
           title={title || "Embedded content"}
           style={{ width: "100%", height: "400px", border: "none" }}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
           loading="lazy"
         />
       </div>
-    ) : (
-      <div>{children}</div>
-    ),
+    );
+  },
   IframeSwitcherGroup: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -426,8 +478,26 @@ export const docsComponents = {
   ReasoningMessages: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  YouTubeVideo: ({ id, title }: { id?: string; title?: string }) =>
-    id ? (
+  YouTubeVideo: ({ id, title }: { id?: string; title?: string }) => {
+    // YouTube video IDs are 11 chars of [A-Za-z0-9_-]. Accept only that
+    // shape — anything else either traversal-injects query params into
+    // the embed URL or points at some non-YouTube origin.
+    if (!id || !/^[A-Za-z0-9_-]{11}$/.test(id)) {
+      if (id && process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[mdx-registry] <YouTubeVideo> invalid id — skipping embed.",
+          { id },
+        );
+      }
+      return null;
+    }
+    const src = validateIframeSrc(
+      "YouTubeVideo",
+      `https://www.youtube.com/embed/${id}`,
+    );
+    if (!src) return null;
+    return (
       <div
         style={{
           position: "relative",
@@ -436,7 +506,7 @@ export const docsComponents = {
         }}
       >
         <iframe
-          src={`https://www.youtube.com/embed/${id}`}
+          src={src}
           title={title || "YouTube video"}
           style={{
             position: "absolute",
@@ -452,7 +522,8 @@ export const docsComponents = {
           allowFullScreen
         />
       </div>
-    ) : null,
+    );
+  },
   CTACards: ({ children }: { children?: React.ReactNode }) => (
     <div
       style={{
@@ -669,17 +740,36 @@ export const docsComponents = {
     children?: React.ReactNode;
     href?: string;
     [key: string]: unknown;
-  }) =>
-    href ? (
-      // Route internal MDX <Link> through next/link so navigation is
-      // client-side (prior impl rendered a plain <a>, triggering a full
-      // page reload on every internal link).
+  }) => {
+    if (!href) {
+      return <a {...(rest as Record<string, unknown>)}>{children}</a>;
+    }
+    // External hrefs (https://..., mailto:..., etc.) must NOT use next/link —
+    // next/link is client-router-only and spuriously prefetches external
+    // URLs. Internal forms (`/foo`, `#id`, `?q=`) route through next/link for
+    // client-side navigation. Add rel/target on external links so they don't
+    // leak the opener reference + open in a new tab by default.
+    if (isExternalHref(href)) {
+      const extraProps = rest as Record<string, unknown>;
+      // Put the spread first so caller-supplied target/rel win; fall back
+      // to safe defaults (_blank + noopener noreferrer) only when absent.
+      return (
+        <a
+          {...extraProps}
+          href={href}
+          target={(extraProps.target as string) ?? "_blank"}
+          rel={(extraProps.rel as string) ?? "noopener noreferrer"}
+        >
+          {children}
+        </a>
+      );
+    }
+    return (
       <Link href={href} {...(rest as Record<string, unknown>)}>
         {children}
       </Link>
-    ) : (
-      <a {...(rest as Record<string, unknown>)}>{children}</a>
-    ),
+    );
+  },
   Code: ({ children }: { children?: React.ReactNode }) => (
     <code>{children}</code>
   ),
@@ -782,12 +872,11 @@ export const docsComponents = {
   ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  Tooltip: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  TooltipProvider: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  // Radix-style <Tooltip content=... label=...> props would be silently
+  // dropped by a plain children-only shim. Route through stub() so dev-mode
+  // gets a one-shot warning listing the discarded prop names.
+  Tooltip: stub("Tooltip"),
+  TooltipProvider: stub("TooltipProvider"),
   Markdown: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -110,11 +110,55 @@ function validateIframeSrc(
 // `?q=`) are safe for next/link.
 function isExternalHref(href: string): boolean {
   if (!href) return false;
+  // Protocol-relative URLs (`//example.com/foo`) are external and must not
+  // go through next/link. Check this BEFORE the `/`-prefix internal guard.
+  if (href.startsWith("//")) return true;
   if (href.startsWith("/") || href.startsWith("#") || href.startsWith("?"))
     return false;
   // Any URL with a scheme that isn't a relative path → treat as external.
   // Covers https://..., http://..., mailto:..., tel:..., ftp:..., etc.
   return /^[a-zA-Z][a-zA-Z0-9+\-.]*:/.test(href);
+}
+
+// Scheme allowlist for MDX-authored hrefs. `javascript:`, `data:`, `vbscript:`,
+// `file:`, and any other scheme classify as external via isExternalHref() but
+// are live XSS vectors — `rel="noopener noreferrer"` does NOT neutralize them.
+// Accept only well-known safe schemes plus relative / protocol-relative /
+// fragment / query-only URLs. Anything else → sanitizeHref() returns null and
+// callers render text instead of an <a>.
+function sanitizeHref(href: string | undefined): string | null {
+  if (!href) return null;
+  // Relative-ish forms are safe.
+  if (
+    href.startsWith("/") ||
+    href.startsWith("#") ||
+    href.startsWith("?") ||
+    href.startsWith("//")
+  ) {
+    return href;
+  }
+  const schemeMatch = href.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*):/);
+  if (!schemeMatch) {
+    // No scheme → relative path. Safe.
+    return href;
+  }
+  const scheme = schemeMatch[1].toLowerCase();
+  if (
+    scheme === "http" ||
+    scheme === "https" ||
+    scheme === "mailto" ||
+    scheme === "tel"
+  ) {
+    return href;
+  }
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[mdx-registry] rejected href with disallowed scheme "${scheme}:" — rendering without link.`,
+      { href },
+    );
+  }
+  return null;
 }
 
 export const docsComponents = {
@@ -688,11 +732,19 @@ export const docsComponents = {
       style={{ borderRadius: "0.5rem", maxWidth: "100%", marginBottom: "1rem" }}
     />
   ),
-  A: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
-    <a href={href} style={{ color: "var(--accent)" }}>
-      {children}
-    </a>
-  ),
+  A: ({ children, href }: { children?: React.ReactNode; href?: string }) => {
+    const safe = sanitizeHref(href);
+    if (!safe) {
+      // Strip the href entirely — rendering as text avoids the XSS vector
+      // while preserving the author's visible content.
+      return <span style={{ color: "var(--accent)" }}>{children}</span>;
+    }
+    return (
+      <a href={safe} style={{ color: "var(--accent)" }}>
+        {children}
+      </a>
+    );
+  },
   Button: ({
     children,
     onClick,
@@ -744,19 +796,26 @@ export const docsComponents = {
     if (!href) {
       return <a {...(rest as Record<string, unknown>)}>{children}</a>;
     }
+    // Scheme allowlist: reject `javascript:`, `data:`, `vbscript:`, etc. These
+    // match the external-href branch (scheme with `:`) but `rel="noopener"`
+    // does NOT neutralize script-URL schemes. Strip the href entirely.
+    const safeHref = sanitizeHref(href);
+    if (!safeHref) {
+      return <span {...(rest as Record<string, unknown>)}>{children}</span>;
+    }
     // External hrefs (https://..., mailto:..., etc.) must NOT use next/link —
     // next/link is client-router-only and spuriously prefetches external
     // URLs. Internal forms (`/foo`, `#id`, `?q=`) route through next/link for
     // client-side navigation. Add rel/target on external links so they don't
     // leak the opener reference + open in a new tab by default.
-    if (isExternalHref(href)) {
+    if (isExternalHref(safeHref)) {
       const extraProps = rest as Record<string, unknown>;
       // Put the spread first so caller-supplied target/rel win; fall back
       // to safe defaults (_blank + noopener noreferrer) only when absent.
       return (
         <a
           {...extraProps}
-          href={href}
+          href={safeHref}
           target={(extraProps.target as string) ?? "_blank"}
           rel={(extraProps.rel as string) ?? "noopener noreferrer"}
         >
@@ -765,7 +824,7 @@ export const docsComponents = {
       );
     }
     return (
-      <Link href={href} {...(rest as Record<string, unknown>)}>
+      <Link href={safeHref} {...(rest as Record<string, unknown>)}>
         {children}
       </Link>
     );

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -365,22 +365,47 @@ export const docsComponents = {
       {children}
     </div>
   ),
-  video: (props: Record<string, unknown>) => (
+  video: (props: Record<string, unknown>) => {
     // Accept user className from MDX — prior impl spread className in then
     // immediately overrode it to `undefined`, silently dropping it.
-    <video
-      {...props}
-      style={{ borderRadius: "0.5rem", width: "100%", marginBottom: "1rem" }}
-    />
-  ),
-  img: (props: Record<string, unknown>) => (
-    // Accept user className from MDX (see note on `video` above).
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-    <img
-      {...props}
-      style={{ borderRadius: "0.5rem", maxWidth: "100%", marginBottom: "1rem" }}
-    />
-  ),
+    // Merge author-provided `style` so we preserve author keys while still
+    // enforcing our layout defaults (maxWidth etc.) last.
+    const authorStyle =
+      typeof props.style === "object" && props.style !== null
+        ? (props.style as React.CSSProperties)
+        : {};
+    return (
+      <video
+        {...props}
+        style={{
+          ...authorStyle,
+          borderRadius: "0.5rem",
+          width: "100%",
+          marginBottom: "1rem",
+        }}
+      />
+    );
+  },
+  img: (props: Record<string, unknown>) => {
+    // Accept user className from MDX (see note on `video` above). Merge
+    // author `style` before our defaults so our layout guards still win.
+    const authorStyle =
+      typeof props.style === "object" && props.style !== null
+        ? (props.style as React.CSSProperties)
+        : {};
+    return (
+      // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+      <img
+        {...props}
+        style={{
+          ...authorStyle,
+          borderRadius: "0.5rem",
+          maxWidth: "100%",
+          marginBottom: "1rem",
+        }}
+      />
+    );
+  },
   CodeGroup: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -243,9 +243,22 @@ export const docsComponents = {
     // otherwise it'd 404 on docs.showcase.copilotkit.ai which has no
     // /integrations route.
     const demoUrl = `${int.backend_url}/demos/${demo}`;
+    // Validate at the sink even though the registry is trusted today —
+    // a malformed backend_url (http://, empty, non-URL) should not silently
+    // embed. If validation fails, render a visible error placeholder so
+    // authors / operators notice rather than ship a broken/unsafe iframe.
+    const safeDemoUrl = validateIframeSrc("InlineDemo", demoUrl);
     const shellHost =
       process.env.NEXT_PUBLIC_SHELL_URL || "https://showcase.copilotkit.ai";
     const profileUrl = `${shellHost}/integrations/${integration}?demo=${demo}`;
+    if (!safeDemoUrl) {
+      return (
+        <div className="my-6 rounded-xl border border-dashed border-[var(--border)] px-4 py-3 text-xs font-mono text-[var(--text-faint)]">
+          [InlineDemo] Refusing to embed — registry entry for &quot;
+          {integration}&quot; has an invalid backend_url.
+        </div>
+      );
+    }
     return (
       <div className="my-6 rounded-xl border border-[var(--border)] overflow-hidden">
         <div className="flex items-center justify-between px-4 py-2 bg-[var(--bg-elevated)] border-b border-[var(--border)]">
@@ -259,11 +272,20 @@ export const docsComponents = {
             Open full demo →
           </a>
         </div>
+        {/*
+          NOTE on sandbox: we intentionally OMIT `allow-same-origin`. Per MDN,
+          combining `allow-scripts` + `allow-same-origin` lets the framed page
+          remove its own sandbox attribute — that's a sandbox escape. The
+          integration demos are served from a different origin (int.backend_url)
+          than the docs host, so they do not need same-origin semantics to
+          function (no shared cookies / storage / DOM access with the parent).
+          Keep forms + popups so the demo can still submit / open new tabs.
+        */}
         <iframe
-          src={demoUrl}
+          src={safeDemoUrl}
           className="w-full"
           style={{ height: "500px" }}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          sandbox="allow-scripts allow-forms allow-popups"
           loading="lazy"
         />
       </div>
@@ -410,11 +432,18 @@ export const docsComponents = {
           marginBottom: "1rem",
         }}
       >
+        {/*
+          Sandbox: drop `allow-same-origin`. Combining it with `allow-scripts`
+          lets the framed page remove its own sandbox attribute (MDN). This
+          component embeds arbitrary MDX-author-supplied URLs — it is NOT
+          trusted content — so defense-in-depth is mandatory. Keep forms +
+          popups for parity with typical embedded content (StackBlitz etc.).
+        */}
         <iframe
           src={safeSrc}
           title={title || "Embedded content"}
           style={{ width: "100%", height: "400px", border: "none" }}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          sandbox="allow-scripts allow-forms allow-popups"
           loading="lazy"
         />
       </div>
@@ -549,6 +578,13 @@ export const docsComponents = {
           marginBottom: "1rem",
         }}
       >
+        {/*
+          Sandbox: drop `allow-same-origin`. YouTube is trusted content, but
+          the `allow-scripts` + `allow-same-origin` combination lets the
+          framed page escape its sandbox regardless of origin trust — pure
+          defense-in-depth loss. YouTube's embed player works without
+          same-origin access to the parent. Keep presentation + popups.
+        */}
         <iframe
           src={src}
           title={title || "YouTube video"}
@@ -561,7 +597,7 @@ export const docsComponents = {
             border: "none",
             borderRadius: "0.5rem",
           }}
-          sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+          sandbox="allow-scripts allow-presentation allow-popups"
           loading="lazy"
           allowFullScreen
         />

--- a/showcase/shell-docs/src/lib/reference-items.ts
+++ b/showcase/shell-docs/src/lib/reference-items.ts
@@ -100,8 +100,25 @@ function loadSubdirItems(subdir: ReferenceSubdir): ReferenceItem[] {
   return items;
 }
 
-// In-memory cache — keyed by subdir, rebuilt once per process in prod. In
-// dev we skip the cache so MDX edits show up without a server restart.
+/**
+ * In-memory reference-item cache. Populated lazily on first access per
+ * subdir and never invalidated for the life of the Node process.
+ *
+ * Lifecycle assumptions:
+ *   - Production: a single `next start` boot caches once and serves cached
+ *     items until the process exits. Next.js redeploys spin up a new
+ *     process, so a fresh cache is a natural boundary — same as the
+ *     title/meta caches in docs-render.tsx.
+ *   - Dev: `isProd()` returns false, so both the read and write paths
+ *     skip the cache and every render reopens the MDX files. This is the
+ *     only way MDX edits show up without a server restart.
+ *
+ * Fragility note: a deployment that uses ISR / on-demand revalidation
+ * against this module would serve stale items forever because nothing
+ * clears the map. If we ever add ISR to /reference routes, refactor this
+ * to key on mtime or add an explicit invalidation hook. For the current
+ * `next start` deployment, the one-shot cache is correct.
+ */
 const __itemsCache = new Map<ReferenceSubdir, ReferenceItem[]>();
 function isProd(): boolean {
   return process.env.NODE_ENV === "production";

--- a/showcase/shell-docs/src/lib/reference-items.ts
+++ b/showcase/shell-docs/src/lib/reference-items.ts
@@ -50,7 +50,50 @@ function walkMdx(dir: string, prefix: string = ""): string[] {
     if (entry.isDirectory()) {
       out.push(...walkMdx(childAbs, childRel));
     } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
-      out.push(childRel.replace(/\.mdx$/, ""));
+      // Normalize `index.mdx` away from the slug so a file at
+      // `components/foo/index.mdx` surfaces as slug `components/foo` (not
+      // `components/foo/index`). Other slug builders in this codebase
+      // (e.g. docs-render's buildNavTreeFromFilesystem) already collapse
+      // `index.mdx` into its parent segment; authors expect
+      // `/reference/components/foo` to resolve rather than
+      // `/reference/components/foo/index`. A top-level `index.mdx`
+      // collapses to the empty string, which the consumer drops.
+      const slug = childRel.replace(/\.mdx$/, "");
+      if (entry.name === "index.mdx") {
+        const parent = prefix; // path up to but not including `index.mdx`
+        if (parent) {
+          // Collision guard: if a sibling flat file `<parent>.mdx` exists
+          // one directory up, the flat file's walkMdx iteration will emit
+          // the same slug. Skip the collapsed `index.mdx` emission so the
+          // consumer doesn't produce duplicate ReferenceItems (and so
+          // Next.js generateStaticParams doesn't hit duplicate-key
+          // warnings). This matches the lookup precedence in
+          // docs-render's loadDoc, which prefers `<slug>.mdx` over
+          // `<slug>/index.mdx`.
+          const parentDir = path.dirname(dir);
+          const parentBase = path.basename(dir); // last segment of `parent`
+          const siblingFlat = path.join(parentDir, `${parentBase}.mdx`);
+          let flatExists = false;
+          try {
+            flatExists = fs.statSync(siblingFlat).isFile();
+          } catch {
+            flatExists = false;
+          }
+          if (flatExists) {
+            if (process.env.NODE_ENV !== "production") {
+              console.warn(
+                `[reference-items] Both ${siblingFlat} and ${childAbs} define slug "${parent}"; using the flat file.`,
+              );
+            }
+          } else {
+            out.push(parent);
+          }
+        }
+        // else: root-level index.mdx (e.g. reference/index.mdx) is
+        // handled by the dedicated index route, not as a subdir slug.
+      } else {
+        out.push(slug);
+      }
     }
   }
   return out;
@@ -67,7 +110,17 @@ function loadSubdirItems(subdir: ReferenceSubdir): ReferenceItem[] {
 
   const items: ReferenceItem[] = [];
   for (const relSlug of walkMdx(dir)) {
-    const filePath = path.join(dir, `${relSlug}.mdx`);
+    // `walkMdx` collapses `foo/index.mdx` into a slug of `foo`, so the
+    // literal `${relSlug}.mdx` path may not exist. Resolve against both
+    // shapes and prefer the direct file (`foo.mdx`) when both happen to
+    // exist — matching the lookup order in docs-render's loadDoc.
+    const directPath = path.join(dir, `${relSlug}.mdx`);
+    const indexPath = path.join(dir, relSlug, "index.mdx");
+    const filePath = fs.existsSync(directPath)
+      ? directPath
+      : fs.existsSync(indexPath)
+        ? indexPath
+        : directPath;
     let raw: string;
     try {
       raw = fs.readFileSync(filePath, "utf-8");


### PR DESCRIPTION
## Summary

Tech-debt follow-up to #4109. This PR fixes a batch of production-relevant issues across the shell-docs runtime, the shared showcase deploy workflow, and the content bundler scripts — MDX rendering correctness, XSS hardening on author-controlled sinks, UI component invariants under edge cases, route-level content handling, and CI reliability.

## Why

#4109 restructured shell-docs and landed a lot of new shared surface area. Reviewing that landing surfaced real bugs that weren't in scope to fix inline: Slack failure alerts that silently never posted, MDX regex bugs that mangled nested `<Tabs>`, XSS vectors via `javascript:` hrefs, iframe sandboxes that negated themselves, undeployed integrations rendered as clickable dead links, a framework-selector that trapped users in redirect loops, and a few bundler correctness bugs that produced captions pointing at the wrong file. All of it is user-visible or deploy-visible, so none of it can stay deferred.

## What changed

### CI workflow (`showcase_deploy.yml`)

Hygiene on the shared deploy pipeline so failures are reported and concurrent runs don't race.

- Slack failure notification was gated on a step-local `env:` it couldn't read from its own `if:`, so alerts never posted. Promoted `SLACK_WEBHOOK_URL` to job-level env.
- Concurrency group included the service name, so a push event and a manual `workflow_dispatch service=all` run could race on the same Railway service. Dropped the suffix.
- Shared-module copy step ran for every service context and polluted build contexts for shell-family services that already have the full repo. Scoped to a `showcase/packages/*` allowlist.
- `shell-dashboard` and `shell-docs` path filters didn't watch `showcase/shared/**` or `showcase/scripts/**`, so shared-code changes rebuilt `shell` but not its siblings. Extended the filters.
- Dropped a redundant `fromJSON()` on an already-numeric matrix value and a dead `HTTP_CODE="000"` sentinel.

### MDX renderer correctness (`showcase/shell-docs/src/lib/docs-render.tsx` + friends)

Regex and rendering bugs that either mangled output or opened XSS holes.

- `convertTablesInJSX` used non-backref alternation on close tags, and JS alternation is leftmost-first — so `<Tabs>…</Tab>` closed the outer container with the inner tag. Added a backref and sorted the tag alternation longest-first.
- `inlineSnippets` matched `components=` props with `[^}]*`, truncating doubled-brace MDX object literals. Replaced with an explicit `\{\{…\}\}` match.
- Frontmatter H1 fallback ran against the raw file including the YAML block, so a `# comment` line inside frontmatter could become the page title. Moved the match to `matter(raw).content` and surfaced the previously-silent parse catch as a log.
- XSS: `<A>` and `<Link>` rendered any href scheme verbatim, making `javascript:` / `data:text/html` a live vector from MDX. Added a scheme allowlist; unsafe schemes render as inert text.
- Iframe sandboxes in `InlineDemo`, `IframeSwitcher`, and `YouTubeVideo` combined `allow-scripts` with `allow-same-origin`, which per MDN lets the iframe remove its own sandbox. Dropped `allow-same-origin`.
- `<InlineDemo>` piped registry `backend_url` into `src` without running it through `validateIframeSrc` like the other iframe sinks do. Harmonized.
- `<img>` and `<video>` style-prop handling spread caller props and then clobbered `style` wholesale, dropping author-supplied keys. Now merges, with component-enforced layout overrides winning.
- `docs-page-view` rendered the FM title as an `<h1>` and then let the MDX body's duplicate `# Title` render again, producing stacked H1s. Strips the body H1 only when it matches the FM title after whitespace normalization; CRLF-safe.

### Component invariants

Tabs, framework-tabs, framework-provider, framework-selector — edge cases around duplicate labels, mismatched lengths, and stale state.

- `docs-tabs` picked the active panel via `.filter(label === active)`, which double-rendered on duplicate labels and blanked out when `items` length diverged from children. Replaced with a positional `findIndex` so pairing is strictly by index.
- `framework-tabs` paired `frameworks[i]` with children by index; a child rendering null shifted the array and every subsequent tab showed the wrong framework's content. Added a count-mismatch guard with dev warn. Seeded `active` only at mount, so swapping `frameworks` left it stale — added a re-sync effect. Removed never-consumed `cell`/`region` interface props.
- `framework-provider` hydrated `stored` from localStorage without validating against the registry, so a stale slug (framework removed from registry) kept redirecting users to a dead route. Added the same `knownFrameworks.includes(...)` check used elsewhere, including the cross-tab `storage` handler.
- `framework-selector` dropdown rendered undeployed options as clickable; clicking persisted the undeployed slug and `router.replace`'d into a dead route, trapping users in a `RouterPivot` redirect loop. Gated undeployed options with `disabled`, aria, and a click-handler guard.

### Route-level content handling

Ag-ui page, docs root, framework route, reference route, brand-nav — duplicate H1s, stale sidebars, dead links, wrong cross-links.

- `ag-ui/[[...slug]]` H1 strip wasn't CRLF-safe and unconditionally removed the first body H1 even when it didn't match the FM title (silent content loss). Now extracts body H1 separately and strips only on whitespace-normalized match.
- `readTitleForSlug` only read `${slug}.mdx`, but the page handler already falls back to `${slug}/index.mdx`. Sidebar titles drifted from actual page content. Mirrored the page handler's precedence.
- Docs overview integration grid rendered undeployed integrations as active `<Link>`s, handing users dead-link cards. Undeployed now render as non-link `<div>` with preserved visual treatment. Also filtered `findFrameworksWithCell` and `previewUrl` derivation to `deployed === true`.
- `[framework]/[[...slug]]` alternative-framework banner pulled from all integrations unfiltered; `slice(0, 3)` could pad with undeployed. Filtered before slice.
- `reference/[...slug]` fallback `<h1>` showed the raw hyphenated slug while the breadcrumb was `titleCase`d. Wrapped the fallback too. Added an `index.mdx` route fallback matching `loadDoc`'s convention.
- `brand-nav` mobile menu's cross-brand link was hardcoded to `/ag-ui`, so on an ag-ui page the link pointed at itself. Now branches on `activeBrandFromPath()`.

### Error boundary

The log effect re-fired on every render because the `error` object identity is fresh each pass, filling console with duplicate reports. Dep array now tracks `error.message` + `error.digest` (stable strings); the raw `error` is still passed through in the body for stack preservation.

### Bundler scripts (`bundle-demo-content.ts`, `reference-items.ts`)

Correctness and platform parity.

- Multi-file regions (same region name in multiple files) kept the first file's span while appending code from all contributors — the caption said `foo.tsx · L5–L20` while showing content from elsewhere. Track contributors per region; relabel `file` to `(multiple: a, b, c)` when more than one.
- Same-file multi-slice regions never extended `endLine`, so captions under-reported the span.
- `fs.watch({ recursive: true })` is silently ignored on Linux; watch mode claimed to be watching while missing nested edits. Added a loud startup warning on Linux.
- Watch-mode path filter used forward slashes only, so on Windows `fs.watch`'s backslashed paths matched no directory pattern. Normalized before testing.
- `walkMdx` emitted `<parent>/index` for `parent/index.mdx`, inconsistent with `loadDoc`'s collapsing to `parent`. Collapsed, and added a collision guard preferring the flat file when `parent.mdx` also exists.

### Regenerated `demo-content.json`

Both the shell and shell-docs bundles, carrying the new `(multiple: ...)` caption format and previously-stale committed state.

## Test plan

- [ ] Local typecheck passes on `showcase/shell-docs` and `showcase/scripts`
- [ ] CI matrix green (Python, Vercel previews, check-binaries, format, oxlint, package-quality, unit 20/22/24, commitlint)
- [ ] Manual spot-check: MDX pages with nested `<Tabs>` render correctly (no stranded close tags)
- [ ] Manual spot-check: framework-selector dropdown — undeployed entries are disabled
- [ ] Manual spot-check: docs overview page — undeployed integration cards are non-clickable
- [ ] Manual spot-check: trigger showcase_deploy on a path-filter test change touching `showcase/shared/**` — confirm shell, shell-dashboard, AND shell-docs rebuild
