### PR TITLE
fix: crewai-crews agent-down + smoke hang

### DIFF
--- a/showcase/packages/crewai-crews/entrypoint.sh
+++ b/showcase/packages/crewai-crews/entrypoint.sh
@@ -1,15 +1,99 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render). Scope NODE_ENV
-# to this exec only — `ENV NODE_ENV=production` at the image level would leak
-# into every child process (Python agent, shell, healthchecks). `env` prefix
-# binds the value to this single invocation.
-env NODE_ENV=production npx next start --port ${PORT:-10000} &
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
 
-# Wait for either process to exit
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting showcase package: crewai-crews"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of this service have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/crewai-crews/src/app/api/smoke/route.ts
+++ b/showcase/packages/crewai-crews/src/app/api/smoke/route.ts
@@ -5,6 +5,16 @@ const INTEGRATION_SLUG = "crewai-crews";
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
+// Upstream fetch timeout. Kept strictly shorter than ``maxDuration`` (60s)
+// so that a hung upstream can't exhaust the whole route budget: a stuck
+// agent surfaces as a clean ``timeout`` stage within ~25s, leaving room
+// for the response JSON to be written before Next.js kills the request.
+// Previously the inner fetch shared the full 45s timeout, which — when
+// the agent hung — caused the smoke route itself to hang for 30s+ of the
+// 60s budget before the platform cut it, producing HTTP 000 at the
+// caller instead of a structured ``stage: "timeout"`` response.
+const UPSTREAM_TIMEOUT_MS = 25_000;
+
 export async function GET() {
   const start = Date.now();
   // Hit our own /api/copilotkit endpoint — tests the full deployed stack
@@ -35,7 +45,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(45000),
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
 
     const latency = Date.now() - start;


### PR DESCRIPTION
## Summary

Production `showcase-crewai-crews` was stuck at `agent:"down"` for ~4-5h on 2026-04-21 (retries #1-8, 503 on `/api/health`, 30s+ hang on `/api/smoke`). Railway runtime logs show the FastAPI agent on `:8000` handled startup and hundreds of requests cleanly, then silently **stopped responding** at ~06:56-07:01 UTC after an `unhandledRejection: UND_ERR_BODY_TIMEOUT`. The Python process did not exit — it hung — so bash's `wait -n` never fired, the container never restarted, and every subsequent runtime-to-agent request waited out undici's default 5-minute headers timeout (`UND_ERR_HEADERS_TIMEOUT` in the logs).

Two defensive fixes in the package:

1. **`entrypoint.sh` — agent watchdog.** Poll `http://127.0.0.1:8000/health` every 30s (5s `curl --max-time`). After 3 consecutive failures (~90s unreachable), SIGKILL the agent PID so `wait -n` returns and Railway restarts the container. Also adds `[entrypoint]` / `[agent]` / `[nextjs]` / `[watchdog]` log prefixes, a startup PID-is-alive check, and `PYTHONUNBUFFERED=1` — bringing this package's entrypoint closer to the starter's richer template.

2. **`src/app/api/smoke/route.ts` — split inner/outer timeouts.** `UPSTREAM_TIMEOUT_MS = 25_000` on the inner fetch, keeping `maxDuration = 60` as the route budget. Previously the single `AbortSignal.timeout(45000)` on the upstream fetch, when the agent hung, consumed nearly all the 60s envelope before Next.js cut the request — producing HTTP 000 at the caller. Now a wedged agent surfaces as a structured `stage: "timeout"` JSON response in ~25s.

Upstream `showcase-crewai-crews-production.up.railway.app` verified RED (503, agent:down) via `curl` before this PR. Merge will trigger GHCR build + Railway redeploy; recovery expected within ~4 min of deploy.

## Test plan

- [ ] Railway deploys latest image after merge; container boots healthy
- [ ] `curl https://showcase-crewai-crews-production.up.railway.app/api/health` returns 200 `agent:"ok"`
- [ ] `curl https://showcase-crewai-crews-production.up.railway.app/api/smoke` returns 200 within ~25s (or 502 `stage:"timeout"` if aimock glitches)
- [ ] Logs show `[entrypoint]` / `[agent]` / `[watchdog]` prefixes (evidence the new entrypoint is active)
- [ ] Induce hang by sending a malformed agent request; verify watchdog kicks in after ~90s (visible in logs as `[watchdog] Agent health probe failed` + container restart)
- [ ] Starter service (`showcase-starter-crewai-crews`) unaffected — only the package entrypoint/smoke route changed