### PR TITLE
fix: crewai-crews root-cause (ag-ui-crewai 0.2.0 + unbuffered stdout)

### DIFF
--- a/showcase/packages/crewai-crews/entrypoint.sh
+++ b/showcase/packages/crewai-crews/entrypoint.sh
@@ -27,8 +27,17 @@ fi
 
 # Start agent backend on :8000 with log prefixing so its output is
 # distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers. The 04-21 incident saw ~15 log lines over
+# 9h of uptime because of pipe-buffering through a previous `sed` formulation.
 echo "[entrypoint] Starting Python agent on port 8000..."
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/packages/crewai-crews/requirements.txt
+++ b/showcase/packages/crewai-crews/requirements.txt
@@ -1,5 +1,5 @@
 crewai>=0.130.0
-ag-ui-crewai>=0.1.4,<0.1.6
+ag-ui-crewai>=0.2.0,<0.3.0
 ag-ui-protocol>=0.1.5
 python-dotenv>=1.0.1
 uvicorn>=0.34.3

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -5,8 +5,6 @@ FastAPI server that hosts the CrewAI crew backend.
 The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
 """
 
-import logging
-
 # ORDER-CRITICAL: load .env and apply aimock redirection FIRST — before any
 # crewai / litellm / openai module is imported. Those modules can construct
 # clients at import time that latch onto OPENAI_BASE_URL / OPENAI_API_KEY as
@@ -18,76 +16,20 @@ from aimock_toggle import configure_aimock
 load_dotenv()
 configure_aimock()
 
-# HARDENING: CrewAI's ChatWithCrewFlow.__init__ (in ag_ui_crewai.crews) makes
-# blocking synchronous LLM calls via generate_crew_chat_inputs, which in turn
-# calls generate_input_description_with_ai and generate_crew_description_with_ai
-# from crewai.cli.crew_chat. In ag-ui-crewai <= 0.1.5 this happens at module
-# import time inside add_crewai_crew_fastapi_endpoint, BEFORE uvicorn binds its
-# port. Any LLM hiccup (aimock regression, OpenAI outage, network blip) will
-# crash the Python process before the HTTP server is listening, which causes
-# Railway/Kubernetes/ECS health checks to fail and deploys to roll back.
+# NOTE: The pre-bind LLM crash hardening shim that previously lived here has
+# been removed. It monkey-patched crewai.cli.crew_chat.generate_*_description_with_ai
+# to static strings so that ChatWithCrewFlow.__init__ — which ag-ui-crewai
+# <= 0.1.5 invoked at endpoint-registration time (i.e. BEFORE uvicorn bound
+# its port) — could not crash the process before the HTTP server was
+# listening. Upstream issue: https://github.com/crewAIInc/crewAI/issues/5510.
 #
-# Patch both functions to return static strings. The AI-generated descriptions
-# are only cosmetic for the CrewAI chat UI (which the CopilotKit runtime does
-# not use), so static defaults are functionally equivalent for our showcase.
-#
-# Upstream issue: https://github.com/crewAIInc/crewAI/issues/5510
-# Upstream fix: ag-ui-crewai repo (deferred ChatWithCrewFlow construction
-# to first-request) — landed on main but not yet released as of 0.1.5.
-# Remove this shim once ag-ui-crewai > 0.1.5 ships and the requirements.txt
-# ceiling is lifted.
-from crewai.cli import crew_chat as _crewai_crew_chat
-
-# Fail loudly if upstream renames/removes these symbols. setattr() on a module
-# always succeeds regardless of prior attribute existence, so without this
-# guard an upstream rename would silently no-op the patch and reintroduce the
-# pre-bind LLM crash bug with a green PR.
-_REQUIRED_ATTRS = (
-    "generate_input_description_with_ai",
-    "generate_crew_description_with_ai",
-)
-for _attr in _REQUIRED_ATTRS:
-    if not hasattr(_crewai_crew_chat, _attr):
-        raise RuntimeError(
-            f"crewai upstream drift: crewai.cli.crew_chat.{_attr} no longer exists. "
-            f"The import-time hardening shim in agent_server.py would silently no-op, "
-            f"reintroducing the pre-bind LLM crash bug. Either update the shim to the "
-            f"new function name, or remove it if ag-ui-crewai > 0.1.5 (with deferred "
-            f"construction fix) has been adopted. See: "
-            f"https://github.com/crewAIInc/crewAI/issues/5510"
-        )
-
-
-def _static_input_description(input_name, *_args, **_kwargs):
-    return f"Input value for '{input_name}'."
-
-
-def _static_crew_description(*_args, **_kwargs):
-    return "A CrewAI crew."
-
-
-_crewai_crew_chat.generate_input_description_with_ai = _static_input_description
-_crewai_crew_chat.generate_crew_description_with_ai = _static_crew_description
-
-# Verify the patch took effect (defense-in-depth against import-order weirdness
-# or re-imports that could shadow our module reference).
-if _crewai_crew_chat.generate_input_description_with_ai is not _static_input_description:
-    raise RuntimeError(
-        "crewai hardening shim: patch verification failed — "
-        "generate_input_description_with_ai was shadowed or re-imported after patching. "
-        "This would reintroduce the pre-bind LLM crash bug."
-    )
-if _crewai_crew_chat.generate_crew_description_with_ai is not _static_crew_description:
-    raise RuntimeError(
-        "crewai hardening shim: patch verification failed — "
-        "generate_crew_description_with_ai was shadowed or re-imported after patching. "
-        "This would reintroduce the pre-bind LLM crash bug."
-    )
-
-logging.getLogger(__name__).info(
-    "Applied crewai.cli.crew_chat hardening shim (upstream issue #5510). "
-    "Remove this shim after ag-ui-crewai > 0.1.5 is adopted."
-)
+# ag-ui-crewai 0.2.0 (PR ag-ui-protocol/ag-ui#1550, released 2026-04-18)
+# defers ChatWithCrewFlow construction to first request via a module-scoped
+# `_cached_flow` + `asyncio.Lock` inside `add_crewai_crew_fastapi_endpoint`.
+# Any LLM hiccup now surfaces as a 5xx on the first request instead of a
+# startup crash, which is the correct failure mode for a runtime outage and
+# is what the shim was reaching for. With the requirements.txt pin bumped to
+# `>=0.2.0,<0.3.0`, the shim is dead code and has been removed.
 
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
 from fastapi import FastAPI

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
   "validatePinsFailCount": 110,
-  "validatePinsFailHash": "958bcf24c27cef69d7856e12deafe92073af7ad716289b2f6e4418827264ae17",
+  "validatePinsFailHash": "e97480d41c371cff74b4725e2618762f71ce22c7249df8833b9ccfbe2fe69b48",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Summary
- Bump `ag-ui-crewai` pin to `>=0.2.0,<0.3.0`. 0.1.5 had three defects (unguarded `source.state.messages`, orphan `asyncio.create_task`, sync `completion()`) that wedged the agent on 2026-04-21. All fixed in ag-ui [PR #1550](https://github.com/ag-ui-protocol/ag-ui/pull/1550), released as 0.2.0 on 2026-04-18 — our pin was blocking it.
- Remove the pre-bind monkey-patch shim in `src/agent_server.py`; superseded by 0.2.0's native deferred `ChatWithCrewFlow` construction (module-scoped `_cached_flow` + `asyncio.Lock` inside `add_crewai_crew_fastapi_endpoint`). Any LLM hiccup now surfaces as a 5xx on first request instead of a startup crash, which is exactly what the shim was reaching for. `logging` import dropped since it was only used by the shim.
- Add `python -u` to the uvicorn invocation in `entrypoint.sh` as a belt-and-suspenders complement to the existing `PYTHONUNBUFFERED=1`. `awk '{...; fflush()}'` in the pipe was already line-flushing; `-u` is not overridable by user code. Railway saw only ~15 log lines over 9h during the 04-21 incident because of pipe-buffering through a previous `sed` formulation.
- Update `showcase/scripts/fail-baseline.json`'s `validatePinsFailHash` to match the new `ag-ui-crewai` spec string in the FAIL set. Pin-drift FAIL count is unchanged (110); only the hashed line text changed.

Root-cause context: Notion [Showcase starters: silent-hang vulnerability class](https://www.notion.so/3493aa3818528191bc08f8b2f3fb1e88).

## Test plan
- [x] `pip install -r requirements.txt` resolves `ag-ui-crewai==0.2.0` (verified locally in a fresh 3.12 venv; no dep conflicts with `crewai==0.130.0` or `crewai-tools`).
- [x] Agent starts cleanly under `python -u -m uvicorn agent_server:app`; `/health` returns 200 `{"status":"ok"}` (verified locally).
- [x] Agent import no longer references the `crewai.cli.crew_chat` hardening shim; `ag_ui_crewai.endpoint.add_crewai_crew_fastapi_endpoint` registers without pre-bind LLM calls (verified via FastAPI route inspection after import).
- [x] `pytest tests/python/` — 94/94 pass.
- [x] `pnpm -C showcase/scripts test` — 1079/1079 pass.
- [x] `validate-pins.ts` — FAIL count matches baseline (110); new hash committed to `fail-baseline.json`.
- [ ] `/api/smoke` completes against live upstream on Railway (requires deploy).
- [ ] Railway deploy logs show uvicorn request lines (not just entrypoint banner).
- [ ] Watchdog from #4114 still loops.

## Intentionally out-of-scope (follow-ups)
- `showcase/starters/crewai-crews/` parity backport (starter still carries the 0.1.5 pin and the shim).
- The 14-starter watchdog generalisation — tracked in the Notion proposal above.