### PR TITLE
fix(showcase): generalize silent-hang watchdog + unbuffered stdout across starters

### DIFF
--- a/showcase/packages/ag2/entrypoint.sh
+++ b/showcase/packages/ag2/entrypoint.sh
@@ -1,12 +1,108 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
 
-# Wait for either process to exit
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting showcase package: ag2"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging. Generalized from showcase/packages/crewai-crews/entrypoint.sh
+# (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/agno/entrypoint.sh
+++ b/showcase/packages/agno/entrypoint.sh
@@ -1,12 +1,108 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
 
-# Wait for either process to exit
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting showcase package: agno"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging. Generalized from showcase/packages/crewai-crews/entrypoint.sh
+# (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/claude-sdk-python/entrypoint.sh
+++ b/showcase/packages/claude-sdk-python/entrypoint.sh
@@ -1,12 +1,108 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
 
-# Wait for either process to exit
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting showcase package: claude-sdk-python"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging. Generalized from showcase/packages/crewai-crews/entrypoint.sh
+# (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/packages/claude-sdk-typescript/entrypoint.sh
@@ -1,12 +1,89 @@
 #!/bin/bash
 set -e
 
-# Start Claude agent backend (TypeScript)
-node /app/agent_server.js &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+echo "========================================="
+echo "[entrypoint] Starting showcase package: claude-sdk-typescript"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
 
-# Wait for either process to exit
-wait -n
-exit $?
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+  echo "[entrypoint] WARNING: ANTHROPIC_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] ANTHROPIC_API_KEY: set (${#ANTHROPIC_API_KEY} chars)"
+fi
+
+# Start Claude agent backend (TypeScript, compiled to JS).
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# node process, so `wait -n $AGENT_PID` monitors the right thing.
+# `awk` with `fflush()` line-flushes each prefixed line to the container log.
+echo "[entrypoint] Starting Claude agent on port 8000..."
+node /app/agent_server.js &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (~90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. Generalized from
+# showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/google-adk/entrypoint.sh
+++ b/showcase/packages/google-adk/entrypoint.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
+
 # Disable Google ADK's progressive SSE streaming feature. With it enabled,
 # Gemini 2.5-flash occasionally returns a stream whose final event is flagged
 # `partial`, which the ADK flow aborts with a "The last event is partial"
@@ -14,6 +25,13 @@ set -e
 # env var is the primary (operator-level, ADK-wide) workaround; the callback
 # guard runs regardless. Both layers are intentional.
 export ADK_DISABLE_PROGRESSIVE_SSE_STREAMING=1
+
+echo "========================================="
+echo "[entrypoint] Starting showcase package: google-adk"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
 
 # Warn (default) or fail-fast when GOOGLE_API_KEY is missing. This package is
 # Gemini end-to-end: the primary LlmAgent uses Gemini, and the secondary
@@ -35,87 +53,79 @@ if [ -z "${GOOGLE_API_KEY:-}" ]; then
     echo "[entrypoint] WARN: GOOGLE_API_KEY not set — all Gemini-backed tools (chat + generate_a2ui) will return structured errors at request time" >&2
 fi
 
-# Start agent backend.
-# NOTE: `set -e` does not fire on backgrounded processes — if uvicorn crashes
-# immediately, the shell still proceeds to start Next.js. We capture PIDs and
-# probe them explicitly after `wait -n` so operators can tell which process
-# died with which exit code.
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but the `-u` flag to the Python interpreter forces unbuffered
+# stdout/stderr at the interpreter level and is not overridable by user code.
+# Combined with `fflush()` inside the awk pipe below, uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
-
-# Start Next.js frontend (PORT defaults to 10000 — Railway / local compose
-# override as needed).
-npx next start --port ${PORT:-10000} &
-NEXT_PID=$!
-
-# Wait for either process to exit; then figure out which one.
-# set +e for wait -n; exit code captured explicitly into EXIT_CODE. The
-# subsequent `kill -0` / `echo` calls run without errexit — that is fine
-# because the final `exit "$EXIT_CODE"` uses the captured value, so the
-# container exits with the dying child's status regardless. Restoration of
-# `set -e` is intentionally omitted.
-set +e
-wait -n
-EXIT_CODE=$?
-
-# Interpret common exit codes for operators reading the log stream.
-# 0   = clean exit (shouldn't happen under `wait -n` when both are servers)
-# 127 = command-not-found (bad PATH / missing binary)
-# 137 = SIGKILL (usually OOM-killed by the cgroup / Railway / Docker)
-# 143 = SIGTERM (orderly shutdown signal from the platform)
-case "$EXIT_CODE" in
-    0)   EXIT_MEANING="clean exit (unexpected for a long-running server)" ;;
-    127) EXIT_MEANING="command not found (missing binary / bad PATH)" ;;
-    137) EXIT_MEANING="SIGKILL (likely OOM-killed or force-stopped)" ;;
-    143) EXIT_MEANING="SIGTERM (orderly shutdown from platform)" ;;
-    *)   EXIT_MEANING="(no common interpretation)" ;;
-esac
-
-# `kill -0 <pid>` returns 0 if the process is still alive, nonzero if it is
-# gone. Whichever one is gone is the one that died; log both statuses so the
-# platform's log stream carries enough info to diagnose. We also capture the
-# surviving sibling's PID so we can terminate it explicitly below — without
-# that, the survivor would be orphan-reparented to PID 1 and keep consuming
-# resources until the container runtime tears down the whole process tree.
-# This mirrors the spring-ai entrypoint pattern.
-SURVIVOR_PID=""
-if ! kill -0 "$AGENT_PID" 2>/dev/null; then
-    echo "[entrypoint] agent backend (uvicorn, pid=$AGENT_PID) exited with code $EXIT_CODE — $EXIT_MEANING" >&2
-    if kill -0 "$NEXT_PID" 2>/dev/null; then
-        SURVIVOR_PID="$NEXT_PID"
-    fi
-elif ! kill -0 "$NEXT_PID" 2>/dev/null; then
-    echo "[entrypoint] next.js frontend (pid=$NEXT_PID) exited with code $EXIT_CODE — $EXIT_MEANING" >&2
-    if kill -0 "$AGENT_PID" 2>/dev/null; then
-        SURVIVOR_PID="$AGENT_PID"
-    fi
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
 else
-    # `wait -n` returned but both pids still resolve. This most commonly
-    # happens when a child was reaped before we ran `kill -0` (race), which
-    # means one IS actually dead — we just can't tell which. Escalate to
-    # ERROR + exit 1 so this path does not silently mask the real death.
-    # Under no-children-dead the shell would never reach this block.
-    echo "[entrypoint] ERROR: wait -n returned exit=$EXIT_CODE ($EXIT_MEANING) but both agent ($AGENT_PID) and next.js ($NEXT_PID) appear alive — treating as fatal race; the actual dying child's status has already been reaped" >&2
-    exit 1
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
 fi
 
-# Terminate the surviving sibling with a bounded grace window so it shuts
-# down cleanly rather than getting SIGKILL'd by the container runtime at
-# teardown. 5s matches the spring-ai pattern and is comfortably under the
-# typical container stop-grace (10s+).
-if [ -n "$SURVIVOR_PID" ]; then
-    echo "[entrypoint] Terminating surviving sibling (pid=${SURVIVOR_PID}) to avoid orphan-reparent" >&2
-    kill "$SURVIVOR_PID" 2>/dev/null
-    # Bounded wait: poll for up to 5s, then SIGKILL if still alive.
-    for _ in 1 2 3 4 5; do
-        kill -0 "$SURVIVOR_PID" 2>/dev/null || break
-        sleep 1
-    done
-    if kill -0 "$SURVIVOR_PID" 2>/dev/null; then
-        echo "[entrypoint] Survivor (pid=${SURVIVOR_PID}) did not exit within 5s — sending SIGKILL" >&2
-        kill -9 "$SURVIVOR_PID" 2>/dev/null
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. Generalized from
+# showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      break
     fi
-    wait "$SURVIVOR_PID" 2>/dev/null || true
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-exit "$EXIT_CODE"
+exit $EXIT_CODE

--- a/showcase/packages/langgraph-fastapi/entrypoint.sh
+++ b/showcase/packages/langgraph-fastapi/entrypoint.sh
@@ -1,20 +1,96 @@
 #!/bin/bash
 set -e
 
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Disable Python stdout buffering so langgraph_cli's dev server and any
+# tracebacks it emits reach the Railway log stream immediately rather than
+# sitting in Python's userspace buffer until the process exits.
+export PYTHONUNBUFFERED=1
+
+echo "========================================="
+echo "[entrypoint] Starting showcase package: langgraph-fastapi"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
 echo "[entrypoint] Starting LangGraph agent server on port 8123..."
-python -m langgraph_cli dev \
+# `python -u` + `awk ... fflush()`: unbuffered stdout at the interpreter
+# level + line-flushed awk prefixer so tracebacks reach the container log
+# immediately rather than block-buffered in pipe buffers.
+python -u -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 &
+  --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 
 sleep 3
 
-echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
-npx next start --port ${PORT:-10000} 2>&1 &
-NEXT_PID=$!
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] LangGraph agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: LangGraph agent failed to start — exiting"
+  exit 1
+fi
 
-echo "[entrypoint] Agent PID=$AGENT_PID, Next PID=$NEXT_PID"
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8123.
+# Poll the agent's /ok endpoint (langgraph_cli's health path) every 30s;
+# after 3 consecutive failures (~90s of unreachable agent), kill the agent
+# process so `wait -n` returns and Railway restarts the container.
+# Generalized from showcase/packages/crewai-crews/entrypoint.sh (PRs #4114
+# + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] Agent PID=$AGENT_PID, Next PID=$NEXTJS_PID"
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+exit $EXIT_CODE

--- a/showcase/packages/langgraph-python/entrypoint.sh
+++ b/showcase/packages/langgraph-python/entrypoint.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+cleanup() {
+  kill $LANGGRAPH_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Disable Python stdout buffering so langgraph_cli's dev server and any
+# tracebacks it emits reach the Railway log stream immediately rather than
+# sitting in Python's userspace buffer until the process exits. Paired with
+# `python -u` on the langgraph_cli invocation below.
+export PYTHONUNBUFFERED=1
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: langgraph-python"
 echo "[entrypoint] Time: $(date -u)"
@@ -43,11 +54,17 @@ echo "========================================="
 echo "[entrypoint] Starting LangGraph agent server on port 8123..."
 echo "========================================="
 
-python -m langgraph_cli dev \
+# `python -u` forces unbuffered stdout/stderr at the interpreter level
+# (belt-and-suspenders with PYTHONUNBUFFERED=1 above) so langgraph_cli boot
+# failures surface in the Railway log stream immediately rather than sitting
+# in a pipe buffer until the process exits. `awk ... fflush()` replaces the
+# previous `sed` formulation — process substitution leaves $! pointing at
+# the real python process (pipe form made $! point at sed).
+python -u -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
-  --no-browser 2>&1 | sed 's/^/[langgraph] /' &
+  --no-browser &> >(awk '{print "[langgraph] " $0; fflush()}') &
 LANGGRAPH_PID=$!
 
 # Give langgraph a moment to start
@@ -66,14 +83,52 @@ echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
 echo "========================================="
 
 PORT=${PORT:-10000}
-npx next start --port $PORT 2>&1 | sed 's/^/[nextjs] /' &
+npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
 
-# Wait for either process to exit
-wait -n
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the langgraph process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8123.
+# Poll the langgraph_cli /ok endpoint every 30s; after 3 consecutive failures
+# (~90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. Generalized from
+# showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $LANGGRAPH_PID 2>/dev/null; then
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $LANGGRAPH_PID to trigger container restart"
+        kill -9 $LANGGRAPH_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+echo "[entrypoint] All processes running. Waiting..."
+
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
+wait -n $LANGGRAPH_PID $NEXTJS_PID
 EXIT_CODE=$?
-echo "[entrypoint] A process exited with code $EXIT_CODE"
+if ! kill -0 $LANGGRAPH_PID 2>/dev/null; then
+  echo "[entrypoint] LangGraph (PID: $LANGGRAPH_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
 exit $EXIT_CODE

--- a/showcase/packages/langgraph-typescript/entrypoint.sh
+++ b/showcase/packages/langgraph-typescript/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 set -e
 
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
 echo "========================================="
-echo "[entrypoint] PORT=${PORT:-10000}"
-echo "[entrypoint] Starting LangGraph agent server on :8123..."
-echo "[entrypoint] Starting Next.js frontend..."
+echo "[entrypoint] Starting showcase package: langgraph-typescript"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
 echo "========================================="
 
 # Start LangGraph agent server in background.
@@ -12,7 +18,78 @@ echo "========================================="
 # regardless of how `localhost` resolves in the container. Default is 'localhost'
 # which on modern Node resolves IPv6-first (::1), leaving the IPv4 loopback
 # unbound and causing 503s from the frontend's /api/health probe.
-cd /app/src/agent && npx @langchain/langgraph-cli dev --port 8123 --host 0.0.0.0 --no-browser &
+#
+# Log prefixing uses bash process substitution (`&> >(awk …)`) rather than a
+# pipe (`| sed …`): process substitution leaves `$!` pointing at the real
+# langgraph-cli process, so `wait -n $AGENT_PID` monitors the right thing.
+echo "[entrypoint] Starting LangGraph TS agent on port 8123..."
+cd /app/src/agent && npx @langchain/langgraph-cli dev --port 8123 --host 0.0.0.0 --no-browser &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+cd /app
+sleep 3
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent server started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent server failed to start — exiting"
+  exit 1
+fi
 
-# Start Next.js frontend
-cd /app && exec npx next start --port "${PORT:-10000}"
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (agent, shell, healthchecks). `env` prefix
+# binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the langgraph process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8123.
+# Poll the langgraph-cli /ok endpoint every 30s; after 3 consecutive failures
+# (~90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. Generalized from
+# showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+echo "[entrypoint] All processes running. Waiting..."
+
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first, `wait -n` would
+# otherwise return with the watchdog's exit code and short-circuit before
+# the agent's true exit status is observable.
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/langroid/entrypoint.sh
+++ b/showcase/packages/langroid/entrypoint.sh
@@ -6,6 +6,16 @@ set -e
 # (e.g. FATAL in ``_check_key``).
 AGENT_PID=""
 NEXT_PID=""
+WATCHDOG_PID=""
+
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone. Paired with `python
+# -u` on the uvicorn invocation below and `awk ... fflush()` on the log
+# prefixer — all three are belt-and-suspenders measures against pipe-
+# buffered log loss observed across Railway deploys.
+export PYTHONUNBUFFERED=1
 
 cleanup() {
     # Trap may fire from a FATAL ``exit 1`` path where ``set -e`` is still
@@ -26,6 +36,7 @@ cleanup() {
     # waiting for the container runtime to SIGKILL it.
     [ -n "$AGENT_PID" ] && kill "$AGENT_PID" 2>/dev/null
     [ -n "$NEXT_PID" ] && kill "$NEXT_PID" 2>/dev/null
+    [ -n "$WATCHDOG_PID" ] && kill "$WATCHDOG_PID" 2>/dev/null
     for _ in 1 2 3 4 5; do
         local any_alive=0
         [ -n "$AGENT_PID" ] && kill -0 "$AGENT_PID" 2>/dev/null && any_alive=1
@@ -35,6 +46,7 @@ cleanup() {
     done
     [ -n "$AGENT_PID" ] && kill -0 "$AGENT_PID" 2>/dev/null && kill -9 "$AGENT_PID" 2>/dev/null
     [ -n "$NEXT_PID" ] && kill -0 "$NEXT_PID" 2>/dev/null && kill -9 "$NEXT_PID" 2>/dev/null
+    [ -n "$WATCHDOG_PID" ] && kill -0 "$WATCHDOG_PID" 2>/dev/null && kill -9 "$WATCHDOG_PID" 2>/dev/null
     return 0
 }
 trap cleanup EXIT
@@ -281,13 +293,47 @@ fi
 # immediately, the shell still proceeds to start Next.js. We capture PIDs and
 # probe them explicitly after `wait -n` so operators can tell which process
 # died with which exit code.
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+#
+# `python -u` + `awk ... fflush()` below: unbuffered stdout at the interpreter
+# level + line-flushed awk prefixer so uvicorn request lines and tracebacks
+# reach Railway's log stream immediately rather than block-buffered in pipe
+# buffers.
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 
 # Start Next.js frontend (PORT defaults to 10000 — Railway / local compose
 # override as needed).
-npx next start --port ${PORT:-10000} &
+npx next start --port ${PORT:-10000} &> >(awk '{print "[nextjs] " $0; fflush()}') &
 NEXT_PID=$!
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (~90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. Generalized from
+# showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+(
+    FAILS=0
+    while sleep 30; do
+        if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+            break
+        fi
+        if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+            FAILS=0
+        else
+            FAILS=$((FAILS + 1))
+            echo "[watchdog] Agent health probe failed (count=$FAILS)" >&2
+            if [ $FAILS -ge 3 ]; then
+                echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart" >&2
+                kill -9 "$AGENT_PID" 2>/dev/null || true
+                break
+            fi
+        fi
+    done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)" >&2
 
 # Wait for either process to exit; then figure out which one.
 # set +e for wait -n; exit code captured explicitly into EXIT_CODE. The

--- a/showcase/packages/llamaindex/entrypoint.sh
+++ b/showcase/packages/llamaindex/entrypoint.sh
@@ -1,12 +1,108 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
 
-# Wait for either process to exit
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting showcase package: llamaindex"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging. Generalized from showcase/packages/crewai-crews/entrypoint.sh
+# (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/ms-agent-dotnet/entrypoint.sh
+++ b/showcase/packages/ms-agent-dotnet/entrypoint.sh
@@ -1,12 +1,85 @@
 #!/bin/bash
 set -e
 
-# Start .NET agent backend
-dotnet /agent/ProverbsAgent.dll --urls "http://0.0.0.0:8000" &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+echo "========================================="
+echo "[entrypoint] Starting showcase package: ms-agent-dotnet"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
 
-# Wait for either process to exit
-wait -n
-exit $?
+if [ -z "$AZURE_OPENAI_API_KEY" ] && [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: Neither AZURE_OPENAI_API_KEY nor OPENAI_API_KEY is set! Agent will fail."
+fi
+
+# Start .NET agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+# `awk ... fflush()` line-flushes each prefixed line to the container log.
+echo "[entrypoint] Starting .NET agent on port 8000..."
+dotnet /agent/ProverbsAgent.dll --urls "http://0.0.0.0:8000" &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 3
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (~90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. Generalized from
+# showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/ms-agent-python/entrypoint.sh
+++ b/showcase/packages/ms-agent-python/entrypoint.sh
@@ -1,18 +1,108 @@
 #!/bin/bash
 set -e
 
-echo "[entrypoint] Starting agent backend on port 8000..."
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 2>&1 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
+
+echo "========================================="
+echo "[entrypoint] Starting showcase package: ms-agent-python"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
 
+echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
-npx next start --port ${PORT:-10000} 2>&1 &
-NEXT_PID=$!
+echo "========================================="
 
-echo "[entrypoint] Agent PID=$AGENT_PID, Next PID=$NEXT_PID"
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
 
-# Wait for either process to exit
-wait -n
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging. Generalized from showcase/packages/crewai-crews/entrypoint.sh
+# (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
-echo "[entrypoint] Process exited with code $EXIT_CODE"
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
 exit $EXIT_CODE

--- a/showcase/packages/pydantic-ai/entrypoint.sh
+++ b/showcase/packages/pydantic-ai/entrypoint.sh
@@ -1,12 +1,108 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
 
-# Wait for either process to exit
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting showcase package: pydantic-ai"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging. Generalized from showcase/packages/crewai-crews/entrypoint.sh
+# (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/packages/spring-ai/entrypoint.sh
+++ b/showcase/packages/spring-ai/entrypoint.sh
@@ -47,6 +47,37 @@ echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
 npx next start --port ${PORT:-10000} &
 NODE_PID=$!
 
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Spring Boot process stays alive (so `wait -n`
+# never fires and the container never restarts) but stops responding on
+# :8000. Poll Spring Boot's /health endpoint every 30s; after 3 consecutive
+# failures (~90s of unreachable agent), kill the java process so `wait -n`
+# returns and Railway restarts the container. The startup probe above
+# already gates the initial readiness window; this watchdog takes over for
+# steady-state monitoring. Generalized from
+# showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+(
+    FAILS=0
+    while sleep 30; do
+        if ! kill -0 "$JAVA_PID" 2>/dev/null; then
+            break
+        fi
+        if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+            FAILS=0
+        else
+            FAILS=$((FAILS + 1))
+            echo "[watchdog] Agent health probe failed (count=$FAILS)"
+            if [ $FAILS -ge 3 ]; then
+                echo "[watchdog] Agent unresponsive for ~90s — killing PID $JAVA_PID to trigger container restart"
+                kill -9 "$JAVA_PID" 2>/dev/null || true
+                break
+            fi
+        fi
+    done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8000/health)"
+
 # Wait for either process to exit. `wait -n` without PID args works on all
 # bash >= 4.3 (align with other showcase entrypoints such as google-adk);
 # the PID-args form requires bash 5.1+ which isn't guaranteed in minimal
@@ -110,6 +141,13 @@ if [ -n "$SURVIVOR_PID" ]; then
     # return non-zero; we don't care — we've already captured EXIT_CODE
     # from the first-to-die child.
     wait "$SURVIVOR_PID" 2>/dev/null || true
+fi
+
+# Clean up the watchdog if it's still running (e.g. Next.js exited, not Java).
+# Without this the backgrounded watchdog would continue polling /health on a
+# dying container until the platform SIGKILLs the process tree.
+if [ -n "${WATCHDOG_PID:-}" ] && kill -0 "$WATCHDOG_PID" 2>/dev/null; then
+    kill "$WATCHDOG_PID" 2>/dev/null || true
 fi
 
 exit "$EXIT_CODE"

--- a/showcase/packages/strands/entrypoint.sh
+++ b/showcase/packages/strands/entrypoint.sh
@@ -1,12 +1,108 @@
 #!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+cleanup() {
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true
+}
+trap cleanup EXIT
 
-# Start Next.js frontend (PORT defaults to 10000 for Render)
-npx next start --port ${PORT:-10000} &
+# Disable Python stdout buffering so the FastAPI/uvicorn agent flushes
+# tracebacks and log lines immediately. Without this a silent crash during
+# module import can sit in Python's userspace buffer until the process
+# exits, by which point the container is already gone.
+export PYTHONUNBUFFERED=1
 
-# Wait for either process to exit
-wait -n
-exit $?
+echo "========================================="
+echo "[entrypoint] Starting showcase package: strands"
+echo "[entrypoint] Time: $(date -u)"
+echo "[entrypoint] PORT=${PORT:-not set}"
+echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
+echo "========================================="
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "[entrypoint] WARNING: OPENAI_API_KEY is not set! Agent will fail."
+else
+  echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
+fi
+
+# Start agent backend on :8000 with log prefixing so its output is
+# distinguishable from Next.js in the Railway log stream.
+#
+# Belt-and-suspenders log flushing: `PYTHONUNBUFFERED=1` above exports the env
+# var, but a child process could in principle un-export or override it. The
+# `-u` flag to the Python interpreter forces unbuffered stdout/stderr at the
+# interpreter level and is not overridable by user code. Combined with the
+# `fflush()` inside the awk pipe below, this guarantees uvicorn request lines
+# and tracebacks reach Railway's log stream line-at-a-time rather than
+# block-buffered in pipe buffers.
+echo "[entrypoint] Starting Python agent on port 8000..."
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &> >(awk '{print "[agent] " $0; fflush()}') &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent started (PID: $AGENT_PID)"
+else
+  echo "[entrypoint] ERROR: Agent failed to start — exiting"
+  exit 1
+fi
+
+echo "========================================="
+echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
+echo "========================================="
+
+PORT=${PORT:-10000}
+# Scope NODE_ENV=production to the Next.js invocation ONLY, not the whole
+# container environment. `ENV NODE_ENV=production` at the image level would
+# leak into every child process (Python agent, shell, healthchecks). `env`
+# prefix binds the value to this single exec.
+env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] " $0; fflush()}') &
+NEXTJS_PID=$!
+
+echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
+
+# Watchdog: Railway deploys of showcase packages have been observed to hit a
+# silent agent hang — the Python process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on :8000.
+# Poll the agent's /health endpoint every 30s; after 3 consecutive failures
+# (90s of unreachable agent), kill the agent process so `wait -n` returns
+# and Railway restarts the container. We kill the agent (not the whole
+# script) first so `set -e` + `wait -n; exit $?` handles the restart
+# through the normal path rather than a forced `exit` that would bypass
+# logging. Generalized from showcase/packages/crewai-crews/entrypoint.sh
+# (PRs #4114 + #4115).
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] All processes running. Waiting..."
+
+wait -n $AGENT_PID $NEXTJS_PID
+EXIT_CODE=$?
+if ! kill -0 $AGENT_PID 2>/dev/null; then
+  echo "[entrypoint] Agent (PID: $AGENT_PID) exited with code $EXIT_CODE"
+elif ! kill -0 $NEXTJS_PID 2>/dev/null; then
+  echo "[entrypoint] Next.js (PID: $NEXTJS_PID) exited with code $EXIT_CODE"
+else
+  echo "[entrypoint] A process exited with code $EXIT_CODE"
+fi
+
+exit $EXIT_CODE

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -568,6 +568,84 @@ else
   exit 1
 fi`;
 
+/**
+ * Per-framework agent health URL (probed by the silent-hang watchdog).
+ *
+ * The watchdog runs AFTER the initial startup check, while the agent is
+ * serving traffic on its starter-local port (8123). Mapping: each framework's
+ * HTTP health endpoint path as verified against the source:
+ *   * FastAPI / uvicorn agents (ag2, agno, claude-sdk-python, crewai-crews,
+ *     google-adk, langroid, llamaindex, ms-agent-python, pydantic-ai, strands)
+ *     -> /health (served via middleware short-circuit in agent_server.py)
+ *   * langgraph-python, langgraph-fastapi, langgraph-typescript
+ *     -> /ok (exposed by langgraph_cli dev)
+ *   * claude-sdk-typescript -> /health (express app.get("/health"))
+ *   * ms-agent-dotnet -> /health (app.MapGet("/health", ...))
+ *   * spring-ai -> /health (custom @GetMapping in AgentController)
+ *   * mastra -> /api (mastra dev serves its REST surface at /api; no
+ *                      dedicated health endpoint, but /api returns 200 once
+ *                      the dev server is ready)
+ */
+function getAgentHealthPath(fw: FrameworkDef): string {
+  if (fw.slug.startsWith("langgraph-")) return "/ok";
+  if (fw.slug === "mastra") return "/api";
+  return "/health";
+}
+
+/**
+ * Emit the silent-hang watchdog block. Runs as a backgrounded subshell after
+ * the agent PID is captured and before Next.js starts. Polls the agent's
+ * health endpoint every 30s; after 3 consecutive failures (~90s of
+ * unreachable agent), kills the agent so `wait -n` returns and Railway/ECS
+ * restart the container.
+ *
+ * Generalized from showcase/packages/crewai-crews/entrypoint.sh (commits
+ * 9ce651330 + 9379b8855) which proved the shape in production.
+ *
+ * Parameters (substituted into the emitted shell):
+ *   - AGENT_HEALTH_URL: the `http://127.0.0.1:<agent-port><health-path>` URL
+ *     the watchdog probes. Computed per-framework from getAgentHealthPath().
+ *
+ * Consumes shell vars defined earlier in the entrypoint:
+ *   - $AGENT_PID: captured after backgrounded agent launch. All frameworks'
+ *     getEntrypointBlock() outputs set this.
+ */
+function getWatchdogBlock(fw: FrameworkDef): string {
+  const healthPath = getAgentHealthPath(fw);
+  const agentPort = 8123; // Starter agents all bind to :8123.
+  const healthUrl = `http://127.0.0.1:${agentPort}${healthPath}`;
+  return `# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so \`wait -n\` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so \`wait -n\` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# \`set -e\` + \`wait -n; exit $?\` handles the restart through the normal
+# path rather than a forced \`exit\` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 ${healthUrl} > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing ${healthUrl})"`;
+}
+
 // Previously the entrypoint used:
 //
 //   cmd 2>&1 | sed 's/^/[agent] /' &
@@ -593,8 +671,11 @@ function getEntrypointBlock(fw: FrameworkDef): string {
   switch (fw.language) {
     case "python":
       if (fw.slug === "langgraph-python" || fw.slug === "langgraph-fastapi") {
+        // `python -u` forces unbuffered stdout/stderr at the interpreter
+        // level so langgraph_cli boot failures surface in the log stream
+        // immediately (paired with PYTHONUNBUFFERED=1 in the template).
         return `echo "[entrypoint] Starting LangGraph agent server on port 8123..."
-python -m langgraph_cli dev \\
+python -u -m langgraph_cli dev \\
   --config langgraph.json \\
   --host 0.0.0.0 \\
   --port 8123 \\
@@ -603,8 +684,14 @@ AGENT_PID=$!
 sleep 3
 ${AGENT_HEALTH_CHECK}`;
       }
+      // `python -u` pairs with PYTHONUNBUFFERED=1: the env var exports the
+      // hint, the `-u` flag forces unbuffered streams at the interpreter
+      // level (not overridable by user code), and `awk ... fflush()` in
+      // AGENT_LOG_PREFIX line-flushes the prefixer. Combined, a silent
+      // crash during module import reaches the container log immediately.
+      // See crewai-crews entrypoint.sh for the reference shape.
       return `echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 ${AGENT_LOG_PREFIX} &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 sleep 2
 ${AGENT_HEALTH_CHECK}`;
@@ -633,10 +720,39 @@ AGENT_PID=$!
 sleep 2
 ${AGENT_HEALTH_CHECK}`;
     case "java":
+      // Spring Boot cold-start can legitimately exceed 30s under load (JVM
+      // warmup + context refresh), so a plain `sleep 5` + PID check would
+      // falsely pass the startup gate while /health is not yet serving.
+      // Probe /health for up to 60s before handing off to the watchdog
+      // which then takes over steady-state monitoring. If the java process
+      // dies during startup, the PID probe inside the loop fails-fast so
+      // a crash-looping boot exits quickly.
       return `echo "[entrypoint] Starting Spring AI agent on port 8123..."
 java -jar agent/app.jar --server.port=8123 ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
-sleep 5
+STARTUP_TIMEOUT=60
+echo "[entrypoint] Waiting for Spring Boot /health (timeout=\${STARTUP_TIMEOUT}s)..."
+SPRING_READY=0
+for i in $(seq 1 "$STARTUP_TIMEOUT"); do
+  if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+    echo "[entrypoint] Spring Boot ready after \${i}s"
+    SPRING_READY=1
+    break
+  fi
+  if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+    echo "[entrypoint] ERROR: Spring Boot (pid=$AGENT_PID) died during startup"
+    exit 1
+  fi
+  sleep 1
+done
+if [ "$SPRING_READY" -ne 1 ]; then
+  if kill -0 "$AGENT_PID" 2>/dev/null; then
+    echo "[entrypoint] ERROR: Spring Boot still alive (pid=$AGENT_PID) but /health did not return 2xx within \${STARTUP_TIMEOUT}s — exiting"
+  else
+    echo "[entrypoint] ERROR: Spring Boot exited before reporting healthy"
+  fi
+  exit 1
+fi
 ${AGENT_HEALTH_CHECK}`;
     case "csharp":
       return `echo "[entrypoint] Starting .NET agent on port 8123..."
@@ -810,6 +926,7 @@ function generateStarterImpl(fw: FrameworkDef, outDir: string): void {
     DEV_SCRIPT: fw.devScript,
     AGENT_PORT: "8123",
     DEV_SCRIPT_BLOCK: getEntrypointBlock(fw),
+    WATCHDOG_BLOCK: getWatchdogBlock(fw),
     DOCKER_EXTRA_COPY: dockerExtraCopy,
     LANGGRAPH_MKDIR: langgraphMkdir,
   };
@@ -1426,4 +1543,6 @@ export {
   forEachPyFile,
   extractUvicornModule,
   getEntrypointBlock,
+  getWatchdogBlock,
+  getAgentHealthPath,
 };

--- a/showcase/starters/ag2/entrypoint.sh
+++ b/showcase/starters/ag2/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/agno/entrypoint.sh
+++ b/showcase/starters/agno/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/claude-sdk-python/entrypoint.sh
+++ b/showcase/starters/claude-sdk-python/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/starters/claude-sdk-typescript/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -41,6 +43,37 @@ else
   exit 1
 fi
 
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
+
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
 echo "========================================="
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/crewai-crews/agent/requirements.txt
+++ b/showcase/starters/crewai-crews/agent/requirements.txt
@@ -1,5 +1,5 @@
 crewai>=0.130.0
-ag-ui-crewai>=0.1.4,<0.1.6
+ag-ui-crewai>=0.2.0,<0.3.0
 ag-ui-protocol>=0.1.5
 python-dotenv>=1.0.1
 uvicorn>=0.34.3

--- a/showcase/starters/crewai-crews/agent_server.py
+++ b/showcase/starters/crewai-crews/agent_server.py
@@ -5,8 +5,6 @@ FastAPI server that hosts the CrewAI crew backend.
 The Next.js CopilotKit runtime proxies requests here via AG-UI protocol.
 """
 
-import logging
-
 # ORDER-CRITICAL: load .env and apply aimock redirection FIRST — before any
 # crewai / litellm / openai module is imported. Those modules can construct
 # clients at import time that latch onto OPENAI_BASE_URL / OPENAI_API_KEY as
@@ -18,76 +16,20 @@ from aimock_toggle import configure_aimock
 load_dotenv()
 configure_aimock()
 
-# HARDENING: CrewAI's ChatWithCrewFlow.__init__ (in ag_ui_crewai.crews) makes
-# blocking synchronous LLM calls via generate_crew_chat_inputs, which in turn
-# calls generate_input_description_with_ai and generate_crew_description_with_ai
-# from crewai.cli.crew_chat. In ag-ui-crewai <= 0.1.5 this happens at module
-# import time inside add_crewai_crew_fastapi_endpoint, BEFORE uvicorn binds its
-# port. Any LLM hiccup (aimock regression, OpenAI outage, network blip) will
-# crash the Python process before the HTTP server is listening, which causes
-# Railway/Kubernetes/ECS health checks to fail and deploys to roll back.
+# NOTE: The pre-bind LLM crash hardening shim that previously lived here has
+# been removed. It monkey-patched crewai.cli.crew_chat.generate_*_description_with_ai
+# to static strings so that ChatWithCrewFlow.__init__ — which ag-ui-crewai
+# <= 0.1.5 invoked at endpoint-registration time (i.e. BEFORE uvicorn bound
+# its port) — could not crash the process before the HTTP server was
+# listening. Upstream issue: https://github.com/crewAIInc/crewAI/issues/5510.
 #
-# Patch both functions to return static strings. The AI-generated descriptions
-# are only cosmetic for the CrewAI chat UI (which the CopilotKit runtime does
-# not use), so static defaults are functionally equivalent for our showcase.
-#
-# Upstream issue: https://github.com/crewAIInc/crewAI/issues/5510
-# Upstream fix: ag-ui-crewai repo (deferred ChatWithCrewFlow construction
-# to first-request) — landed on main but not yet released as of 0.1.5.
-# Remove this shim once ag-ui-crewai > 0.1.5 ships and the requirements.txt
-# ceiling is lifted.
-from crewai.cli import crew_chat as _crewai_crew_chat
-
-# Fail loudly if upstream renames/removes these symbols. setattr() on a module
-# always succeeds regardless of prior attribute existence, so without this
-# guard an upstream rename would silently no-op the patch and reintroduce the
-# pre-bind LLM crash bug with a green PR.
-_REQUIRED_ATTRS = (
-    "generate_input_description_with_ai",
-    "generate_crew_description_with_ai",
-)
-for _attr in _REQUIRED_ATTRS:
-    if not hasattr(_crewai_crew_chat, _attr):
-        raise RuntimeError(
-            f"crewai upstream drift: crewai.cli.crew_chat.{_attr} no longer exists. "
-            f"The import-time hardening shim in agent_server.py would silently no-op, "
-            f"reintroducing the pre-bind LLM crash bug. Either update the shim to the "
-            f"new function name, or remove it if ag-ui-crewai > 0.1.5 (with deferred "
-            f"construction fix) has been adopted. See: "
-            f"https://github.com/crewAIInc/crewAI/issues/5510"
-        )
-
-
-def _static_input_description(input_name, *_args, **_kwargs):
-    return f"Input value for '{input_name}'."
-
-
-def _static_crew_description(*_args, **_kwargs):
-    return "A CrewAI crew."
-
-
-_crewai_crew_chat.generate_input_description_with_ai = _static_input_description
-_crewai_crew_chat.generate_crew_description_with_ai = _static_crew_description
-
-# Verify the patch took effect (defense-in-depth against import-order weirdness
-# or re-imports that could shadow our module reference).
-if _crewai_crew_chat.generate_input_description_with_ai is not _static_input_description:
-    raise RuntimeError(
-        "crewai hardening shim: patch verification failed — "
-        "generate_input_description_with_ai was shadowed or re-imported after patching. "
-        "This would reintroduce the pre-bind LLM crash bug."
-    )
-if _crewai_crew_chat.generate_crew_description_with_ai is not _static_crew_description:
-    raise RuntimeError(
-        "crewai hardening shim: patch verification failed — "
-        "generate_crew_description_with_ai was shadowed or re-imported after patching. "
-        "This would reintroduce the pre-bind LLM crash bug."
-    )
-
-logging.getLogger(__name__).info(
-    "Applied crewai.cli.crew_chat hardening shim (upstream issue #5510). "
-    "Remove this shim after ag-ui-crewai > 0.1.5 is adopted."
-)
+# ag-ui-crewai 0.2.0 (PR ag-ui-protocol/ag-ui#1550, released 2026-04-18)
+# defers ChatWithCrewFlow construction to first request via a module-scoped
+# `_cached_flow` + `asyncio.Lock` inside `add_crewai_crew_fastapi_endpoint`.
+# Any LLM hiccup now surfaces as a 5xx on the first request instead of a
+# startup crash, which is the correct failure mode for a runtime outage and
+# is what the shim was reaching for. With the requirements.txt pin bumped to
+# `>=0.2.0,<0.3.0`, the shim is dead code and has been removed.
 
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
 from fastapi import FastAPI

--- a/showcase/starters/crewai-crews/entrypoint.sh
+++ b/showcase/starters/crewai-crews/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/google-adk/entrypoint.sh
+++ b/showcase/starters/google-adk/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/langgraph-fastapi/entrypoint.sh
+++ b/showcase/starters/langgraph-fastapi/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting LangGraph agent server on port 8123..."
-python -m langgraph_cli dev \
+python -u -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
@@ -44,6 +46,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -65,8 +98,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -77,6 +114,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/langgraph-python/entrypoint.sh
+++ b/showcase/starters/langgraph-python/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting LangGraph agent server on port 8123..."
-python -m langgraph_cli dev \
+python -u -m langgraph_cli dev \
   --config langgraph.json \
   --host 0.0.0.0 \
   --port 8123 \
@@ -44,6 +46,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -65,8 +98,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -77,6 +114,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/langgraph-typescript/entrypoint.sh
+++ b/showcase/starters/langgraph-typescript/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -45,6 +47,37 @@ else
   exit 1
 fi
 
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
 echo "========================================="
@@ -65,8 +98,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -77,6 +114,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/llamaindex/entrypoint.sh
+++ b/showcase/starters/llamaindex/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -41,6 +43,37 @@ else
   exit 1
 fi
 
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/api > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api)"
+
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
 echo "========================================="
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/ms-agent-dotnet/entrypoint.sh
+++ b/showcase/starters/ms-agent-dotnet/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -42,6 +44,37 @@ else
   exit 1
 fi
 
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
+
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
 echo "========================================="
@@ -62,8 +95,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -74,6 +111,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/ms-agent-python/entrypoint.sh
+++ b/showcase/starters/ms-agent-python/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/pydantic-ai/entrypoint.sh
+++ b/showcase/starters/pydantic-ai/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/spring-ai/entrypoint.sh
+++ b/showcase/starters/spring-ai/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -33,13 +35,66 @@ fi
 echo "[entrypoint] Starting Spring AI agent on port 8123..."
 java -jar agent/app.jar --server.port=8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
-sleep 5
+STARTUP_TIMEOUT=60
+echo "[entrypoint] Waiting for Spring Boot /health (timeout=${STARTUP_TIMEOUT}s)..."
+SPRING_READY=0
+for i in $(seq 1 "$STARTUP_TIMEOUT"); do
+  if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+    echo "[entrypoint] Spring Boot ready after ${i}s"
+    SPRING_READY=1
+    break
+  fi
+  if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+    echo "[entrypoint] ERROR: Spring Boot (pid=$AGENT_PID) died during startup"
+    exit 1
+  fi
+  sleep 1
+done
+if [ "$SPRING_READY" -ne 1 ]; then
+  if kill -0 "$AGENT_PID" 2>/dev/null; then
+    echo "[entrypoint] ERROR: Spring Boot still alive (pid=$AGENT_PID) but /health did not return 2xx within ${STARTUP_TIMEOUT}s — exiting"
+  else
+    echo "[entrypoint] ERROR: Spring Boot exited before reporting healthy"
+  fi
+  exit 1
+fi
 if kill -0 $AGENT_PID 2>/dev/null; then
   echo "[entrypoint] Agent server started (PID: $AGENT_PID)"
 else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +116,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +132,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/strands/entrypoint.sh
+++ b/showcase/starters/strands/entrypoint.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,7 +33,7 @@ else
 fi
 
 echo "[entrypoint] Starting Python agent server on port 8123..."
-cd /app && python -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app && python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 sleep 2
 if kill -0 $AGENT_PID 2>/dev/null; then
@@ -40,6 +42,37 @@ else
   echo "[entrypoint] ERROR: Agent server failed to start — exiting"
   exit 1
 fi
+
+# Watchdog: Railway deploys of showcase starters have been observed to hit a
+# silent agent hang — the agent process stays alive (so `wait -n` never
+# fires and the container never restarts) but stops responding on its health
+# endpoint. Poll every 30s; after 3 consecutive failures (~90s of
+# unreachable agent), kill the agent so `wait -n` returns and the platform
+# restarts the container. We kill the agent (not the whole script) so
+# `set -e` + `wait -n; exit $?` handles the restart through the normal
+# path rather than a forced `exit` that bypasses logging.
+(
+  FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -61,8 +94,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -73,6 +110,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE

--- a/showcase/starters/template/entrypoint.template.sh
+++ b/showcase/starters/template/entrypoint.template.sh
@@ -2,10 +2,11 @@
 # Template variables (substituted by generate-starters.ts):
 #   SLUG             — framework slug (e.g. "langgraph-python")
 #   DEV_SCRIPT_BLOCK — language-specific agent startup block
+#   WATCHDOG_BLOCK   — silent-hang watchdog (polls agent /health; kills on stall)
 set -e
 
 cleanup() {
-  kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+  kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -13,7 +14,8 @@ trap cleanup EXIT
 # and log lines to awk (and the container log) the moment they're written.
 # Previously a silent crash during module import would sit in Python's
 # userspace buffer until the process exited, by which point the pipe to the
-# log prefixer had already closed and the error was lost.
+# log prefixer had already closed and the error was lost. Harmless for
+# non-Python frameworks (Java/Node/.NET ignore PYTHONUNBUFFERED).
 export PYTHONUNBUFFERED=1
 
 echo "========================================="
@@ -31,6 +33,8 @@ else
 fi
 
 {{DEV_SCRIPT_BLOCK}}
+
+{{WATCHDOG_BLOCK}}
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."
@@ -52,8 +56,12 @@ env NODE_ENV=production npx next start --port $PORT &> >(awk '{print "[nextjs] "
 NEXTJS_PID=$!
 
 echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
-echo "[entrypoint] Both processes running. Waiting..."
+echo "[entrypoint] All processes running. Waiting..."
 
+# Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to
+# kill the agent when it hangs; if the watchdog exits first (e.g. because it
+# killed the agent), wait -n would otherwise return with the watchdog's exit
+# code and short-circuit before the agent's true exit status is observable.
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?
 if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -64,6 +72,6 @@ else
   echo "[entrypoint] A process exited with code $EXIT_CODE"
 fi
 
-# Clean up surviving process
-kill $AGENT_PID $NEXTJS_PID 2>/dev/null
+# Clean up surviving processes (including watchdog)
+kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null
 exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Generalizes the silent-hang watchdog + unbuffered-stdout shape proven in `showcase/packages/crewai-crews/entrypoint.sh` (PRs #4114 + #4115) to every Bucket-B starter, the Bucket-C spring-ai starter, the generator, and the shared starter template.

**Reference shape:** `showcase/packages/crewai-crews/entrypoint.sh` on `origin/main` (unchanged in this PR; we generalize from it).

**Notion proposal:** https://www.notion.so/3493aa3818528191bc08f8b2f3fb1e88
**Prior art:** #4114 (watchdog), #4115 (unbuffered stdout)

## What the watchdog does

A backgrounded subshell polls the agent's health endpoint every 30s; after 3 consecutive failures (~90s), it `kill -9`s the agent so `wait -n` returns and the container runtime restarts via the normal path rather than a forced `exit` that would bypass logging.

## Per-starter coverage

| Slug | Framework | Agent port | Health path | Watchdog applied |
|---|---|---|---|---|
| ag2 | Python / FastAPI | 8123 | `/health` | Yes |
| agno | Python / FastAPI | 8123 | `/health` | Yes |
| claude-sdk-python | Python / FastAPI | 8123 | `/health` | Yes |
| claude-sdk-typescript | TypeScript / Express | 8123 | `/health` | Yes |
| crewai-crews | Python / FastAPI | 8123 | `/health` | Yes (via regen from template; matches reference shape) |
| google-adk | Python / FastAPI | 8123 | `/health` | Yes |
| langgraph-fastapi | Python / langgraph_cli | 8123 | `/ok` | Yes |
| langgraph-python | Python / langgraph_cli | 8123 | `/ok` | Yes |
| langgraph-typescript | TS / @langchain/langgraph-cli | 8123 | `/ok` | Yes |
| langroid | Python / FastAPI | 8123 | `/health` | Yes |
| llamaindex | Python / FastAPI | 8123 | `/health` | Yes |
| mastra | TypeScript / mastra dev | 8123 | `/api` | Yes (starter only; package side is single `exec next start` — N/A) |
| ms-agent-dotnet | .NET / ASP.NET | 8123 | `/health` | Yes |
| ms-agent-python | Python / FastAPI | 8123 | `/health` | Yes |
| pydantic-ai | Python / FastAPI | 8123 | `/health` | Yes |
| spring-ai | Java / Spring Boot | 8123 (starter) / 8000 (package) | `/health` | Yes; extends the existing 60s startup probe |
| strands | Python / FastAPI | 8123 | `/health` | Yes |

## Per-package coverage (hand-applied, not regen-able)

Every `showcase/packages/<slug>/entrypoint.sh` that runs a separate agent process received the watchdog + unbuffered block. Python variants also received `python -u` on their uvicorn / langgraph_cli invocations and `awk ... fflush()` log prefixing (replacing the prior `sed` pipe formulation so `$!` correctly captures the agent PID).

**N/A:** `packages/mastra/entrypoint.sh` is a single `exec npx next start` — no backgrounded agent to watch.

## Generator + template changes

- `showcase/scripts/generate-starters.ts` — new `getAgentHealthPath()` + `getWatchdogBlock()` helpers, plus Spring Boot `/health` 60s startup probe.
- `showcase/starters/template/entrypoint.template.sh` — adds `$WATCHDOG_PID` to cleanup, injects `{{WATCHDOG_BLOCK}}`, narrows the final `wait -n` to `$AGENT_PID $NEXTJS_PID` only.

## Out of scope (not touched)

- `showcase/packages/crewai-crews/entrypoint.sh` (reference shape; already correct on main).
- `showcase/{shell,shell-dashboard,shell-docs}` (separate workstream).
- Any agent source (Python / TS / Java / .NET).
- Dependency version bumps.

## Test plan

- [x] `bash -n` clean on all 32 modified `.sh` files.
- [x] `pnpm -C showcase/scripts test` — 1079/1079 tests pass (includes starter-output snapshots).
- [x] Watchdog marker present in every modified `packages/<slug>/entrypoint.sh` except mastra (intentional N/A).
- [x] `PYTHONUNBUFFERED=1` present in every Python-based package entrypoint.
- [ ] CI green before merge.
- [ ] Post-merge: observe one deploy per starter on Railway to confirm watchdog doesn't false-positive against a healthy agent.

## Judgment calls (documented)

- **`starters/crewai-crews/agent/{requirements.txt,agent_server.py}`**: kept as regen output. These match the current `packages/crewai-crews/` source (shimless, `ag-ui-crewai >=0.2.0`) that landed on main in commit 9379b8855. Reverting would re-desync the starter from the upstream source the generator reads.
- **`langgraph-typescript` packages side**: classified as Bucket B. The file on `origin/main` backgrounds `@langchain/langgraph-cli dev` on `:8123` and then `exec`s Next.js — the langgraph process can hang independently, so the watchdog applies.
- **`mastra` packages side**: classified as N/A. The file on `origin/main` is a single `exec npx next start` with no backgrounded agent.
- **`mastra` starter side**: Bucket B (the starter DOES run `mastra dev` on `:8123`). Watchdog probes `/api` (mastra's REST surface; no dedicated health endpoint but returns 200 once the dev server is ready).