### PR TITLE
fix(workflows): update docs-sync staging path after shell restructure

### DIFF
--- a/.github/workflows/showcase_docs-sync.yml
+++ b/.github/workflows/showcase_docs-sync.yml
@@ -185,7 +185,7 @@ jobs:
 
           # Stage AFTER manifest has been applied so conflicted files land
           # in the commit.
-          git add showcase/shell/src/content/ showcase/shell/.docs-sync-sha
+          git add showcase/shell-docs/src/content/ showcase/shell-docs/.docs-sync-sha
           CHANGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
 
           if [ "$CHANGED" = "0" ]; then


### PR DESCRIPTION
## Summary
- Docs Sync workflow has been failing since 2026-04-21 with `fatal: pathspec 'showcase/shell/src/content/' did not match any files` (exit 128) on the "Create PR for docs sync" step (example: run 24726678848).
- The path was moved by the shell platform restructure (#4109, #4112) — the docs content now lives under `showcase/shell-docs/src/content/`, and the sync marker at `showcase/shell-docs/.docs-sync-sha`. The sync script (`showcase/scripts/sync-docs-from-main.ts`) already writes to those locations; only the workflow's `git add` was still referencing the old monolithic `showcase/shell/` path.
- One-line path fix.

## Test plan
- [ ] Verify yaml parses.
- [ ] Confirm next docs-sync run succeeds end-to-end (opens a sync PR for the 11 pending review items from run 24726678848).