### PR TITLE
feat(examples/langgraph-python-threads): use intelligence composite image

### DIFF
--- a/examples/integrations/langgraph-python-threads/README.md
+++ b/examples/integrations/langgraph-python-threads/README.md
@@ -14,12 +14,11 @@ This project is a monorepo with three services:
 
 When threads are enabled, additional infrastructure runs via Docker Compose:
 
-| Service              | Port | Description                              |
-| -------------------- | ---- | ---------------------------------------- |
-| **PostgreSQL**       | 5432 | Thread and event storage                 |
-| **Redis**            | 6379 | Session/cache                            |
-| **App API**          | 4201 | Intelligence REST API                    |
-| **Realtime Gateway** | 4401 | WebSocket gateway for live thread events |
+| Service          | Port       | Description                                                                                                                                        |
+| ---------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PostgreSQL**   | 5432       | Thread and event storage                                                                                                                           |
+| **Redis**        | 6379       | Session/cache                                                                                                                                      |
+| **Intelligence** | 4201, 4401 | All-in-one CopilotKit Intelligence container (app-api on 4201, realtime-gateway on 4401, plus thread-culler and db-migrations, under s6-overlay).  |
 
 ## Prerequisites
 
@@ -59,7 +58,7 @@ This authenticates you and issues a `COPILOTKIT_LICENSE_TOKEN`. Add it to your `
 docker compose up -d --wait
 ```
 
-This pulls the GHCR images pinned to `0.1.0-rc.7`.
+This pulls `ghcr.io/copilotkit/intelligence/composite` — a single container that runs app-api, realtime-gateway, thread-culler, and the db-migrations oneshot together under s6-overlay supervision. The per-service images remain available at `ghcr.io/copilotkit/intelligence/{app-api,realtime-gateway,thread-culler,db-migrations}` if you'd rather run them separately.
 
 5. Start all services:
 

--- a/examples/integrations/langgraph-python-threads/docker-compose.yml
+++ b/examples/integrations/langgraph-python-threads/docker-compose.yml
@@ -1,7 +1,8 @@
 # Intelligence infrastructure for threads support.
 #
-# Starts postgres, redis, runs DB migrations, and the intelligence
-# app-api + realtime-gateway services.
+# Starts postgres, redis, and the all-in-one intelligence composite
+# container (runs app-api, realtime-gateway, thread-culler, and the
+# db-migrations oneshot internally under s6-overlay).
 #
 # Usage:
 #   docker compose up -d --wait
@@ -52,96 +53,30 @@ services:
       - intelligence
 
   # ---------------------------------------------------------------------------
-  # Database migrations (runs once then exits)
+  # Intelligence composite (app-api + realtime-gateway + thread-culler +
+  # db-migrations, all in one container under s6-overlay)
   # ---------------------------------------------------------------------------
 
-  db-migrations:
-    image: ghcr.io/copilotkit/intelligence/db-migrations:0.1.0-rc.7
-    environment:
-      DATABASE_URL: postgresql://intelligence:intelligence@postgres:5432/intelligence_app
-    depends_on:
-      postgres:
-        condition: service_healthy
-    restart: "no"
-    networks:
-      - intelligence
-
-  # ---------------------------------------------------------------------------
-  # Intelligence services
-  # ---------------------------------------------------------------------------
-
-  app-api:
-    image: ghcr.io/copilotkit/intelligence/app-api:0.1.0-rc.7
+  intelligence:
+    image: ghcr.io/copilotkit/intelligence/composite:0.0.0-ghcr.20260422.1
     ports:
       - "${APP_API_HOST_PORT:-4201}:4201"
-    environment:
-      NODE_ENV: development
-      HOST: 0.0.0.0
-      PORT: 4201
-      LOG_LEVEL: debug
-      DATABASE_URL: postgresql://intelligence:intelligence@postgres:5432/intelligence_app
-      REDIS_URL: redis://redis:6379
-      AUTH_SECRET: local-dev-secret-must-be-at-least-32-chars
-      AUTH_TRUST_HOST: "true"
-      DEPLOYMENT_MODE: self-hosted
-      DEFAULT_ORGANIZATION_ID: casa-de-erlang
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      db-migrations:
-        condition: service_completed_successfully
-    restart: unless-stopped
-    networks:
-      - intelligence
-
-  realtime-gateway:
-    image: ghcr.io/copilotkit/intelligence/realtime-gateway:0.1.0-rc.7
-    ports:
       - "${REALTIME_GATEWAY_HOST_PORT:-4401}:4401"
     environment:
       DATABASE_URL: postgresql://intelligence:intelligence@postgres:5432/intelligence_app
       REDIS_URL: redis://redis:6379
+      AUTH_SECRET: local-dev-secret-must-be-at-least-32-chars
       RUNNER_AUTH_SECRET: dev-runner-secret
       SECRET_KEY_BASE: local-realtime-gateway-secret-key-base-at-least-64-bytes-long-for-dev
-      PHX_HOST: localhost
-      PORT: 4401
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      db-migrations:
-        condition: service_completed_successfully
-    healthcheck:
-      test: ["CMD-SHELL", "nc -z 127.0.0.1 4401"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 20s
-    restart: unless-stopped
-    networks:
-      - intelligence
-
-  thread-culler:
-    image: ghcr.io/copilotkit/intelligence/thread-culler:0.1.0-rc.7
-    command:
-      [
-        "sh",
-        "-lc",
-        "while true; do node dist/apps/thread-culler/main.mjs; sleep 3600; done",
-      ]
-    environment:
-      DATABASE_URL: postgresql://intelligence:intelligence@postgres:5432/intelligence_app
+      DEFAULT_ORGANIZATION_ID: casa-de-erlang
       COPILOTKIT_LICENSE_TOKEN: "${COPILOTKIT_LICENSE_TOKEN:-}"
       THREAD_STALE_HOURS: "${THREAD_STALE_HOURS:-3}"
       THREAD_CULL_BATCH_SIZE: "${THREAD_CULL_BATCH_SIZE:-1000}"
     depends_on:
       postgres:
         condition: service_healthy
-      db-migrations:
-        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - intelligence


### PR DESCRIPTION
## Summary

Replaces the four separate intelligence containers (`db-migrations`, `app-api`, `realtime-gateway`, `thread-culler`) in the langgraph-python-threads example with a single `intelligence` composite container that runs all of them under `s6-overlay` supervision. Compose file drops from six services to three (`postgres`, `redis`, `intelligence`). README updated to match.