### PR TITLE
fix(showcase): langgraph watchdog regression — startup grace period

### DIFF
--- a/showcase/packages/langgraph-fastapi/entrypoint.sh
+++ b/showcase/packages/langgraph-fastapi/entrypoint.sh
@@ -61,7 +61,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # process so `wait -n` returns and Railway restarts the container.
 # Generalized from showcase/packages/crewai-crews/entrypoint.sh (PRs #4114
 # + #4115).
+#
+# Startup grace: langgraph_cli dev does a heavy cold-start (graph compile
+# + uvicorn boot). On fresh Railway containers this can exceed the 90s
+# (3-strike) budget introduced in PR #4116, matching the restart loop
+# observed on langgraph-typescript (deployment
+# 58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9, 04-20 17:05 UTC). Wait up to 180s
+# for the first healthy /ok probe before arming the strike counter; if
+# /ok comes up sooner, fall through immediately. If 180s elapses without
+# success, arm the counter anyway — the steady-state watchdog will then
+# handle a true hang.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -82,7 +110,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 ) &
 WATCHDOG_PID=$!
 
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, startup grace 180s)"
 echo "[entrypoint] Agent PID=$AGENT_PID, Next PID=$NEXTJS_PID"
 wait -n $AGENT_PID $NEXTJS_PID
 EXIT_CODE=$?

--- a/showcase/packages/langgraph-python/entrypoint.sh
+++ b/showcase/packages/langgraph-python/entrypoint.sh
@@ -95,7 +95,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (~90s of unreachable agent), kill the agent process so `wait -n` returns
 # and Railway restarts the container. Generalized from
 # showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+#
+# Startup grace: langgraph_cli dev does a heavy cold-start (graph compile
+# + uvicorn boot). On fresh Railway containers this can exceed the 90s
+# (3-strike) budget introduced in PR #4116, matching the restart loop
+# observed on langgraph-typescript (deployment
+# 58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9, 04-20 17:05 UTC). Wait up to 180s
+# for the first healthy /ok probe before arming the strike counter; if
+# /ok comes up sooner, fall through immediately. If 180s elapses without
+# success, arm the counter anyway — the steady-state watchdog will then
+# handle a true hang.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $LANGGRAPH_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $LANGGRAPH_PID 2>/dev/null; then
@@ -115,7 +143,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok, startup grace 180s)"
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to

--- a/showcase/packages/langgraph-typescript/entrypoint.sh
+++ b/showcase/packages/langgraph-typescript/entrypoint.sh
@@ -55,7 +55,34 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (~90s of unreachable agent), kill the agent process so `wait -n` returns
 # and Railway restarts the container. Generalized from
 # showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+#
+# Startup grace: langgraph-cli dev does a heavy cold-start (Studio IPC +
+# @langchain/langgraph-api spawn + graph compile). On fresh Railway
+# containers this routinely exceeds the 90s (3-strike) budget introduced
+# in PR #4116, producing the 04-20 restart loop seen on deployment
+# 58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9. Wait up to 180s for the first
+# healthy /ok probe before arming the strike counter; if /ok comes up
+# sooner, fall through immediately. If 180s elapses without success, arm
+# the counter anyway — the steady-state watchdog will handle a true hang.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -75,7 +102,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok, startup grace 180s)"
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -610,10 +610,67 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  *   - $AGENT_PID: captured after backgrounded agent launch. All frameworks'
  *     getEntrypointBlock() outputs set this.
  */
+/**
+ * Per-framework startup grace (seconds) — how long the watchdog waits after
+ * agent spawn before its first strike counts. Lets slow-starting agents
+ * reach their health endpoint without the 90s (3-strike) watchdog killing
+ * the process in a restart loop.
+ *
+ * `langgraph-*` agents use `langgraph-cli dev`, which on first boot does a
+ * Studio browser handshake + `@langchain/langgraph-api` JIT spawn + graph
+ * compile; on cold Railway containers this routinely exceeds the 90s
+ * strike threshold, producing the 04-20 restart loop on deployment
+ * 58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9. 180s is the observed upper bound
+ * across cold-start samples plus a safety margin.
+ *
+ * All other starters keep the 0s grace they had before PR #4116: crewai-
+ * crews and the other uvicorn-based agents are responsive within the
+ * 2–3s `sleep` that precedes `AGENT_HEALTH_CHECK`, so adding a grace
+ * here would only delay legitimate restart on true hangs.
+ */
+function getWatchdogGraceSeconds(fw: FrameworkDef): number {
+  if (fw.slug.startsWith("langgraph-")) return 180;
+  return 0;
+}
+
 function getWatchdogBlock(fw: FrameworkDef): string {
   const healthPath = getAgentHealthPath(fw);
   const agentPort = 8123; // Starter agents all bind to :8123.
   const healthUrl = `http://127.0.0.1:${agentPort}${healthPath}`;
+  const graceSeconds = getWatchdogGraceSeconds(fw);
+  // Grace loop: wait for first successful health probe up to `graceSeconds`
+  // before handing off to the steady-state strike counter. If the agent
+  // reports ready sooner, fall through immediately so the watchdog becomes
+  // effective as early as possible. If the agent hasn't reported ready by
+  // the deadline, still hand off — the watchdog will then strike and kill
+  // per normal, but only after giving slow cold-starts a fair shot.
+  //
+  // We deliberately do NOT `exit 1` on grace timeout (contrast with
+  // spring-ai's startup wait which exits): an agent that's still loading
+  // after 180s might just be a very cold container, and the steady-state
+  // watchdog handles the true-hang case in another 90s.
+  const graceBlock =
+    graceSeconds > 0
+      ? `  GRACE=${graceSeconds}
+  echo "[watchdog] Startup grace: waiting up to \${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 ${healthUrl} > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after \${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
+`
+      : "";
   return `# Watchdog: Railway deploys of showcase starters have been observed to hit a
 # silent agent hang — the agent process stays alive (so \`wait -n\` never
 # fires and the container never restarts) but stops responding on its health
@@ -622,8 +679,14 @@ function getWatchdogBlock(fw: FrameworkDef): string {
 # restarts the container. We kill the agent (not the whole script) so
 # \`set -e\` + \`wait -n; exit $?\` handles the restart through the normal
 # path rather than a forced \`exit\` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
-  FAILS=0
+${graceBlock}  FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -643,7 +706,7 @@ function getWatchdogBlock(fw: FrameworkDef): string {
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing ${healthUrl})"`;
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing ${healthUrl}${graceSeconds > 0 ? `, startup grace ${graceSeconds}s` : ""})"`;
 }
 
 // Previously the entrypoint used:

--- a/showcase/starters/ag2/entrypoint.sh
+++ b/showcase/starters/ag2/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/agno/entrypoint.sh
+++ b/showcase/starters/agno/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/claude-sdk-python/entrypoint.sh
+++ b/showcase/starters/claude-sdk-python/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/starters/claude-sdk-typescript/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/crewai-crews/entrypoint.sh
+++ b/showcase/starters/crewai-crews/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/google-adk/entrypoint.sh
+++ b/showcase/starters/google-adk/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/langgraph-fastapi/entrypoint.sh
+++ b/showcase/starters/langgraph-fastapi/entrypoint.sh
@@ -55,7 +55,31 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -76,7 +100,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok, startup grace 180s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."

--- a/showcase/starters/langgraph-python/entrypoint.sh
+++ b/showcase/starters/langgraph-python/entrypoint.sh
@@ -55,7 +55,31 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -76,7 +100,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok, startup grace 180s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."

--- a/showcase/starters/langgraph-typescript/entrypoint.sh
+++ b/showcase/starters/langgraph-typescript/entrypoint.sh
@@ -55,7 +55,31 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -76,7 +100,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok, startup grace 180s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."

--- a/showcase/starters/llamaindex/entrypoint.sh
+++ b/showcase/starters/llamaindex/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/ms-agent-dotnet/entrypoint.sh
+++ b/showcase/starters/ms-agent-dotnet/entrypoint.sh
@@ -52,6 +52,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/ms-agent-python/entrypoint.sh
+++ b/showcase/starters/ms-agent-python/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/pydantic-ai/entrypoint.sh
+++ b/showcase/starters/pydantic-ai/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/spring-ai/entrypoint.sh
+++ b/showcase/starters/spring-ai/entrypoint.sh
@@ -73,6 +73,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do

--- a/showcase/starters/strands/entrypoint.sh
+++ b/showcase/starters/strands/entrypoint.sh
@@ -51,6 +51,12 @@ fi
 # restarts the container. We kill the agent (not the whole script) so
 # `set -e` + `wait -n; exit $?` handles the restart through the normal
 # path rather than a forced `exit` that bypasses logging.
+#
+# Some frameworks (langgraph-*) have slow cold-start paths that can exceed
+# the 90s strike budget on a fresh Railway container. For those, an
+# initial startup-grace window waits for the first healthy probe (or a
+# per-framework ceiling) before the strike counter is armed. See
+# getWatchdogGraceSeconds() for the mapping.
 (
   FAILS=0
   while sleep 30; do


### PR DESCRIPTION
## Incident

`langgraph-typescript` is in a restart loop on Railway as of **04-20 17:05 UTC** (deployment `58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9`), returning 502 to production traffic.

## Root cause

PR #4116 generalized the silent-hang watchdog from `crewai-crews` to every showcase starter: poll agent health every 30s, kill after 3 consecutive failures (~90s). That's fine for uvicorn/express agents (responsive in <5s), but `langgraph-cli dev` does a heavy cold-start:

- Studio browser IPC handshake (`createIpcServer`)
- `@langchain/langgraph-api` JIT spawn (`spawnServer`)
- Graph compile

On cold Railway containers this routinely exceeds 90s — the watchdog was killing the process before `/ok` ever became reachable, producing a kill-loop every ~90s.

## Phase 1 findings

Verified the health path is correct — not a path bug:

- `@langchain/langgraph-cli@1.1.17/dist/cli/up.mjs:27` uses `/ok` as its own probe.
- `@langchain/langgraph-api@1.1.17/dist/api/meta.mjs:64` registers `api.get("/ok", ...)`.
- `langgraph_cli` (Python) serves `/ok` from the same api surface.

The regression is purely a **timing** issue: 90s strike budget is insufficient for langgraph cold-start on Railway.

## Fix — Option B (startup grace)

Added per-framework `getWatchdogGraceSeconds()` in the generator:

- `langgraph-*` starters: **180s grace**
- All other starters: **0s grace** (matches pre-#4116 behavior)

The grace loop waits up to 180s for the first healthy `/ok` probe before arming the strike counter:

- First success → fall through immediately and arm the counter.
- 180s elapsed without success → arm the counter anyway (steady-state watchdog then handles true hangs on the normal 90s schedule).
- Agent dies during grace → exit grace loop, `wait -n` in main shell handles it.

**Not a revert of #4116.** The silent-hang vulnerability class remains covered (still kills after 90s of steady-state failures); the grace only defers the first strike.

## Per-starter changes

| Starter | Grace | Behavioral change |
|---|---|---|
| langgraph-typescript | 180s | **Fixes restart loop** |
| langgraph-python | 180s | Preemptive |
| langgraph-fastapi | 180s | Preemptive |
| crewai-crews, ag2, agno, claude-sdk-*, google-adk, llamaindex, langroid, mastra, ms-agent-*, pydantic-ai, spring-ai, strands | 0s | None (comment-only diff) |

## Files touched

- `showcase/scripts/generate-starters.ts` — new `getWatchdogGraceSeconds()` + grace block in `getWatchdogBlock()`
- `showcase/starters/*/entrypoint.sh` — regenerated (17 files; grace block for langgraph-*, comment-only for the other 14)
- `showcase/packages/langgraph-typescript/entrypoint.sh` — hand-edited grace block (this package uses its own hand-edited entrypoint, not the template)
- `showcase/packages/langgraph-fastapi/entrypoint.sh` — same
- `showcase/packages/langgraph-python/entrypoint.sh` — same

## Validation

- `bash -n` passes on all 19 edited `entrypoint.sh` files
- 1079/1079 `showcase-scripts` vitest pass (`pnpm --filter @copilotkit/showcase-scripts test`)

## References

- Regression source: #4116
- Railway deployment: `58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9`
- Incident window: 04-20 17:05 UTC — ongoing at PR creation

## Test plan

- [ ] CI green
- [ ] Deploy to Railway — watch first boot log for `[watchdog] Startup grace: waiting up to 180s...` followed by `[watchdog] Agent healthy after Ns — arming strike counter`
- [ ] Confirm no restart loop on `langgraph-typescript`