### PR TITLE
fix(showcase): extend watchdog grace to claude-sdk-typescript and mastra

### DIFF
--- a/showcase/packages/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/packages/claude-sdk-typescript/entrypoint.sh
@@ -52,7 +52,33 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (~90s of unreachable agent), kill the agent process so `wait -n` returns
 # and Railway restarts the container. Generalized from
 # showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
+#
+# Startup grace: `node /app/agent_server.js` runs the compiled
+# @anthropic-ai/claude-agent-sdk bundle and was observed restart-looping
+# on Railway starting 04-20 16:54 UTC — the 90s (3-strike) budget was
+# shorter than the cold-start path on a fresh container. Wait up to 180s
+# for the first successful health probe before arming the strike counter
+# so slow cold-starts aren't killed in a loop. Matches the starter-level
+# grace emitted by getWatchdogGraceSeconds() in generate-starters.ts.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -623,6 +623,15 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  * 58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9. 180s is the observed upper bound
  * across cold-start samples plus a safety margin.
  *
+ * `mastra` starters spawn `mastra dev`, which runs a tsx-based build +
+ * Mastra server boot on first request and was observed restart-looping
+ * on Railway starting 04-20 18:18 UTC — same kill-loop shape as langgraph.
+ *
+ * `claude-sdk-typescript` starters spawn `tsx agent/index.ts` which
+ * performs a full tsx type-strip + @anthropic-ai/claude-agent-sdk init;
+ * observed restart-looping on Railway starting 04-20 16:54 UTC on the
+ * package-level deploy (same generator-emitted watchdog shape).
+ *
  * All other starters keep the 0s grace they had before PR #4116: crewai-
  * crews and the other uvicorn-based agents are responsive within the
  * 2–3s `sleep` that precedes `AGENT_HEALTH_CHECK`, so adding a grace
@@ -630,6 +639,8 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  */
 function getWatchdogGraceSeconds(fw: FrameworkDef): number {
   if (fw.slug.startsWith("langgraph-")) return 180;
+  if (fw.slug === "mastra") return 180;
+  if (fw.slug === "claude-sdk-typescript") return 180;
   return 0;
 }
 

--- a/showcase/starters/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/starters/claude-sdk-typescript/entrypoint.sh
@@ -58,6 +58,24 @@ fi
 # per-framework ceiling) before the strike counter is armed. See
 # getWatchdogGraceSeconds() for the mapping.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -78,7 +96,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health, startup grace 180s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -58,6 +58,24 @@ fi
 # per-framework ceiling) before the strike counter is armed. See
 # getWatchdogGraceSeconds() for the mapping.
 (
+  GRACE=180
+  echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
+  ELAPSED=0
+  while [ $ELAPSED -lt $GRACE ]; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent died during startup — wait -n in the main shell will handle it.
+      exit 0
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/api > /dev/null 2>&1; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+      break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+  done
+  if [ $ELAPSED -ge $GRACE ]; then
+    echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
+  fi
   FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
@@ -78,7 +96,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 180s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."


### PR DESCRIPTION
## Incident

Two more showcase starters are in a Railway restart loop with the same
shape that #4123 fixed for langgraph-*:

- **`claude-sdk-typescript`** (package, :8000) — restart-looping since
  **04-20 16:54 UTC**. Runs compiled `node /app/agent_server.js`.
- **`mastra`** (starter, :8123/api) — restart-looping since
  **04-20 18:18 UTC**. Runs `npx mastra dev` on :8123 alongside
  Next.js on ${PORT:-10000}.

## Root cause

Same as #4123: PR #4116's watchdog has a 90s (3-strike) kill budget.
For agents whose cold-start path on a fresh Railway container exceeds
90s, the watchdog kills the agent before it ever reports healthy, and
the loop never breaks.

- `node /app/agent_server.js` cold-starts the full
  `@anthropic-ai/claude-agent-sdk` bundle.
- `mastra dev` performs a tsx build + Mastra server boot on first
  request.

Both exceed 90s on cold-start consistently enough to kill-loop in
production.

## Fix

Extend the `getWatchdogGraceSeconds()` mapping in
`showcase/scripts/generate-starters.ts` to return 180s for
`mastra` and `claude-sdk-typescript` in addition to `langgraph-*`.
Regenerate the two starter entrypoints. Also apply the same grace
block inline to the **package-level** `claude-sdk-typescript`
entrypoint (hand-written, not generator-emitted).

## Scope decision

**Per-framework grace, not universal.** Cite the alternative for the
record:

> Universal 180s would avoid future "which framework class needs
> grace" debate and cost basically nothing on fast cold-starts
> (uvicorn < 10s) — a 180s grace just delays the first probe from
> 30s to 180s.

Kept per-framework for this PR:

1. Smaller diff, smaller review surface (4 files vs regenerating all
   17 starters).
2. Matches the existing design comment in
   `getWatchdogGraceSeconds()` which explicitly argues that uvicorn-
   responsive agents should keep 0s so legitimate hangs restart
   quickly.
3. We now have 3 framework classes needing grace; if a 4th appears,
   universalizing becomes cheap and justified on aggregate data.

## Mastra starter — watchdog kept, not dropped

PR #4116's finisher classified **package-level** mastra as N/A
(correct — the package IS the Next.js app, no separate agent). The
**starter** is different: `mastra dev` runs as a legitimate separate
process on :8123 alongside Next.js on :10000. The watchdog there is
correctly supervising that process — grace is the right fix, not a
revert.

## Files

- `showcase/scripts/generate-starters.ts` — mapping + justification
  comment
- `showcase/packages/claude-sdk-typescript/entrypoint.sh` — inline
  grace block (package uses :8000, hand-written entrypoint)
- `showcase/starters/claude-sdk-typescript/entrypoint.sh` —
  regenerated
- `showcase/starters/mastra/entrypoint.sh` — regenerated

Package-level `mastra/entrypoint.sh` is intentionally unchanged
(no watchdog, just `exec npx next start`).

## Test plan

- [x] `bash -n` clean on all 3 modified `.sh` files
- [x] `pnpm -C showcase/scripts test` — 1079/1079 pass
- [x] `npx tsc --noEmit` in `showcase/scripts` — clean
- [x] `npx tsx generate-starters.ts` is idempotent after the regen
      commit (no further diff)
- [x] `validate-pins` — pre-existing failures on main unchanged; no
      new failures introduced by this PR
- [ ] Railway redeploy of `claude-sdk-typescript` package service
      shows `[watchdog] Agent healthy after Ns — arming strike
      counter` and exits the restart loop
- [ ] Railway redeploy of `mastra` starter service shows the same
      grace log line and exits the restart loop

## Refs

- #4123 — prior langgraph grace fix (same pattern)
- #4116 — origin of the generalized watchdog
- #4114 / #4115 — original crewai-crews watchdog