### PR TITLE
chore(ci): add interim keep-alive cron for showcase starters

### DIFF
--- a/.github/workflows/showcase_keep-alive.yml
+++ b/.github/workflows/showcase_keep-alive.yml
@@ -1,0 +1,51 @@
+# INTERIM — superseded by showcase-ops smoke cadence (see Notion).
+#
+# Goal: curl /api/health on each showcase starter every 5 min so the agent's
+# in-memory state (JIT, module cache, connection pools) stays warm. Railway Pro
+# tier doesn't sleep containers, but warm-state decays over idle.
+#
+# This workflow is intentionally minimal — no Slack, no metrics, no state.
+# Observability / alerting is already handled by showcase_smoke-monitor.yml.
+# This is strictly keep-alive.
+
+name: "Showcase: Keep-Alive"
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  ping:
+    name: Ping ${{ matrix.slug }}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        slug:
+          - ag2
+          - agno
+          - claude-sdk-python
+          - claude-sdk-typescript
+          - crewai-crews
+          - google-adk
+          - langgraph-fastapi
+          - langgraph-python
+          - langgraph-typescript
+          - langroid
+          - llamaindex
+          - mastra
+          - ms-agent-dotnet
+          - ms-agent-python
+          - pydantic-ai
+          - spring-ai
+          - strands
+    steps:
+      - name: Ping /api/health
+        run: |
+          curl -fsS --max-time 15 \
+            "https://showcase-${{ matrix.slug }}-production.up.railway.app/api/health" \
+            > /dev/null


### PR DESCRIPTION
## Why

Adds an interim GitHub Actions cron that curls `/api/health` on each of the 17 showcase starter services every 5 minutes. The goal is to keep the agent's in-memory state warm — JIT tiers, module cache, connection pools. Railway Pro tier doesn't sleep containers, but warm-state still decays over idle periods.

This is a stopgap until the `showcase-ops` service (see Notion proposal §2a) lands. Its smoke probe runs at the same cadence and will subsume this workflow entirely.

## What

New file: `.github/workflows/showcase_keep-alive.yml`

- Schedule: `*/5 * * * *` (every 5 minutes) + manual `workflow_dispatch`
- Matrix over all 17 starter slugs (`ag2`, `agno`, `claude-sdk-python`, `claude-sdk-typescript`, `crewai-crews`, `google-adk`, `langgraph-fastapi`, `langgraph-python`, `langgraph-typescript`, `langroid`, `llamaindex`, `mastra`, `ms-agent-dotnet`, `ms-agent-python`, `pydantic-ai`, `spring-ai`, `strands`)
- Each cell: `curl -fsS --max-time 15 https://showcase-<slug>-production.up.railway.app/api/health`
- `fail-fast: false` + `continue-on-error: true` so one starter being down doesn't cancel the others
- No Slack notification — `showcase_smoke-monitor.yml` already covers alerting. This workflow is strictly keep-alive, not observability.
- Header comment marks it INTERIM and references the showcase-ops cutover

## Interim marker

Remove this workflow once `showcase-ops` ships its smoke probe at the same 5-min cadence (tracked in the Notion showcase-ops proposal).

## Test plan

- [ ] Verify workflow parses in the Actions UI after merge
- [ ] Trigger `workflow_dispatch` once manually; confirm all 17 cells run and pass for healthy starters
- [ ] Confirm no Slack noise generated by this workflow
- [ ] Remove when showcase-ops cutover lands