### PR TITLE
fix(showcase/scripts): allow generate-search-index stub when scan dirs absent

### DIFF
--- a/showcase/scripts/generate-search-index.ts
+++ b/showcase/scripts/generate-search-index.ts
@@ -294,10 +294,14 @@ function main() {
   }
 
   if (scanDirsPresent.length === 0) {
-    console.error(
-      `[generate-search-index] all scan directories missing — refusing to emit a near-empty index. Missing: ${scanDirsMissing.join(", ")}`,
+    // Some build contexts (e.g. the `shell` Docker build) intentionally
+    // omit the shell-docs content tree — they only need the static-pages
+    // stub so the header search modal has something to render and links
+    // resolve across to docs.showcase.copilotkit.ai. Warn loudly so a
+    // misconfigured full build is still visible in logs, but don't fail.
+    console.warn(
+      `[generate-search-index] all scan directories missing — emitting static-pages stub only. Missing: ${scanDirsMissing.join(", ")}`,
     );
-    process.exit(1);
   }
 
   // Write (dual-emit to shell-docs + shell)


### PR DESCRIPTION
## Summary
- `showcase/scripts/generate-search-index.ts` previously fatal-exited with "all scan directories missing — refusing to emit a near-empty index" when run inside a Docker build context that doesn't COPY the `shell-docs/src/content/` tree (e.g. the `shell` package build).
- This PR softens the guard so it emits a stub/warns when all scan dirs are absent, instead of killing the Docker RUN.

## Why
Regression from #4127 merging on top of generator changes in `c91c7c567` / `debfa6600`. Blocking showcase deploy for `shell` right now.

## Test plan
- [ ] showcase deploy green for `shell` after merge
- [ ] Existing search-index output unchanged when scan dirs are present