### PR TITLE
fix(showcase): restore shell build by copying shell-docs content into scan dir

### DIFF
--- a/showcase/shell/Dockerfile
+++ b/showcase/shell/Dockerfile
@@ -15,6 +15,7 @@ COPY showcase/shared/ ./shared/
 COPY showcase/packages/ ./packages/
 COPY showcase/scripts/ ./scripts/
 COPY showcase/shell/ ./shell/
+COPY showcase/shell-docs/src/content/ ./shell-docs/src/content/
 
 # Bake commit info into Next.js build
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
@@ -37,7 +38,6 @@ COPY --from=builder /app/shell/.next ./.next
 COPY --from=builder /app/shell/node_modules ./node_modules
 COPY --from=builder /app/shell/package.json ./
 COPY --from=builder /app/shell/public ./public
-COPY --from=builder /app/shell/src/content ./src/content
 
 EXPOSE 10000
 CMD ["npx", "next", "start", "-p", "10000"]


### PR DESCRIPTION
## Summary

- The shell app's Docker build ran `generate-search-index.ts` against `/app/shell-docs/src/content/{reference,ag-ui,docs}`, but the shell Dockerfile never copied that directory into the build context. The script's fail-loud guard (refuses to emit a near-empty index when all scan roots are missing) then aborted the build. Fix copies `showcase/shell-docs/src/content/` into the builder stage so the scan finds its input.
- Removed `COPY --from=builder /app/shell/src/content ./src/content` from the runner stage — that path was left over from the pre-split layout and never existed under the current tree, so the runner stage failed before this could ever succeed.

Main was red on `Showcase: Build & Deploy` for both the `shell` and `shell-dashboard` matrix entries after #4127 merged. `shell-dashboard` was unblocked separately (GHCR package linkage). `shell` needed this source fix.

## Test plan

- [x] `depot build --platform linux/amd64 -f showcase/shell/Dockerfile .` — succeeds end-to-end (prior failure was inside the builder RUN; runner stage COPY also failed before the fix).
- [ ] After merge: `Showcase: Build & Deploy` `build (shell, ...)` job green.
- [ ] After merge: Railway redeploys `showcase-shell` from the new `:latest`; `https://showcase.copilotkit.ai/` returns 200.