### PR TITLE
fix(showcase/shell): drop vestigial COPY of non-existent src/content dir

### DIFF
--- a/showcase/shell/Dockerfile
+++ b/showcase/shell/Dockerfile
@@ -37,7 +37,6 @@ COPY --from=builder /app/shell/.next ./.next
 COPY --from=builder /app/shell/node_modules ./node_modules
 COPY --from=builder /app/shell/package.json ./
 COPY --from=builder /app/shell/public ./public
-COPY --from=builder /app/shell/src/content ./src/content
 
 EXPOSE 10000
 CMD ["npx", "next", "start", "-p", "10000"]


### PR DESCRIPTION
## Summary
- Remove `COPY --from=builder /app/shell/src/content ./src/content` from `showcase/shell/Dockerfile` — the source dir doesn't exist in the repo and isn't generated at build time.

## Why
Previously masked by the `generate-search-index.ts` fatal guard (fixed in #4135). With that guard softened, the build now reaches the runner stage and fails on this stale COPY. Blocking showcase/shell deploy.

## Test plan
- [ ] `docker build` green locally
- [ ] Showcase deploy green for shell after merge