### PR TITLE
fix(showcase/langgraph-typescript): restore watchdog health probe after prod-mode migration

### DIFF
--- a/showcase/packages/langgraph-typescript/entrypoint.sh
+++ b/showcase/packages/langgraph-typescript/entrypoint.sh
@@ -60,7 +60,10 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # Watchdog: Railway deploys of showcase packages have been observed to hit a
 # silent agent hang — the langgraph process stays alive (so `wait -n` never
 # fires and the container never restarts) but stops responding on :8123.
-# Poll the langgraph-cli /ok endpoint every 30s; after 3 consecutive failures
+# Poll the liveness sidecar on :8124/ok every 30s (bound synchronously by
+# server.mjs BEFORE startServer, so it is up within ms of node boot —
+# independent of the multi-second graph import + worker_thread spawn that
+# gates the main Hono bind on :8123). After 3 consecutive failures
 # (~90s of unreachable agent), kill the agent process so `wait -n` returns
 # and Railway restarts the container. Generalized from
 # showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
@@ -82,7 +85,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       # Agent died during startup — wait -n in the main shell will handle it.
       exit 0
     fi
-    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+    if curl -fsS --max-time 5 http://127.0.0.1:8124/ok > /dev/null 2>&1; then
       echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
       break
     fi
@@ -97,7 +100,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
     fi
-    if curl -fsS --max-time 5 http://127.0.0.1:8123/ok > /dev/null 2>&1; then
+    if curl -fsS --max-time 5 http://127.0.0.1:8124/ok > /dev/null 2>&1; then
       FAILS=0
     else
       FAILS=$((FAILS + 1))
@@ -111,7 +114,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/ok, startup grace 180s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8124/ok, startup grace 180s)"
 echo "[entrypoint] All processes running. Waiting..."
 
 # Only wait on agent + next.js — NOT the watchdog. The watchdog's job is to

--- a/showcase/packages/langgraph-typescript/src/agent/server.mjs
+++ b/showcase/packages/langgraph-typescript/src/agent/server.mjs
@@ -18,11 +18,44 @@
 
 import process from "node:process";
 import path from "node:path";
+import http from "node:http";
 import { fileURLToPath } from "node:url";
 import { startServer } from "@langchain/langgraph-api/server";
 import { getStaticGraphSchema } from "@langchain/langgraph-api/schema";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Liveness side-car. The main @langchain/langgraph-api Hono server on :8123
+// only starts accepting connections AFTER `registerFromEnv` finishes the
+// initial graph import + `Starting N workers` loop — on Railway this can take
+// longer than the watchdog's 180s grace when the graph drags in the full
+// schema-worker tsx pipeline. Running a bare HTTP server on a sibling port
+// lets the entrypoint watchdog verify the process is alive and its event
+// loop is responsive during cold-start, independent of how slow the Hono
+// bind is. A true hang (event loop pinned) still fails this probe and
+// triggers the container restart.
+function startLivenessProbe() {
+  const livenessPort = Number(process.env.HEALTH_PORT ?? 8124);
+  const livenessHost = process.env.HOST ?? "0.0.0.0";
+  const server = http.createServer((req, res) => {
+    if (req.url === "/ok") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end('{"status":"ok"}');
+      return;
+    }
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end('{"status":"not_found"}');
+  });
+  server.listen(livenessPort, livenessHost, () => {
+    console.log(
+      `[server] Liveness probe listening on ${livenessHost}:${livenessPort}`,
+    );
+  });
+  server.on("error", (err) => {
+    console.warn(`[server] Liveness probe error: ${err?.message ?? err}`);
+  });
+  return server;
+}
 
 // Graph spec mirrors langgraph.json. We pin the compiled .js entry because the
 // production parser walks the source file with the TypeScript API; pointing at
@@ -58,6 +91,10 @@ async function main() {
   const cwd = __dirname; // src/agent
   const port = Number(process.env.PORT ?? 8123);
   const host = process.env.HOST ?? "0.0.0.0";
+
+  // Bring the liveness probe up synchronously before any await — gives the
+  // watchdog a valid /ok target within milliseconds of `node` boot.
+  startLivenessProbe();
 
   // Kick off pre-warm and startServer in parallel. startServer registers
   // graphs synchronously and binds the port — /ok is live before schemas


### PR DESCRIPTION
## Summary

- Root cause: #4132 migrated langgraph-typescript from `langgraph-cli dev` (which exposed `/ok` immediately) to `@langchain/langgraph-api` `startServer`. That server DOES register `/ok` via its meta routes, but only binds the port AFTER `registerFromEnv` imports the graph and spawns the N workers. On Railway that window has been exceeding the watchdog's 180s startup grace + 90s strike budget, producing an infinite restart loop (deploy `ddc88ef9` is flapping ~every 4m30s).
- Fix: move liveness off the heavy Hono path entirely. `server.mjs` now starts a bare `node:http` server on port 8124 (configurable via `HEALTH_PORT`) synchronously before any `await`, answering `GET /ok` with `{"status":"ok"}`. `entrypoint.sh` watchdog now probes `127.0.0.1:8124/ok` instead of `:8123/ok`.

## Why

The service has been 502-ing all day. Railway deploy `ddc88ef9` never serves a single `/api/health` 200 despite `[server] LangGraph API listening on 0.0.0.0:8123` landing in the logs — the `listening` callback fires after the watchdog has already killed PID 4 and triggered a restart.

Liveness on a sibling port is independent of whether :8123 has finished its graph import, so the probe reflects what the watchdog actually cares about: is the Node process alive and its event loop responsive. A true hang (event loop pinned) still fails the probe and triggers container restart, so hang-detection is preserved.

## Test plan

- [x] Local Docker build green (`--platform linux/amd64`, depot)
- [x] Local container `curl http://127.0.0.1:8124/ok` returns `HTTP=200 {"status":"ok"}` within 20s of boot
- [x] `[server] Liveness probe listening on 0.0.0.0:8124` emitted before `[server] LangGraph API listening on 0.0.0.0:8123`
- [ ] Railway redeploy recovers `/api/health` + `/api/smoke`