### PR TITLE
fix(react-core/v2): restore markdown list markers inside chat prose

### DIFF
--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -201,6 +201,49 @@
   scrollbar-color: oklch(0.5 0 0) transparent;
 }
 
+/*
+ * Restore list defaults inside prose.
+ *
+ * scope-preflight.mjs rewrites Tailwind's preflight
+ *   `ol, ul, menu { list-style: none; margin: 0; padding: 0 }`
+ * into `[data-copilotkit] ul, ul[data-copilotkit], ... { ... }`
+ * (specificity 0,1,1). The typography plugin's prose rule is
+ *   `.cpk\:prose :where(ul) { list-style-type: disc; padding-inline-start: 1.625em; ... }`
+ * but `:where()` contributes 0 to specificity, so the rule is only (0,1,0)
+ * and the scoped reset wins — markdown lists inside chat messages render
+ * without bullets, numbers, padding, or spacing.
+ *
+ * These rules sit at (0,2,1) and restore the typography defaults without
+ * touching the preflight itself.
+ */
+[data-copilotkit] .cpk\:prose ul {
+  list-style-type: disc;
+  padding-inline-start: 1.625em;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+[data-copilotkit] .cpk\:prose ol {
+  list-style-type: decimal;
+  padding-inline-start: 1.625em;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+[data-copilotkit] .cpk\:prose ol[type="A"] {
+  list-style-type: upper-alpha;
+}
+[data-copilotkit] .cpk\:prose ol[type="a"] {
+  list-style-type: lower-alpha;
+}
+[data-copilotkit] .cpk\:prose ol[type="I"] {
+  list-style-type: upper-roman;
+}
+[data-copilotkit] .cpk\:prose ol[type="i"] {
+  list-style-type: lower-roman;
+}
+[data-copilotkit] .cpk\:prose ol[type="1"] {
+  list-style-type: decimal;
+}
+
 [data-copilotkit] .prose input[type="checkbox"] {
   appearance: none;
   background-color: #fff;

--- a/showcase/shell/src/data/constraints.json
+++ b/showcase/shell/src/data/constraints.json
@@ -94,10 +94,7 @@
   },
   "interaction_modalities": {
     "headless": {
-      "excluded": [
-        "open-gen-ui",
-        "voice"
-      ]
+      "excluded": ["open-gen-ui", "voice"]
     }
   }
 }

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -366,11 +366,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -422,18 +418,14 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -446,9 +438,7 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": null,
           "highlight": [
@@ -462,9 +452,7 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -477,9 +465,7 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -493,9 +479,7 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools",
           "animated_preview_url": null,
           "highlight": [
@@ -508,9 +492,7 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": null,
           "highlight": [
@@ -524,9 +506,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -540,9 +520,7 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": null,
           "highlight": [
@@ -556,9 +534,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null,
           "highlight": [
@@ -573,9 +549,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null,
           "highlight": [
@@ -589,9 +563,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null,
           "highlight": [
@@ -605,9 +577,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null,
           "highlight": [
@@ -622,9 +592,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null,
           "highlight": [
@@ -638,9 +606,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null,
           "highlight": [
@@ -654,9 +620,7 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": null,
           "highlight": [
@@ -669,9 +633,7 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": null,
           "highlight": [
@@ -684,9 +646,7 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-slots",
           "animated_preview_url": null,
           "highlight": [
@@ -700,9 +660,7 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-simple",
           "animated_preview_url": null,
           "highlight": [
@@ -715,9 +673,7 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-complete",
           "animated_preview_url": null,
           "highlight": [
@@ -732,9 +688,7 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": null,
           "highlight": [
@@ -748,9 +702,7 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": null,
           "highlight": [
@@ -764,9 +716,7 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": null,
           "highlight": [
@@ -782,9 +732,7 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": null,
           "highlight": [
@@ -802,9 +750,7 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/mcp-apps",
           "animated_preview_url": null,
           "highlight": [
@@ -817,9 +763,7 @@
           "id": "open-gen-ui",
           "name": "Open-Ended Generative UI",
           "description": "Minimal — enable open-ended gen UI in the runtime, nothing else",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/open-gen-ui",
           "animated_preview_url": null,
           "highlight": [
@@ -832,9 +776,7 @@
           "id": "open-gen-ui-advanced",
           "name": "Open-Ended Gen UI (Advanced: with frontend function calling)",
           "description": "Agent-authored UI that can invoke frontend sandbox functions from inside the iframe",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/open-gen-ui-advanced",
           "animated_preview_url": null,
           "highlight": [
@@ -848,9 +790,7 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": null,
           "highlight": [
@@ -863,9 +803,7 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": null,
           "highlight": [
@@ -878,9 +816,7 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": null,
           "highlight": [
@@ -893,9 +829,7 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": null,
           "highlight": [
@@ -910,9 +844,7 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -1075,11 +1007,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1107,9 +1035,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1117,9 +1043,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1127,9 +1051,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1137,9 +1059,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1147,9 +1067,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1157,9 +1075,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1167,9 +1083,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1177,9 +1091,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1239,11 +1151,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1271,9 +1179,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1281,9 +1187,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1291,9 +1195,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1301,9 +1203,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1311,9 +1211,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1321,9 +1219,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1331,9 +1227,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1341,9 +1235,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1403,11 +1295,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1431,9 +1319,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1441,9 +1327,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1451,9 +1335,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1461,9 +1343,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1471,9 +1351,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1481,9 +1359,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1491,9 +1367,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1501,9 +1375,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1563,11 +1435,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1595,9 +1463,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1605,9 +1471,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1615,9 +1479,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1625,9 +1487,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1635,9 +1495,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1645,9 +1503,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1655,9 +1511,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1665,9 +1519,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1727,11 +1579,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1759,9 +1607,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1769,9 +1615,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1779,9 +1623,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1789,9 +1631,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1799,9 +1639,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1809,9 +1647,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1819,9 +1655,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1829,9 +1663,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1891,11 +1723,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1919,9 +1747,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1929,9 +1755,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1939,9 +1763,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1949,9 +1771,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1959,9 +1779,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1969,9 +1787,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1979,9 +1795,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1989,9 +1803,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2051,11 +1863,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2071,9 +1879,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2081,9 +1887,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2091,9 +1895,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2101,9 +1903,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2111,9 +1911,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2121,9 +1919,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2131,9 +1927,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2141,9 +1935,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2211,11 +2003,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2231,9 +2019,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2241,9 +2027,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2251,9 +2035,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2261,9 +2043,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2271,9 +2051,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2281,9 +2059,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2291,9 +2067,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2301,9 +2075,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2371,11 +2143,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2399,9 +2167,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2409,9 +2175,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2419,9 +2183,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2429,9 +2191,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2439,9 +2199,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2449,9 +2207,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2459,9 +2215,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2469,9 +2223,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2535,11 +2287,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2555,9 +2303,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2565,9 +2311,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2575,9 +2319,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2585,9 +2327,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2595,9 +2335,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2605,9 +2343,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2615,9 +2351,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2625,9 +2359,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2699,11 +2431,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2727,9 +2455,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2737,9 +2463,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2747,9 +2471,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2757,9 +2479,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2767,9 +2487,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2777,9 +2495,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2787,9 +2503,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2797,9 +2511,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2863,11 +2575,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2891,9 +2599,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2901,9 +2607,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2911,9 +2615,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2921,9 +2623,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2931,9 +2631,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2941,9 +2639,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2951,9 +2647,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2961,9 +2655,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3023,11 +2715,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3043,9 +2731,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3053,9 +2739,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3063,9 +2747,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3073,9 +2755,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3083,9 +2763,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3093,9 +2771,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3103,9 +2779,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3113,9 +2787,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3150,11 +2822,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -3178,9 +2846,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3188,9 +2854,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3198,9 +2862,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3208,9 +2870,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3218,9 +2878,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3228,9 +2886,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3238,9 +2894,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3248,9 +2902,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3310,11 +2962,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -3338,9 +2986,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3348,9 +2994,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3358,9 +3002,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3368,9 +3010,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3378,9 +3018,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3388,9 +3026,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3398,9 +3034,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3408,9 +3042,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3470,11 +3102,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3490,9 +3118,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3500,9 +3126,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3510,9 +3134,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3520,9 +3142,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3530,9 +3150,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3540,9 +3158,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3550,9 +3166,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3560,9 +3174,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }


### PR DESCRIPTION
## Summary
- `scope-preflight.mjs` rewrites Tailwind's preflight `ol, ul, menu { list-style: none; margin: 0; padding: 0 }` into a scoped `[data-copilotkit] ul, ul[data-copilotkit], …` rule at specificity (0,1,1).
- The typography plugin's prose rule is only `.cpk\:prose :where(ul) { list-style-type: disc; … }` — specificity (0,1,0), since `:where()` contributes nothing.
- The scoped reset wins, so markdown lists inside assistant messages render with no bullets, numbers, padding, or spacing.
- Adds a (0,2,1) restore for `ul` / `ol` inside `.cpk:prose` so the typography defaults survive the reset. Preflight itself is untouched — host apps still get the leakage protection it was added for.

## Test plan
- [ ] `pnpm --filter @copilotkit/react-core run build:css` produces the expected `[data-copilotkit] .cpk\:prose ul { list-style-type: disc; … }` rules in `dist/v2/index.css`.
- [ ] In a docs/app using `<CopilotChat />`, an assistant message containing a markdown `- item` list renders with bullet markers; a `1. item` list renders with decimal numbers; both have proper left padding and vertical spacing.
- [ ] Non-prose lists elsewhere in the CopilotKit UI are unaffected (still markerless per the existing reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)