### PR TITLE
fix(vscode-extension): run azure/login in dry-run mode

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -133,7 +133,7 @@ jobs:
           if-no-files-found: error
 
       - name: Login to Azure (OIDC → Entra SP)
-        if: steps.check.outputs.published == 'false'
+        if: steps.check.outputs.published == 'false' || inputs.dry_run == true
         uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}

--- a/.github/workflows/vscode-extension-changelog-sync.yml
+++ b/.github/workflows/vscode-extension-changelog-sync.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'packages/vscode-extension/CHANGELOG.md'
-      - 'packages/vscode-extension/README.md'
+      - "packages/vscode-extension/CHANGELOG.md"
+      - "packages/vscode-extension/README.md"
 
 concurrency:
   group: changelog-sync-${{ github.event.pull_request.number }}

--- a/packages/vscode-extension/RELEASING.md
+++ b/packages/vscode-extension/RELEASING.md
@@ -44,18 +44,23 @@ Once the namespace is claimed, subsequent CI publishes run unattended.
 Cutting a release is one file edit, one commit, one PR.
 
 1. Prepend an entry to `packages/vscode-extension/CHANGELOG.md`:
+
    ```md
    ## 0.1.1 — 2026-04-22
 
    ### Fixed
+
    - Hook Explorer crash on empty workspaces
 
    ### Added
+
    - New "Copy AG-UI run URL" command
    ```
+
    Use Keep-a-Changelog subsections: `Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security`. The date is whatever date you commit.
 
    If you also want to change how the extension is described on the Marketplace / Open VSX listing page, edit the first paragraph under the `# CopilotKit for VS Code` title in `packages/vscode-extension/README.md` in the same PR. The metadata-sync workflow extracts that paragraph, strips inline markdown, and writes it to `package.json.description` (the field both registries render as the one-liner). First paragraph must stay ≤200 chars — the workflow fails fast otherwise so you don't silently ship a truncated listing.
+
 2. Commit with any message (e.g. `docs: changelog for 0.1.1`) and push.
 3. Open a PR.
 4. **Automation**: the **VS Code Extension — Metadata Sync** workflow runs on your PR, reads the top version from CHANGELOG and the first paragraph of README.md, and bumps `packages/vscode-extension/package.json` (`.version` and/or `.description`) to match. If a version bump is needed it commits `chore: release vX.Y.Z`; otherwise, if only the description drifted it commits `chore(vscode-extension): sync description from README`. No action needed from you — just pull the updated branch if you keep working locally.


### PR DESCRIPTION
Verify Marketplace credential expects an active Azure session via azure/login, but login was gated only on published==false. When dry_run=true and version is already published, the verify step ran without a session and failed. Widening the guard to include dry_run.