### PR TITLE
fix(showcase/langgraph-typescript): bind liveness probe before heavy module imports

### DIFF
--- a/showcase/packages/langgraph-typescript/entrypoint.sh
+++ b/showcase/packages/langgraph-typescript/entrypoint.sh
@@ -14,16 +14,19 @@ echo "[entrypoint] NODE_ENV=${NODE_ENV:-not set}"
 echo "========================================="
 
 # Start LangGraph agent server in background.
-# We invoke @langchain/langgraph-api/server directly (see src/agent/server.mjs)
-# instead of `langgraph-cli dev`. Rationale: dev mode wraps the server in
-# `tsx watch` + chokidar + Studio IPC, and its schema-extraction worker is
-# cold on first request (multi-second TS program compile). Production path:
-#   1. `node --import tsx` — tsx is a one-shot ESM hook for graph.ts at load
-#      time only, NOT a watcher (no chokidar, no restart loop).
-#   2. `server.mjs` pre-warms the schema cache before the first external
-#      /assistants/*/schemas hits.
-#   3. /ok liveness stays sub-10ms regardless of graph-compile load because
-#      the schema worker runs in a worker_thread off the main event loop.
+# `npm start` runs `node --import tsx liveness.mjs` (see src/agent/package.json).
+# liveness.mjs binds :8124/ok immediately using only node:http, then dynamic-
+# imports server.mjs to kick off the real @langchain/langgraph-api bootstrap.
+# We avoid `langgraph-cli dev` for the same reasons as before: dev wraps the
+# server in `tsx watch` + chokidar + Studio IPC, and its schema-extraction
+# worker is cold on first request (multi-second TS program compile).
+# Production path:
+#   1. `node --import tsx liveness.mjs` — tsx is a one-shot ESM hook so the
+#      subsequent dynamic import of server.mjs (and thence graph.ts) resolves
+#      without pre-compilation. NOT a watcher.
+#   2. liveness.mjs brings up :8124/ok before any heavy import runs.
+#   3. Dynamic-imported server.mjs pre-warms the schema cache before the
+#      first external /assistants/*/schemas hits.
 #
 # --host 0.0.0.0 via HOST env; binds IPv4+IPv6 so the Next.js frontend can
 # reach the agent regardless of how `localhost` resolves in the container.
@@ -60,10 +63,10 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # Watchdog: Railway deploys of showcase packages have been observed to hit a
 # silent agent hang — the langgraph process stays alive (so `wait -n` never
 # fires and the container never restarts) but stops responding on :8123.
-# Poll the liveness sidecar on :8124/ok every 30s (bound synchronously by
-# server.mjs BEFORE startServer, so it is up within ms of node boot —
-# independent of the multi-second graph import + worker_thread spawn that
-# gates the main Hono bind on :8123). After 3 consecutive failures
+# Poll the liveness sidecar on :8124/ok every 30s (bound by liveness.mjs
+# BEFORE server.mjs is dynamic-imported, so it is up within ms of node boot —
+# independent of the multi-minute @langchain/langgraph-api top-level import
+# that gates the main Hono bind on :8123). After 3 consecutive failures
 # (~90s of unreachable agent), kill the agent process so `wait -n` returns
 # and Railway restarts the container. Generalized from
 # showcase/packages/crewai-crews/entrypoint.sh (PRs #4114 + #4115).

--- a/showcase/packages/langgraph-typescript/src/agent/liveness.mjs
+++ b/showcase/packages/langgraph-typescript/src/agent/liveness.mjs
@@ -1,0 +1,37 @@
+// Liveness front-door. This module is the process entry point (see
+// entrypoint.sh). It binds an HTTP server on :8124/ok using ONLY `node:http`
+// — zero heavy imports — so the watchdog has a valid probe target within
+// milliseconds of `node` boot.
+//
+// ES modules resolve ALL top-level `import` statements before any module-body
+// code runs. `@langchain/langgraph-api/server` (pulled in by server.mjs) takes
+// ~4m30s to cold-import on Railway (graph eval + tsx transpile). The watchdog
+// in entrypoint.sh allows 180s grace + 3×30s strikes = 270s before killing
+// the container — roughly 4s short of when a probe embedded in server.mjs
+// would actually bind. Kill-loop forever.
+//
+// Fix: bind :8124 first from a module with no heavy imports, THEN dynamic-
+// import server.mjs to kick off the real langgraph bootstrap. Dynamic imports
+// are evaluated at call time, not at module load time, so the listen callback
+// fires before the heavy graph is touched.
+
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.HEALTH_PORT || 8124);
+
+createServer((req, res) => {
+  if (req.url === "/ok") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end('{"status":"ok"}\n');
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+}).listen(PORT, "0.0.0.0", () => {
+  console.log(`[liveness] probe listening on 0.0.0.0:${PORT}`);
+  // Defer real server start until AFTER liveness is bound.
+  import("./server.mjs").catch((err) => {
+    console.error("[liveness] server.mjs import failed:", err);
+    process.exit(1);
+  });
+});

--- a/showcase/packages/langgraph-typescript/src/agent/package.json
+++ b/showcase/packages/langgraph-typescript/src/agent/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "npx @langchain/langgraph-cli dev --port 8123 --no-browser",
-    "start": "node --import tsx server.mjs"
+    "start": "node --import tsx liveness.mjs"
   },
   "dependencies": {
     "@copilotkit/sdk-js": "1.51.4",

--- a/showcase/packages/langgraph-typescript/src/agent/server.mjs
+++ b/showcase/packages/langgraph-typescript/src/agent/server.mjs
@@ -1,8 +1,10 @@
 // LangGraph agent — production server (no CLI, no file watch, no Studio IPC).
 //
-// Invoked as `node --import tsx server.mjs`. tsx is used ONLY as a one-shot
-// ESM import hook so the initial import of graph.ts succeeds; nothing is
-// recompiled per-request. Equivalent to langgraph-cli dev for the runs,
+// Dynamic-imported by liveness.mjs (the process entry point) AFTER :8124/ok
+// is bound. The run invocation is `node --import tsx liveness.mjs`; tsx is
+// used ONLY as a one-shot ESM import hook so subsequent imports (this file,
+// graph.ts) resolve without recompilation per-request. Equivalent to
+// langgraph-cli dev for the runs,
 // threads, assistants, ok, and store surface but without:
 //
 //   - chokidar file watcher that recompiles on any .ts change,
@@ -18,44 +20,21 @@
 
 import process from "node:process";
 import path from "node:path";
-import http from "node:http";
 import { fileURLToPath } from "node:url";
 import { startServer } from "@langchain/langgraph-api/server";
 import { getStaticGraphSchema } from "@langchain/langgraph-api/schema";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Liveness side-car. The main @langchain/langgraph-api Hono server on :8123
-// only starts accepting connections AFTER `registerFromEnv` finishes the
-// initial graph import + `Starting N workers` loop — on Railway this can take
-// longer than the watchdog's 180s grace when the graph drags in the full
-// schema-worker tsx pipeline. Running a bare HTTP server on a sibling port
-// lets the entrypoint watchdog verify the process is alive and its event
-// loop is responsive during cold-start, independent of how slow the Hono
-// bind is. A true hang (event loop pinned) still fails this probe and
-// triggers the container restart.
-function startLivenessProbe() {
-  const livenessPort = Number(process.env.HEALTH_PORT ?? 8124);
-  const livenessHost = process.env.HOST ?? "0.0.0.0";
-  const server = http.createServer((req, res) => {
-    if (req.url === "/ok") {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end('{"status":"ok"}');
-      return;
-    }
-    res.writeHead(404, { "content-type": "application/json" });
-    res.end('{"status":"not_found"}');
-  });
-  server.listen(livenessPort, livenessHost, () => {
-    console.log(
-      `[server] Liveness probe listening on ${livenessHost}:${livenessPort}`,
-    );
-  });
-  server.on("error", (err) => {
-    console.warn(`[server] Liveness probe error: ${err?.message ?? err}`);
-  });
-  return server;
-}
+// Liveness is now bound by liveness.mjs BEFORE this module is dynamic-imported
+// — see showcase/packages/langgraph-typescript/src/agent/liveness.mjs. The
+// previous sibling-probe implementation inside this file did not work: ES
+// module semantics resolve all top-level `import` statements before any
+// module-body code runs, so `import { startServer } from "@langchain/
+// langgraph-api/server"` (~4m30s cold on Railway) ran BEFORE the probe got a
+// chance to listen, and the watchdog's 180s + 3×30s = 270s budget killed the
+// container ~4s before the probe would have come up. By the time any code in
+// this file executes, :8124/ok is already serving 200.
 
 // Graph spec mirrors langgraph.json. We pin the compiled .js entry because the
 // production parser walks the source file with the TypeScript API; pointing at
@@ -91,10 +70,6 @@ async function main() {
   const cwd = __dirname; // src/agent
   const port = Number(process.env.PORT ?? 8123);
   const host = process.env.HOST ?? "0.0.0.0";
-
-  // Bring the liveness probe up synchronously before any await — gives the
-  // watchdog a valid /ok target within milliseconds of `node` boot.
-  startLivenessProbe();
 
   // Kick off pre-warm and startServer in parallel. startServer registers
   // graphs synchronously and binds the port — /ok is live before schemas


### PR DESCRIPTION
## Summary
- Split `server.mjs` into `liveness.mjs` (new entry) + `server.mjs` (actual langgraph-api server).
- `liveness.mjs` binds `/ok` on :8124 first, then dynamic-imports `server.mjs` to kick off the real langgraph bootstrap.
- `src/agent/package.json` `start` script now runs `node --import tsx liveness.mjs` as the entry.

## Why
#4140 put the probe inside `server.mjs` under the belief it would bind "synchronously before any await." ES module semantics say otherwise — all top-level `import` declarations resolve before any module-body code runs. Cold start of `@langchain/langgraph-api` + graph transpile takes ~4m30s on Railway, but watchdog grace (180s) + strikes (90s) = 270s kills before the probe ever opens. Dynamic import defers the heavy load until after liveness is already serving 200.

## Test plan
- [x] Local Docker build green (amd64)
- [x] Container serves /ok within <2s of launch (measured: 1.4s)
- [ ] Railway deploy green + smoke passes sustained