### PR TITLE
feat(plugin): expose CopilotKit skills as a Claude Code plugin via mirrored skills/ tree

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "copilotkit",
+  "description": "CopilotKit skill plugin — installable directly from the CopilotKit monorepo",
+  "owner": {
+    "name": "CopilotKit",
+    "email": "support@copilotkit.ai"
+  },
+  "plugins": [
+    {
+      "name": "copilotkit",
+      "description": "CopilotKit v2 skills (runtime, react-core, a2ui-renderer + 6 lifecycle journeys)",
+      "version": "1.56.2",
+      "source": "./",
+      "author": {
+        "name": "CopilotKit",
+        "email": "support@copilotkit.ai"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "copilotkit",
+  "description": "CopilotKit v2 skills for Claude Code — runtime (core), react-core (framework), a2ui-renderer (framework), and 6 lifecycle journey skills (0-to-working-chat, spa-without-runtime, go-to-production, scale-to-multi-agent, v1-to-v2-migration, debug-and-troubleshoot).",
+  "version": "1.56.2",
+  "author": {
+    "name": "CopilotKit",
+    "email": "support@copilotkit.ai"
+  },
+  "homepage": "https://github.com/CopilotKit/CopilotKit",
+  "repository": "https://github.com/CopilotKit/CopilotKit",
+  "license": "MIT",
+  "keywords": [
+    "copilotkit",
+    "ai",
+    "agents",
+    "skills",
+    "ag-ui",
+    "tanstack-intent"
+  ]
+}

--- a/.github/workflows/plugin-skills-check.yml
+++ b/.github/workflows/plugin-skills-check.yml
@@ -1,0 +1,45 @@
+name: plugin-skills-check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/*/skills/**"
+      - "skills/runtime/**"
+      - "skills/react-core/**"
+      - "skills/a2ui-renderer/**"
+      - "scripts/sync-plugin-skills.ts"
+      - "scripts/__tests__/sync-plugin-skills.test.ts"
+      - ".claude-plugin/**"
+      - ".github/workflows/plugin-skills-check.yml"
+  pull_request:
+    paths:
+      - "packages/*/skills/**"
+      - "skills/runtime/**"
+      - "skills/react-core/**"
+      - "skills/a2ui-renderer/**"
+      - "scripts/sync-plugin-skills.ts"
+      - "scripts/__tests__/sync-plugin-skills.test.ts"
+      - ".claude-plugin/**"
+      - ".github/workflows/plugin-skills-check.yml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run sync script unit tests
+        run: pnpm exec vitest run scripts/__tests__/sync-plugin-skills.test.ts
+
+      - name: Check plugin skill mirror is in sync
+        run: pnpm check:plugin-skills

--- a/README.md
+++ b/README.md
@@ -193,6 +193,39 @@ Here are a few useful resources to help you get started:
 
 - Want to contribute but not sure how? [Join our Discord](https://discord.gg/6dffbvGU3D) and we'll help you out!
 
+## Install as a Claude Code plugin
+
+The CopilotKit monorepo doubles as a Claude Code plugin — all 9 skills (3 package meta-skills + 6 lifecycle journey skills) are available once installed.
+
+Add the repo as a Claude Code marketplace:
+
+```bash
+claude plugin marketplace add https://github.com/CopilotKit/CopilotKit
+claude plugin install copilotkit
+```
+
+Skills are discovered from `skills/<slug>/SKILL.md` at the repo root. The three package meta-skills (`runtime`, `react-core`, `a2ui-renderer`) are **generated mirrors** of the source-of-truth files at `packages/<pkg>/skills/<pkg>/` — do not edit the mirror directly. To update content, edit the source under `packages/*/skills/` and run:
+
+```bash
+pnpm sync:plugin-skills
+```
+
+A lefthook pre-commit check (`pnpm check:plugin-skills`) rejects commits that drift the mirror. The plugin version is pinned to `packages/runtime/package.json` and is also kept in sync by the same script.
+
+### Skill inventory
+
+| Slug | Type | Source |
+| --- | --- | --- |
+| `runtime` | core | `packages/runtime/skills/runtime/` |
+| `react-core` | framework | `packages/react-core/skills/react-core/` |
+| `a2ui-renderer` | framework | `packages/a2ui-renderer/skills/a2ui-renderer/` |
+| `0-to-working-chat` | lifecycle | `skills/0-to-working-chat/` |
+| `spa-without-runtime` | lifecycle | `skills/spa-without-runtime/` |
+| `go-to-production` | lifecycle | `skills/go-to-production/` |
+| `scale-to-multi-agent` | lifecycle | `skills/scale-to-multi-agent/` |
+| `v1-to-v2-migration` | lifecycle | `skills/v1-to-v2-migration/` |
+| `debug-and-troubleshoot` | lifecycle | `skills/debug-and-troubleshoot/` |
+
 ## 📄 License
 
 This repository's source code is available under the [MIT License](https://github.com/CopilotKit/CopilotKit/blob/main/LICENSE).

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,6 +29,15 @@ pre-commit:
         NX_TUI: "false"
       run: pnpm run test && pnpm run check:packages
 
+    check-plugin-skills:
+      tags: plugin-skills
+      glob: "{packages/*/skills/**,skills/runtime/**,skills/react-core/**,skills/a2ui-renderer/**,scripts/sync-plugin-skills.ts,.claude-plugin/**}"
+      run: pnpm check:plugin-skills
+      fail_text: |
+        Plugin skill mirror is out of sync with the Intent source.
+        Run: pnpm sync:plugin-skills
+        Then stage the changes and re-commit.
+
 commit-msg:
   commands:
     commitlint:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "publint": "nx run-many -t publint --projects=packages/**",
     "attw": "nx run-many -t attw --projects=packages/**",
     "check:packages": "nx run-many -t publint,attw --projects=packages/**",
-    "validate:model-names": "tsx scripts/validate-doc-model-names.ts"
+    "validate:model-names": "tsx scripts/validate-doc-model-names.ts",
+    "check:plugin-skills": "tsx scripts/sync-plugin-skills.ts --check",
+    "sync:plugin-skills": "tsx scripts/sync-plugin-skills.ts"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",

--- a/scripts/__tests__/sync-plugin-skills.test.ts
+++ b/scripts/__tests__/sync-plugin-skills.test.ts
@@ -1,0 +1,209 @@
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  syncPluginSkills,
+  RESERVED_LIFECYCLE_SLUGS,
+} from "../sync-plugin-skills.js";
+
+// Fixture helper — builds a miniature repo layout inside a tmpdir that mimics
+// the CopilotKit monorepo shape.
+async function makeRepo(root: string) {
+  const pkgRoot = join(root, "packages");
+  // Two package meta-skills — deliberately different shapes to exercise
+  // the recursive-copy path and the single-file path.
+  await mkdir(join(pkgRoot, "runtime/skills/runtime/references"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(pkgRoot, "runtime/skills/runtime/SKILL.md"),
+    "---\nname: runtime\n---\n# Runtime\n",
+  );
+  await writeFile(
+    join(pkgRoot, "runtime/skills/runtime/references/setup-endpoint.md"),
+    "# Setup\n",
+  );
+  await mkdir(join(pkgRoot, "a2ui-renderer/skills/a2ui-renderer"), {
+    recursive: true,
+  });
+  await writeFile(
+    join(pkgRoot, "a2ui-renderer/skills/a2ui-renderer/SKILL.md"),
+    "---\nname: a2ui-renderer\n---\n# A2UI\n",
+  );
+  // Pre-existing lifecycle skill at the mirror root — must be left alone.
+  await mkdir(join(root, "skills/0-to-working-chat"), { recursive: true });
+  await writeFile(
+    join(root, "skills/0-to-working-chat/SKILL.md"),
+    "---\nname: 0-to-working-chat\n---\n# Lifecycle\n",
+  );
+}
+
+describe("syncPluginSkills", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), "ck-plugin-sync-"));
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it("copies package skill SKILL.md and references into the mirror", async () => {
+    await makeRepo(repo);
+    const result = await syncPluginSkills({ cwd: repo, mode: "write" });
+    expect(result.exitCode).toBe(0);
+
+    const runtimeSkill = await readFile(
+      join(repo, "skills/runtime/SKILL.md"),
+      "utf8",
+    );
+    expect(runtimeSkill).toBe("---\nname: runtime\n---\n# Runtime\n");
+
+    const runtimeRef = await readFile(
+      join(repo, "skills/runtime/references/setup-endpoint.md"),
+      "utf8",
+    );
+    expect(runtimeRef).toBe("# Setup\n");
+
+    const a2uiSkill = await readFile(
+      join(repo, "skills/a2ui-renderer/SKILL.md"),
+      "utf8",
+    );
+    expect(a2uiSkill).toBe("---\nname: a2ui-renderer\n---\n# A2UI\n");
+  });
+
+  it("does not modify pre-existing lifecycle skills", async () => {
+    await makeRepo(repo);
+    await syncPluginSkills({ cwd: repo, mode: "write" });
+    const lifecycle = await readFile(
+      join(repo, "skills/0-to-working-chat/SKILL.md"),
+      "utf8",
+    );
+    expect(lifecycle).toBe("---\nname: 0-to-working-chat\n---\n# Lifecycle\n");
+  });
+
+  it("errors with exit code 2 if a package skill collides with a reserved lifecycle slug", async () => {
+    const pkgRoot = join(repo, "packages");
+    await mkdir(join(pkgRoot, "rogue/skills/0-to-working-chat"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(pkgRoot, "rogue/skills/0-to-working-chat/SKILL.md"),
+      "collision\n",
+    );
+    const result = await syncPluginSkills({ cwd: repo, mode: "write" });
+    expect(result.exitCode).toBe(2);
+    expect(result.message).toMatch(/collides with reserved lifecycle slug/);
+  });
+
+  it("check mode returns exitCode 0 when mirror is in sync", async () => {
+    await makeRepo(repo);
+    await syncPluginSkills({ cwd: repo, mode: "write" });
+    const result = await syncPluginSkills({ cwd: repo, mode: "check" });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("check mode returns exitCode 1 when mirror has drifted", async () => {
+    await makeRepo(repo);
+    await syncPluginSkills({ cwd: repo, mode: "write" });
+    // Simulate a maintainer editing the package source without re-running sync.
+    await writeFile(
+      join(repo, "packages/runtime/skills/runtime/SKILL.md"),
+      "---\nname: runtime\n---\n# Runtime (edited)\n",
+    );
+    const result = await syncPluginSkills({ cwd: repo, mode: "check" });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/drift detected/i);
+    expect(result.message).toContain("skills/runtime/SKILL.md");
+  });
+
+  it("check mode flags orphan files in the mirror (e.g., skill deleted from source)", async () => {
+    await makeRepo(repo);
+    await syncPluginSkills({ cwd: repo, mode: "write" });
+    await rm(join(repo, "packages/a2ui-renderer"), { recursive: true });
+    const result = await syncPluginSkills({ cwd: repo, mode: "check" });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/orphan/i);
+    expect(result.message).toContain("skills/a2ui-renderer");
+  });
+
+  it("exports the reserved lifecycle slug set", () => {
+    expect(RESERVED_LIFECYCLE_SLUGS).toContain("0-to-working-chat");
+    expect(RESERVED_LIFECYCLE_SLUGS).toContain("v1-to-v2-migration");
+    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(6);
+  });
+
+  // Version sync — the plugin version tracks packages/runtime/package.json.
+
+  async function addVersionFixtures(
+    repoRoot: string,
+    runtimePkgVersion: string,
+    initialPluginVersion: string,
+  ) {
+    await writeFile(
+      join(repoRoot, "packages/runtime/package.json"),
+      JSON.stringify(
+        { name: "@copilotkit/runtime", version: runtimePkgVersion },
+        null,
+        2,
+      ) + "\n",
+    );
+    await mkdir(join(repoRoot, ".claude-plugin"), { recursive: true });
+    await writeFile(
+      join(repoRoot, ".claude-plugin/plugin.json"),
+      JSON.stringify(
+        { name: "copilotkit", version: initialPluginVersion },
+        null,
+        2,
+      ) + "\n",
+    );
+    await writeFile(
+      join(repoRoot, ".claude-plugin/marketplace.json"),
+      JSON.stringify(
+        {
+          name: "copilotkit",
+          plugins: [
+            { name: "copilotkit", source: "./", version: initialPluginVersion },
+          ],
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+  }
+
+  it("write mode copies runtime package.json version into plugin.json and marketplace.json", async () => {
+    await makeRepo(repo);
+    await addVersionFixtures(repo, "1.56.2", "0.0.0");
+    await syncPluginSkills({ cwd: repo, mode: "write" });
+    const plugin = JSON.parse(
+      await readFile(join(repo, ".claude-plugin/plugin.json"), "utf8"),
+    );
+    const market = JSON.parse(
+      await readFile(join(repo, ".claude-plugin/marketplace.json"), "utf8"),
+    );
+    expect(plugin.version).toBe("1.56.2");
+    expect(market.plugins[0].version).toBe("1.56.2");
+  });
+
+  it("check mode detects plugin.json version drift", async () => {
+    await makeRepo(repo);
+    await addVersionFixtures(repo, "1.56.2", "0.0.0");
+    await syncPluginSkills({ cwd: repo, mode: "write" });
+    // Simulate a maintainer bumping the package but forgetting to run sync.
+    await writeFile(
+      join(repo, "packages/runtime/package.json"),
+      JSON.stringify(
+        { name: "@copilotkit/runtime", version: "1.57.0" },
+        null,
+        2,
+      ) + "\n",
+    );
+    const result = await syncPluginSkills({ cwd: repo, mode: "check" });
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/version.*drift/i);
+    expect(result.message).toContain("1.57.0");
+  });
+});

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -1,0 +1,248 @@
+#!/usr/bin/env tsx
+import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+// Report paths with forward slashes for cross-platform consistency.
+const toPosix = (p: string) => p.split("\\").join("/");
+
+export const RESERVED_LIFECYCLE_SLUGS: ReadonlySet<string> = new Set([
+  "0-to-working-chat",
+  "spa-without-runtime",
+  "go-to-production",
+  "scale-to-multi-agent",
+  "v1-to-v2-migration",
+  "debug-and-troubleshoot",
+]);
+
+// Version sync — plugin version tracks this package's version.
+const VERSION_SOURCE_PACKAGE_JSON = "packages/runtime/package.json";
+const PLUGIN_JSON = ".claude-plugin/plugin.json";
+const MARKETPLACE_JSON = ".claude-plugin/marketplace.json";
+
+export type SyncMode = "write" | "check";
+
+export interface SyncOptions {
+  cwd: string;
+  mode: SyncMode;
+}
+
+export interface SyncResult {
+  exitCode: 0 | 1 | 2;
+  message: string;
+  changed: string[];
+  orphans: string[];
+}
+
+// ─── Source discovery ────────────────────────────────────────────────────────
+
+interface PackageSkill {
+  slug: string; // e.g. "runtime"
+  sourceDir: string; // absolute path of packages/<pkg>/skills/<slug>
+  mirrorDir: string; // absolute path of skills/<slug>
+}
+
+async function findPackageSkills(cwd: string): Promise<PackageSkill[]> {
+  const packagesDir = join(cwd, "packages");
+  if (!existsSync(packagesDir)) return [];
+
+  const pkgs = await readdir(packagesDir, { withFileTypes: true });
+  const out: PackageSkill[] = [];
+
+  for (const pkg of pkgs) {
+    if (!pkg.isDirectory()) continue;
+    const skillsDir = join(packagesDir, pkg.name, "skills");
+    if (!existsSync(skillsDir)) continue;
+    const slugs = await readdir(skillsDir, { withFileTypes: true });
+    for (const slug of slugs) {
+      if (!slug.isDirectory()) continue;
+      const sourceDir = join(skillsDir, slug.name);
+      if (!existsSync(join(sourceDir, "SKILL.md"))) continue;
+      out.push({
+        slug: slug.name,
+        sourceDir,
+        mirrorDir: join(cwd, "skills", slug.name),
+      });
+    }
+  }
+  return out;
+}
+
+async function listFilesRec(dir: string, base = dir): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...(await listFilesRec(full, base)));
+    else if (e.isFile()) out.push(relative(base, full));
+  }
+  return out;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+export async function syncPluginSkills(opts: SyncOptions): Promise<SyncResult> {
+  const skills = await findPackageSkills(opts.cwd);
+
+  // Collision check.
+  for (const s of skills) {
+    if (RESERVED_LIFECYCLE_SLUGS.has(s.slug)) {
+      return {
+        exitCode: 2,
+        message: `package skill slug "${s.slug}" collides with reserved lifecycle slug. Rename the package skill.`,
+        changed: [],
+        orphans: [],
+      };
+    }
+  }
+
+  const changed: string[] = [];
+  const orphans: string[] = [];
+
+  for (const s of skills) {
+    const files = await listFilesRec(s.sourceDir);
+    for (const relPath of files) {
+      const srcPath = join(s.sourceDir, relPath);
+      const dstPath = join(s.mirrorDir, relPath);
+      const src = await readFile(srcPath);
+
+      if (opts.mode === "check") {
+        if (!existsSync(dstPath)) {
+          changed.push(toPosix(join("skills", s.slug, relPath)));
+          continue;
+        }
+        const dst = await readFile(dstPath);
+        if (!src.equals(dst))
+          changed.push(toPosix(join("skills", s.slug, relPath)));
+      } else {
+        await mkdir(dirname(dstPath), { recursive: true });
+        await writeFile(dstPath, src);
+      }
+    }
+
+    // Detect orphan files — files in mirror that are not in source.
+    if (existsSync(s.mirrorDir)) {
+      const mirrorFiles = await listFilesRec(s.mirrorDir);
+      const sourceSet = new Set(files);
+      for (const mf of mirrorFiles) {
+        if (!sourceSet.has(mf))
+          orphans.push(toPosix(join("skills", s.slug, mf)));
+      }
+    }
+  }
+
+  // Full-dir orphan scan — detect mirror skills directories whose source package
+  // was removed entirely. The main loop cannot catch these because it only
+  // iterates over currently discovered source skills.
+  const mirrorRoot = join(opts.cwd, "skills");
+  if (existsSync(mirrorRoot)) {
+    const sourceSlugs = new Set(skills.map((s) => s.slug));
+    const mirrorEntries = await readdir(mirrorRoot, { withFileTypes: true });
+    for (const entry of mirrorEntries) {
+      if (!entry.isDirectory()) continue;
+      if (RESERVED_LIFECYCLE_SLUGS.has(entry.name)) continue;
+      if (sourceSlugs.has(entry.name)) continue;
+      // Orphan directory — source package was removed but mirror still has it.
+      orphans.push(toPosix(join("skills", entry.name)));
+    }
+  }
+
+  // Version sync — read runtime package version, write/check plugin + marketplace.
+  const versionDrift = await handleVersionSync(opts);
+
+  if (opts.mode === "check") {
+    if (changed.length === 0 && orphans.length === 0 && !versionDrift) {
+      return {
+        exitCode: 0,
+        message: "plugin skill mirror in sync",
+        changed,
+        orphans,
+      };
+    }
+    const lines: string[] = [];
+    if (changed.length) {
+      lines.push(`drift detected in ${changed.length} file(s):`);
+      lines.push(...changed.map((p) => `  ${p}`));
+    }
+    if (orphans.length) {
+      lines.push(`orphan file(s) in mirror (source removed):`);
+      lines.push(...orphans.map((p) => `  ${p}`));
+    }
+    if (versionDrift) {
+      lines.push(`version drift: ${versionDrift}`);
+    }
+    lines.push("run: pnpm sync:plugin-skills");
+    return { exitCode: 1, message: lines.join("\n"), changed, orphans };
+  }
+
+  // Write mode — also prune orphans so mirror is exactly the source.
+  if (orphans.length) {
+    const { rm } = await import("node:fs/promises");
+    for (const o of orphans) {
+      await rm(join(opts.cwd, o), { force: true, recursive: true });
+    }
+  }
+
+  return {
+    exitCode: 0,
+    message: `synced ${skills.length} package skill(s)`,
+    changed: [],
+    orphans: [],
+  };
+}
+
+// ─── Version sync helper ─────────────────────────────────────────────────────
+
+// Returns a drift description string (for check mode), or empty string if in sync.
+// In write mode, mutates the files and always returns empty string.
+async function handleVersionSync(opts: SyncOptions): Promise<string> {
+  const srcPath = join(opts.cwd, VERSION_SOURCE_PACKAGE_JSON);
+  if (!existsSync(srcPath)) return "";
+  const srcVersion: string = JSON.parse(
+    await readFile(srcPath, "utf8"),
+  ).version;
+
+  const pluginPath = join(opts.cwd, PLUGIN_JSON);
+  const marketPath = join(opts.cwd, MARKETPLACE_JSON);
+
+  if (existsSync(pluginPath)) {
+    const plugin = JSON.parse(await readFile(pluginPath, "utf8"));
+    if (plugin.version !== srcVersion) {
+      if (opts.mode === "check") {
+        return `plugin.json version is "${plugin.version}", expected "${srcVersion}" (from ${VERSION_SOURCE_PACKAGE_JSON})`;
+      }
+      plugin.version = srcVersion;
+      await writeFile(pluginPath, JSON.stringify(plugin, null, 2) + "\n");
+    }
+  }
+
+  if (existsSync(marketPath)) {
+    const market = JSON.parse(await readFile(marketPath, "utf8"));
+    const marketVersion = market.plugins?.[0]?.version;
+    if (marketVersion !== srcVersion) {
+      if (opts.mode === "check") {
+        return `marketplace.json plugins[0].version is "${marketVersion}", expected "${srcVersion}" (from ${VERSION_SOURCE_PACKAGE_JSON})`;
+      }
+      if (market.plugins?.[0]) {
+        market.plugins[0].version = srcVersion;
+        await writeFile(marketPath, JSON.stringify(market, null, 2) + "\n");
+      }
+    }
+  }
+
+  return "";
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const mode: SyncMode = process.argv.includes("--check") ? "check" : "write";
+  const result = await syncPluginSkills({ cwd: process.cwd(), mode });
+  if (result.message) console.log(result.message);
+  process.exit(result.exitCode);
+}
+
+// Use import.meta detection so the file is testable without triggering the CLI path.
+if (process.argv[1] && process.argv[1].endsWith("sync-plugin-skills.ts")) {
+  void main();
+}

--- a/skills/a2ui-renderer/SKILL.md
+++ b/skills/a2ui-renderer/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: a2ui-renderer
+description: >
+  Render A2UI (Agent-to-UI declarative surfaces) in CopilotKit v2. Enable the
+  runtime via CopilotRuntime({ a2ui: {...} }), then enable the provider via
+  <CopilotKitProvider a2ui={{ theme }}>. Auto-activates via /info — do NOT
+  manually pass renderActivityMessages. createA2UIMessageRenderer ships from
+  @copilotkit/react-core/v2; low-level primitives (A2UIProvider, A2UIRenderer,
+  createCatalog) ship from @copilotkit/a2ui-renderer. Covers theme
+  customization, createSurface dedup, action-bridge try/finally cleanup. Load
+  when an agent emits A2UI operations (createSurface / updateComponents /
+  updateDataModel), when wiring a2ui on CopilotRuntime, or when styling A2UI
+  surfaces.
+type: framework
+library: copilotkit
+framework: react
+library_version: "1.56.2"
+requires:
+  - copilotkit/react-core
+  - copilotkit/runtime
+sources:
+  - "CopilotKit/CopilotKit:packages/a2ui-renderer/src/index.ts"
+  - "CopilotKit/CopilotKit:packages/a2ui-renderer/src/react-renderer/index.ts"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/providers/CopilotKitProvider.tsx"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/runtime.ts"
+---
+
+This skill builds on copilotkit/react-core (for CopilotKitProvider fundamentals) and
+copilotkit/runtime (for CopilotRuntime fundamentals). Read those first.
+
+## Setup
+
+A2UI has two halves. The runtime declares a2ui middleware; the client enables
+the a2ui prop on the provider. Once both are set, `/info` flags A2UI and the
+client auto-mounts `createA2UIMessageRenderer` — you do NOT wire
+`renderActivityMessages` yourself.
+
+### Runtime side (`app/routes/api.copilotkit.$.tsx`)
+
+```tsx
+import type { Route } from "./+types/api.copilotkit.$";
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const agent = new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    return chat({
+      adapter: openaiText("gpt-4o"),
+      messages,
+      systemPrompts,
+      abortController,
+    });
+  },
+});
+
+const runtime = new CopilotRuntime({
+  agents: { default: agent },
+  // Enabling this key causes /info to advertise A2UI to the client.
+  a2ui: {},
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export async function loader({ request }: Route.LoaderArgs) {
+  return handler(request);
+}
+export async function action({ request }: Route.ActionArgs) {
+  return handler(request);
+}
+```
+
+### Client side (`app/root.tsx` or the app shell)
+
+```tsx
+import { CopilotKitProvider, CopilotChat } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+
+export default function App() {
+  return (
+    <CopilotKitProvider
+      runtimeUrl="/api/copilotkit"
+      a2ui={{
+        theme: {
+          // Theme object forwarded to A2UIProvider → ThemeProvider.
+          // Tokens map to A2UI's basic catalog CSS vars.
+          colors: { primary: "#0ea5e9" },
+        },
+      }}
+    >
+      <CopilotChat agentId="default" className="h-full" />
+    </CopilotKitProvider>
+  );
+}
+```
+
+## Core Patterns
+
+### Custom catalog
+
+Pass a custom catalog to extend the built-in component set. `createCatalog`
+and `extractSchema` let the agent see what components it may render.
+
+```tsx
+import { createCatalog } from "@copilotkit/a2ui-renderer";
+import { z } from "zod";
+
+const theme = { colors: { primary: "#0ea5e9" } };
+
+// Definitions are platform-agnostic (Zod schemas + descriptions).
+// Renderers are platform-specific (React components).
+// TypeScript enforces that renderer keys match definition keys exactly.
+const definitions = {
+  ProductCard: {
+    description: "A product card with title and price",
+    props: z.object({ title: z.string(), price: z.number() }),
+  },
+};
+
+const catalog = createCatalog(
+  definitions,
+  {
+    ProductCard: ({ props }) => (
+      <div className="rounded-xl border p-3">
+        <div className="font-medium">{props.title}</div>
+        <div className="text-sm text-muted-foreground">${props.price}</div>
+      </div>
+    ),
+  },
+  { includeBasicCatalog: true },
+);
+
+<CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui={{ theme, catalog }}>
+  <CopilotChat agentId="default" />
+</CopilotKitProvider>;
+```
+
+`extractSchema(definitions)` is available for passing a JSON-serializable
+view of the definitions to the runtime's `a2ui.schema` config — it is not
+a generic type helper. Type parameters erase at runtime; the agent needs a
+real runtime schema value (Zod).
+
+### Override the loading skeleton
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  a2ui={{
+    theme,
+    loadingComponent: () => <div className="animate-pulse">Building UI…</div>,
+  }}
+>
+  <CopilotChat agentId="default" />
+</CopilotKitProvider>
+```
+
+## Common Mistakes
+
+### CRITICAL forgetting runtime.a2ui
+
+Wrong:
+
+```tsx
+// server
+new CopilotRuntime({ agents: { default: agent } });
+// client
+<CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui={{ theme }} />;
+```
+
+Correct:
+
+```tsx
+// server
+new CopilotRuntime({ agents: { default: agent }, a2ui: {} });
+// client
+<CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui={{ theme }} />;
+```
+
+Without `runtime.a2ui`, `/info` never flags A2UI and the provider's a2ui prop
+silently no-ops — the renderer never mounts.
+
+Source: packages/runtime/src/v2/runtime/core/runtime.ts:55-58,217,242
+
+### HIGH manually wiring renderActivityMessages for A2UI
+
+Wrong:
+
+```tsx
+import { createA2UIMessageRenderer } from "@copilotkit/react-core/v2";
+
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  renderActivityMessages={[createA2UIMessageRenderer({ theme })]}
+/>;
+```
+
+Correct:
+
+```tsx
+<CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui={{ theme }} />
+```
+
+CopilotKitProvider auto-detects runtime A2UI via `/info` and injects the
+built-in renderer. Passing it through `renderActivityMessages` duplicates the
+renderer and can race with the auto-injected one.
+
+Source: packages/react-core/src/v2/providers/CopilotKitProvider.tsx:188-222,294-296
+
+### MEDIUM re-emitting createSurface on every snapshot
+
+Wrong:
+
+```python
+# Pseudocode — inside your agent generator. Exact API names/kwargs vary by
+# A2UI SDK version; consult your SDK's docs for real call shapes.
+async def agent_generator():
+    # agent re-emits createSurface operation on every state delta
+    async for update in stream:
+        yield a2ui.create_surface(surface_id="main", ...)  # every tick
+        yield a2ui.update_components(...)
+```
+
+Correct:
+
+```python
+# Pseudocode — inside your agent generator.
+# Emit createSurface once per surfaceId; use updateComponents / updateDataModel
+# for changes.
+async def agent_generator():
+    yield a2ui.create_surface(surface_id="main", ...)  # once
+    async for update in stream:
+        yield a2ui.update_components(surface_id="main", ...)
+```
+
+The MessageProcessor dedups on `surfaceId` but re-emitting is an agent-side
+bug — the client re-runs reconciliation logic for nothing and flickers.
+
+Source: packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx:218-226
+
+### MEDIUM custom action bridge without a2uiAction cleanup
+
+Wrong:
+
+```ts
+copilotkit.setProperties({ ...copilotkit.properties, a2uiAction: msg });
+await copilotkit.runAgent({ agent });
+// no finally — a2uiAction leaks into the next run's properties
+```
+
+Correct:
+
+```ts
+try {
+  copilotkit.setProperties({ ...copilotkit.properties, a2uiAction: msg });
+  await copilotkit.runAgent({ agent });
+} finally {
+  if (copilotkit.properties) {
+    const { a2uiAction, ...rest } = copilotkit.properties;
+    copilotkit.setProperties(rest);
+  }
+}
+```
+
+The built-in bridge always strips `a2uiAction` in `finally`, guarded by a
+`copilotkit.properties` null-check so it can't mask the original `runAgent`
+error with a `TypeError` during destructuring. Skipping cleanup keeps the
+previous action attached to subsequent runs.
+
+Source: packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx:146-167
+
+### MEDIUM installing @copilotkitnext/a2ui-renderer
+
+Wrong:
+
+```ts
+import { createA2UIMessageRenderer } from "@copilotkitnext/a2ui-renderer";
+```
+
+Correct:
+
+```ts
+// Low-level primitives (rarely needed — CopilotKitProvider a2ui prop is the default path):
+import {
+  A2UIProvider,
+  A2UIRenderer,
+  createCatalog,
+} from "@copilotkit/a2ui-renderer";
+// Auto-mounted renderer lives in react-core/v2:
+import { createA2UIMessageRenderer } from "@copilotkit/react-core/v2";
+```
+
+This package ships as `@copilotkit/a2ui-renderer`, not
+`@copilotkitnext/a2ui-renderer`. The `@copilotkitnext/` scope is reserved
+for other packages that ship under it separately — do not assume it applies
+here.
+
+Source: packages/a2ui-renderer/package.json

--- a/skills/react-core/SKILL.md
+++ b/skills/react-core/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: react-core
+description: >
+  @copilotkit/react-core — mount CopilotKitProvider in a Next.js App Router / React Router
+  v7 / TanStack Start / SPA app, drop in CopilotChat/CopilotPopup/CopilotSidebar (v2 chat
+  components ship from react-core/v2 — NOT react-ui, which is CSS-only in v2), access and
+  subscribe to agents with useAgent / useAgentContext / useCapabilities, switch between
+  multiple agents, manage durable Intelligence threads with useThreads, register
+  browser-side tools via useFrontendTool, render tool calls with useRenderTool /
+  useComponent / useDefaultRenderTool, gate execution with useHumanInTheLoop, wire file
+  attachments with useAttachments, configure suggestion pills, and register activity- and
+  custom-message renderers. publicLicenseKey is canonical (publicApiKey is deprecated
+  alias). Load the reference under references/ that matches your task.
+type: framework
+library: copilotkit
+library_version: "1.56.2"
+requires:
+  - copilotkit/runtime
+sources:
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/providers/CopilotKitProvider.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/index.ts"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/components/chat/index.ts"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/components/chat/CopilotChat.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/components/chat/CopilotChatView.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/components/CopilotKitInspector.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-agent.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-agent-context.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-capabilities.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-threads.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-frontend-tool.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-render-tool.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-render-tool-call.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-default-render-tool.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-component.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-attachments.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-configure-suggestions.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-suggestions.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-render-activity-message.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/hooks/use-render-custom-messages.tsx"
+  - "CopilotKit/CopilotKit:packages/react-core/src/v2/lib/slots.tsx"
+  - "CopilotKit/CopilotKit:packages/core/src/core/core.ts"
+  - "CopilotKit/CopilotKit:packages/core/src/core/agent-registry.ts"
+  - "CopilotKit/CopilotKit:packages/core/src/core/run-handler.ts"
+  - "CopilotKit/CopilotKit:packages/core/src/types.ts"
+---
+
+# CopilotKit React Core
+
+`@copilotkit/react-core` is the React frontend half of CopilotKit: it mounts a provider,
+speaks AG-UI over SSE to a runtime (or directly to CopilotKit Cloud in SPA mode), and
+exposes hooks for every interaction surface.
+
+This SKILL.md is the **index**. Read the reference under `references/` that matches
+your task — do not try to absorb the whole package from this file.
+
+## Mental model — three shells you compose
+
+1. **Provider shell** — `CopilotKitProvider` at or near the root (inside `"use client"` for
+   Next.js App Router). Carries `runtimeUrl` (or `publicLicenseKey` for SPA), `headers`,
+   `credentials`, `properties`, `onError`, `debug`, `showDevConsole`.
+2. **Chat shell** — `CopilotChat` / `CopilotPopup` / `CopilotSidebar` or a composed
+   `CopilotChatView` + slot primitives (`CopilotChatInput`, `CopilotChatMessageView`, etc.).
+   All chat components ship from `@copilotkit/react-core/v2`. **`CopilotPanel` does not
+   exist** — it's a common hallucination.
+3. **Hook shell** — inside any component under the provider, call `useAgent`,
+   `useFrontendTool`, `useRenderTool`, etc. Every hook takes optional `{ agentId }` for
+   agent-scoped registration.
+
+## When to load which reference
+
+| Task                                                                                                      | Reference                                                                               |
+| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Mount `CopilotKitProvider`, pick `runtimeUrl` vs `publicLicenseKey`, RSC boundary rules                   | `references/provider-setup.md`                                                          |
+| Drop in `CopilotChat` / `CopilotPopup` / `CopilotSidebar`, compose `CopilotChatView` with slot primitives | `references/chat-components.md`                                                         |
+| File / image attachments via `useAttachments` — drag-drop, click, paste, custom upload                    | `references/attachments.md`                                                             |
+| Client-side debug tooling — `showDevConsole`, `debug` prop, lazy-loaded web inspector                     | `references/debug-mode.md`                                                              |
+| Read / subscribe to an agent (`useAgent`) and push global context (`useAgentContext`)                     | `references/agent-access.md`                                                            |
+| Feature-gate UI on declared agent capabilities (`useCapabilities`)                                        | `references/capabilities.md`                                                            |
+| Build a multi-agent UI (per-panel `useAgent`, agent-scoped tools, key-remount pattern)                    | `references/switching-agents.md` (+ `switching-agents-recipes.md` for concrete layouts) |
+| List / rename / archive / delete durable Intelligence threads (`useThreads`)                              | `references/threads.md` (**requires runtime Intelligence mode**)                        |
+| Register browser-side tools (`useFrontendTool`)                                                           | `references/client-side-tools.md`                                                       |
+| Render per-tool UI (`useRenderTool`, `useComponent`, `useDefaultRenderTool`, `useRenderToolCall`)         | `references/rendering-tool-calls.md`                                                    |
+| Gate tool execution behind user approval (`useHumanInTheLoop`)                                            | `references/human-in-the-loop.md`                                                       |
+| Configure dynamic or static suggestion pills (`useConfigureSuggestions`, `useSuggestions`)                | `references/suggestions.md`                                                             |
+| Render non-chat activity messages (`useRenderActivityMessage`)                                            | `references/rendering-activity-messages.md`                                             |
+| Inject custom UI before/after specific messages (`useRenderCustomMessages`)                               | `references/custom-message-renderers.md`                                                |
+
+## Invariants and gotchas (load-once, before any reference)
+
+- `publicLicenseKey` is canonical. `publicApiKey` is a **deprecated alias** — expect it in legacy code.
+- `agents__unsafe_dev_only` and `selfManagedAgents` are dev-only aliases of each other. **Not production-safe.** See `packages/a2ui-renderer` or the `spa-without-runtime` lifecycle skill for the supported SPA path.
+- `CopilotPanel` does not exist. v2 chat components ship from `react-core/v2` — **not** `react-ui` (v2 `react-ui` is CSS-only).
+- No `useAgents()` hook exists. Discover agents via `copilotkit.subscribe({ onAgentsChanged })`.
+- `useRenderToolCall` is a **resolver** (for custom chat surfaces), **not** a registration hook. Register with `useRenderTool` / `useComponent` / `useDefaultRenderTool`.
+- UI-kit detection rule — any `render` or tool-call UI MUST reuse the consumer's shadcn / MUI / Chakra / Ant / Mantine primitives before writing raw JSX. This applies across `client-side-tools`, `rendering-tool-calls`, and `human-in-the-loop`.
+- Tool-call `status` values are camelCase: `'inProgress' | 'executing' | 'complete'`. In-progress args are `Partial<T>`.
+- `useHumanInTheLoop` synthesized handler **MUST** call `respond(result)` (including reject paths), otherwise the agent run hangs. `respond` is `undefined` outside `Executing` status. Unmounting mid-Executing abandons the run.
+- `useThreads` errors with `'Runtime URL is not configured'` outside Intelligence mode.
+- `v1 → v2` migration renames: `useCopilotAction` → `useFrontendTool` + `useHumanInTheLoop`; `imageUploadsEnabled` → `attachments`. See the `v1-to-v2-migration` lifecycle skill.
+
+## Reading order for a first-time reader
+
+1. `provider-setup` — mount the provider.
+2. `chat-components` — wire a chat surface.
+3. `agent-access` — talk to agents.
+4. `client-side-tools` + `rendering-tool-calls` — add tool-call UI.
+5. Anything else as your feature requires.

--- a/skills/react-core/references/agent-access.md
+++ b/skills/react-core/references/agent-access.md
@@ -1,0 +1,288 @@
+# CopilotKit Agent Access (React)
+
+This skill builds on `copilotkit/provider-setup`. `useAgent` reads from the
+same registry the provider populates from `/info`.
+
+Two complementary surfaces:
+
+- `useAgent` — imperative access to an agent instance, subscribe to
+  messages/state/run-status changes.
+- `useAgentContext` — declarative push of app state to every agent run.
+
+## Setup
+
+```tsx
+"use client";
+import {
+  useAgent,
+  useAgentContext,
+  UseAgentUpdate,
+} from "@copilotkit/react-core/v2";
+import { useMemo } from "react";
+
+export function ChatDriver({
+  route,
+  userId,
+}: {
+  route: string;
+  userId: string;
+}) {
+  const { agent } = useAgent({
+    agentId: "default",
+    threadId: "main",
+    updates: [
+      UseAgentUpdate.OnMessagesChanged,
+      UseAgentUpdate.OnRunStatusChanged,
+    ],
+    throttleMs: 100,
+  });
+
+  const context = useMemo(() => ({ route, userId }), [route, userId]);
+  useAgentContext({ description: "app context", value: context });
+
+  return (
+    <div>
+      {agent.isRunning ? "…thinking" : "idle"} — {agent.messages.length}{" "}
+      messages
+    </div>
+  );
+}
+```
+
+## Core Patterns
+
+### Send a message and stream the response
+
+```tsx
+const { agent } = useAgent({ agentId: "default" });
+const { copilotkit } = useCopilotKit();
+
+async function ask(text: string) {
+  agent.addMessage({ id: crypto.randomUUID(), role: "user", content: text });
+  await copilotkit.runAgent({ agent });
+}
+```
+
+### Subscribe only to run-status to reduce re-renders
+
+```tsx
+const { agent } = useAgent({
+  agentId: "default",
+  updates: [UseAgentUpdate.OnRunStatusChanged],
+});
+const isRunning = agent.isRunning;
+```
+
+`useAgent` returns `{ agent }` only; `isRunning` lives on the agent
+itself. Subscribing to `OnRunStatusChanged` forces a re-render when the
+value flips, so reading `agent.isRunning` stays live.
+
+### Share app state with every agent run (global)
+
+```tsx
+const value = useMemo(
+  () => ({ cartItems: cart.items, currentRoute: router.pathname }),
+  [cart.items, router.pathname],
+);
+useAgentContext({ description: "user cart + route", value });
+```
+
+### Abort the run
+
+```tsx
+const { agent } = useAgent({ agentId: "default" });
+<button onClick={() => agent.abortRun()}>Stop</button>;
+```
+
+## Common Mistakes
+
+### CRITICAL — Custom `AbstractAgent.clone()` that returns `this`
+
+Wrong:
+
+```tsx
+class MyAgent extends AbstractAgent {
+  clone() {
+    return this; // wrong — same instance is reused across threads
+  }
+}
+```
+
+Correct:
+
+```tsx
+class MyAgent extends AbstractAgent {
+  clone() {
+    const next = new MyAgent(this.config);
+    next.state = { ...this.state };
+    return next;
+  }
+}
+```
+
+`useAgent` calls `source.clone()` to build a per-thread clone and throws
+`clone() must return a new, independent object` if the clone is the same
+instance. This guards per-thread isolation.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+
+### HIGH — Mutating `agent.messages` directly
+
+Wrong:
+
+```tsx
+agent.messages.push({ id, role: "user", content: "hi" });
+```
+
+Correct:
+
+```tsx
+agent.addMessage({ id: crypto.randomUUID(), role: "user", content: "hi" });
+// or:
+agent.setMessages([...agent.messages, newMessage]);
+```
+
+AG-UI fires `onMessagesChanged` subscribers via `addMessage` /
+`setMessages`. Direct array mutation bypasses subscribers and the UI never
+re-renders.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx` (throughout)
+
+### HIGH — Registering non-serializable values via `useAgentContext`
+
+Wrong:
+
+```tsx
+useAgentContext({
+  description: "user",
+  value: {
+    name: "Alice",
+    lastLogin: new Date(),
+    onLogout: () => logout(), // dropped silently
+  },
+});
+```
+
+Correct:
+
+```tsx
+useAgentContext({
+  description: "user",
+  value: { name: "Alice", lastLogin: new Date().toISOString() },
+});
+```
+
+`useAgentContext` runs the value through `JSON.stringify`. Functions are
+dropped, `Date` coerces to an ISO string (which the agent has to parse), and
+circular references throw.
+
+Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx:30-35`
+
+### MEDIUM — Expecting lifecycle callbacks to be throttled
+
+Wrong:
+
+```tsx
+useAgent({
+  agentId: "default",
+  throttleMs: 300,
+  // expecting onRunInitialized / onRunFinalized / onRunFailed to also be throttled
+});
+```
+
+Correct:
+
+```tsx
+// Only OnMessagesChanged / OnStateChanged / OnRunStatusChanged are throttled.
+// Lifecycle callbacks always fire immediately — handle them synchronously.
+useAgent({ agentId: "default", throttleMs: 300 });
+```
+
+`throttleMs` only applies to the three subscribed updates enumerated in
+`UseAgentUpdate`. Lifecycle callbacks bypass the throttler.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:36-48`
+
+### MEDIUM — Unstable context value identity
+
+Wrong:
+
+```tsx
+useAgentContext({ description: "cart", value: { items: cart.items } });
+```
+
+Correct:
+
+```tsx
+const value = useMemo(() => ({ items: cart.items }), [cart.items]);
+useAgentContext({ description: "cart", value });
+```
+
+A fresh object literal on every render invalidates the `useMemo` inside
+`useAgentContext` that serializes the value, causing constant
+remove/re-add churn in the core context store.
+
+Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx:30-35`
+
+### MEDIUM — Expecting `useAgentContext` or `copilotkit.addContext` to scope context per agent
+
+Wrong:
+
+```tsx
+useAgentContext({ agentId: "research", description: "paper list", value });
+// or the imperative form:
+copilotkit.addContext({
+  description: "paper list",
+  value: JSON.stringify(value),
+  agentId: "research",
+});
+```
+
+Correct:
+
+```tsx
+// Context is global — every agent run sees every registered entry.
+useAgentContext({ description: "paper list", value });
+
+// When only one agent should key off a value, branch inside its prompt
+// or tool logic instead of trying to scope the context entry.
+```
+
+Context is intentionally global and there is no per-agent scoping hook.
+`useAgentContext` has no `agentId` parameter, and `copilotkit.addContext`
+destructures only `{ description, value }` — any `agentId` passed is
+silently dropped. Treat context as "state of the world" that every agent
+sees.
+
+Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx` (no `agentId` parameter); `packages/core/src/core/context-store.ts:26-31`
+
+### MEDIUM — Two components using the same `(agentId, threadId)` expecting isolation
+
+Wrong:
+
+```tsx
+function A() {
+  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+}
+function B() {
+  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+}
+```
+
+Correct:
+
+```tsx
+function A() {
+  useAgent({ agentId: "default", threadId: "a" });
+}
+function B() {
+  useAgent({ agentId: "default", threadId: "b" });
+}
+```
+
+Per-thread clones are cached in a module-level WeakMap keyed by
+`(registryAgent, threadId)`. Two consumers of the same `(agentId,
+threadId)` observe the same state. Give each surface a distinct `threadId`
+when isolation is intentional.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`

--- a/skills/react-core/references/attachments.md
+++ b/skills/react-core/references/attachments.md
@@ -1,0 +1,291 @@
+# CopilotKit Attachments (React)
+
+This skill builds on `copilotkit/provider-setup` and
+`copilotkit/chat-components`. `useAttachments` is exposed both as an opt-in
+prop on `<CopilotChat>` and as a direct hook for custom chat surfaces.
+
+## Setup
+
+### Easiest: turn attachments on via `<CopilotChat>`
+
+```tsx
+"use client";
+import { CopilotChat } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+
+export function ChatPanel() {
+  return (
+    <CopilotChat
+      agentId="default"
+      attachments={{
+        enabled: true,
+        accept: "image/*",
+        maxSize: 10 * 1024 * 1024, // 10 MB
+        onUploadFailed: ({ reason, file, message }) => {
+          console.warn(`[attachments] ${reason}: ${file.name} — ${message}`);
+        },
+      }}
+    />
+  );
+}
+```
+
+### Direct hook usage for custom surfaces
+
+```tsx
+"use client";
+import {
+  useAttachments,
+  useAgent,
+  useCopilotKit,
+} from "@copilotkit/react-core/v2";
+import type { InputContent } from "@ag-ui/core";
+
+export function CustomChatInput() {
+  const { agent } = useAgent({ agentId: "default" });
+  const { copilotkit } = useCopilotKit();
+  const {
+    attachments,
+    containerRef,
+    fileInputRef,
+    handleFileUpload,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    removeAttachment,
+    consumeAttachments,
+  } = useAttachments({ config: { enabled: true, accept: "*/*" } });
+
+  return (
+    <div
+      ref={containerRef}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <input type="file" ref={fileInputRef} onChange={handleFileUpload} />
+      {attachments.map((a) => (
+        <button key={a.id} onClick={() => removeAttachment(a.id)}>
+          {a.filename} ({a.status})
+        </button>
+      ))}
+      <button
+        onClick={async () => {
+          const ready = consumeAttachments();
+          // `ready` is Attachment[] — map each to an AG-UI InputContent part
+          // before spreading into the message content array.
+          const contentParts: InputContent[] = [
+            { type: "text", text: "See attachments." },
+            ...ready.map(
+              (att) =>
+                ({
+                  type: att.type,
+                  source: att.source,
+                  metadata: {
+                    ...(att.filename ? { filename: att.filename } : {}),
+                    ...att.metadata,
+                  },
+                }) as InputContent,
+            ),
+          ];
+          agent.addMessage({
+            id: crypto.randomUUID(),
+            role: "user",
+            content: contentParts,
+          });
+          await copilotkit.runAgent({ agent });
+        }}
+      >
+        Send
+      </button>
+    </div>
+  );
+}
+```
+
+`consumeAttachments()` returns the `Attachment[]` queue — each entry has
+`{ id, type, source, filename, status, metadata }` and is NOT a valid
+AG-UI content part. Map each attachment to an `InputContent` shape
+(`{ type, source, metadata }`) before spreading into a message's `content`
+array. See `packages/react-core/src/v2/components/chat/CopilotChat.tsx:247-268`
+for the canonical transform.
+
+## Core Patterns
+
+### Custom upload backend (S3 / presigned URL)
+
+`onUpload` replaces the default base64-inline strategy. Return an
+`Attachment.source` describing where the file lives.
+
+```tsx
+useAttachments({
+  config: {
+    enabled: true,
+    accept: "image/*,application/pdf",
+    maxSize: 50 * 1024 * 1024,
+    onUpload: async (file) => {
+      const { url } = await fetch("/api/upload", {
+        method: "POST",
+        body: file,
+      }).then((r) => r.json());
+      return { type: "url", value: url, mimeType: file.type };
+    },
+    onUploadFailed: ({ reason, file, message }) => {
+      toast.error(`${file.name}: ${message}`);
+    },
+  },
+});
+```
+
+### Feedback on failed uploads
+
+```tsx
+useAttachments({
+  config: {
+    enabled: true,
+    maxSize: 5 * 1024 * 1024,
+    onUploadFailed: ({ reason, file, message }) => {
+      // reason: "file-too-large" | "invalid-type" | "upload-failed"
+      toast.error(message);
+    },
+  },
+});
+```
+
+## Common Mistakes
+
+### HIGH — Forgetting to call `consumeAttachments` on submit
+
+Wrong:
+
+```tsx
+const { attachments } = useAttachments({ config: { enabled: true } });
+const onSubmit = () => {
+  sendMessage({ text, attachments });
+  // attachments queue never cleared — sticks around for the next message
+};
+```
+
+Correct:
+
+```tsx
+const { consumeAttachments } = useAttachments({ config: { enabled: true } });
+const onSubmit = () => {
+  const ready = consumeAttachments();
+  sendMessage({ text, attachments: ready });
+};
+```
+
+`consumeAttachments()` returns ready attachments AND drains the internal
+queue. If you submit without calling it, attachments stay in state and
+accompany every subsequent message.
+
+Source: `packages/react-core/src/v2/hooks/use-attachments.tsx:40-46`
+
+### HIGH — Passing `maxSize` in KB or MB
+
+Wrong:
+
+```tsx
+useAttachments({ config: { enabled: true, maxSize: 10 } });
+// 10 bytes! Effectively blocks every file.
+```
+
+Correct:
+
+```tsx
+useAttachments({
+  config: { enabled: true, maxSize: 10 * 1024 * 1024 }, // 10 MB
+});
+```
+
+`maxSize` is bytes. The default is `20 * 1024 * 1024` (20 MB). Passing a
+small number without the multiplier silently rejects every file via
+`onUploadFailed({ reason: "file-too-large" })`.
+
+Source: `packages/react-core/src/v2/hooks/use-attachments.tsx:73-74`
+
+### HIGH — Missing `containerRef` on the paste-scope element
+
+Wrong:
+
+```tsx
+const { enabled } = useAttachments({ config: { enabled: true } });
+return (
+  <div>
+    <input type="text" />
+  </div>
+); // no containerRef attached
+```
+
+Correct:
+
+```tsx
+const { containerRef, handleDragOver, handleDrop } = useAttachments({
+  config: { enabled: true },
+});
+return (
+  <div ref={containerRef} onDragOver={handleDragOver} onDrop={handleDrop}>
+    <input type="text" />
+  </div>
+);
+```
+
+Clipboard paste is scoped to the element `containerRef` points at. Without
+attaching the ref, `Ctrl+V` / `Cmd+V` never reaches the paste handler and
+users silently can't paste images from screenshots.
+
+Source: `packages/react-core/src/v2/hooks/use-attachments.tsx:207-239`
+
+### MEDIUM — Using `imageUploadsEnabled` on `<CopilotChat>`
+
+Wrong:
+
+```tsx
+<CopilotChat imageUploadsEnabled />
+```
+
+Correct:
+
+```tsx
+<CopilotChat
+  attachments={{
+    enabled: true,
+    accept: "image/*",
+    maxSize: 5 * 1024 * 1024,
+  }}
+/>
+```
+
+`imageUploadsEnabled` was the v1 flag. v2 replaces it with the `attachments`
+config object, which is powered by `useAttachments` internally and supports
+any MIME type, not only images.
+
+Source: `docs/content/docs/(root)/migration-guides/migrate-attachments.mdx`
+
+### MEDIUM — Ignoring `onUploadFailed`
+
+Wrong:
+
+```tsx
+useAttachments({ config: { enabled: true } });
+// Rejected files silently disappear. User has no idea why.
+```
+
+Correct:
+
+```tsx
+useAttachments({
+  config: {
+    enabled: true,
+    onUploadFailed: ({ reason, file, message }) => {
+      toast.error(message);
+    },
+  },
+});
+```
+
+Size violations, MIME mismatches, and `onUpload` throws all drop the file
+from the queue with no UI feedback unless `onUploadFailed` is wired.
+
+Source: `packages/react-core/src/v2/hooks/use-attachments.tsx:79-157`

--- a/skills/react-core/references/capabilities.md
+++ b/skills/react-core/references/capabilities.md
@@ -1,0 +1,138 @@
+# CopilotKit Capabilities (React)
+
+This skill builds on `copilotkit/agent-access`. `useCapabilities` internally
+calls `useAgent` and reads the `capabilities` field populated from the
+runtime `/info` response.
+
+`AgentCapabilities` is from `@ag-ui/core`. The hook is synchronous — there
+is no loading state, but the value is `undefined` until the handshake
+completes.
+
+## Setup
+
+```tsx
+"use client";
+import { useCapabilities } from "@copilotkit/react-core/v2";
+
+export function VoiceButton() {
+  const caps = useCapabilities(); // defaults to DEFAULT_AGENT_ID
+
+  // Handshake pending — show a placeholder
+  if (caps === undefined) return <div className="skeleton h-8 w-8" />;
+
+  // Handshake complete — feature-gate
+  if (!caps.transcription) return null;
+
+  return <button>Record</button>;
+}
+```
+
+## Core Patterns
+
+### Scope to a specific agent
+
+```tsx
+const caps = useCapabilities("research");
+```
+
+### Feature-gate tools UI
+
+```tsx
+const caps = useCapabilities("default");
+
+if (caps === undefined) return <ToolsSkeleton />;
+if (caps.tools?.supported === false) return null;
+return <ToolsPanel />;
+```
+
+### Narrow optional fields defensively
+
+`AgentCapabilities` is a partial declaration — fields may be absent when
+the agent opts not to declare them.
+
+```tsx
+const caps = useCapabilities();
+const maxTokens = caps?.maxOutputTokens ?? "unknown";
+```
+
+## Common Mistakes
+
+### HIGH — Treating `undefined` as "no capabilities"
+
+Wrong:
+
+```tsx
+function VoiceButton() {
+  const caps = useCapabilities();
+  if (!caps?.transcription) return null; // hides button forever while handshake pending
+  return <button>Record</button>;
+}
+```
+
+Correct:
+
+```tsx
+function VoiceButton() {
+  const caps = useCapabilities();
+  if (caps === undefined) return <div className="skeleton h-8 w-8" />;
+  if (!caps.transcription) return null;
+  return <button>Record</button>;
+}
+```
+
+`useCapabilities` returns `undefined` until the runtime `/info` handshake
+completes. Treating `undefined` the same as `{ transcription: false }`
+hides features that should be visible post-handshake.
+
+Source: `packages/react-core/src/v2/hooks/use-capabilities.tsx:7-9`
+
+### MEDIUM — Non-null assertion on optional fields
+
+Wrong:
+
+```tsx
+const caps = useCapabilities();
+return <div>Max tokens: {caps!.maxOutputTokens}</div>;
+// Crashes if agent didn't declare capabilities, or didn't declare maxOutputTokens.
+```
+
+Correct:
+
+```tsx
+const caps = useCapabilities();
+return <div>Max tokens: {caps?.maxOutputTokens ?? "unknown"}</div>;
+```
+
+`AgentCapabilities` is a partial declaration. Agents opt in to each
+capability, so every field is optional. Narrow before deref.
+
+Source: `packages/react-core/src/v2/hooks/use-capabilities.tsx:20-22`
+
+### MEDIUM — Expecting deep merge from server-side `capabilities`
+
+Wrong:
+
+```ts
+// Server:
+new BuiltInAgent({
+  // ...
+  capabilities: { tools: { supported: true } },
+});
+// Client expects caps.tools.clientProvided to still be set by the default
+```
+
+Correct:
+
+```ts
+// Server — provide full category:
+new BuiltInAgent({
+  // ...
+  capabilities: { tools: { supported: true, clientProvided: true } },
+});
+```
+
+BuiltInAgent shallow-merges capabilities at the category level — providing
+`tools: {...}` replaces the whole category, not just the specified fields.
+The client then sees exactly what was declared.
+
+Source: `packages/runtime/src/agent/index.ts:821-829,883-887`

--- a/skills/react-core/references/chat-components.md
+++ b/skills/react-core/references/chat-components.md
@@ -1,0 +1,221 @@
+# CopilotKit Chat Components (React)
+
+This skill builds on `copilotkit/provider-setup`. Read it first — every
+chat component must be inside `CopilotKitProvider`.
+
+All chat components live on `@copilotkit/react-core/v2`. The legacy
+`@copilotkit/react-ui` package is v1-only; its `/v2` subpath is a CSS-only
+import.
+
+## Setup
+
+```tsx
+"use client";
+import { CopilotChat } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+
+export function ChatPanel() {
+  return <CopilotChat agentId="default" />;
+}
+```
+
+`<CopilotChat>` manages messages, input, streaming, attachments, and
+suggestions internally via `useAgent`. You do not pass `messages` or
+`isRunning` — they are managed for you.
+
+## Core Patterns
+
+### Floating popup
+
+```tsx
+import { CopilotPopup } from "@copilotkit/react-core/v2";
+
+<CopilotPopup agentId="default" isModalDefaultOpen={false} />;
+```
+
+### Persistent sidebar
+
+```tsx
+import { CopilotSidebar } from "@copilotkit/react-core/v2";
+
+<CopilotSidebar agentId="default">
+  <MainAppContent />
+</CopilotSidebar>;
+```
+
+### Headless composition with slot primitives
+
+Use `CopilotChatView` plus the individual slot components when you need
+full control over messages, input, or layout. This is the path when you
+want to manage `messages`/`isRunning` yourself.
+
+```tsx
+import {
+  CopilotChatView,
+  CopilotChatInput,
+  CopilotChatMessageView,
+  useAgent,
+  useCopilotKit,
+} from "@copilotkit/react-core/v2";
+
+export function HeadlessChat() {
+  const { agent } = useAgent({ agentId: "default" });
+  const { copilotkit } = useCopilotKit();
+
+  return (
+    <CopilotChatView
+      messages={agent.messages}
+      isRunning={agent.isRunning}
+      onSubmitInput={async (text) => {
+        agent.addMessage({
+          id: crypto.randomUUID(),
+          role: "user",
+          content: text,
+        });
+        await copilotkit.runAgent({ agent });
+      }}
+    >
+      <CopilotChatMessageView />
+      <CopilotChatInput />
+    </CopilotChatView>
+  );
+}
+```
+
+### Custom labels
+
+```tsx
+<CopilotChat
+  agentId="default"
+  labels={{
+    chatInputPlaceholder: "Ask about the data…",
+    thinking: "Analyzing…",
+  }}
+/>
+```
+
+## Common Mistakes
+
+### CRITICAL — Importing `CopilotPanel`
+
+Wrong:
+
+```tsx
+import { CopilotPanel } from "@copilotkit/react-core/v2";
+```
+
+Correct:
+
+```tsx
+import {
+  CopilotChat,
+  CopilotPopup,
+  CopilotSidebar,
+  CopilotChatView,
+} from "@copilotkit/react-core/v2";
+```
+
+`CopilotPanel` does not exist in v2 (or v1). This is a common hallucination.
+The four chat surfaces are `CopilotChat`, `CopilotPopup`, `CopilotSidebar`,
+and the headless `CopilotChatView`.
+
+Source: `packages/react-core/src/v2/components/chat/index.ts` (no `CopilotPanel` export)
+
+### CRITICAL — Importing chat components from `@copilotkit/react-ui` in v2
+
+Wrong:
+
+```tsx
+import { CopilotPopup } from "@copilotkit/react-ui";
+import "@copilotkit/react-ui/styles.css";
+```
+
+Correct:
+
+```tsx
+import { CopilotPopup } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+```
+
+`@copilotkit/react-ui` is v1 only. The v2 subpath of `react-ui` is a
+CSS-only import — the components are not there. All v2 chat components ship
+from `@copilotkit/react-core/v2`.
+
+Source: `packages/react-ui/src/v2/index.ts` (CSS-only); v2 migration guide
+
+### HIGH — Passing `messages` or `isRunning` to `<CopilotChat>`
+
+Wrong:
+
+```tsx
+<CopilotChat agentId="default" messages={myMessages} isRunning={busy} />
+```
+
+Correct:
+
+```tsx
+// CopilotChat manages messages and isRunning internally.
+<CopilotChat agentId="default" />
+
+// For manual control, drop down to headless CopilotChatView:
+<CopilotChatView
+  messages={myMessages}
+  isRunning={busy}
+  onSubmitInput={handleSubmit}
+>
+  <CopilotChatMessageView />
+  <CopilotChatInput />
+</CopilotChatView>
+```
+
+`CopilotChatProps` explicitly `Omit`s `messages` and `isRunning` — passing
+them is a TypeScript error, and `<CopilotChat>` always reads from its
+internal `useAgent` call.
+
+Source: `packages/react-core/src/v2/components/chat/CopilotChat.tsx:37-52`
+
+### MEDIUM — Two `<CopilotChat>` with the same `agentId` + `threadId`
+
+Wrong:
+
+```tsx
+<CopilotChat agentId="research" threadId="t1" />
+<CopilotChat agentId="research" threadId="t1" />
+```
+
+Correct:
+
+```tsx
+// Either use distinct threadIds...
+<CopilotChat agentId="research" threadId="panel-a" />
+<CopilotChat agentId="research" threadId="panel-b" />
+
+// ...or mount only one <CopilotChat> instance per agent/thread.
+```
+
+Both components resolve to the same per-thread clone (cached in a
+module-level WeakMap) and submit duplicate messages. See `agent-access` for
+the clone semantics.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+
+### MEDIUM — Missing the v2 CSS import
+
+Wrong:
+
+```tsx
+import { CopilotChat } from "@copilotkit/react-core/v2";
+// …no styles imported
+```
+
+Correct:
+
+```tsx
+import { CopilotChat } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+```
+
+The chat components ship unstyled without the v2 stylesheet. Import it once
+at the root of the app or in the same file that sets up the provider.
+
+Source: `packages/react-core/src/v2/index.ts:3` (imports `./index.css`)

--- a/skills/react-core/references/client-side-tools.md
+++ b/skills/react-core/references/client-side-tools.md
@@ -1,0 +1,358 @@
+# CopilotKit Client-Side Tools (React)
+
+This skill builds on `copilotkit/provider-setup`. Tools registered via
+`useFrontendTool` execute in the browser and are exposed to the agent over
+AG-UI.
+
+Hook signature:
+
+```ts
+useFrontendTool<T>(tool: ReactFrontendTool<T>, deps?: ReadonlyArray<unknown>);
+```
+
+The hook re-registers when `tool.name`, `tool.available`, or any entry in
+`deps` changes. Closures inside `handler` capture React state at
+registration time — pass `deps` when the handler references state.
+
+## UI-kit detection rule
+
+Before writing any `render` JSX, check the consumer's `package.json` for a
+UI kit and reuse its primitives:
+
+- `components/ui/*` (shadcn)
+- `@mui/material` (MUI)
+- `@chakra-ui/react` (Chakra)
+- `antd` (Ant Design)
+- `@mantine/core` (Mantine)
+
+Only write raw JSX if no kit is present.
+
+## Setup
+
+```tsx
+"use client";
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+export function SearchToolHost() {
+  useFrontendTool({
+    name: "searchDocs",
+    description: "Search the in-app documentation",
+    parameters: z.object({ query: z.string() }),
+    handler: async ({ query }, { signal }) => {
+      const r = await fetch(`/api/search?q=${encodeURIComponent(query)}`, {
+        signal,
+      });
+      return (await r.json()).results.join("\n");
+    },
+  });
+  return null;
+}
+```
+
+`zod` is a hard peer dependency — install it alongside `@copilotkit/react-core`.
+
+## Core Patterns
+
+### Handler with React state + deps
+
+```tsx
+const [cart, setCart] = useState<string[]>([]);
+
+useFrontendTool(
+  {
+    name: "addItem",
+    parameters: z.object({ id: z.string() }),
+    handler: async ({ id }) => {
+      setCart((c) => [...c, id]);
+    },
+  },
+  [setCart],
+);
+```
+
+### Forward `signal` into fetch (so `stopAgent` cancels in-flight calls)
+
+```tsx
+useFrontendTool({
+  name: "search",
+  parameters: z.object({ q: z.string() }),
+  handler: async ({ q }, { signal }) => {
+    const r = await fetch(`/search?q=${q}`, { signal });
+    return r.text();
+  },
+});
+```
+
+### Render progress UI for a tool (reuse the consumer's UI kit)
+
+```tsx
+// Consumer has shadcn → use Card + Skeleton
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+useFrontendTool({
+  name: "show",
+  parameters: z.object({ id: z.string() }),
+  handler: async ({ id }) => fetchItem(id),
+  render: ({ status, parameters, result }) => (
+    <Card>
+      {status === "inProgress" ? (
+        <Skeleton className="h-24 w-full" />
+      ) : (
+        <CardContent>{result}</CardContent>
+      )}
+    </Card>
+  ),
+});
+```
+
+### Programmatic invocation with string follow-up
+
+`copilotkit.runTool` accepts `followUp: boolean | "generate" | string`.
+A string is injected as a synthetic user message before the agent runs.
+
+```tsx
+import { useCopilotKit } from "@copilotkit/react-core/v2";
+
+const { copilotkit } = useCopilotKit();
+
+await copilotkit.runTool({
+  name: "searchDocs",
+  parameters: { query: "zod" },
+  followUp: "Summarize these results in 3 bullets", // inject as user message, run agent
+});
+```
+
+## Common Mistakes
+
+### CRITICAL — Writing JSX from scratch for `render` when the app has a UI kit
+
+Wrong:
+
+```tsx
+useFrontendTool({
+  name: "show",
+  parameters: z.object({ id: z.string() }),
+  handler,
+  render: ({ status }) => <div style={{ padding: 12 }}>…</div>,
+});
+```
+
+Correct:
+
+```tsx
+// First check package.json for shadcn / @mui/* / @chakra-ui/* / antd / @mantine/*, then:
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+useFrontendTool({
+  name: "show",
+  parameters: z.object({ id: z.string() }),
+  handler,
+  render: ({ status, result }) => (
+    <Card>
+      {status === "inProgress" ? (
+        <Skeleton />
+      ) : (
+        <CardContent>{result}</CardContent>
+      )}
+    </Card>
+  ),
+});
+```
+
+Consumers almost always have a UI kit. Raw JSX produces unbranded output
+and skips the accessibility patterns their existing primitives encode.
+
+Source: maintainer interview (Phase 2c)
+
+### HIGH — Stale closure inside `handler`
+
+Wrong:
+
+```tsx
+useFrontendTool({
+  name: "addItem",
+  parameters: z.object({ id: z.string() }),
+  handler: async ({ id }) => {
+    addTo(cart, id); // `cart` is captured at registration — goes stale
+  },
+});
+```
+
+Correct:
+
+```tsx
+useFrontendTool(
+  {
+    name: "addItem",
+    parameters: z.object({ id: z.string() }),
+    handler: async ({ id }) => {
+      addTo(cart, id);
+    },
+  },
+  [cart],
+);
+```
+
+`useFrontendTool` only re-registers when `name`, `available`, or `deps`
+change. Without `deps`, closures over React state freeze at first mount.
+
+Source: `packages/react-core/src/v2/hooks/use-frontend-tool.tsx:45`
+
+### HIGH — Ignoring `signal` in async handlers
+
+Wrong:
+
+```tsx
+useFrontendTool({
+  name: "search",
+  parameters: z.object({ q: z.string() }),
+  handler: async ({ q }) => (await fetch(`/search?q=${q}`)).text(),
+});
+```
+
+Correct:
+
+```tsx
+useFrontendTool({
+  name: "search",
+  parameters: z.object({ q: z.string() }),
+  handler: async ({ q }, { signal }) =>
+    (await fetch(`/search?q=${q}`, { signal })).text(),
+});
+```
+
+`stopAgent` / `agent.abortRun` abort via `AbortSignal`. A handler that
+doesn't forward `signal` keeps fetching after cancel, racing the next turn.
+
+Source: `packages/core/src/types.ts:24-30`
+
+### HIGH — Assuming `followUp` defaults to `false`
+
+Wrong:
+
+```tsx
+useFrontendTool({
+  name: "logAnalyticsEvent",
+  parameters: z.object({ name: z.string() }),
+  handler: async ({ name }) => {
+    analytics.track(name);
+  },
+  // followUp omitted → defaults to TRUE. Agent re-runs after every analytics call.
+});
+```
+
+Correct:
+
+```tsx
+useFrontendTool({
+  name: "logAnalyticsEvent",
+  parameters: z.object({ name: z.string() }),
+  handler: async ({ name }) => {
+    analytics.track(name);
+  },
+  followUp: false, // side-effect tool — don't re-invoke the agent
+});
+```
+
+For agent-invoked tools, run-handler checks `tool?.followUp !== false` — so
+`undefined` AND `true` both fire a follow-up `runAgent`. Only explicit
+`false` suppresses it. Pure side-effect tools must opt out or they loop.
+
+Source: `packages/core/src/core/run-handler.ts:607`
+
+### HIGH — Missing `zod` peer dependency
+
+Wrong:
+
+```bash
+pnpm install @copilotkit/react-core
+# zod missing — CopilotKitProvider fails to load
+```
+
+Correct:
+
+```bash
+pnpm install @copilotkit/react-core zod
+```
+
+`zod` is a hard peer of `@copilotkit/react-core` and is imported at
+provider module scope. Without it the provider module throws on load.
+
+Source: `packages/react-core/package.json` (peerDependencies)
+
+### MEDIUM — Duplicate tool name across hooks
+
+Wrong:
+
+```tsx
+// ComponentA
+useFrontendTool({ name: "save", parameters, handler: saveA });
+// ComponentB mounted in same tree:
+useFrontendTool({ name: "save", parameters, handler: saveB });
+// console.warn: "Tool 'save' already exists … Overriding"
+```
+
+Correct:
+
+```tsx
+useFrontendTool({
+  name: "save",
+  agentId: "research",
+  parameters,
+  handler: saveA,
+});
+useFrontendTool({
+  name: "save",
+  agentId: "coding",
+  parameters,
+  handler: saveB,
+});
+```
+
+Tool names must be globally unique per `agentId`. Second mount warns and
+replaces the first. Scope with `agentId` when multiple agents need their
+own "save" handler.
+
+Source: `packages/react-core/src/v2/hooks/use-frontend-tool.tsx:17-22`
+
+### MEDIUM — Passing `"generate"` or a string to `useFrontendTool`'s `followUp`
+
+Wrong:
+
+```tsx
+useFrontendTool({
+  name: "searchDocs",
+  parameters: z.object({ q: z.string() }),
+  handler,
+  followUp: "Summarize these results" as any, // silently truthy on registered tools
+});
+```
+
+Correct:
+
+```tsx
+// Registered tools — boolean only:
+useFrontendTool({
+  name: "searchDocs",
+  parameters: z.object({ q: z.string() }),
+  handler,
+  followUp: true,
+});
+
+// For string follow-ups, call runTool programmatically:
+const { copilotkit } = useCopilotKit();
+await copilotkit.runTool({
+  name: "searchDocs",
+  parameters: { q: "zod" },
+  followUp: "Summarize these results", // injects user message, runs agent
+});
+```
+
+`FrontendTool.followUp` is typed `boolean`. Strings are silently truthy
+(treated as `true`). The `"generate"` and custom-string modes only work
+on `copilotkit.runTool({ followUp })`.
+
+Source: `packages/core/src/types.ts:39`; `packages/core/src/core/run-handler.ts:47,763,848-863`

--- a/skills/react-core/references/custom-message-renderers.md
+++ b/skills/react-core/references/custom-message-renderers.md
@@ -1,0 +1,226 @@
+# CopilotKit Custom Message Renderers (React)
+
+This skill builds on `copilotkit/provider-setup` and
+`copilotkit/chat-components`. `useRenderCustomMessages` is consumed
+internally by `<CopilotChat>` / `<CopilotChatView>`.
+
+Key rules:
+
+- Renderers are passed to `CopilotKitProvider` via `renderCustomMessages`.
+- The hook returns `null` when called outside `CopilotChatConfigurationProvider`.
+- First non-null result wins — agent-scoped renderers evaluated first.
+- `stateSnapshot` is `undefined` before the run's `runId` resolves.
+
+## Setup
+
+```tsx
+"use client";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import type { ReactCustomMessageRenderer } from "@copilotkit/react-core/v2";
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+
+const CopyButton: ReactCustomMessageRenderer = {
+  render: ({ message, position }) => {
+    if (position !== "after") return null;
+    if (message.role !== "assistant") return null;
+    const content = typeof message.content === "string" ? message.content : "";
+    if (!content) return null;
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => navigator.clipboard.writeText(content)}
+      >
+        Copy
+      </Button>
+    );
+  },
+};
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const renderers = useMemo(() => [CopyButton], []);
+  return (
+    <CopilotKitProvider
+      runtimeUrl="/api/copilotkit"
+      renderCustomMessages={renderers}
+    >
+      {children}
+    </CopilotKitProvider>
+  );
+}
+```
+
+## Core Patterns
+
+### State-snapshot viewer after completed runs
+
+```tsx
+const StateSnapshotRenderer: ReactCustomMessageRenderer = {
+  render: ({ message, position, stateSnapshot }) => {
+    if (position !== "after") return null;
+    if (message.role !== "assistant") return null;
+    if (!stateSnapshot) return null; // run not yet resolved
+    return (
+      <details>
+        <summary>Agent state</summary>
+        <pre>{JSON.stringify(stateSnapshot, null, 2)}</pre>
+      </details>
+    );
+  },
+};
+```
+
+### Agent-scoped renderer
+
+```tsx
+const ResearchNotes: ReactCustomMessageRenderer = {
+  agentId: "research",
+  render: ({ message, position, stateSnapshot }) => {
+    if (position !== "after" || !stateSnapshot) return null;
+    const notes = (stateSnapshot as { notes?: string[] }).notes ?? [];
+    return (
+      <ul>
+        {notes.map((n, i) => (
+          <li key={i}>{n}</li>
+        ))}
+      </ul>
+    );
+  },
+};
+```
+
+### Debug panel before user messages
+
+```tsx
+const DebugBefore: ReactCustomMessageRenderer = {
+  render: ({ message, position, messageIndex, runId }) => {
+    if (position !== "before" || message.role !== "user") return null;
+    // `runId` is always a string, but it falls back to a synthetic
+    // "missing-run-id:<messageId>" value before a run is registered.
+    // Slice only when it looks like a real id, otherwise show a dash.
+    const shortId = runId?.startsWith("missing-run-id:")
+      ? "—"
+      : (runId?.slice(0, 6) ?? "—");
+    return (
+      <div style={{ opacity: 0.5, fontSize: 11 }}>
+        #{messageIndex} · run {shortId}
+      </div>
+    );
+  },
+};
+```
+
+## Common Mistakes
+
+### HIGH — Using the hook outside a chat configuration provider
+
+Wrong:
+
+```tsx
+// Component mounted outside <CopilotChat>/<CopilotChatView>
+function StandaloneRenderer() {
+  const render = useRenderCustomMessages(); // returns null — no chat config in tree
+  return render ? render({ message, position: "after" }) : null;
+}
+```
+
+Correct:
+
+```tsx
+// Option A — register renderers via the provider prop so <CopilotChat> picks them up:
+<CopilotKitProvider renderCustomMessages={renderers}>
+  <CopilotChat agentId="default" />
+</CopilotKitProvider>;
+
+// Option B — call the hook only inside a chat-configured subtree:
+import { CopilotChatConfigurationProvider } from "@copilotkit/react-core/v2";
+<CopilotChatConfigurationProvider agentId="default">
+  <ComponentThatCallsUseRenderCustomMessages />
+</CopilotChatConfigurationProvider>;
+```
+
+`useRenderCustomMessages` returns `null` when there is no
+`CopilotChatConfigurationProvider` in the tree. `<CopilotChat>` wraps its
+children in one automatically; direct use outside a chat component
+requires the explicit wrapper.
+
+Source: `packages/react-core/src/v2/hooks/use-render-custom-messages.tsx:15-17`
+
+### MEDIUM — Relying on `stateSnapshot` during early streaming
+
+Wrong:
+
+```tsx
+render: ({ stateSnapshot }) => <pre>{JSON.stringify(stateSnapshot.items)}</pre>;
+// Crashes during the first token — stateSnapshot is undefined before runId resolves.
+```
+
+Correct:
+
+```tsx
+render: ({ stateSnapshot }) => (
+  <pre>{stateSnapshot ? JSON.stringify(stateSnapshot.items) : "…"}</pre>
+);
+```
+
+`stateSnapshot` comes from `copilotkit.getStateByRun(agentId, threadId,
+runId)`. `runId` is `undefined` until the run is registered, so the
+snapshot starts `undefined` and only becomes truthy after the first
+state emit. Guard with a fallback.
+
+Source: `packages/react-core/src/v2/hooks/use-render-custom-messages.tsx:69-71`
+
+### MEDIUM — Expecting every renderer in the array to run
+
+Wrong:
+
+```tsx
+// Both renderers want to add an "after assistant" button and return <div>…</div>
+// Only the first one (or the agent-scoped one) fires — the second is skipped.
+const renderers = [Renderer1, Renderer2];
+```
+
+Correct:
+
+```tsx
+// Merge the two into a single renderer that returns one element:
+const Combined: ReactCustomMessageRenderer = {
+  render: (props) => (
+    <div className="flex gap-1">
+      <Renderer1Inner {...props} />
+      <Renderer2Inner {...props} />
+    </div>
+  ),
+};
+```
+
+The hook iterates the sorted renderer list and breaks at the first non-null
+result. Two independent renderers returning JSX for the same
+`(message, position)` pair will have only one fire. Compose them into a
+single renderer if you want both to appear.
+
+Source: `packages/react-core/src/v2/hooks/use-render-custom-messages.tsx:73-95`
+
+### MEDIUM — Memoization miss on `renderCustomMessages` array
+
+Wrong:
+
+```tsx
+<CopilotKitProvider
+  renderCustomMessages={[CopyButton, DebugBefore]} // fresh array every render
+/>
+```
+
+Correct:
+
+```tsx
+const renderers = useMemo(() => [CopyButton, DebugBefore], []);
+<CopilotKitProvider renderCustomMessages={renderers} />;
+```
+
+The provider's stable-array-prop diff console-errors when a new array
+identity appears every render and thrashes renderer registration.
+Memoize or hoist.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx` (useStableArrayProp)

--- a/skills/react-core/references/debug-mode.md
+++ b/skills/react-core/references/debug-mode.md
@@ -1,0 +1,153 @@
+# CopilotKit Debug Mode (React)
+
+This skill builds on `copilotkit/provider-setup`. Both debug surfaces are
+props on `CopilotKitProvider`.
+
+Two independent knobs:
+
+1. `showDevConsole` mounts the visual web inspector (floating panel).
+2. `debug` controls console logging for the event pipeline.
+
+Both should be `'auto'` / off in production.
+
+## Setup
+
+```tsx
+"use client";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <CopilotKitProvider
+      runtimeUrl="/api/copilotkit"
+      showDevConsole="auto"
+      debug={{ events: true, lifecycle: true, verbose: false }}
+    >
+      {children}
+    </CopilotKitProvider>
+  );
+}
+```
+
+`showDevConsole="auto"` enables the inspector only on `localhost` and
+`127.0.0.1`. In production it evaluates to `false`.
+
+## Core Patterns
+
+### Full payload logging during a repro
+
+`debug: true` enables `events + lifecycle` but keeps `verbose` off to avoid
+leaking PII by default. For a bug repro, explicitly set `verbose: true` to
+dump full message/tool-call payloads.
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  debug={{ events: true, lifecycle: true, verbose: true }}
+/>
+```
+
+### Anchor the inspector on narrow viewports
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  showDevConsole="auto"
+  inspectorDefaultAnchor="bottom-left"
+/>
+```
+
+### Env-gate the inspector
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  showDevConsole={process.env.NODE_ENV !== "production"}
+/>
+```
+
+## Common Mistakes
+
+### HIGH — Shipping `showDevConsole={true}` to production
+
+Wrong:
+
+```tsx
+<CopilotKitProvider runtimeUrl="/api/copilotkit" showDevConsole={true} />
+```
+
+Correct:
+
+```tsx
+<CopilotKitProvider runtimeUrl="/api/copilotkit" showDevConsole="auto" />
+// "auto" enables only on localhost / 127.0.0.1
+```
+
+A hard `true` ships the Lit + markdown bundle to every end user and exposes
+a developer panel in production. `"auto"` is the right default.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx:301-321`
+
+### MEDIUM — Expecting `debug: true` to log full payloads
+
+Wrong:
+
+```tsx
+<CopilotKitProvider debug={true} />
+// Then wondering why message contents aren't in the console
+```
+
+Correct:
+
+```tsx
+<CopilotKitProvider debug={{ events: true, lifecycle: true, verbose: true }} />
+```
+
+`debug: true` is shorthand for `{ events: true, lifecycle: true, verbose: false }`.
+`verbose` defaults to `false` to avoid logging user message bodies / tool
+arguments / state snapshots — it must be opted into explicitly.
+
+Source: `docs/snippets/shared/troubleshooting/debug-mode.mdx:85-93`
+
+### MEDIUM — Passing fields that aren't in `DebugConfig`
+
+Wrong:
+
+```tsx
+<CopilotKitProvider debug={{ events: true, network: true, errors: true }} />
+```
+
+Correct:
+
+```tsx
+<CopilotKitProvider debug={{ events: true, lifecycle: true, verbose: true }} />
+```
+
+`DebugConfig` has exactly three fields: `events`, `lifecycle`, `verbose`.
+Anything else is silently ignored by the type-narrowing at the provider.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx` (DebugConfig type)
+
+### MEDIUM — Inspector crashing in sandboxed iframes
+
+Wrong:
+
+```tsx
+// App embedded in a sandboxed iframe with showDevConsole on
+<CopilotKitProvider runtimeUrl="..." showDevConsole="auto" />
+```
+
+Correct:
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="..."
+  showDevConsole={typeof window !== "undefined" && window.self === window.top}
+/>
+```
+
+The inspector persists its anchor via `localStorage`. In sandboxed iframes
+without storage access, the component throws on mount. Either disable in
+iframes or whitelist storage in the sandbox attrs.
+
+Source: `packages/react-core/src/v2/components/CopilotKitInspector.tsx:16-53`

--- a/skills/react-core/references/human-in-the-loop.md
+++ b/skills/react-core/references/human-in-the-loop.md
@@ -1,0 +1,312 @@
+# CopilotKit Human-in-the-Loop (React)
+
+This skill builds on `copilotkit/provider-setup`, `copilotkit/client-side-tools`,
+and `copilotkit/rendering-tool-calls`.
+
+`useHumanInTheLoop` is `useFrontendTool` minus the `handler` plus a
+`render` that receives a `respond` function. The hook synthesizes a
+Promise-based handler — the Promise resolves when `respond(result)` is
+called. No `respond` call → infinite hang.
+
+Status is camelCase: `"inProgress" | "executing" | "complete"`. `respond`
+is `undefined` except during `"executing"`.
+
+## UI-kit detection rule
+
+Before writing the approval UI, check the consumer's `package.json` for a
+UI kit (shadcn `AlertDialog`, MUI `Dialog`, Chakra `Modal`, Ant `Modal`,
+Mantine `Modal`) and reuse it. Don't hand-roll an overlay.
+
+## Setup
+
+```tsx
+"use client";
+import { useHumanInTheLoop } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export function DeleteConfirmHITL() {
+  useHumanInTheLoop({
+    name: "confirmDelete",
+    description: "Confirm a destructive delete with the user",
+    parameters: z.object({ id: z.string(), label: z.string() }),
+    render: ({ status, args, respond }) => (
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {args.label}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={status !== "executing"}
+              onClick={() => respond?.("denied")}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={status !== "executing"}
+              onClick={() => respond?.("approved")}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ),
+  });
+  return null;
+}
+```
+
+## Core Patterns
+
+### Always call `respond` in every branch
+
+```tsx
+render: ({ status, args, respond }) => {
+  if (status !== "executing" || !respond) {
+    return <div>Awaiting decision…</div>;
+  }
+  return (
+    <div>
+      <button onClick={() => respond("approved")}>Approve</button>
+      <button onClick={() => respond("denied")}>Reject</button>
+      <button onClick={() => respond({ action: "skip", reason: "timeout" })}>
+        Skip
+      </button>
+    </div>
+  );
+};
+```
+
+### Abort the run on unmount so threads unlock
+
+```tsx
+import { useAgent, UseAgentUpdate } from "@copilotkit/react-core/v2";
+import { useEffect, useRef } from "react";
+
+function HITLHost() {
+  const { agent } = useAgent({
+    agentId: "default",
+    updates: [UseAgentUpdate.OnRunStatusChanged],
+  });
+  // Track isRunning in a ref so the unmount cleanup reads the latest value
+  // without re-firing on every transition.
+  const runningRef = useRef(false);
+  useEffect(() => {
+    runningRef.current = agent.isRunning;
+  }, [agent.isRunning]);
+
+  useEffect(() => {
+    return () => {
+      if (runningRef.current) agent.abortRun();
+    };
+  }, [agent]);
+
+  return <DeleteConfirmHITL />;
+}
+```
+
+`useAgent` returns `{ agent }` only — run status lives on `agent.isRunning`.
+Depending the cleanup effect directly on `agent.isRunning` would fire the
+cleanup on every status flip (not just unmount), aborting active runs.
+The ref pattern captures the latest value while the cleanup runs only
+when the host component truly unmounts.
+
+### Collect structured user input mid-run
+
+```tsx
+useHumanInTheLoop({
+  name: "askUserForPriority",
+  parameters: z.object({ taskId: z.string() }),
+  render: ({ status, args, respond }) => {
+    if (status !== "executing" || !respond) return <div>Waiting…</div>;
+    return (
+      <div>
+        {["low", "medium", "high"].map((p) => (
+          <button
+            key={p}
+            onClick={() => respond({ taskId: args.taskId, priority: p })}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+    );
+  },
+});
+```
+
+## Common Mistakes
+
+### CRITICAL — Never calling `respond()`
+
+Wrong:
+
+```tsx
+useHumanInTheLoop({
+  name: "confirmDelete",
+  parameters: z.object({ id: z.string() }),
+  render: ({ args, status, respond }) => (
+    <div>
+      <p>Delete {args.id}?</p>
+      <button>OK</button>
+    </div>
+  ),
+});
+```
+
+Correct:
+
+```tsx
+useHumanInTheLoop({
+  name: "confirmDelete",
+  parameters: z.object({ id: z.string() }),
+  render: ({ args, status, respond }) => (
+    <div>
+      <p>Delete {args.id}?</p>
+      <button onClick={() => respond?.("approved")}>OK</button>
+      <button onClick={() => respond?.("denied")}>Cancel</button>
+    </div>
+  ),
+});
+```
+
+The synthesized handler returns a Promise that resolves only when `respond`
+is called. Never calling it (including reject / cancel paths) hangs the
+run indefinitely and leaves the thread locked on the server.
+
+Source: `packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx:13-26`
+
+### CRITICAL — Writing a custom overlay when the app has a Dialog primitive
+
+Wrong:
+
+```tsx
+render: ({ respond }) => (
+  <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.5)" }}>
+    …
+  </div>
+);
+```
+
+Correct:
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+
+render: ({ respond }) => (
+  <AlertDialog open>
+    <AlertDialogContent>
+      …
+      <AlertDialogAction onClick={() => respond?.("approved")}>
+        OK
+      </AlertDialogAction>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+```
+
+Check `package.json` for shadcn / MUI / Chakra / Ant / Mantine before
+writing an overlay. Their dialog primitives handle focus trapping,
+escape-to-close, and accessibility — raw JSX skips all of that.
+
+Source: maintainer interview (Phase 2c)
+
+### HIGH — Calling `respond` during `inProgress` or `complete`
+
+Wrong:
+
+```tsx
+render: ({ status, respond }) => (
+  <button onClick={() => (respond as any)("yes")}>Yes</button>
+);
+```
+
+Correct:
+
+```tsx
+render: ({ status, respond }) =>
+  status === "executing" && respond ? (
+    <button onClick={() => respond("yes")}>Yes</button>
+  ) : (
+    <p>Waiting…</p>
+  );
+```
+
+`respond` is `undefined` outside `status === "executing"`. Widening it to
+`any` silently no-ops — the button click appears to work, but nothing
+resolves the Promise.
+
+Source: `packages/react-core/src/v2/types/human-in-the-loop.ts:8-32`
+
+### HIGH — Unmounting the render mid-executing
+
+Wrong:
+
+```tsx
+// User clicks away to a different route while the agent is waiting on respond()
+```
+
+Correct:
+
+```tsx
+// Keep the HITL prompt at a layout level that persists across route changes, OR abort on unmount:
+const { agent } = useAgent({
+  agentId: "default",
+  updates: [UseAgentUpdate.OnRunStatusChanged],
+});
+const runningRef = useRef(false);
+useEffect(() => {
+  runningRef.current = agent.isRunning;
+}, [agent.isRunning]);
+useEffect(
+  () => () => {
+    if (runningRef.current) agent.abortRun();
+  },
+  [agent],
+);
+```
+
+`useHumanInTheLoop` removes its renderer on unmount (unlike
+`useFrontendTool`, which keeps renderers for history). If the renderer
+unmounts mid-`executing`, the pending Promise is abandoned and the run
+hangs. Either lift the HITL UI to a layout-level component, or abort the
+run on unmount.
+
+Source: `packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx:76-80`
+
+### MEDIUM — Using hyphenated `"in-progress"` status
+
+Wrong:
+
+```tsx
+render: ({ status }) => (status === "in-progress" ? <Spinner /> : <Form />);
+```
+
+Correct:
+
+```tsx
+render: ({ status }) => (status === "inProgress" ? <Spinner /> : <Form />);
+```
+
+Same camelCase rule as `rendering-tool-calls`: the discriminated union
+only matches `"inProgress" | "executing" | "complete"`.
+
+Source: `packages/react-core/src/v2/types/human-in-the-loop.ts:8-32`

--- a/skills/react-core/references/provider-setup.md
+++ b/skills/react-core/references/provider-setup.md
@@ -1,0 +1,326 @@
+# CopilotKit Provider Setup (React)
+
+Mount `CopilotKitProvider` once near the root of the React tree. Every
+CopilotKit hook (`useAgent`, `useFrontendTool`, `useRenderTool`, etc.) and
+every chat component (`CopilotChat`, `CopilotPopup`, `CopilotSidebar`) must
+be rendered inside this provider.
+
+All v2 imports use the `@copilotkit/react-core/v2` subpath. Imports from the
+package root are v1 and will not work with v2 hooks or components.
+
+## Setup
+
+### Next.js App Router (and any RSC-based framework)
+
+`@copilotkit/react-core/v2` is marked `"use client"`. You must mount the
+provider from a client component, not a server component. The cleanest
+pattern is a dedicated client-only `providers.tsx`.
+
+```tsx
+// app/providers.tsx
+"use client";
+
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <CopilotKitProvider
+      runtimeUrl="/api/copilotkit"
+      credentials="include"
+      onError={({ code, error, context }) => {
+        console.error("[copilotkit]", code, error, context);
+      }}
+    >
+      {children}
+    </CopilotKitProvider>
+  );
+}
+```
+
+For auth headers that change over the session (rotating bearer tokens,
+refreshed cookies), see the "Stable headers for rotating auth tokens"
+pattern below. Avoid putting a `useMemo(() => ({ Authorization: ... }),
+[])` on the provider — an empty deps array captures the token at mount
+and never refreshes.
+
+```tsx
+// app/layout.tsx — server component
+import { Providers } from "./providers";
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}
+```
+
+### Vite / React Router v7 / SPA
+
+```tsx
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+
+export function App({ children }: { children: React.ReactNode }) {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+      {children}
+    </CopilotKitProvider>
+  );
+}
+```
+
+### SPA with CopilotKit Cloud (no self-hosted runtime)
+
+```tsx
+<CopilotKitProvider publicApiKey="ck_pub_..." />
+```
+
+`publicApiKey` is the canonical prop for running CopilotKit from a pure
+client bundle. `publicLicenseKey` is an alias that resolves to the same
+value (`publicApiKey ?? publicLicenseKey`) — accept in old code, but
+always write `publicApiKey` in new code.
+
+## Core Patterns
+
+### Stable headers for rotating auth tokens
+
+For tokens that change during the session, use the imperative setter instead
+of re-rendering the provider with a new `headers` prop.
+
+```tsx
+"use client";
+import { useCopilotKit } from "@copilotkit/react-core/v2";
+import { useEffect } from "react";
+
+export function AuthTokenSync({ token }: { token: string }) {
+  const { copilotkit } = useCopilotKit();
+  useEffect(() => {
+    copilotkit.setHeaders({ Authorization: `Bearer ${token}` });
+  }, [copilotkit, token]);
+  return null;
+}
+```
+
+### Global error handler
+
+`onError` fires for every `CopilotKitCoreErrorCode` emitted by core. Keeps
+UI from getting stuck in "connecting..." when the runtime URL is wrong or
+CORS is misconfigured.
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  onError={({ code, error, context }) => {
+    telemetry.capture({ code, message: error.message, context });
+  }}
+/>
+```
+
+### Sharing app properties with every run
+
+`properties` flows to the runtime on each agent run — useful for tenant IDs,
+feature flags, or anything the server needs.
+
+```tsx
+const properties = useMemo(
+  () => ({ tenantId: user.tenantId, locale: user.locale }),
+  [user.tenantId, user.locale],
+);
+
+<CopilotKitProvider runtimeUrl="/api/copilotkit" properties={properties} />;
+```
+
+## Common Mistakes
+
+### CRITICAL — Mounting the provider from a Server Component
+
+Wrong:
+
+```tsx
+// app/page.tsx (server component — no "use client")
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+export default function Page() {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit">...</CopilotKitProvider>
+  );
+}
+```
+
+Correct:
+
+```tsx
+// app/providers.tsx
+"use client";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+      {children}
+    </CopilotKitProvider>
+  );
+}
+
+// app/layout.tsx imports <Providers>.
+```
+
+`@copilotkit/react-core/v2` begins with `"use client"`. Importing it from a
+server component silently strips interactivity — the provider renders but
+none of the hooks wire up.
+
+Source: `packages/react-core/src/v2/index.ts:1`
+
+### CRITICAL — Using `agents__unsafe_dev_only` or `selfManagedAgents` in production
+
+Wrong:
+
+```tsx
+<CopilotKitProvider
+  agents__unsafe_dev_only={{
+    default: new BuiltInAgent({ apiKey: process.env.OPENAI_KEY! }),
+  }}
+/>
+// or the alias (same thing):
+<CopilotKitProvider
+  selfManagedAgents={{ default: new BuiltInAgent({ apiKey: "..." }) }}
+/>
+```
+
+Correct:
+
+```tsx
+// Route through a runtime that keeps secrets server-side:
+<CopilotKitProvider runtimeUrl="/api/copilotkit" />
+
+// Or for a pure SPA, use CopilotKit Cloud:
+<CopilotKitProvider publicApiKey="ck_pub_..." />
+```
+
+Both props are aliases for the same dev-only mechanism and ship any embedded
+credentials to the browser bundle. Never use either for production agents.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx:136-138,393`
+
+### HIGH — Inline object props rebuilt every render
+
+Wrong:
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  headers={{ Authorization: `Bearer ${token}` }}
+  properties={{ tenantId: user.tenantId }}
+/>
+```
+
+Correct:
+
+```tsx
+const headers = useMemo(() => ({ Authorization: `Bearer ${token}` }), [token]);
+const properties = useMemo(
+  () => ({ tenantId: user.tenantId }),
+  [user.tenantId],
+);
+
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  headers={headers}
+  properties={properties}
+/>;
+```
+
+New object identity on every render causes the provider to diff-churn
+internal state and may thrash tool/renderer registration. `useStableArrayProp`
+also logs a `console.error` when array-prop shape changes without
+memoization.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx:324-340,399-410`
+
+### HIGH — Missing `onError` leaves users stuck in "connecting..."
+
+Wrong:
+
+```tsx
+<CopilotKitProvider runtimeUrl="/api/copilotkit" />
+```
+
+Correct:
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  onError={({ code, error, context }) => {
+    telemetry.capture({ code, error, context });
+  }}
+/>
+```
+
+Without `onError`, connection failures (bad runtime URL, CORS, network) keep
+the provider in a provisional state with `ProxiedCopilotRuntimeAgent`
+instances that never resolve. The chat UI keeps showing "connecting..."
+forever and users never see the actual error.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx:638-660`
+
+### HIGH — Writing `publicLicenseKey` in new code
+
+Wrong:
+
+```tsx
+<CopilotKitProvider publicLicenseKey="ck_pub_..." />
+```
+
+Correct:
+
+```tsx
+<CopilotKitProvider publicApiKey="ck_pub_..." />
+```
+
+`publicLicenseKey` still works as an alias, but `publicApiKey` is the
+canonical name in v2. The provider resolves
+`publicApiKey ?? publicLicenseKey`. Always write the canonical form in
+new code.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx:122-128,391`
+
+### MEDIUM — Putting the provider below a layout that uses CopilotKit
+
+Wrong:
+
+```tsx
+<html>
+  <body>
+    <Header>{/* Header uses useFrontendTool internally */}</Header>
+    <CopilotKitProvider>{children}</CopilotKitProvider>
+  </body>
+</html>
+```
+
+Correct:
+
+```tsx
+<html>
+  <body>
+    <CopilotKitProvider>
+      <Header />
+      {children}
+    </CopilotKitProvider>
+  </body>
+</html>
+```
+
+Any component that calls `useCopilotKit`, `useFrontendTool`, `useAgent`, or
+any other CopilotKit hook must be a descendant of `CopilotKitProvider`.
+Placing the provider beside or below a consumer throws at mount.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx` (context)

--- a/skills/react-core/references/rendering-activity-messages.md
+++ b/skills/react-core/references/rendering-activity-messages.md
@@ -1,0 +1,207 @@
+# CopilotKit Rendering Activity Messages (React)
+
+This skill builds on `copilotkit/provider-setup`. Activity-message
+renderers are registered as entries in the `renderActivityMessages` array
+prop on `CopilotKitProvider` and resolved at render time by
+`useRenderActivityMessage` (consumed internally by chat components).
+
+User renderers are placed first in the array so they override the built-in
+`MCPAppsActivityType` and `OpenGenerativeUIActivityType` renderers for the
+same `activityType`.
+
+Resolver order:
+
+1. `(activityType, agentId)` match
+2. `(activityType, unscoped)` match
+3. `'*'` wildcard
+4. `null`
+
+## Setup
+
+```tsx
+"use client";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import type { ReactActivityMessageRenderer } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { useMemo } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+
+const progressRenderer: ReactActivityMessageRenderer<{
+  percent: number;
+  label: string;
+}> = {
+  activityType: "progress",
+  content: z.object({ percent: z.number().min(0).max(1), label: z.string() }),
+  render: ({ content }) => (
+    <Card>
+      <CardContent>
+        <div>{content.label}</div>
+        <Progress value={content.percent * 100} />
+      </CardContent>
+    </Card>
+  ),
+};
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const renderers = useMemo(() => [progressRenderer], []);
+  return (
+    <CopilotKitProvider
+      runtimeUrl="/api/copilotkit"
+      renderActivityMessages={renderers}
+    >
+      {children}
+    </CopilotKitProvider>
+  );
+}
+```
+
+## Core Patterns
+
+### Agent-scoped renderer
+
+```tsx
+const researchProgress: ReactActivityMessageRenderer<{ step: string }> = {
+  activityType: "research-step",
+  agentId: "research",
+  content: z.object({ step: z.string() }),
+  render: ({ content }) => <ResearchStepBadge step={content.step} />,
+};
+```
+
+### Override a built-in (MCP Apps)
+
+Place your renderer for the same `activityType` — user renderers are
+evaluated before built-ins.
+
+```tsx
+import { MCPAppsActivityType } from "@copilotkit/react-core/v2";
+
+const customMcpRenderer: ReactActivityMessageRenderer<unknown> = {
+  activityType: MCPAppsActivityType, // "mcp-apps" — must match the exported constant
+  content: z.unknown(),
+  render: ({ content, message }) => <CustomMCPCard payload={content} />,
+};
+```
+
+### Using the hook directly (custom chat surface)
+
+```tsx
+import { useRenderActivityMessage } from "@copilotkit/react-core/v2";
+import type { ActivityMessage } from "@ag-ui/core";
+
+export function ActivityList({ messages }: { messages: ActivityMessage[] }) {
+  const { renderActivityMessage } = useRenderActivityMessage();
+  return (
+    <div>
+      {messages.map((m) => (
+        <div key={m.id}>{renderActivityMessage(m)}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Common Mistakes
+
+### HIGH — Incompatible content schema
+
+Wrong:
+
+```tsx
+// Renderer expects `pct`
+const r: ReactActivityMessageRenderer<{ pct: number }> = {
+  activityType: "progress",
+  content: z.object({ pct: z.number() }),
+  render: ({ content }) => <Bar value={content.pct} />,
+};
+// But the server emits { percent: 0.5 } — mismatched field name
+```
+
+Correct:
+
+```tsx
+const r: ReactActivityMessageRenderer<{ percent: number }> = {
+  activityType: "progress",
+  content: z.object({ percent: z.number() }),
+  render: ({ content }) => <Bar value={content.percent} />,
+};
+```
+
+`safeParse` is called on every incoming activity message. Mismatched
+schemas return `null` with only a `console.warn("Failed to parse content
+for activity message …")` — the UI renders nothing and the failure is
+silent unless you read the console.
+
+Source: `packages/react-core/src/v2/hooks/use-render-activity-message.tsx:44-50`
+
+### MEDIUM — Side effects in `render`
+
+Wrong:
+
+```tsx
+render: ({ content }) => {
+  trackEvent(content); // fires on every re-render
+  return <Badge>{content.label}</Badge>;
+};
+```
+
+Wrong (Rules of Hooks violation):
+
+```tsx
+render: ({ content }) => {
+  // `render` is invoked as a plain function by the resolver — NOT as a
+  // React component — so calling hooks directly inside it is illegal.
+  useEffect(() => trackEvent(content), [content]);
+  return <Badge>{content.label}</Badge>;
+};
+```
+
+Correct:
+
+```tsx
+function TrackedBadge({ content }: { content: { label: string } }) {
+  useEffect(() => {
+    trackEvent(content);
+  }, [content]);
+  return <Badge>{content.label}</Badge>;
+}
+
+// In the renderer:
+render: ({ content }) => <TrackedBadge content={content} />;
+```
+
+Activity-message renderers re-render on every message-list tick. Side
+effects in the render body fire repeatedly. Hooks cannot be called
+directly inside `render` because the resolver invokes it as a plain
+function; hoist the effect into a wrapper component that React mounts as
+a real element.
+
+Source: `packages/react-core/src/v2/hooks/use-render-activity-message.tsx`
+
+### MEDIUM — Building the `renderActivityMessages` array inline
+
+Wrong:
+
+```tsx
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  renderActivityMessages={[progressRenderer, customMcpRenderer]}
+/>
+```
+
+Correct:
+
+```tsx
+const renderers = useMemo(() => [progressRenderer, customMcpRenderer], []);
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  renderActivityMessages={renderers}
+/>;
+```
+
+The provider uses `useStableArrayProp` and console-errors when a new array
+identity appears every render. Memoize or hoist the array to module
+scope.
+
+Source: `packages/react-core/src/v2/providers/CopilotKitProvider.tsx` (useStableArrayProp)

--- a/skills/react-core/references/rendering-tool-calls.md
+++ b/skills/react-core/references/rendering-tool-calls.md
@@ -1,0 +1,319 @@
+# CopilotKit Rendering Tool Calls (React)
+
+This skill builds on `copilotkit/provider-setup` and
+`copilotkit/client-side-tools`.
+
+Four hooks, distinct roles:
+
+| Hook                   | Role                                                              |
+| ---------------------- | ----------------------------------------------------------------- |
+| `useRenderTool`        | Primary registration hook for a named tool's progress/result UI   |
+| `useComponent`         | Register a NEW render-only tool (agent calls it just to render)   |
+| `useDefaultRenderTool` | Sanctioned wildcard fallback for tools without a dedicated render |
+| `useRenderToolCall`    | Resolver — returns a function. For custom chat surfaces only      |
+
+Status is camelCase: `"inProgress" | "executing" | "complete"`. The
+`RenderToolProps` discriminated union narrows `parameters` per state.
+
+## UI-kit detection rule
+
+Before writing raw JSX, check the consumer's `package.json` for shadcn /
+MUI / Chakra / Ant / Mantine and reuse those primitives.
+
+## Setup
+
+```tsx
+"use client";
+import { useRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SearchRenderer() {
+  useRenderTool({
+    name: "searchDocs",
+    parameters: z.object({ query: z.string() }),
+    render: ({ status, parameters, result }) => {
+      if (status === "inProgress") return <Skeleton className="h-16 w-full" />;
+      if (status === "executing") {
+        return (
+          <Card>
+            <CardContent>Searching "{parameters.query}"…</CardContent>
+          </Card>
+        );
+      }
+      return (
+        <Card>
+          <CardContent>{result}</CardContent>
+        </Card>
+      );
+    },
+  });
+  return null;
+}
+```
+
+## Core Patterns
+
+### Wildcard fallback with the built-in card
+
+```tsx
+import { useDefaultRenderTool } from "@copilotkit/react-core/v2";
+
+useDefaultRenderTool(); // renders the built-in expandable tool-call card
+```
+
+### Custom wildcard fallback
+
+```tsx
+import { useDefaultRenderTool } from "@copilotkit/react-core/v2";
+
+useDefaultRenderTool({
+  render: ({ name, status, parameters, result }) => {
+    // parameters is unknown — narrow by tool name
+    if (name === "search") {
+      const args = parameters as { q: string };
+      return <SearchCard q={args.q} status={status} result={result} />;
+    }
+    return <GenericCard name={name} status={status} />;
+  },
+});
+```
+
+### Render-only tool (the agent's only reason to call it is to render)
+
+```tsx
+import { useComponent } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+useComponent({
+  name: "productCard",
+  parameters: z.object({ productId: z.string() }),
+  render: ({ productId }) => <ProductCard id={productId} />,
+});
+// `useComponent` registers a NEW tool called "productCard".
+// The agent calls it to render; there is no handler to run.
+```
+
+### Custom chat surface (resolver hook)
+
+`useRenderToolCall` is for building your own message list, NOT for
+registering renderers.
+
+```tsx
+import { useRenderToolCall } from "@copilotkit/react-core/v2";
+import { useAgent } from "@copilotkit/react-core/v2";
+
+export function CustomToolList() {
+  const { agent } = useAgent({ agentId: "default" });
+  const renderToolCall = useRenderToolCall();
+
+  const toolCalls = agent.messages.flatMap((m) =>
+    "toolCalls" in m ? (m.toolCalls ?? []) : [],
+  );
+
+  return (
+    <>
+      {toolCalls.map((tc) => (
+        <div key={tc.id}>{renderToolCall({ toolCall: tc })}</div>
+      ))}
+    </>
+  );
+}
+```
+
+## Common Mistakes
+
+### CRITICAL — Using `useRenderToolCall` for registration
+
+Wrong:
+
+```tsx
+useRenderToolCall({
+  name: "search",
+  args: z.object({ q: z.string() }),
+  render: ({ status, args }) => <Card>…</Card>,
+});
+```
+
+Correct:
+
+```tsx
+useRenderTool({
+  name: "search",
+  parameters: z.object({ q: z.string() }),
+  render: ({ status, parameters }) => <Card>…</Card>,
+});
+```
+
+`useRenderToolCall` takes no arguments — it returns a resolver function for
+custom chat surfaces. Passing config to it does nothing. `useRenderTool` is
+the registration hook.
+
+Source: `packages/react-core/src/v2/hooks/index.ts:2,7`;
+`packages/react-core/src/v2/hooks/use-render-tool.tsx:37-40`
+
+### CRITICAL — Using hyphenated `"in-progress"` status
+
+Wrong:
+
+```tsx
+render: ({ status, parameters, result }) => {
+  if (status === "in-progress") return <Spinner />;
+  if (status === "executing") return <RunningCard args={parameters} />;
+  return <ResultCard result={result} />;
+};
+```
+
+Correct:
+
+```tsx
+render: ({ status, parameters, result }) => {
+  if (status === "inProgress") return <Spinner />;
+  if (status === "executing") return <RunningCard args={parameters} />;
+  return <ResultCard result={result} />;
+};
+```
+
+Real status values are camelCase: `"inProgress" | "executing" | "complete"`.
+Hyphenated branches never match — users see no progress UI and the fallback
+path fires.
+
+Source: `packages/react-core/src/v2/hooks/use-render-tool.tsx:8-35`
+
+### CRITICAL — Writing JSX from scratch when the app has a UI kit
+
+Wrong:
+
+```tsx
+useRenderTool({
+  name: "search",
+  parameters: z.object({ q: z.string() }),
+  render: () => <div className="my-badge">…</div>,
+});
+```
+
+Correct:
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+
+useRenderTool({
+  name: "search",
+  parameters: z.object({ q: z.string() }),
+  render: () => <Badge variant="secondary">…</Badge>,
+});
+```
+
+Check consumer `package.json` for shadcn / MUI / Chakra / Ant / Mantine
+first. Raw JSX ignores their design system.
+
+Source: maintainer interview (Phase 2c)
+
+### HIGH — Dereferencing required fields from `Partial<T>` during `inProgress`
+
+Wrong:
+
+```tsx
+render: ({ status, parameters }) => (
+  <span>{parameters.user.id.toUpperCase()}</span>
+);
+// `parameters` is Partial<T> during inProgress — `parameters.user` may be undefined.
+```
+
+Correct:
+
+```tsx
+render: ({ status, parameters }) =>
+  status === "inProgress" ? (
+    <Skeleton />
+  ) : (
+    <span>{parameters.user.id.toUpperCase()}</span>
+  );
+```
+
+During streaming, `RenderToolInProgressProps` has
+`parameters: Partial<InferSchemaOutput<S>>`. Fields are `undefined` until
+the stream completes. Narrow with `status === "inProgress"` first.
+
+Source: `packages/react-core/src/v2/hooks/use-render-tool.tsx:8-14`
+
+### HIGH — Using `useComponent` to decorate an existing tool
+
+Wrong:
+
+```tsx
+useFrontendTool({ name: "search", parameters, handler });
+useComponent({
+  name: "search", // creates a SECOND tool named "search" — collision
+  parameters: z.object({ q: z.string() }),
+  render: ({ q }) => <SearchCard q={q} />,
+});
+```
+
+Correct:
+
+```tsx
+useFrontendTool({ name: "search", parameters, handler });
+useRenderTool({
+  name: "search",
+  parameters: z.object({ q: z.string() }),
+  render: ({ status, parameters, result }) => {
+    if (status === "inProgress") return <Skeleton />;
+    if (status === "executing") return <div>Searching {parameters.q}…</div>;
+    return <div>{result}</div>;
+  },
+});
+
+// useComponent is only for render-only tools the agent invokes:
+useComponent({
+  name: "productCard",
+  parameters: z.object({ productId: z.string() }),
+  render: ({ productId }) => <ProductCard id={productId} />,
+});
+```
+
+`useComponent` synthesizes a NEW tool whose only job is to render —
+description is auto-prefixed with "Use this tool to display the …
+component". It does NOT decorate an existing tool. The misleading name
+trap: agents read "useComponent" as "register a component for this tool"
+and end up with two tools colliding on the same name.
+
+Source: `packages/react-core/src/v2/hooks/use-component.tsx:59-88`
+
+### HIGH — Hand-rolling `useRenderTool({ name: "*" })` instead of `useDefaultRenderTool`
+
+Wrong:
+
+```tsx
+useRenderTool({
+  name: "*",
+  render: ({ parameters }) => <pre>{JSON.stringify(parameters)}</pre>,
+});
+```
+
+Correct:
+
+```tsx
+// Use the built-in default card:
+useDefaultRenderTool();
+
+// Or customize, with the correct DefaultRenderProps typing (parameters: unknown):
+useDefaultRenderTool({
+  render: ({ name, status, parameters, result }) => {
+    if (name === "search") {
+      const args = parameters as { q: string };
+      return <SearchCard q={args.q} status={status} />;
+    }
+    return <GenericCard name={name} status={status} />;
+  },
+});
+```
+
+The sanctioned wildcard API is `useDefaultRenderTool`. It wraps
+`useRenderTool({ name: "*" })` with the correct `DefaultRenderProps`
+typing (`parameters: unknown`) and provides a built-in default card when
+no `render` is passed. Hand-rolling loses the default card and invites
+the untyped-args footgun.
+
+Source: `packages/react-core/src/v2/hooks/use-default-render-tool.tsx:15-64`

--- a/skills/react-core/references/suggestions.md
+++ b/skills/react-core/references/suggestions.md
@@ -1,0 +1,211 @@
+# CopilotKit Suggestions (React)
+
+This skill builds on `copilotkit/provider-setup` and
+`copilotkit/chat-components`. Suggestions render via
+`CopilotChatSuggestionView` which `<CopilotChat>` mounts automatically.
+
+Two sides:
+
+- `useConfigureSuggestions(config, deps?)` — register dynamic (LLM) or
+  static suggestions.
+- `useSuggestions({ agentId })` — read current suggestions + trigger
+  reload / clear.
+
+## Setup
+
+### Dynamic suggestions (LLM-generated)
+
+```tsx
+"use client";
+import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
+import { useMemo } from "react";
+
+export function DynamicSuggestionsHost({ page }: { page: string }) {
+  const instructions = useMemo(
+    () => `Suggest 3 follow-up questions about the "${page}" page.`,
+    [page],
+  );
+
+  useConfigureSuggestions(
+    {
+      instructions,
+      minSuggestions: 2,
+      maxSuggestions: 4,
+      available: "always",
+    },
+    [page],
+  );
+
+  return null;
+}
+```
+
+### Static suggestions
+
+```tsx
+"use client";
+import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
+
+export function StaticStarters() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Summarize this page", message: "Summarize the current page." },
+      { title: "Explain like I'm 5", message: "Explain this in simple terms." },
+    ],
+    available: "before-first-message",
+  });
+  return null;
+}
+```
+
+## Core Patterns
+
+### Read and refresh suggestions from any component
+
+```tsx
+import { useSuggestions } from "@copilotkit/react-core/v2";
+
+export function RefreshButton() {
+  const { suggestions, reloadSuggestions, clearSuggestions, isLoading } =
+    useSuggestions({ agentId: "default" });
+  return (
+    <div>
+      <button onClick={reloadSuggestions} disabled={isLoading}>
+        {isLoading ? "Loading…" : "Refresh"}
+      </button>
+      <button onClick={clearSuggestions}>Clear</button>
+      <span>{suggestions.length} suggestions</span>
+    </div>
+  );
+}
+```
+
+### Feature-flag the suggestions config
+
+```tsx
+const enabled = useFeatureFlag("suggestions");
+useConfigureSuggestions(
+  enabled ? { instructions: "Suggest 3 follow-ups" } : null,
+);
+```
+
+### Agent-scoped dynamic suggestions
+
+```tsx
+useConfigureSuggestions({
+  instructions: "Suggest follow-ups for the research agent.",
+  consumerAgentId: "research",
+});
+```
+
+## Common Mistakes
+
+### MEDIUM — Using `available: "disabled"` expecting reload to still fire
+
+Wrong:
+
+```tsx
+useConfigureSuggestions({
+  instructions: "Suggest 3 follow-ups",
+  available: "disabled",
+});
+// Then calling reloadSuggestions() — no-op
+```
+
+Correct:
+
+```tsx
+const enabled = useFeatureFlag("suggestions");
+useConfigureSuggestions(
+  enabled ? { instructions: "Suggest 3 follow-ups" } : null,
+);
+```
+
+`available: "disabled"` is normalized to a `null` config — the same as
+passing `null`/`undefined`. Reloads become no-ops. Pass `null` (or gate on
+a condition) when you want to fully disable suggestions.
+
+Source: `packages/react-core/src/v2/hooks/use-configure-suggestions.tsx:59-62`
+
+### MEDIUM — Inline config object without `deps`
+
+Wrong:
+
+```tsx
+useConfigureSuggestions({ instructions: `about ${currentPage}` });
+// Config re-serialized every render — reload may or may not fire depending on cache equality
+```
+
+Correct:
+
+```tsx
+useConfigureSuggestions({ instructions: `about ${currentPage}` }, [
+  currentPage,
+]);
+```
+
+`useConfigureSuggestions` uses a serialized-config cache keyed off the
+JSON-stringified value. Without `deps`, React invariance + inline objects
+produce unstable identities that thrash the cache. Always pass `deps` that
+cover the values interpolated into the config.
+
+Source: `packages/react-core/src/v2/hooks/use-configure-suggestions.tsx:166-171`
+
+### MEDIUM — Calling `reloadSuggestions` mid-run
+
+Wrong:
+
+```tsx
+<button onClick={() => reloadSuggestions()}>Refresh</button>
+// Fires during agent streaming → competes with the running agent
+```
+
+Correct:
+
+```tsx
+import { useAgent, UseAgentUpdate } from "@copilotkit/react-core/v2";
+
+const { agent } = useAgent({
+  agentId: "default",
+  updates: [UseAgentUpdate.OnRunStatusChanged],
+});
+const isRunning = agent.isRunning;
+<button
+  disabled={isRunning}
+  onClick={() => {
+    if (!isRunning) reloadSuggestions();
+  }}
+>
+  Refresh
+</button>;
+```
+
+The internal auto-reload skips when `isRunning`, but the user-triggered
+`reloadSuggestions()` does not guard itself. Guard the caller, or the
+suggestion generation races the active agent run.
+
+Source: `packages/react-core/src/v2/hooks/use-configure-suggestions.tsx:121-124`
+
+### MEDIUM — Expecting `maxSuggestions` above 3 without setting it
+
+Wrong:
+
+```tsx
+useConfigureSuggestions({ instructions: "…" });
+// Then surprised the UI only shows 3 pills even when the LLM returned 8
+```
+
+Correct:
+
+```tsx
+useConfigureSuggestions({
+  instructions: "…",
+  minSuggestions: 1,
+  maxSuggestions: 6,
+});
+```
+
+`minSuggestions` and `maxSuggestions` default to 1 and 3 respectively. Set
+them explicitly when you want a different count.
+
+Source: `packages/core/src/types.ts` (DynamicSuggestionsConfig defaults)

--- a/skills/react-core/references/switching-agents-recipes.md
+++ b/skills/react-core/references/switching-agents-recipes.md
@@ -1,0 +1,160 @@
+# Agent Switcher Recipes
+
+Three copy-paste patterns for multi-agent UIs. All subscribe to
+`copilotkit.subscribe({ onAgentsChanged })` for live agent discovery — there
+is no `useAgents()` hook.
+
+## Recipe 1 — Dropdown switcher
+
+```tsx
+"use client";
+import { CopilotChat, useCopilotKit } from "@copilotkit/react-core/v2";
+import { useEffect, useState } from "react";
+
+export function DropdownAgentSwitcher() {
+  const { copilotkit } = useCopilotKit();
+  const [agentIds, setAgentIds] = useState<string[]>(() =>
+    Object.keys(copilotkit.agents ?? {}),
+  );
+  const [activeAgent, setActiveAgent] = useState<string>(
+    () => Object.keys(copilotkit.agents ?? {})[0] ?? "default",
+  );
+
+  useEffect(() => {
+    const sub = copilotkit.subscribe({
+      onAgentsChanged: ({ agents }) => {
+        setAgentIds(Object.keys(agents ?? {}));
+      },
+    });
+    return () => sub.unsubscribe();
+  }, [copilotkit]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <select
+        value={activeAgent}
+        onChange={(e) => setActiveAgent(e.target.value)}
+      >
+        {agentIds.map((id) => (
+          <option key={id} value={id}>
+            {id}
+          </option>
+        ))}
+      </select>
+      <CopilotChat key={activeAgent} agentId={activeAgent} />
+    </div>
+  );
+}
+```
+
+## Recipe 2 — Tabs switcher
+
+```tsx
+"use client";
+import { CopilotChat, useCopilotKit } from "@copilotkit/react-core/v2";
+import { useEffect, useRef, useState } from "react";
+
+export function TabsAgentSwitcher() {
+  const { copilotkit } = useCopilotKit();
+  const [agentIds, setAgentIds] = useState<string[]>(() =>
+    Object.keys(copilotkit.agents ?? {}),
+  );
+  const [activeAgent, setActiveAgent] = useState<string>(
+    () => agentIds[0] ?? "default",
+  );
+
+  // Hold activeAgent in a ref so the subscribe effect only re-binds when
+  // `copilotkit` changes. Depending on `activeAgent` would tear down and
+  // re-establish the subscription on every tab click.
+  const activeAgentRef = useRef(activeAgent);
+  useEffect(() => {
+    activeAgentRef.current = activeAgent;
+  }, [activeAgent]);
+
+  useEffect(() => {
+    const sub = copilotkit.subscribe({
+      onAgentsChanged: ({ agents }) => {
+        const ids = Object.keys(agents ?? {});
+        setAgentIds(ids);
+        if (!ids.includes(activeAgentRef.current) && ids.length > 0) {
+          setActiveAgent(ids[0]);
+        }
+      },
+    });
+    return () => sub.unsubscribe();
+  }, [copilotkit]);
+
+  return (
+    <div>
+      <div role="tablist" className="flex gap-2 border-b">
+        {agentIds.map((id) => (
+          <button
+            key={id}
+            role="tab"
+            aria-selected={id === activeAgent}
+            onClick={() => setActiveAgent(id)}
+          >
+            {id}
+          </button>
+        ))}
+      </div>
+      <CopilotChat key={activeAgent} agentId={activeAgent} />
+    </div>
+  );
+}
+```
+
+## Recipe 3 — Keyboard shortcut switcher
+
+Cycles through agents with `Cmd/Ctrl + Shift + A`.
+
+```tsx
+"use client";
+import { CopilotChat, useCopilotKit } from "@copilotkit/react-core/v2";
+import { useEffect, useState } from "react";
+
+export function KeyboardAgentSwitcher() {
+  const { copilotkit } = useCopilotKit();
+  const [agentIds, setAgentIds] = useState<string[]>(() =>
+    Object.keys(copilotkit.agents ?? {}),
+  );
+  const [activeAgent, setActiveAgent] = useState<string>(
+    () => agentIds[0] ?? "default",
+  );
+
+  useEffect(() => {
+    const sub = copilotkit.subscribe({
+      onAgentsChanged: ({ agents }) => setAgentIds(Object.keys(agents ?? {})),
+    });
+    return () => sub.unsubscribe();
+  }, [copilotkit]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const isCombo = (e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "A";
+      if (!isCombo || agentIds.length === 0) return;
+      e.preventDefault();
+      const idx = agentIds.indexOf(activeAgent);
+      const next = agentIds[(idx + 1) % agentIds.length];
+      setActiveAgent(next);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [agentIds, activeAgent]);
+
+  return (
+    <div>
+      <div className="text-xs opacity-60">
+        Active: {activeAgent} — press ⌘/Ctrl+Shift+A to cycle
+      </div>
+      <CopilotChat key={activeAgent} agentId={activeAgent} />
+    </div>
+  );
+}
+```
+
+## Key rules across all three recipes
+
+- Use `copilotkit.subscribe({ onAgentsChanged })` — there is no `useAgents()` hook.
+- Always `key={activeAgent}` on `<CopilotChat>` so thread state doesn't leak when swapping agents in the same slot.
+- Clean up the subscription with `sub.unsubscribe()` in the effect cleanup.

--- a/skills/react-core/references/switching-agents.md
+++ b/skills/react-core/references/switching-agents.md
@@ -1,0 +1,231 @@
+# CopilotKit Switching Agents (React)
+
+This skill builds on `copilotkit/agent-access`, `copilotkit/client-side-tools`,
+and `copilotkit/rendering-tool-calls`.
+
+Three main patterns:
+
+1. **Parallel panels** — one `useAgent({ agentId })` per surface.
+2. **Slot swap** — `<CopilotChat key={agentId} agentId={agentId} />`.
+3. **Discovery** — subscribe to `onAgentsChanged` (no `useAgents()` hook).
+
+## Setup
+
+```tsx
+"use client";
+import { CopilotChat } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+
+export function AgentSwitcherChat() {
+  const [activeAgent, setActiveAgent] = useState("research");
+
+  return (
+    <div>
+      <div>
+        <button onClick={() => setActiveAgent("research")}>Research</button>
+        <button onClick={() => setActiveAgent("coding")}>Coding</button>
+      </div>
+
+      {/* key={activeAgent} forces remount so thread state doesn't leak */}
+      <CopilotChat key={activeAgent} agentId={activeAgent} />
+    </div>
+  );
+}
+```
+
+## Core Patterns
+
+### Side-by-side chat panels
+
+```tsx
+<div className="grid grid-cols-2 gap-4">
+  <CopilotChat agentId="research" threadId="research-main" />
+  <CopilotChat agentId="coding" threadId="coding-main" />
+</div>
+```
+
+### Agent-scoped tool
+
+```tsx
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+useFrontendTool({
+  name: "saveFindings",
+  agentId: "research", // ← only the research agent sees this tool
+  parameters: z.object({ summary: z.string() }),
+  handler: async ({ summary }) => {
+    await fetch("/api/findings", { method: "POST", body: summary });
+  },
+});
+```
+
+### Agent-scoped renderer
+
+```tsx
+import { useRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+useRenderTool({
+  name: "search",
+  agentId: "research", // ← only applies to research's "search" tool
+  parameters: z.object({ q: z.string() }),
+  render: ({ status, parameters, result }) => {
+    if (status === "inProgress") return <div>Preparing...</div>;
+    if (status === "executing") return <div>Searching {parameters.q}</div>;
+    return <div>{result}</div>;
+  },
+});
+```
+
+### Discover available agents (no `useAgents` hook)
+
+```tsx
+"use client";
+import { useCopilotKit } from "@copilotkit/react-core/v2";
+import { useEffect, useState } from "react";
+
+export function useAvailableAgents() {
+  const { copilotkit } = useCopilotKit();
+  const [ids, setIds] = useState<string[]>(() =>
+    Object.keys(copilotkit.agents ?? {}),
+  );
+
+  useEffect(() => {
+    const subscription = copilotkit.subscribe({
+      onAgentsChanged: ({ agents }) => {
+        setIds(Object.keys(agents ?? {}));
+      },
+    });
+    return () => subscription.unsubscribe();
+  }, [copilotkit]);
+
+  return ids;
+}
+```
+
+## Common Mistakes
+
+### HIGH — Switching `agentId` on a persisted `<CopilotChat>` without `key`
+
+Wrong:
+
+```tsx
+<CopilotChat agentId={activeAgent} />
+```
+
+Correct:
+
+```tsx
+<CopilotChat key={activeAgent} agentId={activeAgent} />
+```
+
+Without remount via `key`, prior thread state and in-flight runs leak into
+the new agent's view. The remount pattern gives each agent a clean slate.
+
+Source: `examples/v2/react-router/app/routes/_index.tsx:38-39`
+
+### MEDIUM — Omitting `agentId` when multiple agents share a tool name
+
+Wrong:
+
+```tsx
+// Both research and coding agents have a "search" tool — unscoped wins globally
+useRenderToolCall({
+  name: "search",
+  args: z.object({ q: z.string() }),
+  render,
+});
+```
+
+Correct:
+
+```tsx
+useRenderTool({
+  name: "search",
+  agentId: "research",
+  parameters: z.object({ q: z.string() }),
+  render: researchSearchRender,
+});
+useRenderTool({
+  name: "search",
+  agentId: "coding",
+  parameters: z.object({ q: z.string() }),
+  render: codingSearchRender,
+});
+```
+
+Unscoped renderers apply to every agent. When two agents have a tool with
+the same name and only one has a renderer, the unscoped renderer wins
+globally and the other agent never gets its intended renderer.
+
+Source: `packages/react-core/src/v2/hooks/use-render-tool-call.tsx:145-154`
+
+### MEDIUM — Tools registered without `agentId` leak across panels
+
+Wrong:
+
+```tsx
+useFrontendTool({
+  name: "saveFindings",
+  parameters: z.object({ summary: z.string() }),
+  handler,
+});
+// Both research and coding agents now see saveFindings.
+```
+
+Correct:
+
+```tsx
+useFrontendTool({
+  name: "saveFindings",
+  agentId: "research",
+  parameters: z.object({ summary: z.string() }),
+  handler,
+});
+```
+
+Omitting `agentId` attaches the tool to every agent. In a multi-agent UI
+this leaks the handler across panels. Scope tools explicitly when they
+should only apply to one agent.
+
+Source: `packages/react-core/src/v2/hooks/use-frontend-tool.tsx`
+
+### MEDIUM — Using `useAgents()` (does not exist)
+
+Wrong:
+
+```tsx
+import { useAgents } from "@copilotkit/react-core/v2"; // not exported
+const agents = useAgents();
+```
+
+Correct:
+
+```tsx
+import { useCopilotKit } from "@copilotkit/react-core/v2";
+import { useEffect, useState } from "react";
+
+function useAvailableAgents() {
+  const { copilotkit } = useCopilotKit();
+  const [ids, setIds] = useState<string[]>(() =>
+    Object.keys(copilotkit.agents ?? {}),
+  );
+  useEffect(() => {
+    const sub = copilotkit.subscribe({
+      onAgentsChanged: ({ agents }) => setIds(Object.keys(agents ?? {})),
+    });
+    return () => sub.unsubscribe();
+  }, [copilotkit]);
+  return ids;
+}
+```
+
+There is no `useAgents` hook in v2. Discover agents by subscribing to
+`onAgentsChanged` on the core client.
+
+Source: `packages/react-core/src/v2/hooks/index.ts` (no `useAgents` export)
+
+## References
+
+- [Agent switcher recipes](switching-agents-recipes.md) — dropdown, tabs, keyboard shortcuts

--- a/skills/react-core/references/threads.md
+++ b/skills/react-core/references/threads.md
@@ -1,0 +1,226 @@
+# CopilotKit Threads (React)
+
+This skill builds on `copilotkit/agent-access`. Durable threads only exist
+in Intelligence mode — a runtime pointed at `api.cloud.copilotkit.ai` or a
+self-managed Intelligence instance. In plain SSE mode the hook errors.
+
+## Setup
+
+```tsx
+"use client";
+import { useThreads } from "@copilotkit/react-core/v2";
+
+export function ThreadSidebar({ agentId }: { agentId: string }) {
+  const {
+    threads,
+    isLoading,
+    error,
+    hasMoreThreads,
+    fetchMoreThreads,
+    renameThread,
+    archiveThread,
+    deleteThread,
+  } = useThreads({ agentId });
+
+  if (error) return <div className="text-red-500">{error.message}</div>;
+  if (isLoading) return <div>Loading threads…</div>;
+
+  return (
+    <ul className="space-y-1">
+      {threads.map((t) => (
+        <li key={t.id} className="flex gap-2">
+          <span>{t.name ?? "Untitled"}</span>
+          <button onClick={() => renameThread(t.id, "Renamed")}>Rename</button>
+          <button onClick={() => archiveThread(t.id)}>Archive</button>
+        </li>
+      ))}
+      {hasMoreThreads && <button onClick={fetchMoreThreads}>Load more</button>}
+    </ul>
+  );
+}
+```
+
+## Core Patterns
+
+### Paginated list
+
+```tsx
+const { threads, hasMoreThreads, fetchMoreThreads, isFetchingMoreThreads } =
+  useThreads({ agentId: "default", limit: 25 });
+```
+
+### Include archived threads
+
+```tsx
+const { threads: archived } = useThreads({
+  agentId: "default",
+  includeArchived: true,
+});
+```
+
+### Optimistic archive with error rollback
+
+```tsx
+const { threads, archiveThread } = useThreads({ agentId: "default" });
+
+async function onArchive(id: string) {
+  try {
+    await archiveThread(id);
+    toast.success("Archived");
+  } catch (err) {
+    toast.error(`Failed to archive: ${String(err)}`);
+  }
+}
+```
+
+### Thread-switcher + `<CopilotChat>`
+
+```tsx
+import { CopilotChat, useThreads } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+
+export function ThreadSwitcher() {
+  const { threads } = useThreads({ agentId: "default" });
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  return (
+    <div className="grid grid-cols-[200px_1fr]">
+      <ul>
+        {threads.map((t) => (
+          <li key={t.id}>
+            <button onClick={() => setActiveId(t.id)}>
+              {t.name ?? "Untitled"}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {activeId && (
+        <CopilotChat key={activeId} agentId="default" threadId={activeId} />
+      )}
+    </div>
+  );
+}
+```
+
+## Common Mistakes
+
+### HIGH — Using `useThreads` with an SSE-only runtime
+
+Wrong:
+
+```tsx
+// Runtime has no Intelligence configured
+new CopilotRuntime({ agents });
+
+// Client side:
+const { threads, error } = useThreads({ agentId: "default" });
+// error: "Runtime URL is not configured" or empty list forever
+```
+
+Correct:
+
+```ts
+// Server — upgrade to Intelligence mode:
+import {
+  CopilotIntelligenceRuntime,
+  CopilotKitIntelligence,
+} from "@copilotkit/runtime/v2";
+
+const intelligence = new CopilotKitIntelligence({
+  apiUrl: process.env.COPILOTKIT_INTELLIGENCE_API_URL!,
+  wsUrl: process.env.COPILOTKIT_INTELLIGENCE_WS_URL!,
+  apiKey: process.env.COPILOTKIT_INTELLIGENCE_API_KEY!,
+  organizationId: process.env.COPILOTKIT_ORG_ID!,
+});
+
+const runtime = new CopilotIntelligenceRuntime({
+  agents,
+  intelligence,
+  identifyUser: async (req) => ({ userId: await getUserId(req) }),
+});
+```
+
+`CopilotKitIntelligence` and `CopilotIntelligenceRuntime` are only exposed
+on the `@copilotkit/runtime/v2` subpath — the package root exports SSE
+primitives only.
+
+Thread routes only exist in Intelligence mode. In plain SSE the list fetch
+fails and mutations reject.
+
+Source: `packages/react-core/src/v2/hooks/use-threads.tsx:207-213,229`
+
+### HIGH — Expecting `deleteThread` to be recoverable
+
+Wrong:
+
+```tsx
+await deleteThread(id); // user expected a trash bin
+```
+
+Correct:
+
+```tsx
+// For soft-delete UX, use archive:
+await archiveThread(id);
+
+// Then expose archived threads in a separate view:
+const { threads: archived } = useThreads({
+  agentId: "default",
+  includeArchived: true,
+});
+```
+
+`deleteThread` is irreversible at the Intelligence platform level. Use
+`archiveThread` for user-facing delete UX and only call `deleteThread` for
+genuine "permanently erase" flows.
+
+Source: `packages/react-core/src/v2/hooks/use-threads.tsx:101-105`
+
+### MEDIUM — Assuming archived threads appear by default
+
+Wrong:
+
+```tsx
+const { threads } = useThreads({ agentId: "default" });
+// User archived a thread. User opens the "Archived" tab. It's empty.
+```
+
+Correct:
+
+```tsx
+const { threads: activeThreads } = useThreads({ agentId: "default" });
+const { threads: archivedThreads } = useThreads({
+  agentId: "default",
+  includeArchived: true,
+});
+```
+
+`includeArchived` defaults to `false`. Archived threads are filtered out of
+the default list; opt in explicitly for an archived-view tab.
+
+Source: `packages/react-core/src/v2/hooks/use-threads.tsx:60-62`
+
+### MEDIUM — Not handling `error`
+
+Wrong:
+
+```tsx
+const { threads } = useThreads({ agentId: "default" });
+return <ul>{threads.map(...)}</ul>;
+// Silent failures — handshake errors, network errors all vanish.
+```
+
+Correct:
+
+```tsx
+const { threads, isLoading, error } = useThreads({ agentId: "default" });
+if (error) return <ErrorBanner message={error.message} />;
+if (isLoading) return <Spinner />;
+return <ul>{threads.map(...)}</ul>;
+```
+
+`error` holds the most recent fetch/mutation error until the next
+successful fetch clears it. Surface it or you'll miss Intelligence-mode
+mis-configuration.
+
+Source: `packages/react-core/src/v2/hooks/use-threads.tsx:70-74`

--- a/skills/runtime/SKILL.md
+++ b/skills/runtime/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: runtime
+description: >
+  @copilotkit/runtime — mount a fetch-native CopilotRuntime on any JS server, wire
+  middleware, pick an AgentRunner, instantiate BuiltInAgent (Factory Mode with TanStack AI
+  is the preferred default) or plug in any of 12 external agent frameworks (Mastra,
+  LangGraph, CrewAI Crews/Flows, PydanticAI, ADK, LlamaIndex, Agno, AWS Strands, MS Agent
+  Framework, AG2, A2A), enable Intelligence mode for durable threads + websocket,
+  register server-side tools via defineTool, and wire voice transcription. Uses the
+  fetch-based createCopilotRuntimeHandler primitive — the Express/Hono adapters are
+  discouraged. Load the reference under references/ that matches your task.
+type: core
+library: copilotkit
+library_version: "1.56.2"
+requires: []
+sources:
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/fetch-handler.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/runtime.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/hooks.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/middleware.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/runner/agent-runner.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/runner/in-memory.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/runner/intelligence.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/intelligence-platform/client.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/transcription-service/transcription-service.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/agent/index.ts"
+  - "CopilotKit/CopilotKit:packages/runtime/src/agent/converters/tanstack.ts"
+  - "CopilotKit/CopilotKit:packages/sqlite-runner/src/sqlite-runner.ts"
+  - "CopilotKit/CopilotKit:packages/shared/src/transcription-errors.ts"
+---
+
+# CopilotKit Runtime
+
+`@copilotkit/runtime` is the server half of CopilotKit: it accepts AG-UI protocol
+requests, dispatches them to an `AbstractAgent` (built-in or external), runs the
+stream through an `AgentRunner`, and responds as Server-Sent Events.
+
+This SKILL.md is the **index**. Read the reference under `references/` that matches
+your task — do not try to absorb the whole package from this file.
+
+## Mental Model — the three dictionaries you hand to `CopilotRuntime`
+
+```ts
+new CopilotRuntime({
+  agents, // Record<string, AbstractAgent>     — see wiring-external-agents or built-in-agent
+  runner, // AgentRunner (optional)            — see agent-runners
+  intelligence, // CopilotKitIntelligence (optional) — see intelligence-mode (auto-wires runner)
+  mcpApps, // McpAppsConfig (optional)          — see wiring-mcp-apps-middleware
+  a2ui, // A2UIConfig (optional)             — see packages/a2ui-renderer skill
+  hooks, // { onRequest, onBeforeHandler }    — see middleware
+  beforeRequestMiddleware,
+  afterRequestMiddleware, // legacy — see middleware
+  transcription, // TranscriptionService (optional)  — see transcription
+});
+```
+
+You then mount it:
+
+```ts
+import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+export default { fetch: handler };
+```
+
+## When to load which reference
+
+| Task                                                                                                                                                                           | Reference                                                                                                                                                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mounting on any fetch-native server (Cloudflare Workers, Bun, Deno, Vercel Edge, Next.js App Router, React Router v7, TanStack Start) or delegating from Express/Node          | `references/setup-endpoint.md`                                                                                                                                                                                                                                                                                                                     |
+| Auth / logging / rate-limit / request-scoped guards via `hooks.onRequest` / `hooks.onBeforeHandler` (preferred) or legacy `beforeRequestMiddleware` / `afterRequestMiddleware` | `references/middleware.md`                                                                                                                                                                                                                                                                                                                         |
+| Choosing between `InMemoryAgentRunner`, `SqliteAgentRunner`, or a custom subclass — including thread-locking semantics and the runner/Intelligence mutual exclusion            | `references/agent-runners.md` (+ `-in-memory.md`, `-sqlite.md`, `-custom.md` for backend-specific detail)                                                                                                                                                                                                                                          |
+| Enabling durable threads + realtime websocket via CopilotKit Cloud (Intelligence is **Cloud-only**, not self-hostable)                                                         | `references/intelligence-mode.md`                                                                                                                                                                                                                                                                                                                  |
+| Voice transcription — implementing a `TranscriptionService` subclass for the `/transcribe` endpoint                                                                            | `references/transcription.md`                                                                                                                                                                                                                                                                                                                      |
+| Instantiating `BuiltInAgent` — Simple Mode (classic) or Factory Mode with TanStack AI (preferred AG-UI-compliant default), AI SDK, or custom factory                           | `references/built-in-agent.md` (+ `-factory-modes.md`, `-helper-utilities.md`, `-model-identifiers.md`)                                                                                                                                                                                                                                            |
+| Defining server-side tools via `defineTool` for `BuiltInAgent.config.tools` (Simple Mode only)                                                                                 | `references/server-side-tools.md`                                                                                                                                                                                                                                                                                                                  |
+| Wiring an external agent framework into `CopilotRuntime({ agents })`                                                                                                           | `references/wiring-external-agents.md` (index) + per-framework refs (`wiring-mastra.md`, `wiring-langgraph.md`, `wiring-crewai-crews.md`, `wiring-crewai-flows.md`, `wiring-pydantic-ai.md`, `wiring-adk.md`, `wiring-llamaindex.md`, `wiring-agno.md`, `wiring-aws-strands.md`, `wiring-ms-agent-framework.md`, `wiring-ag2.md`, `wiring-a2a.md`) |
+| Wiring MCP Apps (runtime-level middleware, not an agent)                                                                                                                       | `references/wiring-mcp-apps-middleware.md`                                                                                                                                                                                                                                                                                                         |
+
+## Invariants and gotchas (load-once, before any reference)
+
+- `createCopilotRuntimeHandler` is the canonical primitive. `createCopilotExpressHandler` / `createCopilotHonoHandler` exist but are **avoid at all costs** — delegate from Express/Hono routes to the fetch primitive instead.
+- `publicLicenseKey` is the canonical provider-side field. `publicApiKey` is a **deprecated alias** — expect to see it in legacy code, emit the canonical name in new code.
+- Intelligence mode auto-wires `IntelligenceAgentRunner`. Passing both `runner` and `intelligence` to `CopilotRuntime` is rejected at construction.
+- Intelligence mode targets CopilotKit Cloud (`api.cloud.copilotkit.ai`) and is **not self-hostable**.
+- `hooks.onRequest` runs **before** `beforeRequestMiddleware` (hook-based middleware wins for Response short-circuits). `beforeRequestMiddleware` runs **after** `hooks.onRequest` (see `fetch-handler.ts:136-147`).
+- `identifyUser` (Intelligence) does **not** forward thrown `Response` objects — convert to 500. Gate auth rejection in `hooks.onRequest`, which does forward Responses.
+- `agents__unsafe_dev_only` and `selfManagedAgents` are dev-only aliases of each other; do not reach for them in production. Either signals that the SPA is in dev mode.
+
+## Reading order for a first-time reader
+
+1. `setup-endpoint` — the primitive.
+2. `built-in-agent` **or** pick one from `wiring-external-agents` — the agent.
+3. `agent-runners` — production persistence choice.
+4. Optional: `middleware`, `intelligence-mode`, `server-side-tools`, `transcription`.

--- a/skills/runtime/references/agent-runners-custom.md
+++ b/skills/runtime/references/agent-runners-custom.md
@@ -1,0 +1,161 @@
+Custom AgentRunner — subclass the abstract `AgentRunner` to back thread state with Redis,
+Postgres, Durable Objects, or anything else you own.
+
+## The abstract contract
+
+```typescript
+// packages/runtime/src/v2/runtime/runner/agent-runner.ts
+import {
+  AbstractAgent,
+  BaseEvent,
+  Message,
+  RunAgentInput,
+} from "@ag-ui/client";
+import { Observable } from "rxjs";
+
+export interface AgentRunnerRunRequest {
+  threadId: string;
+  agent: AbstractAgent;
+  input: RunAgentInput;
+  joinCode?: string;
+  persistedInputMessages?: Message[];
+}
+export interface AgentRunnerConnectRequest {
+  threadId: string;
+  headers?: Record<string, string>;
+  joinCode?: string;
+}
+export interface AgentRunnerIsRunningRequest {
+  threadId: string;
+}
+export interface AgentRunnerStopRequest {
+  threadId: string;
+}
+
+export abstract class AgentRunner {
+  abstract run(request: AgentRunnerRunRequest): Observable<BaseEvent>;
+  abstract connect(request: AgentRunnerConnectRequest): Observable<BaseEvent>;
+  abstract isRunning(request: AgentRunnerIsRunningRequest): Promise<boolean>;
+  abstract stop(request: AgentRunnerStopRequest): Promise<boolean | undefined>;
+}
+```
+
+## Redis-backed skeleton (for reference)
+
+```typescript
+import { AgentRunner } from "@copilotkit/runtime/v2";
+import type {
+  AgentRunnerRunRequest,
+  AgentRunnerConnectRequest,
+  AgentRunnerIsRunningRequest,
+  AgentRunnerStopRequest,
+} from "@copilotkit/runtime/v2";
+import { Observable, ReplaySubject } from "rxjs";
+import type { BaseEvent } from "@ag-ui/client";
+import { Redis } from "ioredis";
+
+const RUNNING_KEY = (t: string) => `copilotkit:running:${t}`;
+const STREAM_KEY = (t: string) => `copilotkit:stream:${t}`;
+
+export class RedisAgentRunner extends AgentRunner {
+  constructor(private redis: Redis) {
+    super();
+  }
+
+  run(request: AgentRunnerRunRequest): Observable<BaseEvent> {
+    const { threadId, agent, input } = request;
+    const subject = new ReplaySubject<BaseEvent>();
+
+    (async () => {
+      // NX guard — return 409-equivalent if another instance is running this thread
+      const acquired = await this.redis.set(
+        RUNNING_KEY(threadId),
+        "1",
+        "EX",
+        600,
+        "NX",
+      );
+      if (!acquired) {
+        subject.error(new Error("Thread already running"));
+        return;
+      }
+
+      const sub = agent.run(input).subscribe({
+        next: async (event) => {
+          subject.next(event);
+          await this.redis.xadd(
+            STREAM_KEY(threadId),
+            "*",
+            "event",
+            JSON.stringify(event),
+          );
+        },
+        error: async (err) => {
+          subject.error(err);
+          await this.redis.del(RUNNING_KEY(threadId));
+        },
+        complete: async () => {
+          subject.complete();
+          await this.redis.del(RUNNING_KEY(threadId));
+        },
+      });
+
+      // stop hook
+      this.stopHandlers.set(threadId, () => sub.unsubscribe());
+    })();
+
+    return subject.asObservable();
+  }
+
+  connect(request: AgentRunnerConnectRequest): Observable<BaseEvent> {
+    const subject = new ReplaySubject<BaseEvent>();
+    (async () => {
+      const entries = await this.redis.xrange(
+        STREAM_KEY(request.threadId),
+        "-",
+        "+",
+      );
+      for (const [, fields] of entries) {
+        const eventStr = fields[1];
+        if (eventStr) subject.next(JSON.parse(eventStr));
+      }
+      subject.complete();
+    })();
+    return subject.asObservable();
+  }
+
+  async isRunning(request: AgentRunnerIsRunningRequest): Promise<boolean> {
+    return (await this.redis.exists(RUNNING_KEY(request.threadId))) === 1;
+  }
+
+  async stop(request: AgentRunnerStopRequest): Promise<boolean | undefined> {
+    const stop = this.stopHandlers.get(request.threadId);
+    if (stop) {
+      stop();
+      this.stopHandlers.delete(request.threadId);
+    }
+    await this.redis.del(RUNNING_KEY(request.threadId));
+    return true;
+  }
+
+  private stopHandlers = new Map<string, () => void>();
+}
+```
+
+## Contract gotchas
+
+- `run()` must throw `Error("Thread already running")` (or let a distributed lock return a
+  non-acquired state) when a run is already active. Intelligence mode surfaces the 409 to
+  the client as the typed `agent_thread_locked` error code; SSE mode (direct runner use)
+  only emits a generic 500 response with the error message — so clients cannot depend on
+  the typed code there, and should additionally guard with a busy flag on submit.
+- `connect()` must replay historic events so late clients can catch up on an active run.
+- `stop()` is optional to implement in the sense that returning `undefined` is allowed, but
+  surface cancellations through `abortController.abort()` to the underlying agent if you can.
+- The runner does not persist user messages on its own — that is the Intelligence platform's
+  job. A custom runner that persists only its own event stream is still a drop-in replacement
+  for `InMemoryAgentRunner` / `SqliteAgentRunner`.
+
+Source: `packages/runtime/src/v2/runtime/runner/agent-runner.ts`,
+`packages/runtime/src/v2/runtime/runner/in-memory.ts`,
+`packages/sqlite-runner/src/sqlite-runner.ts`.

--- a/skills/runtime/references/agent-runners-in-memory.md
+++ b/skills/runtime/references/agent-runners-in-memory.md
@@ -1,0 +1,64 @@
+InMemoryAgentRunner — default ephemeral runner. Keyed on a `globalThis` Symbol so thread state survives hot-module reloads during development.
+
+## Store layout
+
+```typescript
+// packages/runtime/src/v2/runtime/runner/in-memory.ts
+const GLOBAL_STORE_KEY = Symbol.for("@copilotkit/runtime/in-memory-store");
+
+interface GlobalStoreData {
+  stores: Map<string, InMemoryEventStore>; // per-threadId
+  historicRunsBackup: Map<string, HistoricRun[]>; // restored after HMR
+}
+```
+
+One `InMemoryEventStore` per `threadId`. Each store tracks:
+
+- `subject: ReplaySubject<BaseEvent> | null` — current consumers
+- `isRunning: boolean` — gate for the `"Thread already running"` throw
+- `currentRunId: string | null`
+- `historicRuns: HistoricRun[]` — completed runs (backed up across HMR)
+- `agent: AbstractAgent | null` — the instance that owns the active run
+- `runSubject`, `currentEvents`, `stopRequested`
+
+## Lifecycle
+
+1. `run({ threadId, agent, input })` — if `store.isRunning` throw `Error("Thread already running")`. Otherwise create a `ReplaySubject`, subscribe to `agent.run(input)`, push events into the subject, track them in `currentEvents`, mark the store `isRunning`.
+2. On `RunFinishedEvent` / `RunErrorEvent`: finalize the run, push its events into `historicRuns`, clear `isRunning`, `currentRunId`, `agent`.
+3. `connect({ threadId })` — returns a `ReplaySubject` that replays the active run events or (if no active run) the most recent historic run.
+4. `stop({ threadId })` — sets `stopRequested = true`; the active subscription checks the flag on each event and tears down.
+
+## Hot reload (development)
+
+In dev, bundlers replace modules. `GLOBAL_STORE_KEY` uses `Symbol.for(...)` so the same well-known symbol is reused across module instances — `globalThis[KEY]` survives. On module re-evaluation, if the `stores` map is empty but `historicRunsBackup` still has entries, the runner rehydrates historic-only stores from the backup (active runs are lost, historic runs come back).
+
+## When NOT to use
+
+- Multi-instance production deploys — each process has its own store.
+- Long-lived servers — restart wipes active threads (historic runs are only preserved in the HMR-dev backup, not across process exit).
+- Load-balanced serverless with cold starts — new workers see empty stores.
+
+## When it is OK
+
+- Local development.
+- Single-instance preview environments.
+- Tests (each `new InMemoryAgentRunner()` still shares the globalThis store — pass a fresh threadId per test, or clear the captured store in place between tests). Do NOT `delete globalThis[Symbol.for("@copilotkit/runtime/in-memory-store")]`: `in-memory.ts:98` captures `GLOBAL_STORE = getGlobalStore()` as a module-level const referencing the inner `stores` Map, so replacing `globalThis[KEY]` creates a new object that the module no longer consults. Mutate the existing maps in place:
+
+  ```ts
+  // test setup
+  const storeKey = Symbol.for("@copilotkit/runtime/in-memory-store");
+  const data = (globalThis as any)[storeKey] as
+    | {
+        stores: Map<string, unknown>;
+        historicRunsBackup: Map<string, unknown>;
+      }
+    | undefined;
+  if (data) {
+    data.stores.clear();
+    data.historicRunsBackup.clear();
+  }
+  ```
+
+  The runtime does not yet expose an official reset helper — a `__TEST_ONLY_clearGlobalStore` export would be a reasonable follow-up.
+
+Source: `packages/runtime/src/v2/runtime/runner/in-memory.ts`.

--- a/skills/runtime/references/agent-runners-sqlite.md
+++ b/skills/runtime/references/agent-runners-sqlite.md
@@ -1,0 +1,90 @@
+SqliteAgentRunner — file-backed agent runner in `@copilotkit/sqlite-runner`. Uses `better-sqlite3` as a required peer dep.
+
+## Install
+
+```bash
+pnpm add @copilotkit/sqlite-runner better-sqlite3
+```
+
+If `better-sqlite3` is missing, the `import` of `@copilotkit/sqlite-runner` itself fails
+at module load (`Cannot find module 'better-sqlite3'`). The runner's constructor has a
+friendlier multi-line install hint as a fallback, but you will see the bare resolution
+error first — install the peer before the runner import resolves.
+
+## Configure
+
+```typescript
+import { CopilotRuntime } from "@copilotkit/runtime/v2";
+import { SqliteAgentRunner } from "@copilotkit/sqlite-runner";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+  runner: new SqliteAgentRunner({
+    dbPath: "./data/threads.db", // REQUIRED — default is ":memory:"
+  }),
+});
+```
+
+`dbPath: ":memory:"` is the default if omitted — that reverts to an in-memory store and
+loses data at restart. Always set a file path in production.
+
+## Schema
+
+Three tables are created on first use (`packages/sqlite-runner/src/sqlite-runner.ts:75-109`):
+
+```sql
+CREATE TABLE IF NOT EXISTS agent_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  thread_id TEXT NOT NULL,
+  run_id TEXT NOT NULL UNIQUE,
+  parent_run_id TEXT,
+  events TEXT NOT NULL,    -- JSON-encoded BaseEvent[]
+  input TEXT NOT NULL,     -- JSON-encoded RunAgentInput
+  created_at INTEGER NOT NULL,
+  version INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS run_state (
+  thread_id TEXT PRIMARY KEY,
+  is_running INTEGER DEFAULT 0,
+  current_run_id TEXT,
+  updated_at INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_thread_id ON agent_runs(thread_id);
+CREATE INDEX IF NOT EXISTS idx_parent_run_id ON agent_runs(parent_run_id);
+```
+
+`agent_runs` is append-only — one row per completed run, full event log in the `events`
+column. `run_state` gates concurrent runs (the `"Thread already running"` check).
+`schema_version` tracks applied migrations so future releases can upgrade existing
+databases in place.
+
+## Retention
+
+There is no automatic retention. If you need bounded history, add a periodic purge:
+
+```typescript
+import Database from "better-sqlite3";
+
+const db = new Database("./data/threads.db");
+setInterval(
+  () => {
+    const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000; // 30 days
+    db.prepare("DELETE FROM agent_runs WHERE created_at < ?").run(cutoff);
+  },
+  60 * 60 * 1000,
+);
+```
+
+## When NOT to use
+
+- Multi-instance deploys without shared storage — each instance would have its own DB file.
+  Either put the DB on a shared volume (EFS, persistent disk) with a single writer, or
+  choose Intelligence mode or a custom Redis/Postgres runner.
+
+Source: `packages/sqlite-runner/src/sqlite-runner.ts`.

--- a/skills/runtime/references/agent-runners.md
+++ b/skills/runtime/references/agent-runners.md
@@ -1,0 +1,304 @@
+# CopilotKit Agent Runners
+
+`AgentRunner` is the abstraction that owns thread run state — active runs, the event stream
+replay, and stop semantics. Pick one per `CopilotRuntime` instance.
+
+- `InMemoryAgentRunner` — default; globalThis-keyed Map; lost on restart.
+- `SqliteAgentRunner` — file-backed; requires `better-sqlite3` peer.
+- `IntelligenceAgentRunner` — auto-wired by `CopilotIntelligenceRuntime`. You do NOT
+  construct this directly and you cannot pass `runner` alongside `intelligence`.
+- Custom — subclass `AgentRunner` for Redis / Postgres / any backend.
+
+## Setup
+
+Default (in-memory, dev only):
+
+```typescript
+import { CopilotRuntime } from "@copilotkit/runtime/v2";
+
+// Equivalent to passing `runner: new InMemoryAgentRunner()`
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+});
+```
+
+Production (file-backed SQLite):
+
+```typescript
+import { CopilotRuntime } from "@copilotkit/runtime/v2";
+import { SqliteAgentRunner } from "@copilotkit/sqlite-runner";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+  runner: new SqliteAgentRunner({ dbPath: "./data/threads.db" }),
+});
+```
+
+Installation for the SQLite runner (the `better-sqlite3` peer is required):
+
+```bash
+pnpm add @copilotkit/sqlite-runner better-sqlite3
+```
+
+## Core Patterns
+
+### The AgentRunner contract
+
+```typescript
+import { AgentRunner } from "@copilotkit/runtime/v2";
+import type {
+  AgentRunnerRunRequest,
+  AgentRunnerConnectRequest,
+  AgentRunnerIsRunningRequest,
+  AgentRunnerStopRequest,
+} from "@copilotkit/runtime/v2";
+import { Observable } from "rxjs";
+import type { BaseEvent } from "@ag-ui/client";
+
+class MyRunner extends AgentRunner {
+  run(request: AgentRunnerRunRequest): Observable<BaseEvent> {
+    // Start a new run for request.threadId. Throw `new Error("Thread already running")`
+    // if a run is in flight. Stream events from agent.run(request.input).
+    return new Observable<BaseEvent>();
+  }
+  connect(request: AgentRunnerConnectRequest): Observable<BaseEvent> {
+    // Replay events for an active run, or historic runs for request.threadId.
+    return new Observable<BaseEvent>();
+  }
+  async isRunning(request: AgentRunnerIsRunningRequest): Promise<boolean> {
+    return false;
+  }
+  async stop(request: AgentRunnerStopRequest): Promise<boolean | undefined> {
+    return true;
+  }
+}
+```
+
+### Handle double-submit on the client
+
+Both `InMemoryAgentRunner` and `SqliteAgentRunner` throw
+`"Thread already running"` on concurrent `run()` calls for the same `threadId`. How
+that surfaces to the client depends on the runtime mode:
+
+- **Intelligence mode** — the Intelligence platform returns HTTP `409` when a lock is
+  held. The client core maps this to `CopilotKitCoreErrorCode.AGENT_THREAD_LOCKED`
+  and fires `onError({ code: "agent_thread_locked", ... })`. Handle this in
+  `<CopilotKitProvider onError>`.
+- **SSE mode** (default, in-memory / SQLite runners) — the runner throws
+  synchronously and the handler returns a plain `500` JSON body like
+  `{ "error": "Failed to run agent", "message": "Thread already running" }`.
+  There is no typed `agent_thread_locked` code — match on the message text or
+  just guard on the client with a busy flag.
+
+```tsx
+// client — Intelligence mode (typed code)
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+<CopilotKitProvider
+  onError={({ code }) => {
+    if (code === "agent_thread_locked") {
+      alert("Agent is busy — wait for the current response to finish.");
+    }
+  }}
+/>;
+```
+
+```tsx
+// client — any mode: guard with a busy flag so double-submit is impossible
+import { useAgent } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+
+function Composer() {
+  const agent = useAgent({ agentId: "default" });
+  const [busy, setBusy] = useState(false);
+
+  async function send(text: string) {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await agent?.addMessage({ role: "user", content: text });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return null;
+}
+```
+
+## Common Mistakes
+
+### HIGH Shipping InMemoryAgentRunner to production
+
+Wrong:
+
+```typescript
+// production:
+new CopilotRuntime({ agents: { default: agent } });
+```
+
+Correct:
+
+```typescript
+import { SqliteAgentRunner } from "@copilotkit/sqlite-runner";
+
+new CopilotRuntime({
+  agents: { default: agent },
+  runner: new SqliteAgentRunner({ dbPath: "./data/threads.db" }),
+});
+// Or upgrade to Intelligence mode for managed durability.
+```
+
+The default runner is `new InMemoryAgentRunner()`. It keeps state in a `globalThis`-keyed
+Map — threads are lost on restart, and horizontally-scaled instances see divergent state.
+
+Source: `packages/runtime/src/v2/runtime/runner/in-memory.ts:63-96`.
+
+### HIGH Setting runner alongside intelligence option
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  runner: new SqliteAgentRunner({ dbPath: "./data/threads.db" }),
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser: (req) => ({ id: req.headers.get("x-user-id")! }),
+});
+```
+
+`CopilotIntelligenceRuntimeOptions` does not declare a `runner` field — Intelligence mode
+auto-wires `IntelligenceAgentRunner` pointed at the Cloud socket. Excess-property checks will
+flag a `runner:` key on an Intelligence-shaped options object as a type error, and at runtime
+the auto-wired Intelligence runner wins regardless of what you pass.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts:149-173,285-294`.
+
+### HIGH Forgetting the better-sqlite3 peer
+
+Wrong:
+
+```bash
+pnpm add @copilotkit/sqlite-runner
+```
+
+Correct:
+
+```bash
+pnpm add @copilotkit/sqlite-runner better-sqlite3
+```
+
+`@copilotkit/sqlite-runner` imports `better-sqlite3` at the top of its module, so if the peer
+is missing, `import { SqliteAgentRunner } from "@copilotkit/sqlite-runner"` itself fails at
+module load with `Cannot find module 'better-sqlite3'` — long before the constructor runs.
+(The constructor has a friendlier multi-line install hint as a belt-and-suspenders fallback,
+but in practice you will see the bare module-resolution error first.) It is a peer dependency,
+not a direct dep.
+
+Source: `packages/sqlite-runner/src/sqlite-runner.ts:18`, `:55-66`.
+
+### HIGH Default SqliteAgentRunner with :memory: dbPath
+
+Wrong:
+
+```typescript
+new SqliteAgentRunner();
+```
+
+Correct:
+
+```typescript
+new SqliteAgentRunner({ dbPath: "./data/threads.db" });
+```
+
+The default `dbPath` is `":memory:"` — SQLite's in-memory mode. Data is lost at restart,
+defeating the reason to use the file-backed runner.
+
+Source: `packages/sqlite-runner/src/sqlite-runner.ts:48-54`.
+
+### MEDIUM Concurrent run() on the same threadId
+
+Wrong:
+
+```tsx
+// Double-click send button → two POST /agent/:id/run to the same thread
+<button onClick={() => agent.addMessage({ role: "user", content })}>
+  Send
+</button>
+```
+
+Correct:
+
+```tsx
+const [busy, setBusy] = useState(false);
+<button
+  disabled={busy}
+  onClick={async () => {
+    setBusy(true);
+    try {
+      await agent.addMessage({ role: "user", content });
+    } finally {
+      setBusy(false);
+    }
+  }}
+>
+  Send
+</button>;
+```
+
+Both runners throw `"Thread already running"` on concurrent runs. Debounce on the client.
+In Intelligence mode you can additionally handle `code === "agent_thread_locked"` in
+`<CopilotKitProvider onError>`; SSE mode surfaces only a generic 500 with that message.
+
+Source: `packages/runtime/src/v2/runtime/runner/in-memory.ts:110`;
+`packages/core/src/intelligence-agent.ts:368-369`.
+
+### HIGH In-memory runner + horizontal scaling
+
+Wrong:
+
+```typescript
+// 3 Fly.io / Cloud Run instances, each with its own InMemoryAgentRunner
+new CopilotRuntime({ agents });
+```
+
+Correct:
+
+```typescript
+// Either sticky-session a single instance per thread, or use shared state:
+new CopilotRuntime({
+  agents,
+  runner: new SqliteAgentRunner({ dbPath: process.env.THREADS_DB! }),
+});
+// Best: Intelligence mode for managed multi-instance durability.
+```
+
+`InMemoryAgentRunner`'s `globalThis` store is per-process — multi-instance deploys see
+totally different thread state per worker, making reconnects and `GET /connect` non-deterministic.
+
+Source: `packages/runtime/src/v2/runtime/runner/in-memory.ts:63-96`.
+
+## References
+
+- [InMemoryAgentRunner — internals and hot-reload note](agent-runners-in-memory.md)
+- [SqliteAgentRunner — schema, retention, ops](agent-runners-sqlite.md)
+- [Custom runner — Redis/Postgres skeleton](agent-runners-custom.md)
+
+## See also
+
+- `copilotkit/intelligence-mode` — managed durability alternative (Cloud-only)
+- `copilotkit/setup-endpoint` — runner is passed via the CopilotRuntime constructor
+- `copilotkit/scale-to-multi-agent` — horizontal scaling considerations

--- a/skills/runtime/references/built-in-agent-factory-modes.md
+++ b/skills/runtime/references/built-in-agent-factory-modes.md
@@ -1,0 +1,232 @@
+BuiltInAgent Factory Modes — cookbook for TanStack AI, AI SDK, and custom AG-UI factories.
+
+## The AgentFactoryContext
+
+```typescript
+// packages/runtime/src/agent/index.ts
+export interface AgentFactoryContext {
+  input: RunAgentInput; // messages, tools, forwardedProps, context
+  abortController: AbortController; // prefer abortSignal
+  abortSignal: AbortSignal; // pass to AI SDK / fetch / custom
+}
+```
+
+Rule of thumb:
+
+- Prefer `abortSignal` for AI SDK, fetch, custom backends.
+- Use `abortController` for TanStack AI (its `chat()` takes the controller, not the signal).
+- NEVER call `ctx.abortController.abort()` inside the factory — use
+  `agent.abortRun()` from outside.
+
+## TanStack AI factory (preferred)
+
+```typescript
+import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    systemPrompts.unshift("You are a helpful assistant.");
+    return chat({
+      adapter: openaiText("gpt-4o"),
+      messages,
+      systemPrompts,
+      tools: [
+        /* TanStack AI toolDefinition()s */
+      ],
+      abortController,
+    });
+  },
+});
+```
+
+### TanStack AI + forwardedProps
+
+```typescript
+new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    const fwd = input.forwardedProps as
+      | { model?: string; temperature?: number }
+      | undefined;
+    return chat({
+      adapter: openaiText(fwd?.model ?? "gpt-4o"),
+      messages,
+      systemPrompts,
+      modelOptions: { temperature: fwd?.temperature ?? 0.2 },
+      abortController,
+    });
+  },
+});
+```
+
+## AI SDK factory (use when reasoning events are required)
+
+```typescript
+import {
+  BuiltInAgent,
+  convertMessagesToVercelAISDKMessages,
+  convertToolsToVercelAITools,
+} from "@copilotkit/runtime/v2";
+import { streamText, stepCountIs } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) => {
+    const messages = convertMessagesToVercelAISDKMessages(input.messages, {
+      forwardSystemMessages: true,
+    });
+    const tools = convertToolsToVercelAITools(input.tools);
+    return streamText({
+      model: openai("gpt-4o"),
+      messages,
+      tools,
+      abortSignal,
+      stopWhen: stepCountIs(5),
+    });
+  },
+});
+```
+
+The `BuiltInAgentAISDKFactoryConfig` contract requires an object with a `fullStream`
+async iterable — this is exactly what `streamText()` returns.
+
+## AI SDK + reasoning (Anthropic thinking)
+
+```typescript
+import { anthropic } from "@ai-sdk/anthropic";
+import { streamText } from "ai";
+import {
+  BuiltInAgent,
+  convertMessagesToVercelAISDKMessages,
+} from "@copilotkit/runtime/v2";
+
+new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) =>
+    streamText({
+      model: anthropic("claude-sonnet-4"),
+      messages: convertMessagesToVercelAISDKMessages(input.messages),
+      providerOptions: {
+        anthropic: { thinking: { type: "enabled", budgetTokens: 10000 } },
+      },
+      abortSignal,
+    }),
+});
+```
+
+TanStack AI silently drops reasoning events — only AI SDK surfaces them.
+
+## Custom factory (raw AG-UI events)
+
+```typescript
+import { BuiltInAgent } from "@copilotkit/runtime/v2";
+import type { BaseEvent } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+
+new BuiltInAgent({
+  type: "custom",
+  factory: async function* ({ input, abortSignal }): AsyncIterable<BaseEvent> {
+    // Check abortSignal.aborted on every iteration — agent.abortRun() signals
+    // cancellation via this flag, but the generator must consult it to stop yielding.
+    if (abortSignal.aborted) return;
+
+    const messageId = crypto.randomUUID();
+    yield {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId,
+      role: "assistant",
+    } as any;
+
+    for (const delta of ["Hello", ", ", "world."]) {
+      if (abortSignal.aborted) return; // honor cancellation between yields
+      yield {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId,
+        delta,
+      } as any;
+    }
+
+    yield { type: EventType.TEXT_MESSAGE_END, messageId } as any;
+  },
+});
+```
+
+A custom factory that never checks `abortSignal.aborted` (or registers an
+`addEventListener("abort", …)` handler to break its loop) is non-cancellable —
+`agent.abortRun()` will flip the flag but the generator will keep yielding until it
+exhausts its own source. Pass `abortSignal` through to any underlying `fetch` /
+streaming API as well so the upstream request is torn down.
+
+## Manual state-tool wiring (Factory Mode only)
+
+Simple Mode auto-injects `AGUISendStateSnapshot` / `AGUISendStateDelta`. In Factory Mode
+you must register them by hand for shared-state updates to reach the LLM. The AI SDK
+factory works out of the box because `defineTool` output adapts through
+`convertToolDefinitionsToVercelAITools`:
+
+```typescript
+import {
+  BuiltInAgent,
+  convertMessagesToVercelAISDKMessages,
+  convertToolDefinitionsToVercelAITools,
+  defineTool,
+} from "@copilotkit/runtime/v2";
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+const sendStateSnapshot = defineTool({
+  name: "AGUISendStateSnapshot",
+  description: "Replace the entire application state with a new snapshot",
+  parameters: z.object({
+    snapshot: z.any().describe("The complete new state object"),
+  }),
+  execute: async ({ snapshot }) => ({ success: true, snapshot }),
+});
+const sendStateDelta = defineTool({
+  name: "AGUISendStateDelta",
+  description:
+    "Apply incremental updates to application state using JSON Patch operations",
+  // MUST mirror the Simple-Mode auto-injected schema (src/agent/index.ts:1140-1176)
+  // or the frontend's state handler won't recognize the payload.
+  parameters: z.object({
+    delta: z
+      .array(
+        z.object({
+          op: z.enum(["add", "replace", "remove"]),
+          path: z.string(),
+          value: z.any().optional(),
+        }),
+      )
+      .describe("Array of JSON Patch operations"),
+  }),
+  execute: async ({ delta }) => ({ success: true, delta }),
+});
+
+new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) =>
+    streamText({
+      model: openai("gpt-4o"),
+      messages: convertMessagesToVercelAISDKMessages(input.messages),
+      tools: convertToolDefinitionsToVercelAITools([
+        sendStateSnapshot,
+        sendStateDelta,
+      ]),
+      abortSignal,
+    }),
+});
+```
+
+For TanStack AI factories, `defineTool` output is NOT a TanStack tool — passing it to
+`chat({ tools })` does not work. Either switch to the AI SDK factory above, or redefine
+the tools with `toolDefinition()` from `@tanstack/ai`.
+
+Source: `packages/runtime/src/agent/index.ts`,
+`docs/content/docs/integrations/built-in-agent/custom-agent.mdx`.

--- a/skills/runtime/references/built-in-agent-helper-utilities.md
+++ b/skills/runtime/references/built-in-agent-helper-utilities.md
@@ -1,0 +1,123 @@
+BuiltInAgent helper utilities — exported from `@copilotkit/runtime/v2`.
+
+## convertInputToTanStackAI
+
+```typescript
+import { convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+
+// signature (simplified):
+// convertInputToTanStackAI(input: RunAgentInput): {
+//   messages: TanStackAIMessage[];
+//   systemPrompts: string[];
+// }
+```
+
+Converts the AG-UI `RunAgentInput` into TanStack AI's `chat()` inputs. System messages in
+the input are collected into the `systemPrompts` array (not the `messages` array). Unshift
+your own system prompt onto `systemPrompts` before calling `chat()`:
+
+```typescript
+const { messages, systemPrompts } = convertInputToTanStackAI(input);
+systemPrompts.unshift("You are a helpful assistant.");
+return chat({ adapter, messages, systemPrompts, abortController });
+```
+
+Source: `packages/runtime/src/agent/converters/tanstack.ts:156`.
+
+## convertMessagesToVercelAISDKMessages
+
+```typescript
+import { convertMessagesToVercelAISDKMessages } from "@copilotkit/runtime/v2";
+
+// signature:
+// convertMessagesToVercelAISDKMessages(
+//   messages: Message[],
+//   options?: { forwardSystemMessages?: boolean; forwardDeveloperMessages?: boolean }
+// ): ModelMessage[]
+```
+
+Converts AG-UI `Message[]` to the Vercel AI SDK's `ModelMessage[]`. Handles multimodal
+content (text, image, audio/video/document, and legacy `binary`). By default drops
+`role: "system"` and `role: "developer"` messages — set the options to opt in.
+
+```typescript
+const messages = convertMessagesToVercelAISDKMessages(input.messages, {
+  forwardSystemMessages: true,
+});
+```
+
+Source: `packages/runtime/src/agent/index.ts:435`.
+
+## convertToolsToVercelAITools
+
+```typescript
+import { convertToolsToVercelAITools } from "@copilotkit/runtime/v2";
+
+// signature:
+// convertToolsToVercelAITools(tools: RunAgentInput["tools"]): ToolSet
+```
+
+Converts AG-UI `input.tools` (tools registered on the frontend — their parameters are plain
+JSON Schema) into the AI SDK's `ToolSet`. Throws `Invalid JSON schema for tool ${name}`
+when a tool's parameters aren't a JSON schema object. The resulting tools have no
+`execute` — the AI SDK emits tool-call events and the frontend handles them.
+
+```typescript
+const tools = convertToolsToVercelAITools(input.tools);
+return streamText({ model, messages, tools, abortSignal });
+```
+
+Source: `packages/runtime/src/agent/index.ts:599`.
+
+## convertToolDefinitionsToVercelAITools
+
+```typescript
+import { convertToolDefinitionsToVercelAITools } from "@copilotkit/runtime/v2";
+
+// signature:
+// convertToolDefinitionsToVercelAITools(tools: ToolDefinition[]): ToolSet
+```
+
+Converts server-side `ToolDefinition[]` (Standard Schema V1 parameters + `execute`
+function) into an AI SDK `ToolSet`. Zod schemas pass through directly; non-Zod Standard
+Schema V1 parameters (Valibot, ArkType, ...) are converted to JSON Schema via
+`schemaToJsonSchema` and wrapped with `jsonSchema()` from `ai`.
+
+```typescript
+import { defineTool } from "@copilotkit/runtime/v2";
+import { z } from "zod";
+
+const searchTool = defineTool({
+  name: "search",
+  description: "Search the web.",
+  parameters: z.object({ query: z.string() }),
+  execute: async ({ query }) => ({ results: [] }),
+});
+
+const tools = convertToolDefinitionsToVercelAITools([searchTool]);
+return streamText({ model, messages, tools, abortSignal });
+```
+
+Source: `packages/runtime/src/agent/index.ts:633`.
+
+## resolveModel
+
+```typescript
+import { resolveModel } from "@copilotkit/runtime/v2";
+
+// signature:
+// resolveModel(spec: ModelSpecifier, apiKey?: string): LanguageModel
+```
+
+Resolves a `"provider/model"` (or `"provider:model"`) string to a `LanguageModel`. If
+`spec` is already a `LanguageModel`, it's returned as-is. Throws
+`Invalid model string "..."` when the provider separator is missing.
+
+Supported providers: `openai`, `anthropic`, `google`/`gemini`/`google-gemini`, `vertex`.
+Unknown providers throw `Unknown provider "..." in "...". Supported: openai, anthropic, google (gemini).`
+
+```typescript
+const model = resolveModel("openai/gpt-4o", process.env.OPENAI_API_KEY);
+```
+
+Source: `packages/runtime/src/agent/index.ts:176-249`.

--- a/skills/runtime/references/built-in-agent-model-identifiers.md
+++ b/skills/runtime/references/built-in-agent-model-identifiers.md
@@ -1,0 +1,59 @@
+BuiltInAgent model identifiers — the full set of `"provider/model"` strings that
+`resolveModel` accepts out of the box.
+
+## Shape
+
+`"provider/model"` or `"provider:model"` — both separators are normalized. Case-insensitive on the provider segment.
+
+```typescript
+new BuiltInAgent({ model: "openai/gpt-4o" });
+new BuiltInAgent({ model: "anthropic:claude-sonnet-4.5" });
+```
+
+## Supported providers
+
+| Provider                              | Env var             | Notes                              |
+| ------------------------------------- | ------------------- | ---------------------------------- |
+| `openai`                              | `OPENAI_API_KEY`    | Lazily creates `@ai-sdk/openai`    |
+| `anthropic`                           | `ANTHROPIC_API_KEY` | Lazily creates `@ai-sdk/anthropic` |
+| `google` / `gemini` / `google-gemini` | `GOOGLE_API_KEY`    | `@ai-sdk/google` under the hood    |
+| `vertex`                              | (GCP auth)          | `@ai-sdk/google-vertex`            |
+
+Pass `apiKey` on the constructor to override env vars.
+
+## Pinned identifiers in the union type
+
+These are the concrete strings typed in `BuiltInAgentModel`:
+
+```
+openai/gpt-5            openai/gpt-5-mini
+openai/gpt-4.1          openai/gpt-4.1-mini        openai/gpt-4.1-nano
+openai/gpt-4o           openai/gpt-4o-mini
+openai/o3               openai/o3-mini             openai/o4-mini
+
+anthropic/claude-sonnet-4.5   anthropic/claude-sonnet-4
+anthropic/claude-3.7-sonnet   anthropic/claude-opus-4.1
+anthropic/claude-opus-4       anthropic/claude-3.5-haiku
+
+google/gemini-2.5-pro   google/gemini-2.5-flash    google/gemini-2.5-flash-lite
+```
+
+Any other valid model id is still accepted — the type is
+`BuiltInAgentModel = "openai/gpt-5" | ... | (string & {})`, and the AI SDK provider will
+accept any id it knows about. The pinned union is for autocomplete, not an exhaustive allowlist.
+
+## Passing a LanguageModel instance directly
+
+Instead of a string, pass a pre-configured `LanguageModel`:
+
+```typescript
+import { BuiltInAgent } from "@copilotkit/runtime/v2";
+import { createOpenAI } from "@ai-sdk/openai";
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+new BuiltInAgent({ model: openai("gpt-4o") });
+```
+
+This bypasses `resolveModel` entirely.
+
+Source: `packages/runtime/src/agent/index.ts:82-109, 176-249`.

--- a/skills/runtime/references/built-in-agent.md
+++ b/skills/runtime/references/built-in-agent.md
@@ -1,0 +1,523 @@
+# CopilotKit BuiltInAgent
+
+`BuiltInAgent` has two modes:
+
+- **Factory Mode** (preferred default) — you own the LLM call, BuiltInAgent owns the AG-UI
+  lifecycle. TanStack AI factory is AG-UI-native and the canonical preferred choice. AI SDK
+  and custom (raw AG-UI event) factories are also supported.
+- **Simple Mode** (classic config) — `{ model, apiKey, prompt, tools, mcpServers, maxSteps, ... }`.
+  Convenient for quickstarts. Simple Mode auto-injects the `AGUISendStateSnapshot` /
+  `AGUISendStateDelta` state tools; Factory Mode does not.
+
+Use Factory Mode with TanStack AI for new code.
+
+## Setup
+
+Factory Mode with TanStack AI (preferred default):
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const agent = new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    systemPrompts.unshift("You are a helpful assistant.");
+    return chat({
+      adapter: openaiText("gpt-4o"),
+      messages,
+      systemPrompts,
+      abortController,
+    });
+  },
+});
+
+const runtime = new CopilotRuntime({ agents: { default: agent } });
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+Simple Mode (quickstart only):
+
+```typescript
+import {
+  BuiltInAgent,
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+
+const agent = new BuiltInAgent({
+  model: "openai/gpt-4o",
+  apiKey: process.env.OPENAI_API_KEY,
+  prompt: "You are a helpful assistant.",
+  maxSteps: 5, // enable the tool-call loop
+});
+
+const runtime = new CopilotRuntime({ agents: { default: agent } });
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+export default { fetch: handler };
+```
+
+## Core Patterns
+
+### Factory Mode with AI SDK (needed for reasoning events)
+
+```typescript
+import {
+  BuiltInAgent,
+  convertMessagesToVercelAISDKMessages,
+  convertToolsToVercelAITools,
+} from "@copilotkit/runtime/v2";
+import { streamText, stepCountIs } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+
+const agent = new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) => {
+    const messages = convertMessagesToVercelAISDKMessages(input.messages);
+    const tools = convertToolsToVercelAITools(input.tools);
+    return streamText({
+      model: anthropic("claude-sonnet-4-5-20250929"),
+      messages,
+      tools,
+      abortSignal,
+      stopWhen: stepCountIs(5),
+    });
+  },
+});
+```
+
+### Per-request agent via a factory function on CopilotRuntime
+
+```typescript
+import {
+  CopilotRuntime,
+  BuiltInAgent,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const runtime = new CopilotRuntime({
+  agents: ({ request }) => {
+    const tenantId = request.headers.get("x-tenant-id") ?? "default";
+    return {
+      default: new BuiltInAgent({
+        type: "tanstack",
+        factory: ({ input, abortController }) => {
+          const { messages, systemPrompts } = convertInputToTanStackAI(input);
+          systemPrompts.unshift(`You are the ${tenantId} assistant.`);
+          return chat({
+            adapter: openaiText("gpt-4o"),
+            messages,
+            systemPrompts,
+            abortController,
+          });
+        },
+      }),
+    };
+  },
+});
+```
+
+### Simple Mode — MCP servers
+
+```typescript
+new BuiltInAgent({
+  model: "openai/gpt-4o",
+  maxSteps: 5,
+  mcpServers: [
+    { type: "http", url: "https://mcp.example.com/mcp" },
+    {
+      type: "sse",
+      url: "https://mcp.example.com/sse",
+      headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` },
+    },
+  ],
+});
+```
+
+### Model specifier format
+
+`"provider/model"` or `"provider:model"`. Supported providers: `openai`, `anthropic`,
+`google` (aliases `gemini`, `google-gemini`), `vertex`. The bare model id (`"gpt-4o"`) is
+rejected.
+
+```typescript
+new BuiltInAgent({ model: "openai/gpt-4o" });
+new BuiltInAgent({ model: "anthropic/claude-sonnet-4.5" });
+new BuiltInAgent({ model: "google/gemini-2.5-pro" });
+```
+
+## Common Mistakes
+
+### HIGH Defaulting to Simple Mode when Factory Mode (TanStack AI) is preferred
+
+Wrong:
+
+```typescript
+const agent = new BuiltInAgent({
+  model: "openai/gpt-4o",
+  prompt: "You are a helpful assistant.",
+});
+```
+
+Correct:
+
+```typescript
+import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const agent = new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    systemPrompts.unshift("You are a helpful assistant.");
+    return chat({
+      adapter: openaiText("gpt-4o"),
+      messages,
+      systemPrompts,
+      abortController,
+    });
+  },
+});
+```
+
+Factory Mode with TanStack AI is the canonical in-tree default (see
+`examples/v2/react-router/app/routes/api.copilotkit.$.tsx`) and is AG-UI-native. Simple
+Mode is fine for quickstarts but reaches its ceiling on anything non-standard.
+
+Source: `examples/v2/react-router/app/routes/api.copilotkit.$.tsx`; maintainer Phase 4c.
+
+### HIGH Expecting tool-call loop without raising maxSteps
+
+Wrong:
+
+```typescript
+new BuiltInAgent({
+  model: "openai/gpt-4o",
+  tools: [searchTool],
+  // maxSteps defaults to undefined → AI SDK stops after one generation; tool results
+  // are never fed back. Set maxSteps: N to enable the tool-call loop.
+});
+```
+
+Correct:
+
+```typescript
+new BuiltInAgent({
+  model: "openai/gpt-4o",
+  tools: [searchTool],
+  maxSteps: 5,
+});
+```
+
+`maxSteps` defaults to `undefined`, so `stopWhen` is `undefined` and the AI SDK's own
+default applies — `streamText` stops after a single generation, the tool call happens,
+but results are never fed back for a second turn. Set `maxSteps: N` to install
+`stepCountIs(N)` and enable the tool-call loop up to N steps.
+
+Source: `packages/runtime/src/agent/index.ts:988-990`.
+
+### HIGH Wrong model specifier format
+
+Wrong:
+
+```typescript
+new BuiltInAgent({ model: "gpt-4o" });
+```
+
+Correct:
+
+```typescript
+new BuiltInAgent({ model: "openai/gpt-4o" });
+// Also valid: "openai:gpt-4o"
+```
+
+`resolveModel` throws `Invalid model string "gpt-4o". Use "openai/gpt-5",
+"anthropic/claude-sonnet-4.5", or "google/gemini-2.5-pro".` when the provider separator
+is missing.
+
+Source: `packages/runtime/src/agent/index.ts:186-204`.
+
+### HIGH Concurrent run() on the same BuiltInAgent instance
+
+Wrong:
+
+```typescript
+// One shared instance across tenants
+const agent = new BuiltInAgent({ model: "openai/gpt-4o" });
+new CopilotRuntime({ agents: { default: agent } });
+```
+
+Correct:
+
+```typescript
+// Use the agents-as-factory form for per-request instances
+new CopilotRuntime({
+  agents: ({ request }) => ({
+    default: new BuiltInAgent({ model: "openai/gpt-4o" }),
+  }),
+});
+```
+
+A single `BuiltInAgent` instance guards against concurrent `run()` with
+`"Agent is already running. Call abortRun() first or create a new instance."` Multi-tenant
+servers that share one instance see errors on the second concurrent user.
+
+Source: `packages/runtime/src/agent/index.ts:895-898`.
+
+### HIGH Expecting state tools to auto-inject in Factory Mode
+
+Wrong:
+
+```typescript
+new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    return chat({
+      adapter: openaiText("gpt-4o"),
+      messages,
+      systemPrompts,
+      abortController,
+    });
+  },
+});
+// Frontend uses useAgent + shared state — but no state-tool calls come back
+```
+
+Correct (AI SDK factory — `defineTool` output converts via
+`convertToolDefinitionsToVercelAITools`):
+
+```typescript
+import {
+  BuiltInAgent,
+  convertMessagesToVercelAISDKMessages,
+  convertToolDefinitionsToVercelAITools,
+  defineTool,
+} from "@copilotkit/runtime/v2";
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+const sendStateSnapshot = defineTool({
+  name: "AGUISendStateSnapshot",
+  description: "Replace the entire application state with a new snapshot",
+  parameters: z.object({
+    snapshot: z.any().describe("The complete new state object"),
+  }),
+  execute: async ({ snapshot }) => ({ success: true, snapshot }),
+});
+const sendStateDelta = defineTool({
+  name: "AGUISendStateDelta",
+  description:
+    "Apply incremental updates to application state using JSON Patch operations",
+  // MUST mirror the Simple-Mode auto-injected schema (src/agent/index.ts:1140-1176)
+  // or the frontend's state handler won't recognize the payload.
+  parameters: z.object({
+    delta: z
+      .array(
+        z.object({
+          op: z.enum(["add", "replace", "remove"]),
+          path: z.string(), // JSON Pointer, e.g. "/foo/bar"
+          value: z.any().optional(), // required for add/replace, ignored for remove
+        }),
+      )
+      .describe("Array of JSON Patch operations"),
+  }),
+  execute: async ({ delta }) => ({ success: true, delta }),
+});
+// If you don't want to hand-wire this, use Simple Mode — it auto-injects both
+// AGUISendStateSnapshot and AGUISendStateDelta with the correct JSON Patch schema.
+// Source: packages/runtime/src/agent/index.ts:1140-1176
+
+new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) =>
+    streamText({
+      model: openai("gpt-4o"),
+      messages: convertMessagesToVercelAISDKMessages(input.messages),
+      tools: convertToolDefinitionsToVercelAITools([
+        sendStateSnapshot,
+        sendStateDelta,
+      ]),
+      abortSignal,
+    }),
+});
+```
+
+Only Simple Mode auto-injects the AG-UI state tools. In Factory Mode you must register
+them by hand or shared-state updates never reach the LLM. `defineTool` produces a Standard
+Schema V1 + `execute` shape — use `convertToolDefinitionsToVercelAITools([...])` to adapt
+it to the AI SDK's `streamText({ tools })`. TanStack AI factories cannot consume
+`defineTool` output directly; either redefine the tools with `toolDefinition()` from
+`@tanstack/ai`, or switch to the AI SDK factory above.
+
+Source: `docs/snippets/shared/backend/custom-agent.mdx:495-588`.
+
+### MEDIUM Mixing Simple Mode tools with Factory Mode
+
+Wrong:
+
+```typescript
+new BuiltInAgent({
+  type: "tanstack",
+  factory: myFactory,
+  tools: [t1, t2], // ignored in Factory Mode
+});
+```
+
+Correct:
+
+```typescript
+new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    return chat({
+      adapter: openaiText("gpt-4o"),
+      messages,
+      systemPrompts,
+      tools: [t1, t2],
+      abortController,
+    });
+  },
+});
+```
+
+Factory Mode ignores `config.tools`, `config.mcpServers`, `config.prompt` entirely — the
+factory owns the call. Wire tools inside `chat({ tools })` for TanStack AI, or via
+`convertToolsToVercelAITools(input.tools)` / `convertToolDefinitionsToVercelAITools([...])`
+for AI SDK.
+
+Source: `packages/runtime/src/agent/index.ts:1581-1671`.
+
+### HIGH Expecting reasoning events from TanStack AI
+
+Wrong:
+
+```typescript
+new BuiltInAgent({
+  type: "tanstack",
+  factory: ({ input, abortController }) => {
+    const { messages, systemPrompts } = convertInputToTanStackAI(input);
+    return chat({
+      adapter: anthropicText("claude-sonnet-4-5-20250929"),
+      messages,
+      systemPrompts,
+      modelOptions: { thinking: { type: "enabled", budgetTokens: 10000 } },
+      abortController,
+    });
+  },
+});
+// expecting REASONING_START / REASONING_MESSAGE_CONTENT / REASONING_END — nothing arrives
+```
+
+Correct:
+
+```typescript
+import {
+  BuiltInAgent,
+  convertMessagesToVercelAISDKMessages,
+} from "@copilotkit/runtime/v2";
+import { streamText } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+
+new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) =>
+    streamText({
+      model: anthropic("claude-sonnet-4-5-20250929"),
+      messages: convertMessagesToVercelAISDKMessages(input.messages),
+      providerOptions: {
+        anthropic: { thinking: { type: "enabled", budgetTokens: 10000 } },
+      },
+      abortSignal,
+    }),
+});
+```
+
+The TanStack AI converter does NOT surface `REASONING_START` /
+`REASONING_MESSAGE_CONTENT` / `REASONING_END` events — even with a thinking-capable model.
+Use AI SDK when the frontend needs a reasoning UI.
+
+Source: `docs/snippets/shared/backend/custom-agent.mdx:315-317` (warn callout).
+
+### MEDIUM Expecting forwarded system messages
+
+Wrong:
+
+```typescript
+// Client sends { role: "system", content: "You are..." } and expects it prefixed
+new BuiltInAgent({ model: "openai/gpt-4o" });
+```
+
+Correct:
+
+```typescript
+// Either set the server-side prompt
+new BuiltInAgent({ model: "openai/gpt-4o", prompt: "You are..." });
+// or opt in explicitly
+new BuiltInAgent({ model: "openai/gpt-4o", forwardSystemMessages: true });
+```
+
+`forwardSystemMessages` and `forwardDeveloperMessages` default to `false`. System/developer
+messages from the AG-UI input are dropped unless opted in.
+
+Source: `packages/runtime/src/agent/index.ts:440-456,809-815`.
+
+### MEDIUM Aborting factory's abortController directly
+
+Wrong:
+
+```typescript
+factory: (ctx) => {
+  ctx.abortController.abort(); // JSDoc says don't
+  return streamText({
+    /* ... */
+  });
+};
+```
+
+Correct:
+
+```typescript
+factory: (ctx) => streamText({ /* ... */, abortSignal: ctx.abortSignal });
+// Externally, from outside the factory:
+agent.abortRun();
+```
+
+The JSDoc on `AgentFactoryContext.abortController` explicitly warns against calling
+`.abort()` on it inside the factory — use `agent.abortRun()` or pass `abortSignal` to the
+downstream fetch/LLM call.
+
+Source: `packages/runtime/src/agent/index.ts:670-672`.
+
+## References
+
+- [Model identifiers — supported strings](built-in-agent-model-identifiers.md)
+- [Factory modes — TanStack AI / AI SDK / custom cookbook](built-in-agent-factory-modes.md)
+- [Helper utilities — converter function signatures](built-in-agent-helper-utilities.md)
+
+## See also
+
+- `copilotkit/server-side-tools` — `defineTool` powers `config.tools` in Simple Mode
+- `copilotkit/setup-endpoint` — mount the runtime that hosts this agent
+- `copilotkit/wiring-external-agents` — alternative when you want an external framework

--- a/skills/runtime/references/intelligence-mode.md
+++ b/skills/runtime/references/intelligence-mode.md
@@ -1,0 +1,336 @@
+# CopilotKit Intelligence Mode
+
+Intelligence currently ships as a managed cloud service. The only supported `apiUrl` /
+`wsUrl` today is the CopilotKit-managed cloud Intelligence instance — the `ɵ`-prefixed
+runtime internals and REST/WebSocket contract that back Intelligence are still
+stabilizing and `organizationId` is reserved for future self-hosted deployments. If you
+need on-prem durable threads today, use SSE mode with a persistent runner
+(`SqliteAgentRunner` or a custom one) instead.
+
+Obtain `apiKey` and `organizationId` from the CopilotKit Cloud dashboard.
+
+### URL format
+
+The client prepends `/api/...` and the Intelligence websocket layer derives `/runner`
+or `/client` suffixes internally. Pass the bare base URLs — do NOT append `/api`,
+`/socket`, `/runner`, or `/client` yourself:
+
+```typescript
+// Correct — bare base URLs
+apiUrl: "https://api.copilotkit.ai",
+wsUrl:  "wss://api.copilotkit.ai",
+
+// Wrong — adding /api produces /api/api/... on every REST call; /socket/runner is not a real path
+apiUrl: "https://api.copilotkit.ai/api",
+wsUrl:  "wss://api.copilotkit.ai/socket",
+```
+
+Source: `packages/runtime/src/v2/runtime/intelligence-platform/client.ts:41-46, 259,
+356-357, 437, 468, 682-708`.
+
+## Setup
+
+```typescript
+import {
+  CopilotRuntime,
+  CopilotKitIntelligence,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+
+const intelligence = new CopilotKitIntelligence({
+  apiUrl: "https://api.copilotkit.ai",
+  wsUrl: "wss://api.copilotkit.ai",
+  apiKey: process.env.COPILOTKIT_CLOUD_API_KEY!,
+  organizationId: process.env.COPILOTKIT_CLOUD_ORG_ID!,
+});
+
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+  intelligence,
+  identifyUser: (request) => ({
+    id: request.headers.get("x-user-id") ?? "anonymous",
+  }),
+  // Optional tuning:
+  generateThreadNames: true, // default true — 1 LLM call per new thread
+  lockTtlSeconds: 20, // clamped to ≤ 3600
+  lockHeartbeatIntervalSeconds: 15, // clamped to ≤ 3000
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+When `intelligence` is set, the runtime auto-wires `IntelligenceAgentRunner` internally.
+Do NOT pass `runner` — see the failure-modes section.
+
+## Core Patterns
+
+### Identify the user from an auth cookie
+
+`identifyUser` is for user identification only — it does NOT forward thrown `Response`s.
+`resolveIntelligenceUser` (`handlers/shared/resolve-intelligence-user.ts:14-24`) wraps the
+call in try/catch and converts any thrown value (including `Response`) into a generic
+`errorResponse("Failed to identify user", 500)`. Gate auth in `hooks.onRequest`
+(see the `middleware` skill) and keep `identifyUser` focused on returning an id:
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { parse } from "cookie";
+
+const runtime = new CopilotRuntime({
+  agents,
+  intelligence,
+  // identifyUser returns the id; auth rejection is hooked elsewhere.
+  identifyUser: async (request) => {
+    const cookies = parse(request.headers.get("cookie") ?? "");
+    const user = await resolveSession(cookies["session"]); // your auth lib
+    return { id: user?.id ?? "anonymous" };
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onRequest: async ({ request }) => {
+      const cookies = parse(request.headers.get("cookie") ?? "");
+      const user = await resolveSession(cookies["session"]);
+      // onRequest DOES forward thrown Responses — use it for auth rejection.
+      if (!user) throw new Response("Unauthorized", { status: 401 });
+    },
+  },
+});
+
+async function resolveSession(token: string | undefined) {
+  if (!token) return null;
+  return { id: "user-123" };
+}
+```
+
+### Disable thread-name generation to avoid a per-thread LLM call
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser: (req) => ({ id: req.headers.get("x-user-id")! }),
+  generateThreadNames: false,
+});
+```
+
+### Frontend — no config change
+
+The frontend reads `GET /info` on mount. When the runtime reports `mode: "intelligence"`
+and an `intelligence.wsUrl`, `CopilotKitCore` auto-switches from SSE to the websocket
+transport. The React integration just points at the runtime URL:
+
+```tsx
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+export function App({ children }: { children: React.ReactNode }) {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+      {children}
+    </CopilotKitProvider>
+  );
+}
+```
+
+## Common Mistakes
+
+### CRITICAL Missing identifyUser
+
+Wrong:
+
+```typescript
+new CopilotRuntime({ agents, intelligence });
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser: (req) => ({ id: req.headers.get("x-user-id")! }),
+});
+```
+
+`identifyUser` is required on `CopilotIntelligenceRuntimeOptions` — omitting it is a
+TypeScript error and (if suppressed) crashes handlers at request time. Every thread is
+scoped to a user ID.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts:156-160`.
+
+### CRITICAL Adding /api or /socket suffixes, or pointing at an unsupported self-hosted server
+
+Wrong:
+
+```typescript
+new CopilotKitIntelligence({
+  apiUrl: "https://api.copilotkit.ai/api", // double /api prefix
+  wsUrl: "wss://api.copilotkit.ai/socket", // /socket is not a real path
+  apiKey,
+  organizationId,
+});
+
+new CopilotKitIntelligence({
+  apiUrl: "https://internal.myco.com/intelligence", // self-hosting is not yet supported
+  wsUrl: "wss://internal.myco.com/intelligence",
+  apiKey,
+  organizationId,
+});
+```
+
+Correct:
+
+```typescript
+new CopilotKitIntelligence({
+  apiUrl: "https://api.copilotkit.ai",
+  wsUrl: "wss://api.copilotkit.ai",
+  apiKey: process.env.COPILOTKIT_CLOUD_API_KEY!,
+  organizationId: process.env.COPILOTKIT_CLOUD_ORG_ID!,
+});
+// For on-prem durability without Intelligence: SSE mode + SqliteAgentRunner.
+```
+
+Two failure modes to avoid:
+
+1. The client prepends `/api/...` to every REST call (`#request` at line 356-357) and
+   the websocket layer derives `/runner` / `/client` suffixes from `wsUrl` internally.
+   Passing `apiUrl: ".../api"` produces double-prefixed `/api/api/threads`; passing
+   `wsUrl: ".../socket"` produces a broken `.../socket/runner` upgrade path.
+2. Self-hosting Intelligence is not yet supported. The `ɵ`-prefixed runtime internals
+   and REST/WebSocket contract are still stabilizing. `organizationId` is reserved for
+   future self-hosted instances. For on-prem durable threads today, use SSE mode +
+   `SqliteAgentRunner` (see `copilotkit/agent-runners`).
+
+Source: `packages/runtime/src/v2/runtime/intelligence-platform/client.ts:41-46, 68-69,
+259, 356-357, 437, 682-708`.
+
+### HIGH Setting runner alongside intelligence
+
+Wrong:
+
+```typescript
+import { SqliteAgentRunner } from "@copilotkit/sqlite-runner";
+
+new CopilotRuntime({
+  agents,
+  intelligence,
+  runner: new SqliteAgentRunner({ dbPath: "./threads.db" }),
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser,
+});
+```
+
+`CopilotIntelligenceRuntimeOptions` excludes `runner` at the type level. Intelligence
+forces its own `IntelligenceAgentRunner` tied to the Cloud WebSocket; a user-supplied
+runner is rejected.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts:149-173,285-294`.
+
+### HIGH Calling /threads against an SSE-mode runtime
+
+Wrong:
+
+```typescript
+// SSE-only runtime (no `intelligence` configured)
+await fetch("/api/copilotkit/threads");
+```
+
+Correct:
+
+```typescript
+// Enable Intelligence mode first, OR don't call thread routes.
+// Client-side, the useThreads hook errors with "Runtime URL is not configured" when
+// the runtime isn't in Intelligence mode.
+```
+
+The `/threads`, `/threads/subscribe`, `PATCH /threads/:id`, `POST /threads/:id/archive`,
+`DELETE /threads/:id`, and `/threads/:id/messages` routes always resolve in the router,
+but the handlers call `requireIntelligenceRuntime(runtime)` first and return HTTP 422
+("Missing CopilotKitIntelligence configuration. Thread operations require a
+CopilotKitIntelligence instance to be provided in CopilotRuntime options.") when the
+runtime isn't an `IntelligenceRuntime`.
+
+Source: `packages/runtime/src/v2/runtime/handlers/intelligence/threads.ts:37-48`;
+route table in `dev-docs/architecture/setup-intelligence.md:179-183`.
+
+### LOW Over-clamping lockTtlSeconds
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser,
+  lockTtlSeconds: 86400, // "I want 1-day lock"
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser,
+  lockTtlSeconds: 3600, // max is 1 hour
+});
+// Rethink long-running workflows if 1 hour is insufficient.
+```
+
+`lockTtlSeconds` is silently `Math.min(value, 3600)`; `lockHeartbeatIntervalSeconds` is
+`Math.min(value, 3000)`. Requests over the cap are clamped without warning.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts:281-307`.
+
+### MEDIUM generateThreadNames unset expecting no LLM cost
+
+Wrong:
+
+```typescript
+new CopilotRuntime({ agents, intelligence, identifyUser });
+// assumes no extra LLM spend
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser,
+  generateThreadNames: false,
+});
+```
+
+`generateThreadNames` defaults to `true`. Every newly created thread triggers an extra
+LLM call on the Cloud side to generate a short name, billed against your Cloud quota.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts` (generateThreadNames default).
+
+## See also
+
+- `copilotkit/agent-runners` — Intelligence forces `IntelligenceAgentRunner`
+- `copilotkit/setup-endpoint` — `/threads/*` routes flip on with Intelligence
+- `copilotkit/threads` (react-core) — `useThreads` depends on Intelligence routes

--- a/skills/runtime/references/middleware.md
+++ b/skills/runtime/references/middleware.md
@@ -1,0 +1,376 @@
+# CopilotKit Runtime Middleware
+
+Two coexisting middleware surfaces:
+
+- **`hooks`** (preferred, newer) — pass to `createCopilotRuntimeHandler({ hooks })`.
+  Route-aware via `onBeforeHandler({ route })`. Throw a `Response` to short-circuit.
+- **`beforeRequestMiddleware` / `afterRequestMiddleware`** (legacy) — pass to
+  `new CopilotRuntime({ ... })`. Runs **after `hooks.onRequest` but before routing** (see
+  `fetch-handler.ts:136-147` for exact order). Pre-routing only.
+
+Use **hooks** for new code.
+
+## Setup
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onRequest: async ({ request }) => {
+      const token = request.headers.get("authorization");
+      if (!token) throw new Response("Unauthorized", { status: 401 });
+    },
+    onBeforeHandler: async ({ route, request }) => {
+      if (route.method === "agent/run" && route.agentId === "admin") {
+        const user = await verifyAdminToken(
+          request.headers.get("authorization"),
+        );
+        if (!user) throw new Response("Forbidden", { status: 403 });
+      }
+    },
+    onResponse: async ({ response }) => {
+      const headers = new Headers(response.headers);
+      headers.set("x-copilot-version", "2.0");
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
+    },
+    onError: async ({ error, route }) => {
+      console.error("[copilotkit]", route?.method, error);
+    },
+  },
+});
+
+async function verifyAdminToken(
+  header: string | null,
+): Promise<{ id: string } | null> {
+  if (!header) return null;
+  // delegate to your auth lib
+  return { id: "admin" };
+}
+
+export default { fetch: handler };
+```
+
+## Core Patterns
+
+### Reject unauthenticated requests at the runtime boundary
+
+```typescript
+createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onRequest: ({ request }) => {
+      const token = request.headers.get("authorization");
+      if (!token?.startsWith("Bearer ")) {
+        throw new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    },
+  },
+});
+```
+
+### Route-aware authorization
+
+Use `onBeforeHandler` — the `route` object carries `method`, `agentId`, and (for thread/stop
+methods) `threadId`.
+
+```typescript
+createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onBeforeHandler: async ({ route, request }) => {
+      if (route.method === "agent/run" && route.agentId === "billing") {
+        const ok = await canAccessBilling(request);
+        if (!ok) throw new Response("Forbidden", { status: 403 });
+      }
+    },
+  },
+});
+
+async function canAccessBilling(request: Request): Promise<boolean> {
+  // delegate to your policy engine
+  return true;
+}
+```
+
+### Rate-limit by calling an external limiter from the hook
+
+Delegate to a dedicated lib — do not implement a rate limiter inline.
+
+```typescript
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+const ratelimit = new Ratelimit({
+  redis: Redis.fromEnv(),
+  limiter: Ratelimit.slidingWindow(60, "1 m"),
+});
+
+createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onRequest: async ({ request }) => {
+      const userId = request.headers.get("x-user-id") ?? "anon";
+      const { success } = await ratelimit.limit(userId);
+      if (!success) throw new Response("Too Many Requests", { status: 429 });
+    },
+  },
+});
+```
+
+### Non-blocking telemetry on response
+
+`afterRequestMiddleware` runs non-blocking (errors inside only log). Do not await heavy
+work that the user's response waits on.
+
+```typescript
+import { CopilotRuntime } from "@copilotkit/runtime/v2";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+  afterRequestMiddleware: async ({ threadId, messages }) => {
+    // fire-and-forget; do not await heavy work that blocks response
+    void queue.enqueue({ type: "chat", threadId, messages });
+  },
+});
+```
+
+## Common Mistakes
+
+### HIGH Returning a Response instead of throwing
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async () =>
+    new Response("Unauthorized", { status: 401 }),
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async ({ request }) => {
+    if (!request.headers.get("authorization")) {
+      throw new Response("Unauthorized", { status: 401 });
+    }
+  },
+});
+```
+
+The middleware contract returns `Request | void`. Returning a Response corrupts the
+request object — `fetch-handler.ts:140-147` assigns any truthy return value back to
+`request`, so the router then tries to read `request.method` / `request.headers.get(...)`
+from the Response and downstream handling blows up. Always `throw` a Response to
+short-circuit; never return one.
+
+Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:140-156`.
+
+### MEDIUM Defaulting to beforeRequestMiddleware when hooks are preferred
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async ({ request, path }) => {
+    if (path.includes("/agent/admin/")) {
+      /* check admin auth */
+    }
+  },
+});
+```
+
+Correct:
+
+```typescript
+const runtime = new CopilotRuntime({ agents });
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onBeforeHandler: ({ route, request }) => {
+      if (route.method === "agent/run" && route.agentId === "admin") {
+        /* ... */
+      }
+    },
+  },
+});
+```
+
+Both surfaces coexist. For new code the hook API on `createCopilotRuntimeHandler` is
+preferred — `onBeforeHandler` receives typed `route` info, so you don't string-match paths.
+
+Source: `packages/runtime/src/v2/runtime/core/hooks.ts:84-117`; maintainer Phase 4c.
+
+### MEDIUM Route-specific auth in global beforeRequestMiddleware
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async ({ path, request }) => {
+    if (path.includes("/agent/admin/")) {
+      /* ... */
+    }
+  },
+});
+```
+
+Correct:
+
+```typescript
+createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onBeforeHandler: ({ route, request }) => {
+      if (route.method === "agent/run" && route.agentId === "admin") {
+        /* ... */
+      }
+    },
+  },
+});
+```
+
+`beforeRequestMiddleware` fires before routing, so no route info exists yet — string-matching
+paths is fragile. `onBeforeHandler` fires after routing with typed `route.method`, `route.agentId`.
+
+Source: `packages/runtime/src/v2/runtime/core/hooks.ts:94-103`.
+
+### MEDIUM Blocking on afterRequestMiddleware
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  afterRequestMiddleware: async ({ response, threadId, messages }) => {
+    await heavyAnalytics(response, threadId, messages);
+  },
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  afterRequestMiddleware: async ({ response, threadId, messages }) => {
+    void queue.enqueue({ type: "chat", threadId, messages, response });
+  },
+});
+```
+
+The `afterRequestMiddleware` callback receives
+`{ runtime, response, path, messages?, threadId?, runId? }` — all these fields are always
+available (`messages`/`threadId`/`runId` are populated from the SSE stream when present,
+undefined otherwise). The hook runs non-blocking via `.catch()` so errors only log and any
+heavy awaited work can be lost on process exit — fire-and-forget is the intended shape.
+
+Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:225-234`.
+
+### MEDIUM Passing a webhook URL string as middleware
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: "https://hooks.example/auth" as any,
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async ({ request }) => {
+    await fetch("https://hooks.example/auth", {
+      method: "POST",
+      body: request.headers.get("authorization") ?? "",
+    });
+  },
+});
+```
+
+Webhook-URL middleware is dead code in v2 — the runtime logs
+`"Unsupported beforeRequestMiddleware value – skipped"` and does nothing. Only function
+middleware is wired.
+
+Source: `packages/runtime/src/v2/runtime/core/middleware.ts:72-87`.
+
+### HIGH Implementing auth / rate-limit inside CopilotKit middleware
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async ({ request }) => {
+    // hand-rolling a token-bucket rate limiter inline with Redis calls...
+  },
+});
+```
+
+Correct:
+
+```typescript
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+const ratelimit = new Ratelimit({
+  redis: Redis.fromEnv(),
+  limiter: Ratelimit.slidingWindow(60, "1 m"),
+});
+
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async ({ request }) => {
+    const { success } = await ratelimit.limit(
+      request.headers.get("x-user-id") ?? "anon",
+    );
+    if (!success) throw new Response("Too Many Requests", { status: 429 });
+  },
+});
+```
+
+Auth, rate-limiting, and observability are server-framework concerns. CopilotKit middleware
+is the hook to invoke them, not a replacement.
+
+Source: maintainer interview (Phase 2c).
+
+## See also
+
+- `copilotkit/setup-endpoint` — `hooks` are passed to `createCopilotRuntimeHandler`
+- `copilotkit/go-to-production` — production checklist lists auth/rate-limit wiring
+- `copilotkit/debug-and-troubleshoot` — `onError` telemetry pattern

--- a/skills/runtime/references/server-side-tools.md
+++ b/skills/runtime/references/server-side-tools.md
@@ -1,0 +1,414 @@
+# CopilotKit Server-Side Tools
+
+Server-side tools run in the runtime process. They are the right choice when the tool needs
+to touch server-only state: DB connections, API keys, filesystem, signed URLs.
+
+`defineTool` returns a `ToolDefinition`. Pass an array of them to the Simple-Mode
+`BuiltInAgent.config.tools`, or into the `tools:` option of `chat()` / `streamText()` inside
+a Factory Mode factory.
+
+## Setup
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+  defineTool,
+} from "@copilotkit/runtime/v2";
+import { z } from "zod";
+
+const getInventory = defineTool({
+  name: "getInventory",
+  description: "Look up stock for a product SKU.",
+  parameters: z.object({ sku: z.string() }),
+  execute: async ({ sku }) => {
+    const row = await db.product.findUnique({ where: { sku } });
+    return { sku, inStock: row?.inStock ?? 0 };
+  },
+});
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({
+      model: "openai/gpt-4o",
+      maxSteps: 5,
+      tools: [getInventory],
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+
+declare const db: {
+  product: { findUnique: (q: any) => Promise<{ inStock: number } | null> };
+};
+```
+
+## Core Patterns
+
+### Zod parameters (most common)
+
+```typescript
+import { defineTool } from "@copilotkit/runtime/v2";
+import { z } from "zod";
+
+const searchDocs = defineTool({
+  name: "searchDocs",
+  description: "Search the internal docs index.",
+  parameters: z.object({
+    query: z.string().min(1),
+    limit: z.number().int().min(1).max(20).default(5),
+  }),
+  execute: async ({ query, limit }) => {
+    const results = await searchIndex(query, limit);
+    return { results };
+  },
+});
+
+declare const searchIndex: (q: string, n: number) => Promise<unknown[]>;
+```
+
+### Valibot parameters (Standard Schema V1)
+
+```typescript
+import { defineTool } from "@copilotkit/runtime/v2";
+import * as v from "valibot";
+
+const translate = defineTool({
+  name: "translate",
+  description: "Translate text between languages.",
+  parameters: v.object({
+    text: v.pipe(v.string(), v.minLength(1)),
+    target: v.picklist(["en", "es", "fr", "de"]),
+  }),
+  execute: async ({ text, target }) => ({ translated: `[${target}] ${text}` }),
+});
+```
+
+### Graceful error handling inside execute
+
+```typescript
+import { defineTool } from "@copilotkit/runtime/v2";
+import { z } from "zod";
+
+const runQuery = defineTool({
+  name: "runQuery",
+  description: "Run an analytics query.",
+  parameters: z.object({ sql: z.string() }),
+  execute: async ({ sql }) => {
+    try {
+      return { rows: await warehouse.query(sql) };
+    } catch (e) {
+      return { error: String(e), retryable: true };
+    }
+  },
+});
+
+declare const warehouse: { query: (sql: string) => Promise<unknown[]> };
+```
+
+### Server tool + client tool side by side
+
+Server tools for I/O, client tools for UI. Both can coexist.
+
+```typescript
+// server
+import { defineTool } from "@copilotkit/runtime/v2";
+import { z } from "zod";
+
+export const fetchOrder = defineTool({
+  name: "fetchOrder",
+  description: "Fetch order details from the orders service.",
+  parameters: z.object({ orderId: z.string() }),
+  execute: async ({ orderId }) => fetchOrderFromService(orderId),
+});
+declare const fetchOrderFromService: (id: string) => Promise<unknown>;
+```
+
+```tsx
+// client — a render-only tool lets the LLM display a modal
+import { useComponent } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+useComponent({
+  name: "showOrderDetails",
+  parameters: z.object({ orderId: z.string(), status: z.string() }),
+  // Schema fields arrive DIRECTLY as props (InferRenderProps<TSchema>) —
+  // no { args } wrapper. See packages/react-core/src/v2/hooks/use-component.tsx.
+  render: ({ orderId, status }) => (
+    <div className="modal">
+      Order {orderId} — {status}
+    </div>
+  ),
+});
+```
+
+### Factory Mode — pass tools into the factory
+
+Simple-Mode `config.tools` is ignored in Factory Mode.
+
+```typescript
+import {
+  BuiltInAgent,
+  convertToolDefinitionsToVercelAITools,
+  convertMessagesToVercelAISDKMessages,
+  defineTool,
+} from "@copilotkit/runtime/v2";
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+const searchDocs = defineTool({
+  name: "searchDocs",
+  description: "Search the internal docs index.",
+  parameters: z.object({ query: z.string() }),
+  execute: async ({ query }) => ({ results: [] }),
+});
+
+new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) => {
+    const serverTools = convertToolDefinitionsToVercelAITools([searchDocs]);
+    return streamText({
+      model: openai("gpt-4o"),
+      messages: convertMessagesToVercelAISDKMessages(input.messages),
+      tools: serverTools,
+      abortSignal,
+    });
+  },
+});
+```
+
+## Common Mistakes
+
+### HIGH Using defineTool for tools that should render UI
+
+Wrong:
+
+```typescript
+defineTool({
+  name: "showModal",
+  description: "Show a confirmation modal to the user.",
+  parameters: z.object({ title: z.string() }),
+  execute: async () => "rendered",
+});
+```
+
+Correct:
+
+```tsx
+// Keep UI on the client — frontend tool with a renderer
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+useFrontendTool({
+  name: "showModal",
+  parameters: z.object({ title: z.string() }),
+  handler: async (args) => ({ confirmed: true }),
+});
+```
+
+Server tools execute on the server and stream only results back. The browser never sees a
+`TOOL_CALL_START` for a server tool, so there is nothing to mount a renderer against.
+
+Source: `dev-docs/architecture/plugin-points.md:36-77`;
+`docs/content/docs/integrations/built-in-agent/server-tools.mdx:9-14`.
+
+### MEDIUM Redefining AG-UI reserved names
+
+Wrong:
+
+```typescript
+defineTool({
+  name: "AGUISendStateSnapshot",
+  description: "My own snapshot tool.",
+  parameters: z.object({ snapshot: z.any() }),
+  execute: async () => ({ success: true }),
+});
+```
+
+Correct:
+
+```typescript
+defineTool({
+  name: "mySnapshotExport",
+  description: "Export a user-facing state snapshot.",
+  parameters: z.object({ snapshot: z.any() }),
+  execute: async () => ({ success: true }),
+});
+```
+
+`AGUISendStateSnapshot` and `AGUISendStateDelta` are auto-injected by BuiltInAgent in
+Simple Mode — redefining them silently overwrites the built-ins.
+
+Source: `packages/runtime/src/agent/index.ts:1139-1177`.
+
+### MEDIUM Throwing from execute without a result
+
+Wrong:
+
+```typescript
+defineTool({
+  name: "runQuery",
+  description: "Run a database query.",
+  parameters: z.object({ sql: z.string() }),
+  execute: async () => {
+    throw new Error("db down");
+  },
+});
+```
+
+Correct:
+
+```typescript
+defineTool({
+  name: "runQuery",
+  description: "Run a database query.",
+  parameters: z.object({ sql: z.string() }),
+  execute: async ({ sql }) => {
+    try {
+      return await db.query(sql);
+    } catch (e) {
+      return { error: String(e), retryable: true };
+    }
+  },
+});
+```
+
+Thrown errors kill the run; unserializable results (class instances, circular refs) become
+the string `"[Unserializable tool result from X]"`. Return a plain-object error shape
+instead and let the LLM retry.
+
+Source: `packages/runtime/src/agent/index.ts:1469-1474`.
+
+### MEDIUM Passing a JSON-schema object as parameters
+
+Wrong:
+
+```typescript
+defineTool({
+  name: "x",
+  description: "...",
+  parameters: {
+    type: "object",
+    properties: { q: { type: "string" } },
+    required: ["q"],
+  } as any,
+  execute: async ({ q }) => q,
+});
+```
+
+Correct:
+
+```typescript
+import { z } from "zod";
+
+defineTool({
+  name: "x",
+  description: "...",
+  parameters: z.object({ q: z.string() }),
+  execute: async ({ q }) => q,
+});
+```
+
+`parameters` must be a Standard Schema V1 validator (Zod, Valibot, ArkType, ...). Plain
+JSON Schema throws in `schemaToJsonSchema()`. Also, Standard Schema V1 preserves static
+types — `execute`'s arg type is inferred.
+
+Source: `packages/runtime/src/agent/index.ts:633-659`.
+
+### HIGH Unavailable in Factory Mode via config.tools
+
+Wrong:
+
+```typescript
+new BuiltInAgent({
+  type: "tanstack",
+  factory: myFactory,
+  tools: [searchDocs], // ignored in Factory Mode
+} as any);
+```
+
+Correct:
+
+```typescript
+// Factory Mode — AI SDK factory: convert defineTool → Vercel AI SDK tools
+import {
+  BuiltInAgent,
+  convertToolDefinitionsToVercelAITools,
+  convertMessagesToVercelAISDKMessages,
+} from "@copilotkit/runtime/v2";
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+new BuiltInAgent({
+  type: "aisdk",
+  factory: ({ input, abortSignal }) => {
+    const tools = convertToolDefinitionsToVercelAITools([searchDocs]);
+    return streamText({
+      model: openai("gpt-4o"),
+      messages: convertMessagesToVercelAISDKMessages(input.messages),
+      tools,
+      abortSignal,
+    });
+  },
+});
+
+// Factory Mode — TanStack AI factory: defineTool output is NOT a TanStack tool.
+// There is no built-in converter in @copilotkit/runtime for TanStack. Either
+// redefine the tool with TanStack's `toolDefinition()` API from `@tanstack/ai`,
+// or write a small adapter that translates your `defineTool` output into
+// TanStack's tool shape before passing it into `chat({ tools })`.
+```
+
+Factory Mode ignores `config.tools`. Wire server tools through the factory's LLM call —
+AI SDK has `convertToolDefinitionsToVercelAITools([...])` out of the box; TanStack AI has
+its own `toolDefinition()` API you need to build the tools with directly.
+
+Source: `packages/runtime/src/agent/index.ts:1581-1671`.
+
+### MEDIUM Shared name between client and server tool
+
+Wrong:
+
+```tsx
+// frontend
+useFrontendTool({
+  name: "getWeather",
+  parameters: z.object({ city: z.string() }),
+  handler,
+});
+
+// server
+defineTool({
+  name: "getWeather",
+  parameters: z.object({ city: z.string() }),
+  execute,
+});
+// Server silently wins on the merge — handler never fires
+```
+
+Correct:
+
+```tsx
+// Pick one side and give tools distinct names if both sides need their own
+useFrontendTool({ name: "getWeatherClientSide" /* ... */ });
+defineTool({ name: "getWeatherServer" /* ... */ });
+```
+
+On collisions, `config.tools` (server) overwrites frontend-registered tools. The LLM sees
+only one `getWeather` — the server version.
+
+Source: `packages/runtime/src/agent/index.ts` (tool merge).
+
+## See also
+
+- `copilotkit/built-in-agent` — `config.tools` only applies in Simple Mode
+- `copilotkit/client-side-tools` (react-core) — browser-side tools, paired decision
+- `copilotkit/rendering-tool-calls` (react-core) — rendering tool invocations in chat

--- a/skills/runtime/references/setup-endpoint.md
+++ b/skills/runtime/references/setup-endpoint.md
@@ -1,0 +1,503 @@
+# CopilotKit Runtime Endpoint
+
+`createCopilotRuntimeHandler` is the strongly-preferred primitive. It returns a
+`(Request) => Promise<Response>` that works in every fetch-native runtime and can be
+delegated to from Express/Hono/Node. Avoid `createCopilotExpressHandler` and
+`createCopilotHonoHandler` in new code.
+
+## Setup
+
+Minimal runtime on any fetch server (Bun, Deno, Cloudflare Workers, Vercel Edge):
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({
+      type: "tanstack",
+      factory: ({ input, abortController }) => {
+        const { messages, systemPrompts } = convertInputToTanStackAI(input);
+        return chat({
+          adapter: openaiText("gpt-4o"),
+          messages,
+          systemPrompts,
+          abortController,
+        });
+      },
+    }),
+  },
+});
+
+export const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  cors: true,
+});
+
+// Bun / Deno / Vercel Edge:
+//   Bun.serve({ fetch: handler });
+//   Deno.serve(handler);
+// Cloudflare Workers:
+//   export default { fetch: handler };
+```
+
+## Core Patterns
+
+### React Router v7 framework mode
+
+```typescript
+// app/routes/api.copilotkit.$.tsx
+import type { Route } from "./+types/api.copilotkit.$";
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({
+      type: "tanstack",
+      factory: ({ input, abortController }) => {
+        const { messages, systemPrompts } = convertInputToTanStackAI(input);
+        return chat({
+          adapter: openaiText("gpt-4o"),
+          messages,
+          systemPrompts,
+          abortController,
+        });
+      },
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export async function loader({ request }: Route.LoaderArgs) {
+  return handler(request);
+}
+export async function action({ request }: Route.ActionArgs) {
+  return handler(request);
+}
+```
+
+### Next.js App Router
+
+```typescript
+// app/api/copilotkit/[...slug]/route.ts
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({
+      type: "tanstack",
+      factory: ({ input, abortController }) => {
+        const { messages, systemPrompts } = convertInputToTanStackAI(input);
+        return chat({
+          adapter: openaiText("gpt-4o"),
+          messages,
+          systemPrompts,
+          abortController,
+        });
+      },
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handler;
+export const POST = handler;
+export const OPTIONS = handler;
+```
+
+### Cloudflare Workers with env-sourced keys
+
+Workers don't expose `env` at module scope, so build the runtime + handler lazily on the
+first request and cache them in module-scoped variables. `openaiText(model, config)` does
+NOT accept an `apiKey` in its config (it auto-reads `OPENAI_API_KEY` from env) — for an
+explicit key, use `createOpenaiChat(model, apiKey, config?)`.
+
+```typescript
+// worker.ts
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { chat } from "@tanstack/ai";
+import { createOpenaiChat } from "@tanstack/ai-openai";
+
+interface Env {
+  OPENAI_API_KEY: string;
+}
+
+type Handler = (request: Request) => Promise<Response>;
+let handler: Handler | undefined;
+
+function getHandler(env: Env): Handler {
+  if (handler) return handler;
+  const runtime = new CopilotRuntime({
+    agents: {
+      default: new BuiltInAgent({
+        type: "tanstack",
+        factory: ({ input, abortController }) => {
+          const { messages, systemPrompts } = convertInputToTanStackAI(input);
+          return chat({
+            adapter: createOpenaiChat("gpt-4o", env.OPENAI_API_KEY),
+            messages,
+            systemPrompts,
+            abortController,
+          });
+        },
+      }),
+    },
+  });
+  handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    cors: true,
+  });
+  return handler;
+}
+
+export default {
+  fetch(request: Request, env: Env) {
+    return getHandler(env)(request);
+  },
+};
+```
+
+### Delegate from Express / Hono to the fetch primitive
+
+Do not use `createCopilotExpressHandler` / `createCopilotHonoHandler`.
+
+```typescript
+// Express — requires Node 18.17+ for Readable.fromWeb + fetch body: req
+import express from "express";
+import { Readable } from "node:stream";
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+
+const app = express();
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+});
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+app.all("/api/copilotkit/*", async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  // `body: req` + `duplex: "half"` lets us stream the Node IncomingMessage
+  // into a Web Request without buffering (Node 18.17+).
+  const webReq = new Request(url, {
+    method: req.method,
+    headers: req.headers as any,
+    body: ["GET", "HEAD"].includes(req.method!) ? undefined : req,
+    duplex: "half",
+  } as any);
+  const webRes = await handler(webReq);
+  res.status(webRes.status);
+  webRes.headers.forEach((v, k) => res.setHeader(k, v));
+  // Stream the response body through — required for SSE on
+  // /agent/*/run and /agent/*/connect. Buffering via arrayBuffer()
+  // would collapse the stream and deliver all events at end-of-stream.
+  if (webRes.body) {
+    Readable.fromWeb(webRes.body as unknown as WebReadableStream).pipe(res);
+  } else {
+    res.end();
+  }
+});
+
+app.listen(3000);
+```
+
+```typescript
+// Hono — already speaks Request/Response
+import { Hono } from "hono";
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+
+const app = new Hono();
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+});
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+app.all("/api/copilotkit/*", (c) => handler(c.req.raw));
+
+export default app;
+```
+
+### Route table
+
+Multi-route mode (default) exposes: `GET /info`, `POST /agent/:agentId/run`,
+`GET /agent/:agentId/connect`, `POST /agent/:agentId/stop/:threadId`, `POST /transcribe`,
+`GET/POST /threads`, `GET /threads/subscribe`, `PATCH /threads/:threadId`,
+`POST /threads/:threadId/archive`, `DELETE /threads/:threadId`,
+`GET /threads/:threadId/messages`. Thread routes are only wired when Intelligence mode
+is configured.
+
+Single-route mode exposes a single `POST basePath` that accepts
+`{ method, params, body }` envelopes — use when behind a strict reverse proxy.
+
+## Common Mistakes
+
+### CRITICAL Using createCopilotExpressHandler / createCopilotHonoHandler in new code
+
+Wrong:
+
+```typescript
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
+app.use(
+  "/api/copilotkit",
+  createCopilotExpressHandler({ runtime, basePath: "/api/copilotkit" }),
+);
+```
+
+Correct:
+
+```typescript
+import { Readable } from "node:stream";
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
+import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+app.all("/api/copilotkit/*", async (req, res) => {
+  // Requires Node 18.17+ (Readable.fromWeb + duplex: "half")
+  const webReq = new Request(new URL(req.url, `http://${req.headers.host}`), {
+    method: req.method,
+    headers: req.headers as any,
+    body: ["GET", "HEAD"].includes(req.method!) ? undefined : req,
+    duplex: "half",
+  } as any);
+  const webRes = await handler(webReq);
+  res.status(webRes.status);
+  webRes.headers.forEach((v, k) => res.setHeader(k, v));
+  // Stream, don't buffer — /agent/*/run is SSE.
+  if (webRes.body) {
+    Readable.fromWeb(webRes.body as unknown as WebReadableStream).pipe(res);
+  } else {
+    res.end();
+  }
+});
+```
+
+The Express and Hono adapters are a discouraged surface — the maintainer flags them as
+"avoid at all costs." They pull in heavier dependencies, add framework binding, and make
+it harder to port. The fetch handler works from any Express/Hono route.
+
+Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:1-27`; maintainer Phase 4d.
+
+### CRITICAL Instantiating Express handler without basePath
+
+Wrong:
+
+```typescript
+app.use(createCopilotExpressHandler({ runtime }));
+```
+
+Correct:
+
+```typescript
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+app.all("/api/copilotkit/*", (req, res) => {
+  /* delegate as shown above */
+});
+```
+
+`normalizeBasePath` throws `"basePath must be provided for Express endpoint"` at mount time
+and crashes the server.
+
+Source: `packages/runtime/src/v2/runtime/endpoints/express.ts:161`.
+
+### HIGH Using framework adapter on Workers / Bun / Deno
+
+Wrong:
+
+```typescript
+// Cloudflare Worker
+import { createCopilotHonoHandler } from "@copilotkit/runtime/v2/hono";
+export default app;
+```
+
+Correct:
+
+```typescript
+import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+export default { fetch: (req: Request) => handler(req) };
+```
+
+Adapters bundle Node polyfills unnecessarily in fetch-native runtimes.
+
+Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:1-27`.
+
+### HIGH Returning a Response from beforeRequestMiddleware
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  beforeRequestMiddleware: async () =>
+    new Response("Unauthorized", { status: 401 }),
+});
+```
+
+Correct:
+
+```typescript
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onRequest: ({ request }) => {
+      if (!request.headers.get("authorization")) {
+        throw new Response("Unauthorized", { status: 401 });
+      }
+    },
+  },
+});
+```
+
+Only `Request | void` returns are honored. Any other return is ignored. Responses must be
+thrown.
+
+Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:148-156`.
+
+### MEDIUM Calling multi-route paths against a single-route handler
+
+Wrong:
+
+```typescript
+// handler = createCopilotRuntimeHandler({ mode: "single-route", ... })
+fetch("/api/copilotkit/agent/x/run", {
+  method: "POST",
+  body: JSON.stringify(input),
+});
+```
+
+Correct:
+
+```typescript
+fetch("/api/copilotkit", {
+  method: "POST",
+  body: JSON.stringify({
+    method: "agent/run",
+    params: { agentId: "x" },
+    body: input,
+  }),
+});
+// On the client, pair with <CopilotKitProvider useSingleEndpoint />.
+```
+
+Single-route expects a POST envelope with `{ method, params, body }`; URL-pattern calls 404.
+
+Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:86-90,350-401`.
+
+### MEDIUM Double-layering CORS in Express
+
+Wrong:
+
+```typescript
+import cors from "cors";
+app.use(cors());
+app.use(
+  createCopilotExpressHandler({ runtime, basePath, cors: { origin: "..." } }),
+);
+```
+
+Correct:
+
+```typescript
+// Pick one — handler's cors option OR your own cors(), not both:
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  cors: { origin: "https://my.app" },
+});
+app.all("/api/copilotkit/*", (req, res) => {
+  /* delegate as above */
+});
+```
+
+Both layers add CORS headers and the duplicates break strict browser enforcement.
+
+Source: `packages/runtime/src/v2/runtime/endpoints/express.ts:100-143`.
+
+### HIGH Mixing v1 and v2 import paths
+
+Wrong:
+
+```typescript
+import { CopilotRuntime } from "@copilotkit/runtime";
+import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
+```
+
+Correct:
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+```
+
+Both v1 and v2 APIs compile together but route through different implementations. Always
+use the `/v2` subpath in v2 code.
+
+Source: `packages/runtime/src/v2/index.ts`.
+
+## See also
+
+- `copilotkit/middleware` — hook lifecycle into this handler
+- `copilotkit/agent-runners` — pair with a persistent runner for production
+- `copilotkit/intelligence-mode` — thread routes flip on when Intelligence is configured

--- a/skills/runtime/references/transcription.md
+++ b/skills/runtime/references/transcription.md
@@ -1,0 +1,287 @@
+# CopilotKit Transcription
+
+Subclass `TranscriptionService`, pass an instance to `CopilotRuntime({ transcriptionService })`,
+and the `POST /transcribe` endpoint lights up. The service has a single method,
+`transcribeFile`, that returns the transcript as a plain string.
+
+## Setup
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  TranscriptionService,
+  type TranscribeFileOptions,
+} from "@copilotkit/runtime/v2";
+import OpenAI from "openai";
+
+class OpenAIWhisperTranscription extends TranscriptionService {
+  private client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  async transcribeFile({ audioFile }: TranscribeFileOptions): Promise<string> {
+    const result = await this.client.audio.transcriptions.create({
+      file: audioFile,
+      model: "whisper-1",
+    });
+    return result.text;
+  }
+}
+
+const runtime = new CopilotRuntime({
+  agents: {
+    /* ... */
+  } as any,
+  transcriptionService: new OpenAIWhisperTranscription(),
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Core Patterns
+
+### Abstract contract
+
+```typescript
+// packages/runtime/src/v2/runtime/transcription-service/transcription-service.ts
+export interface TranscribeFileOptions {
+  audioFile: File;
+  mimeType?: string;
+  size?: number;
+}
+
+export abstract class TranscriptionService {
+  abstract transcribeFile(options: TranscribeFileOptions): Promise<string>;
+}
+```
+
+### Supported request shapes
+
+Multipart (REST mode):
+
+```typescript
+const form = new FormData();
+form.append("audio", blob, "recording.webm");
+await fetch("/api/copilotkit/transcribe", { method: "POST", body: form });
+```
+
+JSON (works in both multi-route and single-endpoint modes — dispatch is by
+`Content-Type: application/json`; `mimeType` is required in the payload):
+
+```typescript
+await fetch("/api/copilotkit/transcribe", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    audio: base64String,
+    mimeType: "audio/webm",
+    filename: "recording.webm", // optional
+  }),
+});
+```
+
+### Reject oversize audio with a graceful 400
+
+```typescript
+class OpenAIWhisperTranscription extends TranscriptionService {
+  private client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  async transcribeFile({
+    audioFile,
+    size,
+  }: TranscribeFileOptions): Promise<string> {
+    const max = 25 * 1024 * 1024; // 25 MB
+    if ((size ?? audioFile.size) > max) {
+      // "too long" keyword → audio_too_long response
+      throw new Error("Audio duration too long — max 25MB per upload");
+    }
+    const result = await this.client.audio.transcriptions.create({
+      file: audioFile,
+      model: "whisper-1",
+    });
+    return result.text;
+  }
+}
+```
+
+### Error auto-categorization
+
+The runtime inspects `String(error).toLowerCase()` thrown by your service and maps keywords
+to error codes. Let the provider error bubble up — do not re-categorize inside the service.
+
+| Keyword substrings                       | Maps to                          |
+| ---------------------------------------- | -------------------------------- |
+| `rate`, `429`, `too many`                | `rate_limited` (retryable)       |
+| `auth`, `401`, `api key`, `unauthorized` | `auth_failed` (not retryable)    |
+| `too long`, `duration`, `length`         | `audio_too_long` (not retryable) |
+| (anything else)                          | `provider_error` (retryable)     |
+
+Full error-code enum:
+
+```typescript
+// packages/shared/src/transcription-errors.ts
+export enum TranscriptionErrorCode {
+  SERVICE_NOT_CONFIGURED = "service_not_configured",
+  INVALID_AUDIO_FORMAT = "invalid_audio_format",
+  AUDIO_TOO_LONG = "audio_too_long",
+  AUDIO_TOO_SHORT = "audio_too_short",
+  RATE_LIMITED = "rate_limited",
+  AUTH_FAILED = "auth_failed",
+  PROVIDER_ERROR = "provider_error",
+  NETWORK_ERROR = "network_error",
+  INVALID_REQUEST = "invalid_request",
+}
+```
+
+## Common Mistakes
+
+### HIGH Calling /transcribe without configuring transcriptionService
+
+Wrong:
+
+```typescript
+new CopilotRuntime({ agents });
+// client calls /api/copilotkit/transcribe → 503
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents,
+  transcriptionService: new MyWhisperService(),
+});
+```
+
+Unconfigured runtime returns HTTP 503 with
+`{ error: "service_not_configured" }`. The frontend gets no transcript with no obvious
+server-side failure.
+
+Source: `packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts:203-207`.
+
+### MEDIUM Form field named "file" instead of "audio"
+
+Wrong:
+
+```typescript
+const form = new FormData();
+form.append("file", blob, "recording.webm");
+await fetch("/api/copilotkit/transcribe", { method: "POST", body: form });
+```
+
+Correct:
+
+```typescript
+const form = new FormData();
+form.append("audio", blob, "recording.webm");
+await fetch("/api/copilotkit/transcribe", { method: "POST", body: form });
+```
+
+The handler reads `formData.get("audio")` — any other field name yields `null` and returns
+`invalid_request`.
+
+Source: `packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts:91-97`.
+
+### MEDIUM Base64 payload missing mimeType
+
+Wrong:
+
+```typescript
+await fetch("/api/copilotkit/transcribe", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ audio: b64 }),
+});
+```
+
+Correct:
+
+```typescript
+await fetch("/api/copilotkit/transcribe", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ audio: b64, mimeType: "audio/webm" }),
+});
+```
+
+JSON mode requires `mimeType` — the handler explicitly rejects payloads missing it with
+`invalid_request`.
+
+Source: `packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts:131-136`.
+
+### LOW Re-categorizing errors inside the service
+
+Wrong:
+
+```typescript
+class MyService extends TranscriptionService {
+  async transcribeFile(opts: TranscribeFileOptions): Promise<string> {
+    try {
+      return await doTranscribe(opts);
+    } catch (e) {
+      // trying to hand-pick error codes
+      throw new Error("RATE_LIMITED");
+    }
+  }
+}
+```
+
+Correct:
+
+```typescript
+class MyService extends TranscriptionService {
+  async transcribeFile(opts: TranscribeFileOptions): Promise<string> {
+    return doTranscribe(opts); // let provider errors bubble up verbatim
+  }
+}
+```
+
+The runtime scans `String(error).toLowerCase()` for `"rate"`, `"429"`, `"auth"`, `"too long"`
+etc. Provider-native messages (`"OpenAI returned 429 rate limited"`) auto-map to the right
+code. Hand-crafted codes bypass the keyword matcher and end up as `provider_error`.
+
+Source: `packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts:160-196`.
+
+### MEDIUM Returning a rich object instead of a string
+
+Wrong:
+
+```typescript
+class MyService extends TranscriptionService {
+  async transcribeFile(opts: TranscribeFileOptions): Promise<string> {
+    // @ts-expect-error returning the wrong shape
+    return {
+      text: "hi",
+      segments: [
+        /* ... */
+      ],
+    };
+  }
+}
+```
+
+Correct:
+
+```typescript
+class MyService extends TranscriptionService {
+  async transcribeFile(opts: TranscribeFileOptions): Promise<string> {
+    const result = await provider.transcribe(opts.audioFile);
+    return result.text;
+  }
+}
+```
+
+`transcribeFile` returns `Promise<string>`. The handler sends
+`{ transcription: string }` back to the client — any other shape is a TypeScript error and
+would be JSON-stringified wrongly at runtime.
+
+Source: `packages/runtime/src/v2/runtime/transcription-service/transcription-service.ts:9-11`.
+
+## See also
+
+- `copilotkit/setup-endpoint` — `/transcribe` is one of the routes the handler mounts
+- `copilotkit/debug-and-troubleshoot` — `TranscriptionErrorCode` catalog

--- a/skills/runtime/references/wiring-a2a.md
+++ b/skills/runtime/references/wiring-a2a.md
@@ -1,0 +1,40 @@
+A2A (Agent2Agent) — wired via `@ag-ui/a2a`. Requires a pre-built `A2AClient` (not a URL).
+
+## Install
+
+```bash
+pnpm add @ag-ui/a2a @a2a-js/sdk
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { A2AAgent } from "@ag-ui/a2a";
+import { A2AClient } from "@a2a-js/sdk/client";
+
+const a2aClient = new A2AClient(process.env.A2A_URL!);
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new A2AAgent({ a2aClient }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Gotcha — do NOT pass `{ url }`
+
+`A2AAgent` takes `{ a2aClient }`. The A2A protocol has its own handshake; the client
+object handles it. Passing `{ url: "..." }` is a type error and will fail at runtime.
+
+Source: `examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx:12`.

--- a/skills/runtime/references/wiring-adk.md
+++ b/skills/runtime/references/wiring-adk.md
@@ -1,0 +1,45 @@
+Google ADK (Agent Development Kit) — wired via the bare `HttpAgent` from `@ag-ui/client`.
+
+## Install
+
+```bash
+pnpm add @ag-ui/client
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new HttpAgent({
+      url: process.env.ADK_URL ?? "http://localhost:8000/",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Server side
+
+Your ADK Python agent must speak AG-UI. ADK ships an AG-UI FastAPI adapter — use it
+and point `HttpAgent({ url })` at the FastAPI route.
+
+## Gotcha — env-sourced credentials
+
+ADK typically authenticates to Google Cloud via service-account credentials
+(`GOOGLE_APPLICATION_CREDENTIALS`). Those live on the ADK Python server, not in the
+CopilotKit runtime. The runtime just forwards AG-UI events.
+
+Source: `docs/content/docs/integrations/adk/quickstart.mdx`.

--- a/skills/runtime/references/wiring-ag2.md
+++ b/skills/runtime/references/wiring-ag2.md
@@ -1,0 +1,41 @@
+AG2 — wired via the bare `HttpAgent` from `@ag-ui/client`. No dedicated `@ag-ui/ag2`
+package exists; AG2 is a standard HTTP AG-UI framework.
+
+## Install
+
+```bash
+pnpm add @ag-ui/client
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new HttpAgent({
+      url: process.env.AG2_URL ?? "http://localhost:8000/",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Gotcha — no dedicated package
+
+Unlike Mastra / LangGraph / CrewAI / LlamaIndex / Agno, AG2 has no `@ag-ui/ag2` package.
+Always use the generic `HttpAgent`. If an older doc references a dedicated AG2 package,
+treat it as stale.
+
+Source: `docs/content/docs/integrations/ag2/quickstart.mdx`; maintainer Phase 4 resolution.

--- a/skills/runtime/references/wiring-agno.md
+++ b/skills/runtime/references/wiring-agno.md
@@ -1,0 +1,39 @@
+Agno — wired via `@ag-ui/agno`. Requires an `/agui` URL suffix.
+
+## Install
+
+```bash
+pnpm add @ag-ui/agno
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { AgnoAgent } from "@ag-ui/agno";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new AgnoAgent({
+      url: process.env.AGNO_URL ?? "http://localhost:8000/agui",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Gotcha — the `/agui` suffix is mandatory
+
+Agno's AG-UI FastAPI app mounts at `/agui`. Pointing `url` at the server root
+(`http://localhost:8000`) returns 404. Always include `/agui`.
+
+Source: `docs/content/docs/integrations/agno/quickstart.mdx:215`.

--- a/skills/runtime/references/wiring-aws-strands.md
+++ b/skills/runtime/references/wiring-aws-strands.md
@@ -1,0 +1,59 @@
+AWS Strands — wired via the bare `HttpAgent` from `@ag-ui/client`.
+
+## Install
+
+```bash
+pnpm add @ag-ui/client
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new HttpAgent({
+      url: process.env.STRANDS_URL ?? "http://localhost:8000",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Server side
+
+Strands agents run on AWS and typically expose an AG-UI-speaking endpoint (API Gateway or
+Lambda Function URL). Point `HttpAgent({ url })` at that endpoint.
+
+## Gotcha — AWS auth
+
+Strands deployments often require IAM SigV4 or a custom header. `HttpAgent` accepts a
+`headers: Record<string, string>` option that is attached to every outbound runtime →
+Strands call:
+
+```typescript
+new HttpAgent({
+  url: process.env.STRANDS_URL!,
+  headers: { Authorization: `Bearer ${process.env.STRANDS_TOKEN!}` },
+});
+```
+
+`hooks.onBeforeHandler` will NOT work for this — those hooks run on the inbound frontend
+→ runtime request, not on the outbound runtime → Strands call that `HttpAgent` issues.
+For SigV4 (which needs a per-request signature over the body), front Strands with a
+lightweight Lambda / API Gateway authorizer that strips client credentials and adds the
+IAM signing, then point `HttpAgent({ url })` at that shim.
+
+Source: `node_modules/@ag-ui/client/dist/index.d.ts` (`HttpAgentConfig.headers`);
+`docs/content/docs/integrations/aws-strands/quickstart.mdx`.

--- a/skills/runtime/references/wiring-crewai-crews.md
+++ b/skills/runtime/references/wiring-crewai-crews.md
@@ -1,0 +1,51 @@
+CrewAI Crews — multi-agent crews wired via `@ag-ui/crewai`.
+
+## Install
+
+```bash
+pnpm add @ag-ui/crewai
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { CrewAIAgent } from "@ag-ui/crewai";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new CrewAIAgent({
+      url: process.env.CREWAI_URL ?? "http://localhost:8000/",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Crews vs Flows
+
+CrewAI ships two products:
+
+- **Crews** — multi-agent orchestration. Use `CrewAIAgent` from `@ag-ui/crewai`.
+- **Flows** — event-driven pipelines. Use the generic `HttpAgent` from `@ag-ui/client`
+  (there's no framework-specific wrapper). See [crewai-flows.md](crewai-flows.md).
+
+## Gotcha — trailing slash
+
+The `url` for `CrewAIAgent` traditionally ends with a trailing slash
+(`http://localhost:8000/`). Follow whatever your CrewAI server exposes — don't strip it.
+
+Source: `@ag-ui/crewai` package types (`CrewAIAgent` constructor);
+`docs/content/docs/reference/v1/sdk/python/CrewAIAgent.mdx` for v1 Python-side
+reference. The v2 integrations docs currently ship only a Flows quickstart at
+`docs/content/docs/integrations/crewai-flows/quickstart.mdx` — there is no dedicated
+Crews quickstart yet.

--- a/skills/runtime/references/wiring-crewai-flows.md
+++ b/skills/runtime/references/wiring-crewai-flows.md
@@ -1,0 +1,45 @@
+CrewAI Flows — wired via the bare `HttpAgent` from `@ag-ui/client`. No dedicated wrapper.
+
+## Install
+
+```bash
+pnpm add @ag-ui/client
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new HttpAgent({
+      url: process.env.CREWAI_FLOWS_URL ?? "http://localhost:8000/",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Flows vs Crews
+
+Flows is the event-driven pipeline product. For multi-agent Crews orchestration, use
+`CrewAIAgent` from `@ag-ui/crewai` instead — see [crewai-crews.md](crewai-crews.md).
+
+## Gotcha — AG-UI compatibility
+
+Your CrewAI Flows server must speak AG-UI over HTTP. If you control the server, use the
+official CrewAI Python AG-UI adapter. `HttpAgent` is a thin bridge — any server that
+emits AG-UI events at the URL works.
+
+Source: `docs/content/docs/integrations/crewai-flows/quickstart.mdx`.

--- a/skills/runtime/references/wiring-external-agents.md
+++ b/skills/runtime/references/wiring-external-agents.md
@@ -1,0 +1,348 @@
+# CopilotKit — Wire External Agent Frameworks
+
+`CopilotRuntime` takes any `AbstractAgent` subclass. Every framework below ships a
+ready-made subclass you construct and hand to `agents: { ... }`.
+
+| Framework                 | Package                     | Construct                                                                                                                    |
+| ------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Mastra                    | `@ag-ui/mastra`             | `MastraAgent.getLocalAgents({ mastra, resourceId? })` (record; `resourceId` required only when the agent has Memory enabled) |
+| LangGraph                 | `@ag-ui/langgraph`          | `new LangGraphAgent({ deploymentUrl, graphId })`                                                                             |
+| CrewAI Crews              | `@ag-ui/crewai`             | `new CrewAIAgent({ url })`                                                                                                   |
+| CrewAI Flows              | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
+| PydanticAI                | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
+| Google ADK                | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
+| LlamaIndex                | `@ag-ui/llamaindex`         | `new LlamaIndexAgent({ url: ".../run" })` (`/run` suffix)                                                                    |
+| Agno                      | `@ag-ui/agno`               | `new AgnoAgent({ url: ".../agui" })` (`/agui` suffix)                                                                        |
+| AWS Strands               | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
+| Microsoft Agent Framework | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
+| AG2                       | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
+| A2A                       | `@ag-ui/a2a`                | `new A2AAgent({ a2aClient })` (pre-built `A2AClient`, not a URL)                                                             |
+
+MCP Apps is NOT a framework — it's a runtime middleware:
+`new CopilotRuntime({ agents, mcpApps: { servers: [...] } })`. See
+[wiring-mcp-apps-middleware.md](wiring-mcp-apps-middleware.md).
+
+## Setup
+
+Generic shape for every framework:
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new HttpAgent({ url: process.env.AGENT_URL! }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Core Patterns
+
+### Mastra (local agents)
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { MastraAgent } from "@ag-ui/mastra";
+import { mastra } from "./mastra";
+
+const runtime = new CopilotRuntime({
+  // resourceId scopes Mastra Memory's working-memory buckets. Required when
+  // the Mastra agent has Memory enabled (the runtime always supplies a
+  // threadId, so Memory-enabled agents effectively always need it). Agents
+  // without Memory can omit it — `examples/integrations/mastra` calls
+  // `getLocalAgents({ mastra })` with no resourceId. See wiring-mastra.md.
+  agents: MastraAgent.getLocalAgents({ mastra, resourceId: "default" }),
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+See [wiring-mastra.md](wiring-mastra.md).
+
+### LangGraph
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { LangGraphAgent } from "@ag-ui/langgraph";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    supportAgent: new LangGraphAgent({
+      deploymentUrl: process.env.LANGGRAPH_URL!,
+      graphId: "support",
+      langsmithApiKey: process.env.LANGSMITH_API_KEY,
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+See [wiring-langgraph.md](wiring-langgraph.md).
+
+### Multi-framework single runtime
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { LangGraphAgent } from "@ag-ui/langgraph";
+import { CrewAIAgent } from "@ag-ui/crewai";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    research: new LangGraphAgent({
+      deploymentUrl: process.env.LANGGRAPH_URL!,
+      graphId: "research",
+    }),
+    writer: new CrewAIAgent({ url: process.env.CREWAI_URL! }),
+    translator: new HttpAgent({ url: process.env.PYDANTIC_AI_URL! }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+### MCP Apps (runtime middleware, not an agent)
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+} from "@copilotkit/runtime/v2";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({ model: "openai/gpt-4o" }),
+  },
+  mcpApps: {
+    servers: [{ type: "http", url: "https://mcp.example.com/mcp" }],
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Common Mistakes
+
+### HIGH Using runtimeUrl as the agent URL
+
+Wrong:
+
+```typescript
+import { LangGraphAgent } from "@ag-ui/langgraph";
+
+new LangGraphAgent({ deploymentUrl: "/api/copilotkit", graphId: "agent" });
+```
+
+Correct:
+
+```typescript
+new LangGraphAgent({
+  deploymentUrl: process.env.LANGGRAPH_URL!,
+  graphId: "agent",
+});
+```
+
+External agents take their own upstream URL — the framework's server or deployment. The
+CopilotKit runtime URL (`/api/copilotkit`) is the frontend↔runtime hop, not the
+runtime↔agent hop.
+
+Source: `docs/integrations/langgraph/quickstart.mdx:355`.
+
+### HIGH Wrapping MastraAgent.getLocalAgents in a key
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents: {
+    mastra: MastraAgent.getLocalAgents({ mastra, resourceId: "default" }),
+  },
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents: MastraAgent.getLocalAgents({ mastra, resourceId: "default" }),
+});
+```
+
+`MastraAgent.getLocalAgents` already returns a `Record<string, AbstractAgent>`. Wrapping
+it turns the record into a nested value on one key, which fails the registry's shape check.
+
+Source: `docs/integrations/mastra/quickstart.mdx:213-220`.
+
+### MEDIUM Missing /run or /agui suffix on LlamaIndex / Agno
+
+Wrong:
+
+```typescript
+import { LlamaIndexAgent } from "@ag-ui/llamaindex";
+import { AgnoAgent } from "@ag-ui/agno";
+
+new LlamaIndexAgent({ url: "http://localhost:8000" });
+new AgnoAgent({ url: "http://localhost:8000" });
+```
+
+Correct:
+
+```typescript
+new LlamaIndexAgent({ url: "http://localhost:8000/run" });
+new AgnoAgent({ url: "http://localhost:8000/agui" });
+```
+
+LlamaIndex requires a `/run` suffix, Agno requires `/agui`. The generic HttpAgent fallback
+would 404 without these.
+
+Source: `docs/integrations/llamaindex/quickstart.mdx:258`;
+`docs/integrations/agno/quickstart.mdx:215`.
+
+### MEDIUM Passing a URL to A2AAgent instead of an A2AClient
+
+Wrong:
+
+```typescript
+import { A2AAgent } from "@ag-ui/a2a";
+
+new A2AAgent({ url: "https://a2a.example" } as any);
+```
+
+Correct:
+
+```typescript
+import { A2AAgent } from "@ag-ui/a2a";
+import { A2AClient } from "@a2a-js/sdk/client";
+
+const a2aClient = new A2AClient("https://a2a.example");
+new A2AAgent({ a2aClient });
+```
+
+`A2AAgent` expects a pre-built `A2AClient` instance — A2A has its own handshake that
+the client handles.
+
+Source: `examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx:12`.
+
+### HIGH Treating MCP Apps as an agent
+
+Wrong:
+
+```typescript
+new CopilotRuntime({
+  agents: {
+    mcpApps: new MCPAppsAgent({
+      /* ... */
+    } as any),
+  } as any,
+});
+```
+
+Correct:
+
+```typescript
+new CopilotRuntime({
+  agents: {
+    /* your real agents */
+  },
+  mcpApps: {
+    servers: [{ type: "http", url: "https://mcp.example.com/mcp" }],
+  },
+});
+```
+
+MCP Apps is runtime-level middleware auto-applied to all agents. Configure via
+`runtime.mcpApps`, not `agents`.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts:39-63`.
+
+### MEDIUM Passing a framework `client` instead of its Agent wrapper
+
+Wrong:
+
+```typescript
+import { mastraClient } from "./mastra"; // a Mastra client object
+
+new CopilotRuntime({
+  agents: { default: mastraClient as any },
+});
+```
+
+Correct:
+
+```typescript
+import { MastraAgent } from "@ag-ui/mastra";
+import { mastra } from "./mastra";
+
+new CopilotRuntime({
+  agents: MastraAgent.getLocalAgents({ mastra, resourceId: "default" }),
+});
+```
+
+`CopilotRuntime` expects `AbstractAgent` subclasses. Framework SDK clients are not
+AbstractAgent instances — always pass the `@ag-ui/<framework>` wrapper or `HttpAgent`.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts:111-128`.
+
+## References
+
+- [Mastra](wiring-mastra.md)
+- [LangGraph](wiring-langgraph.md)
+- [CrewAI Crews](wiring-crewai-crews.md)
+- [CrewAI Flows](wiring-crewai-flows.md)
+- [PydanticAI](wiring-pydantic-ai.md)
+- [Google ADK](wiring-adk.md)
+- [LlamaIndex](wiring-llamaindex.md)
+- [Agno](wiring-agno.md)
+- [AWS Strands](wiring-aws-strands.md)
+- [Microsoft Agent Framework](wiring-ms-agent-framework.md)
+- [AG2](wiring-ag2.md)
+- [A2A](wiring-a2a.md)
+- [MCP Apps middleware](wiring-mcp-apps-middleware.md)
+
+## See also
+
+- `copilotkit/setup-endpoint` — mount the runtime that fronts these agents
+- `copilotkit/built-in-agent` — alternative when you want an in-tree agent
+- `copilotkit/agent-runners` — runner choice is independent of framework

--- a/skills/runtime/references/wiring-langgraph.md
+++ b/skills/runtime/references/wiring-langgraph.md
@@ -1,0 +1,50 @@
+LangGraph — wired via `@ag-ui/langgraph`. Supports LangGraph Platform deployments and
+self-hosted LangGraph servers.
+
+## Install
+
+```bash
+pnpm add @ag-ui/langgraph
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { LangGraphAgent } from "@ag-ui/langgraph";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new LangGraphAgent({
+      deploymentUrl: process.env.LANGGRAPH_URL!,
+      graphId: "agent",
+      langsmithApiKey: process.env.LANGSMITH_API_KEY, // optional
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Config fields
+
+| Field             | Notes                                                                 |
+| ----------------- | --------------------------------------------------------------------- |
+| `deploymentUrl`   | Base URL of the LangGraph Platform deployment (or self-hosted server) |
+| `graphId`         | The graph name registered with the deployment (e.g. `"agent"`)        |
+| `langsmithApiKey` | Optional — enables LangSmith tracing                                  |
+
+## Gotcha — `deploymentUrl` is NOT the CopilotKit runtime URL
+
+The most common mistake is setting `deploymentUrl` to `/api/copilotkit`. That is the
+frontend↔runtime URL, not the LangGraph server. Use the actual LangGraph deployment URL.
+
+Source: `docs/content/docs/integrations/langgraph/quickstart.mdx:355`.

--- a/skills/runtime/references/wiring-llamaindex.md
+++ b/skills/runtime/references/wiring-llamaindex.md
@@ -1,0 +1,39 @@
+LlamaIndex — wired via `@ag-ui/llamaindex`. Requires a `/run` URL suffix.
+
+## Install
+
+```bash
+pnpm add @ag-ui/llamaindex
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { LlamaIndexAgent } from "@ag-ui/llamaindex";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new LlamaIndexAgent({
+      url: process.env.LLAMAINDEX_URL ?? "http://localhost:8000/run",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Gotcha — the `/run` suffix is mandatory
+
+LlamaIndex's AG-UI adapter mounts its workflow endpoint at `/run`. Pointing `url` at the
+server root (`http://localhost:8000`) returns 404. Always include `/run`.
+
+Source: `docs/content/docs/integrations/llamaindex/quickstart.mdx:258`.

--- a/skills/runtime/references/wiring-mastra.md
+++ b/skills/runtime/references/wiring-mastra.md
@@ -1,0 +1,70 @@
+Mastra — local-first TypeScript agent framework wired via `@ag-ui/mastra`.
+
+## Install
+
+```bash
+pnpm add @ag-ui/mastra
+# plus your Mastra SDK:
+pnpm add @mastra/core
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { MastraAgent } from "@ag-ui/mastra";
+import { Mastra } from "@mastra/core";
+import { weatherAgent } from "./agents/weather"; // your Mastra agent
+
+const mastra = new Mastra({
+  agents: { weather: weatherAgent },
+});
+
+const runtime = new CopilotRuntime({
+  agents: MastraAgent.getLocalAgents({
+    mastra,
+    // Required ONLY when your Mastra agent has Memory enabled AND a threadId
+    // is supplied (the runtime always supplies a threadId, so Memory-enabled
+    // agents effectively always need this). Passing an empty string throws
+    // AGENT_MEMORY_MISSING_RESOURCE_ID on every turn. Agents without Memory
+    // can omit resourceId — e.g. the in-tree `examples/integrations/mastra`
+    // quickstart calls `MastraAgent.getLocalAgents({ mastra })` with no
+    // resourceId. Pick a stable per-user identifier in production; a literal
+    // "default" is fine as a placeholder for single-tenant demos.
+    resourceId: "default",
+  }),
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Remote Mastra server
+
+If Mastra is running as a separate HTTP service, the simplest wiring is the
+generic `HttpAgent` from `@ag-ui/client` — it speaks the AG-UI protocol that
+Mastra's HTTP server already emits:
+
+```typescript
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    weather: new HttpAgent({ url: `${process.env.MASTRA_URL!}/weather` }),
+  },
+});
+```
+
+## Gotcha — do NOT wrap the record
+
+`getLocalAgents` already returns `Record<string, AbstractAgent>`. Wrapping it in a key
+(`{ mastra: getLocalAgents(...) }`) breaks the registry.
+
+Source: `docs/content/docs/integrations/mastra/quickstart.mdx:213-220`.

--- a/skills/runtime/references/wiring-mcp-apps-middleware.md
+++ b/skills/runtime/references/wiring-mcp-apps-middleware.md
@@ -1,0 +1,68 @@
+MCP Apps — runtime-level middleware that auto-applies to all agents. NOT an agent.
+
+MCP Apps lets any agent in the runtime access tools from external MCP servers. It is
+configured on `CopilotRuntime` directly, not as an entry in `agents`.
+
+## Install
+
+MCP support is provided by the runtime directly — no extra package install for the
+middleware itself. Your MCP servers are separate services you point at.
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+} from "@copilotkit/runtime/v2";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({ model: "openai/gpt-4o", maxSteps: 5 }),
+  },
+  mcpApps: {
+    servers: [
+      {
+        type: "http",
+        url: "https://mcp.example.com/mcp",
+      },
+      {
+        type: "http",
+        url: "https://another-mcp.example.com/mcp",
+        agentId: "default", // scope this server to one agent only
+      },
+    ],
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Per-agent scoping
+
+Each server entry accepts an optional `agentId`. When set, the server's tools are only
+exposed to that agent. Omit it to expose to all agents.
+
+## Gotcha — do NOT put MCP under agents
+
+```typescript
+// WRONG
+new CopilotRuntime({
+  agents: {
+    mcpApps: new MCPAppsAgent({
+      /* ... */
+    }),
+  } as any,
+});
+```
+
+There is no `MCPAppsAgent`. MCP Apps is runtime middleware and belongs on the top-level
+`CopilotRuntime` options.
+
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts:39-63`.

--- a/skills/runtime/references/wiring-ms-agent-framework.md
+++ b/skills/runtime/references/wiring-ms-agent-framework.md
@@ -1,0 +1,41 @@
+Microsoft Agent Framework — wired via the bare `HttpAgent` from `@ag-ui/client`.
+Both Python and .NET variants use the same HTTP bridge.
+
+## Install
+
+```bash
+pnpm add @ag-ui/client
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new HttpAgent({
+      url: process.env.MS_AGENT_URL!, // Python or .NET AG-UI endpoint
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Gotcha — pick the right endpoint path
+
+Microsoft Agent Framework ships both Python and .NET adapters. The AG-UI mount path
+depends on which adapter you chose and how you configured it — follow the framework's
+quickstart to find the exact URL. `HttpAgent` simply forwards.
+
+Source: `docs/content/docs/integrations/microsoft-agent-framework/quickstart.mdx`.

--- a/skills/runtime/references/wiring-pydantic-ai.md
+++ b/skills/runtime/references/wiring-pydantic-ai.md
@@ -1,0 +1,45 @@
+PydanticAI — wired via the bare `HttpAgent` from `@ag-ui/client`.
+
+## Install
+
+```bash
+pnpm add @ag-ui/client
+```
+
+## Minimal wire-up
+
+```typescript
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new HttpAgent({
+      url: process.env.PYDANTIC_AI_URL ?? "http://localhost:8000/",
+    }),
+  },
+});
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export default { fetch: handler };
+```
+
+## Server side
+
+On the Python side, PydanticAI exposes an AG-UI-compliant endpoint via its built-in
+ASGI adapter. The URL you pass to `HttpAgent` is that endpoint (e.g. an FastAPI route
+that returns a streaming response of AG-UI events).
+
+## Gotcha — no suffix required
+
+Unlike LlamaIndex (`/run`) and Agno (`/agui`), PydanticAI does not mandate a specific
+sub-path. Whatever path your Python server mounts the AG-UI app at — use that.
+
+Source: `docs/content/docs/integrations/pydantic-ai/quickstart.mdx`.


### PR DESCRIPTION
## Summary

Makes the CopilotKit monorepo installable as a Claude Code plugin. Claude Code's plugin system strictly requires skills at `<plugin-root>/skills/<slug>/SKILL.md` and offers no path-override in `plugin.json` (verified against `code.claude.com/docs/en/plugins-reference.md`). Intent's distribution model keeps package meta-skills under `packages/<pkg>/skills/` so they ship via `npm publish`. This PR satisfies both: the Intent source stays put, and a committed byte-for-byte mirror of the 3 package meta-skills is placed at the repo-root `skills/` alongside the 6 existing lifecycle skills. A TypeScript sync script keeps the two in sync; a lefthook pre-commit check + GitHub Actions workflow reject commits that drift.

**Stacked on #4121.** Base branch is `worktree-lucky-popping-wren`; merge that first (or into main) before merging this.

## What's in here

- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — plugin + marketplace manifests (single-plugin marketplace-of-self). Plugin version tracks `packages/runtime/package.json` (currently `1.56.2`).
- `scripts/sync-plugin-skills.ts` — TypeScript sync/check script with 9 Vitest unit tests (tmpdir fixtures, no network). Also keeps the plugin + marketplace `version` fields in lockstep with `packages/runtime/package.json`.
- `pnpm sync:plugin-skills` + `pnpm check:plugin-skills` scripts wired into root `package.json`.
- `lefthook.yml` pre-commit command `check-plugin-skills` gated on a glob that only fires when mirror-relevant files are staged.
- `.github/workflows/plugin-skills-check.yml` — CI gate that runs the Vitest suite + the mirror check on push + PR (same path glob as lefthook).
- Committed initial mirror: `skills/runtime/` (28 files), `skills/react-core/` (16 files), `skills/a2ui-renderer/` (1 file). Total 45 new mirror files.
- `README.md` section documenting the plugin install command and the sync invariant.

## Why not symlinks

Symlinks break on Windows clones by default (git writes them as text files containing the link target). This repo has Windows contributors. Committed file copies are portable.

## Why both locations

`packages/*/skills/` is the **source of truth** — that's where the Intent framework discovers skills via `npx @tanstack/intent list` once the package is installed from npm. `skills/<slug>/` at the repo root is the **Claude Code plugin surface** — that's the only layout Claude Code's plugin discovery accepts.

## Usage after merge

```bash
claude plugin marketplace add https://github.com/CopilotKit/CopilotKit
claude plugin install copilotkit
```

## Test plan

- [x] `pnpm exec vitest run scripts/__tests__/sync-plugin-skills.test.ts` — 9/9 pass.
- [x] `pnpm check:plugin-skills` — exits 0 on a fresh tree.
- [x] Edit a package skill without running sync, stage it, invoke pre-commit → `check-plugin-skills` fails with the "mirror out of sync" message. (Verified via `lefthook run pre-commit` against a staged drift edit.)
- [x] `pnpm sync:plugin-skills` after the edit → mirror regenerates → check passes.
- [x] `npx @tanstack/intent validate` passes in all 3 packages (unchanged by this PR — sanity check).
- [x] All 9 skill slugs discoverable at `skills/<slug>/SKILL.md`.
- [ ] `claude plugin marketplace add file://$(pwd) && claude plugin install copilotkit` — 9 skills visible. (Reviewer's optional smoke test.)

## Follow-ups (out of scope)

- Decide plugin versioning cadence for future minor/major bumps beyond the current `1.56.x` synchronized-with-runtime scheme.
- If the repo migrates off husky entirely, revisit lefthook install to ensure the pre-commit hook is wired on fresh clones.
