### PR TITLE
fix(showcase): narrow aimock fixture patterns + add drift guardrail

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -182,6 +182,18 @@ jobs:
         # cache miss.
         run: pnpm exec tsx validate-parity.ts
 
+      - name: Run validate-fixture-tool-surface (aimock drift)
+        working-directory: showcase/scripts
+        # Cross-references every aimock fixture's returned tool-call names
+        # against the tool surface of each demo whose suggestion prompt
+        # contains the fixture's match substring. Catches the class of
+        # drift that caused the 2026-04-22 regression where generic
+        # substring matches (e.g. "pie chart") cross-fired across demos
+        # with different tool surfaces, leaving the UI blank in prod.
+        # See showcase/scripts/validate-fixture-tool-surface.ts and the
+        # postmortem linked from there.
+        run: pnpm exec tsx validate-fixture-tool-surface.ts
+
       - name: Run validate-workflow-starters (parity with workflows)
         working-directory: showcase/scripts
         # Gate: for every directory under showcase/starters/ (excluding

--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -23,20 +23,7 @@
     },
     {
       "match": {
-        "userMessage": "pie chart"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "query_data",
-            "arguments": "{\"query\":\"revenue by category\"}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "show pie"
+        "userMessage": "revenue distribution by category"
       },
       "response": {
         "toolCalls": [
@@ -49,130 +36,78 @@
     },
     {
       "match": {
-        "userMessage": "bar chart"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "query_data",
-            "arguments": "{\"query\":\"monthly sales\"}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "show bar"
+        "userMessage": "expenses by category"
       },
       "response": {
         "toolCalls": [
           {
             "name": "barChart",
-            "arguments": "{\"title\":\"Monthly Sales\",\"description\":\"Sales performance January through June\",\"data\":[{\"label\":\"Jan\",\"value\":15000},{\"label\":\"Feb\",\"value\":22000},{\"label\":\"Mar\",\"value\":18000},{\"label\":\"Apr\",\"value\":31000},{\"label\":\"May\",\"value\":27000},{\"label\":\"Jun\",\"value\":35000}]}"
+            "arguments": "{\"title\":\"Expenses by Category\",\"description\":\"Monthly expense breakdown\",\"data\":[{\"label\":\"Rent\",\"value\":15000},{\"label\":\"Salaries\",\"value\":80000},{\"label\":\"Marketing\",\"value\":12000},{\"label\":\"Travel\",\"value\":5000}]}"
           }
         ]
       }
     },
     {
       "match": {
-        "userMessage": "schedule"
+        "userMessage": "pie chart of website traffic by source"
       },
       "response": {
         "toolCalls": [
           {
-            "name": "schedule_meeting",
-            "arguments": "{\"reason\":\"Team sync to discuss Q3 roadmap\",\"duration_minutes\":30}"
+            "name": "render_pie_chart",
+            "arguments": "{\"title\":\"Website Traffic by Source\",\"description\":\"Traffic sources this month\",\"data\":[{\"label\":\"Organic Search\",\"value\":45},{\"label\":\"Direct\",\"value\":25},{\"label\":\"Social\",\"value\":18},{\"label\":\"Referral\",\"value\":12}]}"
           }
         ]
       }
     },
     {
       "match": {
-        "userMessage": "meeting"
+        "userMessage": "smartphone market share by brand"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "render_pie_chart",
+            "arguments": "{\"title\":\"Smartphone Market Share\",\"description\":\"Global smartphone market share by brand\",\"data\":[{\"label\":\"Apple\",\"value\":28},{\"label\":\"Samsung\",\"value\":22},{\"label\":\"Xiaomi\",\"value\":14},{\"label\":\"Others\",\"value\":36}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "bar chart of quarterly sales for Q1, Q2, Q3, Q4"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "render_bar_chart",
+            "arguments": "{\"title\":\"Quarterly Sales\",\"description\":\"Sales across Q1-Q4\",\"data\":[{\"label\":\"Q1\",\"value\":145000},{\"label\":\"Q2\",\"value\":178000},{\"label\":\"Q3\",\"value\":162000},{\"label\":\"Q4\",\"value\":215000}]}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "30-minute meeting to learn about CopilotKit"
       },
       "response": {
         "toolCalls": [
           {
             "name": "scheduleTime",
-            "arguments": "{\"reasonForScheduling\":\"Weekly standup\",\"meetingDuration\":15}"
+            "arguments": "{\"reasonForScheduling\":\"Learn about CopilotKit\",\"meetingDuration\":30}"
           }
         ]
       }
     },
     {
       "match": {
-        "userMessage": "sales"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "get_sales_todos",
-            "arguments": "{}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "pipeline"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "get_sales_todos",
-            "arguments": "{}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "todo"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "get_sales_todos",
-            "arguments": "{}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "flight"
+        "userMessage": "flights from SFO to JFK"
       },
       "response": {
         "toolCalls": [
           {
             "name": "search_flights",
             "arguments": "{\"flights\":[{\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=128\",\"flightNumber\":\"UA123\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"08:00\",\"arrivalTime\":\"16:30\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$349\",\"currency\":\"USD\"},{\"airline\":\"Delta\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=delta.com&sz=128\",\"flightNumber\":\"DL456\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"10:15\",\"arrivalTime\":\"18:45\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$289\",\"currency\":\"USD\"}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "fly"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "search_flights",
-            "arguments": "{\"flights\":[{\"airline\":\"United Airlines\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=united.com&sz=128\",\"flightNumber\":\"UA123\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"08:00\",\"arrivalTime\":\"16:30\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$349\",\"currency\":\"USD\"},{\"airline\":\"Delta\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=delta.com&sz=128\",\"flightNumber\":\"DL456\",\"origin\":\"SFO\",\"destination\":\"JFK\",\"date\":\"Tue, Apr 15\",\"departureTime\":\"10:15\",\"arrivalTime\":\"18:45\",\"duration\":\"5h 30m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$289\",\"currency\":\"USD\"}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "theme"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "toggleTheme",
-            "arguments": "{}"
           }
         ]
       }
@@ -338,19 +273,6 @@
     },
     {
       "match": {
-        "userMessage": "trip"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "search_flights",
-            "arguments": "{\"flights\":[{\"airline\":\"ANA\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=ana.co.jp&sz=128\",\"flightNumber\":\"NH7\",\"origin\":\"SFO\",\"destination\":\"NRT\",\"date\":\"Mon, Apr 21\",\"departureTime\":\"11:30\",\"arrivalTime\":\"15:30+1\",\"duration\":\"11h 00m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$850\",\"currency\":\"USD\"},{\"airline\":\"JAL\",\"airlineLogo\":\"https://www.google.com/s2/favicons?domain=jal.co.jp&sz=128\",\"flightNumber\":\"JL1\",\"origin\":\"SFO\",\"destination\":\"NRT\",\"date\":\"Mon, Apr 21\",\"departureTime\":\"13:00\",\"arrivalTime\":\"17:00+1\",\"duration\":\"11h 00m\",\"status\":\"On Time\",\"statusColor\":\"#22c55e\",\"price\":\"$920\",\"currency\":\"USD\"}]}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
         "userMessage": "paris"
       },
       "response": {
@@ -388,13 +310,13 @@
     },
     {
       "match": {
-        "userMessage": "background"
+        "userMessage": "sunset-themed gradient"
       },
       "response": {
         "toolCalls": [
           {
             "name": "change_background",
-            "arguments": "{\"background\":\"linear-gradient(135deg, #667eea 0%, #764ba2 100%)\"}"
+            "arguments": "{\"background\":\"linear-gradient(135deg, #ff7e5f 0%, #feb47b 50%, #ffd194 100%)\"}"
           }
         ]
       }

--- a/showcase/packages/langgraph-python/Dockerfile
+++ b/showcase/packages/langgraph-python/Dockerfile
@@ -41,7 +41,8 @@ WORKDIR /app
 # image too, not just the generated starter.
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
  && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
- && mkdir -p /home/app && chown app:app /home/app
+ && mkdir -p /home/app && chown app:app /home/app \
+ && chown app:app /app
 
 # Python venv (prebuilt in agent-builder stage — no pip in the runner).
 COPY --chown=app:app --from=agent-builder /opt/venv /opt/venv

--- a/showcase/scripts/__tests__/generate-registry.test.ts
+++ b/showcase/scripts/__tests__/generate-registry.test.ts
@@ -74,6 +74,8 @@ describe("Registry Generator", () => {
     expect(langgraph.name).toBe("LangGraph (Python)");
     expect(langgraph.category).toBe("popular");
     expect(langgraph.language).toBe("python");
+    // Count matches current manifest after #4029 scrubbed open-gen-ui (5→4
+    // GenUI strategies).
     expect(langgraph.features.length).toBe(30);
     expect(langgraph.demos.length).toBe(30);
   });

--- a/showcase/scripts/__tests__/validate-fixture-tool-surface.test.ts
+++ b/showcase/scripts/__tests__/validate-fixture-tool-surface.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Guardrail for aimock fixture drift.
+ *
+ * Background: aimock serves deterministic responses in prod to save LLM cost.
+ * Fixtures substring-match the user message and return a hardcoded tool call.
+ * When a fixture returns a tool name that the matched demo's agent doesn't
+ * actually register, the tool call dangles and the UI renders nothing.
+ * That's what broke gen-ui-tool-based and beautiful-chat in prod before the
+ * fixture cleanup landed. This validator catches that class of drift.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  validate,
+  type Fixture,
+  type DemoSurface,
+  type Violation,
+} from "../validate-fixture-tool-surface";
+
+const demoGenUiToolBased: DemoSurface = {
+  slug: "langgraph-python",
+  demoId: "gen-ui-tool-based",
+  agentId: "gen-ui-tool-based",
+  suggestions: [
+    "Show me a pie chart of website traffic by source.",
+    "Show me a bar chart of quarterly sales for Q1, Q2, Q3, Q4.",
+  ],
+  tools: ["render_pie_chart", "render_bar_chart"],
+};
+
+const demoBeautifulChat: DemoSurface = {
+  slug: "langgraph-python",
+  demoId: "beautiful-chat",
+  agentId: "beautiful-chat",
+  suggestions: [
+    "Show me a pie chart of our revenue distribution by category.",
+    "Toggle the app theme using the toggleTheme tool.",
+  ],
+  tools: ["query_data", "pieChart", "barChart", "scheduleTime", "toggleTheme"],
+};
+
+describe("validateFixtureToolSurface", () => {
+  it("flags a fixture whose tool name isn't registered by the matched demo", () => {
+    const badFixture: Fixture = {
+      match: { userMessage: "pie chart" },
+      response: {
+        toolCalls: [
+          {
+            name: "query_data",
+            arguments: '{"query":"revenue by category"}',
+          },
+        ],
+      },
+    };
+
+    const violations = validate([badFixture], [demoGenUiToolBased]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject<Partial<Violation>>({
+      fixtureMatch: "pie chart",
+      fixtureTool: "query_data",
+      demo: { slug: "langgraph-python", demoId: "gen-ui-tool-based" },
+    });
+  });
+
+  it("accepts a fixture whose tool name is in the matched demo's surface", () => {
+    const goodFixture: Fixture = {
+      match: { userMessage: "pie chart of website traffic by source" },
+      response: {
+        toolCalls: [{ name: "render_pie_chart", arguments: "{}" }],
+      },
+    };
+
+    const violations = validate([goodFixture], [demoGenUiToolBased]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("ignores content-only fixtures (no toolCalls → no drift possible)", () => {
+    const contentFixture: Fixture = {
+      match: { userMessage: "hello" },
+      response: { content: "Hi there!" },
+    };
+
+    const violations = validate([contentFixture], [demoGenUiToolBased]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("ignores fixtures that don't match any demo's suggestions", () => {
+    const orphanFixture: Fixture = {
+      match: { userMessage: "something no suggestion contains" },
+      response: {
+        toolCalls: [{ name: "made_up_tool", arguments: "{}" }],
+      },
+    };
+
+    const violations = validate([orphanFixture], [demoGenUiToolBased]);
+
+    // Ad-hoc prompts that users type manually may legitimately fire these
+    // fixtures with no matching suggestion. That's out of scope for this
+    // validator — we only assert "fixtures that THE SHOWCASE ITSELF TRIGGERS
+    // via its own suggestion pills line up with the agent's tool surface".
+    expect(violations).toEqual([]);
+  });
+
+  it("matches case-insensitively", () => {
+    const badFixture: Fixture = {
+      match: { userMessage: "PIE CHART" },
+      response: {
+        toolCalls: [{ name: "query_data", arguments: "{}" }],
+      },
+    };
+
+    const violations = validate([badFixture], [demoGenUiToolBased]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].fixtureMatch).toBe("PIE CHART");
+  });
+
+  it("reports a violation per (fixture, matching demo) pair when multiple demos match", () => {
+    const genericFixture: Fixture = {
+      match: { userMessage: "pie chart" },
+      response: {
+        toolCalls: [{ name: "query_data", arguments: "{}" }],
+      },
+    };
+
+    const violations = validate(
+      [genericFixture],
+      [demoGenUiToolBased, demoBeautifulChat],
+    );
+
+    // gen-ui-tool-based does NOT have query_data → 1 violation
+    // beautiful-chat DOES have query_data → no violation
+    expect(violations).toHaveLength(1);
+    expect(violations[0].demo.demoId).toBe("gen-ui-tool-based");
+  });
+
+  it("reports one violation per unregistered tool in a multi-tool response", () => {
+    const multiToolFixture: Fixture = {
+      match: { userMessage: "pie chart of website traffic by source" },
+      response: {
+        toolCalls: [
+          { name: "render_pie_chart", arguments: "{}" }, // OK
+          { name: "query_data", arguments: "{}" }, // drift
+          { name: "generate_a2ui", arguments: "{}" }, // drift
+        ],
+      },
+    };
+
+    const violations = validate([multiToolFixture], [demoGenUiToolBased]);
+
+    expect(violations).toHaveLength(2);
+    const badTools = violations.map((v) => v.fixtureTool).sort();
+    expect(badTools).toEqual(["generate_a2ui", "query_data"]);
+  });
+});

--- a/showcase/scripts/validate-fixture-tool-surface.ts
+++ b/showcase/scripts/validate-fixture-tool-surface.ts
@@ -1,0 +1,402 @@
+/**
+ * Fixture ↔ demo-tool-surface drift validator.
+ *
+ * In production we route showcase LLM traffic through aimock for cost
+ * reasons. Fixtures substring-match the user message and return hardcoded
+ * tool calls. When a fixture returns a tool name the target demo's agent
+ * doesn't actually register, the tool call dangles and the demo silently
+ * breaks. That was the April 22 regression. This script catches that
+ * class of drift at CI time before it reaches prod.
+ *
+ * Usage:
+ *   npx tsx showcase/scripts/validate-fixture-tool-surface.ts
+ *
+ * Exit 0 = clean. Exit 1 = drift detected, with a per-fixture report.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export interface Fixture {
+  match: { userMessage?: string };
+  response: {
+    toolCalls?: Array<{ name: string; arguments?: string }>;
+    content?: string;
+  };
+}
+
+export interface DemoSurface {
+  /** Package slug, e.g. "langgraph-python". */
+  slug: string;
+  /** Demo id, e.g. "gen-ui-tool-based" — the URL segment under /demos. */
+  demoId: string;
+  /** CopilotKit `agent=` prop value used by this demo page. */
+  agentId: string;
+  /** Suggestion message strings from useConfigureSuggestions(...). */
+  suggestions: string[];
+  /** Union of every tool name this demo's agent can legitimately call
+   *  (frontend useComponent/useHumanInTheLoop/useFrontendTool + backend). */
+  tools: string[];
+}
+
+export interface Violation {
+  fixtureMatch: string;
+  fixtureTool: string;
+  demo: { slug: string; demoId: string };
+  matchedSuggestion: string;
+}
+
+// -----------------------------------------------------------------------------
+// Pure validation
+// -----------------------------------------------------------------------------
+
+export function validate(
+  fixtures: Fixture[],
+  demos: DemoSurface[],
+): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const fixture of fixtures) {
+    const toolCalls = fixture.response.toolCalls;
+    if (!toolCalls || toolCalls.length === 0) continue;
+
+    const match = fixture.match.userMessage;
+    if (!match) continue;
+    const needle = match.toLowerCase();
+
+    for (const demo of demos) {
+      const matchedSuggestion = demo.suggestions.find((s) =>
+        s.toLowerCase().includes(needle),
+      );
+      if (!matchedSuggestion) continue;
+
+      const registered = new Set(demo.tools);
+      for (const tc of toolCalls) {
+        if (registered.has(tc.name)) continue;
+        violations.push({
+          fixtureMatch: match,
+          fixtureTool: tc.name,
+          demo: { slug: demo.slug, demoId: demo.demoId },
+          matchedSuggestion,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+// -----------------------------------------------------------------------------
+// File loaders (used by the CLI, not the pure `validate()` function).
+// Regex-based parsing is good enough for the showcase conventions; if a demo
+// diverges from the conventions it will silently produce an empty tool list
+// and any fixture targeting it will flag as drift — which is the loud, safe
+// failure mode.
+// -----------------------------------------------------------------------------
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHOWCASE_ROOT = path.resolve(__dirname, "..");
+
+export function loadFixtures(aimockDir: string): Fixture[] {
+  const out: Fixture[] = [];
+  if (!fs.existsSync(aimockDir)) return out;
+  for (const file of fs.readdirSync(aimockDir)) {
+    if (!file.endsWith(".json")) continue;
+    const raw = fs.readFileSync(path.join(aimockDir, file), "utf-8");
+    const parsed = JSON.parse(raw) as { fixtures?: Fixture[] };
+    if (Array.isArray(parsed.fixtures)) out.push(...parsed.fixtures);
+  }
+  return out;
+}
+
+const SUGGESTION_MESSAGE_RE =
+  /message:\s*(`[^`]*`|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')/g;
+const USE_COMPONENT_BLOCK_RE =
+  /use(?:Component|HumanInTheLoop|FrontendTool|RenderTool|DefaultRenderTool)\s*\(\s*\{[\s\S]*?name:\s*["']([^"']+)["']/g;
+const AGENT_PROP_RE = /<CopilotKit[^>]*\bagent\s*=\s*["']([^"']+)["']/;
+
+function extractStringLiteral(rawLiteral: string): string {
+  // Strip outer quotes and unescape — conservative: only \" \' \\ \n
+  const stripped = rawLiteral.slice(1, -1);
+  return stripped
+    .replace(/\\"/g, '"')
+    .replace(/\\'/g, "'")
+    .replace(/\\\\/g, "\\")
+    .replace(/\\n/g, "\n");
+}
+
+function parseDemoPage(pageTsxPath: string): {
+  agentId: string | null;
+  suggestions: string[];
+  frontendTools: string[];
+} {
+  const src = fs.readFileSync(pageTsxPath, "utf-8");
+  const agentMatch = src.match(AGENT_PROP_RE);
+  const suggestions: string[] = [];
+  for (const m of src.matchAll(SUGGESTION_MESSAGE_RE)) {
+    suggestions.push(extractStringLiteral(m[1]));
+  }
+  const frontendTools: string[] = [];
+  for (const m of src.matchAll(USE_COMPONENT_BLOCK_RE)) {
+    frontendTools.push(m[1]);
+  }
+  return {
+    agentId: agentMatch ? agentMatch[1] : null,
+    suggestions,
+    frontendTools,
+  };
+}
+
+const PY_TOOLS_ARRAY_RE = /tools\s*=\s*\[([^\]]*)\]/g;
+const PY_NAME_TOKEN_RE = /[a-zA-Z_][a-zA-Z0-9_]*/g;
+const PY_TOOL_DECORATOR_DEF_RE =
+  /@tool\b[\s\S]*?def\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+function parseBackendTools(agentFilePath: string): string[] {
+  if (!fs.existsSync(agentFilePath)) return [];
+  const src = fs.readFileSync(agentFilePath, "utf-8");
+  const names = new Set<string>();
+
+  for (const m of src.matchAll(PY_TOOL_DECORATOR_DEF_RE)) {
+    names.add(m[1]);
+  }
+  for (const m of src.matchAll(PY_TOOLS_ARRAY_RE)) {
+    const body = m[1];
+    // Skip LangGraph's `tools=[]` empty case and middleware-only agents.
+    if (!body.trim()) continue;
+    for (const tok of body.matchAll(PY_NAME_TOKEN_RE)) {
+      const name = tok[0];
+      // Filter obvious non-tool tokens (keywords, literals).
+      if (["None", "True", "False", "self", "cls"].includes(name)) continue;
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+/**
+ * Parse packages/<slug>/src/app/api/copilotkit/route.ts for the
+ * agentId→graphId map. Recognizes the two patterns the showcase uses:
+ *   agents["agent-id"] = createAgent("graph_id")
+ *   agents["agent-id"] = createAgent()         // defaults to sample_agent
+ * and the `for (const name of neutralAssistantCells)` loop that bulk-assigns
+ * the default graph. Packages without a route.ts (or without this pattern —
+ * e.g. TS/Mastra) return {} and the caller falls back to file-name guessing.
+ */
+const routeCache = new Map<string, Record<string, string>>();
+function loadAgentRoutes(
+  packagesDir: string,
+  slug: string,
+): Record<string, string> {
+  const cached = routeCache.get(slug);
+  if (cached) return cached;
+
+  // Walk every src/app/api/copilotkit*/route.ts — some demos (beautiful-chat,
+  // declarative-gen-ui, mcp-apps, ogui, a2ui-fixed-schema) live on their own
+  // dedicated runtime endpoint with its own createAgent wiring.
+  const apiDir = path.join(packagesDir, slug, "src", "app", "api");
+  const out: Record<string, string> = {};
+  if (!fs.existsSync(apiDir)) {
+    routeCache.set(slug, out);
+    return out;
+  }
+
+  for (const entry of fs.readdirSync(apiDir)) {
+    if (!entry.startsWith("copilotkit")) continue;
+    const routePath = path.join(apiDir, entry, "route.ts");
+    if (!fs.existsSync(routePath)) continue;
+    const src = fs.readFileSync(routePath, "utf-8");
+
+    for (const m of src.matchAll(
+      /agents\[\s*["']([^"']+)["']\s*\]\s*=\s*createAgent\(\s*["']([^"']+)["']/g,
+    )) {
+      out[m[1]] = m[2];
+    }
+    for (const m of src.matchAll(
+      /agents\[\s*["']([^"']+)["']\s*\]\s*=\s*createAgent\(\s*\)/g,
+    )) {
+      if (!(m[1] in out)) out[m[1]] = "sample_agent";
+    }
+    // new LangGraphAgent({ ..., graphId: "X" }) — the dedicated routes
+    // (e.g. copilotkit-beautiful-chat) construct the agent inline instead of
+    // going through createAgent.
+    for (const m of src.matchAll(/graphId\s*:\s*["']([^"']+)["']/g)) {
+      // In single-agent dedicated routes the URL segment IS the agent ID.
+      // entry looks like "copilotkit-beautiful-chat" → "beautiful-chat".
+      const agentFromUrl = entry.replace(/^copilotkit-?/, "");
+      if (agentFromUrl && !(agentFromUrl in out)) out[agentFromUrl] = m[1];
+    }
+    const listMatch = src.match(
+      /const\s+neutralAssistantCells\s*=\s*\[([\s\S]*?)\]/,
+    );
+    if (listMatch) {
+      for (const nameMatch of listMatch[1].matchAll(/["']([^"']+)["']/g)) {
+        if (!(nameMatch[1] in out)) out[nameMatch[1]] = "sample_agent";
+      }
+    }
+  }
+
+  routeCache.set(slug, out);
+  return out;
+}
+
+const graphCache = new Map<string, Record<string, string>>();
+function loadGraphs(packagesDir: string, slug: string): Record<string, string> {
+  const cached = graphCache.get(slug);
+  if (cached) return cached;
+
+  const lgPath = path.join(packagesDir, slug, "langgraph.json");
+  const out: Record<string, string> = {};
+  if (!fs.existsSync(lgPath)) {
+    graphCache.set(slug, out);
+    return out;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lgPath, "utf-8")) as {
+      graphs?: Record<string, string>;
+    };
+    const graphs = parsed.graphs ?? {};
+    for (const [name, ref] of Object.entries(graphs)) {
+      // "./src/agents/foo.py:graph" → absolute path to foo.py
+      const relPath = ref.split(":")[0];
+      out[name] = path.resolve(packagesDir, slug, relPath);
+    }
+  } catch {
+    // Malformed langgraph.json → skip silently; caller falls back to heuristics.
+  }
+
+  graphCache.set(slug, out);
+  return out;
+}
+
+/**
+ * Scan the showcase tree and produce a DemoSurface per discovered demo page.
+ *
+ * Conventions assumed (see showcase/packages/*):
+ *   - One demo per directory under packages/<slug>/src/app/demos/<demoId>/
+ *   - The demo's entry is page.tsx with `<CopilotKit agent="..." ...>`
+ *   - Suggestions live in a useConfigureSuggestions({ suggestions: [...] }) call
+ *     in the same file (or one of its hook imports — we walk hooks/*.tsx too)
+ *   - Backend tools for each agentId live in packages/<slug>/src/agents/<agentId>.py
+ *     with hyphens mapped to underscores
+ */
+export function collectDemoSurfaces(showcaseRoot: string): DemoSurface[] {
+  const packagesDir = path.join(showcaseRoot, "packages");
+  if (!fs.existsSync(packagesDir)) return [];
+
+  const surfaces: DemoSurface[] = [];
+
+  for (const slug of fs.readdirSync(packagesDir)) {
+    const demosDir = path.join(packagesDir, slug, "src", "app", "demos");
+    if (!fs.existsSync(demosDir)) continue;
+
+    for (const demoId of fs.readdirSync(demosDir)) {
+      const pageTsx = path.join(demosDir, demoId, "page.tsx");
+      if (!fs.existsSync(pageTsx)) continue;
+
+      const { agentId, suggestions, frontendTools } = parseDemoPage(pageTsx);
+      if (!agentId) continue;
+
+      // Collect suggestions from sibling hooks/*.tsx — Beautiful Chat puts
+      // its useConfigureSuggestions in hooks/use-example-suggestions.tsx.
+      const hooksDir = path.join(demosDir, demoId, "hooks");
+      if (fs.existsSync(hooksDir)) {
+        for (const f of fs.readdirSync(hooksDir)) {
+          if (!f.endsWith(".tsx") && !f.endsWith(".ts")) continue;
+          const parsed = parseDemoPage(path.join(hooksDir, f));
+          suggestions.push(...parsed.suggestions);
+          frontendTools.push(...parsed.frontendTools);
+        }
+      }
+
+      // Backend agent file resolution:
+      //   1. Use the authoritative agentId→graphId map parsed from route.ts
+      //      (handles the common pattern where multiple demos share one graph,
+      //      e.g. tool-rendering-custom-catchall routes to the tool_rendering
+      //      graph, not a file named after the demo).
+      //   2. Use the graphId to look up the Python file via langgraph.json.
+      //   3. Fall back to file-name heuristics for packages without that
+      //      wiring (TypeScript/Mastra/etc.).
+      const agentRoutes = loadAgentRoutes(packagesDir, slug);
+      const graphs = loadGraphs(packagesDir, slug);
+      const graphId = agentRoutes[agentId];
+      const agentFileFromGraph = graphId ? graphs[graphId] : undefined;
+
+      const candidates = [
+        agentFileFromGraph,
+        path.join(
+          packagesDir,
+          slug,
+          "src",
+          "agents",
+          agentId.replace(/-/g, "_") + ".py",
+        ),
+        path.join(packagesDir, slug, "src", "agents", agentId + ".py"),
+        path.join(
+          packagesDir,
+          slug,
+          "src",
+          "agents",
+          agentId.replace(/-/g, "_") + "_agent.py",
+        ),
+      ].filter((p): p is string => Boolean(p));
+
+      let backendTools: string[] = [];
+      for (const c of candidates) {
+        if (fs.existsSync(c)) {
+          backendTools = parseBackendTools(c);
+          break;
+        }
+      }
+
+      surfaces.push({
+        slug,
+        demoId,
+        agentId,
+        suggestions: [...new Set(suggestions)],
+        tools: [...new Set([...frontendTools, ...backendTools])],
+      });
+    }
+  }
+
+  return surfaces;
+}
+
+// -----------------------------------------------------------------------------
+// CLI
+// -----------------------------------------------------------------------------
+
+function cli(): void {
+  const aimockDir = path.join(SHOWCASE_ROOT, "aimock");
+  const fixtures = loadFixtures(aimockDir);
+  const demos = collectDemoSurfaces(SHOWCASE_ROOT);
+  const violations = validate(fixtures, demos);
+
+  if (violations.length === 0) {
+    console.log(
+      `✓ validate-fixture-tool-surface: ${fixtures.length} fixtures × ${demos.length} demos — no drift`,
+    );
+    return;
+  }
+
+  console.error(
+    `✗ validate-fixture-tool-surface: ${violations.length} drift violation(s)\n`,
+  );
+  for (const v of violations) {
+    console.error(
+      `  - fixture match "${v.fixtureMatch}" → tool "${v.fixtureTool}" is NOT in ${v.demo.slug}/${v.demo.demoId}'s tool surface`,
+    );
+    console.error(`    triggering suggestion: "${v.matchedSuggestion}"`);
+  }
+  process.exit(1);
+}
+
+// Run CLI when invoked directly.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  cli();
+}


### PR DESCRIPTION
## Summary

Showcase demos (e.g. gen-ui-tool-based's "Traffic pie chart", Beautiful Chat's pie/bar-chart suggestions) were rendering nothing in prod because aimock's substring-match fixtures cross-fired across demos with different tool surfaces, returning tool names the target agent never registered. This PR narrows the fixture patterns to fix the immediate breakage and adds a static validator so the same class of drift fails CI before it reaches prod.

## What broke

Aimock serves deterministic responses in prod for cost reasons. Fixtures substring-match the user message and return hardcoded tool calls. The `"pie chart"` pattern returned `query_data` (for Beautiful Chat's two-step flow where it has that tool), but the same substring also fires for gen-ui-tool-based's suggestions — which only registers `render_pie_chart`. The returned `query_data` call dangles, no UI renders.

Beautiful Chat also looped on the same fixture: aimock has no conversation-turn awareness, so after `query_data` returned its tool result, the follow-up model call had the same user-message context and the fixture re-matched, emitting `query_data` again — infinite until LangGraph's iteration cap.

Exposed by PR #4113 (showcase-ops) / the prod-mode migration cluster that started routing prod traffic through aimock. The fixtures themselves had been incrementally drifting for a while, but the routing change turned silent drift into user-visible breakage across many demos simultaneously.

## Fix #1 — narrow the fixture patterns

`showcase/aimock/feature-parity.json`:

- Replaced the generic `"pie chart"` / `"bar chart"` / `"show pie"` / `"show bar"` patterns with **6 per-suggestion specific-phrase matches**. gen-ui-tool-based and declarative-gen-ui get `render_pie_chart` / `render_bar_chart` directly; Beautiful Chat gets `pieChart` / `barChart` with real data (skipping the query_data loop).
- Narrowed `"schedule"` + `"meeting"` into one match for Beautiful Chat's "30-minute meeting to learn about CopilotKit" → `scheduleTime`.
- Narrowed `"flight"` / `"fly"` to `"flights from SFO to JFK"`.
- Narrowed `"background"` to `"sunset-themed gradient"`.
- Removed `"trip"`, `"sales"`, `"pipeline"`, `"todo"` — too generic, substring-false-firing across unrelated demos. Interrupt and A2UI demos with those prompts fall through to the real LLM proxy.

## Fix #2 — static drift guardrail

New `showcase/scripts/validate-fixture-tool-surface.ts`:

- Pure `validate()` function: for each fixture with tool-call responses, finds every demo whose suggestion prompt contains the fixture's match substring, then asserts the fixture's returned tool names are all registered by that demo's agent.
- CLI walks `packages/*/` collecting:
  - suggestions from `page.tsx` + sibling `hooks/*.tsx`
  - frontend tools from `useComponent` / `useHumanInTheLoop` / `useFrontendTool` / `useRenderTool` / `useDefaultRenderTool` calls
  - backend tools via `api/copilotkit*/route.ts` → agentId→graphId map → `langgraph.json` graph→Python-file → `@tool` decorators + `tools=[...]` arrays
- 7 vitest cases written TDD-first (watched fail, then implemented) covering: drift detection, content-only fixtures, no-matching-demo, case-insensitivity, multi-demo cross-check, multi-tool responses.

Runs as `npx tsx showcase/scripts/validate-fixture-tool-surface.ts`. Exit 0 = clean; exit 1 = per-fixture drift report.

Current state: **33 fixtures × 191 demos, no drift.**

Counterfactual: reverting just the pie-chart fixture fix correctly flags `langgraph-python/gen-ui-tool-based` and `langgraph-python/declarative-gen-ui` — i.e. the exact demos that broke in prod.

## Also fixed — unrelated LangGraph Python Dockerfile bug

`showcase/packages/langgraph-python/Dockerfile`: `WORKDIR /app` left `/app` owned by root; the explicit `--chown=app:app` on COPY lines chowned *contents* but not the directory itself, so the `app` user couldn't create `.langgraph_api` (the in-memory LangGraph runtime's cache dir) and the agent crashed on boot with `PermissionError: [Errno 13]`. Added a non-recursive `chown app:app /app` (preserves the perf intent of not doing a recursive chown).

## Known follow-ups (out of scope for this PR)

- Interrupt demos (`gen-ui-interrupt`, `interrupt-headless`, `hitl-in-chat`) and A2UI demos (`declarative-gen-ui`, `a2ui-fixed-schema`, `mcp-apps`, Calculator App) currently fall through to the real LLM when unmatched. Faithful fakes would need per-agent fixture keying in the aimock engine — separate upstream change.
- Python backend-tool parser uses regex; misses star-spread collections like `tools=[query_data, *todo_tools]`. Safe failure mode — missing tools surface as guardrail drift rather than silently pass.
- Add this validator to `.github/workflows/showcase_*.yml` so CI runs it on every PR touching fixtures or demos.

## Test plan

- [x] `npx vitest run showcase/scripts/__tests__/validate-fixture-tool-surface.test.ts` — 7/7 pass
- [x] `npx vitest run showcase/scripts/__tests__/aimock-fixtures.test.ts` — 17/17 still pass (no regression)
- [x] `npx tsx showcase/scripts/validate-fixture-tool-surface.ts` — 33 fixtures × 191 demos, 0 drift
- [x] Counterfactual: revert fixture fix, validator flags gen-ui-tool-based + declarative-gen-ui exactly
- [x] Direct aimock probe (localhost:4010) for all 8 fixed prompts → returns correct tool call
- [x] End-to-end through local LangGraph agent (localhost:3100) → gen-ui-tool-based "Traffic pie chart" suggestion → `render_pie_chart` with real data
- [ ] Merge → Railway redeploys aimock + langgraph-python → smoke cycle on Beautiful Chat + gen-ui-tool-based + declarative-gen-ui suggestions