### PR TITLE
fix: require identifyUser name in intelligence runtime

### DIFF
--- a/examples/integrations/langgraph-python-threads/apps/bff/src/server.ts
+++ b/examples/integrations/langgraph-python-threads/apps/bff/src/server.ts
@@ -25,7 +25,7 @@ const app = createCopilotEndpoint({
   basePath: "/api/copilotkit",
   runtime: new CopilotRuntime({
     intelligence,
-    identifyUser: () => ({ id: "jordan-beamson" }),
+    identifyUser: () => ({ id: "jordan-beamson", name: "Jordan Beamson" }),
     licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
     agents: { default: agent },
     openGenerativeUI: true,

--- a/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
@@ -228,7 +228,9 @@ describe("handleConnectAgent", () => {
         afterRequestMiddleware: undefined,
         runner,
         mode: "intelligence",
-        identifyUser: vi.fn().mockResolvedValue({ id: "user-1" }),
+        identifyUser: vi
+          .fn()
+          .mockResolvedValue({ id: "user-1", name: "User One" }),
         intelligence: platform,
       } as unknown as CopilotRuntime;
     };
@@ -384,7 +386,9 @@ describe("handleConnectAgent", () => {
       const platform = {
         ɵconnectThread: vi.fn().mockResolvedValue(null),
       };
-      const identifyUser = vi.fn().mockResolvedValue({ id: "resolved-user" });
+      const identifyUser = vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-user", name: "Resolved User" });
       const runtime = createIntelligenceRuntime(platform);
       runtime.identifyUser = identifyUser;
       const request = createConnectRequest(
@@ -414,7 +418,28 @@ describe("handleConnectAgent", () => {
         ɵconnectThread: vi.fn(),
       };
       const runtime = createIntelligenceRuntime(platform);
-      runtime.identifyUser = vi.fn().mockResolvedValue({ id: "" });
+      runtime.identifyUser = vi
+        .fn()
+        .mockResolvedValue({ id: "", name: "User" });
+
+      const response = await handleConnectAgent({
+        runtime,
+        request: createConnectRequest(),
+        agentId: "my-agent",
+      });
+
+      expect(response.status).toBe(400);
+      expect(platform.ɵconnectThread).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when identifyUser returns an invalid name", async () => {
+      const platform = {
+        ɵconnectThread: vi.fn(),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+      runtime.identifyUser = vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", name: "" });
 
       const response = await handleConnectAgent({
         runtime,

--- a/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
@@ -298,7 +298,9 @@ describe("handleRunAgent", () => {
         generateThreadNames?: boolean;
         identifyUser?: (
           request: Request,
-        ) => { id: string } | Promise<{ id: string }>;
+        ) =>
+          | { id: string; name: string }
+          | Promise<{ id: string; name: string }>;
       },
     ) => {
       const runner = Object.create(IntelligenceAgentRunner.prototype);
@@ -318,7 +320,8 @@ describe("handleRunAgent", () => {
         generateThreadNames: options?.generateThreadNames ?? false,
         intelligence: platform,
         identifyUser:
-          options?.identifyUser ?? vi.fn().mockResolvedValue({ id: "user-1" }),
+          options?.identifyUser ??
+          vi.fn().mockResolvedValue({ id: "user-1", name: "User One" }),
       } as unknown as CopilotRuntime;
     };
 
@@ -395,7 +398,9 @@ describe("handleRunAgent", () => {
           .fn()
           .mockResolvedValue({ joinToken: "jt-123", joinCode: "jc-123" }),
       };
-      const identifyUser = vi.fn().mockResolvedValue({ id: "resolved-user" });
+      const identifyUser = vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-user", name: "Resolved User" });
       const runtime = createIntelligenceRuntime(agent, platform, {
         identifyUser,
       });
@@ -870,7 +875,29 @@ describe("handleRunAgent", () => {
         ɵacquireThreadLock: vi.fn(),
       };
       const runtime = createIntelligenceRuntime(agent, platform, {
-        identifyUser: vi.fn().mockResolvedValue({ id: "" }),
+        identifyUser: vi.fn().mockResolvedValue({ id: "", name: "User" }),
+      });
+
+      const response = await handleRunAgent({
+        runtime,
+        request: createRunRequest(),
+        agentId: "my-agent",
+      });
+
+      expect(response.status).toBe(400);
+      expect(platform.getOrCreateThread).not.toHaveBeenCalled();
+      expect(platform.ɵacquireThreadLock).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when identifyUser returns an invalid name", async () => {
+      const agent = createAgentForIntelligence();
+      const platform = {
+        getOrCreateThread: vi.fn(),
+        getThreadMessages: vi.fn(),
+        ɵacquireThreadLock: vi.fn(),
+      };
+      const runtime = createIntelligenceRuntime(agent, platform, {
+        identifyUser: vi.fn().mockResolvedValue({ id: "user-1", name: "" }),
       });
 
       const response = await handleRunAgent({

--- a/packages/runtime/src/v2/runtime/__tests__/handle-threads.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-threads.test.ts
@@ -10,12 +10,13 @@ import {
 import { CopilotRuntime } from "../core/runtime";
 
 describe("thread handlers", () => {
-  const createIdentifyUser = () => vi.fn().mockResolvedValue({ id: "user-1" });
+  const createIdentifyUser = () =>
+    vi.fn().mockResolvedValue({ id: "user-1", name: "User One" });
 
   const createIntelligenceRuntime = (options?: {
     identifyUser?: (
       request: Request,
-    ) => { id: string } | Promise<{ id: string }>;
+    ) => { id: string; name: string } | Promise<{ id: string; name: string }>;
     intelligence?: Record<string, unknown>;
   }) =>
     ({
@@ -92,7 +93,25 @@ describe("thread handlers", () => {
     };
     const runtime = createIntelligenceRuntime({
       intelligence,
-      identifyUser: vi.fn().mockResolvedValue({ id: "" }),
+      identifyUser: vi.fn().mockResolvedValue({ id: "", name: "User" }),
+    });
+
+    const response = await handleListThreads({
+      runtime,
+      request: new Request("https://example.com/threads?agentId=agent-1"),
+    });
+
+    expect(response.status).toBe(400);
+    expect(intelligence.listThreads).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when identifyUser returns an invalid name for thread list", async () => {
+    const intelligence = {
+      listThreads: vi.fn(),
+    };
+    const runtime = createIntelligenceRuntime({
+      intelligence,
+      identifyUser: vi.fn().mockResolvedValue({ id: "user-1", name: "" }),
     });
 
     const response = await handleListThreads({
@@ -258,7 +277,50 @@ describe("thread handlers", () => {
     };
     const runtime = createIntelligenceRuntime({
       intelligence,
-      identifyUser: vi.fn().mockResolvedValue({ id: "" }),
+      identifyUser: vi.fn().mockResolvedValue({ id: "", name: "User" }),
+    });
+
+    const updateResponse = await handleUpdateThread({
+      runtime,
+      request: createMutationRequest("/threads/thread-1", "PATCH", {
+        agentId: "agent-1",
+      }),
+      threadId: "thread-1",
+    });
+    expect(updateResponse.status).toBe(400);
+
+    const archiveResponse = await handleArchiveThread({
+      runtime,
+      request: createMutationRequest("/threads/thread-1/archive", "POST", {
+        agentId: "agent-1",
+      }),
+      threadId: "thread-1",
+    });
+    expect(archiveResponse.status).toBe(400);
+
+    const deleteResponse = await handleDeleteThread({
+      runtime,
+      request: createMutationRequest("/threads/thread-1", "DELETE", {
+        agentId: "agent-1",
+      }),
+      threadId: "thread-1",
+    });
+    expect(deleteResponse.status).toBe(400);
+
+    expect(intelligence.updateThread).not.toHaveBeenCalled();
+    expect(intelligence.archiveThread).not.toHaveBeenCalled();
+    expect(intelligence.deleteThread).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when identifyUser returns an invalid name for thread mutations", async () => {
+    const intelligence = {
+      updateThread: vi.fn(),
+      archiveThread: vi.fn(),
+      deleteThread: vi.fn(),
+    };
+    const runtime = createIntelligenceRuntime({
+      intelligence,
+      identifyUser: vi.fn().mockResolvedValue({ id: "user-1", name: "" }),
     });
 
     const updateResponse = await handleUpdateThread({

--- a/packages/runtime/src/v2/runtime/__tests__/runtime.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/runtime.test.ts
@@ -11,7 +11,9 @@ import { IntelligenceAgentRunner } from "../runner/intelligence";
 
 describe("runtime construction", () => {
   const agents = {};
-  const identifyUser = vi.fn().mockResolvedValue({ id: "user-1" });
+  const identifyUser = vi
+    .fn()
+    .mockResolvedValue({ id: "user-1", name: "User One" });
   const createMockIntelligence = (): CopilotKitIntelligence =>
     ({
       ɵgetRunnerWsUrl: vi.fn().mockReturnValue("ws://runner.example"),

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -141,6 +141,7 @@ interface BaseCopilotRuntimeOptions extends CopilotRuntimeMiddlewares {
 
 export interface CopilotRuntimeUser {
   id: string;
+  name: string;
 }
 
 export type IdentifyUserCallback = (

--- a/packages/runtime/src/v2/runtime/handlers/shared/resolve-intelligence-user.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/resolve-intelligence-user.ts
@@ -16,8 +16,11 @@ export async function resolveIntelligenceUser(params: {
     if (!isValidIdentifier(user?.id)) {
       return errorResponse("identifyUser must return a valid user id", 400);
     }
+    if (typeof user?.name !== "string" || user.name.trim().length === 0) {
+      return errorResponse("identifyUser must return a valid user name", 400);
+    }
 
-    return { id: user.id };
+    return { id: user.id, name: user.name };
   } catch (error) {
     console.error("Error identifying intelligence user:", error);
     return errorResponse("Failed to identify user", 500);


### PR DESCRIPTION
## Summary
- require the Intelligence runtime `identifyUser` callback to return both `id` and `name`
- reject blank user names at request resolution time alongside invalid ids
- update runtime tests and the LangGraph Python threads example to provide a user name

## Verification
- `./node_modules/.bin/nx run @copilotkit/runtime:test -- src/v2/runtime/__tests__/runtime.test.ts src/v2/runtime/__tests__/handle-connect.test.ts src/v2/runtime/__tests__/handle-run.test.ts src/v2/runtime/__tests__/handle-threads.test.ts`
- `./node_modules/.bin/nx run @copilotkit/runtime:check-types`
- repo pre-commit hook (`oxlint .`, `oxfmt --write .`, `nx run-many -t test --projects=packages/**`, `nx run-many -t publint,attw --projects=packages/**`)