### PR TITLE
fix(shell-docs): add missing demos import to root slug page

### DIFF
--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -24,6 +24,14 @@ import {
   getCategoryLabel,
   type Integration,
 } from "@/lib/registry";
+import demoContent from "@/data/demo-content.json";
+
+interface DemoRecord {
+  regions?: Record<string, unknown>;
+}
+const demos: Record<string, DemoRecord> = (
+  demoContent as { demos: Record<string, DemoRecord> }
+).demos;
 
 function findFrameworksWithCell(cell: string): string[] {
   const matches: string[] = [];


### PR DESCRIPTION
## Summary

After PR #4113 merged (`5ed233f01`), `build (shell-docs)` is failing on main with:

```
./src/app/[[...slug]]/page.tsx:31:9
Type error: Cannot find name 'demos'.
```

`showcase/shell-docs/src/app/[[...slug]]/page.tsx` referenced `demos` at line 31 but never imported or declared it. The sibling `showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx` has the correct pattern — this PR copies that pattern exactly into the root slug page.

## Why

Unblock main CI for `build (shell-docs)`.

## Test plan

- [x] Local `npm run build` in `showcase/shell-docs/` no longer reports `Cannot find name 'demos'`
- [x] Fix matches the sibling file's pattern (import + DemoRecord interface + demos const)

## Note on additional build failures

After this fix, `npm run build` surfaces two more pre-existing errors that are independent from the `demos` issue and out of scope for this PR:

1. `findFrameworksWithCell` is imported by `src/components/unscoped-docs-page.tsx` from `@/lib/docs-render` but is never exported there (only declared locally in both `page.tsx` files).
2. `SidebarLink` requires a `scope` prop that the root page's Step-2 cards don't pass.

These appear to have been introduced by the earlier `feat(showcase/shell-docs): error boundary consolidation` commit (`9b05ed41b3`) and need separate follow-up PRs.