### PR TITLE
chore(commitlint): skip merge commits from subject validation

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -166,7 +166,17 @@ jobs:
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
-        run: npx commitlint --last --verbose
+        run: |
+          # Skip merge commits. GitHub's "Create a merge commit" option takes
+          # the message from the PR body, which can contain markdown lists
+          # that parse as additional (empty) commit subjects and fail
+          # subject-empty / type-empty — see commit 5ed233f01.
+          parents=$(git rev-list --parents -n 1 HEAD | awk '{print NF - 1}')
+          if [ "$parents" -gt 1 ]; then
+            echo "HEAD is a merge commit ($parents parents) — skipping commitlint."
+            exit 0
+          fi
+          npx commitlint --last --verbose
 
       - name: Validate PR commits with commitlint
         id: commitlint

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,12 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  // Skip standard git merge commits (e.g. "Merge pull request #N",
+  // "Merge branch '...'"). The push-path workflow additionally guards
+  // `--last` with a parent-count check so GitHub "Create a merge commit"
+  // style merges (which take their message from the PR body and can
+  // therefore contain markdown lists that parse as empty subjects) are
+  // skipped before commitlint even runs.
+  ignores: [(message) => /^Merge /.test(message)],
   rules: {
     "subject-case": [0],
     // GitHub merge commits append " (#NNNN)" which eats 8+ chars.


### PR DESCRIPTION
## Summary

Skip merge commits in the commitlint step so GitHub-generated merge messages (which inherit the PR body, markdown and all) stop tripping `subject-empty` / `type-empty`.

## Why

After merging PR #4113 into `main` as commit `5ed233f01`, the push-path `commitlint --last` run failed:

```
probe shares one loader + invoker + typed-error taxonomy, configured
4. `feat(showcase/shell-docs)` — error-boundary consolidation + docs
  subject may not be empty [subject-empty]
  type may not be empty [type-empty]
```

GitHub's "Create a merge commit" option takes the message from the PR body. Markdown bullets and blank lines in that body get parsed as additional commit subjects, most of which are empty. Standard commitlint guidance is to skip merge commits entirely — they aren't authored, they're generated.

## Fix

Two-layer so we catch both merge styles:

1. `commitlint.config.js` — `ignores: [(m) => /^Merge /.test(m)]` covers the standard `Merge pull request #N ...` / `Merge branch '...'` shapes.
2. `.github/workflows/static_quality.yml` — the push-path step now checks parent count via `git rev-list --parents -n 1 HEAD` and short-circuits when HEAD has >1 parent. This catches merges whose header is the PR title (no `Merge ` prefix), which is exactly how `5ed233f01` slipped through.

## Verification

- Commit `5ed233f01` has 2 parents → guard skips it.
- `89eb0734b` (normal squash commit) has 1 parent → guard passes through, commitlint runs normally.
- `echo "Merge pull request #123 ..." | npx commitlint` → 0 problems (ignores rule).
- A non-conventional subject still fails as expected.

## Test plan

- [ ] CI `commitlint` job passes on this PR (pull_request path).
- [ ] On merge to main, the push-path step reports "HEAD is a merge commit (2 parents) — skipping commitlint."