### PR TITLE
fix(showcase/scripts): capture-previews skips demos without a route

### DIFF
--- a/showcase/scripts/capture-previews.ts
+++ b/showcase/scripts/capture-previews.ts
@@ -245,6 +245,16 @@ function buildTargets(
       if (filterDemo && demo.id !== filterDemo) {
         continue;
       }
+      // Skip demos without a route — these are non-navigable entries
+      // (e.g., CLI command copy-paste cards like langgraph-python/cli-start)
+      // that live in the manifest but do not have a browser-navigable URL.
+      // Without this guard the script builds `${backendUrl}undefined` and
+      // wastes ~30s per entry on a DNS timeout before the 45s response
+      // timeout kicks in.
+      if (!demo.route) {
+        console.log(`  [SKIP] ${m.slug}/${demo.id} — no route (not navigable)`);
+        continue;
+      }
       targets.push({
         integrationSlug: m.slug,
         integrationName: m.name,


### PR DESCRIPTION
## Summary

- The `Capture Preview MP4s` workflow was emitting a `[FAIL] langgraph-python/cli-start: page.goto: net::ERR_NAME_NOT_RESOLVED at https://showcase-langgraph-python-production.up.railway.appundefined/` on every run.
- Root cause: `cli-start` is a manifest entry for a CLI-command copy-paste card. It has no `route` field, so `${backendUrl}${route}` produced `...appundefined/`. Playwright chased it until the 45s response timeout.
- Fix: in `buildTargets`, skip demos without a `route` with a visible `[SKIP]` log so they drop out of the capture set.

## Why

- Kills a recurring `[FAIL]` line in every capture run.
- Saves ~45s/run of wasted Playwright budget.
- The previous main-push rejection (GH013 from `PROTECT_OUR_MAIN`) is already fixed on main via `dff94fb42` (devops-bot token bypass); this PR addresses the remaining per-demo noise surfaced in those logs.

## Test plan

- [x] `node --import tsx ./capture-previews.ts --slug langgraph-python --demo cli-start --skip-upload --skip-registry-update` — prints `[SKIP] langgraph-python/cli-start — no route (not navigable)`, exits 0.
- [x] `node --import tsx ./capture-previews.ts --slug langgraph-python --demo agentic-chat --skip-upload --skip-registry-update` — still captures the MP4 (36 KB) and exits 0.
- [ ] Watch next `Showcase: Capture Previews` run on main post-merge to confirm `cli-start` no longer appears in the `Failed: N/158` tally.