### PR TITLE
fix(shell-docs): resolve findFrameworksWithCell + SidebarLink scope type errors

### DIFF
--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -25,14 +25,6 @@ import {
   type Integration,
 } from "@/lib/registry";
 
-function findFrameworksWithCell(cell: string): string[] {
-  const matches: string[] = [];
-  for (const integration of getIntegrations()) {
-    if (demos[`${integration.slug}::${cell}`]) matches.push(integration.slug);
-  }
-  return matches;
-}
-
 // Category ordering for the framework picker grid is imported from
 // @/lib/docs-render so the landing grid, sidebar dropdown, and this
 // overview share a single source of truth.

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -23,6 +23,7 @@ import { UnscopedDocsPage } from "@/components/unscoped-docs-page";
 import {
   CONTENT_DIR,
   buildNavTree,
+  findFrameworksWithCell,
   loadDoc,
   type NavNode,
 } from "@/lib/docs-render";
@@ -111,7 +112,11 @@ export default async function FrameworkScopedDocsPage({
   const missingCell =
     doc.fm.defaultCell && !frameworkHasCellFor(framework, doc.fm.defaultCell);
   const alternativeFrameworks = doc.fm.defaultCell
-    ? findFrameworksWithCell(doc.fm.defaultCell)
+    ? findFrameworksWithCell(
+        doc.fm.defaultCell,
+        getIntegrations().map((i) => i.slug),
+        demos,
+      )
     : [];
 
   const banner = missingCell ? (
@@ -168,14 +173,6 @@ export default async function FrameworkScopedDocsPage({
       bannerSlot={banner}
     />
   );
-}
-
-function findFrameworksWithCell(cell: string): string[] {
-  const matches: string[] = [];
-  for (const integration of getIntegrations()) {
-    if (demos[`${integration.slug}::${cell}`]) matches.push(integration.slug);
-  }
-  return matches;
 }
 
 // ---------------------------------------------------------------------------

--- a/showcase/shell-docs/src/components/sidebar-link.tsx
+++ b/showcase/shell-docs/src/components/sidebar-link.tsx
@@ -23,9 +23,10 @@ export interface SidebarLinkProps {
   active?: boolean;
   /**
    * The render context. `"docs"` = we're on `/docs/*`; `"framework"`
-   * = we're on `/<framework>/*`. Affects which prefix we prefer.
+   * = we're on `/<framework>/*`. Currently unused by the resolver (see
+   * note below) — kept optional on the interface for call-site clarity.
    */
-  scope: "docs" | "framework";
+  scope?: "docs" | "framework";
   /**
    * Deprecated. Previously held a server-rendered best-guess href used
    * before hydration; the component now resolves the href identically

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -678,6 +678,31 @@ export function convertTablesInJSX(content: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Framework / cell lookups
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the slugs of integrations that have a demo region tagged for
+ * the given feature cell. Pure helper — the caller supplies the list of
+ * candidate integration slugs and the demo-content map so this file
+ * stays framework-agnostic and free of registry imports.
+ *
+ * Shape of `demos`: keys are `"<integrationSlug>::<cell>"`; values are
+ * opaque demo records (we only check key presence here).
+ */
+export function findFrameworksWithCell(
+  cell: string,
+  integrationSlugs: readonly string[],
+  demos: Record<string, unknown>,
+): string[] {
+  const matches: string[] = [];
+  for (const slug of integrationSlugs) {
+    if (demos[`${slug}::${cell}`]) matches.push(slug);
+  }
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Frontmatter helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two pre-existing TypeScript errors from commit 9b05ed41 (\"feat(showcase/shell-docs): error boundary consolidation + docs components\") were surfacing on main's Docker build — fixed here in parallel with #4160 (which resolved a separate missing-import bug).

## Why

1. `unscoped-docs-page.tsx` imports `findFrameworksWithCell` from `@/lib/docs-render`, but the helper was only declared locally in the two page.tsx routes — with a 1-arg signature (and dead code referencing an undeclared `demos` in one case). The component called it with 3 args.
2. The Step-2 overview cards in `[[...slug]]/page.tsx` render `<SidebarLink>` without the required `scope` prop; the component already ignored `scope` internally (destructured as `_scope`).

## Changes

- Export a shared 3-arg `findFrameworksWithCell(cell, integrationSlugs, demos)` from `src/lib/docs-render.tsx` so the helper stays framework-agnostic (no registry imports).
- Drop the dead local in `src/app/[[...slug]]/page.tsx` (referenced undeclared `demos` — would have been a runtime error if ever called).
- Rewire the live caller in `src/app/[framework]/[[...slug]]/page.tsx` to use the shared export, passing `getIntegrations()` slugs + local `demos` map.
- Relax `SidebarLinkProps.scope` to optional — it was already effectively unused internally.

## Test plan

- [x] `cd showcase/shell-docs && npm run build` — clean compile, all 26 static pages generate.
- [x] `pnpm -w format` — no formatter churn.
- [ ] CI green on the PR.