### PR TITLE
fix(showcase/langgraph-fastapi): pre-create .langgraph_api dir so app user can write

### DIFF
--- a/showcase/packages/langgraph-fastapi/Dockerfile
+++ b/showcase/packages/langgraph-fastapi/Dockerfile
@@ -65,6 +65,15 @@ ENV PYTHONPATH=/app/shared/python
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Pre-create .langgraph_api (CWD-relative state dir) with app ownership.
+# langgraph_runtime_inmem/store.py calls `os.makedirs(".langgraph_api",
+# exist_ok=True)` at import time, which resolves against CWD (/app). WORKDIR
+# creates /app as root; USER app then can't write there. A fresh container
+# imports the module, hits PermissionError [Errno 13], crashes the agent
+# subprocess, and the watchdog/Railway restart loops forever.
+# Creating the dir up-front with the right owner sidesteps the write.
+RUN mkdir -p /app/.langgraph_api && chown app:app /app /app/.langgraph_api
+
 USER app
 
 EXPOSE 10000


### PR DESCRIPTION
## Summary

Railway deploys of `langgraph-fastapi` have been failing health within the 600s budget ever since main@5ed233f01 (PR #4113) triggered the first rebuild of this package after b9bcf2e6b dropped it to `USER app`. The PR #4113 diff itself is runtime-inert for the service (QA markdown + workflow refactor), but rebuilding + fresh GHCR push + Railway `serviceInstanceRedeploy` was the first time the `USER app` image actually ran in production.

Deployment `952df5c6-32b4-4b2e-bb28-b97cb391a2a7` logs show the real error:

```
File "/opt/venv/lib/python3.12/site-packages/langgraph_runtime_inmem/store.py", line 85
  os.makedirs(".langgraph_api", exist_ok=True)
PermissionError: [Errno 13] Permission denied: '.langgraph_api'
```

`langgraph_runtime_inmem` creates a CWD-relative state dir at import time. CWD is `/app` (WORKDIR), which Docker creates as `root`-owned; `--chown=app:app` on the `COPY` lines only chowns the files copied in, not `/app` itself. With `USER app` the agent subprocess can no longer `makedirs` there.

The agent crashes, Next.js stays alive so `wait -n` never fires, and the watchdog/Railway restart loop eats the entire 600s budget on every attempt. Other 16 starters weren't in the matrix for this run (no langgraph_fastapi-adjacent file changes on them) so they didn't pull the new image, hence only this service went red.

## Fix

Pre-create `/app/.langgraph_api` with `app:app` ownership and chown `/app` itself so the startup `makedirs` is a no-op. Single-line change in the Dockerfile; no code, no env, no Railway-side work needed.

## Test plan

- [x] `docker buildx build --load` completes clean
- [x] Container run: agent `/ok` → 200, next `/api/health` → 200
- [x] `docker logs` grep for `PermissionError` / `Errno 13` → empty
- [ ] CI `build (langgraph-fastapi ...)` → green
- [ ] Railway deploy → SUCCESS within 600s budget