### PR TITLE
fix(docs): restore Cloud sign-up CTAs

### DIFF
--- a/docs/content/docs/(root)/index.mdx
+++ b/docs/content/docs/(root)/index.mdx
@@ -6,7 +6,8 @@ hideTOC: true
 hideHeader: true
 ---
 
-import { MessageSquare, Layers, Code, Bot, Server, BookOpen, Play, Book } from "lucide-react"
+import { MessageSquare, Layers, Code, Bot, Server, BookOpen, Play, Book, CloudIcon } from "lucide-react"
+import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud"
 import LandingCodeShowcase from "@/snippets/landing-code-showcase.mdx"
 import { IntegrationGrid } from "@/components/content/integration-grid"
 import { LazyIframe } from "@/components/content/lazy-iframe"
@@ -19,7 +20,7 @@ CopilotKit is the __frontend stack for agents__ and __generative UI__. Connect a
 
 Look below to find right guide for your needs, whether you're starting from nothing or have existing agent you want to give a prebuilt chat UI or fully custom UI.
 
-<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 not-prose mb-10 mt-10">
+<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 not-prose mb-10 mt-10">
   <a href="/quickstart" className="group flex items-start gap-3 bg-card border border-border/80 rounded-lg p-4 no-underline hover:border-primary/60 hover:bg-accent/50 transition-colors shadow-sm">
     <Play className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
     <div>
@@ -46,6 +47,13 @@ Look below to find right guide for your needs, whether you're starting from noth
     <div>
       <div className="font-semibold text-foreground group-hover:text-primary mb-1">Generative UI</div>
       <div className="text-sm text-muted-foreground leading-relaxed">Render tools as React components.</div>
+    </div>
+  </a>
+  <a href="https://cloud.copilotkit.ai" target="_blank" className="group flex items-start gap-3 bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-indigo-950/30 dark:to-purple-950/30 border border-indigo-200 dark:border-indigo-800 rounded-lg p-4 no-underline hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-950/50 transition-colors shadow-sm">
+    <CloudIcon className="h-5 w-5 text-indigo-600 dark:text-indigo-400 mt-0.5 flex-shrink-0" />
+    <div>
+      <div className="font-semibold text-indigo-800 dark:text-indigo-300 group-hover:text-indigo-600 mb-1">Copilot Cloud</div>
+      <div className="text-sm text-muted-foreground leading-relaxed">Get started the easiest way with our hosted service.</div>
     </div>
   </a>
 </div>

--- a/docs/content/docs/(root)/quickstart.mdx
+++ b/docs/content/docs/(root)/quickstart.mdx
@@ -5,6 +5,13 @@ icon: "lucide/Play"
 hideTOC: true
 ---
 import { IntegrationGrid } from "@/components/content/integration-grid";
+import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
+
+## Start from Copilot Cloud
+
+The fastest way to get started — no backend setup required. Sign up for free, get your API key, and connect it to your frontend.
+
+<LinkToCopilotCloud asButton={true} />
 
 ## Start from our CLI
 Starting from scratch? Use our CLI to get started in minutes, it will bootstrap a

--- a/docs/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/docs/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -6,6 +6,8 @@ hideTOC: true
 ---
 
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
+import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
+import CopilotCloudConfigureCopilotKitProvider from "@/snippets/copilot-cloud-configure-copilotkit-provider.mdx";
 import {
   WrenchIcon,
   PlugIcon,
@@ -33,6 +35,10 @@ Before you begin, you'll need the following:
 - Your favorite package manager
 
 ## Getting started
+
+<Callout type="info" title="Prefer a hosted backend?">
+  Skip the self-hosting steps below — <LinkToCopilotCloud asButton={false}>sign up for Copilot Cloud for free</LinkToCopilotCloud> and use a `publicApiKey` instead of `runtimeUrl`. See the [Copilot Cloud setup snippet](#copilot-cloud-alternative) at the bottom of this page.
+</Callout>
 
 <Steps>
     <Step>
@@ -194,6 +200,12 @@ Before you begin, you'll need the following:
 
     </Step>
 </Steps>
+
+## Copilot Cloud alternative
+
+Instead of self-hosting the runtime, you can use Copilot Cloud. Replace the runtime setup and provider steps above with:
+
+<CopilotCloudConfigureCopilotKitProvider components={props.components} />
 
 ## What's next?
 

--- a/docs/content/docs/integrations/langgraph/quickstart.mdx
+++ b/docs/content/docs/integrations/langgraph/quickstart.mdx
@@ -17,6 +17,7 @@ import CopilotCloudConfigureRemoteEndpointLangGraph from "@/snippets/copilot-clo
 import CopilotKitCloudCopilotKitProvider from "@/snippets/copilot-cloud-configure-copilotkit-provider.mdx";
 import LangGraphPlatformDeploymentTabs from "@/snippets/langgraph-platform-deployment-tabs.mdx";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
+import { LinkToCopilotCloud } from "@/components/react/link-to-copilot-cloud";
 import FindYourCopilotRuntime from "@/snippets/find-your-copilot-runtime.mdx";
 import ConnectCopilotUI from "@/snippets/copilot-ui.mdx";
 import CloudCopilotKitProvider from "@/snippets/coagents/cloud-configure-copilotkit-provider.mdx";
@@ -57,6 +58,10 @@ Before you begin, you'll need the following:
 - (Optional) A LangSmith API key - only required if using an existing LangChain agent
 
 ## Getting started
+
+<Callout type="info" title="Prefer a hosted backend?">
+  Skip the self-hosting steps below — <LinkToCopilotCloud asButton={false}>sign up for Copilot Cloud for free</LinkToCopilotCloud> and use a `publicApiKey` instead of `runtimeUrl`. See the [Copilot Cloud setup snippet](#copilot-cloud-alternative) at the bottom of this page.
+</Callout>
 
 <Steps>
     <TailoredContent
@@ -539,6 +544,12 @@ Before you begin, you'll need the following:
 
     </Step>
 </Steps>
+
+## Copilot Cloud alternative
+
+Instead of self-hosting the runtime, you can use Copilot Cloud. Replace the runtime setup and provider steps above with:
+
+<CopilotKitCloudCopilotKitProvider components={props.components} />
 
 ## What's next?
 


### PR DESCRIPTION
## Summary

- Restore **Copilot Cloud** card on the docs landing page (`/`) — was removed in `cc8c94589` (Feb 23)
- Add **"Start from Copilot Cloud"** as the first section on the quickstart page
- Add **Cloud alternative callout + snippet** to the built-in-agent and LangGraph quickstarts — these had Cloud setup removed during the Jan 8 docs rebranding (`374c2c013`)

See the full audit: [cloud-signup-audit.md](https://github.com/CopilotKit/CopilotKit/blob/fix/restore-cloud-signup-ctas/docs/cloud-signup-audit.md) _(not committed, for reference only)_

## Context

During the Jan/Feb 2026 docs rebranding, Cloud sign-up CTAs were removed from most quickstart pages. The old `direct-to-llm` quickstart had "Copilot Cloud (Recommended)" as the primary tab — that file was deleted and its successors (root quickstart, built-in-agent quickstart) had no Cloud option at all.

## Test plan

- [x] Run `pnpm dev` in `docs/` and verify the Cloud card appears on the landing page
- [x] Verify the quickstart page shows "Start from Copilot Cloud" with a working link
- [x] Verify built-in-agent and LangGraph quickstarts show the Cloud callout and Cloud alternative section

🤖 Generated with [Claude Code](https://claude.com/claude-code)