### PR TITLE
fix: main CI recovery after #4113 — consolidated shell-docs + shell-dashboard + langgraph-fastapi + commitlint + capture-previews fixes

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -166,7 +166,17 @@ jobs:
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
-        run: npx commitlint --last --verbose
+        run: |
+          # Skip merge commits. GitHub's "Create a merge commit" option takes
+          # the message from the PR body, which can contain markdown lists
+          # that parse as additional (empty) commit subjects and fail
+          # subject-empty / type-empty — see commit 5ed233f01.
+          parents=$(git rev-list --parents -n 1 HEAD | awk '{print NF - 1}')
+          if [ "$parents" -gt 1 ]; then
+            echo "HEAD is a merge commit ($parents parents) — skipping commitlint."
+            exit 0
+          fi
+          npx commitlint --last --verbose
 
       - name: Validate PR commits with commitlint
         id: commitlint

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,12 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  // Skip standard git merge commits (e.g. "Merge pull request #N",
+  // "Merge branch '...'"). The push-path workflow additionally guards
+  // `--last` with a parent-count check so GitHub "Create a merge commit"
+  // style merges (which take their message from the PR body and can
+  // therefore contain markdown lists that parse as empty subjects) are
+  // skipped before commitlint even runs.
+  ignores: [(message) => /^Merge /.test(message)],
   rules: {
     "subject-case": [0],
     // GitHub merge commits append " (#NNNN)" which eats 8+ chars.

--- a/showcase/packages/langgraph-fastapi/Dockerfile
+++ b/showcase/packages/langgraph-fastapi/Dockerfile
@@ -65,6 +65,15 @@ ENV PYTHONPATH=/app/shared/python
 COPY --chown=app:app entrypoint.sh ./
 RUN chmod +x entrypoint.sh
 
+# Pre-create .langgraph_api (CWD-relative state dir) with app ownership.
+# langgraph_runtime_inmem/store.py calls `os.makedirs(".langgraph_api",
+# exist_ok=True)` at import time, which resolves against CWD (/app). WORKDIR
+# creates /app as root; USER app then can't write there. A fresh container
+# imports the module, hits PermissionError [Errno 13], crashes the agent
+# subprocess, and the watchdog/Railway restart loops forever.
+# Creating the dir up-front with the right owner sidesteps the write.
+RUN mkdir -p /app/.langgraph_api && chown app:app /app /app/.langgraph_api
+
 USER app
 
 EXPOSE 10000

--- a/showcase/scripts/capture-previews.ts
+++ b/showcase/scripts/capture-previews.ts
@@ -245,6 +245,16 @@ function buildTargets(
       if (filterDemo && demo.id !== filterDemo) {
         continue;
       }
+      // Skip demos without a route — these are non-navigable entries
+      // (e.g., CLI command copy-paste cards like langgraph-python/cli-start)
+      // that live in the manifest but do not have a browser-navigable URL.
+      // Without this guard the script builds `${backendUrl}undefined` and
+      // wastes ~30s per entry on a DNS timeout before the 45s response
+      // timeout kicks in.
+      if (!demo.route) {
+        console.log(`  [SKIP] ${m.slug}/${demo.id} — no route (not navigable)`);
+        continue;
+      }
       targets.push({
         integrationSlug: m.slug,
         integrationName: m.name,

--- a/showcase/scripts/package-lock.json
+++ b/showcase/scripts/package-lock.json
@@ -20,7 +20,68 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/prompts": "^2.4.9",
-        "vitest": "^4.1.3"
+        "@vitest/coverage-v8": "^4.1.5",
+        "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@copilotkit/aimock": {
@@ -503,12 +564,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -657,9 +739,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -677,9 +756,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,9 +773,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,9 +790,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,9 +807,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,9 +824,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -910,17 +974,48 @@
         "kleur": "^3.0.3"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -929,13 +1024,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -956,9 +1051,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -969,13 +1064,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -983,14 +1078,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -999,9 +1094,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1009,13 +1104,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1088,6 +1183,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1359,6 +1466,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1374,6 +1498,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -1388,6 +1551,13 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1547,9 +1717,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1571,9 +1738,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1595,9 +1759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1619,9 +1780,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1691,6 +1849,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -1929,6 +2115,19 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2091,6 +2290,19 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -2281,19 +2493,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2321,12 +2533,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/showcase/shell-dashboard/Dockerfile
+++ b/showcase/shell-dashboard/Dockerfile
@@ -12,8 +12,8 @@ WORKDIR /app
 COPY showcase/scripts/package.json showcase/scripts/package-lock.json ./scripts/
 COPY showcase/shell-dashboard/package.json showcase/shell-dashboard/package-lock.json ./shell-dashboard/
 
-RUN cd scripts && npm ci --silent \
-    && cd ../shell-dashboard && npm ci --silent
+RUN cd scripts && npm ci \
+    && cd ../shell-dashboard && npm ci
 
 # Copy source
 COPY showcase/shared/ ./shared/

--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -25,14 +25,6 @@ import {
   type Integration,
 } from "@/lib/registry";
 
-function findFrameworksWithCell(cell: string): string[] {
-  const matches: string[] = [];
-  for (const integration of getIntegrations()) {
-    if (demos[`${integration.slug}::${cell}`]) matches.push(integration.slug);
-  }
-  return matches;
-}
-
 // Category ordering for the framework picker grid is imported from
 // @/lib/docs-render so the landing grid, sidebar dropdown, and this
 // overview share a single source of truth.

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -23,6 +23,7 @@ import { UnscopedDocsPage } from "@/components/unscoped-docs-page";
 import {
   CONTENT_DIR,
   buildNavTree,
+  findFrameworksWithCell,
   loadDoc,
   type NavNode,
 } from "@/lib/docs-render";
@@ -111,7 +112,11 @@ export default async function FrameworkScopedDocsPage({
   const missingCell =
     doc.fm.defaultCell && !frameworkHasCellFor(framework, doc.fm.defaultCell);
   const alternativeFrameworks = doc.fm.defaultCell
-    ? findFrameworksWithCell(doc.fm.defaultCell)
+    ? findFrameworksWithCell(
+        doc.fm.defaultCell,
+        getIntegrations().map((i) => i.slug),
+        demos,
+      )
     : [];
 
   const banner = missingCell ? (
@@ -168,14 +173,6 @@ export default async function FrameworkScopedDocsPage({
       bannerSlot={banner}
     />
   );
-}
-
-function findFrameworksWithCell(cell: string): string[] {
-  const matches: string[] = [];
-  for (const integration of getIntegrations()) {
-    if (demos[`${integration.slug}::${cell}`]) matches.push(integration.slug);
-  }
-  return matches;
 }
 
 // ---------------------------------------------------------------------------

--- a/showcase/shell-docs/src/components/sidebar-link.tsx
+++ b/showcase/shell-docs/src/components/sidebar-link.tsx
@@ -23,9 +23,10 @@ export interface SidebarLinkProps {
   active?: boolean;
   /**
    * The render context. `"docs"` = we're on `/docs/*`; `"framework"`
-   * = we're on `/<framework>/*`. Affects which prefix we prefer.
+   * = we're on `/<framework>/*`. Currently unused by the resolver (see
+   * note below) — kept optional on the interface for call-site clarity.
    */
-  scope: "docs" | "framework";
+  scope?: "docs" | "framework";
   /**
    * Deprecated. Previously held a server-rendered best-guess href used
    * before hydration; the component now resolves the href identically

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -678,6 +678,31 @@ export function convertTablesInJSX(content: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Framework / cell lookups
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the slugs of integrations that have a demo region tagged for
+ * the given feature cell. Pure helper — the caller supplies the list of
+ * candidate integration slugs and the demo-content map so this file
+ * stays framework-agnostic and free of registry imports.
+ *
+ * Shape of `demos`: keys are `"<integrationSlug>::<cell>"`; values are
+ * opaque demo records (we only check key presence here).
+ */
+export function findFrameworksWithCell(
+  cell: string,
+  integrationSlugs: readonly string[],
+  demos: Record<string, unknown>,
+): string[] {
+  const matches: string[] = [];
+  for (const slug of integrationSlugs) {
+    if (demos[`${slug}::${cell}`]) matches.push(slug);
+  }
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Frontmatter helpers
 // ---------------------------------------------------------------------------
 

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -366,11 +366,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -420,18 +416,14 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat.mp4",
           "highlight": [
@@ -444,9 +436,7 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-customization-css.mp4",
           "highlight": [
@@ -460,9 +450,7 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-default-catchall.mp4",
           "highlight": [
@@ -475,9 +463,7 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-custom-catchall.mp4",
           "highlight": [
@@ -491,9 +477,7 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools.mp4",
           "highlight": [
@@ -506,9 +490,7 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools-async.mp4",
           "highlight": [
@@ -522,9 +504,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-chat.mp4",
           "highlight": [
@@ -538,9 +518,7 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-app.mp4",
           "highlight": [
@@ -554,9 +532,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering.mp4",
           "highlight": [
@@ -571,9 +547,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-tool-based.mp4",
           "highlight": [
@@ -587,9 +561,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-agent.mp4",
           "highlight": [
@@ -603,9 +575,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-read-write.mp4",
           "highlight": [
@@ -620,9 +590,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-streaming.mp4",
           "highlight": [
@@ -636,9 +604,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_subagents.mp4",
           "highlight": [
@@ -652,9 +618,7 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-sidebar.mp4",
           "highlight": [
@@ -667,9 +631,7 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-popup.mp4",
           "highlight": [
@@ -682,9 +644,7 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-slots",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-slots.mp4",
           "highlight": [
@@ -698,9 +658,7 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-simple",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-simple.mp4",
           "highlight": [
@@ -713,9 +671,7 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-complete",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-complete.mp4",
           "highlight": [
@@ -730,9 +686,7 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat-reasoning.mp4",
           "highlight": [
@@ -746,9 +700,7 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-interrupt.mp4",
           "highlight": [
@@ -762,9 +714,7 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_declarative-gen-ui.mp4",
           "highlight": [
@@ -780,9 +730,7 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_a2ui-fixed-schema.mp4",
           "highlight": [
@@ -800,9 +748,7 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/mcp-apps",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_mcp-apps.mp4",
           "highlight": [
@@ -815,9 +761,7 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_interrupt-headless.mp4",
           "highlight": [
@@ -830,9 +774,7 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_readonly-state-agent-context.mp4",
           "highlight": [
@@ -845,9 +787,7 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_reasoning-default-render.mp4",
           "highlight": [
@@ -860,9 +800,7 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-reasoning-chain.mp4",
           "highlight": [
@@ -877,9 +815,7 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_beautiful-chat.mp4",
           "highlight": [
@@ -1042,11 +978,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1074,9 +1006,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_agentic-chat.mp4"
         },
@@ -1084,9 +1014,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_hitl-in-chat.mp4"
         },
@@ -1094,9 +1022,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_tool-rendering.mp4"
         },
@@ -1104,9 +1030,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-tool-based.mp4"
         },
@@ -1114,9 +1038,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-agent.mp4"
         },
@@ -1124,9 +1046,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-read-write.mp4"
         },
@@ -1134,9 +1054,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-streaming.mp4"
         },
@@ -1144,9 +1062,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_subagents.mp4"
         }
@@ -1206,11 +1122,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1238,9 +1150,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_agentic-chat.mp4"
         },
@@ -1248,9 +1158,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_tool-rendering.mp4"
         },
@@ -1258,9 +1166,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_hitl-in-chat.mp4"
         },
@@ -1268,9 +1174,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-tool-based.mp4"
         },
@@ -1278,9 +1182,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-agent.mp4"
         },
@@ -1288,9 +1190,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-read-write.mp4"
         },
@@ -1298,9 +1198,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-streaming.mp4"
         },
@@ -1308,9 +1206,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_subagents.mp4"
         }
@@ -1370,11 +1266,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1398,9 +1290,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_agentic-chat.mp4"
         },
@@ -1408,9 +1298,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_hitl-in-chat.mp4"
         },
@@ -1418,9 +1306,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_tool-rendering.mp4"
         },
@@ -1428,9 +1314,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-tool-based.mp4"
         },
@@ -1438,9 +1322,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-agent.mp4"
         },
@@ -1448,9 +1330,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-read-write.mp4"
         },
@@ -1458,9 +1338,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-streaming.mp4"
         },
@@ -1468,9 +1346,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_subagents.mp4"
         }
@@ -1530,11 +1406,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1562,9 +1434,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_agentic-chat.mp4"
         },
@@ -1572,9 +1442,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_hitl-in-chat.mp4"
         },
@@ -1582,9 +1450,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_tool-rendering.mp4"
         },
@@ -1592,9 +1458,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-tool-based.mp4"
         },
@@ -1602,9 +1466,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-agent.mp4"
         },
@@ -1612,9 +1474,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-read-write.mp4"
         },
@@ -1622,9 +1482,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-streaming.mp4"
         },
@@ -1632,9 +1490,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_subagents.mp4"
         }
@@ -1694,11 +1550,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1726,9 +1578,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_agentic-chat.mp4"
         },
@@ -1736,9 +1586,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_hitl-in-chat.mp4"
         },
@@ -1746,9 +1594,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_tool-rendering.mp4"
         },
@@ -1756,9 +1602,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-tool-based.mp4"
         },
@@ -1766,9 +1610,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-agent.mp4"
         },
@@ -1776,9 +1618,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-read-write.mp4"
         },
@@ -1786,9 +1626,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-streaming.mp4"
         },
@@ -1796,9 +1634,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_subagents.mp4"
         }
@@ -1858,11 +1694,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1886,9 +1718,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_agentic-chat.mp4"
         },
@@ -1896,9 +1726,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_hitl-in-chat.mp4"
         },
@@ -1906,9 +1734,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_tool-rendering.mp4"
         },
@@ -1916,9 +1742,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-tool-based.mp4"
         },
@@ -1926,9 +1750,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-agent.mp4"
         },
@@ -1936,9 +1758,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-read-write.mp4"
         },
@@ -1946,9 +1766,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-streaming.mp4"
         },
@@ -1956,9 +1774,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_subagents.mp4"
         }
@@ -2018,11 +1834,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2038,9 +1850,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_agentic-chat.mp4"
         },
@@ -2048,9 +1858,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_hitl-in-chat.mp4"
         },
@@ -2058,9 +1866,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_tool-rendering.mp4"
         },
@@ -2068,9 +1874,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-tool-based.mp4"
         },
@@ -2078,9 +1882,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-agent.mp4"
         },
@@ -2088,9 +1890,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-read-write.mp4"
         },
@@ -2098,9 +1898,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-streaming.mp4"
         },
@@ -2108,9 +1906,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_subagents.mp4"
         }
@@ -2178,11 +1974,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2198,9 +1990,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_agentic-chat.mp4"
         },
@@ -2208,9 +1998,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_hitl-in-chat.mp4"
         },
@@ -2218,9 +2006,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_tool-rendering.mp4"
         },
@@ -2228,9 +2014,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-tool-based.mp4"
         },
@@ -2238,9 +2022,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-agent.mp4"
         },
@@ -2248,9 +2030,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-read-write.mp4"
         },
@@ -2258,9 +2038,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-streaming.mp4"
         },
@@ -2268,9 +2046,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_subagents.mp4"
         }
@@ -2338,11 +2114,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2366,9 +2138,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_agentic-chat.mp4"
         },
@@ -2376,9 +2146,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_hitl-in-chat.mp4"
         },
@@ -2386,9 +2154,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_tool-rendering.mp4"
         },
@@ -2396,9 +2162,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-tool-based.mp4"
         },
@@ -2406,9 +2170,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-agent.mp4"
         },
@@ -2416,9 +2178,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-read-write.mp4"
         },
@@ -2426,9 +2186,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-streaming.mp4"
         },
@@ -2436,9 +2194,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_subagents.mp4"
         }
@@ -2502,11 +2258,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2522,9 +2274,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_agentic-chat.mp4"
         },
@@ -2532,9 +2282,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_hitl-in-chat.mp4"
         },
@@ -2542,9 +2290,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_tool-rendering.mp4"
         },
@@ -2552,9 +2298,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-tool-based.mp4"
         },
@@ -2562,9 +2306,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-agent.mp4"
         },
@@ -2572,9 +2314,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-read-write.mp4"
         },
@@ -2582,9 +2322,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-streaming.mp4"
         },
@@ -2592,9 +2330,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_subagents.mp4"
         }
@@ -2666,11 +2402,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2694,9 +2426,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_agentic-chat.mp4"
         },
@@ -2704,9 +2434,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_hitl-in-chat.mp4"
         },
@@ -2714,9 +2442,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_tool-rendering.mp4"
         },
@@ -2724,9 +2450,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-tool-based.mp4"
         },
@@ -2734,9 +2458,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-agent.mp4"
         },
@@ -2744,9 +2466,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-read-write.mp4"
         },
@@ -2754,9 +2474,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-streaming.mp4"
         },
@@ -2764,9 +2482,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_subagents.mp4"
         }
@@ -2830,11 +2546,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2858,9 +2570,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_agentic-chat.mp4"
         },
@@ -2868,9 +2578,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_hitl-in-chat.mp4"
         },
@@ -2878,9 +2586,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_tool-rendering.mp4"
         },
@@ -2888,9 +2594,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-tool-based.mp4"
         },
@@ -2898,9 +2602,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-agent.mp4"
         },
@@ -2908,9 +2610,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-read-write.mp4"
         },
@@ -2918,9 +2618,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-streaming.mp4"
         },
@@ -2928,9 +2626,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_subagents.mp4"
         }
@@ -2990,11 +2686,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3010,9 +2702,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_agentic-chat.mp4"
         },
@@ -3020,9 +2710,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_hitl-in-chat.mp4"
         },
@@ -3030,9 +2718,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_tool-rendering.mp4"
         },
@@ -3040,9 +2726,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-tool-based.mp4"
         },
@@ -3050,9 +2734,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-agent.mp4"
         },
@@ -3060,9 +2742,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-read-write.mp4"
         },
@@ -3070,9 +2750,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-streaming.mp4"
         },
@@ -3080,9 +2758,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_subagents.mp4"
         }
@@ -3117,11 +2793,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -3145,9 +2817,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_agentic-chat.mp4"
         },
@@ -3155,9 +2825,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_hitl-in-chat.mp4"
         },
@@ -3165,9 +2833,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_tool-rendering.mp4"
         },
@@ -3175,9 +2841,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-tool-based.mp4"
         },
@@ -3185,9 +2849,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-agent.mp4"
         },
@@ -3195,9 +2857,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-read-write.mp4"
         },
@@ -3205,9 +2865,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-streaming.mp4"
         },
@@ -3215,9 +2873,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_subagents.mp4"
         }
@@ -3277,11 +2933,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -3305,9 +2957,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_agentic-chat.mp4"
         },
@@ -3315,9 +2965,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_hitl-in-chat.mp4"
         },
@@ -3325,9 +2973,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_tool-rendering.mp4"
         },
@@ -3335,9 +2981,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-tool-based.mp4"
         },
@@ -3345,9 +2989,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-agent.mp4"
         },
@@ -3355,9 +2997,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-read-write.mp4"
         },
@@ -3365,9 +3005,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-streaming.mp4"
         },
@@ -3375,9 +3013,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_subagents.mp4"
         }
@@ -3437,11 +3073,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3457,9 +3089,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_agentic-chat.mp4"
         },
@@ -3467,9 +3097,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_hitl-in-chat.mp4"
         },
@@ -3477,9 +3105,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_tool-rendering.mp4"
         },
@@ -3487,9 +3113,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-tool-based.mp4"
         },
@@ -3497,9 +3121,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-agent.mp4"
         },
@@ -3507,9 +3129,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-read-write.mp4"
         },
@@ -3517,9 +3137,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-streaming.mp4"
         },
@@ -3527,9 +3145,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_subagents.mp4"
         }


### PR DESCRIPTION
## Summary

Consolidates the 5 independent fixes needed to return main CI to green after #4113 (showcase-ops) merged. Supersedes individual PRs #4160, #4161, #4162, #4163, #4164, #4165 — closing those in favor of this one.

## Fixes (5 grouped commits, one per area of concern)

1. **`fix(shell-docs): resolve findFrameworksWithCell + SidebarLink scope type errors`**
   - Exports shared 3-arg `findFrameworksWithCell` from `docs-render.tsx`, drops dead 1-arg locals in both `[[...slug]]/page.tsx` files (the root copy was unused and referenced an undeclared `demos`).
   - Makes `SidebarLink.scope` optional (was already effectively unused internally — destructured as `_scope`). Step-2 cards on the overview page now typecheck.
   - Supersedes #4160 (missing `demos` import) — the underlying dead-code removal makes the import unnecessary.

2. **`chore(commitlint): skip merge commits from subject validation`**
   - `commitlint.config.js` ignore for `Merge ` prefix.
   - `.github/workflows/static_quality.yml` guard: `git rev-list --parents -n 1 HEAD` short-circuit when parent count >1. Catches GitHub's "Create merge commit" flow where the subject is the PR title but the body pulls markdown list lines that commitlint reads as additional subjects.

3. **`fix(shell-dashboard): resync scripts lockfile + unsilence npm ci`**
   - `showcase/scripts/package-lock.json` drifted from `package.json` (pinned old `vitest@4.1.4`, missing `@vitest/coverage-v8@4.1.5`) — regenerated via `npm install --package-lock-only`.
   - Removes `--silent` from the Dockerfile's builder-stage `npm ci` calls so next same-class failure surfaces the error directly.

4. **`fix(showcase/scripts): capture-previews skips demos without a route`**
   - `langgraph-python/cli-start` has no `route` field (it's a CLI copy-paste card, not a navigable page). Script was building `${backendUrl}undefined` → 45s DNS timeout. 10-line guard in `buildTargets` + visible `[SKIP]` log.

5. **`fix(showcase/langgraph-fastapi): pre-create .langgraph_api dir with app ownership`**
   - Commit `b9bcf2e6b` added `USER app` to the Dockerfile. `langgraph_runtime_inmem/store.py` calls `os.makedirs(".langgraph_api")` at import time against CWD=`/app` — the `app` user can't write → `PermissionError [Errno 13]` → Next.js stays alive so `wait -n` never fires → watchdog restart-loops until the 600s budget expires.
   - #4113 was the first rebuild that actually ran the new image (other 16 starters kept their pre-USER-app cached containers via paths-filter).

## Test plan

- [x] Each fix was verified individually in its original PR (all 6 PRs were green).
- [x] `npm run build` in `showcase/shell-docs` — clean (26 static pages generated).
- [x] `docker build -f showcase/shell-dashboard/Dockerfile .` through `--target builder` — clean on Depot.
- [ ] CI on this PR will reverify all four Docker builds + commitlint.