### PR TITLE
fix(ci): inline Slack payload on test_smoke-starter to stop silent alert suppression

### DIFF
--- a/.github/workflows/test_smoke-starter.yml
+++ b/.github/workflows/test_smoke-starter.yml
@@ -118,12 +118,22 @@ jobs:
           path: showcase/tests/test-results/
           retention-days: 7
 
-      - name: Build Slack payload
+      # Sanitize the failure summary and stash it in $GITHUB_ENV so the
+      # inline Slack payload can reference it via `env.summary`. We don't
+      # write to a payload file because slackapi/slack-github-action@v2.1.0
+      # rejects payload files that don't end in `.json`/`.yaml`/`.yml`
+      # (mktemp produces extensionless files), and `jq --rawfile` can also
+      # crash under `set -e` on edge-case inputs, leaving an empty/missing
+      # payload and silently suppressing the alert. Inline `payload:` with
+      # `toJSON(format(...))` sidesteps both failure modes — quotes,
+      # backslashes, newlines in the summary are safely JSON-encoded by
+      # toJSON, and there's no intermediate file to mishandle. This is the
+      # same pattern used in test_smoke-starter-deployed.yml (PR #4068) and
+      # showcase_validate.yml.
+      - name: Prepare Slack alert fields
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
-        id: slack-payload
         env:
           SUMMARY_RAW: ${{ steps.failure-cause.outputs.summary }}
-          STARTER: ${{ matrix.starter }}
         run: |
           # Strip ANSI sequences (SGR, OSC, and G0/G1 charset designators), then truncate
           # to 200 bytes and drop any trailing partial UTF-8 bytes so we don't emit mojibake.
@@ -133,21 +143,13 @@ jobs:
           if [ -z "$SUMMARY" ]; then
             SUMMARY="(no failure detail captured — see job log)"
           fi
-          URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          JOB_URL="${URL}/job/${{ github.job }}"
-
-          SLACK_MSG=$(mktemp)
-          SLACK_PAYLOAD=$(mktemp)
-
-          # Build the message with REAL newlines, then hand it to jq via --rawfile so escaping is handled correctly.
+          # Emit via heredoc so embedded `=`, quotes, or newlines don't
+          # break KEY=VALUE parsing in $GITHUB_ENV.
           {
-            printf ':x: *Starter smoke test failing: %s*\n' "$STARTER"
-            printf '<%s|View run> · <%s|View job>\n' "$URL" "$JOB_URL"
-            printf '```\n%s\n```\n' "$SUMMARY"
-          } > "$SLACK_MSG"
-          jq -n --rawfile text "$SLACK_MSG" '{text: $text}' > "$SLACK_PAYLOAD"
-          rm -f "$SLACK_MSG"
-          echo "payload_path=${SLACK_PAYLOAD}" >> "$GITHUB_OUTPUT"
+            echo "summary<<EOF_SUMMARY_7a4c"
+            printf '%s\n' "$SUMMARY"
+            echo "EOF_SUMMARY_7a4c"
+          } >> "$GITHUB_ENV"
 
       - name: Alert Slack on failure
         if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_run')
@@ -155,8 +157,5 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           webhook-type: incoming-webhook
-          payload-file-path: ${{ steps.slack-payload.outputs.payload_path }}
-
-      - name: Clean up Slack payload tmpfile
-        if: always() && steps.slack-payload.outputs.payload_path
-        run: rm -f "${{ steps.slack-payload.outputs.payload_path }}"
+          payload: |
+            { "text": ${{ toJSON(format(':x: *Starter smoke test failing: {0}*\n<{1}/{2}/actions/runs/{3}|View run> · <{1}/{2}/actions/runs/{3}/job/{4}|View job>\n```{5}```', matrix.starter, github.server_url, github.repository, github.run_id, github.job, env.summary)) }} }

--- a/examples/integrations/langgraph-python-threads/README.md
+++ b/examples/integrations/langgraph-python-threads/README.md
@@ -14,11 +14,11 @@ This project is a monorepo with three services:
 
 When threads are enabled, additional infrastructure runs via Docker Compose:
 
-| Service          | Port       | Description                                                                                                                                        |
-| ---------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **PostgreSQL**   | 5432       | Thread and event storage                                                                                                                           |
-| **Redis**        | 6379       | Session/cache                                                                                                                                      |
-| **Intelligence** | 4201, 4401 | All-in-one CopilotKit Intelligence container (app-api on 4201, realtime-gateway on 4401, plus thread-culler and db-migrations, under s6-overlay).  |
+| Service          | Port       | Description                                                                                                                                       |
+| ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PostgreSQL**   | 5432       | Thread and event storage                                                                                                                          |
+| **Redis**        | 6379       | Session/cache                                                                                                                                     |
+| **Intelligence** | 4201, 4401 | All-in-one CopilotKit Intelligence container (app-api on 4201, realtime-gateway on 4401, plus thread-culler and db-migrations, under s6-overlay). |
 
 ## Prerequisites
 

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -366,11 +366,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -420,18 +416,14 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat.mp4",
           "highlight": [
@@ -444,9 +436,7 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-customization-css.mp4",
           "highlight": [
@@ -460,9 +450,7 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-default-catchall.mp4",
           "highlight": [
@@ -475,9 +463,7 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-custom-catchall.mp4",
           "highlight": [
@@ -491,9 +477,7 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools.mp4",
           "highlight": [
@@ -506,9 +490,7 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools-async.mp4",
           "highlight": [
@@ -522,9 +504,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-chat.mp4",
           "highlight": [
@@ -538,9 +518,7 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-app.mp4",
           "highlight": [
@@ -554,9 +532,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering.mp4",
           "highlight": [
@@ -571,9 +547,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-tool-based.mp4",
           "highlight": [
@@ -587,9 +561,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-agent.mp4",
           "highlight": [
@@ -603,9 +575,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-read-write.mp4",
           "highlight": [
@@ -620,9 +590,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-streaming.mp4",
           "highlight": [
@@ -636,9 +604,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_subagents.mp4",
           "highlight": [
@@ -652,9 +618,7 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-sidebar.mp4",
           "highlight": [
@@ -667,9 +631,7 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-popup.mp4",
           "highlight": [
@@ -682,9 +644,7 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-slots",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-slots.mp4",
           "highlight": [
@@ -698,9 +658,7 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-simple",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-simple.mp4",
           "highlight": [
@@ -713,9 +671,7 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-complete",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-complete.mp4",
           "highlight": [
@@ -730,9 +686,7 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat-reasoning.mp4",
           "highlight": [
@@ -746,9 +700,7 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-interrupt.mp4",
           "highlight": [
@@ -762,9 +714,7 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_declarative-gen-ui.mp4",
           "highlight": [
@@ -780,9 +730,7 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_a2ui-fixed-schema.mp4",
           "highlight": [
@@ -800,9 +748,7 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/mcp-apps",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_mcp-apps.mp4",
           "highlight": [
@@ -815,9 +761,7 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_interrupt-headless.mp4",
           "highlight": [
@@ -830,9 +774,7 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_readonly-state-agent-context.mp4",
           "highlight": [
@@ -845,9 +787,7 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_reasoning-default-render.mp4",
           "highlight": [
@@ -860,9 +800,7 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-reasoning-chain.mp4",
           "highlight": [
@@ -877,9 +815,7 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_beautiful-chat.mp4",
           "highlight": [
@@ -1042,11 +978,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1074,9 +1006,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_agentic-chat.mp4"
         },
@@ -1084,9 +1014,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_hitl-in-chat.mp4"
         },
@@ -1094,9 +1022,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_tool-rendering.mp4"
         },
@@ -1104,9 +1030,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-tool-based.mp4"
         },
@@ -1114,9 +1038,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-agent.mp4"
         },
@@ -1124,9 +1046,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-read-write.mp4"
         },
@@ -1134,9 +1054,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-streaming.mp4"
         },
@@ -1144,9 +1062,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_subagents.mp4"
         }
@@ -1206,11 +1122,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1238,9 +1150,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_agentic-chat.mp4"
         },
@@ -1248,9 +1158,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_tool-rendering.mp4"
         },
@@ -1258,9 +1166,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_hitl-in-chat.mp4"
         },
@@ -1268,9 +1174,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-tool-based.mp4"
         },
@@ -1278,9 +1182,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-agent.mp4"
         },
@@ -1288,9 +1190,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-read-write.mp4"
         },
@@ -1298,9 +1198,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-streaming.mp4"
         },
@@ -1308,9 +1206,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_subagents.mp4"
         }
@@ -1370,11 +1266,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1398,9 +1290,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_agentic-chat.mp4"
         },
@@ -1408,9 +1298,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_hitl-in-chat.mp4"
         },
@@ -1418,9 +1306,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_tool-rendering.mp4"
         },
@@ -1428,9 +1314,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-tool-based.mp4"
         },
@@ -1438,9 +1322,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-agent.mp4"
         },
@@ -1448,9 +1330,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-read-write.mp4"
         },
@@ -1458,9 +1338,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-streaming.mp4"
         },
@@ -1468,9 +1346,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_subagents.mp4"
         }
@@ -1530,11 +1406,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1562,9 +1434,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_agentic-chat.mp4"
         },
@@ -1572,9 +1442,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_hitl-in-chat.mp4"
         },
@@ -1582,9 +1450,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_tool-rendering.mp4"
         },
@@ -1592,9 +1458,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-tool-based.mp4"
         },
@@ -1602,9 +1466,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-agent.mp4"
         },
@@ -1612,9 +1474,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-read-write.mp4"
         },
@@ -1622,9 +1482,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-streaming.mp4"
         },
@@ -1632,9 +1490,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_subagents.mp4"
         }
@@ -1694,11 +1550,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1726,9 +1578,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_agentic-chat.mp4"
         },
@@ -1736,9 +1586,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_hitl-in-chat.mp4"
         },
@@ -1746,9 +1594,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_tool-rendering.mp4"
         },
@@ -1756,9 +1602,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-tool-based.mp4"
         },
@@ -1766,9 +1610,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-agent.mp4"
         },
@@ -1776,9 +1618,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-read-write.mp4"
         },
@@ -1786,9 +1626,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-streaming.mp4"
         },
@@ -1796,9 +1634,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_subagents.mp4"
         }
@@ -1858,11 +1694,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1886,9 +1718,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_agentic-chat.mp4"
         },
@@ -1896,9 +1726,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_hitl-in-chat.mp4"
         },
@@ -1906,9 +1734,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_tool-rendering.mp4"
         },
@@ -1916,9 +1742,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-tool-based.mp4"
         },
@@ -1926,9 +1750,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-agent.mp4"
         },
@@ -1936,9 +1758,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-read-write.mp4"
         },
@@ -1946,9 +1766,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-streaming.mp4"
         },
@@ -1956,9 +1774,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_subagents.mp4"
         }
@@ -2018,11 +1834,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2038,9 +1850,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_agentic-chat.mp4"
         },
@@ -2048,9 +1858,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_hitl-in-chat.mp4"
         },
@@ -2058,9 +1866,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_tool-rendering.mp4"
         },
@@ -2068,9 +1874,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-tool-based.mp4"
         },
@@ -2078,9 +1882,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-agent.mp4"
         },
@@ -2088,9 +1890,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-read-write.mp4"
         },
@@ -2098,9 +1898,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-streaming.mp4"
         },
@@ -2108,9 +1906,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_subagents.mp4"
         }
@@ -2178,11 +1974,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2198,9 +1990,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_agentic-chat.mp4"
         },
@@ -2208,9 +1998,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_hitl-in-chat.mp4"
         },
@@ -2218,9 +2006,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_tool-rendering.mp4"
         },
@@ -2228,9 +2014,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-tool-based.mp4"
         },
@@ -2238,9 +2022,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-agent.mp4"
         },
@@ -2248,9 +2030,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-read-write.mp4"
         },
@@ -2258,9 +2038,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-streaming.mp4"
         },
@@ -2268,9 +2046,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_subagents.mp4"
         }
@@ -2338,11 +2114,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2366,9 +2138,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_agentic-chat.mp4"
         },
@@ -2376,9 +2146,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_hitl-in-chat.mp4"
         },
@@ -2386,9 +2154,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_tool-rendering.mp4"
         },
@@ -2396,9 +2162,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-tool-based.mp4"
         },
@@ -2406,9 +2170,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-agent.mp4"
         },
@@ -2416,9 +2178,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-read-write.mp4"
         },
@@ -2426,9 +2186,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-streaming.mp4"
         },
@@ -2436,9 +2194,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_subagents.mp4"
         }
@@ -2502,11 +2258,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2522,9 +2274,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_agentic-chat.mp4"
         },
@@ -2532,9 +2282,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_hitl-in-chat.mp4"
         },
@@ -2542,9 +2290,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_tool-rendering.mp4"
         },
@@ -2552,9 +2298,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-tool-based.mp4"
         },
@@ -2562,9 +2306,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-agent.mp4"
         },
@@ -2572,9 +2314,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-read-write.mp4"
         },
@@ -2582,9 +2322,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-streaming.mp4"
         },
@@ -2592,9 +2330,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_subagents.mp4"
         }
@@ -2666,11 +2402,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2694,9 +2426,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_agentic-chat.mp4"
         },
@@ -2704,9 +2434,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_hitl-in-chat.mp4"
         },
@@ -2714,9 +2442,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_tool-rendering.mp4"
         },
@@ -2724,9 +2450,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-tool-based.mp4"
         },
@@ -2734,9 +2458,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-agent.mp4"
         },
@@ -2744,9 +2466,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-read-write.mp4"
         },
@@ -2754,9 +2474,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-streaming.mp4"
         },
@@ -2764,9 +2482,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_subagents.mp4"
         }
@@ -2830,11 +2546,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2858,9 +2570,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_agentic-chat.mp4"
         },
@@ -2868,9 +2578,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_hitl-in-chat.mp4"
         },
@@ -2878,9 +2586,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_tool-rendering.mp4"
         },
@@ -2888,9 +2594,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-tool-based.mp4"
         },
@@ -2898,9 +2602,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-agent.mp4"
         },
@@ -2908,9 +2610,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-read-write.mp4"
         },
@@ -2918,9 +2618,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-streaming.mp4"
         },
@@ -2928,9 +2626,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_subagents.mp4"
         }
@@ -2990,11 +2686,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3010,9 +2702,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_agentic-chat.mp4"
         },
@@ -3020,9 +2710,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_hitl-in-chat.mp4"
         },
@@ -3030,9 +2718,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_tool-rendering.mp4"
         },
@@ -3040,9 +2726,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-tool-based.mp4"
         },
@@ -3050,9 +2734,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-agent.mp4"
         },
@@ -3060,9 +2742,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-read-write.mp4"
         },
@@ -3070,9 +2750,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-streaming.mp4"
         },
@@ -3080,9 +2758,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_subagents.mp4"
         }
@@ -3117,11 +2793,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -3145,9 +2817,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_agentic-chat.mp4"
         },
@@ -3155,9 +2825,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_hitl-in-chat.mp4"
         },
@@ -3165,9 +2833,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_tool-rendering.mp4"
         },
@@ -3175,9 +2841,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-tool-based.mp4"
         },
@@ -3185,9 +2849,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-agent.mp4"
         },
@@ -3195,9 +2857,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-read-write.mp4"
         },
@@ -3205,9 +2865,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-streaming.mp4"
         },
@@ -3215,9 +2873,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_subagents.mp4"
         }
@@ -3277,11 +2933,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -3305,9 +2957,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_agentic-chat.mp4"
         },
@@ -3315,9 +2965,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_hitl-in-chat.mp4"
         },
@@ -3325,9 +2973,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_tool-rendering.mp4"
         },
@@ -3335,9 +2981,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-tool-based.mp4"
         },
@@ -3345,9 +2989,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-agent.mp4"
         },
@@ -3355,9 +2997,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-read-write.mp4"
         },
@@ -3365,9 +3005,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-streaming.mp4"
         },
@@ -3375,9 +3013,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_subagents.mp4"
         }
@@ -3437,11 +3073,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3457,9 +3089,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_agentic-chat.mp4"
         },
@@ -3467,9 +3097,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_hitl-in-chat.mp4"
         },
@@ -3477,9 +3105,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_tool-rendering.mp4"
         },
@@ -3487,9 +3113,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-tool-based.mp4"
         },
@@ -3497,9 +3121,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-agent.mp4"
         },
@@ -3507,9 +3129,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-read-write.mp4"
         },
@@ -3517,9 +3137,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-streaming.mp4"
         },
@@ -3527,9 +3145,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_subagents.mp4"
         }


### PR DESCRIPTION
## Summary

- Replace `jq -n --rawfile text … > \$(mktemp)` + `payload-file-path` with inline `payload:` + `toJSON(format(...))` on the scheduled Slack-alert step in `test_smoke-starter.yml`.
- Pattern already in use in `test_smoke-starter-deployed.yml` (PR #4068) and `showcase_validate.yml` — this brings the last holdout in line.

## Why

Every scheduled run of `test / smoke / starter` that legitimately fails a matrix leg (upstream outage, floating-dep breakage, etc.) has been crashing the downstream alert step with:

```
##[error]Invalid input! Failed to parse contents of the provided payload file
```

Two compounding causes:

1. `slackapi/slack-github-action@v2.1.0` rejects payload files whose name does not end in `.json`/`.yaml`/`.yml`. `mktemp` produces extensionless files.
2. `jq -n --rawfile text "$SLACK_MSG"` under `set -e` can abort on edge-case summary input (missing tmpfile, non-UTF-8 bytes surviving the sanitizer), leaving an empty or missing payload.

Either way, the notifier failed before firing, so genuine outages went unreported in `#oss-alerts`. The user reported this as "Showcase: Drift Detection" — that specific workflow was already retired to showcase-ops on 2026-04-22 (commit `89eb0734b`), but the same jq-rawfile-then-payload-file-path pattern still lived in `test_smoke-starter.yml`.

Inline `payload:` with `toJSON(format(...))` sidesteps both failure modes: quotes, backslashes, and newlines in the sanitized summary are safely JSON-encoded at template-eval time, and there is no intermediate file to mishandle.

Audit of remaining file-based payloads left intentionally unchanged:
- `test_smoke-starter-deployed.yml` recovery step writes to `/tmp/starter-smoke-recovery.json` (valid extension, simple `jq --arg` scalar) — safe.
- `showcase_docs-sync.yml` writes to `slack-payloads/*.json` (valid extensions, `jq --arg` scalars) — safe.

## Test plan

- [ ] `actionlint .github/workflows/test_smoke-starter.yml` reports no new findings (confirmed locally — one pre-existing line-64 warning unrelated to this diff)
- [ ] Next scheduled run on `main` that has a genuinely failing matrix leg posts a well-formed red alert to `#oss-alerts` instead of `Invalid input! Failed to parse contents of the provided payload file`
- [ ] A scheduled run where all matrix legs pass remains silent (no behavior change on the green path)