### PR TITLE
debug(showcase/langgraph-typescript): instrument probe + event-loop to diagnose recurring Railway kill-loop

### DIFF
--- a/examples/integrations/langgraph-python-threads/README.md
+++ b/examples/integrations/langgraph-python-threads/README.md
@@ -14,11 +14,11 @@ This project is a monorepo with three services:
 
 When threads are enabled, additional infrastructure runs via Docker Compose:
 
-| Service          | Port       | Description                                                                                                                                        |
-| ---------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **PostgreSQL**   | 5432       | Thread and event storage                                                                                                                           |
-| **Redis**        | 6379       | Session/cache                                                                                                                                      |
-| **Intelligence** | 4201, 4401 | All-in-one CopilotKit Intelligence container (app-api on 4201, realtime-gateway on 4401, plus thread-culler and db-migrations, under s6-overlay).  |
+| Service          | Port       | Description                                                                                                                                       |
+| ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PostgreSQL**   | 5432       | Thread and event storage                                                                                                                          |
+| **Redis**        | 6379       | Session/cache                                                                                                                                     |
+| **Intelligence** | 4201, 4401 | All-in-one CopilotKit Intelligence container (app-api on 4201, realtime-gateway on 4401, plus thread-culler and db-migrations, under s6-overlay). |
 
 ## Prerequisites
 

--- a/showcase/packages/langgraph-typescript/Dockerfile
+++ b/showcase/packages/langgraph-typescript/Dockerfile
@@ -26,6 +26,13 @@ RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \
  && (useradd --system --uid 1001 --gid 1001 --no-create-home app 2>/dev/null || true) \
  && mkdir -p /home/app && chown app:app /home/app
 
+# Install iproute2 for `ss` so the watchdog can snapshot :8123/:8124 listeners
+# when a probe fails. TEMPORARY — remove alongside the instrumentation once
+# the Railway kill-loop is root-caused (see debug/langgraph-ts-probe-instrumentation).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends iproute2 \
+ && rm -rf /var/lib/apt/lists/*
+
 # Next.js build artifacts
 COPY --chown=app:app --from=frontend /app/.next ./.next
 COPY --chown=app:app --from=frontend /app/node_modules ./node_modules

--- a/showcase/packages/langgraph-typescript/entrypoint.sh
+++ b/showcase/packages/langgraph-typescript/entrypoint.sh
@@ -88,10 +88,14 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       # Agent died during startup — wait -n in the main shell will handle it.
       exit 0
     fi
-    if curl -fsS --max-time 5 http://127.0.0.1:8124/ok > /dev/null 2>&1; then
-      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
+    probe_out=$(curl -sS --max-time 5 -w "\nHTTP=%{http_code} TIME=%{time_total}" http://127.0.0.1:8124/ok 2>&1)
+    probe_rc=$?
+    if [ $probe_rc -eq 0 ] && echo "$probe_out" | grep -q "HTTP=200"; then
+      echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter (probe_out=$probe_out)"
       break
     fi
+    echo "[watchdog] Grace probe FAIL at ${ELAPSED}s rc=$probe_rc output=$probe_out"
+    (ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null) | grep -E ":(8123|8124)" | sed 's/^/[watchdog] /' || echo "[watchdog] no listener tool / no matches for :8123/:8124"
     sleep 5
     ELAPSED=$((ELAPSED + 5))
   done
@@ -103,11 +107,14 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
     fi
-    if curl -fsS --max-time 5 http://127.0.0.1:8124/ok > /dev/null 2>&1; then
+    probe_out=$(curl -sS --max-time 5 -w "\nHTTP=%{http_code} TIME=%{time_total}" http://127.0.0.1:8124/ok 2>&1)
+    probe_rc=$?
+    if [ $probe_rc -eq 0 ] && echo "$probe_out" | grep -q "HTTP=200"; then
       FAILS=0
     else
       FAILS=$((FAILS + 1))
-      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      echo "[watchdog] Agent health probe failed (count=$FAILS) rc=$probe_rc output=$probe_out"
+      (ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null) | grep -E ":(8123|8124)" | sed 's/^/[watchdog] /' || echo "[watchdog] no listener tool / no matches for :8123/:8124"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true

--- a/showcase/packages/langgraph-typescript/src/agent/liveness.mjs
+++ b/showcase/packages/langgraph-typescript/src/agent/liveness.mjs
@@ -29,6 +29,12 @@ createServer((req, res) => {
   res.end();
 }).listen(PORT, "0.0.0.0", () => {
   console.log(`[liveness] probe listening on 0.0.0.0:${PORT}`);
+  // Event-loop heartbeat — if this stops ticking, the loop is blocked
+  // (e.g. by a synchronous phase inside a heavy dynamic import). TEMPORARY
+  // diagnostic instrumentation (see debug/langgraph-ts-probe-instrumentation).
+  setInterval(() => {
+    console.log(`[liveness] tick ${new Date().toISOString()}`);
+  }, 5000);
   // Defer real server start until AFTER liveness is bound.
   import("./server.mjs").catch((err) => {
     console.error("[liveness] server.mjs import failed:", err);


### PR DESCRIPTION
## Summary
- Watchdog probe now logs curl's actual stdout/stderr + exit code + HTTP status (not silenced).
- Watchdog emits `ss`/`netstat` snapshot for :8123/:8124 on probe failure.
- `liveness.mjs` emits 5-second event-loop heartbeats.
- Dockerfile installs `iproute2` so `ss` is available in the runtime image.

## Why
Temporary instrumentation. Local smoke works (`/ok` in ~14ms, liveness ticks every 5s, ss reports both listeners) but Railway's 36 grace-window probes all silently fail — we can't see why because the existing curl suppresses all output with `> /dev/null 2>&1`. Ship this, let one kill-cycle run on Railway, read the logs, then revert.

## Test plan
- [ ] Docker build green locally (verified: amd64 build succeeds with depot)
- [ ] Local smoke: liveness binds, heartbeat ticks, /ok returns 200 (verified)
- [ ] After merge + Railway redeploy, next kill-cycle logs show either (a) curl's actual error OR (b) event-loop heartbeat gaps revealing a blocking import