### PR TITLE
fix(react-core): Restore welcome screen when a generated thread UUID is pass from wrappers

### DIFF
--- a/examples/integrations/langgraph-python-threads/apps/app/src/lib/a2ui-theme.css
+++ b/examples/integrations/langgraph-python-threads/apps/app/src/lib/a2ui-theme.css
@@ -153,7 +153,6 @@ body {
   --font-family-mono:
     "Google Sans Code", "Helvetica Neue", Helvetica, Arial, sans-serif;
 
-  background: var(--background-light);
   font-family: var(--font-family);
   margin: 0;
   padding: 0;

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -1,2 +1,2 @@
 // This is auto generated!
-export const LIB_VERSION = "1.0.0";
+export const LIB_VERSION = "1.0.2";

--- a/packages/react-core/src/components/copilot-provider/__tests__/v1-explicit-threadid-bridge.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/v1-explicit-threadid-bridge.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CopilotKit } from "../copilotkit";
+import { useCopilotContext } from "../../../context/copilot-context";
+import { useCopilotChatConfiguration } from "../../../v2";
+import type { CopilotKitProps } from "../copilotkit-props";
+
+/**
+ * Probe that reads hasExplicitThreadId from the CopilotChatConfigurationProvider
+ * that the v1 <CopilotKit> bridge renders. This is the surface CopilotChat
+ * itself reads from to gate /connect and the welcome screen.
+ */
+function ExplicitProbe() {
+  const config = useCopilotChatConfiguration();
+  return (
+    <>
+      <div data-testid="explicit">{String(config?.hasExplicitThreadId)}</div>
+      <div data-testid="threadId">{config?.threadId ?? ""}</div>
+    </>
+  );
+}
+
+/**
+ * Exposes the v1 context's setThreadId so tests can drive the
+ * auto → explicit transition from outside React.
+ */
+function SetThreadIdButton({ nextId }: { nextId: string }) {
+  const { setThreadId } = useCopilotContext();
+  return (
+    <button data-testid="setThread" onClick={() => setThreadId(nextId)}>
+      set
+    </button>
+  );
+}
+
+// `agents__unsafe_dev_only` isn't declared on v1 CopilotKitProps but is
+// forwarded via spread to the v2 provider underneath. Cast once here rather
+// than every render.
+type V1Props = CopilotKitProps & {
+  agents__unsafe_dev_only?: Record<string, unknown>;
+};
+const CopilotKitAny = CopilotKit as unknown as React.FC<V1Props>;
+
+/**
+ * Regression coverage for fix/welcome-not-showing-at-all at the v1 bridge
+ * boundary. The v1 <CopilotKit> wrapper pipes a ThreadsProvider-minted UUID
+ * through as `threadId`, but that UUID is NOT a caller choice — the bridge
+ * must mark it as non-explicit so downstream consumers don't treat it as a
+ * real backend thread. These tests verify the signal makes it all the way
+ * through to CopilotChatConfigurationProvider.
+ */
+describe("v1 <CopilotKit> bridge → hasExplicitThreadId", () => {
+  // Silence the in-dev/test "missing runtimeUrl" warning — we pass publicApiKey.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("is false on mount when no threadId prop is supplied", () => {
+    render(
+      <CopilotKitAny publicApiKey="test-key">
+        <ExplicitProbe />
+      </CopilotKitAny>,
+    );
+
+    // ThreadsProvider auto-minted the UUID — it's not a caller-picked thread.
+    expect(screen.getByTestId("explicit").textContent).toBe("false");
+    // threadId still resolves to a value (mock-thread-id from setupTests),
+    // but downstream consumers must NOT treat it as real.
+    expect(screen.getByTestId("threadId").textContent).toBe("mock-thread-id");
+  });
+
+  it("is true when threadId prop is supplied to <CopilotKit>", () => {
+    render(
+      <CopilotKitAny publicApiKey="test-key" threadId="caller-thread">
+        <ExplicitProbe />
+      </CopilotKitAny>,
+    );
+
+    expect(screen.getByTestId("explicit").textContent).toBe("true");
+    expect(screen.getByTestId("threadId").textContent).toBe("caller-thread");
+  });
+
+  it("flips from false to true after setThreadId() is called on the v1 context", () => {
+    render(
+      <CopilotKitAny publicApiKey="test-key">
+        <ExplicitProbe />
+        <SetThreadIdButton nextId="user-picked-thread" />
+      </CopilotKitAny>,
+    );
+
+    expect(screen.getByTestId("explicit").textContent).toBe("false");
+
+    act(() => {
+      screen.getByTestId("setThread").click();
+    });
+
+    expect(screen.getByTestId("threadId").textContent).toBe(
+      "user-picked-thread",
+    );
+    expect(screen.getByTestId("explicit").textContent).toBe("true");
+  });
+});

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -478,7 +478,11 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     }
   }, [props.agent]);
 
-  const { threadId, setThreadId: setInternalThreadId } = useThreads();
+  const {
+    threadId,
+    setThreadId: setInternalThreadId,
+    isThreadIdExplicit,
+  } = useThreads();
 
   const setThreadId = useCallback(
     (value: SetStateAction<string>) => {
@@ -757,6 +761,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       // isModalDefaultOpen={isModalDefaultOpen}
       agentId={props.agent ?? "default"}
       threadId={threadId}
+      hasExplicitThreadId={isThreadIdExplicit}
     >
       <CopilotContext.Provider value={copilotContextValue}>
         <CopilotListeners />

--- a/packages/react-core/src/context/__tests__/threads-context.test.tsx
+++ b/packages/react-core/src/context/__tests__/threads-context.test.tsx
@@ -1,10 +1,26 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
 import { ThreadsProvider, useThreads } from "../threads-context";
 
 function ThreadIdViewer() {
-  const { threadId } = useThreads();
-  return <div data-testid="threadId">{threadId}</div>;
+  const { threadId, isThreadIdExplicit } = useThreads();
+  return (
+    <>
+      <div data-testid="threadId">{threadId}</div>
+      <div data-testid="isExplicit">{String(isThreadIdExplicit)}</div>
+    </>
+  );
+}
+
+// Exposes setThreadId to the test so it can trigger the auto→explicit flip.
+function ThreadIdController({ nextId }: { nextId: string }) {
+  const { setThreadId } = useThreads();
+  return (
+    <button data-testid="setThread" onClick={() => setThreadId(nextId)}>
+      set
+    </button>
+  );
 }
 
 describe("ThreadsProvider", () => {
@@ -24,5 +40,100 @@ describe("ThreadsProvider", () => {
     );
 
     expect(screen.getByTestId("threadId").textContent).toBe("customer-thread");
+  });
+
+  describe("isThreadIdExplicit", () => {
+    it("is false on first mount when no threadId prop is supplied", () => {
+      // Auto-minted UUID — the backend has never seen it, so downstream
+      // consumers (e.g. /connect) must NOT treat this as a real thread.
+      render(
+        <ThreadsProvider>
+          <ThreadIdViewer />
+        </ThreadsProvider>,
+      );
+
+      expect(screen.getByTestId("threadId").textContent).toBe("mock-thread-id");
+      expect(screen.getByTestId("isExplicit").textContent).toBe("false");
+    });
+
+    it("is true when threadId prop is supplied on mount", () => {
+      render(
+        <ThreadsProvider threadId="customer-thread">
+          <ThreadIdViewer />
+        </ThreadsProvider>,
+      );
+
+      expect(screen.getByTestId("threadId").textContent).toBe("customer-thread");
+      expect(screen.getByTestId("isExplicit").textContent).toBe("true");
+    });
+
+    it("flips from false to true after setThreadId() is called", () => {
+      render(
+        <ThreadsProvider>
+          <ThreadIdViewer />
+          <ThreadIdController nextId="user-picked-thread" />
+        </ThreadsProvider>,
+      );
+
+      expect(screen.getByTestId("isExplicit").textContent).toBe("false");
+
+      act(() => {
+        screen.getByTestId("setThread").click();
+      });
+
+      expect(screen.getByTestId("threadId").textContent).toBe(
+        "user-picked-thread",
+      );
+      expect(screen.getByTestId("isExplicit").textContent).toBe("true");
+    });
+
+    it("reverts to false when an explicit prop is removed and setThreadId was never called", () => {
+      // Current contract: explicitness via the `threadId` prop is prop-derived,
+      // so removing the prop returns the provider to its auto-minted state.
+      // Pinning this guards against an accidental "sticky explicit" regression.
+      const { rerender } = render(
+        <ThreadsProvider threadId="customer-thread">
+          <ThreadIdViewer />
+        </ThreadsProvider>,
+      );
+
+      expect(screen.getByTestId("isExplicit").textContent).toBe("true");
+
+      rerender(
+        <ThreadsProvider>
+          <ThreadIdViewer />
+        </ThreadsProvider>,
+      );
+
+      expect(screen.getByTestId("threadId").textContent).toBe("mock-thread-id");
+      expect(screen.getByTestId("isExplicit").textContent).toBe("false");
+    });
+
+    it("stays true after prop is removed if setThreadId was called while prop was present", () => {
+      // Once the caller has touched setThreadId, explicitness is sticky —
+      // the internal "user picked a thread" flag outlives any prop churn.
+      const { rerender } = render(
+        <ThreadsProvider threadId="customer-thread">
+          <ThreadIdViewer />
+          <ThreadIdController nextId="user-picked-thread" />
+        </ThreadsProvider>,
+      );
+
+      act(() => {
+        screen.getByTestId("setThread").click();
+      });
+
+      rerender(
+        <ThreadsProvider>
+          <ThreadIdViewer />
+          <ThreadIdController nextId="user-picked-thread" />
+        </ThreadsProvider>,
+      );
+
+      expect(screen.getByTestId("threadId").textContent).toBe(
+        "user-picked-thread",
+      );
+      expect(screen.getByTestId("isExplicit").textContent).toBe("true");
+    });
   });
 });

--- a/packages/react-core/src/context/__tests__/threads-context.test.tsx
+++ b/packages/react-core/src/context/__tests__/threads-context.test.tsx
@@ -63,7 +63,9 @@ describe("ThreadsProvider", () => {
         </ThreadsProvider>,
       );
 
-      expect(screen.getByTestId("threadId").textContent).toBe("customer-thread");
+      expect(screen.getByTestId("threadId").textContent).toBe(
+        "customer-thread",
+      );
       expect(screen.getByTestId("isExplicit").textContent).toBe("true");
     });
 

--- a/packages/react-core/src/context/threads-context.tsx
+++ b/packages/react-core/src/context/threads-context.tsx
@@ -1,5 +1,6 @@
 import React, {
   createContext,
+  useCallback,
   useContext,
   useState,
   ReactNode,
@@ -10,6 +11,12 @@ import { randomUUID } from "@copilotkit/shared";
 export interface ThreadsContextValue {
   threadId: string;
   setThreadId: (value: SetStateAction<string>) => void;
+  // True when the current threadId was chosen by the caller — either via
+  // the `threadId` prop on <CopilotKit> / <ThreadsProvider>, or via a later
+  // setThreadId() call. False when the provider minted a UUID on first
+  // mount so downstream consumers don't have to treat that placeholder as
+  // a real backend thread.
+  isThreadIdExplicit: boolean;
 }
 
 const ThreadsContext = createContext<ThreadsContextValue | undefined>(
@@ -25,15 +32,25 @@ export function ThreadsProvider({
   children,
   threadId: explicitThreadId,
 }: ThreadsProviderProps) {
-  const [internalThreadId, setThreadId] = useState<string>(() => randomUUID());
+  const [internalThreadId, setInternalThreadId] = useState<string>(() =>
+    randomUUID(),
+  );
+  const [internalIsExplicit, setInternalIsExplicit] = useState<boolean>(false);
 
   const threadId = explicitThreadId ?? internalThreadId;
+  const isThreadIdExplicit = explicitThreadId != null || internalIsExplicit;
+
+  const setThreadId = useCallback((value: SetStateAction<string>) => {
+    setInternalThreadId(value);
+    setInternalIsExplicit(true);
+  }, []);
 
   return (
     <ThreadsContext.Provider
       value={{
         threadId,
         setThreadId,
+        isThreadIdExplicit,
       }}
     >
       {children}

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -106,6 +106,15 @@ export function CopilotChat({
     () => providedThreadId ?? randomUUID(),
     [providedThreadId],
   );
+  // "Explicit" means a caller actually picked this thread — via the
+  // `threadId` prop on CopilotChat or a wrapping provider that marked its
+  // threadId as caller-chosen. An auto-minted UUID leaking down through a
+  // CopilotChatConfigurationProvider (e.g. from the v1 CopilotKit →
+  // ThreadsProvider chain) does NOT count; treating it as explicit is
+  // what made /connect fire against 404s and the welcome screen stay
+  // hidden for fresh empty chats.
+  const hasExplicitThreadId =
+    !!threadId || !!existingConfig?.hasExplicitThreadId;
 
   const { agent } = useAgent({
     agentId: resolvedAgentId,
@@ -205,14 +214,15 @@ export function CopilotChat({
     string | null
   >(null);
   const isConnecting =
-    !!providedThreadId && lastConnectedThreadId !== resolvedThreadId;
+    hasExplicitThreadId && lastConnectedThreadId !== resolvedThreadId;
 
   useEffect(() => {
-    // When no threadId was supplied by the caller, resolvedThreadId is a UUID
-    // minted in this browser tab. The backend has never seen it, so /connect
-    // would always 404. Skip the call — a real thread is only created once
-    // the user runs the agent for the first time.
-    if (!providedThreadId) return;
+    // When the caller hasn't picked a specific thread, resolvedThreadId is a
+    // UUID minted locally (either in this CopilotChat or in a wrapping
+    // ThreadsProvider). The backend has never seen it, so /connect would
+    // always 404 — skip the call. A real thread is only created once the
+    // user runs the agent for the first time.
+    if (!hasExplicitThreadId) return;
 
     let detached = false;
 
@@ -270,7 +280,7 @@ export function CopilotChat({
     };
     // copilotkit is intentionally excluded — it is a stable ref that never changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resolvedThreadId, agent, resolvedAgentId, providedThreadId]);
+  }, [resolvedThreadId, agent, resolvedAgentId, hasExplicitThreadId]);
 
   const onSubmitInput = useCallback(
     async (value: string) => {
@@ -594,7 +604,7 @@ export function CopilotChat({
     onDragLeave: handleDragLeave,
     onDrop: handleDrop,
     isConnecting,
-    hasExplicitThreadId: !!providedThreadId,
+    hasExplicitThreadId,
   };
 
   // Always create a provider with merged values
@@ -605,6 +615,7 @@ export function CopilotChat({
     <CopilotChatConfigurationProvider
       agentId={resolvedAgentId}
       threadId={resolvedThreadId}
+      hasExplicitThreadId={hasExplicitThreadId}
       labels={labels}
       isModalDefaultOpen={isModalDefaultOpen}
     >

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
@@ -36,9 +36,7 @@ class TrackingAgent extends MockStepwiseAgent {
 
 function renderWithKit(ui: React.ReactNode, agent: TrackingAgent) {
   return render(
-    <CopilotKitProvider
-      agents__unsafe_dev_only={{ [DEFAULT_AGENT_ID]: agent }}
-    >
+    <CopilotKitProvider agents__unsafe_dev_only={{ [DEFAULT_AGENT_ID]: agent }}>
       <div style={{ height: 400 }}>{ui}</div>
     </CopilotKitProvider>,
   );

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { CopilotChat } from "../CopilotChat";
+import { MockStepwiseAgent } from "../../../__tests__/utils/test-helpers";
+import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+
+/**
+ * Mock agent that records every connectAgent() invocation and resolves
+ * immediately with an empty run result. Tracking lives on the class so
+ * per-thread clones (from useAgent's WeakMap) share the counter.
+ */
+class TrackingAgent extends MockStepwiseAgent {
+  static connectCalls: Array<{
+    threadId: string | undefined;
+    agentId: string | undefined;
+  }> = [];
+
+  static reset() {
+    TrackingAgent.connectCalls = [];
+  }
+
+  async connectAgent(
+    _params: unknown,
+    _subscriber: unknown,
+  ): Promise<{ result: unknown; newMessages: [] }> {
+    TrackingAgent.connectCalls.push({
+      threadId: this.threadId,
+      agentId: this.agentId,
+    });
+    return { result: undefined, newMessages: [] };
+  }
+}
+
+function renderWithKit(ui: React.ReactNode, agent: TrackingAgent) {
+  return render(
+    <CopilotKitProvider
+      agents__unsafe_dev_only={{ [DEFAULT_AGENT_ID]: agent }}
+    >
+      <div style={{ height: 400 }}>{ui}</div>
+    </CopilotKitProvider>,
+  );
+}
+
+/**
+ * Regression coverage for fix/welcome-not-showing-at-all.
+ *
+ * The underlying bug: the v1 <CopilotKit> wrapper pipes a ThreadsProvider-
+ * minted UUID through to CopilotChatConfigurationProvider as `threadId`.
+ * CopilotChat previously treated any non-empty providedThreadId as "caller
+ * supplied a real backend thread" and (a) fired /connect (→ 404 for an
+ * auto-minted UUID) and (b) suppressed the welcome screen forever. The
+ * fix threads an `hasExplicitThreadId` signal through the provider chain;
+ * these tests pin the contract that /connect and welcome-screen gating
+ * now follow that signal rather than `!!threadId`.
+ */
+describe("CopilotChat welcome / connect integration", () => {
+  beforeEach(() => {
+    TrackingAgent.reset();
+  });
+
+  describe("v1 bridge scenario (config provider marks threadId as non-explicit)", () => {
+    it("does not call connectAgent and shows the welcome screen", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(
+        <CopilotChatConfigurationProvider
+          threadId="auto-minted-uuid"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChat />
+        </CopilotChatConfigurationProvider>,
+        agent,
+      );
+
+      // Give the connect-effect a chance to misfire.
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(TrackingAgent.connectCalls).toHaveLength(0);
+      expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+  });
+
+  describe("plain CopilotChat (no threadId anywhere)", () => {
+    it("does not call connectAgent and shows the welcome screen", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat />, agent);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(TrackingAgent.connectCalls).toHaveLength(0);
+      expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+  });
+
+  describe("explicit threadId via CopilotChat prop", () => {
+    it("calls connectAgent with that threadId and suppresses the welcome screen", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="real-thread" />, agent);
+
+      await waitFor(() => {
+        expect(TrackingAgent.connectCalls.length).toBeGreaterThan(0);
+      });
+
+      // The per-thread clone carries threadId; agentId is the default.
+      expect(
+        TrackingAgent.connectCalls.some((c) => c.threadId === "real-thread"),
+      ).toBe(true);
+
+      // Welcome screen is suppressed even after connect resolves, because the
+      // thread was caller-picked (hasExplicitThreadId=true).
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+    });
+  });
+
+  describe("explicit threadId via wrapping CopilotChatConfigurationProvider", () => {
+    it("inherits explicitness from the provider and connects", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(
+        <CopilotChatConfigurationProvider threadId="from-config">
+          <CopilotChat />
+        </CopilotChatConfigurationProvider>,
+        agent,
+      );
+
+      await waitFor(() => {
+        expect(TrackingAgent.connectCalls.length).toBeGreaterThan(0);
+      });
+
+      expect(
+        TrackingAgent.connectCalls.some((c) => c.threadId === "from-config"),
+      ).toBe(true);
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+    });
+  });
+
+  describe("thread switch between two explicit threads", () => {
+    it("keeps the welcome screen hidden across the switch", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      const { rerender } = renderWithKit(
+        <CopilotChat threadId="thread-a" />,
+        agent,
+      );
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some((c) => c.threadId === "thread-a"),
+        ).toBe(true);
+      });
+      // After thread-a's connect resolves, welcome must still be hidden
+      // because the thread is caller-picked.
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      rerender(
+        <CopilotKitProvider
+          agents__unsafe_dev_only={{ [DEFAULT_AGENT_ID]: agent }}
+        >
+          <div style={{ height: 400 }}>
+            <CopilotChat threadId="thread-b" />
+          </div>
+        </CopilotKitProvider>,
+      );
+
+      // During the switch (lastConnected="thread-a" !== "thread-b") isConnecting
+      // is true — welcome must not flash.
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some((c) => c.threadId === "thread-b"),
+        ).toBe(true);
+      });
+      // And after thread-b's connect resolves.
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+    });
+  });
+});

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -45,6 +45,11 @@ export interface CopilotChatConfigurationValue {
   threadId: string;
   isModalOpen: boolean;
   setModalOpen: (open: boolean) => void;
+  // True when the current threadId was chosen by the caller rather than
+  // silently minted inside the provider chain. Consumers that only make
+  // sense against a real backend thread (e.g. /connect, suppressing the
+  // welcome screen on switch) gate on this instead of `!!threadId`.
+  hasExplicitThreadId: boolean;
 }
 
 // Create the configuration context
@@ -57,13 +62,26 @@ export interface CopilotChatConfigurationProviderProps {
   labels?: Partial<CopilotChatLabels>;
   agentId?: string;
   threadId?: string;
+  // Lets internal wrappers (e.g. the v1 CopilotKit bridge, which pipes a
+  // ThreadsProvider-minted UUID through as `threadId`) declare that the
+  // threadId they are supplying is NOT a caller choice. When omitted, the
+  // provider infers explicitness from whether the `threadId` prop itself
+  // was supplied.
+  hasExplicitThreadId?: boolean;
   isModalDefaultOpen?: boolean;
 }
 
 // Provider component
 export const CopilotChatConfigurationProvider: React.FC<
   CopilotChatConfigurationProviderProps
-> = ({ children, labels, agentId, threadId, isModalDefaultOpen }) => {
+> = ({
+  children,
+  labels,
+  agentId,
+  threadId,
+  hasExplicitThreadId,
+  isModalDefaultOpen,
+}) => {
   const parentConfig = useContext(CopilotChatConfiguration);
 
   // Stabilize labels references so that inline objects (new reference on every
@@ -91,6 +109,14 @@ export const CopilotChatConfigurationProvider: React.FC<
     }
     return randomUUID();
   }, [threadId, parentConfig?.threadId]);
+
+  // If a caller passed `hasExplicitThreadId`, trust it verbatim (lets the v1
+  // bridge mark an auto-minted UUID as non-explicit). Otherwise infer: a
+  // threadId supplied as a prop here is by definition a caller choice.
+  const ownHasExplicitThreadId =
+    hasExplicitThreadId !== undefined ? hasExplicitThreadId : !!threadId;
+  const resolvedHasExplicitThreadId =
+    ownHasExplicitThreadId || !!parentConfig?.hasExplicitThreadId;
 
   const resolvedDefaultOpen = isModalDefaultOpen ?? true;
 
@@ -141,6 +167,7 @@ export const CopilotChatConfigurationProvider: React.FC<
       labels: mergedLabels,
       agentId: resolvedAgentId,
       threadId: resolvedThreadId,
+      hasExplicitThreadId: resolvedHasExplicitThreadId,
       isModalOpen: resolvedIsModalOpen,
       setModalOpen: resolvedSetModalOpen,
     }),
@@ -148,6 +175,7 @@ export const CopilotChatConfigurationProvider: React.FC<
       mergedLabels,
       resolvedAgentId,
       resolvedThreadId,
+      resolvedHasExplicitThreadId,
       resolvedIsModalOpen,
       resolvedSetModalOpen,
     ],

--- a/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
@@ -513,6 +513,112 @@ describe("CopilotChatConfigurationProvider", () => {
     });
   });
 
+  /**
+   * Regression coverage for the welcome-screen / /connect 404 bug
+   * (fix/welcome-not-showing-at-all). `hasExplicitThreadId` distinguishes a
+   * caller-chosen thread from a UUID auto-minted inside the provider chain —
+   * consumers that only make sense against a real backend thread (/connect,
+   * switch-flash suppression) must gate on this signal, not on !!threadId.
+   */
+  describe("hasExplicitThreadId", () => {
+    function ExplicitProbe({ id = "probe" }: { id?: string } = {}) {
+      const config = useCopilotChatConfiguration();
+      return (
+        <div data-testid={`${id}-explicit`}>
+          {String(config?.hasExplicitThreadId)}
+        </div>
+      );
+    }
+
+    it("infers true when threadId prop is supplied and hasExplicitThreadId is omitted", () => {
+      render(
+        <CopilotChatConfigurationProvider threadId="customer-thread">
+          <ExplicitProbe />
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("probe-explicit").textContent).toBe("true");
+    });
+
+    it("infers false when no threadId prop is supplied and hasExplicitThreadId is omitted", () => {
+      render(
+        <CopilotChatConfigurationProvider>
+          <ExplicitProbe />
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("probe-explicit").textContent).toBe("false");
+    });
+
+    it("respects hasExplicitThreadId={false} even when a threadId prop is present (v1 bridge case)", () => {
+      // The v1 <CopilotKit> wrapper always pipes a UUID through as `threadId`
+      // (from ThreadsProvider). Without this override the provider would
+      // mis-infer the UUID as explicit, causing /connect to 404 and the
+      // welcome screen to stay hidden for fresh empty chats.
+      render(
+        <CopilotChatConfigurationProvider
+          threadId="auto-minted-uuid"
+          hasExplicitThreadId={false}
+        >
+          <ExplicitProbe />
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("probe-explicit").textContent).toBe("false");
+    });
+
+    it("parent=true overrides child's hasExplicitThreadId={false} via OR inheritance", () => {
+      // resolvedHasExplicitThreadId = ownHasExplicit || parentHasExplicit.
+      // Once an ancestor has marked the thread as caller-chosen, descendants
+      // cannot mask that — pinning the contract so "try to hide explicitness
+      // from a child" doesn't silently work.
+      render(
+        <CopilotChatConfigurationProvider threadId="real-thread">
+          <CopilotChatConfigurationProvider
+            threadId="other-uuid"
+            hasExplicitThreadId={false}
+          >
+            <ExplicitProbe />
+          </CopilotChatConfigurationProvider>
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("probe-explicit").textContent).toBe("true");
+    });
+
+    it("propagates through a three-level chain where the middle provider is bare", () => {
+      // Matches the real stack: outer layout provider (no threadId) →
+      // CopilotChat's own provider (no threadId) → inner feature provider
+      // (explicit threadId). Explicitness must cross the empty middle.
+      render(
+        <CopilotChatConfigurationProvider>
+          <CopilotChatConfigurationProvider>
+            <CopilotChatConfigurationProvider threadId="deeply-picked-thread">
+              <ExplicitProbe />
+            </CopilotChatConfigurationProvider>
+          </CopilotChatConfigurationProvider>
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("probe-explicit").textContent).toBe("true");
+    });
+
+    it("non-explicit parent does not taint an explicit child", () => {
+      render(
+        <CopilotChatConfigurationProvider
+          threadId="auto-uuid"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChatConfigurationProvider threadId="user-picked">
+            <ExplicitProbe />
+          </CopilotChatConfigurationProvider>
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("probe-explicit").textContent).toBe("true");
+    });
+  });
+
   describe("Nested providers", () => {
     it("should handle multiple nested providers correctly", () => {
       render(


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fresh empty chats were hitting `/connect` against thread IDs the backend had never seen (404s) and the
  welcome screen stayed hidden. Root cause: the v1 `<CopilotKit>` wrapper pipes a
  `ThreadsProvider`-minted UUID down as `threadId`, and downstream consumers were treating `!!threadId`
  as "caller-chosen," so an auto-minted placeholder looked identical to a real thread.

  Fix: introduce an explicit `hasExplicitThreadId` signal and plumb it end-to-end, so consumers that only
   make sense against a real backend thread (`/connect`, switch-flash suppression, welcome-screen gating)
   can distinguish a caller-chosen thread from an internal placeholder.

 ## Changes

  - **`ThreadsProvider`** — exposes `isThreadIdExplicit`. True when the `threadId` prop is supplied or
  `setThreadId()` has been called; false for the first-mount auto-minted UUID. Explicitness via
  `setThreadId` is sticky across prop churn.
  - **`CopilotChatConfigurationProvider`** — accepts an optional `hasExplicitThreadId` prop (overrides
  inference), otherwise infers from `!!threadId`. OR-inherits from parent config so explicitness
  propagates through nested/bare providers.
  - **v1 `CopilotKit` bridge** (`copilotkit.tsx`) — reads `isThreadIdExplicit` from `useThreads()` and
  forwards it to `CopilotChatConfigurationProvider`, so the auto-minted UUID no longer masquerades as
  caller-chosen.
  - **`CopilotChat`** — `isConnecting` and the `/connect` effect now gate on `hasExplicitThreadId`
  instead of `!!providedThreadId`, so a caller-chosen thread from a wrapping provider is honored while a
  leaked auto-UUID is not.

  ## Test plan

  - [x] `threads-context.test.tsx` — `isThreadIdExplicit` transitions: auto→explicit via `setThreadId`,
  prop-driven explicitness, stickiness after prop removal
  - [x] `CopilotChatConfigurationProvider.test.tsx` — inference, explicit `false` override (v1 bridge
  case), OR-inheritance through nested chains
  - [x] `v1-explicit-threadid-bridge.test.tsx` (new) — regression coverage for the v1 wrapper
  specifically
  - [x] `CopilotChat.welcomeGate.test.tsx` (new) — welcome screen stays visible on a bare mount;
  `/connect` is not called without an explicit thread
  - [x] `packages/react-core` full test suite passes (1149 tests)
  - [ ] Manual smoke in `examples/integrations/langgraph-python-threads`: fresh app → welcome screen
  shows → first message starts a real thread

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
