### PR TITLE
feat(showcase/ops): L1-L4 alert rules for agent/chat/tools depth signals

### DIFF
--- a/showcase/ops/config/alerts/agent-red-tick.yml
+++ b/showcase/ops/config/alerts/agent-red-tick.yml
@@ -1,0 +1,40 @@
+id: agent-red-tick
+name: "Starter agent reachability failing"
+owner: "@oss"
+
+signal:
+  dimension: agent
+
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+conditions:
+  escalations:
+    - whenFailCount: 4
+      mention: "!channel"
+      severity: critical
+
+  guards:
+    - minDeployAgeMin: 20
+
+  rate_limit:
+    perKey: "{{signal.slug}}:{{triggerName}}"
+    window: 15m
+
+  suppress:
+    when: 'trigger == "sustained_red" && lastAlertAgeMin < 15'
+
+targets:
+  - kind: slack_webhook
+    webhook: oss_alerts
+
+template:
+  text: |
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — agent unreachable, error: {{signal.errorDesc}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — agent attempt: {{signal.failCount}}, error: {{signal.errorDesc}}{{/trigger.sustained_red}}
+    {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* agent recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
+    {{#escalated}}<!channel> :rotating_light: *{{signal.slug}}* agent has been failing for 1 hour (since {{signal.firstFailureAt}}){{/escalated}}
+
+    <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>

--- a/showcase/ops/config/alerts/chat-red-tick.yml
+++ b/showcase/ops/config/alerts/chat-red-tick.yml
@@ -1,0 +1,40 @@
+id: chat-red-tick
+name: "Starter chat turn failing"
+owner: "@oss"
+
+signal:
+  dimension: chat
+
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+conditions:
+  escalations:
+    - whenFailCount: 4
+      mention: "!channel"
+      severity: critical
+
+  guards:
+    - minDeployAgeMin: 20
+
+  rate_limit:
+    perKey: "{{signal.slug}}:{{triggerName}}"
+    window: 15m
+
+  suppress:
+    when: 'trigger == "sustained_red" && lastAlertAgeMin < 15'
+
+targets:
+  - kind: slack_webhook
+    webhook: oss_alerts
+
+template:
+  text: |
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — chat turn failed, error: {{signal.errorDesc}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — chat attempt: {{signal.failCount}}, error: {{signal.errorDesc}}{{/trigger.sustained_red}}
+    {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* chat recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
+    {{#escalated}}<!channel> :rotating_light: *{{signal.slug}}* chat has been failing for 1 hour (since {{signal.firstFailureAt}}){{/escalated}}
+
+    <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>

--- a/showcase/ops/config/alerts/tools-red-tick.yml
+++ b/showcase/ops/config/alerts/tools-red-tick.yml
@@ -1,0 +1,40 @@
+id: tools-red-tick
+name: "Starter tool invocation failing"
+owner: "@oss"
+
+signal:
+  dimension: tools
+
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+conditions:
+  escalations:
+    - whenFailCount: 4
+      mention: "!channel"
+      severity: critical
+
+  guards:
+    - minDeployAgeMin: 20
+
+  rate_limit:
+    perKey: "{{signal.slug}}:{{triggerName}}"
+    window: 15m
+
+  suppress:
+    when: 'trigger == "sustained_red" && lastAlertAgeMin < 15'
+
+targets:
+  - kind: slack_webhook
+    webhook: oss_alerts
+
+template:
+  text: |
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — tool invocation failed, error: {{signal.errorDesc}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — tools attempt: {{signal.failCount}}, error: {{signal.errorDesc}}{{/trigger.sustained_red}}
+    {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* tools recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
+    {{#escalated}}<!channel> :rotating_light: *{{signal.slug}}* tools have been failing for 1 hour (since {{signal.firstFailureAt}}){{/escalated}}
+
+    <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>

--- a/showcase/ops/src/types/index.ts
+++ b/showcase/ops/src/types/index.ts
@@ -22,6 +22,14 @@ export const DIMENSIONS = [
   "redirect_decommission",
   "deploy",
   "aimock_wiring",
+  // L1-L4 buildout: per-starter depth signals side-emitted by the smoke
+  // and e2e-smoke drivers. `agent` covers L2 (agent reachability from the
+  // runtime), `chat` covers L3 (chat turn round-trip), `tools` covers L4
+  // (tool invocation within a chat turn). Each emits as `<dim>:<slug>` so
+  // deriveDimension() routes them to their dedicated rule YAMLs.
+  "agent",
+  "chat",
+  "tools",
 ] as const;
 export type Dimension = (typeof DIMENSIONS)[number];
 


### PR DESCRIPTION
## Summary
- New alert rule YAMLs for the L2/L3/L4 side-channel signals emitted by the smoke + e2e-smoke drivers (`agent:<slug>`, `chat:<slug>`, `tools:<slug>`).
- Each rule mirrors `smoke-red-tick.yml` exactly: `green_to_red` / `sustained_red` / `red_to_green` triggers, `!channel` escalation at failCount=4, 20-minute minDeployAgeMin guard, 15-minute per-key rate limit, and suppression of chatty `sustained_red` ticks within a 15-minute window.
- Extends the closed `DIMENSIONS` enum in `src/types/index.ts` with `agent`, `chat`, `tools` so the Zod schema derived from it accepts the new rules at load; typo'd dimensions continue to fail with a listed-valid-members error.

## Why
Slots 1 + 2 of the L1-L4 buildout extend the smoke + e2e-smoke drivers to emit per-starter depth signals. Without dedicated rules those ticks land in the status store but never page anyone — L2-L4 regressions would be silent even though the probes went red. These rules close that gap.

## Scope guardrails
- Pure YAML work plus the single-line enum extension the schema requires.
- No driver, discovery, orchestrator, or template-filter changes.
- Templates use only double-brace for `signal.*` fields (no new `slackSafeFields` wiring needed); triple-brace is restricted to loader-known-safe `env.dashboardUrl` / `event.runId`.

## Test plan
- [x] `pnpm exec vitest run src/rules/rule-loader.test.ts` — 64 passed (new rules load cleanly alongside the existing 8).
- [x] `pnpm exec vitest run` — 692 passed across 37 files.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm -w format` — no drift.
- [ ] Smoke that a synthesised `agent:<slug>` red tick renders the expected template in staging before flipping discovery to emit these dimensions in production.