### PR TITLE
fix(showcase): install curl in TS runtime stages — watchdog probes were silently exiting rc=127

### DIFF
--- a/showcase/packages/claude-sdk-typescript/Dockerfile
+++ b/showcase/packages/claude-sdk-typescript/Dockerfile
@@ -17,6 +17,13 @@ RUN npx tsc --outDir /app/dist --module commonjs --moduleResolution node \
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Install curl — entrypoint.sh watchdog uses it to probe the liveness endpoint.
+# node:22-slim does NOT include curl by default, so without this the probe
+# exits rc=127 "command not found" every cycle and the watchdog kill-loops
+# the agent process indefinitely.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create unprivileged runtime user BEFORE any COPY so --chown resolves
 # by name and so recursive chown over /app is never needed (fast builds).
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \

--- a/showcase/packages/langgraph-typescript/Dockerfile
+++ b/showcase/packages/langgraph-typescript/Dockerfile
@@ -20,6 +20,13 @@ RUN npm ci --legacy-peer-deps
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Install curl — entrypoint.sh watchdog uses it to probe the liveness endpoint.
+# node:22-slim does NOT include curl by default, so without this the probe
+# exits rc=127 "command not found" every cycle and the watchdog kill-loops
+# the agent process indefinitely.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create unprivileged runtime user BEFORE any COPY so --chown resolves
 # by name and so recursive chown over /app is never needed (fast builds).
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \

--- a/showcase/packages/mastra/Dockerfile
+++ b/showcase/packages/mastra/Dockerfile
@@ -15,6 +15,13 @@ RUN npx next build
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Install curl — entrypoint.sh watchdog uses it to probe the liveness endpoint.
+# node:22-slim does NOT include curl by default, so without this the probe
+# exits rc=127 "command not found" every cycle and the watchdog kill-loops
+# the agent process indefinitely.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create unprivileged runtime user BEFORE any COPY so --chown resolves
 # by name and so recursive chown over /app is never needed (fast builds).
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \

--- a/showcase/starters/claude-sdk-typescript/Dockerfile
+++ b/showcase/starters/claude-sdk-typescript/Dockerfile
@@ -22,6 +22,13 @@ RUN npx tsc --outDir /app/dist --rootDir . \
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Install curl — entrypoint.sh watchdog uses it to probe the liveness endpoint.
+# node:22-slim does NOT include curl by default, so without this the probe
+# exits rc=127 "command not found" every cycle and the watchdog kill-loops
+# the agent process indefinitely.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create unprivileged runtime user BEFORE any COPY so --chown resolves
 # by name and so recursive chown over /app is never needed (fast builds).
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \

--- a/showcase/starters/langgraph-typescript/Dockerfile
+++ b/showcase/starters/langgraph-typescript/Dockerfile
@@ -13,6 +13,13 @@ RUN npm run build
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Install curl — entrypoint.sh watchdog uses it to probe the liveness endpoint.
+# node:22-slim does NOT include curl by default, so without this the probe
+# exits rc=127 "command not found" every cycle and the watchdog kill-loops
+# the agent process indefinitely.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create unprivileged runtime user BEFORE any COPY so --chown resolves
 # by name and so recursive chown over /app is never needed (fast builds).
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \

--- a/showcase/starters/langgraph-typescript/agent/liveness.mjs
+++ b/showcase/starters/langgraph-typescript/agent/liveness.mjs
@@ -1,0 +1,37 @@
+// Liveness front-door. This module is the process entry point (see
+// entrypoint.sh). It binds an HTTP server on :8124/ok using ONLY `node:http`
+// — zero heavy imports — so the watchdog has a valid probe target within
+// milliseconds of `node` boot.
+//
+// ES modules resolve ALL top-level `import` statements before any module-body
+// code runs. `@langchain/langgraph-api/server` (pulled in by server.mjs) takes
+// ~4m30s to cold-import on Railway (graph eval + tsx transpile). The watchdog
+// in entrypoint.sh allows 180s grace + 3×30s strikes = 270s before killing
+// the container — roughly 4s short of when a probe embedded in server.mjs
+// would actually bind. Kill-loop forever.
+//
+// Fix: bind :8124 first from a module with no heavy imports, THEN dynamic-
+// import server.mjs to kick off the real langgraph bootstrap. Dynamic imports
+// are evaluated at call time, not at module load time, so the listen callback
+// fires before the heavy graph is touched.
+
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.HEALTH_PORT || 8124);
+
+createServer((req, res) => {
+  if (req.url === "/ok") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end('{"status":"ok"}\n');
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+}).listen(PORT, "0.0.0.0", () => {
+  console.log(`[liveness] probe listening on 0.0.0.0:${PORT}`);
+  // Defer real server start until AFTER liveness is bound.
+  import("./server.mjs").catch((err) => {
+    console.error("[liveness] server.mjs import failed:", err);
+    process.exit(1);
+  });
+});

--- a/showcase/starters/mastra/Dockerfile
+++ b/showcase/starters/mastra/Dockerfile
@@ -19,6 +19,13 @@ RUN npx mastra build --dir src/mastra
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Install curl — entrypoint.sh watchdog uses it to probe the liveness endpoint.
+# node:22-slim does NOT include curl by default, so without this the probe
+# exits rc=127 "command not found" every cycle and the watchdog kill-loops
+# the agent process indefinitely.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create unprivileged runtime user BEFORE any COPY so --chown resolves
 # by name and so recursive chown over /app is never needed (fast builds).
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \

--- a/showcase/starters/template/dockerfiles/Dockerfile.typescript
+++ b/showcase/starters/template/dockerfiles/Dockerfile.typescript
@@ -13,6 +13,13 @@ RUN npm run build
 FROM node:22-slim AS runner
 WORKDIR /app
 
+# Install curl — entrypoint.sh watchdog uses it to probe the liveness endpoint.
+# node:22-slim does NOT include curl by default, so without this the probe
+# exits rc=127 "command not found" every cycle and the watchdog kill-loops
+# the agent process indefinitely.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Create unprivileged runtime user BEFORE any COPY so --chown resolves
 # by name and so recursive chown over /app is never needed (fast builds).
 RUN (groupadd --system --gid 1001 app 2>/dev/null || true) \


### PR DESCRIPTION
## Summary
- Add `curl` to the runtime `apt-get install` line in:
  - `showcase/starters/template/dockerfiles/Dockerfile.typescript`
  - `showcase/packages/{claude-sdk-typescript,langgraph-typescript,mastra}/Dockerfile`
  - 3 starter Dockerfiles (regenerated from template)

## Why
Multi-stage Docker refactor (#4147) moved TS showcase services to `node:22-slim` runtime. That base image doesn't include `curl`. The watchdog's liveness probe invokes `curl -sS --max-time 5 http://127.0.0.1:8124/ok` — which exits `rc=127 "command not found"` every cycle. After 180s grace + 3×30s strikes the watchdog kills the agent. Railway auto-restarts. Loop forever.

Verified via `railway ssh`:
```
sh: 1: curl: not found
rc=127
```
while `ss -tlnp` on the same container confirmed both :8123 (langgraph-api) and :8124 (liveness.mjs) LISTEN. The agent was always healthy — the probe was broken.

## Test plan
- [ ] Local amd64 docker build for starter+package variants succeeds
- [ ] `docker run ... sh -c "which curl"` prints `/usr/bin/curl`
- [ ] After Railway redeploy of langgraph-typescript, steady-state: no kill-loop, `/api/health` green