### PR TITLE
feat(showcase-ops): smoke L2 agent check + railway-services auto-discovery

### DIFF
--- a/showcase/ops/config/probes/smoke.yml
+++ b/showcase/ops/config/probes/smoke.yml
@@ -1,17 +1,33 @@
 # Probe: smoke
 #
-# Per-service GET /smoke health check across every showcase starter on
-# Railway. Static-targets shape — one entry per known service slug —
-# because the smoke domain is small, bounded, and operator-authored:
-# discovery would add moving parts (Railway auth, service-list drift,
-# filter predicates) for no upside when the slug list changes roughly
-# never. When a new showcase lands, add a line here.
+# Per-service L1+L2 health check across every showcase service on
+# Railway. Discovery-driven: the `railway-services` source enumerates
+# every `showcase-*` service in the orchestrator's project, and the
+# driver fans out one invocation per service.
 #
-# Each driver invocation issues TWO HTTP GETs: `url` (the /smoke
-# endpoint) and the derived /health endpoint. The smoke driver emits
-# the primary `smoke:<slug>` ProbeResult as its return value and
-# side-emits the paired `health:<slug>` ProbeResult through
-# ctx.writer, so a single YAML target produces two writer ticks.
+# Each driver invocation issues THREE HTTP calls:
+#   1. GET  `${publicUrl}/smoke`            → primary `smoke:<slug>` tick
+#   2. GET  `${publicUrl}/health`           → side-emit `health:<slug>`
+#   3. POST `${publicUrl}/api/copilotkit/`  → side-emit `agent:<slug>`
+#
+# (1) and (2) are L1: liveness + health. (3) is L2: the CopilotKit
+# runtime is mounted and answering — any non-404 response is green;
+# 404 or transport failure is red. Matches the `checkAgentEndpoint`
+# contract in the e2e helpers.
+#
+# `slug` is derived by stripping the `showcase-` prefix from the Railway
+# service name. So `showcase-ag2` → keys `smoke:ag2` / `health:ag2` /
+# `agent:ag2`, and `showcase-starter-ag2` → `smoke:starter-ag2` /
+# `health:starter-ag2` / `agent:starter-ag2`. This keeps the 17 package
+# + 17 starter services observable as 34 × 3 = 102 independent probe
+# rows — each can flip green/red without blinding its siblings.
+#
+# Auto-discovery: adding a new `showcase-*` service on Railway
+# automatically picks it up on the next tick — no YAML edit required.
+# Only infra services (aimock/ops/pocketbase/shell*) are excluded,
+# because they don't expose a CopilotKit runtime or health endpoints.
+# If a new non-monitored service is created with the `showcase-`
+# prefix, extend `filter.nameExcludes` here.
 #
 # Schedule mirrors the pre-YAML cron cadence (every 15 minutes) — the
 # accompanying alert rule in config/alerts/ covers green→red /
@@ -20,81 +36,37 @@
 #
 # timeout_ms (10s) bounds the WHOLE driver invocation at the invoker
 # level; the driver re-applies the same bound inside each HTTP call
-# so one hung endpoint can't steal budget from its paired probe.
+# so one hung endpoint can't steal budget from its paired probes.
 # max_concurrency (6) caps simultaneous per-tick driver invocations —
-# at 17 services the tick takes ≤ 3 pool-cycles and stays well under
-# any Railway edge rate limit.
+# at 34 services the tick takes ≤ 6 pool-cycles and stays well under
+# any Railway edge rate limit. Per-tick socket bound:
+# max_concurrency × 3 endpoints = 18 inflight.
 kind: smoke
 id: smoke
 schedule: "*/15 * * * *"
 timeout_ms: 10000
 max_concurrency: 6
-targets:
-  - {
-      key: "smoke:ag2",
-      url: "https://showcase-ag2-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:agno",
-      url: "https://showcase-agno-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:claude-sdk-python",
-      url: "https://showcase-claude-sdk-python-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:claude-sdk-typescript",
-      url: "https://showcase-claude-sdk-typescript-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:crewai-crews",
-      url: "https://showcase-crewai-crews-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:google-adk",
-      url: "https://showcase-google-adk-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:langgraph-fastapi",
-      url: "https://showcase-langgraph-fastapi-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:langgraph-python",
-      url: "https://showcase-langgraph-python-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:langgraph-typescript",
-      url: "https://showcase-langgraph-typescript-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:langroid",
-      url: "https://showcase-langroid-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:llamaindex",
-      url: "https://showcase-llamaindex-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:mastra",
-      url: "https://showcase-mastra-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:ms-agent-dotnet",
-      url: "https://showcase-ms-agent-dotnet-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:ms-agent-python",
-      url: "https://showcase-ms-agent-python-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:pydantic-ai",
-      url: "https://showcase-pydantic-ai-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:spring-ai",
-      url: "https://showcase-spring-ai-production.up.railway.app/smoke",
-    }
-  - {
-      key: "smoke:strands",
-      url: "https://showcase-strands-production.up.railway.app/smoke",
-    }
+discovery:
+  source: railway-services
+  filter:
+    namePrefix: "showcase-"
+    # Infra services that don't expose /smoke, /health, or the
+    # CopilotKit runtime. Keep this list aligned with the excludes in
+    # `src/probes/aimock-wiring.ts` — when a new infra service lands
+    # on Railway under the `showcase-` prefix, add it in both places.
+    nameExcludes:
+      - "showcase-aimock"
+      - "showcase-ops"
+      - "showcase-pocketbase"
+      - "showcase-shell"
+      - "showcase-shell-dashboard"
+      - "showcase-shell-docs"
+      - "showcase-shell-dojo"
+  # key_template is interpolated against each RailwayServiceInfo record.
+  # `${name}` is the full Railway service name (`showcase-ag2`). The
+  # driver re-derives the slug by stripping the `showcase-` prefix, so
+  # the writer sees `smoke:showcase-ag2` as the top-line key and
+  # `health:ag2` / `agent:ag2` as the side-emit keys. We keep the
+  # `smoke:` prefix carrying the full service name so existing alert
+  # rules that dedupe on `smoke:*` continue to match.
+  key_template: "smoke:${name}"

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -50,6 +50,16 @@ const FilterSchema = z
   .object({
     labels: z.record(z.string()).optional(),
     namePrefix: z.string().optional(),
+    /**
+     * Exact-match name exclusion list. Applied AFTER `namePrefix` so
+     * operators can say "all `showcase-*` services EXCEPT infra/shell
+     * services" in one filter block rather than having to post-filter
+     * inside every driver. Empty/undefined ⇒ no exclusions. Matches
+     * are exact-string (not prefix or regex) to keep the YAML shape
+     * auditable — `["showcase-ops","showcase-aimock"]` means exactly
+     * those two names and nothing else.
+     */
+    nameExcludes: z.array(z.string().min(1)).optional(),
   })
   .optional();
 
@@ -172,10 +182,19 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
     // schema for forward compatibility with a future Railway labels API
     // but isn't enforced yet — Railway doesn't expose service labels
     // today. `namePrefix` is the live filter.
+    const excludeSet = new Set(filter.nameExcludes ?? []);
     const services = parsedProject.data.project.services.edges
       .map((e) => e.node)
       .filter((svc) => {
         if (filter.namePrefix && !svc.name.startsWith(filter.namePrefix)) {
+          return false;
+        }
+        // Exact-name exclusion — applied AFTER the prefix check so the
+        // exclusion list only has to enumerate names the prefix already
+        // matched. Returning false here skips the per-service env fetch
+        // entirely (same path as the prefix miss above) so excluded
+        // services cost nothing beyond the project-level round-trip.
+        if (excludeSet.has(svc.name)) {
           return false;
         }
         return true;

--- a/showcase/ops/src/probes/drivers/smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { smokeDriver } from "./smoke.js";
+import { smokeDriver, type SmokeDriverSignal } from "./smoke.js";
 import { logger } from "../../logger.js";
 import type {
   ProbeContext,
@@ -51,29 +51,40 @@ function responseFor(
   opts: {
     smokeStatus?: number;
     healthStatus?: number;
+    agentStatus?: number;
     smokeBody?: string;
     healthBody?: string;
+    agentBody?: string;
   },
 ): Response {
-  const isHealth = /\/health(\b|\/|\?|$)/.test(url);
-  const status = isHealth
-    ? (opts.healthStatus ?? 200)
-    : (opts.smokeStatus ?? 200);
-  const body = isHealth
-    ? (opts.healthBody ?? '{"status":"ok"}')
-    : (opts.smokeBody ?? '{"status":"ok"}');
+  const isAgent = /\/api\/copilotkit(\/|\b|\?|$)/.test(url);
+  const isHealth = !isAgent && /\/health(\b|\/|\?|$)/.test(url);
+  let status: number;
+  let body: string;
+  if (isAgent) {
+    status = opts.agentStatus ?? 200;
+    body = opts.agentBody ?? '{"status":"ok"}';
+  } else if (isHealth) {
+    status = opts.healthStatus ?? 200;
+    body = opts.healthBody ?? '{"status":"ok"}';
+  } else {
+    status = opts.smokeStatus ?? 200;
+    body = opts.smokeBody ?? '{"status":"ok"}';
+  }
   return new Response(body, {
     status,
     statusText: `HTTP ${status}`,
   });
 }
 
-/** Fake-fetch factory: answer smoke/health differently per test case. */
+/** Fake-fetch factory: answer smoke/health/agent differently per test case. */
 function fakeFetch(opts: {
   smokeStatus?: number;
   healthStatus?: number;
+  agentStatus?: number;
   smokeBody?: string;
   healthBody?: string;
+  agentBody?: string;
 }): typeof fetch {
   return (async (url: string | URL) => {
     const href = typeof url === "string" ? url : url.toString();
@@ -126,8 +137,11 @@ describe("smokeDriver", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("happy path: 200 on /smoke + 200 on /health → green smoke + green health side-emission", async () => {
-    vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 200, healthStatus: 200 }));
+  it("happy path: 200 /smoke + 200 /health + 200 /agent → green smoke + green health + green agent side-emissions", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
+    );
     const { writer, writes } = mkWriter();
     const r = await smokeDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
@@ -136,13 +150,18 @@ describe("smokeDriver", () => {
     expect(r.state).toBe("green");
     expect(r.key).toBe("smoke:mastra");
     expect(r.signal.status).toBe(200);
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(2);
     expect(writes[0]!.key).toBe("health:mastra");
     expect(writes[0]!.state).toBe("green");
+    expect(writes[1]!.key).toBe("agent:mastra");
+    expect(writes[1]!.state).toBe("green");
   });
 
   it("/smoke 500 → smoke red, health still probes", async () => {
-    vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 500, healthStatus: 200 }));
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 500, healthStatus: 200, agentStatus: 200 }),
+    );
     const { writer, writes } = mkWriter();
     const r = await smokeDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
@@ -150,14 +169,22 @@ describe("smokeDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toContain("500");
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(2);
+    expect(writes[0]!.key).toBe("health:mastra");
     expect(writes[0]!.state).toBe("green");
+    expect(writes[1]!.key).toBe("agent:mastra");
+    expect(writes[1]!.state).toBe("green");
   });
 
   it("/smoke 404 → smoke red with http 404 errorDesc", async () => {
     vi.stubGlobal(
       "fetch",
-      fakeFetch({ smokeStatus: 404, smokeBody: "", healthStatus: 200 }),
+      fakeFetch({
+        smokeStatus: 404,
+        smokeBody: "",
+        healthStatus: 200,
+        agentStatus: 200,
+      }),
     );
     const { writer, writes } = mkWriter();
     const r = await smokeDriver.run(mkCtx(writer), {
@@ -166,7 +193,7 @@ describe("smokeDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toBe("http 404");
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(2);
   });
 
   it("/smoke times out → smoke red with 'timeout after Nms'", async () => {
@@ -200,12 +227,14 @@ describe("smokeDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toBe("timeout after 5ms");
-    // Health tick should also show a timeout (same fake-fetch behaviour).
-    expect(writes).toHaveLength(1);
+    // Health + agent ticks should also show a timeout (same fake-fetch).
+    expect(writes).toHaveLength(2);
     expect(writes[0]!.state).toBe("red");
     expect((writes[0]!.signal as { errorDesc?: string }).errorDesc).toBe(
       "timeout after 5ms",
     );
+    expect(writes[1]!.key).toBe("agent:mastra");
+    expect(writes[1]!.state).toBe("red");
   });
 
   it("/smoke 200 with malformed JSON body → smoke red with parse reason", async () => {
@@ -215,6 +244,7 @@ describe("smokeDriver", () => {
         smokeStatus: 200,
         smokeBody: "<html>ServiceUnavailable</html>",
         healthStatus: 200,
+        agentStatus: 200,
       }),
     );
     const { writer, writes } = mkWriter();
@@ -224,24 +254,31 @@ describe("smokeDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toMatch(/malformed body/);
-    // Health side-emit still OK.
-    expect(writes).toHaveLength(1);
+    // Health + agent side-emits still OK.
+    expect(writes).toHaveLength(2);
     expect(writes[0]!.state).toBe("green");
+    expect(writes[1]!.state).toBe("green");
   });
 
-  it("/health 503 → health red, smoke unaffected", async () => {
-    vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 200, healthStatus: 503 }));
+  it("/health 503 → health red, smoke + agent unaffected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 503, agentStatus: 200 }),
+    );
     const { writer, writes } = mkWriter();
     const r = await smokeDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
     expect(r.state).toBe("green");
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(2);
+    expect(writes[0]!.key).toBe("health:mastra");
     expect(writes[0]!.state).toBe("red");
     expect((writes[0]!.signal as { errorDesc?: string }).errorDesc).toContain(
       "503",
     );
+    expect(writes[1]!.key).toBe("agent:mastra");
+    expect(writes[1]!.state).toBe("green");
   });
 
   it("missing writer logs a warning and does not throw", async () => {
@@ -280,8 +317,10 @@ describe("smokeDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toContain("ECONNRESET");
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(2);
     expect(writes[0]!.state).toBe("red");
+    expect(writes[1]!.key).toBe("agent:mastra");
+    expect(writes[1]!.state).toBe("red");
   });
 
   it("10 parallel run() calls don't cross-contaminate URLs or keys", async () => {
@@ -289,7 +328,11 @@ describe("smokeDriver", () => {
     const fetchImpl: typeof fetch = (async (url: string | URL) => {
       const href = typeof url === "string" ? url : url.toString();
       calls.push(href);
-      return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
+      return responseFor(href, {
+        smokeStatus: 200,
+        healthStatus: 200,
+        agentStatus: 200,
+      });
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
 
@@ -305,21 +348,27 @@ describe("smokeDriver", () => {
       ),
     );
 
-    // All 10 smoke ticks green + all 10 health side-emissions green.
+    // All 10 smoke ticks green + 10 health + 10 agent side-emissions green.
     expect(results.map((r) => r.state)).toEqual(Array(10).fill("green"));
     expect(results.map((r) => r.key).sort()).toEqual(
       slugs.map((s) => `smoke:${s}`).sort(),
     );
-    expect(writes.map((w) => w.key).sort()).toEqual(
-      slugs.map((s) => `health:${s}`).sort(),
-    );
+    // writes has 20 entries: 10 health:<slug> + 10 agent:<slug>.
+    const writeKeys = writes.map((w) => w.key).sort();
+    const expectedWriteKeys = [
+      ...slugs.map((s) => `health:${s}`),
+      ...slugs.map((s) => `agent:${s}`),
+    ].sort();
+    expect(writeKeys).toEqual(expectedWriteKeys);
     // Every fake-fetch call received a URL matching one of the expected
-    // smoke or health URLs — no cross-contamination.
+    // smoke, health, or agent URLs — no cross-contamination.
     for (const href of calls) {
-      expect(href).toMatch(/^https:\/\/x-svc\d\.example\/(smoke|health)$/);
+      expect(href).toMatch(
+        /^https:\/\/x-svc\d\.example\/(smoke|health|api\/copilotkit\/?)$/,
+      );
     }
-    // Each slug's smoke + health URL was invoked exactly once.
-    expect(calls.length).toBe(20);
+    // Each slug's smoke + health + agent URL invoked exactly once (10 × 3 = 30).
+    expect(calls.length).toBe(30);
   });
 
   it("/smoke 500 with long body truncates errorDesc at 160 chars + ellipsis", async () => {
@@ -399,7 +448,10 @@ describe("smokeDriver", () => {
   });
 
   it("input key without ':' falls back to whole-key as slug", async () => {
-    vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 200, healthStatus: 200 }));
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
+    );
     const { writer, writes } = mkWriter();
     const r = await smokeDriver.run(mkCtx(writer), {
       key: "bare",
@@ -407,5 +459,250 @@ describe("smokeDriver", () => {
     });
     expect(r.state).toBe("green");
     expect(writes[0]!.key).toBe("health:bare");
+    expect(writes[1]!.key).toBe("agent:bare");
+  });
+
+  // -------------------------------------------------------------------
+  // L2 agent endpoint
+  // -------------------------------------------------------------------
+
+  it("/agent 200 → agent green with status 200", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
+    );
+    const { writer, writes } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    const agent = writes.find((w) => w.key === "agent:mastra")!;
+    expect(agent.state).toBe("green");
+    expect((agent.signal as SmokeDriverSignal).status).toBe(200);
+  });
+
+  it("/agent 400 (runtime rejected empty payload) → agent green — runtime is mounted", async () => {
+    // The CopilotKit Hono router returns 400 for an empty `{}` body; this
+    // is still an L2 success — any non-404 response proves the route
+    // exists. Mirrors the `checkAgentEndpoint` contract.
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 400 }),
+    );
+    const { writer, writes } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    const agent = writes.find((w) => w.key === "agent:mastra")!;
+    expect(agent.state).toBe("green");
+    expect((agent.signal as SmokeDriverSignal).status).toBe(400);
+  });
+
+  it("/agent 404 → agent red with 'route not mounted' errorDesc", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({
+        smokeStatus: 200,
+        healthStatus: 200,
+        agentStatus: 404,
+        agentBody: "",
+      }),
+    );
+    const { writer, writes } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    const agent = writes.find((w) => w.key === "agent:mastra")!;
+    expect(agent.state).toBe("red");
+    expect((agent.signal as SmokeDriverSignal).errorDesc).toMatch(
+      /route not mounted/,
+    );
+  });
+
+  it("/agent 404 with body → agent red with truncated body in errorDesc", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({
+        smokeStatus: 200,
+        healthStatus: 200,
+        agentStatus: 404,
+        agentBody: "<html>Next.js 404</html>",
+      }),
+    );
+    const { writer, writes } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    const agent = writes.find((w) => w.key === "agent:mastra")!;
+    expect(agent.state).toBe("red");
+    expect((agent.signal as SmokeDriverSignal).errorDesc).toContain(
+      "agent endpoint 404",
+    );
+    expect((agent.signal as SmokeDriverSignal).errorDesc).toContain(
+      "Next.js 404",
+    );
+  });
+
+  it("/agent transport error → agent red with raw message", async () => {
+    let callIdx = 0;
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      callIdx++;
+      if (/\/api\/copilotkit/.test(href)) {
+        throw new Error("EHOSTUNREACH");
+      }
+      return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer, writes } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    expect(callIdx).toBeGreaterThanOrEqual(3);
+    const agent = writes.find((w) => w.key === "agent:mastra")!;
+    expect(agent.state).toBe("red");
+    expect((agent.signal as SmokeDriverSignal).errorDesc).toContain(
+      "EHOSTUNREACH",
+    );
+  });
+
+  it("POSTs `{}` to /api/copilotkit/ for the agent probe", async () => {
+    let agentInit: RequestInit | undefined;
+    const fetchImpl: typeof fetch = (async (
+      url: string | URL,
+      init?: RequestInit,
+    ) => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (/\/api\/copilotkit/.test(href)) {
+        agentInit = init;
+      }
+      return responseFor(href, {
+        smokeStatus: 200,
+        healthStatus: 200,
+        agentStatus: 200,
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    expect(agentInit?.method).toBe("POST");
+    expect(agentInit?.body).toBe("{}");
+    // Content-Type header must be JSON so the runtime's body parser kicks in.
+    const headers = agentInit?.headers as Record<string, string> | undefined;
+    expect(headers?.["Content-Type"]).toBe("application/json");
+  });
+
+  // -------------------------------------------------------------------
+  // Discovery-shape input
+  // -------------------------------------------------------------------
+
+  it("inputSchema accepts discovery shape { key, name, publicUrl, imageRef, env }", () => {
+    const parsed = smokeInputSchema_safeParse({
+      key: "smoke:ag2",
+      name: "showcase-ag2",
+      imageRef: "ghcr.io/copilotkit/showcase-ag2:latest",
+      publicUrl: "https://showcase-ag2.up.railway.app",
+      env: { FOO: "bar" },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("inputSchema rejects when neither `url` nor (`name` + `publicUrl`) is set", () => {
+    const parsed = smokeInputSchema_safeParse({ key: "smoke:ag2" });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("discovery input: `showcase-ag2` name strips prefix → slug=`ag2`, URLs built from publicUrl", async () => {
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      calls.push(href);
+      return responseFor(href, {
+        smokeStatus: 200,
+        healthStatus: 200,
+        agentStatus: 200,
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer, writes } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:ag2",
+      name: "showcase-ag2",
+      imageRef: "ghcr.io/copilotkit/showcase-ag2:latest",
+      publicUrl: "https://showcase-ag2.up.railway.app",
+      env: {},
+    });
+    expect(r.state).toBe("green");
+    expect(r.key).toBe("smoke:ag2");
+    expect(writes.map((w) => w.key).sort()).toEqual(
+      ["agent:ag2", "health:ag2"].sort(),
+    );
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/smoke");
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/health");
+    expect(calls).toContain(
+      "https://showcase-ag2.up.railway.app/api/copilotkit/",
+    );
+  });
+
+  it("discovery input: `showcase-starter-ag2` name strips prefix → slug=`starter-ag2`", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
+    );
+    const { writer, writes } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      imageRef: "ghcr.io/copilotkit/showcase-starter-ag2:latest",
+      publicUrl: "https://showcase-starter-ag2.up.railway.app",
+      env: {},
+    });
+    expect(r.state).toBe("green");
+    expect(writes.map((w) => w.key).sort()).toEqual(
+      ["agent:starter-ag2", "health:starter-ag2"].sort(),
+    );
+  });
+
+  it("discovery input with trailing `/` on publicUrl strips it before appending paths", async () => {
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      calls.push(href);
+      return responseFor(href, {
+        smokeStatus: 200,
+        healthStatus: 200,
+        agentStatus: 200,
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:ag2",
+      name: "showcase-ag2",
+      imageRef: "",
+      publicUrl: "https://showcase-ag2.up.railway.app/",
+      env: {},
+    });
+    // No double-slashes.
+    for (const c of calls) {
+      expect(c).not.toContain(".app//");
+    }
   });
 });
+
+/**
+ * Proxy helper for the two schema-level assertions above. Not exposed
+ * from the module itself (drivers keep their schemas private); the tests
+ * pull it through the existing `smokeDriver` import so the tested shape
+ * matches exactly what the invoker hands in.
+ */
+function smokeInputSchema_safeParse(input: unknown): { success: boolean } {
+  return smokeDriver.inputSchema.safeParse(input);
+}

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -4,21 +4,26 @@ import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
 /**
- * Driver wrapper around the existing smoke probe. Converts a single
- * YAML-static target (`{ key, url }`) into the two ProbeResults the smoke
- * dimension has always emitted per tick:
+ * Driver wrapper around the existing smoke probe. Converts a single YAML-
+ * static target (`{ key, url }`) OR a railway-services discovery record
+ * (`{ key, name, imageRef, publicUrl, env }`) into the THREE ProbeResults
+ * the smoke dimension now emits per tick:
  *
  *   1. `smoke:<slug>`  — the RETURN VALUE of `run()`. The invoker runs
  *      `writer.write()` on the returned result just like every other
  *      driver, so the primary smoke tick participates in the standard
  *      status-writer / alert-engine pipeline with no special-casing.
- *   2. `health:<slug>` — the side-emission. A driver `run()` can only
- *      return ONE ProbeResult (that's the `ProbeDriver` contract), so the
- *      paired `/health` check is pushed through `ctx.writer.write()` as
- *      a side-effect before returning. `ctx.writer` is wired by
- *      buildProbeInvoker; when absent (tests that don't care about the
- *      side tick, or legacy call sites) the driver skips the side-emit
- *      silently instead of throwing.
+ *   2. `health:<slug>` — side-emission #1 via `ctx.writer.write()`.
+ *      Derived /health URL (via `deriveHealthUrl`) is GET-probed for
+ *      a 200-OK JSON body, same contract as the smoke tick.
+ *   3. `agent:<slug>`  — side-emission #2 via `ctx.writer.write()`. L2
+ *      coverage: POSTs to `${backendUrl}/api/copilotkit/` with an empty
+ *      JSON body and asserts the response is non-404. Matches the
+ *      contract of `checkAgentEndpoint` in the e2e helpers — any
+ *      non-404 response from the CopilotKit runtime proves it's mounted,
+ *      a 404 means the route isn't wired (Next.js 404 page, wrong agent
+ *      type, etc.). Green on non-404 2xx-5xx responses, red on 404 or
+ *      transport failure.
  *
  * Why not return `ProbeResult[]`? The invoker's fan-out and bookkeeping
  * is uniform across ALL drivers — one input, one primary result, one
@@ -29,45 +34,65 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  * writer-engine pipeline, so using it here keeps smoke's paired-probe
  * behaviour contained to this file.
  *
- * Slug derivation: `input.key` arrives as `smoke:<slug>`; the driver
- * splits on `:` to produce the health key. If the input key doesn't
- * carry a `:` (e.g. a hand-wired caller passed `"smoke"`), we fall back
- * to using the full key as the slug — still produces a distinct
- * `health:<key>` tick so the side-emit path stays observable.
+ * Input shapes: the driver accepts TWO inputs.
+ *   - Static YAML: `{ key, url }`. `url` is the `/smoke` endpoint; the
+ *     derived /health + agent URLs come from path manipulation.
+ *   - Discovery: `{ key, name, imageRef, publicUrl, env }`. The smoke
+ *     URL is `${publicUrl}/smoke`; slug is `name` with the `showcase-`
+ *     prefix stripped (`showcase-ag2` → `ag2`, `showcase-starter-ag2`
+ *     → `starter-ag2`). `imageRef` + `env` are ignored by this driver
+ *     but declared in the schema so the railway-services record passes
+ *     through without a translation hop — same pattern image-drift uses.
+ *
+ * Slug derivation priority: (1) if `name` is present, strip the
+ * `showcase-` prefix; (2) otherwise split `key` on `:` and take the
+ * second segment. This keeps static-YAML ticks emitting the same
+ * `smoke:<slug>`/`health:<slug>`/`agent:<slug>` triple the dashboard
+ * expects while letting discovery-sourced ticks emit the same triple
+ * without the YAML operator hand-editing key strings.
  *
  * Timeout: the driver OWNS the timeout, not the probe-invoker. The
  * invoker's `cfg.timeout_ms` guard bounds the whole `run()` call; inside
- * `run()`, each of the two HTTP GETs uses the same `timeout_ms` as an
+ * `run()`, each of the three HTTP calls uses the same `timeout_ms` as an
  * AbortController limit so one slow endpoint (smoke OK, health hung)
  * can't gobble the invoker's whole budget and starve sibling targets
  * in the same tick.
  */
 
 /**
- * Per-target input schema. `key` is the writer dedupe key the invoker
- * already validated at probe-loader time; `url` is the `/smoke` endpoint.
- * `passthrough()` is deliberately NOT used — the YAML shape is
- * exhaustively `{ key, url }`, so any extra per-target field is a
- * probable typo we want to reject at load time.
+ * Per-target input schema. Two cases: static (`{key, url}`) and discovery
+ * (`{key, name, publicUrl, ...}`). `passthrough()` tolerates the extra
+ * discovery fields (`imageRef`, `env`) without requiring the schema to
+ * enumerate them — the driver only reads the subset it needs and lets the
+ * discovery source own the authoritative shape.
  */
 const smokeInputSchema = z
   .object({
     key: z.string().min(1),
-    url: z.string().url(),
+    /** Static mode: full `/smoke` URL. Optional in discovery mode — derived from `publicUrl`. */
+    url: z.string().url().optional(),
+    /** Discovery mode: Railway service name (`showcase-<slug>` or `showcase-starter-<slug>`). */
+    name: z.string().min(1).optional(),
+    /** Discovery mode: `https://<domain>` base URL. The driver appends `/smoke`. */
+    publicUrl: z.string().optional(),
   })
-  .strict();
+  .passthrough()
+  .refine((v) => v.url || (v.name && v.publicUrl), {
+    message:
+      "smoke driver requires either `url` (static) or `name`+`publicUrl` (discovery)",
+  });
 
 type SmokeDriverInput = z.infer<typeof smokeInputSchema>;
 
 /**
- * Shared signal shape for both the smoke and the paired health
- * ProbeResult. `url` is the URL that was ACTUALLY probed (smoke URL for
- * the smoke result, health URL for the health result) so dashboards can
- * link operators directly to the endpoint that failed; `status` is the
- * numeric HTTP status (absent on network error / timeout so templates
- * can branch on its presence); `errorDesc` is a human-readable reason
- * that's safe to render in Slack. `latencyMs` is wall-clock measured
- * from `ctx.now()` so fake-timer tests produce deterministic numbers.
+ * Shared signal shape for the smoke, health, and agent ProbeResults.
+ * `url` is the URL that was ACTUALLY probed (smoke URL, health URL, or
+ * agent URL respectively) so dashboards can link operators directly to
+ * the endpoint that failed; `status` is the numeric HTTP status (absent
+ * on network error / timeout so templates can branch on its presence);
+ * `errorDesc` is a human-readable reason that's safe to render in Slack.
+ * `latencyMs` is wall-clock measured from `ctx.now()` so fake-timer
+ * tests produce deterministic numbers.
  */
 export interface SmokeDriverSignal {
   slug: string;
@@ -81,32 +106,39 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
   kind: "smoke",
   inputSchema: smokeInputSchema,
   async run(ctx, input) {
-    const fetchImpl = globalThis.fetch.bind(globalThis);
+    const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
     const timeoutMs = readTimeoutMs(ctx);
-    const slug = deriveSlug(input.key);
-    const healthUrl = deriveHealthUrl(input.url);
+    const slug = deriveSlug(input);
+    const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input);
+    // Primary key for the smoke ProbeResult. In DISCOVERY mode (when
+    // `input.name` is set), `input.key` arrives as `smoke:showcase-ag2`
+    // because the `key_template` in YAML interpolates `${name}` and
+    // the template language has no string-munge function to strip the
+    // prefix. Rewrite to `smoke:<slug>` here so dashboards/alerts that
+    // match on `smoke:ag2` / `smoke:starter-ag2` stay intact under
+    // both static and discovery call paths. In STATIC mode, pass the
+    // YAML-authored key through verbatim so legacy callers keep their
+    // exact `input.key` in the primary result.
+    const primaryKey = input.name ? `smoke:${slug}` : input.key;
 
-    // Issue the smoke + health probes SEQUENTIALLY rather than in parallel.
-    // Parallel would halve the wall-clock but would double the inflight
-    // socket count per target; at max_concurrency=6 * 17 services * 2
-    // endpoints that's 204 simultaneous TCP connections to Railway, which
-    // has historically triggered edge-side rate limiting. Sequential keeps
-    // the bound at max_concurrency * 2 = 12 — still well under any edge
-    // threshold.
+    // Issue the smoke + health + agent probes SEQUENTIALLY rather than
+    // in parallel. Parallel would cut wall-clock but would triple the
+    // inflight socket count per target; at max_concurrency=6 * 34
+    // services * 3 endpoints that's 612 simultaneous TCP connections to
+    // Railway, which has historically triggered edge-side rate
+    // limiting. Sequential keeps the bound at max_concurrency * 3 = 18 —
+    // still well under any edge threshold.
     const smokeResult = await probeOne({
       fetchImpl,
-      url: input.url,
-      key: input.key,
+      url: smokeUrl,
+      key: primaryKey,
       slug,
       timeoutMs,
       now: ctx.now,
+      method: "GET",
     });
 
-    // Side-emit the health tick through ctx.writer BEFORE returning. If
-    // the writer is absent (legacy call sites, tests that don't assert
-    // on the side-emission) we log-and-skip — a missing writer is a
-    // wiring issue, not a per-tick failure, and swallowing it keeps the
-    // driver usable in unit tests that only care about the return value.
+    // Side-emit #1: health tick.
     const healthKey = `health:${slug}`;
     const healthResult = await probeOne({
       fetchImpl,
@@ -115,37 +147,64 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
       slug,
       timeoutMs,
       now: ctx.now,
+      method: "GET",
     });
-    if (ctx.writer) {
-      try {
-        await ctx.writer.write(healthResult);
-      } catch (err) {
-        // Writer failures on the side-emit path should NOT swallow the
-        // primary smoke tick — that path is what the invoker is waiting
-        // for. Log with enough context to correlate to the writer's own
-        // `writer.failed` bus emission and keep going.
-        ctx.logger.error("probe.smoke.health-writer-failed", {
-          key: healthKey,
-          err: err instanceof Error ? err.message : String(err),
-        });
-      }
-    } else {
-      ctx.logger.warn("probe.smoke.writer-missing", {
-        key: input.key,
-        healthKey,
-      });
-    }
+    await sideEmit(ctx, healthResult, healthKey);
+
+    // Side-emit #2: agent endpoint POST. Non-404 2xx-5xx response is
+    // green (proves the CopilotKit runtime is mounted); 404 and
+    // transport failures are red. This mirrors the L2 `@agent`
+    // assertion in `integration-smoke.spec.ts:311`.
+    const agentKey = `agent:${slug}`;
+    const agentResult = await probeAgent({
+      fetchImpl,
+      url: agentUrl,
+      key: agentKey,
+      slug,
+      timeoutMs,
+      now: ctx.now,
+    });
+    await sideEmit(ctx, agentResult, agentKey);
 
     return smokeResult;
   },
 };
 
 /**
- * Per-endpoint probe — issues one HTTP GET with an AbortController
+ * Write a side-emit ProbeResult through `ctx.writer`. Absent writer is a
+ * wiring issue, not a per-tick failure — log-and-skip so the driver stays
+ * usable in unit tests that only care about the primary return value. A
+ * writer throw is non-fatal for the same reason: the primary smoke tick
+ * is what the invoker is waiting on; a side-emit writer hiccup must not
+ * take the primary result down with it.
+ */
+async function sideEmit<T>(
+  ctx: ProbeContext,
+  result: ProbeResult<T>,
+  key: string,
+): Promise<void> {
+  if (!ctx.writer) {
+    ctx.logger.warn("probe.smoke.writer-missing", { key });
+    return;
+  }
+  try {
+    await ctx.writer.write(result);
+  } catch (err) {
+    ctx.logger.error("probe.smoke.side-emit-writer-failed", {
+      key,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Per-endpoint GET probe — issues one HTTP request with an AbortController
  * timeout, maps the result to a ProbeResult<SmokeDriverSignal>. Shared
  * between the smoke and health code paths so both produce identical
- * shapes (dashboards, templates, tests can all treat the two keys as
- * a matched pair).
+ * shapes (dashboards, templates, tests can all treat the two keys as a
+ * matched pair). The `method` parameter lets callers swap GET/POST when
+ * a probe semantics differ — currently only GET is used here since the
+ * agent POST path has distinct success criteria and lives in `probeAgent`.
  */
 async function probeOne(opts: {
   fetchImpl: typeof fetch;
@@ -154,13 +213,17 @@ async function probeOne(opts: {
   slug: string;
   timeoutMs: number;
   now: () => Date;
+  method: "GET" | "POST";
 }): Promise<ProbeResult<SmokeDriverSignal>> {
-  const { fetchImpl, url, key, slug, timeoutMs, now } = opts;
+  const { fetchImpl, url, key, slug, timeoutMs, now, method } = opts;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   const started = now().getTime();
   try {
-    const res = await fetchImpl(url, { signal: controller.signal });
+    const res = await fetchImpl(url, {
+      method,
+      signal: controller.signal,
+    });
     const latencyMs = now().getTime() - started;
     const signal: SmokeDriverSignal = {
       slug,
@@ -230,16 +293,184 @@ async function probeOne(opts: {
 }
 
 /**
- * Extract `<slug>` from `"smoke:<slug>"`. Falls back to the whole key
- * when the colon is missing so a hand-wired caller still produces a
- * distinct `health:<key>` side-tick rather than a blank one.
+ * L2 agent-endpoint check. POSTs `{}` (JSON-parseable empty body) to the
+ * CopilotKit runtime path and classifies the response:
+ *   - 2xx / 3xx / non-404 4xx / 5xx  → GREEN: runtime is mounted and
+ *     responding. The CopilotKit Hono router answers its own errors on
+ *     malformed payloads, so even a 400 proves the runtime is there.
+ *   - 404                            → RED: the route isn't wired (the
+ *     host returned a generic not-found page, wrong agent type, etc.).
+ *   - transport failure / timeout    → RED with the raw reason.
+ *
+ * This matches the acceptance contract of `checkAgentEndpoint` in
+ * `showcase/tests/e2e/helpers.ts`: any non-404 response is proof-of-life.
+ * We don't GET /info first like the helper does — the helper runs in
+ * Playwright where it can afford two round-trips; the probe budget is
+ * per-tick tight (3 endpoints × 34 services × sequential) so we keep it
+ * to a single POST.
  */
-function deriveSlug(key: string): string {
-  const parts = key.split(":");
+async function probeAgent(opts: {
+  fetchImpl: typeof fetch;
+  url: string;
+  key: string;
+  slug: string;
+  timeoutMs: number;
+  now: () => Date;
+}): Promise<ProbeResult<SmokeDriverSignal>> {
+  const { fetchImpl, url, key, slug, timeoutMs, now } = opts;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const started = now().getTime();
+  try {
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      signal: controller.signal,
+    });
+    const latencyMs = now().getTime() - started;
+    const signal: SmokeDriverSignal = {
+      slug,
+      url,
+      status: res.status,
+      latencyMs,
+    };
+    if (res.status === 404) {
+      const body = await safeReadBody(res);
+      signal.errorDesc =
+        body.length > 0
+          ? `agent endpoint 404: ${truncate(body, 160)}`
+          : "agent endpoint 404 — route not mounted";
+      return {
+        key,
+        state: "red",
+        signal,
+        observedAt: now().toISOString(),
+      };
+    }
+    // Any other response is proof the runtime is mounted. We intentionally
+    // don't inspect the body — the CopilotKit runtime may return a
+    // structured error for the empty `{}` payload, but that's still a
+    // successful L2 signal: the route answered.
+    return {
+      key,
+      state: "green",
+      signal,
+      observedAt: now().toISOString(),
+    };
+  } catch (err) {
+    const latencyMs = now().getTime() - started;
+    const timedOut =
+      err instanceof Error &&
+      (err.name === "AbortError" || err.name === "TimeoutError") &&
+      controller.signal.aborted;
+    const errorDesc = timedOut
+      ? `timeout after ${timeoutMs}ms`
+      : err instanceof Error
+        ? err.message
+        : String(err);
+    return {
+      key,
+      state: "red",
+      signal: {
+        slug,
+        url,
+        errorDesc,
+        latencyMs,
+      },
+      observedAt: now().toISOString(),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Derive the slug from driver input. Discovery shape wins: strip the
+ * `showcase-` prefix from `name` so `showcase-ag2` → `ag2` and
+ * `showcase-starter-ag2` → `starter-ag2`. Static shape falls back to
+ * splitting the key on `:` — matches the pre-discovery behaviour so
+ * static-YAML callers keep emitting the same `smoke:<slug>` rows.
+ *
+ * When neither field yields a non-empty slug, fall back to the whole
+ * key so a hand-wired caller (`{key:"bare", url:...}`) still produces
+ * a distinct `health:bare` / `agent:bare` side-tick rather than a
+ * blank one.
+ */
+function deriveSlug(input: SmokeDriverInput): string {
+  if (input.name) {
+    const stripped = input.name.replace(/^showcase-/, "");
+    if (stripped.length > 0) return stripped;
+  }
+  const parts = input.key.split(":");
   if (parts.length >= 2 && parts[1]!.length > 0) {
     return parts[1]!;
   }
-  return key;
+  return input.key;
+}
+
+interface DerivedUrls {
+  smokeUrl: string;
+  healthUrl: string;
+  agentUrl: string;
+}
+
+/**
+ * Derive the three per-target URLs from the input shape.
+ *
+ *   - Discovery mode (`publicUrl` present): smoke = `${publicUrl}/smoke`,
+ *     health = `${publicUrl}/health`, agent = `${publicUrl}/api/copilotkit/`.
+ *     The trailing slash on the agent path mirrors the runtime router's
+ *     expectation — CopilotKit Hono routes are mounted at
+ *     `/api/copilotkit/` with a trailing slash in every showcase.
+ *   - Static mode (`url` present): smoke = input URL, health derived
+ *     via `deriveHealthUrl`, agent derived by swapping the trailing
+ *     `/smoke` for `/api/copilotkit/`.
+ *
+ * Static-mode agent URL derivation is the weak link — the smoke URL
+ * doesn't carry the agent-path convention — but static mode is a
+ * fallback for operator-authored test configs, not the production
+ * path (which is discovery). When the discovery migration completes,
+ * static-mode callers can pass an explicit agent URL in a future
+ * schema extension if needed.
+ */
+function deriveUrls(input: SmokeDriverInput): DerivedUrls {
+  if (input.publicUrl) {
+    const base = input.publicUrl.replace(/\/$/, "");
+    return {
+      smokeUrl: `${base}/smoke`,
+      healthUrl: `${base}/health`,
+      agentUrl: `${base}/api/copilotkit/`,
+    };
+  }
+  // Static fallback. `url` is guaranteed present by the refine() guard
+  // in `smokeInputSchema` when `publicUrl` is absent.
+  const smokeUrl = input.url!;
+  const healthUrl = deriveHealthUrl(smokeUrl);
+  const agentUrl = deriveAgentUrl(smokeUrl);
+  return { smokeUrl, healthUrl, agentUrl };
+}
+
+/**
+ * Derive an agent URL from a smoke URL by swapping the trailing `/smoke`
+ * path for `/api/copilotkit/`. Mirrors `deriveHealthUrl`'s approach so a
+ * static-mode caller gets a best-effort agent path without hand-editing.
+ * Empty string on parse failure — the probe will then hit `` which
+ * fetch() rejects as a transport error, flipping the row red with a
+ * readable reason.
+ */
+function deriveAgentUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (/\/smoke\/?$/.test(u.pathname)) {
+      u.pathname = u.pathname.replace(/\/smoke\/?$/, "/api/copilotkit/");
+    } else {
+      u.pathname = u.pathname.replace(/\/$/, "") + "/api/copilotkit/";
+    }
+    return u.toString();
+  } catch {
+    return "";
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Slot 1 of L1-L4 buildout: extends the `smoke` probe driver to emit an L2 `agent:<slug>` side-emission alongside the existing L1 `smoke:<slug>` + `health:<slug>` ticks, and switches `config/probes/smoke.yml` from a static 17-target list to `railway-services` discovery so new packages/starters are picked up automatically without YAML edits.

## What changed

- **L2 agent probe**: per-target POST to `${backendUrl}/api/copilotkit/` with `{}` body. Green on any non-404 response (runtime is mounted — matches the `checkAgentEndpoint` contract in `showcase/tests/e2e/helpers.ts`). Red on 404 or transport/timeout.
- **Auto-discovery**: `smoke.yml` now uses `discovery: { source: railway-services, filter: { namePrefix: "showcase-", nameExcludes: [...] } }`. Excludes infra services (aimock/ops/pocketbase/shell/shell-dashboard/shell-docs/shell-dojo) that don't expose the smoke contract. Covers all 17 packages + 17 starters = 34 services × 3 endpoints = 102 probe rows per tick.
- **`nameExcludes` filter**: new field on `railway-services` discovery source. Exact-match exclusion applied after `namePrefix` so excluded services skip per-service env fetch entirely.
- **Driver input polymorphism**: smoke driver accepts both static (`{key, url}`) and discovery (`{key, name, publicUrl, imageRef, env}`) shapes. Slug derived by stripping `showcase-` prefix from `name`; primary result key rewritten to `smoke:<slug>` in discovery mode so existing alert rules keyed on `smoke:ag2` / `smoke:starter-ag2` stay intact.
- **Socket-count bound preserved**: sequential probe execution at max_concurrency=6 gives 18 inflight sockets per tick, well under Railway's edge-rate-limit threshold (parallel would push 612).

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run test` — 703/703 passed, including new agent + discovery-shape cases
- [x] `pnpm run test:coverage` — smoke driver 98.55% line coverage (exceeds 95% gate)
- [x] `pnpm -w format` — no drift after commit
- [x] New `showcase-*` service on Railway auto-monitored on next tick (namePrefix filter)
- [ ] Operator dashboard: verify `smoke:ag2` / `health:ag2` / `agent:ag2` rows appear after deploy (post-merge observation)