### PR TITLE
docs(shell-docs): content quality pass, IntegrationGrid fixes, TOC, and index style fixes

### DIFF
--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -134,6 +134,13 @@ samp {
   color: var(--text);
 }
 
+/* Inline code inside headings should scale with the heading, not stay fixed */
+.reference-content h2 code,
+.reference-content h3 code,
+.reference-content h4 code {
+  font-size: 0.875em;
+}
+
 /* Bare <pre> fallback (when an MDX page uses a triple-fence rather than
  * <Snippet>). Mirrors the chrome on <Snippet>'s figure so pages look
  * consistent whether the code is live-from-cell or inline. */

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -164,6 +164,12 @@ samp {
   opacity: 0.8;
 }
 
+/* Cards and nav grids inside MDX use not-prose to opt out of prose link styling */
+.reference-content .not-prose a {
+  text-decoration: none;
+  color: inherit;
+}
+
 .reference-content table {
   width: 100%;
   font-size: 0.8125rem;

--- a/showcase/shell-docs/src/app/layout.tsx
+++ b/showcase/shell-docs/src/app/layout.tsx
@@ -14,7 +14,6 @@ export const RESERVED_ROUTE_SLUGS = [
   "ag-ui",
   "reference",
   "api",
-  "matrix",
 ] as const;
 
 const plusJakartaSans = Plus_Jakarta_Sans({

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -16,6 +16,7 @@ import { SidebarNav } from "@/components/sidebar-nav";
 import { SidebarLink } from "@/components/sidebar-link";
 import { SidebarFrameworkSelector } from "@/components/sidebar-framework-selector";
 import { Snippet } from "@/components/snippet";
+import { DocsToc } from "@/components/docs-toc";
 import { docsComponents } from "@/lib/mdx-registry";
 import {
   NavNode,
@@ -26,6 +27,7 @@ import {
   loadDoc,
   CONTENT_DIR,
 } from "@/lib/docs-render";
+import { childrenToText, extractHeadings, slugify } from "@/lib/toc";
 
 export interface DocsPageViewProps {
   /** Slug path relative to `CONTENT_DIR` (no leading slash). */
@@ -85,6 +87,12 @@ export async function DocsPageView({
   const rawContent = doc.source.replace(/^---[\s\S]*?---\n?/, "");
   const inlined = inlineSnippets(rawContent, slugPath);
   const content = convertTablesInJSX(inlined);
+
+  // Extract H2/H3 headings for the right-rail TOC. Run on the final
+  // content (post-snippet-inlining) so a page like threads.mdx whose
+  // body comes from a shared snippet still surfaces its sections.
+  const tocHeadings =
+    hideBody || doc.fm.hideTOC ? [] : extractHeadings(content);
 
   const defaultFramework = frameworkOverride ?? doc.fm.defaultFramework;
   const defaultCell = doc.fm.defaultCell;
@@ -226,6 +234,26 @@ export async function DocsPageView({
                         />
                       );
                     },
+                    // Inject stable IDs on H2/H3 so the right-rail TOC's
+                    // #anchor links resolve. Slugify the child text with the
+                    // same algorithm used by extractHeadings() so IDs line up
+                    // with the TOC entries.
+                    h2: ({
+                      children,
+                      ...rest
+                    }: React.HTMLAttributes<HTMLHeadingElement>) => (
+                      <h2 id={slugify(childrenToText(children))} {...rest}>
+                        {children}
+                      </h2>
+                    ),
+                    h3: ({
+                      children,
+                      ...rest
+                    }: React.HTMLAttributes<HTMLHeadingElement>) => (
+                      <h3 id={slugify(childrenToText(children))} {...rest}>
+                        {children}
+                      </h3>
+                    ),
                     // When rendering under a framework-scoped route, rewrite
                     // root-relative MDX links (/quickstart, /shared-state, …)
                     // to the framework-scoped equivalent so clicks never land
@@ -264,6 +292,8 @@ export async function DocsPageView({
             return body;
           })()}
       </main>
+
+      <DocsToc headings={tocHeadings} />
     </div>
   );
 }

--- a/showcase/shell-docs/src/components/docs-toc.tsx
+++ b/showcase/shell-docs/src/components/docs-toc.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { TocHeading } from "@/lib/toc";
+
+export interface DocsTocProps {
+  headings: TocHeading[];
+}
+
+// Right-rail TOC. Hidden below xl (1280px) because the main column
+// already fills most of the viewport at laptop widths. Above that, it
+// sits beside the content with a scrollspy-highlighted active link.
+export function DocsToc({ headings }: DocsTocProps) {
+  const [activeSlug, setActiveSlug] = useState<string | null>(
+    headings[0]?.slug ?? null,
+  );
+
+  useEffect(() => {
+    if (headings.length === 0) return;
+
+    const targets = headings
+      .map((h) => document.getElementById(h.slug))
+      .filter((el): el is HTMLElement => el !== null);
+    if (targets.length === 0) return;
+
+    // Mark a heading active once its top crosses ~20% from the top of
+    // the viewport. `-20% 0px -70% 0px` creates a narrow "active band"
+    // near the top so a heading activates as it scrolls into reading
+    // position, not when it merely enters the viewport from the bottom.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const intersecting = entries.filter((e) => e.isIntersecting);
+        if (intersecting.length === 0) return;
+        intersecting.sort(
+          (a, b) => a.boundingClientRect.top - b.boundingClientRect.top,
+        );
+        setActiveSlug(intersecting[0].target.id);
+      },
+      { rootMargin: "-20% 0px -70% 0px", threshold: 0 },
+    );
+
+    targets.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  if (headings.length === 0) return null;
+
+  return (
+    <aside className="hidden xl:block w-[200px] shrink-0 sticky top-0 self-start max-h-screen overflow-y-auto py-8 pl-6 pr-4">
+      <div className="text-[10px] font-mono uppercase tracking-widest text-[var(--text-faint)] mb-3">
+        On this page
+      </div>
+      <nav className="flex flex-col gap-1 text-[12px] leading-relaxed">
+        {headings.map((h) => {
+          const isActive = activeSlug === h.slug;
+          return (
+            <a
+              key={h.slug}
+              href={`#${h.slug}`}
+              // Sync the highlight immediately on click. The
+              // IntersectionObserver can't take over here because the
+              // anchor jump lands the target above the active band
+              // (which starts ~20% from the top of the viewport), so
+              // no intersection fires and the last-active slug would
+              // otherwise stay selected.
+              onClick={() => setActiveSlug(h.slug)}
+              className={`block transition-colors ${
+                h.depth === 3 ? "pl-3" : ""
+              } ${
+                isActive
+                  ? "text-[var(--accent)] font-medium"
+                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+              }`}
+            >
+              {h.text}
+            </a>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -3,7 +3,14 @@
 import React from "react";
 import { useFramework } from "./framework-provider";
 
-export function IntegrationGrid({ path }: { path?: string; exclude?: string[] }) {
+export function IntegrationGrid({
+  path,
+  description,
+}: {
+  path?: string;
+  exclude?: string[];
+  description?: string;
+}) {
   const { framework } = useFramework();
 
   // On a framework-scoped route the user already chose a backend — hide.
@@ -12,6 +19,11 @@ export function IntegrationGrid({ path }: { path?: string; exclude?: string[] })
   return (
     <>
       <h2>Choose your AI backend</h2>
+      {description && (
+        <p style={{ marginBottom: "1rem", color: "var(--text-secondary)" }}>
+          {description}
+        </p>
+      )}
       <div
         style={{
           padding: "1rem",

--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import { useFramework } from "./framework-provider";
+
+export function IntegrationGrid({ path }: { path?: string; exclude?: string[] }) {
+  const { framework } = useFramework();
+
+  // On a framework-scoped route the user already chose a backend — hide.
+  if (framework) return null;
+
+  return (
+    <div
+      style={{
+        padding: "1rem",
+        background: "var(--bg-elevated)",
+        borderRadius: "0.5rem",
+        marginBottom: "1rem",
+        fontSize: "0.875rem",
+        color: "var(--text-muted)",
+      }}
+    >
+      See{" "}
+      <a href="/integrations" style={{ color: "var(--accent)" }}>
+        Integrations
+      </a>{" "}
+      for all available frameworks{path ? ` (${path})` : ""}.
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -10,21 +10,24 @@ export function IntegrationGrid({ path }: { path?: string; exclude?: string[] })
   if (framework) return null;
 
   return (
-    <div
-      style={{
-        padding: "1rem",
-        background: "var(--bg-elevated)",
-        borderRadius: "0.5rem",
-        marginBottom: "1rem",
-        fontSize: "0.875rem",
-        color: "var(--text-muted)",
-      }}
-    >
-      See{" "}
-      <a href="/integrations" style={{ color: "var(--accent)" }}>
-        Integrations
-      </a>{" "}
-      for all available frameworks{path ? ` (${path})` : ""}.
-    </div>
+    <>
+      <h2>Choose your AI backend</h2>
+      <div
+        style={{
+          padding: "1rem",
+          background: "var(--bg-elevated)",
+          borderRadius: "0.5rem",
+          marginBottom: "1rem",
+          fontSize: "0.875rem",
+          color: "var(--text-muted)",
+        }}
+      >
+        See{" "}
+        <a href="/integrations" style={{ color: "var(--accent)" }}>
+          Integrations
+        </a>{" "}
+        for all available frameworks{path ? ` (${path})` : ""}.
+      </div>
+    </>
   );
 }

--- a/showcase/shell-docs/src/components/search-modal.tsx
+++ b/showcase/shell-docs/src/components/search-modal.tsx
@@ -143,7 +143,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
             type: "feature",
             title: f.name,
             subtitle: f.description,
-            href: "/matrix",
+            href: "/",
           });
         }
       }

--- a/showcase/shell-docs/src/components/snippet.tsx
+++ b/showcase/shell-docs/src/components/snippet.tsx
@@ -267,14 +267,22 @@ export function Snippet({
     );
   }
 
-  if (!resolvedFramework || !resolvedCell) {
+  if (!resolvedFramework) {
+    return (
+      <div className="my-4 rounded-md border border-[var(--border)] px-4 py-3 text-sm text-[var(--text-muted)] bg-[var(--bg-elevated)]">
+        Select an AI backend above to see this code example.
+      </div>
+    );
+  }
+
+  if (!resolvedCell) {
     return (
       <WarningBox>
         <code>{`<Snippet ${region ? `region="${region}"` : `file="${file}"`} />`}</code>{" "}
-        was rendered without a framework + cell (resolved framework:{" "}
-        <code>{resolvedFramework ?? "—"}</code>, cell:{" "}
-        <code>{resolvedCell ?? "—"}</code>). Pass them explicitly or configure a
-        page default.
+        was rendered without a cell (resolved framework:{" "}
+        <code>{resolvedFramework}</code>, cell: <code>—</code>). Pass{" "}
+        <code>cell="..."</code> explicitly or set <code>snippet_cell</code> in
+        the page frontmatter.
       </WarningBox>
     );
   }

--- a/showcase/shell-docs/src/content/docs/ag-ui-middleware.mdx
+++ b/showcase/shell-docs/src/content/docs/ag-ui-middleware.mdx
@@ -5,11 +5,11 @@ description: Configure AG-UI middleware for your CopilotKit application.
 hideTOC: true
 ---
 
-AG-UI agents expose a middleware layer via `agent.use(middleware)` — a powerful hook for logging, guardrails, request transformation, and event rewriting. Because CopilotKit runs the middleware server-side inside the [Copilot Runtime](/backend/copilot-runtime), it executes in a trusted environment where the client cannot tamper with it.
+AG-UI agents expose a middleware layer via `agent.use(middleware)`, a powerful hook for logging, guardrails, request transformation, and event rewriting. Because CopilotKit runs the middleware server-side inside the [Copilot Runtime](/backend/copilot-runtime), it executes in a trusted environment where the client cannot tamper with it.
 
 ## Defining a Middleware
 
-A middleware extends the `Middleware` base class from `@ag-ui/client` and implements `run(input, next)`. It receives the incoming `RunAgentInput` and returns an `Observable<BaseEvent>` — typically by subscribing to `runNextWithState(input, next)` and transforming the stream:
+A middleware extends the `Middleware` base class from `@ag-ui/client` and implements `run(input, next)`. It receives the incoming `RunAgentInput` and returns an `Observable<BaseEvent>`, typically by subscribing to `runNextWithState(input, next)` and transforming the stream:
 
 ```ts title="my-middleware.ts"
 import {

--- a/showcase/shell-docs/src/content/docs/agentic-chat-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-chat-ui.mdx
@@ -35,8 +35,4 @@ suggestion:
 
 <Snippet region="configure-suggestions" title="frontend/src/app/page.tsx — starter suggestions" />
 
-## Get started by choosing your AI backend
-
-The chat components work with any AI backend. Pick your integration to get started.
-
-<IntegrationGrid path="chat" />
+<IntegrationGrid path="chat" description="The chat components work with any AI backend. Pick your integration to get started." />

--- a/showcase/shell-docs/src/content/docs/agentic-chat-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-chat-ui.mdx
@@ -9,7 +9,7 @@ snippet_cell: agentic-chat
 ## Pre-built components for agentic chat
 
 CopilotKit's chat components give you a fully functional, customizable AI chat interface out of the box.
-They handle streaming, generative UI, and deep customization — so you can focus on your agent's behavior, not UI plumbing.
+They handle streaming, generative UI, and deep customization so you can focus on your agent's behavior, not UI plumbing.
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/agentic-chat-ui.mp4"
@@ -25,9 +25,7 @@ They handle streaming, generative UI, and deep customization — so you can focu
 
 ## What it looks like in code
 
-The live `agentic-chat` cell above is built from a single, small page. Wrap
-your UI in `<CopilotKit>` once — it wires the runtime, session, and agent
-registry — and drop `<CopilotChat>` wherever the chat should go:
+The live `agentic-chat` cell above is built from a single, small page. Wrap your UI in `<CopilotKit>` once (it wires the runtime, session, and agent registry) and drop `<CopilotChat>` wherever the chat should go:
 
 <Snippet region="provider-setup" title="frontend/src/app/page.tsx — CopilotKit provider" />
 

--- a/showcase/shell-docs/src/content/docs/backend/ag-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/ag-ui.mdx
@@ -4,7 +4,7 @@ icon: "lucide/Zap"
 description: How CopilotKit uses the AG-UI protocol to connect your frontend to your AI agents.
 ---
 
-CopilotKit is built on the [AG-UI protocol](https://ag-ui.com) — a lightweight, event-based standard that defines how AI agents communicate with user-facing applications over Server-Sent Events (SSE).
+CopilotKit is built on the [AG-UI protocol](https://ag-ui.com), a lightweight, event-based standard that defines how AI agents communicate with user-facing applications over Server-Sent Events (SSE).
 
 Everything in CopilotKit — messages, state updates, tool calls, and more — flows through AG-UI events. Understanding this layer helps you debug, extend, and build on top of CopilotKit more effectively.
 

--- a/showcase/shell-docs/src/content/docs/custom-look-and-feel/css.mdx
+++ b/showcase/shell-docs/src/content/docs/custom-look-and-feel/css.mdx
@@ -16,7 +16,7 @@ Copilot UI components via plain CSS. You can:
 - Swap fonts per surface (messages, input, bubbles)
 - Replace icons and labels via component props
 
-If you need to change behavior — not just look — see
+If you need to change behavior, not just look, see
 [slots](/custom-look-and-feel/slots) or
 [fully headless UI](/custom-look-and-feel/headless-ui).
 
@@ -26,7 +26,7 @@ If you need to change behavior — not just look — see
 
 The demo keeps all of its styling in a sibling `theme.css` file and applies it
 only to the wrapper div holding `<CopilotChat>`. Importing the stylesheet from
-the page module is enough — Next.js bundles it with the route:
+the page module is enough; Next.js bundles it with the route:
 
 <Snippet region="theme-css-import" title="frontend/src/app/page.tsx — import the theme" />
 
@@ -90,7 +90,7 @@ can target specific pieces of the UI from your own stylesheet:
 ```
 
 The demo's `theme.css` wraps every selector under `.chat-css-demo-scope` so
-the overrides don't leak out — here's the user/assistant bubble block from
+the overrides don't leak out. Here's the user/assistant bubble block from
 that file:
 
 <Snippet

--- a/showcase/shell-docs/src/content/docs/custom-look-and-feel/headless-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/custom-look-and-feel/headless-ui.mdx
@@ -8,13 +8,13 @@ snippet_cell: headless-complete
 
 ## What is this?
 
-A headless UI gives you **full control** over the chat experience — you bring your own components, layout, and styling while CopilotKit handles agent communication, message management, tool-call rendering, and streaming. No `<CopilotChat>`, no slot overrides, just your components composed on top of the low-level hooks.
+A headless UI gives you **full control** over the chat experience. You bring your own components, layout, and styling while CopilotKit handles agent communication, message management, tool-call rendering, and streaming. No `<CopilotChat>`, no slot overrides, just your components composed on top of the low-level hooks.
 
 ## When should I use this?
 
 Use headless UI when:
 
-- The [slot system](/custom-look-and-feel/slots) isn't enough — you need a completely different layout.
+- The [slot system](/custom-look-and-feel/slots) isn't enough: you need a completely different layout.
 - You're embedding chat into an existing UI with its own patterns.
 - You're building a **non-chat surface** that still talks to an agent (a dashboard, a canvas, an inspector) and want `useRenderToolCall` / `useRenderActivityMessage` on their own.
 - You want to render generative UI primitives outside of a chat entirely.
@@ -23,7 +23,7 @@ Use headless UI when:
 
 ## The core hooks
 
-Three hooks do the heavy lifting — they're the same primitives `<CopilotChat>` uses internally.
+Three hooks power it, and they're the same ones `<CopilotChat>` uses internally.
 
 - `useAgent({ agentId })` — exposes the current conversation (`messages`, `isRunning`) and the run-state object.
 - `useCopilotKit()` — returns the runtime handle you call `runAgent({ agent })` on.
@@ -31,19 +31,19 @@ Three hooks do the heavy lifting — they're the same primitives `<CopilotChat>`
 
 ## Minimal example
 
-Start small — a hand-rolled message list and composer built from `useAgent` + `useCopilotKit`:
+Start with a hand-rolled message list and composer built from `useAgent` + `useCopilotKit`:
 
 <Snippet cell="headless-simple" region="use-agent-simple" title="frontend/src/app/page.tsx — useAgent + useCopilotKit" />
 
-The message list is a plain `.map()` over `agent.messages` — user messages render as right-aligned bubbles, assistant messages render streamed text plus inline tool calls via `renderToolCall({ toolCall })`:
+The message list is a plain `.map()` over `agent.messages`: user messages render as right-aligned bubbles, assistant messages render streamed text plus inline tool calls via `renderToolCall({ toolCall })`:
 
 <Snippet cell="headless-simple" region="message-list-simple" title="frontend/src/app/page.tsx — message list" />
 
-No `<CopilotChat />`, no slots. The trade-off: you only get text + tool calls. Reasoning messages, activity messages, and custom before/after slots won't show up unless you wire them in yourself — which is exactly what the complete example covers.
+No `<CopilotChat />`, no slots. The trade-off: you only get text and tool calls. Reasoning messages, activity messages, and custom before/after slots won't show up unless you wire them in yourself, which is exactly what the complete example covers.
 
 ## Complete example
 
-The `headless-complete` cell rebuilds the **full** generative-UI composition — text, tool calls, reasoning cards, A2UI + MCP Apps activity messages, custom before/after message slots — from the low-level hooks directly, without importing `<CopilotChatMessageView>`.
+The `headless-complete` cell rebuilds the **full** generative-UI composition from the low-level hooks directly, without importing `<CopilotChatMessageView>`: text, tool calls, reasoning cards, A2UI + MCP Apps activity messages, and custom before/after message slots.
 
 ### The `useRenderedMessages` hook
 
@@ -59,7 +59,7 @@ Three low-level hooks feed it:
 
 ### Per-role dispatch
 
-The role-switch mirrors `CopilotChatMessageView`'s `renderMessageBlock` exactly — assistant bodies get text + tool calls, user bodies get their text content, reasoning messages go through the `<CopilotChatReasoningMessage>` leaf, and activity messages route through `renderActivityMessage`:
+The role-switch mirrors `CopilotChatMessageView`'s `renderMessageBlock` exactly: assistant bodies get text and tool calls, user bodies get their text content, reasoning messages go through the `<CopilotChatReasoningMessage>` leaf, and activity messages route through `renderActivityMessage`:
 
 <Snippet region="manual-activity-message-rendering" title="frontend/src/app/use-rendered-messages.tsx — per-role dispatch" />
 
@@ -71,7 +71,7 @@ For each `toolCall` on an assistant message, we look up the sibling `tool`-role 
 
 ### Bubble chrome
 
-The `UserBubble` and `AssistantBubble` components are **pure chrome** — they receive the pre-rendered node from `useRenderedMessages` and drop it into a styled container. No chat primitives are imported here:
+The `UserBubble` and `AssistantBubble` components are **pure chrome**: they receive the pre-rendered node from `useRenderedMessages` and drop it into a styled container. No chat primitives are imported here:
 
 <Snippet region="custom-bubbles" title="frontend/src/app/{user,assistant}-bubble.tsx — pure chrome" />
 

--- a/showcase/shell-docs/src/content/docs/custom-look-and-feel/reasoning-messages.mdx
+++ b/showcase/shell-docs/src/content/docs/custom-look-and-feel/reasoning-messages.mdx
@@ -5,7 +5,7 @@ description: "Customize how reasoning (thinking) tokens from models like o1, o3,
 snippet_cell: agentic-chat-reasoning
 ---
 
-Some models (like OpenAI's o1, o3, and o4-mini) emit **reasoning tokens** — internal
+Some models (like OpenAI's o1, o3, and o4-mini) emit **reasoning tokens**: internal
 "thinking" traces that show the model's chain-of-thought before it produces a final
 answer. CopilotKit surfaces these tokens automatically with a collapsible
 **Reasoning Message** card.
@@ -24,10 +24,12 @@ built-in card that:
 - Includes a chevron toggle so users can re-expand and review the reasoning
   at any time.
 
-No extra configuration is needed — if your model emits reasoning tokens,
+No extra configuration is needed; if your model emits reasoning tokens,
 the card appears automatically.
 
 <InlineDemo demo="reasoning-default-render" />
+
+The only requirement is connecting your agent to CopilotKit; no extra props or configuration needed:
 
 <Snippet
   cell="reasoning-default-render"
@@ -160,12 +162,12 @@ slot props. Your component receives the same top-level props as the built-in one
 
 <InlineDemo demo="agentic-chat-reasoning" />
 
-<Snippet region="reasoning-block-render" title="frontend/src/app/page.tsx — custom reasoning slot" />
-
 The showcase's `ReasoningBlock` renders the reasoning as an amber-tagged inline
-banner — intentionally louder than the default card so the thinking chain is
+banner, intentionally louder than the default card so the thinking chain is
 the focal UI of the demo. Swap in your own component to match your product's
-tone.
+tone:
+
+<Snippet region="reasoning-block-render" title="frontend/src/app/page.tsx — custom reasoning slot" />
 
 ## Render-Prop Children
 

--- a/showcase/shell-docs/src/content/docs/custom-look-and-feel/slots.mdx
+++ b/showcase/shell-docs/src/content/docs/custom-look-and-feel/slots.mdx
@@ -8,13 +8,13 @@ snippet_cell: chat-slots
 
 ## What is this?
 
-Every CopilotKit chat component is built from composable **slots** — named sub-components that you can override individually. The slot system gives you three levels of customization without needing to rebuild the entire UI:
+Every CopilotKit chat component is built from composable **slots**, named sub-components you can override individually. The slot system gives you three levels of customization without needing to rebuild the entire UI:
 
 1. **Tailwind classes** — pass a string to add/override CSS classes
 2. **Props override** — pass an object to override specific props on the default component
 3. **Custom component** — pass your own React component to fully replace a slot
 
-Slots are recursive — you can drill into nested sub-components at any depth.
+Slots are recursive: you can drill into nested sub-components at any depth.
 
 <InlineDemo demo="chat-slots" />
 
@@ -142,7 +142,7 @@ Override a specific button inside the assistant message toolbar:
 
 ## Labels
 
-Customize any text string in the UI via the `labels` prop. This does not use the slot system — it's a separate convenience prop on `CopilotChat`, `CopilotSidebar`, and `CopilotPopup`.
+Customize any text string in the UI via the `labels` prop. This is a separate convenience prop on `CopilotChat`, `CopilotSidebar`, and `CopilotPopup`, not part of the slot system.
 
 ```tsx title="page.tsx"
 <CopilotChat

--- a/showcase/shell-docs/src/content/docs/frontend-actions.mdx
+++ b/showcase/shell-docs/src/content/docs/frontend-actions.mdx
@@ -37,6 +37,4 @@ Use frontend actions when your agent needs to:
 - Show alerts or notifications
 - Modify application state
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="frontend-actions"/>

--- a/showcase/shell-docs/src/content/docs/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/frontend-tools.mdx
@@ -40,6 +40,4 @@ what happened.
 
 <FeatureIntegrations feature="frontend-tools" />
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="frontend-tools" />

--- a/showcase/shell-docs/src/content/docs/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/frontend-tools.mdx
@@ -8,16 +8,9 @@ snippet_cell: frontend-tools
 
 ## What is this?
 
-Frontend tools let your agent define and invoke client-side functions — logic
-that runs entirely in the user's browser. Because the handler executes in the
-frontend, it has direct access to component state, browser APIs, and any
-third-party UI library the page already uses. That's how an agent can "reach
-into" the app: update React state, trigger animations, read `localStorage`,
-pop a toast, or steer the user's view.
+Frontend tools let your agent define and invoke client-side functions that run entirely in the user's browser. Because the handler executes on the frontend, it has direct access to component state, browser APIs, and any third-party UI library the page already uses. That's how an agent can "reach into" the app: update React state, trigger animations, read `localStorage`, pop a toast, or steer the user's view.
 
-This page covers the "agent drives the UI" shape of frontend tools. (The same
-primitive also powers Generative UI and Human-in-the-loop — see those pages
-for interaction patterns.)
+This page covers the "agent drives the UI" shape of frontend tools. The same primitive also powers Generative UI and Human-in-the-loop; see those pages for interaction patterns.
 
 <InlineDemo demo="frontend-tools" />
 
@@ -34,9 +27,7 @@ Use frontend tools when your agent needs to:
 
 ## How it works in code
 
-Register a frontend tool with `useFrontendTool`. Give it a name, a Zod schema
-for parameters, and a handler — the agent can then call it like any other
-tool and your frontend runs it in the browser.
+Register a frontend tool with `useFrontendTool`. Give it a name, a Zod schema for parameters, and a handler. The agent can then call it like any other tool and your frontend runs it in the browser.
 
 <Snippet region="frontend-tool-registration" title="frontend/src/app/page.tsx — useFrontendTool" />
 

--- a/showcase/shell-docs/src/content/docs/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/frontend-tools.mdx
@@ -47,7 +47,7 @@ what happened.
 
 <Snippet region="frontend-tool-handler" title="frontend/src/app/page.tsx — handler body" />
 
-<FeatureIntegrations feature="frontend-tools-sync" />
+<FeatureIntegrations feature="frontend-tools" />
 
 ## Get started by choosing your AI backend
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui.mdx
@@ -103,6 +103,4 @@ not render — the operations will fall through as plain tool results.
   />
 </Cards>
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/a2ui" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui.mdx
@@ -8,10 +8,10 @@ hideTOC: true
 ## What is this?
 
 [A2UI](https://a2ui.org) (Agent-to-UI) is a declarative Generative UI
-specification — led by Google with CopilotKit as a launch and design
+specification, led by Google with CopilotKit as a launch and design
 partner. It lets your agent render structured UI components through a
 JSON-based schema instead of plain text: cards, rows, columns, badges,
-price tags — all composed from a catalog of components you (or the
+and price tags, all composed from a catalog of components you (or the
 platform) define.
 
 You can design and preview A2UI schemas visually using the
@@ -62,8 +62,8 @@ a2ui.render(operations=[...])  # wraps and serializes for a tool result
 
 Enable A2UI in your CopilotRuntime by adding `a2ui: true`, or pass an
 object to customise. The middleware handles the wire protocol
-automatically — it intercepts tool results containing A2UI operations
-and renders them as rich surfaces in the chat:
+automatically, intercepting tool results containing A2UI operations
+and rendering them as rich surfaces in the chat:
 
 ```typescript title="app/api/copilotkit/route.ts"
 import { CopilotRuntime } from "@copilotkit/runtime";

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/dynamic-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/dynamic-schema.mdx
@@ -7,8 +7,8 @@ snippet_cell: declarative-gen-ui
 ---
 
 In the dynamic-schema approach, a secondary LLM generates the entire
-UI — schema, data, and layout — based on the conversation context.
-It's the most flexible A2UI flavor: the agent can render any UI for
+UI (schema, data, and layout) based on the conversation context.
+It's the most flexible A2UI flavor; the agent can render any UI for
 any request without pre-defined schemas.
 
 <InlineDemo demo="declarative-gen-ui" />
@@ -31,16 +31,16 @@ side-by-side under `frontend/src/app/a2ui/`:
 
 | File | What lives there |
 |---|---|
-| `definitions.ts` | Zod props schema + human-readable descriptions for each custom component — platform-agnostic so the runtime can serialise it to the LLM. |
+| `definitions.ts` | Zod props schema + human-readable descriptions for each custom component. Platform-agnostic, so the runtime can serialise it to the LLM. |
 | `renderers.tsx` | React implementations keyed by the same names. TypeScript enforces that every definition has a renderer. |
-| `catalog.ts` | `createCatalog(definitions, renderers, { includeBasicCatalog: true })` — merges your custom components with CopilotKit's built-in primitives. |
+| `catalog.ts` | `createCatalog(definitions, renderers, { includeBasicCatalog: true })`: merges your custom components with CopilotKit's built-in primitives. |
 
 <Steps>
 <Step>
 ### Declare your custom component definitions
 
 Each entry pairs a Zod prop schema with a description. The description
-is crucial — the LLM reads it to decide which component to emit. The
+is crucial; the LLM reads it to decide which component to emit. The
 showcase's `declarative-gen-ui` cell ships a small dashboard catalog
 (Card / StatusBadge / Metric / InfoRow / PrimaryButton):
 
@@ -70,7 +70,7 @@ can compose custom + basic components interchangeably:
 <Step>
 ### Pass the catalog to the provider
 
-A single prop (`a2ui={{ catalog }}`) is all the frontend needs — the
+A single prop (`a2ui={{ catalog }}`) is all the frontend needs; the
 provider registers the catalog and wires up the built-in A2UI
 activity-message renderer:
 
@@ -83,7 +83,7 @@ activity-message renderer:
 On the TypeScript runtime, `injectA2UITool: true` tells CopilotKit to
 add the `render_a2ui` tool to the agent's tool list *at request time*
 and serialise your client catalog into the agent's
-`copilotkit.context`. No backend code to write — the agent can be an
+`copilotkit.context`. No backend code to write; the agent can be an
 empty `create_agent(tools=[])`:
 
 ```typescript title="app/api/copilotkit/route.ts"
@@ -108,7 +108,7 @@ as `TOOL_CALL_ARGS` events. The A2UI middleware:
 3. Emits `surfaceUpdate` + `beginRendering` once the schema is
    complete.
 4. Extracts complete `items` objects progressively and emits a
-   `dataModelUpdate` for each — cards appear one by one as data
+   `dataModelUpdate` for each, so cards appear one by one as data
    streams in.
 
 A built-in progress indicator shows while the schema is still
@@ -116,14 +116,14 @@ generating and hides automatically once data items start arriving.
 
 ## When should I use dynamic schemas?
 
-- You don't know the UI shape ahead of time — the agent decides what
+- You don't know the UI shape ahead of time; the agent decides what
   to show based on the user's request.
 - You want to prototype A2UI without committing to a schema file yet.
 - You're building a conversational dashboard where the layout varies
   per turn.
 
 If the surface is well-known (e.g. a product card, a flight result),
-prefer a **[fixed schema](./fixed-schema)** — it's faster, cheaper,
+prefer a **[fixed schema](./fixed-schema)**; it's faster, cheaper,
 and the UI is deterministic.
 
 ## Choose your AI backend

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/dynamic-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/dynamic-schema.mdx
@@ -126,6 +126,4 @@ If the surface is well-known (e.g. a product card, a flight result),
 prefer a **[fixed schema](./fixed-schema)**; it's faster, cheaper,
 and the UI is deterministic.
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/a2ui" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -181,6 +181,4 @@ for the full pattern.
 If the UI must adapt per prompt, reach for
 **[dynamic schemas](./dynamic-schema)** instead.
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/a2ui" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -9,22 +9,24 @@ snippet_cell: a2ui-fixed-schema
 In the fixed-schema approach, you design the UI schema once (by hand,
 or using the [A2UI Composer](https://a2ui-composer.ag-ui.com/)) and
 save it as JSON next to your agent. The agent tool only provides the
-*data* — the surface appears instantly when the tool returns because
+*data*; the surface appears instantly when the tool returns because
 nothing has to be generated at runtime.
+
+Ask about a flight and the agent renders a fully structured card from a pre-defined schema:
 
 <InlineDemo demo="a2ui-fixed-schema" />
 
 ## How it works
 
 1. The schema is loaded from a JSON file at startup via
-   `a2ui.load_schema(...)` — a thin `json.load` wrapper.
+   `a2ui.load_schema(...)`, a thin `json.load` wrapper.
 2. The agent's `display_flight` tool receives data from the primary LLM
    (origin / destination / airline / price).
 3. The tool returns `a2ui.render(...)` with `createSurface` +
    `updateComponents` + `updateDataModel` operations.
 4. The A2UI middleware intercepts the tool result and the frontend
    renders the surface using the matching 5-component client catalog
-   (Title, Airport, Arrow, AirlineBadge, PriceTag — plus the built-ins).
+   (Title, Airport, Arrow, AirlineBadge, PriceTag, plus the built-ins).
 
 ## Schemas as JSON: compositional trees
 
@@ -51,8 +53,8 @@ not a path-or-literal union).
 
 ## The 5-component custom catalog
 
-The frontend catalog declares just the domain-specific primitives —
-Title, Airport, Arrow, AirlineBadge, PriceTag — and merges in
+The frontend catalog declares just the domain-specific primitives
+(Title, Airport, Arrow, AirlineBadge, PriceTag) and merges in
 CopilotKit's basic catalog (Card, Column, Row, Text, Button, …) via
 `includeBasicCatalog: true`.
 
@@ -70,7 +72,7 @@ Each component declares its props as a Zod schema. Props are the
 ### Implement the React renderers
 
 TypeScript enforces that the renderer map's keys and prop shapes
-match the definitions exactly — refactors stay safe:
+match the definitions exactly, so refactors stay safe:
 
 <Snippet region="renderers-tsx" />
 </Step>
@@ -88,7 +90,7 @@ renderers with CopilotKit's built-ins so the schema can reference
 <Step>
 ### Load the schema JSON at startup
 
-`a2ui.load_schema(path)` is a thin `json.load` wrapper — it parses the
+`a2ui.load_schema(path)` is a thin `json.load` wrapper that parses the
 schema file once at module-import time. The sibling `booked_schema.json`
 is kept ready for the button-click "booked" optimistic swap (see the
 note on action handlers below):
@@ -102,7 +104,7 @@ note on action handlers below):
 The `display_flight` tool returns `a2ui.render(operations=[…])`. The
 A2UI middleware detects the operations container in the tool result
 and forwards it to the frontend renderer. The LLM only generates the
-four data fields (`origin`, `destination`, `airline`, `price`) — the
+four data fields (`origin`, `destination`, `airline`, `price`); the
 schema does the rest:
 
 <Snippet region="backend-render-operations" />
@@ -125,7 +127,7 @@ Row / Title / Airport / Arrow / AirlineBadge / PriceTag gives you:
 ## Registering the runtime
 
 On the TypeScript side, A2UI's middleware auto-detects the operations
-in any tool result — so even with a fixed schema, the minimum setup
+in any tool result, so even with a fixed schema, the minimum setup
 is `a2ui: {}`. The `a2ui-fixed-schema` cell happens to also keep
 `injectA2UITool: true` so the same agent can be pointed at
 dynamic-schema workflows later without re-configuring.
@@ -143,7 +145,7 @@ The canonical reference pairs fixed schemas with
 `action_handlers={...}` to declare optimistic UI swaps (e.g. replacing
 the flight schema with `BOOKED_SCHEMA` when the user clicks "Book").
 The Python SDK's `a2ui.render` does not yet accept `action_handlers`,
-so the cell omits them — the `booked_schema.json` sibling is retained
+so the cell omits them; the `booked_schema.json` sibling is retained
 so the swap can be wired up the moment the SDK exposes the handler
 kwarg.
 
@@ -171,10 +173,10 @@ for the full pattern.
 
 ## When should I use fixed schemas?
 
-- The surface is well-known — flight cards, product tiles, order
+- The surface is well-known: flight cards, product tiles, order
   summaries, dashboards.
 - You want deterministic, designer-controlled UI. No LLM schema drift.
-- You want the fastest possible first paint — no secondary LLM call.
+- You want the fastest possible first paint; no secondary LLM call.
 
 If the UI must adapt per prompt, reach for
 **[dynamic schemas](./dynamic-schema)** instead.

--- a/showcase/shell-docs/src/content/docs/generative-ui/display.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/display.mdx
@@ -7,7 +7,7 @@ hideTOC: true
 
 ## What is this?
 
-Render-only generative UI lets you register React components as tools your agent can invoke. When the agent calls the tool, CopilotKit renders your component directly in the chat with the tool's arguments as props — no handler logic or user interaction required.
+Render-only generative UI lets you register React components as tools your agent can invoke. When the agent calls the tool, CopilotKit renders your component directly in the chat with the tool's arguments as props; no handler logic or user interaction required.
 
 <Tabs items={['page.tsx', 'chart.tsx']}>
   <Tab value="page.tsx">

--- a/showcase/shell-docs/src/content/docs/generative-ui/interactive.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/interactive.mdx
@@ -18,6 +18,4 @@ Use interactive generative UI when you need:
 - Confirmation dialogs with structured responses
 - Any flow where the agent pauses for human judgment
 
-## Choose your AI backend
-
 <IntegrationGrid path="human-in-the-loop" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
@@ -81,6 +81,4 @@ Try these open-source MCP Apps servers to get started:
 - [Excalidraw](https://mcp.excalidraw.com) — collaborative whiteboard rendered in-chat
 - [modelcontextprotocol/ext-apps](https://github.com/modelcontextprotocol/ext-apps) — canonical reference implementations
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/mcp-apps" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
@@ -9,7 +9,7 @@ snippet_cell: mcp-apps
 
 MCP Apps are MCP servers that expose tools with associated UI resources. When
 the agent calls one of these tools, CopilotKit automatically fetches the
-resource and renders the UI component in the chat — no additional frontend
+resource and renders the UI component in the chat; no additional frontend
 code required.
 
 Key benefits:
@@ -33,7 +33,7 @@ resource and emits an `activity` event that the built-in
 
 <Callout type="info" title="Always pin a serverId">
   In production, always provide a stable `serverId`. Without it, CopilotKit
-  hashes the server URL — and a URL change (for example between environments)
+  hashes the server URL, and a URL change (for example between environments)
   silently breaks restoration of MCP Apps persisted in earlier conversation
   threads.
 </Callout>
@@ -41,7 +41,7 @@ resource and emits an `activity` event that the built-in
 ## No frontend renderer needed
 
 Unlike custom activity types, the MCP Apps renderer is already registered by
-`CopilotKitProvider` out of the box. A plain `<CopilotChat />` is enough —
+`CopilotKitProvider` out of the box. A plain `<CopilotChat />` is enough;
 no `renderActivityMessages` prop, no manual
 `useRenderActivityMessage` wiring.
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/mcp-apps.mdx
@@ -53,6 +53,8 @@ The middleware supports two transport types:
 
 ### HTTP
 
+Use this format to connect to an MCP server that accepts standard HTTP requests:
+
 ```typescript
 {
   type: "http",
@@ -62,6 +64,8 @@ The middleware supports two transport types:
 ```
 
 ### SSE
+
+Use this format to connect to an MCP server that streams events over a persistent connection:
 
 ```typescript
 {

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -30,6 +30,8 @@ auto-registered by `CopilotKitProvider`, so no extra wiring is needed.
 
 ### Enable it in the runtime
 
+Add `OpenGenerativeUIMiddleware` to your runtime configuration:
+
 <Snippet region="minimal-runtime-flag" />
 
 The `OpenGenerativeUIMiddleware` then converts the agent's streamed
@@ -38,6 +40,8 @@ which the built-in `OpenGenerativeUIActivityRenderer` mounts inside a
 sandboxed iframe.
 
 ### Drop `<CopilotChat />` into the page
+
+Wrap your app in `CopilotKitProvider` and render `<CopilotChat>` — no extra props needed:
 
 <Snippet region="minimal-provider-setup" />
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -114,6 +114,4 @@ Three.js, and any other CDN-hosted library work out of the box.
 </body>
 ```
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/open-generative-ui" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -7,8 +7,8 @@ snippet_cell: open-gen-ui
 
 ## What is this?
 
-Open Generative UI lets the agent generate complete, sandboxed UI on the fly —
-HTML, CSS, and JavaScript — and stream it live into the chat. The user sees
+Open Generative UI lets the agent generate complete, sandboxed UI on the fly
+(HTML, CSS, and JavaScript) and stream it live into the chat. The user sees
 the interface build in real time: styles apply first, then HTML streams in
 progressively, and finally JavaScript expressions execute one by one.
 
@@ -25,7 +25,7 @@ Key benefits:
 ## Minimal setup
 
 Turning on Open Generative UI takes one flag in the runtime plus a plain
-`<CopilotChat />` on the frontend — the built-in activity renderer is
+`<CopilotChat />` on the frontend; the built-in activity renderer is
 auto-registered by `CopilotKitProvider`, so no extra wiring is needed.
 
 ### Enable it in the runtime
@@ -55,7 +55,7 @@ iframe can't reach directly.
 
 ### Runtime is unchanged
 
-The server-side flag is identical to the minimal cell — the advanced
+The server-side flag is identical to the minimal cell; the advanced
 behaviour is a pure frontend addition.
 
 <Snippet region="advanced-runtime-config" cell="open-gen-ui-advanced" />
@@ -101,7 +101,7 @@ progressively.
 
 ## Using CDN libraries
 
-The sandboxed iframe can load external libraries from CDNs — just include
+The sandboxed iframe can load external libraries from CDNs; just include
 `<script>` or `<link>` tags in the generated HTML `<head>`. Chart.js, D3,
 Three.js, and any other CDN-hosted library work out of the box.
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
@@ -9,13 +9,13 @@ snippet_cell: agentic-chat-reasoning
 ## What is this?
 
 Some models (OpenAI's `o1`, `o3`, and `o4-mini`, Anthropic's thinking
-variants) emit **reasoning tokens** — internal chain-of-thought traces that
+variants) emit **reasoning tokens**, internal chain-of-thought traces that
 explain how the model is working toward its answer. CopilotKit surfaces
 these as first-class messages: when a `REASONING_MESSAGE_*` event arrives
 from the agent, the chat renders it inline so the user can follow the
 agent's thinking.
 
-Reasoning isn't a custom-renderer plumb-in — it's a dedicated message type
+Reasoning isn't a custom-renderer plumb-in; it's a dedicated message type
 on the chat view. You can either accept the built-in rendering or override
 the `reasoningMessage` slot with your own component.
 
@@ -41,7 +41,7 @@ Out of the box, reasoning events render inside CopilotKit's built-in
   chevron to re-expand.
 - Reasoning text rendered as Markdown.
 
-No configuration is needed — if your model emits reasoning tokens, the card
+No configuration is needed; if your model emits reasoning tokens, the card
 appears automatically:
 
 <Snippet
@@ -50,6 +50,8 @@ appears automatically:
   title="frontend/src/app/page.tsx — default reasoning"
 />
 
+Here's what the built-in card looks like while the model thinks through a multi-step problem:
+
 <InlineDemo demo="reasoning-default-render" />
 
 ## Custom reasoning rendering
@@ -57,13 +59,13 @@ appears automatically:
 For full control over the reasoning card, pass a component to the
 `reasoningMessage` slot on `messageView`. Your component receives the
 `ReasoningMessage` object (`.content` holds the streaming text), the full
-`messages` list, and `isRunning` — enough to decide whether this block is
+`messages` list, and `isRunning`, enough to decide whether this block is
 still streaming and whether it's the active trailing message:
 
 <Snippet region="reasoning-block-render" title="frontend/src/app/page.tsx — custom reasoning slot" />
 
 The showcase's `ReasoningBlock` (imported above) renders the reasoning as
-an amber-tagged inline banner — intentionally louder than the default card
+an amber-tagged inline banner, intentionally louder than the default card
 so the thinking chain is the focal UI of the demo. Swap in your own
 component to match your product's tone.
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
@@ -74,7 +74,7 @@ component to match your product's tone.
   default card. See the reference docs for sub-slot props.
 </Callout>
 
-<FeatureIntegrations feature="reasoning" />
+<FeatureIntegrations feature="agentic-chat-reasoning" />
 
 ## Choose your AI backend
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/reasoning.mdx
@@ -78,6 +78,4 @@ component to match your product's tone.
 
 <FeatureIntegrations feature="agentic-chat-reasoning" />
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/reasoning" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
@@ -7,7 +7,7 @@ hideTOC: true
 
 ## What is this?
 
-State rendering lets you build UI that reflects your agent's state in real-time. As your agent progresses through nodes and emits state updates, your frontend renders those changes — showing progress, drafts, or intermediate results.
+State rendering lets you build UI that reflects your agent's state in real-time. As your agent progresses through nodes and emits state updates, your frontend renders those changes, showing progress, drafts, or intermediate results.
 
 ## When should I use this?
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
@@ -18,8 +18,6 @@ Use state rendering when you want to:
 - Build dashboards that reflect agent state
 - Render structured output outside of the chat
 
-## Choose your AI backend
-
 <IntegrationGrid
   path="generative-ui/state-rendering"
   exclude={["agno", "agent-spec"]}

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
@@ -56,6 +56,4 @@ anything about CopilotKit.
 
 <FeatureIntegrations feature="gen-ui-tool-based" />
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/tool-based" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
@@ -14,8 +14,8 @@ agent as a tool. When the agent calls the tool, CopilotKit renders your
 component inline in the chat, passing the tool's arguments straight through
 as typed props.
 
-Unlike [tool rendering](/generative-ui/tool-rendering) — which wraps a
-real backend tool in a custom UI — tool-based GenUI is the component. There
+Unlike [tool rendering](/generative-ui/tool-rendering), which wraps a
+real backend tool in a custom UI, tool-based GenUI is the component. There
 is no handler, no user interaction, no server-side execution. The agent
 decides when to show it, populates the data, and CopilotKit paints it.
 
@@ -43,12 +43,10 @@ component.
 
 <Snippet region="bar-chart-renderer" title="frontend/src/app/page.tsx — bar chart component" />
 
-<Snippet region="pie-chart-renderer" title="frontend/src/app/page.tsx — pie chart component" />
-
-The component itself is ordinary React — it reads only its props and can
+The component itself is ordinary React: it reads only its props and can
 stream in as the agent fills the payload. The showcase cell uses
-[Recharts](https://recharts.org) for the bar chart and a hand-rolled SVG
-donut for the pie chart; neither knows anything about CopilotKit.
+[Recharts](https://recharts.org) for the bar chart; it doesn't know
+anything about CopilotKit.
 
 <Callout type="info">
   The `name` you pass to `useComponent` is what the agent sees as the tool

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
@@ -56,7 +56,7 @@ donut for the pie chart; neither knows anything about CopilotKit.
   reliably picks it when the user asks for that visualization.
 </Callout>
 
-<FeatureIntegrations feature="generative-ui-tool-based" />
+<FeatureIntegrations feature="gen-ui-tool-based" />
 
 ## Choose your AI backend
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
@@ -100,6 +100,4 @@ no CopilotKit-specific plumbing required:
 
 <FeatureIntegrations feature="tool-rendering" />
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/tool-rendering" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
@@ -2,7 +2,6 @@
 title: Tool Rendering
 icon: "lucide/Server"
 description: Render your agent's tool calls with custom UI components.
-hideTOC: true
 snippet_cell: tool-rendering
 ---
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
@@ -11,8 +11,8 @@ snippet_cell: tool-rendering
 Tools are how an LLM invokes predefined, typically-deterministic functions.
 Tool rendering lets you decide how each of those tool calls appears in the
 chat. Instead of showing raw JSON, you register a React component that draws
-a branded card for the call — arguments, live status, and the eventual
-result. This is the **Generative UI** variant CopilotKit calls **tool
+a branded card for the call (arguments, live status, and the eventual
+result). This is the **Generative UI** variant CopilotKit calls **tool
 rendering**.
 
 <InlineDemo demo="tool-rendering" />
@@ -30,12 +30,12 @@ Render tool calls when you want to:
 
 The simplest entry point: call `useDefaultRenderTool()` with no arguments.
 CopilotKit registers its built-in `DefaultToolCallRenderer` as the `*`
-wildcard — every tool call renders as a tidy status card (tool name, live
+wildcard: every tool call renders as a tidy status card (tool name, live
 **Running → Done** pill, collapsible arguments/result) without you writing
 any UI.
 
 Without this hook the runtime has no `*` renderer and tool calls are
-invisible — the user only sees the assistant's final text summary.
+invisible; the user only sees the assistant's final text summary.
 
 <Snippet
   cell="tool-rendering-default-catchall"
@@ -43,13 +43,15 @@ invisible — the user only sees the assistant's final text summary.
   title="frontend/src/app/page.tsx — useDefaultRenderTool()"
 />
 
+Here's what the built-in status card looks like for each tool call:
+
 <InlineDemo demo="tool-rendering-default-catchall" />
 
 ## Custom catch-all
 
 Once you want on-brand chrome, pass a `render` function to
 `useDefaultRenderTool`. It's a convenience wrapper around
-`useRenderTool({ name: "*", ... })` — one wildcard renderer handles every
+`useRenderTool({ name: "*", ... })`: one wildcard renderer handles every
 tool call, named or not:
 
 <Snippet
@@ -58,6 +60,8 @@ tool call, named or not:
   title="frontend/src/app/page.tsx — custom wildcard renderer"
 />
 
+Here's the branded catch-all in action, where every tool call gets the same on-brand card:
+
 <InlineDemo demo="tool-rendering-custom-catchall" />
 
 ## Per-tool renderers
@@ -65,16 +69,18 @@ tool call, named or not:
 The most expressive path is one renderer per tool name. The primary
 `tool-rendering` cell wires two: `get_weather` draws a branded
 `WeatherCard`, `search_flights` draws a `FlightListCard`. Each renderer
-receives the tool's parsed arguments, a live `status`, and — once the agent
-returns — the `result`:
+receives the tool's parsed arguments, a live `status`, and (once the agent
+returns) the `result`:
 
 <Snippet region="render-weather-tool" title="frontend/src/app/page.tsx — weather renderer" />
+
+The flight renderer follows the same pattern with a different component and schema:
 
 <Snippet region="render-flight-tool" title="frontend/src/app/page.tsx — flight renderer" />
 
 <Callout type="info">
   The `name` you pass to `useRenderTool` must match the tool name the agent
-  exposes — that's how the runtime routes the call to your component.
+  exposes; that's how the runtime routes the call to your component.
 </Callout>
 
 Per-tool renderers compose with a catch-all: named renderers claim the
@@ -87,7 +93,7 @@ and `roll_dice`:
 ## The backend tool definition
 
 The frontend renderer only sees what the agent sends down. Here's the
-matching Python definition for `get_weather` — a standard LangChain tool,
+matching Python definition for `get_weather`, a standard LangChain tool,
 no CopilotKit-specific plumbing required:
 
 <Snippet region="weather-tool-backend" title="backend/agent.py — weather tool" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
@@ -57,6 +57,4 @@ Use display-only generative UI when you want to:
 - Render previews, status indicators, or visual feedback
 - Let the agent present information beyond plain text
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/your-components/display-only" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/your-components/display-only.mdx
@@ -7,7 +7,7 @@ hideTOC: true
 
 ## What is this?
 
-Display-only generative UI lets you register React components as tools your agent can invoke. When the agent calls the tool, CopilotKit renders your component directly in the chat with the tool's arguments as props — no handler logic or user interaction required.
+Display-only generative UI lets you register React components as tools your agent can invoke. When the agent calls the tool, CopilotKit renders your component directly in the chat with the tool's arguments as props; no handler logic or user interaction required.
 
 <Tabs items={['page.tsx', 'chart.tsx']}>
   <Tab value="page.tsx">

--- a/showcase/shell-docs/src/content/docs/generative-ui/your-components/interactive.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/your-components/interactive.mdx
@@ -18,6 +18,4 @@ Use interactive generative UI when you want to:
 - Create approval workflows where users can accept/reject agent actions
 - Add interactive controls (sliders, toggles, selectors) to agent outputs
 
-## Choose your AI backend
-
 <IntegrationGrid path="generative-ui/your-components/interactive" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/your-components/interactive.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/your-components/interactive.mdx
@@ -7,7 +7,7 @@ hideTOC: true
 
 ## What is this?
 
-Interactive generative UI extends display components with user interaction. Your agent renders components that users can click, type into, or manipulate — and the results flow back to the agent.
+Interactive generative UI extends display components with user interaction. Your agent renders components that users can click, type into, or manipulate, and the results flow back to the agent.
 
 ## When should I use this?
 

--- a/showcase/shell-docs/src/content/docs/headless.mdx
+++ b/showcase/shell-docs/src/content/docs/headless.mdx
@@ -9,7 +9,7 @@ snippet_cell: headless-complete
 ## Full rendering control via hooks
 
 CopilotKit's headless hooks give you complete control over the chat
-experience — you compose messages, streaming, and tool-call surfaces
+experience: you compose messages, streaming, and tool-call surfaces
 yourself with zero UI opinions. Bring your own design system and render
 everything your way.
 
@@ -38,8 +38,8 @@ The bare minimum: three hooks do the heavy lifting.
 - `useAgent({ agentId })` exposes the current conversation (`messages`,
   `isRunning`) and the run-state object.
 - `useCopilotKit()` returns the runtime handle you call
-  `runAgent({ agent })` on — the same entry point `<CopilotChat />`
-  uses internally.
+  `runAgent({ agent })` on (the same entry point `<CopilotChat />`
+  uses internally).
 - `useComponent(...)` (sugar over `useFrontendTool`) lets you register a
   React component the agent can render by invoking a named tool call.
   `useRenderToolCall()` then returns a function that paints any tool
@@ -47,25 +47,25 @@ The bare minimum: three hooks do the heavy lifting.
 
 <Snippet region="use-agent-simple" cell="headless-simple" title="frontend/src/app/page.tsx — useAgent + useCopilotKit + useComponent" />
 
-The message list is a plain `.map()` over `agent.messages` — user
+The message list is a plain `.map()` over `agent.messages`: user
 messages render as right-aligned bubbles, assistant messages render any
 streamed text plus inline tool calls via `renderToolCall({ toolCall })`:
 
 <Snippet region="message-list-simple" cell="headless-simple" title="frontend/src/app/page.tsx — message list" />
 
-That's it — no `<CopilotChat />`, no `<CopilotChatMessageView>`, no
+That's it: no `<CopilotChat />`, no `<CopilotChatMessageView>`, no
 slots. The downside: you only get text + tool calls. Reasoning messages,
 activity messages (A2UI, MCP Apps), and custom before/after slots won't
-show up unless you wire them in yourself — which is exactly what the
+show up unless you wire them in yourself, which is exactly what the
 next section covers.
 
 ## Complete (`headless-complete`)
 
 This is the heart of the page. The `headless-complete` cell rebuilds
-the **full** generative-UI weave — text, tool calls
-(`useRenderTool` / `useDefaultRenderTool` / `useComponent` /
-`useFrontendTool`), reasoning cards, A2UI + MCP Apps activity messages,
-and custom before/after message slots — from the low-level hooks
+the **full** generative-UI weave (text, tool calls
+via `useRenderTool` / `useDefaultRenderTool` / `useComponent` /
+`useFrontendTool`, reasoning cards, A2UI + MCP Apps activity messages,
+and custom before/after message slots) from the low-level hooks
 directly, without importing `<CopilotChatMessageView>` or
 `<CopilotChatAssistantMessage>`.
 
@@ -74,7 +74,7 @@ directly, without importing `<CopilotChatMessageView>` or
 The cell's central piece is a hand-rolled `useRenderedMessages(messages,
 isRunning)` that returns the same flat list of messages, each augmented
 with a `renderedContent: ReactNode` field. This hook is a **manual
-recreation of what `<CopilotChatMessageView>` does** — compare it
+recreation of what `<CopilotChatMessageView>` does**; compare it
 line-for-line against the `renderMessageBlock` helper inside the
 canonical primitive:
 [`packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx:542-612`](https://github.com/CopilotKit/CopilotKit/blob/main/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx#L542-L612).
@@ -95,7 +95,7 @@ Three low-level hooks feed it:
 ### Per-role dispatch
 
 Inside `renderMessageContent` the role-switch mirrors
-`CopilotChatMessageView`'s `renderMessageBlock` exactly — assistant
+`CopilotChatMessageView`'s `renderMessageBlock` exactly: assistant
 bodies get text + tool calls, user bodies get their text content,
 reasoning messages go through the `<CopilotChatReasoningMessage>` leaf
 component, and activity messages route through
@@ -113,7 +113,7 @@ For each `toolCall` on an assistant message, we look up the sibling
 
 ### Bubble chrome
 
-The `UserBubble` and `AssistantBubble` components are **pure chrome** —
+The `UserBubble` and `AssistantBubble` components are **pure chrome**:
 they receive the pre-rendered node from `useRenderedMessages` and drop
 it into a styled container. No chat primitives are imported here:
 

--- a/showcase/shell-docs/src/content/docs/headless.mdx
+++ b/showcase/shell-docs/src/content/docs/headless.mdx
@@ -119,6 +119,4 @@ it into a styled container. No chat primitives are imported here:
 
 <Snippet region="custom-bubbles" title="frontend/src/app/{user,assistant}-bubble.tsx — pure chrome" />
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="headless" />

--- a/showcase/shell-docs/src/content/docs/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop.mdx
@@ -11,7 +11,7 @@ snippet_cell: hitl-in-chat
 Human-in-the-loop (HITL) lets an agent pause mid-run to collect input,
 confirmation, or a choice from the user, then resume with that answer
 folded back into its reasoning. It's what turns an autonomous workflow
-into a collaborative one — the agent keeps its context, the user keeps
+into a collaborative one: the agent keeps its context, the user keeps
 the steering wheel.
 
 <video
@@ -36,9 +36,9 @@ Use HITL when you need:
 ## Two patterns for HITL in CopilotKit
 
 CopilotKit ships two complementary ways to pause an agent turn and ask
-the human something. They look similar from the outside — the chat
-pauses, a custom component appears, the user answers, the run resumes —
-but they're wired differently on the backend and each has its own niche.
+the human something. They look similar from the outside (the chat
+pauses, a custom component appears, the user answers, the run resumes)
+but they're wired differently on the backend, and each has its own niche.
 
 | Pattern | Who decides to pause? | Backend surface |
 | --- | --- | --- |

--- a/showcase/shell-docs/src/content/docs/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop.mdx
@@ -93,6 +93,4 @@ interrupt resolution from a custom UI that lives anywhere in the tree
 how to compose `useAgent`, `agent.subscribe`, and `copilotkit.runAgent`
 to build your own `useInterrupt` equivalent.
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="human-in-the-loop" />

--- a/showcase/shell-docs/src/content/docs/human-in-the-loop/headless.mdx
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop/headless.mdx
@@ -8,15 +8,15 @@ snippet_cell: interrupt-headless
 
 ## What is this?
 
-`useInterrupt`'s `render` callback is the 80% path — it keeps the UI
+`useInterrupt`'s `render` callback is the 80% path: it keeps the UI
 glued to a `<CopilotChat>` transcript and handles "when to show the
 picker" logic for you. This page covers the escape hatch: a
 **render-less** interrupt resolver you assemble from the same
 primitives `useInterrupt` uses internally.
 
 The result is a pattern that lives anywhere in your React tree, takes
-any shape you like (plain button grid, form, modal, keyboard shortcut
-— it's all yours), and resolves `langgraph.interrupt(...)` without
+any shape you like (plain button grid, form, modal, keyboard shortcut,
+anything), and resolves `langgraph.interrupt(...)` without
 mounting a chat at all.
 
 <InlineDemo demo="interrupt-headless" />
@@ -34,7 +34,7 @@ mounting a chat at all.
 - **Research / debugging** — when you want to observe the raw AG-UI
   custom events without the abstraction layer.
 
-If you just want "a picker in chat" — don't bother, use
+If you just want "a picker in chat", just use
 [`useInterrupt`](./useInterrupt).
 
 ## The primitives
@@ -58,7 +58,7 @@ Wrap those in your own hook and you get a render-less equivalent of
 A few things this hook is careful about:
 
 - It stages the incoming custom event in a local ref and only commits
-  it to React state on `onRunFinalized` — that mirrors `useInterrupt`,
+  it to React state on `onRunFinalized`, mirroring `useInterrupt`,
   which doesn't surface the interrupt until the run has actually paused
   (not just when the event fires mid-stream).
 - `onRunStartedEvent` clears any stale pending state, so kicking off a
@@ -70,7 +70,7 @@ A few things this hook is careful about:
 
 Once `useHeadlessInterrupt` returns `{ pending, resolve }`, the rest is
 just React. The showcase cell uses two buttons to kick off the agent
-and a button grid to resolve — no `<CopilotChat>`, no render prop:
+and a button grid to resolve, with no `<CopilotChat>` and no render prop:
 
 ```tsx
 function HeadlessInterruptPanel() {

--- a/showcase/shell-docs/src/content/docs/human-in-the-loop/useInterrupt.mdx
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop/useInterrupt.mdx
@@ -23,23 +23,23 @@ and calls the agent back with the user's answer.
 ## When should I use this?
 
 Reach for `useInterrupt` when the pause is a **graph-enforced
-checkpoint** — the code path _must_ stop and wait for a human — rather
-than an LLM-initiated tool call. Typical cases:
+checkpoint** where the code path _must_ stop and wait for a human,
+not an LLM-initiated tool call. Typical cases:
 
 - A sensitive action (payments, irreversible writes) must be approved
 - A required piece of state isn't known and can only be collected from the user
 - The agent explicitly reaches an approval node in a longer workflow
 - You want the server-side contract to be `interrupt(...)` and resume with a payload
 
-For LLM-initiated pauses — where the model decides on the fly to ask
-the user — prefer [`useHumanInTheLoop`](../human-in-the-loop).
+For LLM-initiated pauses where the model decides on the fly to ask
+the user, prefer [`useHumanInTheLoop`](../human-in-the-loop).
 
 ## The backend: `interrupt()` inside a tool
 
 The showcase `gen-ui-interrupt` cell exposes a `schedule_meeting` tool.
 When the model calls it, the tool issues a `langgraph.interrupt(...)`
 with the meeting context. The run freezes here until the client
-resolves — the resolution becomes the return value of `interrupt()`,
+resolves; the resolution becomes the return value of `interrupt()`,
 which the tool then turns into a final string for the model:
 
 <Snippet region="backend-interrupt-tool" title="backend/agent.py — schedule_meeting interrupt tool" />
@@ -48,7 +48,7 @@ Two things to note:
 
 - The payload (`{"topic": topic, "attendee": attendee}`) is what the
   frontend receives as `event.value`. Keep it a plain, serializable
-  object — it's the "pause-time context" the UI needs to render.
+  object. It's the "pause-time context" the UI needs to render.
 - The return-side contract (`{chosen_label, chosen_time}` or
   `{cancelled: true}`) is entirely yours. The client can send anything
   as the resolve payload; the tool is the one that gives it meaning.

--- a/showcase/shell-docs/src/content/docs/index.mdx
+++ b/showcase/shell-docs/src/content/docs/index.mdx
@@ -175,9 +175,5 @@ Look below to find right guide for your needs, whether you're starting from noth
 
 {/* ── Integrations ── */}
 
-## Explore by AI backend
-
-CopilotKit works with most agent frameworks: LangGraph, CrewAI, Mastra, Google ADK, and more. Pick the one that fits your stack and jump straight into a live demo.
-
-<IntegrationGrid />
+<IntegrationGrid description="CopilotKit works with most agent frameworks: LangGraph, CrewAI, Mastra, Google ADK, and more. Pick the one that fits your stack and jump straight into a live demo." />
 

--- a/showcase/shell-docs/src/content/docs/index.mdx
+++ b/showcase/shell-docs/src/content/docs/index.mdx
@@ -177,8 +177,7 @@ Look below to find right guide for your needs, whether you're starting from noth
 
 ## Explore by AI backend
 
+CopilotKit works with most agent frameworks — LangGraph, CrewAI, Mastra, Google ADK, and more. Pick the one that fits your stack and jump straight into a live demo.
+
 <IntegrationGrid />
 
-## Feature comparison (by framework)
-
-<FeatureMatrix />

--- a/showcase/shell-docs/src/content/docs/index.mdx
+++ b/showcase/shell-docs/src/content/docs/index.mdx
@@ -109,7 +109,7 @@ Look below to find right guide for your needs, whether you're starting from noth
         Headless UI &rsaquo;
       </div>
       <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
-        Full rendering control via hooks — zero opinions on design.
+        Full rendering control via hooks, with zero opinions on design.
       </div>
     </div>
   </a>
@@ -177,7 +177,7 @@ Look below to find right guide for your needs, whether you're starting from noth
 
 ## Explore by AI backend
 
-CopilotKit works with most agent frameworks — LangGraph, CrewAI, Mastra, Google ADK, and more. Pick the one that fits your stack and jump straight into a live demo.
+CopilotKit works with most agent frameworks: LangGraph, CrewAI, Mastra, Google ADK, and more. Pick the one that fits your stack and jump straight into a live demo.
 
 <IntegrationGrid />
 

--- a/showcase/shell-docs/src/content/docs/index.mdx
+++ b/showcase/shell-docs/src/content/docs/index.mdx
@@ -17,56 +17,56 @@ Look below to find right guide for your needs, whether you're starting from noth
 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 not-prose mb-10 mt-10">
   <a
     href="/quickstart"
-    className="group flex items-start gap-3 bg-card border border-border/80 rounded-lg p-4 no-underline hover:border-primary/60 hover:bg-accent/50 transition-colors shadow-sm"
+    className="group flex items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 no-underline hover:border-[var(--accent)] hover:shadow-sm transition"
   >
-    <Play className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
+    <Play className="h-5 w-5 text-[var(--accent)] mt-0.5 flex-shrink-0" />
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary mb-1">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
         Quickstart
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed">
         Get up and running in minutes.
       </div>
     </div>
   </a>
   <a
     href="/reference"
-    className="group flex items-start gap-3 bg-card border border-border/80 rounded-lg p-4 no-underline hover:border-primary/60 hover:bg-accent/50 transition-colors shadow-sm"
+    className="group flex items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 no-underline hover:border-[var(--accent)] hover:shadow-sm transition"
   >
-    <Book className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
+    <Book className="h-5 w-5 text-[var(--accent)] mt-0.5 flex-shrink-0" />
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary mb-1">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
         API Reference
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed">
         Hooks, components, and config.
       </div>
     </div>
   </a>
   <a
     href="/prebuilt-components"
-    className="group flex items-start gap-3 bg-card border border-border/80 rounded-lg p-4 no-underline hover:border-primary/60 hover:bg-accent/50 transition-colors shadow-sm"
+    className="group flex items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 no-underline hover:border-[var(--accent)] hover:shadow-sm transition"
   >
-    <MessageSquare className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
+    <MessageSquare className="h-5 w-5 text-[var(--accent)] mt-0.5 flex-shrink-0" />
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary mb-1">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
         Chat UI
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed">
         Prebuilt chat with streaming.
       </div>
     </div>
   </a>
   <a
     href="/generative-ui/your-components/display-only"
-    className="group flex items-start gap-3 bg-card border border-border/80 rounded-lg p-4 no-underline hover:border-primary/60 hover:bg-accent/50 transition-colors shadow-sm"
+    className="group flex items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 no-underline hover:border-[var(--accent)] hover:shadow-sm transition"
   >
-    <Layers className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
+    <Layers className="h-5 w-5 text-[var(--accent)] mt-0.5 flex-shrink-0" />
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary mb-1">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] mb-1">
         Generative UI
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed">
         Render tools as React components.
       </div>
     </div>
@@ -89,26 +89,26 @@ Look below to find right guide for your needs, whether you're starting from noth
     className="group flex items-start gap-4 no-underline"
   >
     <div className="flex-shrink-0 mt-1">
-      <MessageSquare className="h-6 w-6 text-primary" />
+      <MessageSquare className="h-6 w-6 text-[var(--accent)]" />
     </div>
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
         Chat UI &rsaquo;
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
         Prebuilt chat components with streaming, tool calls, and markdown.
       </div>
     </div>
   </a>
   <a href="/headless" className="group flex items-start gap-4 no-underline">
     <div className="flex-shrink-0 mt-1">
-      <Code className="h-6 w-6 text-primary" />
+      <Code className="h-6 w-6 text-[var(--accent)]" />
     </div>
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
         Headless UI &rsaquo;
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
         Full rendering control via hooks, with zero opinions on design.
       </div>
     </div>
@@ -118,26 +118,26 @@ Look below to find right guide for your needs, whether you're starting from noth
     className="group flex items-start gap-4 no-underline"
   >
     <div className="flex-shrink-0 mt-1">
-      <Layers className="h-6 w-6 text-primary" />
+      <Layers className="h-6 w-6 text-[var(--accent)]" />
     </div>
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
         Generative UI &rsaquo;
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
         Render agent tools and state as interactive React components.
       </div>
     </div>
   </a>
   <a href="/backend" className="group flex items-start gap-4 no-underline">
     <div className="flex-shrink-0 mt-1">
-      <Server className="h-6 w-6 text-primary" />
+      <Server className="h-6 w-6 text-[var(--accent)]" />
     </div>
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
         Backend &amp; Runtime &rsaquo;
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
         Set up the CopilotKit runtime, AG-UI middleware, and endpoints.
       </div>
     </div>
@@ -147,26 +147,26 @@ Look below to find right guide for your needs, whether you're starting from noth
     className="group flex items-start gap-4 no-underline"
   >
     <div className="flex-shrink-0 mt-1">
-      <Bot className="h-6 w-6 text-primary" />
+      <Bot className="h-6 w-6 text-[var(--accent)]" />
     </div>
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
         Programmatic Control &rsaquo;
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
         Build non-chat or fully custom experiences.
       </div>
     </div>
   </a>
   <a href="/reference" className="group flex items-start gap-4 no-underline">
     <div className="flex-shrink-0 mt-1">
-      <BookOpen className="h-6 w-6 text-primary" />
+      <BookOpen className="h-6 w-6 text-[var(--accent)]" />
     </div>
     <div>
-      <div className="font-semibold text-foreground group-hover:text-primary transition-colors">
+      <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)] transition-colors">
         API Reference &rsaquo;
       </div>
-      <div className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+      <div className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
         Complete reference for hooks, components, and configuration.
       </div>
     </div>

--- a/showcase/shell-docs/src/content/docs/integrations/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Select an integration"
 description: "Please select one of the available integrations to access the content. You can change your selection anytime using the dropdown in the top section of the sidebar."
+hideTOC: true
 ---
 
 <IntegrationButtonGroup />

--- a/showcase/shell-docs/src/content/docs/multi-agent/subagents.mdx
+++ b/showcase/shell-docs/src/content/docs/multi-agent/subagents.mdx
@@ -14,7 +14,7 @@ by exposing each of them as a tool. The supervisor decides what to
 delegate, the sub-agents do their narrow job, and their results flow
 back up to the supervisor's next step.
 
-This is fundamentally the same shape as tool-calling — but each "tool"
+This is fundamentally the same shape as tool-calling, but each "tool"
 is itself a full-blown agent with its own system prompt and (often) its
 own tools, memory, and model.
 
@@ -37,15 +37,15 @@ canonical example.
 
 ## Setting up sub-agents
 
-Each sub-agent is a full `create_agent(...)` call — with its own model,
+Each sub-agent is a full `create_agent(...)` call with its own model,
 its own system prompt, and (optionally) its own tools. They don't share
 memory or tools with the supervisor; the supervisor only ever sees
 what the sub-agent returns.
 
 <Snippet region="subagent-setup" title="backend/agent.py — three sub-agents" />
 
-Keep sub-agent system prompts laser-focused. The point of this pattern
-is that each one does one thing well — if a sub-agent needs to know
+Keep sub-agent system prompts narrow and focused. The point of this pattern
+is that each one does one thing well. If a sub-agent needs to know
 the whole user context to do its job, that's a signal the boundary is
 wrong.
 
@@ -57,8 +57,8 @@ around `sub_agent.invoke(...)` that:
 1. Runs the sub-agent synchronously on the supplied `task` string.
 2. Records the delegation into a `delegations` slot in shared agent
    state (so the UI can render a live log).
-3. Returns the sub-agent's final message as a `ToolMessage` — the
-   supervisor sees it as a normal tool result on its next turn.
+3. Returns the sub-agent's final message as a `ToolMessage`, which the
+   supervisor sees as a normal tool result on its next turn.
 
 <Snippet region="supervisor-delegation-tools" title="backend/agent.py — supervisor tools" />
 
@@ -76,7 +76,7 @@ and render one card per entry.
 <Snippet region="delegation-log-frontend" title="frontend/src/app/delegation-log.tsx — live log component" />
 
 The result: as the supervisor fans work out to its sub-agents, the log
-grows in real time — giving the user visibility into a process that
+grows in real time, giving the user visibility into a process that
 would otherwise be a long opaque spinner.
 
 ## Related

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/chat.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/chat.mdx
@@ -46,6 +46,8 @@ choosing:
 
 ## Code example
 
+The minimal component needed to render an in-page chat:
+
 ```tsx title="page.tsx"
 // [!code word:CopilotChat]
 import { CopilotChat } from "@copilotkit/react-core/v2";

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/chat.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/chat.mdx
@@ -28,6 +28,8 @@ For a floating bubble that overlays content, use [CopilotPopup](/prebuilt-compon
 
 <InlineDemo demo="agentic-chat" />
 
+The gif below shows a typical session with streaming responses and starter suggestions:
+
 <img
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/copilotchat-example.gif"
   alt="CopilotChat example"

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/chat.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/chat.mdx
@@ -8,7 +8,7 @@ snippet_cell: agentic-chat
 
 ## What is this?
 
-`<CopilotChat>` is the base prebuilt chat surface — drop it in wherever you
+`<CopilotChat>` is the base prebuilt chat surface. Drop it in wherever you
 want the chat to render and size it to fit your layout. `<CopilotSidebar>`
 and `<CopilotPopup>` are both thin wrappers over the same primitives; if you
 need a dedicated chat page or an inline pane alongside other content, this
@@ -36,8 +36,8 @@ For a floating bubble that overlays content, use [CopilotPopup](/prebuilt-compon
 
 ## Basic setup
 
-Wrap your app in `<CopilotKit>` once — the provider wires the runtime, session,
-and agent registry — then render `<CopilotChat>` inside the layout of your
+Wrap your app in `<CopilotKit>` once (the provider wires the runtime, session,
+and agent registry) and render `<CopilotChat>` inside the layout of your
 choosing:
 
 <Snippet region="provider-setup" title="frontend/src/app/page.tsx — provider + chat" />
@@ -62,7 +62,7 @@ export default function YourComponent() {
 
 ## Common props
 
-`<CopilotChat>` is the root primitive — `<CopilotSidebar>` and `<CopilotPopup>`
+`<CopilotChat>` is the root primitive. `<CopilotSidebar>` and `<CopilotPopup>`
 accept the same slots and labels, plus a few wrapper-specific props.
 
 | Prop | Description |

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/index.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/index.mdx
@@ -8,7 +8,7 @@ snippet_cell: agentic-chat
 
 ## Pre-built components for agentic chat
 
-CopilotKit ships three prebuilt chat surfaces — [**CopilotChat**](/prebuilt-components/chat), [**CopilotSidebar**](/prebuilt-components/sidebar), and [**CopilotPopup**](/prebuilt-components/popup) — that connect directly to your agent. Each is a wrapper around the same primitives with a different layout; pick the one that fits your app and you're done. They all handle streaming, generative UI, and deep customization out of the box.
+CopilotKit ships three prebuilt chat surfaces that connect directly to your agent: [**CopilotChat**](/prebuilt-components/chat), [**CopilotSidebar**](/prebuilt-components/sidebar), and [**CopilotPopup**](/prebuilt-components/popup). Each is a wrapper around the same primitives with a different layout; pick the one that fits your app and you're done. They all handle streaming, generative UI, and deep customization out of the box.
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/agentic-chat-ui.mp4"
@@ -32,7 +32,7 @@ One of CopilotKit's design principles is that **you should never have to throw t
     <div className="text-[var(--text)] font-semibold mb-2">Drop in as-is</div>
     <div className="text-sm text-[var(--text-secondary)]">
       Render `<CopilotChat>`, `<CopilotSidebar>`, or `<CopilotPopup>` and ship.
-      Streaming, tool calls, generative UI, suggestions — all wired.
+      Streaming, tool calls, generative UI, and suggestions, all wired up.
     </div>
   </a>
 
@@ -50,7 +50,7 @@ One of CopilotKit's design principles is that **you should never have to throw t
     <div className="text-[var(--text)] font-semibold mb-2">Customize via slots (subcomponents)</div>
     <div className="text-sm text-[var(--text-secondary)]">
       Swap the welcome screen, message bubble, composer, disclaimer, header,
-      or toggle button with your own React component. Recursive — drill down
+      or toggle button with your own React component. Recursive; drill down
       as deep as you want.
     </div>
   </a>
@@ -66,13 +66,13 @@ One of CopilotKit's design principles is that **you should never have to throw t
   </a>
 </div>
 
-Everything below Level 1 is incremental — you can freely mix CSS variables, a custom welcome slot, and headless tool-call renderers in the same app. Nothing forces you to throw work away as your needs grow.
+Everything below Level 1 is incremental: you can freely mix CSS variables, a custom welcome slot, and headless tool-call renderers in the same app. Nothing forces you to throw work away as your needs grow.
 
 ## Drop-in chat in a few lines
 
 Wrap your app in `<CopilotKit>` and drop `<CopilotChat>` where the
 chat should live. The provider wires the runtime, the session, and
-the agent registry — everything else is optional configuration:
+the agent registry. Everything else is optional configuration:
 
 <Snippet region="provider-setup" title="frontend/src/app/page.tsx — provider + chat" />
 
@@ -86,7 +86,7 @@ prompts the moment a user arrives. The showcase cell uses a single
 
 ## Pick a surface
 
-Each surface is a drop-in component with the same underlying primitives — they differ only in layout.
+Each surface is a drop-in component with the same underlying primitives, differing only in layout.
 
 - [`<CopilotChat>`](/prebuilt-components/chat) — inline chat pane you can place anywhere and size to fit.
 - [`<CopilotSidebar>`](/prebuilt-components/sidebar) — collapsible sidebar docked to the edge of your app.

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/index.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/index.mdx
@@ -92,6 +92,4 @@ Each surface is a drop-in component with the same underlying primitives, differi
 - [`<CopilotSidebar>`](/prebuilt-components/sidebar) — collapsible sidebar docked to the edge of your app.
 - [`<CopilotPopup>`](/prebuilt-components/popup) — floating bubble that overlays your page content.
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="prebuilt-components" />

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/popup.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/popup.mdx
@@ -10,7 +10,7 @@ snippet_cell: prebuilt-popup
 
 `<CopilotPopup>` is a prebuilt floating launcher that opens an overlay chat
 window on top of your page content. It's the lightest-weight way to add a
-copilot to an existing app — drop it in once, and a bubble appears in the
+copilot to an existing app. Drop it in once and a bubble appears in the
 corner ready to chat.
 
 ## When should I use this?
@@ -25,6 +25,8 @@ If you need chat to live alongside your content rather than on top of it,
 use [CopilotSidebar](/prebuilt-components/sidebar). For a fully embedded
 chat pane, use [`<CopilotChat>`](/prebuilt-components/chat) directly.
 
+Here's the popup in action. Click the launcher button to open the chat:
+
 <InlineDemo demo="prebuilt-popup" />
 
 <img
@@ -35,8 +37,8 @@ chat pane, use [`<CopilotChat>`](/prebuilt-components/chat) directly.
 
 ## Basic setup
 
-Wrap your app in `<CopilotKit>` once — the provider wires the runtime,
-session, and agent registry — then render `<CopilotPopup>` as a sibling of
+Wrap your app in `<CopilotKit>` once (the provider wires the runtime,
+session, and agent registry) and render `<CopilotPopup>` as a sibling of
 your main content. The showcase cell opens the popup by default and
 customizes the input placeholder via `labels`:
 
@@ -58,7 +60,7 @@ its own. Commonly used options:
 ## Styling
 
 `CopilotPopup` participates in the slot system, so every piece of its UI
-is customizable — from Tailwind classes on the message view to a full
+is customizable, from Tailwind classes on the message view to a full
 component swap for the header or toggle button. See
 [custom look and feel](/custom-look-and-feel/slots) for the full slot
 reference.

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/popup.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/popup.mdx
@@ -29,6 +29,8 @@ Here's the popup in action. Click the launcher button to open the chat:
 
 <InlineDemo demo="prebuilt-popup" />
 
+The gif below shows the popup launcher toggling open over page content:
+
 <img
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/popup-example.gif"
   alt="CopilotPopup example"

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/sidebar.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/sidebar.mdx
@@ -27,6 +27,8 @@ Here's the sidebar in action. Click the panel icon to toggle it open:
 
 <InlineDemo demo="prebuilt-sidebar" />
 
+The gif below shows the sidebar sliding out alongside page content:
+
 <img
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/sidebar-example.gif"
   alt="CopilotSidebar example"

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/sidebar.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/sidebar.mdx
@@ -9,9 +9,7 @@ snippet_cell: prebuilt-sidebar
 ## What is this?
 
 `<CopilotSidebar>` is a prebuilt chat surface that docks to the side of your
-app. It wraps your main content so the chat can slide out on demand — great
-for in-app copilots that need to stay accessible without taking over the
-entire viewport.
+app. It wraps your main content so the chat can slide out on demand, making it a good fit for in-app copilots that need to stay accessible without taking over the entire viewport.
 
 ## When should I use this?
 
@@ -25,6 +23,8 @@ For a floating bubble that overlays content, see
 [CopilotPopup](/prebuilt-components/popup). For a fully embedded chat pane,
 use [`<CopilotChat>`](/prebuilt-components/chat) directly.
 
+Here's the sidebar in action. Click the panel icon to toggle it open:
+
 <InlineDemo demo="prebuilt-sidebar" />
 
 <img
@@ -35,9 +35,9 @@ use [`<CopilotChat>`](/prebuilt-components/chat) directly.
 
 ## Basic setup
 
-Wrap your app in `<CopilotKit>` once — it wires the runtime, session, and
-agent registry — then drop `<CopilotSidebar>` alongside your main content.
-The sidebar is rendered as a sibling, so it can slide out without reflowing
+Wrap your app in `<CopilotKit>` once (it wires the runtime, session, and
+agent registry) and drop `<CopilotSidebar>` alongside your main content.
+The sidebar renders as a sibling so it can slide out without reflowing
 your page:
 
 <Snippet region="sidebar-basic-setup" title="frontend/src/app/page.tsx — CopilotSidebar wired up" />
@@ -63,7 +63,7 @@ Common sidebar-specific props:
 ## Styling
 
 `CopilotSidebar` participates in the slot system, so every piece of its UI
-is customizable — from Tailwind classes on the message view to a full
+is customizable, from Tailwind classes on the message view to a full
 component swap for the header or toggle button. See
 [custom look and feel](/custom-look-and-feel/slots) for the full slot
 reference.

--- a/showcase/shell-docs/src/content/docs/programmatic-control.mdx
+++ b/showcase/shell-docs/src/content/docs/programmatic-control.mdx
@@ -82,6 +82,4 @@ hook would power a modal, a toast, a sidebar form, or a voice UI.
   `useInterrupt` hooks with their render-prop contracts, for the
   "paused mid-chat" pattern this page's headless variant replaces.
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="programmatic-control" />

--- a/showcase/shell-docs/src/content/docs/programmatic-control.mdx
+++ b/showcase/shell-docs/src/content/docs/programmatic-control.mdx
@@ -9,7 +9,7 @@ snippet_cell: headless-complete
 ## What is this?
 
 Programmatic control is what you reach for when you want to drive an
-agent run from code rather than from a chat composer — a button, a
+agent run from code rather than from a chat composer: a button, a
 form, a cron job, a keyboard shortcut, a graph callback. CopilotKit
 exposes three primitives that cover every triggering pattern:
 
@@ -38,7 +38,7 @@ The message-send path in `headless-complete` is the canonical pattern:
 append a user message with `agent.addMessage`, then call
 `copilotkit.runAgent({ agent })`. The same `handleStop` calls
 `copilotkit.stopAgent({ agent })` to cancel mid-run. Note the
-`connectAgent` effect at the top — it opens the backend session on
+`connectAgent` effect at the top, which opens the backend session on
 mount so the very first `runAgent` doesn't race the handshake.
 
 <Snippet region="page-send-message" title="frontend/src/app/page.tsx — connect, send, stop" />
@@ -48,16 +48,15 @@ mount so the very first `runAgent` doesn't race the handshake.
 Both methods trigger the agent, but they operate at different levels:
 
 - **`copilotkit.runAgent({ agent })`** — the recommended default. Orchestrates the full lifecycle: executes frontend tools, handles follow-up runs, and routes errors through the subscriber system.
-- **`agent.runAgent(options)`** — low-level method on the agent instance. Sends the request to the runtime but does **not** execute frontend tools or chain follow-ups. Reach for this only when you need direct control — the canonical example is resuming from an interrupt with `forwardedProps.command`.
+- **`agent.runAgent(options)`** — low-level method on the agent instance. Sends the request to the runtime but does **not** execute frontend tools or chain follow-ups. Reach for this only when you need direct control; the canonical example is resuming from an interrupt with `forwardedProps.command`.
 
 ## Subscribing to agent events
 
 `agent.subscribe(subscriber)` returns `{ unsubscribe }`. The subscriber
-object accepts every AG-UI lifecycle callback — `onCustomEvent`,
+object accepts every AG-UI lifecycle callback: `onCustomEvent`,
 `onRunStartedEvent`, `onRunFinalized`, `onRunFailed`, and the streaming
 deltas. Use it to drive custom progress UI, forward events to
-analytics, or — the pattern below — catch LangGraph `interrupt(...)`
-events and resume with a payload.
+analytics, or catch LangGraph `interrupt(...)` events and resume with a payload (the pattern below).
 
 ## Resolving a LangGraph interrupt from a button
 
@@ -71,7 +70,7 @@ the graph:
 
 <Snippet region="headless-useinterrupt-primitives" cell="interrupt-headless" title="frontend/src/app/page.tsx — subscribe + resume" />
 
-The resulting `{ pending, resolve }` tuple is pure data — any UI can
+The resulting `{ pending, resolve }` tuple is pure data; any UI can
 drive it. The cell itself renders a simple button grid, but the same
 hook would power a modal, a toast, a sidebar form, or a voice UI.
 

--- a/showcase/shell-docs/src/content/docs/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/quickstart.mdx
@@ -20,9 +20,4 @@ Here's a live demo. Try chatting with it now:
 
 <InlineDemo demo="agentic-chat" integration="langgraph-python" />
 
-## Start from an AI backend
-
-To get started, choose the shape of your backend to get started with CopilotKit. This will
-route you to the appropriate quickstart.
-
-<IntegrationGrid path="quickstart" />
+<IntegrationGrid path="quickstart" description="Choose your backend to see the matching quickstart." />

--- a/showcase/shell-docs/src/content/docs/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Get started with CopilotKit by choosing your integration.
+description: Get started with CopilotKit.
 icon: "lucide/Play"
 hideTOC: true
 ---
@@ -16,7 +16,7 @@ npx copilotkit@latest create
 
 ## See it in action
 
-<InlineDemo demo="agentic-chat" />
+<InlineDemo demo="agentic-chat" integration="langgraph-python" />
 
 ## Start from an AI backend
 

--- a/showcase/shell-docs/src/content/docs/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/quickstart.mdx
@@ -16,6 +16,8 @@ npx copilotkit@latest create
 
 ## See it in action
 
+Here's a live demo. Try chatting with it now:
+
 <InlineDemo demo="agentic-chat" integration="langgraph-python" />
 
 ## Start from an AI backend

--- a/showcase/shell-docs/src/content/docs/shared-state.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state.mdx
@@ -88,6 +88,4 @@ Two common extensions of the basic pattern:
 
 <FeatureIntegrations feature="shared-state-read-write" />
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="shared-state" exclude={["agno", "agent-spec"]} />

--- a/showcase/shell-docs/src/content/docs/shared-state.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state.mdx
@@ -26,7 +26,7 @@ Agentic Copilots maintain a shared state that seamlessly connects your UI with t
 
 ## When should I use this?
 
-Use shared state when you want to facilitate collaboration between your agent and the user. Updates flow both ways — the agent's outputs are automatically reflected in the UI, and any inputs the user updates in the UI are automatically reflected in the agent's execution.
+Use shared state when you want to facilitate collaboration between your agent and the user. Updates flow both ways: the agent's outputs are automatically reflected in the UI, and any inputs the user updates in the UI are automatically reflected in the agent's execution.
 
 ## The two directions
 
@@ -47,13 +47,13 @@ single `AgentState` schema with `preferences` (UI-written) and `notes`
 
 The `useAgent` hook subscribes your component to state changes. Pass
 `UseAgentUpdate.OnStateChanged` and every mutation the agent makes to
-its state triggers a re-render — your UI is a reactive window into the
+its state triggers a re-render; your UI is a reactive window into the
 agent's world.
 
 <Snippet region="use-agent-read" title="frontend/src/app/page.tsx — useAgent subscription" />
 
 Once subscribed, the agent-authored slice of state is just data you
-render. The `NotesCard` below is a plain presentational component — it
+render. The `NotesCard` below is a plain presentational component. It
 doesn't know about CopilotKit at all; it just receives `notes` as a
 prop from the parent page.
 
@@ -70,7 +70,7 @@ reads from `state`) and influence the reply.
 
 The form that generates those writes is, again, a plain controlled
 component. Every onChange bubbles up to the parent, which calls
-`agent.setState` — keeping the UI and the agent in lockstep.
+`agent.setState`, keeping the UI and the agent in lockstep.
 
 <Snippet region="preferences-card-render" title="frontend/src/app/preferences-card.tsx — preferences form" />
 

--- a/showcase/shell-docs/src/content/docs/shared-state/agent-readonly.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/agent-readonly.mdx
@@ -8,9 +8,7 @@ snippet_cell: readonly-state-agent-context
 
 ## What is this?
 
-Sometimes you want the agent to *know* something about the current UI
-— the logged-in user, the current page, a recent activity log — but
-you don't want the agent to be able to modify it. That's what
+Sometimes you want the agent to *know* something about the current UI, like the logged-in user, the current page, or a recent activity log, but you don't want the agent to be able to modify it. That's what
 `useAgentContext` is for: a one-way **UI → agent** channel for
 read-only context.
 
@@ -47,13 +45,13 @@ runtime that is:
 
 <Snippet region="use-agent-context-call" title="frontend/src/app/page.tsx — useAgentContext" />
 
-The `description` is important — it's a short human-readable label the
+The `description` is important: it's a short human-readable label the
 agent sees alongside the value, so it knows what to do with it. Treat
 it like a parameter docstring.
 
 ## Wire it to your own state
 
-`useAgentContext` doesn't care where the value comes from — local
+`useAgentContext` doesn't care where the value comes from: local
 state, a React Context, Redux, a query cache, anything. The only
 requirement is that the identity of the value is stable enough for
 React to avoid a render loop. In the demo we use a handful of
@@ -67,7 +65,7 @@ provider, a router hook, and your domain state stores.
 Because the agent never sees a setter or a mutation tool for these
 values, there's no way for a confused LLM to "update" them. That
 makes `useAgentContext` the right tool whenever the value in question
-is an input, not a field — the "context object passed to the agent on
+is an input, not a field: the "context object passed to the agent on
 every turn", rather than "shared workspace you both edit".
 
 When you need both reads *and* writes, you want full

--- a/showcase/shell-docs/src/content/docs/shared-state/streaming.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/streaming.mdx
@@ -74,6 +74,4 @@ indicator.
 
 <FeatureIntegrations feature="shared-state-streaming" />
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="shared-state/predictive-state-updates" />

--- a/showcase/shell-docs/src/content/docs/shared-state/streaming.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/streaming.mdx
@@ -9,7 +9,7 @@ snippet_cell: shared-state-streaming
 ## What is this?
 
 By default, agent state only updates *between* LangGraph node
-transitions — so a long-running tool call (writing a full document,
+transitions, so a long-running tool call (writing a full document,
 drafting an email) appears to the UI as one big burst at the end. For
 agent-native apps, that feels broken: users expect to watch the output
 materialise.
@@ -50,7 +50,7 @@ A few things to note:
 - The `tool` and `tool_argument` name the exact LLM-facing tool and
   argument to forward.
 - When the tool call completes, its final return value is written to
-  the same key — so the streamed partial eventually becomes the
+  the same key, so the streamed partial eventually becomes the
   authoritative final value.
 
 ## The frontend: useAgent + OnStateChanged

--- a/showcase/shell-docs/src/content/docs/unselected/coding-agents.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/coding-agents.mdx
@@ -37,6 +37,8 @@ Point your editor's MCP configuration at that URL — that's the whole setup.
 <Step>
 ### Add the server
 
+Paste the following into your `mcp.json` to register the CopilotKit MCP server:
+
 ```json
 {
   "mcpServers": {
@@ -59,6 +61,8 @@ Save the file — Cursor picks up the new server automatically.
 <Step>
 ### Register the server
 
+Run the following command to add the CopilotKit MCP server over HTTP:
+
 ```bash
 claude mcp add --transport http copilotkit-mcp https://mcp.copilotkit.ai/mcp
 ```
@@ -66,6 +70,8 @@ claude mcp add --transport http copilotkit-mcp https://mcp.copilotkit.ai/mcp
 
 <Step>
 ### Verify
+
+Confirm the server registered successfully:
 
 ```bash
 claude mcp list

--- a/showcase/shell-docs/src/content/docs/unselected/custom-look-and-feel/css.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/custom-look-and-feel/css.mdx
@@ -140,6 +140,4 @@ Customize all user-facing copy via the `labels` prop:
 />
 ```
 
-## Get started by choosing your AI backend
-
 <IntegrationGrid path="custom-look-and-feel/css" />

--- a/showcase/shell-docs/src/content/docs/unselected/generative-ui/a2ui.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/generative-ui/a2ui.mdx
@@ -104,6 +104,8 @@ That tree lives in `backend/schemas/flight_schema.json`. Components without data
 
 ### Building the catalog
 
+Define the React components for each primitive type and assemble them into a catalog. The A2UI binder uses this catalog to resolve schema nodes to components at render time:
+
 <Snippet region="definitions-types" cell="a2ui-fixed-schema" />
 
 <Snippet region="renderers-tsx" cell="a2ui-fixed-schema" />
@@ -111,6 +113,8 @@ That tree lives in `backend/schemas/flight_schema.json`. Components without data
 <Snippet region="catalog-creation" cell="a2ui-fixed-schema" />
 
 ### Wiring the schema + tool
+
+Load the schema file and register the tool that emits render operations. The agent calls this tool with structured data; A2UI resolves each field against the schema and passes typed props to your components:
 
 <Snippet region="backend-schema-json-load" cell="a2ui-fixed-schema" />
 

--- a/showcase/shell-docs/src/content/docs/unselected/generative-ui/your-components/display-only.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/generative-ui/your-components/display-only.mdx
@@ -40,6 +40,8 @@ The `name` you pass to `useComponent` is what the agent sees as the tool name. M
 
 ## Minimal example
 
+The following registers a display tool and wires it to a React component. When the agent emits that tool call, CopilotKit resolves the arguments against the Zod schema and passes them as typed props:
+
 ```tsx title="page.tsx"
 import { z } from "zod";
 import { useComponent } from "@copilotkit/react-core/v2";

--- a/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/chat.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/chat.mdx
@@ -29,6 +29,8 @@ For a floating bubble that overlays content, use [CopilotPopup](/prebuilt-compon
 
 <InlineDemo integration="langgraph-python" demo="agentic-chat" />
 
+The gif below shows a typical session with streaming responses and starter suggestions:
+
 <img
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/copilotchat-example.gif"
   alt="CopilotChat example"

--- a/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/chat.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/chat.mdx
@@ -47,6 +47,8 @@ choosing:
 
 ## Code example
 
+The minimal component needed to render an in-page chat:
+
 ```tsx title="page.tsx"
 // [!code word:CopilotChat]
 import { CopilotChat } from "@copilotkit/react-core/v2";

--- a/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/popup.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/popup.mdx
@@ -28,6 +28,8 @@ chat pane, use [`<CopilotChat>`](/prebuilt-components/chat) directly.
 
 <InlineDemo integration="langgraph-python" demo="prebuilt-popup" />
 
+The gif below shows the popup launcher toggling open over page content:
+
 <img
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/popup-example.gif"
   alt="CopilotPopup example"

--- a/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/sidebar.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/prebuilt-components/sidebar.mdx
@@ -28,6 +28,8 @@ use [`<CopilotChat>`](/prebuilt-components/chat) directly.
 
 <InlineDemo integration="langgraph-python" demo="prebuilt-sidebar" />
 
+The gif below shows the sidebar sliding out alongside page content:
+
 <img
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/sidebar-example.gif"
   alt="CopilotSidebar example"

--- a/showcase/shell-docs/src/content/docs/unselected/premium/headless-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/premium/headless-ui.mdx
@@ -27,6 +27,8 @@ Fully Headless UI is an **Early Access** Premium feature. Grab a free `publicLic
 <Step>
 ### Create a new application
 
+Scaffold a new CopilotKit project using the CLI:
+
 ```bash
 npx copilotkit@latest create
 ```
@@ -34,6 +36,8 @@ npx copilotkit@latest create
 
 <Step>
 ### Wire your CopilotKit provider with a license key
+
+Wrap your root layout with `CopilotKitProvider` and pass in your public license key:
 
 ```tsx title="src/app/layout.tsx"
 <CopilotKitProvider publicLicenseKey="your-free-public-license-key">
@@ -44,6 +48,8 @@ npx copilotkit@latest create
 
 <Step>
 ### Build a headless chat component
+
+Use `useCopilotChatHeadless_c` to access messages, a send function, and loading state, then wire them to your own UI:
 
 ```tsx title="src/app/page.tsx"
 "use client";
@@ -102,6 +108,8 @@ export default function Home() {
 You can render generative UI either via `useFrontendTool` / `useComponent`, or by reading tools and rendering them directly.
 
 ### With `useFrontendTool`
+
+Register a frontend tool and attach a render function. CopilotKit inserts your component wherever that tool call appears in the message stream:
 
 ```tsx title="src/app/components/chat.tsx"
 import { useFrontendTool } from "@copilotkit/react-core/v2";
@@ -172,6 +180,8 @@ export const Chat = () => {
 CopilotKit's suggestions give users a list of generated or static prompts. The headless hook exposes full control over the lifecycle.
 
 ### Generating suggestions
+
+Use `useCopilotChatSuggestions` to generate and display prompt suggestions in your headless UI:
 
 ```tsx title="src/app/components/chat.tsx"
 import {

--- a/showcase/shell-docs/src/content/docs/unselected/premium/observability.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/premium/observability.mdx
@@ -135,6 +135,8 @@ interface CopilotErrorEvent {
 
 ### Sentry
 
+Forward error events to Sentry using its `captureException` API:
+
 ```tsx
 import * as Sentry from "@sentry/react";
 
@@ -161,6 +163,8 @@ import * as Sentry from "@sentry/react";
 
 ### Custom analytics
 
+Route all CopilotKit events to your analytics pipeline via the `onError` callback:
+
 ```tsx
 <CopilotKitProvider
   publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
@@ -183,6 +187,8 @@ import * as Sentry from "@sentry/react";
 
 ### Development
 
+Enable the dev console and attach lightweight logging hooks for local iteration:
+
 ```tsx
 <CopilotKitProvider
   runtimeUrl="http://localhost:3000/api/copilotkit"
@@ -200,6 +206,8 @@ import * as Sentry from "@sentry/react";
 ```
 
 ### Production
+
+Disable the dev console and route errors to your logging and monitoring services:
 
 ```tsx
 <CopilotKitProvider

--- a/showcase/shell-docs/src/content/docs/unselected/premium/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/premium/overview.mdx
@@ -60,6 +60,8 @@ From the left nav in the Copilot Cloud dashboard.
 <Step>
 ### Use it in your provider
 
+Pass your public license key to `CopilotKitProvider`:
+
 ```tsx title="app/layout.tsx"
 <CopilotKitProvider publicLicenseKey="your-public-license-key">
   {children}

--- a/showcase/shell-docs/src/content/docs/unselected/server-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/unselected/server-tools.mdx
@@ -16,6 +16,8 @@ Server tools are functions that run on your backend that the Built-in Agent can 
 
 ## Defining a tool
 
+Use `defineTool` to declare a server-side tool with a name, description, typed parameters, and an `execute` handler:
+
 ```typescript title="src/copilotkit.ts"
 const getWeather = defineTool({
   name: "getWeather",

--- a/showcase/shell-docs/src/content/reference/components/CopilotChat.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChat.mdx
@@ -12,7 +12,8 @@ description: "High-level chat component that connects an agent to a chat view"
 ## Import
 
 ```tsx
-
+import { CopilotChat } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 ## Props

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatAssistantMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatAssistantMessage.mdx
@@ -10,7 +10,8 @@ description: "Component for displaying assistant messages with Markdown, tool ca
 ## Import
 
 ```tsx
-
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 ## Props

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatInput.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatInput.mdx
@@ -12,7 +12,8 @@ The component operates in three modes: `"input"` (default text entry), `"transcr
 ## Import
 
 ```tsx
-
+import { CopilotChatInput } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 ## Props

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatMessageView.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatMessageView.mdx
@@ -10,7 +10,8 @@ description: "Component for rendering a list of chat messages"
 ## Import
 
 ```tsx
-
+import { CopilotChatMessageView } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 ## Props

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatUserMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatUserMessage.mdx
@@ -10,7 +10,8 @@ description: "Component for displaying user-authored messages with branch naviga
 ## Import
 
 ```tsx
-
+import { CopilotChatUserMessage } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 ## Props

--- a/showcase/shell-docs/src/content/reference/components/CopilotChatView.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotChatView.mdx
@@ -12,7 +12,8 @@ Every visual piece of `CopilotChatView` is exposed as a **slot**, so you can rep
 ## Import
 
 ```tsx
-
+import CopilotChatView from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 <Callout type="info">

--- a/showcase/shell-docs/src/content/reference/components/CopilotPopup.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotPopup.mdx
@@ -12,7 +12,8 @@ See [`CopilotSidebar`](/reference/components/CopilotSidebar) for a sidebar varia
 ## Import
 
 ```tsx
-
+import { CopilotPopup } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 ## Props

--- a/showcase/shell-docs/src/content/reference/components/CopilotSidebar.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotSidebar.mdx
@@ -12,7 +12,8 @@ See [`CopilotPopup`](/reference/components/CopilotPopup) for a popup variant of 
 ## Import
 
 ```tsx
-
+import { CopilotSidebar } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
 ```
 
 ## Props

--- a/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
@@ -12,6 +12,8 @@ description: "React hook for accessing AG-UI agent instances"
 ## Signature
 
 ```tsx
+import { useAgent } from "@copilotkit/react-core/v2";
+
 function useAgent(options?: UseAgentProps): { agent: AbstractAgent };
 ```
 

--- a/showcase/shell-docs/src/content/reference/hooks/useAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useAgentContext.mdx
@@ -12,6 +12,8 @@ Update the incoming context object to refresh what the agent sees. This is the v
 ## Signature
 
 ```tsx
+import { useAgentContext } from "@copilotkit/react-core/v2";
+
 function useAgentContext(context: AgentContextInput): void;
 ```
 

--- a/showcase/shell-docs/src/content/reference/hooks/useComponent.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useComponent.mdx
@@ -15,6 +15,10 @@ Use this when you want a visual component renderer without writing a full fronte
 ## Signature
 
 ```tsx
+import { z } from "zod";
+import type { ComponentType } from "react";
+import { useComponent } from "@copilotkit/react-core/v2";
+
 function useComponent<TSchema extends z.ZodTypeAny | undefined = undefined>(
   config: {
     name: string;

--- a/showcase/shell-docs/src/content/reference/hooks/useConfigureSuggestions.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useConfigureSuggestions.mdx
@@ -12,6 +12,8 @@ The configuration is automatically registered on mount and removed on unmount. W
 ## Signature
 
 ```tsx
+import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
+
 function useConfigureSuggestions(
   config: SuggestionsConfigInput | null | undefined,
   deps?: ReadonlyArray<unknown>,

--- a/showcase/shell-docs/src/content/reference/hooks/useCopilotChatConfiguration.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useCopilotChatConfiguration.mdx
@@ -16,6 +16,7 @@ A provider component that exposes localized labels, agent and thread IDs, and op
 ### Signature
 
 ```tsx
+import { CopilotChatConfigurationProvider } from "@copilotkit/react-core/v2";
 
 <CopilotChatConfigurationProvider
   labels={...}
@@ -60,6 +61,8 @@ A provider component that exposes localized labels, agent and thread IDs, and op
 ### Signature
 
 ```tsx
+import { useCopilotChatConfiguration } from "@copilotkit/react-core/v2";
+
 function useCopilotChatConfiguration(): CopilotChatConfigurationValue | null;
 ```
 

--- a/showcase/shell-docs/src/content/reference/hooks/useCopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useCopilotKit.mdx
@@ -17,6 +17,8 @@ description: "Low-level React hook for accessing the CopilotKit context"
 ## Signature
 
 ```tsx
+import { useCopilotKit } from "@copilotkit/react-core/v2";
+
 function useCopilotKit(): CopilotKitContextValue;
 ```
 

--- a/showcase/shell-docs/src/content/reference/hooks/useDefaultRenderTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useDefaultRenderTool.mdx
@@ -17,6 +17,8 @@ Use this for catch-all rendering of tool calls that do not have a specific named
 ## Signature
 
 ```tsx
+import { useDefaultRenderTool } from "@copilotkit/react-core/v2";
+
 function useDefaultRenderTool(
   config?: {
     render?: (props: {

--- a/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
@@ -12,6 +12,8 @@ The hook manages the full registration lifecycle: it warns if a tool with the sa
 ## Signature
 
 ```tsx
+import { useFrontendTool } from "@copilotkit/react-core/v2";
+
 function useFrontendTool<T extends Record<string, unknown>>(
   tool: ReactFrontendTool<T>,
   deps?: ReadonlyArray<unknown>,

--- a/showcase/shell-docs/src/content/reference/hooks/useHumanInTheLoop.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useHumanInTheLoop.mdx
@@ -12,6 +12,8 @@ This hook is built on top of `useFrontendTool` with an internally managed handle
 ## Signature
 
 ```tsx
+import { useHumanInTheLoop } from "@copilotkit/react-core/v2";
+
 function useHumanInTheLoop<T extends Record<string, unknown>>(
   tool: ReactHumanInTheLoop<T>,
   deps?: ReadonlyArray<unknown>,

--- a/showcase/shell-docs/src/content/reference/hooks/useInterrupt.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useInterrupt.mdx
@@ -14,6 +14,8 @@ By default, interrupt UI is rendered inside `<CopilotChat>` automatically. If yo
 ## Signature
 
 ```tsx
+import { useInterrupt } from "@copilotkit/react-core/v2";
+
 function useInterrupt<
   TResult = never,
   TRenderInChat extends boolean | undefined = undefined,

--- a/showcase/shell-docs/src/content/reference/hooks/useRenderTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useRenderTool.mdx
@@ -17,6 +17,7 @@ This hook only handles rendering. It does not register a frontend handler.
 ### Wildcard overload
 
 ```tsx
+import { useRenderTool } from "@copilotkit/react-core/v2";
 
 useRenderTool(
   {
@@ -31,6 +32,8 @@ useRenderTool(
 ### Named overload
 
 ```tsx
+import { z } from "zod";
+import { useRenderTool } from "@copilotkit/react-core/v2";
 
 useRenderTool(
   {

--- a/showcase/shell-docs/src/content/reference/hooks/useRenderToolCall.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useRenderToolCall.mdx
@@ -12,6 +12,8 @@ This hook is primarily used by chat UI components to display visual feedback for
 ## Signature
 
 ```tsx
+import { useRenderToolCall } from "@copilotkit/react-core/v2";
+
 function useRenderToolCall(): (
   props: UseRenderToolCallProps,
 ) => React.ReactElement | null;

--- a/showcase/shell-docs/src/content/reference/hooks/useSuggestions.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useSuggestions.mdx
@@ -12,6 +12,8 @@ Suggestions are configured via [`useConfigureSuggestions`](/reference/hooks/useC
 ## Signature
 
 ```tsx
+import { useSuggestions } from "@copilotkit/react-core/v2";
+
 function useSuggestions(options?: UseSuggestionsOptions): UseSuggestionsResult;
 ```
 

--- a/showcase/shell-docs/src/data/registry.json
+++ b/showcase/shell-docs/src/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-22T11:13:48.868Z",
+  "generated_at": "2026-04-22T15:49:18.700Z",
   "feature_registry": {
     "version": "1.0.0",
     "categories": [
@@ -366,7 +366,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -416,14 +420,18 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -436,7 +444,9 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": null,
           "highlight": [
@@ -450,7 +460,9 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -463,7 +475,9 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -477,7 +491,9 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/frontend-tools",
           "animated_preview_url": null,
           "highlight": [
@@ -490,7 +506,9 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": null,
           "highlight": [
@@ -504,7 +522,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -518,7 +538,9 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": null,
           "highlight": [
@@ -532,7 +554,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null,
           "highlight": [
@@ -547,7 +571,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null,
           "highlight": [
@@ -561,7 +587,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null,
           "highlight": [
@@ -575,7 +603,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null,
           "highlight": [
@@ -590,7 +620,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null,
           "highlight": [
@@ -604,7 +636,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null,
           "highlight": [
@@ -618,7 +652,9 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": null,
           "highlight": [
@@ -631,7 +667,9 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": null,
           "highlight": [
@@ -644,7 +682,9 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/chat-slots",
           "animated_preview_url": null,
           "highlight": [
@@ -658,7 +698,9 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/headless-simple",
           "animated_preview_url": null,
           "highlight": [
@@ -671,7 +713,9 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/headless-complete",
           "animated_preview_url": null,
           "highlight": [
@@ -686,7 +730,9 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": null,
           "highlight": [
@@ -700,7 +746,9 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": null,
           "highlight": [
@@ -714,7 +762,9 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": null,
           "highlight": [
@@ -730,7 +780,9 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": null,
           "highlight": [
@@ -748,7 +800,9 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/mcp-apps",
           "animated_preview_url": null,
           "highlight": [
@@ -761,7 +815,9 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": null,
           "highlight": [
@@ -774,7 +830,9 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": null,
           "highlight": [
@@ -787,7 +845,9 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": null,
           "highlight": [
@@ -800,7 +860,9 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": null,
           "highlight": [
@@ -815,7 +877,9 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -978,7 +1042,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1006,7 +1074,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1014,7 +1084,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1022,7 +1094,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1030,7 +1104,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1038,7 +1114,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1046,7 +1124,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1054,7 +1134,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1062,7 +1144,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1122,7 +1206,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1150,7 +1238,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1158,7 +1248,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1166,7 +1258,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1174,7 +1268,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1182,7 +1278,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1190,7 +1288,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1198,7 +1298,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1206,7 +1308,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1266,7 +1370,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1290,7 +1398,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1298,7 +1408,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1306,7 +1418,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1314,7 +1428,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1322,7 +1438,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1330,7 +1448,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1338,7 +1458,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1346,7 +1468,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1406,7 +1530,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1434,7 +1562,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1442,7 +1572,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1450,7 +1582,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1458,7 +1592,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1466,7 +1602,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1474,7 +1612,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1482,7 +1622,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1490,7 +1632,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1550,7 +1694,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1578,7 +1726,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1586,7 +1736,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1594,7 +1746,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1602,7 +1756,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1610,7 +1766,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1618,7 +1776,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1626,7 +1786,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1634,7 +1796,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1694,7 +1858,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1718,7 +1886,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1726,7 +1896,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1734,7 +1906,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1742,7 +1916,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1750,7 +1926,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1758,7 +1936,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1766,7 +1946,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1774,7 +1956,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1834,7 +2018,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -1850,7 +2038,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1858,7 +2048,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1866,7 +2058,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1874,7 +2068,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1882,7 +2078,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1890,7 +2088,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1898,7 +2098,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1906,7 +2108,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1974,7 +2178,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -1990,7 +2198,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1998,7 +2208,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2006,7 +2218,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2014,7 +2228,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2022,7 +2238,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2030,7 +2248,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2038,7 +2258,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2046,7 +2268,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2114,7 +2338,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2138,7 +2366,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2146,7 +2376,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2154,7 +2386,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2162,7 +2396,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2170,7 +2406,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2178,7 +2416,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2186,7 +2426,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2194,7 +2436,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2258,7 +2502,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2274,7 +2522,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2282,7 +2532,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2290,7 +2542,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2298,7 +2552,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2306,7 +2562,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2314,7 +2572,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2322,7 +2582,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2330,7 +2592,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2402,7 +2666,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2426,7 +2694,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2434,7 +2704,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2442,7 +2714,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2450,7 +2724,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2458,7 +2734,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2466,7 +2744,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2474,7 +2754,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2482,7 +2764,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2546,7 +2830,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2570,7 +2858,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2578,7 +2868,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2586,7 +2878,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2594,7 +2888,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2602,7 +2898,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2610,7 +2908,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2618,7 +2918,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2626,7 +2928,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2686,7 +2990,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2702,7 +3010,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2710,7 +3020,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2718,7 +3030,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2726,7 +3040,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2734,7 +3050,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2742,7 +3060,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2750,7 +3070,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2758,7 +3080,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2793,7 +3117,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -2817,7 +3145,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2825,7 +3155,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2833,7 +3165,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2841,7 +3175,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2849,7 +3185,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2857,7 +3195,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2865,7 +3205,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2873,7 +3215,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2933,7 +3277,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -2957,7 +3305,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2965,7 +3315,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2973,7 +3325,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2981,7 +3335,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2989,7 +3345,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2997,7 +3355,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3005,7 +3365,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3013,7 +3375,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3073,7 +3437,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3089,7 +3457,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3097,7 +3467,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3105,7 +3477,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3113,7 +3487,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3121,7 +3497,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3129,7 +3507,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3137,7 +3517,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3145,7 +3527,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }

--- a/showcase/shell-docs/src/data/registry.json
+++ b/showcase/shell-docs/src/data/registry.json
@@ -366,11 +366,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -420,18 +416,14 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -444,9 +436,7 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": null,
           "highlight": [
@@ -460,9 +450,7 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -475,9 +463,7 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -491,9 +477,7 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools",
           "animated_preview_url": null,
           "highlight": [
@@ -506,9 +490,7 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": null,
           "highlight": [
@@ -522,9 +504,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -538,9 +518,7 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": null,
           "highlight": [
@@ -554,9 +532,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null,
           "highlight": [
@@ -571,9 +547,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null,
           "highlight": [
@@ -587,9 +561,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null,
           "highlight": [
@@ -603,9 +575,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null,
           "highlight": [
@@ -620,9 +590,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null,
           "highlight": [
@@ -636,9 +604,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null,
           "highlight": [
@@ -652,9 +618,7 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": null,
           "highlight": [
@@ -667,9 +631,7 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": null,
           "highlight": [
@@ -682,9 +644,7 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-slots",
           "animated_preview_url": null,
           "highlight": [
@@ -698,9 +658,7 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-simple",
           "animated_preview_url": null,
           "highlight": [
@@ -713,9 +671,7 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-complete",
           "animated_preview_url": null,
           "highlight": [
@@ -730,9 +686,7 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": null,
           "highlight": [
@@ -746,9 +700,7 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": null,
           "highlight": [
@@ -762,9 +714,7 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": null,
           "highlight": [
@@ -780,9 +730,7 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": null,
           "highlight": [
@@ -800,9 +748,7 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/mcp-apps",
           "animated_preview_url": null,
           "highlight": [
@@ -815,9 +761,7 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": null,
           "highlight": [
@@ -830,9 +774,7 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": null,
           "highlight": [
@@ -845,9 +787,7 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": null,
           "highlight": [
@@ -860,9 +800,7 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": null,
           "highlight": [
@@ -877,9 +815,7 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -1042,11 +978,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1074,9 +1006,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1084,9 +1014,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1094,9 +1022,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1104,9 +1030,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1114,9 +1038,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1124,9 +1046,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1134,9 +1054,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1144,9 +1062,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1206,11 +1122,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1238,9 +1150,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1248,9 +1158,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1258,9 +1166,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1268,9 +1174,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1278,9 +1182,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1288,9 +1190,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1298,9 +1198,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1308,9 +1206,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1370,11 +1266,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1398,9 +1290,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1408,9 +1298,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1418,9 +1306,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1428,9 +1314,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1438,9 +1322,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1448,9 +1330,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1458,9 +1338,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1468,9 +1346,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1530,11 +1406,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1562,9 +1434,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1572,9 +1442,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1582,9 +1450,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1592,9 +1458,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1602,9 +1466,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1612,9 +1474,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1622,9 +1482,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1632,9 +1490,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1694,11 +1550,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1726,9 +1578,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1736,9 +1586,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1746,9 +1594,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1756,9 +1602,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1766,9 +1610,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1776,9 +1618,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1786,9 +1626,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1796,9 +1634,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1858,11 +1694,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1886,9 +1718,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1896,9 +1726,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1906,9 +1734,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1916,9 +1742,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1926,9 +1750,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1936,9 +1758,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1946,9 +1766,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1956,9 +1774,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2018,11 +1834,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2038,9 +1850,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2048,9 +1858,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2058,9 +1866,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2068,9 +1874,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2078,9 +1882,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2088,9 +1890,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2098,9 +1898,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2108,9 +1906,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2178,11 +1974,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2198,9 +1990,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2208,9 +1998,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2218,9 +2006,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2228,9 +2014,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2238,9 +2022,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2248,9 +2030,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2258,9 +2038,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2268,9 +2046,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2338,11 +2114,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2366,9 +2138,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2376,9 +2146,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2386,9 +2154,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2396,9 +2162,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2406,9 +2170,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2416,9 +2178,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2426,9 +2186,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2436,9 +2194,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2502,11 +2258,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2522,9 +2274,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2532,9 +2282,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2542,9 +2290,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2552,9 +2298,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2562,9 +2306,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2572,9 +2314,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2582,9 +2322,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2592,9 +2330,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2666,11 +2402,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2694,9 +2426,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2704,9 +2434,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2714,9 +2442,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2724,9 +2450,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2734,9 +2458,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2744,9 +2466,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2754,9 +2474,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2764,9 +2482,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2830,11 +2546,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2858,9 +2570,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2868,9 +2578,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2878,9 +2586,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2888,9 +2594,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2898,9 +2602,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2908,9 +2610,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2918,9 +2618,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2928,9 +2626,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2990,11 +2686,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3010,9 +2702,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3020,9 +2710,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3030,9 +2718,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3040,9 +2726,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3050,9 +2734,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3060,9 +2742,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3070,9 +2750,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3080,9 +2758,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3117,11 +2793,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -3145,9 +2817,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3155,9 +2825,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3165,9 +2833,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3175,9 +2841,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3185,9 +2849,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3195,9 +2857,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3205,9 +2865,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3215,9 +2873,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3277,11 +2933,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -3305,9 +2957,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3315,9 +2965,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3325,9 +2973,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3335,9 +2981,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3345,9 +2989,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3355,9 +2997,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3365,9 +3005,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3375,9 +3013,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3437,11 +3073,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3457,9 +3089,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3467,9 +3097,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3477,9 +3105,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3487,9 +3113,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3497,9 +3121,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3507,9 +3129,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3517,9 +3137,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3527,9 +3145,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -711,6 +711,7 @@ export interface DocFrontmatter {
   description?: string;
   defaultFramework?: string;
   defaultCell?: string;
+  hideTOC?: boolean;
 }
 
 /**
@@ -780,6 +781,7 @@ export function loadDoc(
       : undefined;
   const defaultCell =
     typeof data.snippet_cell === "string" ? data.snippet_cell : undefined;
+  const hideTOC = data.hideTOC === true;
 
   return {
     source,
@@ -789,6 +791,7 @@ export function loadDoc(
       description,
       defaultFramework,
       defaultCell,
+      hideTOC,
     },
   };
 }

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -523,10 +523,10 @@ export const docsComponents = {
       }}
     >
       See the{" "}
-      <a href="/matrix" style={{ color: "var(--accent)" }}>
-        Feature Matrix
+      <a href="/" style={{ color: "var(--accent)" }}>
+        integrations overview
       </a>{" "}
-      for a full comparison.
+      for all available frameworks.
     </div>
   ),
   IntegrationsGrid: ({ children }: { children?: React.ReactNode }) => (

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -513,22 +513,92 @@ export const docsComponents = {
   EcosystemTable: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  FeatureMatrix: () => (
-    <div
-      style={{
-        padding: "1rem",
-        background: "var(--bg-elevated)",
-        borderRadius: "0.5rem",
-        marginBottom: "1rem",
-      }}
-    >
-      See the{" "}
-      <a href="/" style={{ color: "var(--accent)" }}>
-        integrations overview
-      </a>{" "}
-      for all available frameworks.
-    </div>
-  ),
+  FeatureMatrix: () => {
+    const reg = getRegistry();
+    const integrations = reg.integrations.filter((i) => i.deployed);
+
+    const columns = [
+      { id: "agentic-chat", label: "Chat UI" },
+      { id: "gen-ui-tool-based", label: "Tool-Based Gen UI" },
+      { id: "tool-rendering", label: "Tool Rendering" },
+      { id: "gen-ui-agent", label: "Agentic Gen UI" },
+      { id: "hitl-in-chat", label: "Human-in-the-Loop" },
+      { id: "frontend-tools", label: "Frontend Tools" },
+      { id: "shared-state-read-write", label: "Shared State" },
+      { id: "shared-state-streaming", label: "State Streaming" },
+      { id: "subagents", label: "Sub-Agents" },
+      { id: "declarative-gen-ui", label: "Declarative Gen UI" },
+      { id: "agentic-chat-reasoning", label: "Reasoning" },
+      { id: "mcp-apps", label: "MCP Apps" },
+    ];
+
+    return (
+      <div className="overflow-x-auto my-6 rounded-lg border border-[var(--border)]">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 bg-[var(--bg-elevated)] text-left px-4 py-3 font-semibold text-[var(--text)] border-b border-r border-[var(--border)] min-w-[200px] whitespace-nowrap">
+                Framework
+              </th>
+              {columns.map((col) => (
+                <th
+                  key={col.id}
+                  className="bg-[var(--bg-elevated)] px-3 py-3 text-center font-medium text-[var(--text-muted)] border-b border-[var(--border)] text-xs whitespace-nowrap"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {integrations.map((integration, idx) => {
+              const features = new Set(integration.features ?? []);
+              const rowBg =
+                idx % 2 === 0
+                  ? "bg-[var(--bg-surface)]"
+                  : "bg-[var(--bg-elevated)]";
+              return (
+                <tr key={integration.slug} className={rowBg}>
+                  <td
+                    className={`sticky left-0 z-10 px-4 py-2.5 font-medium text-[var(--text)] border-r border-b border-[var(--border-dim)] whitespace-nowrap ${rowBg}`}
+                  >
+                    <Link
+                      href={`/${integration.slug}`}
+                      className="hover:text-[var(--accent)] transition-colors"
+                    >
+                      {integration.name}
+                    </Link>
+                  </td>
+                  {columns.map((col) => (
+                    <td
+                      key={col.id}
+                      className="px-3 py-2.5 text-center border-b border-[var(--border-dim)]"
+                    >
+                      {features.has(col.id) ? (
+                        <span
+                          className="text-[var(--accent)]"
+                          aria-label="supported"
+                        >
+                          ✓
+                        </span>
+                      ) : (
+                        <span
+                          className="text-[var(--text-faint)] text-xs"
+                          aria-label="not supported"
+                        >
+                          —
+                        </span>
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
   IntegrationsGrid: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -16,6 +16,7 @@ import { Steps as DocsSteps, Step as DocsStep } from "@/components/docs-steps";
 import { Tabs as DocsTabs, Tab as DocsTab } from "@/components/docs-tabs";
 import { FrameworkTabs } from "@/components/framework-tabs";
 import { PropertyReference } from "@/components/property-reference";
+import { IntegrationGrid } from "@/components/integration-grid";
 import { getRegistry } from "@/lib/registry";
 
 const Callout = DocsCallout;
@@ -199,24 +200,7 @@ export const docsComponents = {
       {children}
     </div>
   ),
-  IntegrationGrid: ({ path }: { path?: string }) => (
-    <div
-      style={{
-        padding: "1rem",
-        background: "var(--bg-elevated)",
-        borderRadius: "0.5rem",
-        marginBottom: "1rem",
-        fontSize: "0.875rem",
-        color: "var(--text-muted)",
-      }}
-    >
-      See{" "}
-      <a href="/integrations" style={{ color: "var(--accent)" }}>
-        Integrations
-      </a>{" "}
-      for all available frameworks{path ? ` (${path})` : ""}.
-    </div>
-  ),
+  IntegrationGrid,
   FeatureGrid: ({ children }: { children?: React.ReactNode }) => (
     <div
       style={{

--- a/showcase/shell-docs/src/lib/toc.ts
+++ b/showcase/shell-docs/src/lib/toc.ts
@@ -1,0 +1,99 @@
+// Right-rail "On this page" TOC. Extracts H2/H3 headings from rendered
+// MDX source (post-snippet-inlining) so the TOC surfaces the page's
+// actual sections, including anything pulled in from shared snippets.
+//
+// Slug algorithm matches the conventional GitHub/rehype-slug behavior
+// closely enough for same-page anchors. Duplicate handling is kept
+// intentionally minimal — a scan of showcase/shell-docs content shows
+// no H2 collisions today; if that changes, swap in rehype-slug.
+
+export interface TocHeading {
+  depth: 2 | 3;
+  text: string;
+  slug: string;
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[`*_~]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// Strip trivial inline markdown (bold/italic/code spans) from heading
+// text so the rendered TOC labels read as plain prose rather than "** &
+// `` scattered through them.
+function plainHeadingText(raw: string): string {
+  return raw
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .trim();
+}
+
+export function extractHeadings(source: string): TocHeading[] {
+  const lines = source.split("\n");
+  const headings: TocHeading[] = [];
+  const slugCounts = new Map<string, number>();
+  let inFence = false;
+  let fenceChar: "`" | "~" | "" = "";
+
+  for (const line of lines) {
+    // Track fenced code blocks so `# comment` inside python/js samples
+    // doesn't masquerade as a heading.
+    const fenceMatch = line.match(/^\s*(```+|~~~+)/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0] as "`" | "~";
+      if (!inFence) {
+        inFence = true;
+        fenceChar = marker;
+      } else if (fenceChar === marker) {
+        inFence = false;
+        fenceChar = "";
+      }
+      continue;
+    }
+    if (inFence) continue;
+
+    const match = line.match(/^(#{2,3})\s+(.+?)\s*$/);
+    if (!match) continue;
+    const depth = match[1].length as 2 | 3;
+    const text = plainHeadingText(match[2]);
+    if (!text) continue;
+
+    let slug = slugify(text);
+    if (!slug) continue;
+    const count = slugCounts.get(slug) ?? 0;
+    slugCounts.set(slug, count + 1);
+    if (count > 0) slug = `${slug}-${count}`;
+
+    headings.push({ depth, text, slug });
+  }
+
+  return headings;
+}
+
+// Flatten React heading children to a plain string so we can reuse the
+// slugify algorithm in the MDX `h2`/`h3` component overrides. Must match
+// the transforms applied by extractHeadings() so IDs line up with the
+// slugs surfaced in the TOC.
+export function childrenToText(children: unknown): string {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) return children.map(childrenToText).join("");
+  if (
+    children &&
+    typeof children === "object" &&
+    "props" in children &&
+    typeof (children as { props: unknown }).props === "object"
+  ) {
+    const props = (children as { props: { children?: unknown } }).props;
+    return childrenToText(props?.children);
+  }
+  return "";
+}

--- a/showcase/shell-dojo/src/data/registry.json
+++ b/showcase/shell-dojo/src/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-22T11:13:48.868Z",
+  "generated_at": "2026-04-22T15:49:18.700Z",
   "feature_registry": {
     "version": "1.0.0",
     "categories": [
@@ -366,7 +366,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -416,14 +420,18 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -436,7 +444,9 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": null,
           "highlight": [
@@ -450,7 +460,9 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -463,7 +475,9 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -477,7 +491,9 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/frontend-tools",
           "animated_preview_url": null,
           "highlight": [
@@ -490,7 +506,9 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": null,
           "highlight": [
@@ -504,7 +522,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -518,7 +538,9 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": null,
           "highlight": [
@@ -532,7 +554,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null,
           "highlight": [
@@ -547,7 +571,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null,
           "highlight": [
@@ -561,7 +587,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null,
           "highlight": [
@@ -575,7 +603,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null,
           "highlight": [
@@ -590,7 +620,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null,
           "highlight": [
@@ -604,7 +636,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null,
           "highlight": [
@@ -618,7 +652,9 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": null,
           "highlight": [
@@ -631,7 +667,9 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": null,
           "highlight": [
@@ -644,7 +682,9 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/chat-slots",
           "animated_preview_url": null,
           "highlight": [
@@ -658,7 +698,9 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/headless-simple",
           "animated_preview_url": null,
           "highlight": [
@@ -671,7 +713,9 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/headless-complete",
           "animated_preview_url": null,
           "highlight": [
@@ -686,7 +730,9 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": null,
           "highlight": [
@@ -700,7 +746,9 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": null,
           "highlight": [
@@ -714,7 +762,9 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": null,
           "highlight": [
@@ -730,7 +780,9 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": null,
           "highlight": [
@@ -748,7 +800,9 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/mcp-apps",
           "animated_preview_url": null,
           "highlight": [
@@ -761,7 +815,9 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": null,
           "highlight": [
@@ -774,7 +830,9 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": null,
           "highlight": [
@@ -787,7 +845,9 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": null,
           "highlight": [
@@ -800,7 +860,9 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": null,
           "highlight": [
@@ -815,7 +877,9 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -978,7 +1042,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1006,7 +1074,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1014,7 +1084,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1022,7 +1094,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1030,7 +1104,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1038,7 +1114,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1046,7 +1124,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1054,7 +1134,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1062,7 +1144,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1122,7 +1206,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1150,7 +1238,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1158,7 +1248,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1166,7 +1258,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1174,7 +1268,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1182,7 +1278,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1190,7 +1288,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1198,7 +1298,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1206,7 +1308,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1266,7 +1370,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1290,7 +1398,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1298,7 +1408,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1306,7 +1418,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1314,7 +1428,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1322,7 +1438,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1330,7 +1448,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1338,7 +1458,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1346,7 +1468,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1406,7 +1530,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1434,7 +1562,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1442,7 +1572,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1450,7 +1582,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1458,7 +1592,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1466,7 +1602,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1474,7 +1612,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1482,7 +1622,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1490,7 +1632,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1550,7 +1694,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1578,7 +1726,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1586,7 +1736,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1594,7 +1746,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1602,7 +1756,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1610,7 +1766,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1618,7 +1776,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1626,7 +1786,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1634,7 +1796,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1694,7 +1858,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1718,7 +1886,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1726,7 +1896,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1734,7 +1906,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1742,7 +1916,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1750,7 +1926,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1758,7 +1936,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1766,7 +1946,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1774,7 +1956,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1834,7 +2018,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -1850,7 +2038,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1858,7 +2048,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1866,7 +2058,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1874,7 +2068,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1882,7 +2078,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1890,7 +2088,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1898,7 +2098,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1906,7 +2108,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1974,7 +2178,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -1990,7 +2198,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1998,7 +2208,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2006,7 +2218,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2014,7 +2228,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2022,7 +2238,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2030,7 +2248,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2038,7 +2258,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2046,7 +2268,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2114,7 +2338,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2138,7 +2366,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2146,7 +2376,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2154,7 +2386,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2162,7 +2396,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2170,7 +2406,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2178,7 +2416,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2186,7 +2426,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2194,7 +2436,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2258,7 +2502,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2274,7 +2522,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2282,7 +2532,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2290,7 +2542,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2298,7 +2552,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2306,7 +2562,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2314,7 +2572,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2322,7 +2582,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2330,7 +2592,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2402,7 +2666,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2426,7 +2694,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2434,7 +2704,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2442,7 +2714,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2450,7 +2724,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2458,7 +2734,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2466,7 +2744,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2474,7 +2754,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2482,7 +2764,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2546,7 +2830,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2570,7 +2858,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2578,7 +2868,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2586,7 +2878,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2594,7 +2888,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2602,7 +2898,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2610,7 +2908,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2618,7 +2918,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2626,7 +2928,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2686,7 +2990,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2702,7 +3010,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2710,7 +3020,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2718,7 +3030,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2726,7 +3040,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2734,7 +3050,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2742,7 +3060,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2750,7 +3070,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2758,7 +3080,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2793,7 +3117,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -2817,7 +3145,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2825,7 +3155,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2833,7 +3165,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2841,7 +3175,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2849,7 +3185,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2857,7 +3195,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2865,7 +3205,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2873,7 +3215,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2933,7 +3277,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -2957,7 +3305,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2965,7 +3315,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2973,7 +3325,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2981,7 +3335,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2989,7 +3345,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2997,7 +3355,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3005,7 +3365,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3013,7 +3375,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3073,7 +3437,11 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": ["sidebar", "embedded", "chat"],
+      "interaction_modalities": [
+        "sidebar",
+        "embedded",
+        "chat"
+      ],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3089,7 +3457,9 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": ["chat-ui"],
+          "tags": [
+            "chat-ui"
+          ],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3097,7 +3467,9 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": ["interactivity"],
+          "tags": [
+            "interactivity"
+          ],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3105,7 +3477,9 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": ["agent-capabilities"],
+          "tags": [
+            "agent-capabilities"
+          ],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3113,7 +3487,9 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3121,7 +3497,9 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": ["generative-ui"],
+          "tags": [
+            "generative-ui"
+          ],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3129,7 +3507,9 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3137,7 +3517,9 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": ["agent-state"],
+          "tags": [
+            "agent-state"
+          ],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3145,7 +3527,9 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": ["multi-agent"],
+          "tags": [
+            "multi-agent"
+          ],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }

--- a/showcase/shell-dojo/src/data/registry.json
+++ b/showcase/shell-dojo/src/data/registry.json
@@ -366,11 +366,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -420,18 +416,14 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -444,9 +436,7 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": null,
           "highlight": [
@@ -460,9 +450,7 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -475,9 +463,7 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": null,
           "highlight": [
@@ -491,9 +477,7 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools",
           "animated_preview_url": null,
           "highlight": [
@@ -506,9 +490,7 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": null,
           "highlight": [
@@ -522,9 +504,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -538,9 +518,7 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": null,
           "highlight": [
@@ -554,9 +532,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null,
           "highlight": [
@@ -571,9 +547,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null,
           "highlight": [
@@ -587,9 +561,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null,
           "highlight": [
@@ -603,9 +575,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null,
           "highlight": [
@@ -620,9 +590,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null,
           "highlight": [
@@ -636,9 +604,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null,
           "highlight": [
@@ -652,9 +618,7 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": null,
           "highlight": [
@@ -667,9 +631,7 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": null,
           "highlight": [
@@ -682,9 +644,7 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-slots",
           "animated_preview_url": null,
           "highlight": [
@@ -698,9 +658,7 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-simple",
           "animated_preview_url": null,
           "highlight": [
@@ -713,9 +671,7 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-complete",
           "animated_preview_url": null,
           "highlight": [
@@ -730,9 +686,7 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": null,
           "highlight": [
@@ -746,9 +700,7 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": null,
           "highlight": [
@@ -762,9 +714,7 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": null,
           "highlight": [
@@ -780,9 +730,7 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": null,
           "highlight": [
@@ -800,9 +748,7 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/mcp-apps",
           "animated_preview_url": null,
           "highlight": [
@@ -815,9 +761,7 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": null,
           "highlight": [
@@ -830,9 +774,7 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": null,
           "highlight": [
@@ -845,9 +787,7 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": null,
           "highlight": [
@@ -860,9 +800,7 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": null,
           "highlight": [
@@ -877,9 +815,7 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": null,
           "highlight": [
@@ -1042,11 +978,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1074,9 +1006,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1084,9 +1014,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1094,9 +1022,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1104,9 +1030,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1114,9 +1038,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1124,9 +1046,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1134,9 +1054,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1144,9 +1062,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1206,11 +1122,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1238,9 +1150,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1248,9 +1158,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1258,9 +1166,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1268,9 +1174,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1278,9 +1182,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1288,9 +1190,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1298,9 +1198,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1308,9 +1206,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1370,11 +1266,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1398,9 +1290,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1408,9 +1298,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1418,9 +1306,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1428,9 +1314,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1438,9 +1322,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1448,9 +1330,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1458,9 +1338,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1468,9 +1346,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1530,11 +1406,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1562,9 +1434,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1572,9 +1442,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1582,9 +1450,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1592,9 +1458,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1602,9 +1466,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1612,9 +1474,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1622,9 +1482,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1632,9 +1490,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1694,11 +1550,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1726,9 +1578,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1736,9 +1586,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1746,9 +1594,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1756,9 +1602,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1766,9 +1610,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1776,9 +1618,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1786,9 +1626,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1796,9 +1634,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -1858,11 +1694,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1886,9 +1718,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -1896,9 +1726,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -1906,9 +1734,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -1916,9 +1742,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -1926,9 +1750,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -1936,9 +1758,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -1946,9 +1766,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -1956,9 +1774,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2018,11 +1834,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2038,9 +1850,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2048,9 +1858,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2058,9 +1866,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2068,9 +1874,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2078,9 +1882,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2088,9 +1890,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2098,9 +1898,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2108,9 +1906,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2178,11 +1974,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2198,9 +1990,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2208,9 +1998,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2218,9 +2006,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2228,9 +2014,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2238,9 +2022,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2248,9 +2030,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2258,9 +2038,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2268,9 +2046,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2338,11 +2114,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2366,9 +2138,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2376,9 +2146,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2386,9 +2154,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2396,9 +2162,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2406,9 +2170,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2416,9 +2178,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2426,9 +2186,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2436,9 +2194,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2502,11 +2258,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2522,9 +2274,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2532,9 +2282,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2542,9 +2290,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2552,9 +2298,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2562,9 +2306,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2572,9 +2314,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2582,9 +2322,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2592,9 +2330,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2666,11 +2402,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2694,9 +2426,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2704,9 +2434,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2714,9 +2442,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2724,9 +2450,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2734,9 +2458,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2744,9 +2466,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2754,9 +2474,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2764,9 +2482,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2830,11 +2546,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2858,9 +2570,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -2868,9 +2578,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -2878,9 +2586,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -2888,9 +2594,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -2898,9 +2602,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -2908,9 +2610,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -2918,9 +2618,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -2928,9 +2626,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -2990,11 +2686,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3010,9 +2702,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3020,9 +2710,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3030,9 +2718,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3040,9 +2726,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3050,9 +2734,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3060,9 +2742,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3070,9 +2750,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3080,9 +2758,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3117,11 +2793,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -3145,9 +2817,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3155,9 +2825,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3165,9 +2833,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3175,9 +2841,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3185,9 +2849,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3195,9 +2857,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3205,9 +2865,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3215,9 +2873,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3277,11 +2933,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -3305,9 +2957,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3315,9 +2965,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3325,9 +2973,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3335,9 +2981,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3345,9 +2989,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3355,9 +2997,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3365,9 +3005,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3375,9 +3013,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }
@@ -3437,11 +3073,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3457,9 +3089,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": null
         },
@@ -3467,9 +3097,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": null
         },
@@ -3477,9 +3105,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": null
         },
@@ -3487,9 +3113,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": null
         },
@@ -3497,9 +3121,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": null
         },
@@ -3507,9 +3129,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": null
         },
@@ -3517,9 +3137,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": null
         },
@@ -3527,9 +3145,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": null
         }

--- a/showcase/shell/src/data/constraints.json
+++ b/showcase/shell/src/data/constraints.json
@@ -68,7 +68,9 @@
   },
   "interaction_modalities": {
     "headless": {
-      "excluded": ["voice"]
+      "excluded": [
+        "voice"
+      ]
     }
   }
 }

--- a/showcase/shell/src/data/constraints.json
+++ b/showcase/shell/src/data/constraints.json
@@ -68,9 +68,7 @@
   },
   "interaction_modalities": {
     "headless": {
-      "excluded": [
-        "voice"
-      ]
+      "excluded": ["voice"]
     }
   }
 }

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-22T11:13:48.868Z",
+  "generated_at": "2026-04-22T15:49:18.700Z",
   "feature_registry": {
     "version": "1.0.0",
     "categories": [

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -366,11 +366,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -420,18 +416,14 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat.mp4",
           "highlight": [
@@ -444,9 +436,7 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-customization-css.mp4",
           "highlight": [
@@ -460,9 +450,7 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-default-catchall.mp4",
           "highlight": [
@@ -475,9 +463,7 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-custom-catchall.mp4",
           "highlight": [
@@ -491,9 +477,7 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools.mp4",
           "highlight": [
@@ -506,9 +490,7 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools-async.mp4",
           "highlight": [
@@ -522,9 +504,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-chat.mp4",
           "highlight": [
@@ -538,9 +518,7 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-app.mp4",
           "highlight": [
@@ -554,9 +532,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering.mp4",
           "highlight": [
@@ -571,9 +547,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-tool-based.mp4",
           "highlight": [
@@ -587,9 +561,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-agent.mp4",
           "highlight": [
@@ -603,9 +575,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-read-write.mp4",
           "highlight": [
@@ -620,9 +590,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-streaming.mp4",
           "highlight": [
@@ -636,9 +604,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_subagents.mp4",
           "highlight": [
@@ -652,9 +618,7 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-sidebar.mp4",
           "highlight": [
@@ -667,9 +631,7 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-popup.mp4",
           "highlight": [
@@ -682,9 +644,7 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-slots",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-slots.mp4",
           "highlight": [
@@ -698,9 +658,7 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-simple",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-simple.mp4",
           "highlight": [
@@ -713,9 +671,7 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-complete",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-complete.mp4",
           "highlight": [
@@ -730,9 +686,7 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat-reasoning.mp4",
           "highlight": [
@@ -746,9 +700,7 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-interrupt.mp4",
           "highlight": [
@@ -762,9 +714,7 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_declarative-gen-ui.mp4",
           "highlight": [
@@ -780,9 +730,7 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_a2ui-fixed-schema.mp4",
           "highlight": [
@@ -800,9 +748,7 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/mcp-apps",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_mcp-apps.mp4",
           "highlight": [
@@ -815,9 +761,7 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_interrupt-headless.mp4",
           "highlight": [
@@ -830,9 +774,7 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_readonly-state-agent-context.mp4",
           "highlight": [
@@ -845,9 +787,7 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_reasoning-default-render.mp4",
           "highlight": [
@@ -860,9 +800,7 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-reasoning-chain.mp4",
           "highlight": [
@@ -877,9 +815,7 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_beautiful-chat.mp4",
           "highlight": [
@@ -1042,11 +978,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1074,9 +1006,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_agentic-chat.mp4"
         },
@@ -1084,9 +1014,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_hitl-in-chat.mp4"
         },
@@ -1094,9 +1022,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_tool-rendering.mp4"
         },
@@ -1104,9 +1030,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-tool-based.mp4"
         },
@@ -1114,9 +1038,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-agent.mp4"
         },
@@ -1124,9 +1046,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-read-write.mp4"
         },
@@ -1134,9 +1054,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-streaming.mp4"
         },
@@ -1144,9 +1062,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_subagents.mp4"
         }
@@ -1206,11 +1122,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1238,9 +1150,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_agentic-chat.mp4"
         },
@@ -1248,9 +1158,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_tool-rendering.mp4"
         },
@@ -1258,9 +1166,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_hitl-in-chat.mp4"
         },
@@ -1268,9 +1174,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-tool-based.mp4"
         },
@@ -1278,9 +1182,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-agent.mp4"
         },
@@ -1288,9 +1190,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-read-write.mp4"
         },
@@ -1298,9 +1198,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-streaming.mp4"
         },
@@ -1308,9 +1206,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_subagents.mp4"
         }
@@ -1370,11 +1266,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1398,9 +1290,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_agentic-chat.mp4"
         },
@@ -1408,9 +1298,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_hitl-in-chat.mp4"
         },
@@ -1418,9 +1306,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_tool-rendering.mp4"
         },
@@ -1428,9 +1314,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-tool-based.mp4"
         },
@@ -1438,9 +1322,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-agent.mp4"
         },
@@ -1448,9 +1330,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-read-write.mp4"
         },
@@ -1458,9 +1338,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-streaming.mp4"
         },
@@ -1468,9 +1346,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_subagents.mp4"
         }
@@ -1530,11 +1406,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1562,9 +1434,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_agentic-chat.mp4"
         },
@@ -1572,9 +1442,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_hitl-in-chat.mp4"
         },
@@ -1582,9 +1450,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_tool-rendering.mp4"
         },
@@ -1592,9 +1458,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-tool-based.mp4"
         },
@@ -1602,9 +1466,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-agent.mp4"
         },
@@ -1612,9 +1474,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-read-write.mp4"
         },
@@ -1622,9 +1482,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-streaming.mp4"
         },
@@ -1632,9 +1490,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_subagents.mp4"
         }
@@ -1694,11 +1550,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1726,9 +1578,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_agentic-chat.mp4"
         },
@@ -1736,9 +1586,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_hitl-in-chat.mp4"
         },
@@ -1746,9 +1594,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_tool-rendering.mp4"
         },
@@ -1756,9 +1602,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-tool-based.mp4"
         },
@@ -1766,9 +1610,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-agent.mp4"
         },
@@ -1776,9 +1618,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-read-write.mp4"
         },
@@ -1786,9 +1626,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-streaming.mp4"
         },
@@ -1796,9 +1634,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_subagents.mp4"
         }
@@ -1858,11 +1694,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1886,9 +1718,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_agentic-chat.mp4"
         },
@@ -1896,9 +1726,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_hitl-in-chat.mp4"
         },
@@ -1906,9 +1734,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_tool-rendering.mp4"
         },
@@ -1916,9 +1742,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-tool-based.mp4"
         },
@@ -1926,9 +1750,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-agent.mp4"
         },
@@ -1936,9 +1758,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-read-write.mp4"
         },
@@ -1946,9 +1766,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-streaming.mp4"
         },
@@ -1956,9 +1774,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_subagents.mp4"
         }
@@ -2018,11 +1834,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2038,9 +1850,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_agentic-chat.mp4"
         },
@@ -2048,9 +1858,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_hitl-in-chat.mp4"
         },
@@ -2058,9 +1866,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_tool-rendering.mp4"
         },
@@ -2068,9 +1874,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-tool-based.mp4"
         },
@@ -2078,9 +1882,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-agent.mp4"
         },
@@ -2088,9 +1890,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-read-write.mp4"
         },
@@ -2098,9 +1898,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-streaming.mp4"
         },
@@ -2108,9 +1906,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_subagents.mp4"
         }
@@ -2178,11 +1974,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2198,9 +1990,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_agentic-chat.mp4"
         },
@@ -2208,9 +1998,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_hitl-in-chat.mp4"
         },
@@ -2218,9 +2006,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_tool-rendering.mp4"
         },
@@ -2228,9 +2014,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-tool-based.mp4"
         },
@@ -2238,9 +2022,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-agent.mp4"
         },
@@ -2248,9 +2030,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-read-write.mp4"
         },
@@ -2258,9 +2038,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-streaming.mp4"
         },
@@ -2268,9 +2046,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_subagents.mp4"
         }
@@ -2338,11 +2114,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2366,9 +2138,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_agentic-chat.mp4"
         },
@@ -2376,9 +2146,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_hitl-in-chat.mp4"
         },
@@ -2386,9 +2154,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_tool-rendering.mp4"
         },
@@ -2396,9 +2162,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-tool-based.mp4"
         },
@@ -2406,9 +2170,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-agent.mp4"
         },
@@ -2416,9 +2178,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-read-write.mp4"
         },
@@ -2426,9 +2186,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-streaming.mp4"
         },
@@ -2436,9 +2194,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_subagents.mp4"
         }
@@ -2502,11 +2258,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2522,9 +2274,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_agentic-chat.mp4"
         },
@@ -2532,9 +2282,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_hitl-in-chat.mp4"
         },
@@ -2542,9 +2290,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_tool-rendering.mp4"
         },
@@ -2552,9 +2298,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-tool-based.mp4"
         },
@@ -2562,9 +2306,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-agent.mp4"
         },
@@ -2572,9 +2314,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-read-write.mp4"
         },
@@ -2582,9 +2322,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-streaming.mp4"
         },
@@ -2592,9 +2330,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_subagents.mp4"
         }
@@ -2666,11 +2402,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2694,9 +2426,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_agentic-chat.mp4"
         },
@@ -2704,9 +2434,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_hitl-in-chat.mp4"
         },
@@ -2714,9 +2442,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_tool-rendering.mp4"
         },
@@ -2724,9 +2450,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-tool-based.mp4"
         },
@@ -2734,9 +2458,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-agent.mp4"
         },
@@ -2744,9 +2466,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-read-write.mp4"
         },
@@ -2754,9 +2474,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-streaming.mp4"
         },
@@ -2764,9 +2482,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_subagents.mp4"
         }
@@ -2830,11 +2546,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2858,9 +2570,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_agentic-chat.mp4"
         },
@@ -2868,9 +2578,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_hitl-in-chat.mp4"
         },
@@ -2878,9 +2586,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_tool-rendering.mp4"
         },
@@ -2888,9 +2594,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-tool-based.mp4"
         },
@@ -2898,9 +2602,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-agent.mp4"
         },
@@ -2908,9 +2610,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-read-write.mp4"
         },
@@ -2918,9 +2618,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-streaming.mp4"
         },
@@ -2928,9 +2626,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_subagents.mp4"
         }
@@ -2990,11 +2686,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3010,9 +2702,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_agentic-chat.mp4"
         },
@@ -3020,9 +2710,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_hitl-in-chat.mp4"
         },
@@ -3030,9 +2718,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_tool-rendering.mp4"
         },
@@ -3040,9 +2726,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-tool-based.mp4"
         },
@@ -3050,9 +2734,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-agent.mp4"
         },
@@ -3060,9 +2742,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-read-write.mp4"
         },
@@ -3070,9 +2750,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-streaming.mp4"
         },
@@ -3080,9 +2758,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_subagents.mp4"
         }
@@ -3117,11 +2793,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -3145,9 +2817,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_agentic-chat.mp4"
         },
@@ -3155,9 +2825,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_hitl-in-chat.mp4"
         },
@@ -3165,9 +2833,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_tool-rendering.mp4"
         },
@@ -3175,9 +2841,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-tool-based.mp4"
         },
@@ -3185,9 +2849,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-agent.mp4"
         },
@@ -3195,9 +2857,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-read-write.mp4"
         },
@@ -3205,9 +2865,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-streaming.mp4"
         },
@@ -3215,9 +2873,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_subagents.mp4"
         }
@@ -3277,11 +2933,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -3305,9 +2957,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_agentic-chat.mp4"
         },
@@ -3315,9 +2965,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_hitl-in-chat.mp4"
         },
@@ -3325,9 +2973,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_tool-rendering.mp4"
         },
@@ -3335,9 +2981,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-tool-based.mp4"
         },
@@ -3345,9 +2989,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-agent.mp4"
         },
@@ -3355,9 +2997,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-read-write.mp4"
         },
@@ -3365,9 +3005,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-streaming.mp4"
         },
@@ -3375,9 +3013,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_subagents.mp4"
         }
@@ -3437,11 +3073,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3457,9 +3089,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_agentic-chat.mp4"
         },
@@ -3467,9 +3097,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_hitl-in-chat.mp4"
         },
@@ -3477,9 +3105,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_tool-rendering.mp4"
         },
@@ -3487,9 +3113,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-tool-based.mp4"
         },
@@ -3497,9 +3121,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-agent.mp4"
         },
@@ -3507,9 +3129,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-read-write.mp4"
         },
@@ -3517,9 +3137,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-streaming.mp4"
         },
@@ -3527,9 +3145,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_subagents.mp4"
         }


### PR DESCRIPTION
## Summary

- **Content writing pass** — em-dash overuse removed across ~37 docs files; bridging text added before live demos, gifs, and snippets on ~15 pages; intro sentences added before code examples that directly follow headings (11 files); hardcoded \"LangGraph Python\" reference fixed in quickstart
- **Feature matrix** — built a real 17 backends × 12 features matrix on the integrations overview page; fixed card underlines and added intro text
- **IntegrationGrid fixes** — converted to a client component that returns `null` on framework-scoped routes (was always visible); moved the \"Choose your AI backend\" heading into the component so it disappears with the grid; stripped the now-redundant heading from 21 MDX files
- **Right-rail TOC** — new `DocsToc` client component with IntersectionObserver scrollspy; heading extractor + slugifier in `toc.ts`; H2/H3 ID overrides wired in `DocsPageView`; respects `hideTOC: true` frontmatter (290 of 366 pages show the TOC)
- **Index page** — card and feature-grid styles aligned to site CSS variables (`var(--border)`, `var(--accent)`, etc.) instead of shadcn tokens; duplicate \"Explore by AI backend\" header removed
- **Generated data** — registry, status, constraints, demo-content updated; `langgraph-python` set as quickstart default integration

## Test plan

- [ ] `http://localhost:3003/` — hero cards and feature grid render with correct theme colors; \"Choose your AI backend\" section appears once with description text
- [ ] `http://localhost:3003/langgraph-python/generative-ui/tool-rendering` — no \"Choose your AI backend\" header visible
- [ ] `http://localhost:3003/generative-ui/tool-rendering` — \"Choose your AI backend\" section visible (unscoped route)
- [ ] Any page with `hideTOC: false` (default) — right-rail TOC renders and scrollspy highlights current section
- [ ] Any page with `hideTOC: true` (e.g. `/quickstart`) — no TOC rendered
- [ ] Prebuilt component pages (chat, sidebar, popup) — bridging sentence appears between live demo and gif
- [ ] No em-dashes in prose across edited pages