### PR TITLE
fix(showcase-ops): correct probe contract for starter services

### DIFF
--- a/showcase/ops/src/probes/discovery/railway-services.test.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.test.ts
@@ -494,7 +494,7 @@ describe("railwayServicesSource", () => {
   // single-app integration at `/` with health at `/api/health`; packages
   // are the shell-based showcases with `/smoke`, `/health`, and
   // `/demos/*` routing. Without the field, probes hit `/smoke` on every
-  // starter and produce 17×3 false-red alerts per tick.
+  // starter and emit one false-red row per starter per probed endpoint.
   // -----------------------------------------------------------------
 
   it("tags services whose name starts with `showcase-starter-` as shape='starter'", async () => {
@@ -582,12 +582,12 @@ describe("railwayServicesSource", () => {
     expect(byName["showcase-starter-mastra"]).toBe("starter");
   });
 
-  it("threads ctx.abortSignal into every Railway GraphQL fetch (CR A1)", async () => {
-    // Regression guard: the source previously called the gql helper
-    // without plumbing an abortSignal, so a slow Railway endpoint kept
-    // its sockets open past the invoker's per-tick timeout. This test
-    // captures init.signal on every fetch and asserts the same signal
-    // ctx carries is forwarded.
+  it("threads ctx.abortSignal into every Railway GraphQL fetch", async () => {
+    // Invariant: a slow Railway endpoint must not keep sockets open past
+    // the invoker's per-tick timeout. The source plumbs `ctx.abortSignal`
+    // into every GraphQL round-trip; this test captures `init.signal` on
+    // every fetch and asserts the controller signal ctx carries is the
+    // one the source forwards.
     const captured: Array<AbortSignal | undefined> = [];
     const fetchImpl: typeof fetch = async (_url, init) => {
       captured.push((init as RequestInit | undefined)?.signal ?? undefined);

--- a/showcase/ops/src/probes/discovery/railway-services.test.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { railwayServicesSource } from "./railway-services.js";
+import { describe, it, expect, vi } from "vitest";
+import {
+  classifyShape,
+  railwayServicesSource,
+  resolveShape,
+} from "./railway-services.js";
 import {
   DiscoverySourceAuthError,
   DiscoverySourceBackendError,
@@ -580,6 +584,50 @@ describe("railwayServicesSource", () => {
     expect(byName["showcase-starter-ag2"]).toBe("starter");
     expect(byName["showcase-mastra"]).toBe("package");
     expect(byName["showcase-starter-mastra"]).toBe("starter");
+  });
+
+  // -----------------------------------------------------------------
+  // Audit-warn branch on classifyShape: any `showcase-*` name that is
+  // neither a well-formed `showcase-starter-<slug>` nor a well-formed
+  // package root `showcase-<slug>` (lowercase-alnum-hyphen) falls to
+  // `package` but logs an audit warn. Covers typos like
+  // `showcase-strater-foo`, underscore forms, and future archetypes
+  // that would otherwise silently misclassify.
+  // -----------------------------------------------------------------
+
+  it("classifyShape warns on a `showcase-*` typo name but still returns 'package'", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("showcase-strater-ag2", { logger: { warn } });
+    expect(shape).toBe("package");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "discovery.railway-services.name-shape-unknown",
+      { name: "showcase-strater-ag2" },
+    );
+  });
+
+  it("classifyShape does not warn on a well-formed package root", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("showcase-ag2", { logger: { warn } });
+    expect(shape).toBe("package");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("classifyShape does not warn on a well-formed starter name", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("showcase-starter-ag2", { logger: { warn } });
+    expect(shape).toBe("starter");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("resolveShape debug-logs when neither name nor shape is supplied", () => {
+    const debug = vi.fn();
+    const shape = resolveShape({}, { logger: { debug } });
+    expect(shape).toBe("package");
+    expect(debug).toHaveBeenCalledWith(
+      "discovery.railway-services.resolve-shape-fallback",
+      { reason: "no-name-or-shape" },
+    );
   });
 
   it("threads ctx.abortSignal into every Railway GraphQL fetch", async () => {

--- a/showcase/ops/src/probes/discovery/railway-services.test.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.test.ts
@@ -485,6 +485,103 @@ describe("railwayServicesSource", () => {
     expect(out[0].imageRef).toBe("");
   });
 
+  // -----------------------------------------------------------------
+  // Shape classification: starter vs. package
+  //
+  // Each discovered service is tagged with `shape: "package" | "starter"`
+  // so downstream drivers (smoke, e2e-smoke) can branch on the URL
+  // surface without re-parsing the service name. Starters mount as a
+  // single-app integration at `/` with health at `/api/health`; packages
+  // are the shell-based showcases with `/smoke`, `/health`, and
+  // `/demos/*` routing. Without the field, probes hit `/smoke` on every
+  // starter and produce 17×3 false-red alerts per tick.
+  // -----------------------------------------------------------------
+
+  it("tags services whose name starts with `showcase-starter-` as shape='starter'", async () => {
+    const { fetchImpl } = makeFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse([
+          {
+            id: "s-1",
+            name: "showcase-starter-ag2",
+            image: "ghcr.io/copilotkit/showcase-starter-ag2:latest",
+            domain: "showcase-starter-ag2-production.up.railway.app",
+          },
+        ]),
+      },
+      { status: 200, body: { data: { variables: {} } } },
+    ]);
+    const out = await railwayServicesSource.enumerate(makeCtx(fetchImpl), {});
+    expect(out).toHaveLength(1);
+    expect(out[0].shape).toBe("starter");
+  });
+
+  it("tags non-starter `showcase-*` services as shape='package'", async () => {
+    const { fetchImpl } = makeFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse([
+          {
+            id: "s-1",
+            name: "showcase-langgraph-python",
+            image: "ghcr.io/copilotkit/showcase-langgraph-python:latest",
+            domain: "showcase-langgraph-python.up.railway.app",
+          },
+        ]),
+      },
+      { status: 200, body: { data: { variables: {} } } },
+    ]);
+    const out = await railwayServicesSource.enumerate(makeCtx(fetchImpl), {});
+    expect(out).toHaveLength(1);
+    expect(out[0].shape).toBe("package");
+  });
+
+  it("classifies a mixed batch of starter + package services correctly", async () => {
+    const { fetchImpl } = makeFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse([
+          {
+            id: "s-1",
+            name: "showcase-ag2",
+            image: "ghcr.io/copilotkit/showcase-ag2:latest",
+            domain: "showcase-ag2.up.railway.app",
+          },
+          {
+            id: "s-2",
+            name: "showcase-starter-ag2",
+            image: "ghcr.io/copilotkit/showcase-starter-ag2:latest",
+            domain: "showcase-starter-ag2-production.up.railway.app",
+          },
+          {
+            id: "s-3",
+            name: "showcase-mastra",
+            image: "ghcr.io/copilotkit/showcase-mastra:latest",
+            domain: "showcase-mastra.up.railway.app",
+          },
+          {
+            id: "s-4",
+            name: "showcase-starter-mastra",
+            image: "ghcr.io/copilotkit/showcase-starter-mastra:latest",
+            domain: "showcase-starter-mastra-production.up.railway.app",
+          },
+        ]),
+      },
+      { status: 200, body: { data: { variables: {} } } },
+      { status: 200, body: { data: { variables: {} } } },
+      { status: 200, body: { data: { variables: {} } } },
+      { status: 200, body: { data: { variables: {} } } },
+    ]);
+    const out = await railwayServicesSource.enumerate(makeCtx(fetchImpl), {});
+    expect(out).toHaveLength(4);
+    const byName = Object.fromEntries(out.map((s) => [s.name, s.shape]));
+    expect(byName["showcase-ag2"]).toBe("package");
+    expect(byName["showcase-starter-ag2"]).toBe("starter");
+    expect(byName["showcase-mastra"]).toBe("package");
+    expect(byName["showcase-starter-mastra"]).toBe("starter");
+  });
+
   it("threads ctx.abortSignal into every Railway GraphQL fetch (CR A1)", async () => {
     // Regression guard: the source previously called the gql helper
     // without plumbing an abortSignal, so a slow Railway endpoint kept

--- a/showcase/ops/src/probes/discovery/railway-services.test.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.test.ts
@@ -541,7 +541,13 @@ describe("railwayServicesSource", () => {
     expect(out[0].shape).toBe("package");
   });
 
-  it("classifies a mixed batch of starter + package services correctly", async () => {
+  it("classifies a mixed batch of starter + package services correctly without any warn", async () => {
+    // Regression guard: prior iteration silently produced warns on the
+    // hyphen-bearing package names below. The return-value check is not
+    // enough — we also assert the classifier logger was not invoked,
+    // otherwise the audit warn fires every tick in production.
+    const warn = vi.fn();
+    const ctxLogger = { ...logger, warn };
     const { fetchImpl } = makeFetch([
       {
         status: 200,
@@ -560,9 +566,9 @@ describe("railwayServicesSource", () => {
           },
           {
             id: "s-3",
-            name: "showcase-mastra",
-            image: "ghcr.io/copilotkit/showcase-mastra:latest",
-            domain: "showcase-mastra.up.railway.app",
+            name: "showcase-langgraph-python",
+            image: "ghcr.io/copilotkit/showcase-langgraph-python:latest",
+            domain: "showcase-langgraph-python.up.railway.app",
           },
           {
             id: "s-4",
@@ -577,13 +583,22 @@ describe("railwayServicesSource", () => {
       { status: 200, body: { data: { variables: {} } } },
       { status: 200, body: { data: { variables: {} } } },
     ]);
-    const out = await railwayServicesSource.enumerate(makeCtx(fetchImpl), {});
+    const out = await railwayServicesSource.enumerate(
+      { fetchImpl, logger: ctxLogger, env: BASE_ENV },
+      {},
+    );
     expect(out).toHaveLength(4);
     const byName = Object.fromEntries(out.map((s) => [s.name, s.shape]));
     expect(byName["showcase-ag2"]).toBe("package");
     expect(byName["showcase-starter-ag2"]).toBe("starter");
-    expect(byName["showcase-mastra"]).toBe("package");
+    expect(byName["showcase-langgraph-python"]).toBe("package");
     expect(byName["showcase-starter-mastra"]).toBe("starter");
+    // No name-shape-unknown warn should have fired — every name above
+    // matches either the starter or widened-package regex.
+    const shapeWarns = warn.mock.calls.filter(
+      (c) => c[0] === "discovery.railway-services.name-shape-unknown",
+    );
+    expect(shapeWarns).toHaveLength(0);
   });
 
   // -----------------------------------------------------------------
@@ -595,14 +610,21 @@ describe("railwayServicesSource", () => {
   // that would otherwise silently misclassify.
   // -----------------------------------------------------------------
 
-  it("classifyShape warns on a `showcase-*` typo name but still returns 'package'", () => {
+  it("classifyShape warns on an underscore-form `showcase_starter_*` name but still returns 'package'", () => {
+    // Underscore forms fail both regexes because the package pattern
+    // only allows hyphens. The widened multi-segment package pattern
+    // can no longer distinguish typos that happen to be hyphen-shaped
+    // (`showcase-strater-foo` is now accepted as a valid package name
+    // — indistinguishable from legit multi-segment names like
+    // `showcase-langgraph-python`) so the warn-on-typo assertion
+    // migrates to a structurally-invalid form instead.
     const warn = vi.fn();
-    const shape = classifyShape("showcase-strater-ag2", { logger: { warn } });
+    const shape = classifyShape("showcase_starter_ag2", { logger: { warn } });
     expect(shape).toBe("package");
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       "discovery.railway-services.name-shape-unknown",
-      { name: "showcase-strater-ag2" },
+      { name: "showcase_starter_ag2" },
     );
   });
 
@@ -618,6 +640,70 @@ describe("railwayServicesSource", () => {
     const shape = classifyShape("showcase-starter-ag2", { logger: { warn } });
     expect(shape).toBe("starter");
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  // Hyphen-bearing multi-segment package names. The prior single-segment
+  // regex (`^showcase-[a-z0-9]+$`) rejected these and fired a warn per
+  // tick for real production services. Widened pattern accepts them as
+  // `"package"` without warning.
+  it("classifyShape returns 'package' on `showcase-langgraph-python` without warning", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("showcase-langgraph-python", {
+      logger: { warn },
+    });
+    expect(shape).toBe("package");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("classifyShape returns 'package' on `showcase-claude-sdk-typescript` without warning", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("showcase-claude-sdk-typescript", {
+      logger: { warn },
+    });
+    expect(shape).toBe("package");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("classifyShape returns 'package' on `showcase-ms-agent-dotnet` without warning", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("showcase-ms-agent-dotnet", {
+      logger: { warn },
+    });
+    expect(shape).toBe("package");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // Non-`showcase-*` names also trip the warn. A Railway service renamed
+  // to drop the prefix, or an unrelated workload picked up by discovery,
+  // otherwise silently gets the package contract and floods /smoke 404s.
+  it("classifyShape warns on a non-`showcase-*` name but still returns 'package'", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("my-random-service", { logger: { warn } });
+    expect(shape).toBe("package");
+    expect(warn).toHaveBeenCalledWith(
+      "discovery.railway-services.name-shape-unknown",
+      { name: "my-random-service" },
+    );
+  });
+
+  it("classifyShape warns on a `copilotkit-*` workload name but still returns 'package'", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("copilotkit-cloud", { logger: { warn } });
+    expect(shape).toBe("package");
+    expect(warn).toHaveBeenCalledWith(
+      "discovery.railway-services.name-shape-unknown",
+      { name: "copilotkit-cloud" },
+    );
+  });
+
+  it("classifyShape warns on a mixed-case `showcase-*` name but still returns 'package'", () => {
+    const warn = vi.fn();
+    const shape = classifyShape("ShowCase-Ag2", { logger: { warn } });
+    expect(shape).toBe("package");
+    expect(warn).toHaveBeenCalledWith(
+      "discovery.railway-services.name-shape-unknown",
+      { name: "ShowCase-Ag2" },
+    );
   });
 
   it("resolveShape debug-logs when neither name nor shape is supplied", () => {

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -39,11 +39,54 @@ import {
  * behaviour of the legacy adapter in `orchestrator.ts`.
  */
 
+/**
+ * Service shape — distinguishes the two deployment archetypes that share
+ * the `showcase-*` naming scheme on Railway but have wildly different URL
+ * surfaces. Drivers branch on this field to pick the right probe contract
+ * (see `drivers/smoke.ts` and `drivers/e2e-smoke.ts`).
+ *
+ *   - `package`  Shell-based showcases (`showcase-ag2`, `showcase-mastra`,
+ *                ...). They expose `/smoke`, `/health`, `/demos/*`, and
+ *                `/api/copilotkit/` as distinct routes.
+ *   - `starter`  Single-app integrations deployed from
+ *                `showcase/starters/*` (Railway service name pattern
+ *                `showcase-starter-*`). They mount the integration at
+ *                `/`, health at `/api/health`, and have NO `/smoke` or
+ *                `/demos/*` routing.
+ *
+ * Classification is derived from the Railway service name, so adding a
+ * new starter requires no YAML edit — the next tick picks it up with
+ * `shape: "starter"` automatically.
+ */
+export type ShowcaseServiceShape = "package" | "starter";
+
 export interface RailwayServiceInfo {
   name: string;
   imageRef: string;
   publicUrl: string;
   env: Record<string, string>;
+  /**
+   * Deployment archetype, classified from the service name. Drivers
+   * that probe per-service URLs branch on this field to pick the right
+   * contract (starter: `/api/health` + skip `/smoke` + skip `/demos/*`;
+   * package: legacy `/smoke` + `/health` + `/demos/*`).
+   */
+  shape: ShowcaseServiceShape;
+}
+
+/**
+ * Classify a Railway service name into a `ShowcaseServiceShape`. Exported
+ * so tests can exercise the classifier directly and downstream drivers
+ * can reclassify from a bare name when the discovery record wasn't
+ * threaded through (static-YAML callers). The rule is deliberately tight:
+ * ONLY the literal `showcase-starter-` prefix is classified as starter.
+ * Everything else — `showcase-ag2`, `showcase-shell`, `some-other-svc` —
+ * falls to `package`. Keeping the rule a simple prefix check keeps it
+ * auditable in the YAML comments and matches the 17 starter Railway
+ * service names 1:1.
+ */
+export function classifyShape(name: string): ShowcaseServiceShape {
+  return name.startsWith("showcase-starter-") ? "starter" : "package";
 }
 
 const FilterSchema = z
@@ -245,7 +288,13 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
         });
       }
 
-      out.push({ name: svc.name, imageRef, publicUrl, env });
+      out.push({
+        name: svc.name,
+        imageRef,
+        publicUrl,
+        env,
+        shape: classifyShape(svc.name),
+      });
     }
     return out;
   },

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -57,8 +57,15 @@ import {
  * Classification is derived from the Railway service name, so adding a
  * new starter requires no YAML edit — the next tick picks it up with
  * `shape: "starter"` automatically.
+ *
+ * Single-source tuple: the driver schemas import `showcaseShapeSchema`
+ * below so every consumer of `shape` shares the exact enum — adding a new
+ * archetype (e.g. `static`) is a one-line edit here plus a matching
+ * classifier branch, not a cross-file ripple.
  */
-export type ShowcaseServiceShape = "package" | "starter";
+export const SHOWCASE_SHAPES = ["package", "starter"] as const;
+export type ShowcaseServiceShape = (typeof SHOWCASE_SHAPES)[number];
+export const showcaseShapeSchema = z.enum(SHOWCASE_SHAPES);
 
 export interface RailwayServiceInfo {
   name: string;
@@ -82,11 +89,33 @@ export interface RailwayServiceInfo {
  * ONLY the literal `showcase-starter-` prefix is classified as starter.
  * Everything else — `showcase-ag2`, `showcase-shell`, `some-other-svc` —
  * falls to `package`. Keeping the rule a simple prefix check keeps it
- * auditable in the YAML comments and matches the 17 starter Railway
- * service names 1:1.
+ * auditable in the YAML comments.
+ *
+ * Ambiguity warning: when a name matches the `showcase-` umbrella but
+ * doesn't match either archetype pattern cleanly (i.e. `showcase-foo`
+ * where `foo` isn't a known package slug and isn't prefixed `starter-`),
+ * we cannot tell from the name alone whether it's a new package or a
+ * mis-named starter. Default to `package` (safe — probes the legacy
+ * `/smoke` + `/health` surface which most new services support) but emit
+ * a one-shot audit warning via `opts.logger` when supplied so operators
+ * adding a new archetype see the nudge on the first tick.
  */
-export function classifyShape(name: string): ShowcaseServiceShape {
-  return name.startsWith("showcase-starter-") ? "starter" : "package";
+export function classifyShape(
+  name: string,
+  opts: {
+    logger?: {
+      warn: (msg: string, meta?: Record<string, unknown>) => void;
+    };
+  } = {},
+): ShowcaseServiceShape {
+  if (name.startsWith("showcase-starter-")) return "starter";
+  // Umbrella-match but not an obvious package: the bare `showcase-` with
+  // no further segment, or the literal `showcase-starter` with no trailing
+  // slug. Both are likely wiring typos on a new service.
+  if (name === "showcase-" || name === "showcase-starter") {
+    opts.logger?.warn("railway.name_shape_unknown", { name });
+  }
+  return "package";
 }
 
 const FilterSchema = z
@@ -293,7 +322,7 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
         imageRef,
         publicUrl,
         env,
-        shape: classifyShape(svc.name),
+        shape: classifyShape(svc.name, { logger: ctx.logger }),
       });
     }
     return out;

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -95,34 +95,38 @@ interface ShapeLogger {
  * Classify a Railway service name into a `ShowcaseServiceShape`. Exported
  * so tests can exercise the classifier directly and downstream drivers
  * can reclassify from a bare name when the discovery record wasn't
- * threaded through (static-YAML callers). The rule is deliberately tight:
- * ONLY the literal `showcase-starter-<slug>` pattern is classified as
- * starter. A well-formed package root matches `showcase-<slug>` with
- * lowercase, digits, and hyphens. Anything that starts with `showcase-`
- * but fits neither pattern (typos like `showcase-strater-foo`,
- * `showcase_starter_bar`, future archetypes like `showcase-static-landing`)
- * still returns `"package"` as a safe default but emits an audit warn via
- * `opts.logger?.warn` so operators adding a new archetype see the nudge
- * on the first tick. That was the original fall-through path that
- * produced the false-red flood this contract exists to eliminate.
+ * threaded through (static-YAML callers). The rule set:
+ *   - `showcase-starter-<slug>` → `"starter"`.
+ *   - `showcase-<slug>` where `<slug>` is lowercase-alphanumeric plus
+ *     hyphens (multi-segment names like `showcase-langgraph-python`,
+ *     `showcase-claude-sdk-typescript`, `showcase-ms-agent-dotnet`) →
+ *     `"package"`. The earlier single-segment regex misclassified every
+ *     hyphen-bearing package as unknown and fired a warn per tick on
+ *     real production services.
+ *   - Any other name — typos like `showcase-strater-foo`, mixed case,
+ *     or unrelated workloads (`copilotkit-cloud`, `my-random-service`)
+ *     — still returns `"package"` as a safe default but emits an audit
+ *     warn via `opts.logger?.warn`. That preserves the fall-through
+ *     behaviour while alerting operators on drift (renamed service,
+ *     unrelated workload picked up by discovery) on the first tick.
  */
 export function classifyShape(
   name: string,
   opts: { logger?: ShapeLogger } = {},
 ): ShowcaseServiceShape {
   if (/^showcase-starter-[a-z0-9-]+$/.test(name)) return "starter";
-  // Well-formed package root = `showcase-<single-segment lowercase alnum>`.
-  // The spec deliberately excludes hyphen-bearing suffixes from the
-  // "known-package" shape so multi-segment names (`showcase-langgraph-
-  // python`, `showcase-static-landing`) land in the warn branch as an
-  // audit nudge. Returning `"package"` either way keeps behaviour
-  // backwards-compatible; the warn is purely advisory.
-  if (/^showcase-[a-z0-9]+$/.test(name)) return "package";
-  if (name.startsWith("showcase-")) {
-    opts.logger?.warn?.("discovery.railway-services.name-shape-unknown", {
-      name,
-    });
-  }
+  // Widened package regex: starts with `showcase-`, not followed by
+  // `starter-` (that path is the branch above), then lowercase-alnum
+  // plus hyphens. Accepts `showcase-ag2`, `showcase-langgraph-python`,
+  // `showcase-claude-sdk-typescript`, etc. without firing a warn.
+  if (/^showcase-(?!starter-)[a-z0-9][a-z0-9-]*$/.test(name)) return "package";
+  // Everything else — a `showcase-*` typo, a mixed-case variant, or a
+  // name that doesn't start with `showcase-` at all — gets a warn. The
+  // return value stays `"package"` so downstream drivers keep
+  // operating; the warn is the audit trail.
+  opts.logger?.warn?.("discovery.railway-services.name-shape-unknown", {
+    name,
+  });
   return "package";
 }
 

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -63,9 +63,8 @@ import {
  * archetype (e.g. `static`) is a one-line edit here plus a matching
  * classifier branch, not a cross-file ripple.
  */
-export const SHOWCASE_SHAPES = ["package", "starter"] as const;
-export type ShowcaseServiceShape = (typeof SHOWCASE_SHAPES)[number];
-export const showcaseShapeSchema = z.enum(SHOWCASE_SHAPES);
+export const showcaseShapeSchema = z.enum(["package", "starter"]);
+export type ShowcaseServiceShape = z.infer<typeof showcaseShapeSchema>;
 
 export interface RailwayServiceInfo {
   name: string;
@@ -82,39 +81,77 @@ export interface RailwayServiceInfo {
 }
 
 /**
+ * Minimal logger surface used by shape helpers. A structural subset of
+ * the orchestrator's `Logger` — kept local so `classifyShape` /
+ * `resolveShape` can accept ad-hoc test loggers without importing the
+ * full `Logger` type tree.
+ */
+interface ShapeLogger {
+  warn?: (msg: string, meta?: Record<string, unknown>) => void;
+  debug?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+/**
  * Classify a Railway service name into a `ShowcaseServiceShape`. Exported
  * so tests can exercise the classifier directly and downstream drivers
  * can reclassify from a bare name when the discovery record wasn't
  * threaded through (static-YAML callers). The rule is deliberately tight:
- * ONLY the literal `showcase-starter-` prefix is classified as starter.
- * Everything else — `showcase-ag2`, `showcase-shell`, `some-other-svc` —
- * falls to `package`. Keeping the rule a simple prefix check keeps it
- * auditable in the YAML comments.
- *
- * Ambiguity warning: when a name matches the `showcase-` umbrella but
- * doesn't match either archetype pattern cleanly (i.e. `showcase-foo`
- * where `foo` isn't a known package slug and isn't prefixed `starter-`),
- * we cannot tell from the name alone whether it's a new package or a
- * mis-named starter. Default to `package` (safe — probes the legacy
- * `/smoke` + `/health` surface which most new services support) but emit
- * a one-shot audit warning via `opts.logger` when supplied so operators
- * adding a new archetype see the nudge on the first tick.
+ * ONLY the literal `showcase-starter-<slug>` pattern is classified as
+ * starter. A well-formed package root matches `showcase-<slug>` with
+ * lowercase, digits, and hyphens. Anything that starts with `showcase-`
+ * but fits neither pattern (typos like `showcase-strater-foo`,
+ * `showcase_starter_bar`, future archetypes like `showcase-static-landing`)
+ * still returns `"package"` as a safe default but emits an audit warn via
+ * `opts.logger?.warn` so operators adding a new archetype see the nudge
+ * on the first tick. That was the original fall-through path that
+ * produced the false-red flood this contract exists to eliminate.
  */
 export function classifyShape(
   name: string,
-  opts: {
-    logger?: {
-      warn: (msg: string, meta?: Record<string, unknown>) => void;
-    };
-  } = {},
+  opts: { logger?: ShapeLogger } = {},
 ): ShowcaseServiceShape {
-  if (name.startsWith("showcase-starter-")) return "starter";
-  // Umbrella-match but not an obvious package: the bare `showcase-` with
-  // no further segment, or the literal `showcase-starter` with no trailing
-  // slug. Both are likely wiring typos on a new service.
-  if (name === "showcase-" || name === "showcase-starter") {
-    opts.logger?.warn("railway.name_shape_unknown", { name });
+  if (/^showcase-starter-[a-z0-9-]+$/.test(name)) return "starter";
+  // Well-formed package root = `showcase-<single-segment lowercase alnum>`.
+  // The spec deliberately excludes hyphen-bearing suffixes from the
+  // "known-package" shape so multi-segment names (`showcase-langgraph-
+  // python`, `showcase-static-landing`) land in the warn branch as an
+  // audit nudge. Returning `"package"` either way keeps behaviour
+  // backwards-compatible; the warn is purely advisory.
+  if (/^showcase-[a-z0-9]+$/.test(name)) return "package";
+  if (name.startsWith("showcase-")) {
+    opts.logger?.warn?.("discovery.railway-services.name-shape-unknown", {
+      name,
+    });
   }
+  return "package";
+}
+
+/**
+ * Resolve the deployment shape for a driver invocation. Classifier wins
+ * when `name` is present — silent defaulting at the driver boundary
+ * inverts the fix this contract exists to make, so we throw on any
+ * explicit-vs-classifier disagreement rather than pick one. When `name`
+ * is absent, honour the caller-supplied `shape` verbatim. When neither
+ * is present, fall back to `package` and log a debug entry so the
+ * assumption is greppable if it ever breaks.
+ */
+export function resolveShape(
+  input: { name?: string; shape?: ShowcaseServiceShape },
+  opts: { logger?: ShapeLogger } = {},
+): ShowcaseServiceShape {
+  if (input.name) {
+    const classified = classifyShape(input.name, { logger: opts.logger });
+    if (input.shape && input.shape !== classified) {
+      throw new Error(
+        `Shape mismatch: classifier="${classified}" input="${input.shape}" — check discovery wiring`,
+      );
+    }
+    return classified;
+  }
+  if (input.shape) return input.shape;
+  opts.logger?.debug?.("discovery.railway-services.resolve-shape-fallback", {
+    reason: "no-name-or-shape",
+  });
   return "package";
 }
 

--- a/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
@@ -422,6 +422,104 @@ describe("e2eSmokeDriver side-emits", () => {
   });
 });
 
+// --- Starter shape: skip L3/L4 ---------------------------------------
+//
+// Starters are single-app integrations deployed from showcase/starters/*;
+// they mount at `/` with no `/demos/*` routing. Running L3/L4 against a
+// starter would 404 the navigation step and produce false-red alerts on
+// every tick. The driver must detect `shape === "starter"` (from the
+// discovery source) and skip both levels with explicit `l3/l4: "skipped"`
+// rather than silently producing a red page-error. This also avoids the
+// registry-lookup path (starters aren't keyed in registry.json).
+
+describe("e2eSmokeDriver starter shape", () => {
+  it("aggregate green-skipped when shape='starter' — L3 and L4 both skipped", async () => {
+    // The fake browser is never used, but we still wire it in to verify
+    // the driver short-circuits BEFORE launching chromium (no newContext
+    // calls, no pages opened).
+    const { browser, state } = makeBrowser([]);
+    const driver = createE2eSmokeDriver({ launcher: async () => browser });
+    const writer = new CapturingWriter();
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      backendUrl: "https://showcase-starter-ag2-production.up.railway.app",
+      shape: "starter",
+    });
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eSmokeSignal;
+    expect(sig.l3).toBe("skipped");
+    expect(sig.l4).toBe("skipped");
+    // Zero chromium contexts opened — shape check happens before launch.
+    expect(state.contextsOpened).toBe(0);
+    // No side-emits written for skipped levels so dashboards don't count
+    // them as flaps; operators reading the primary aggregate see the
+    // explicit `skipped` state.
+    expect(writer.results).toHaveLength(0);
+  });
+
+  it("starter shape: never navigates to /demos/* (no registry lookup needed)", async () => {
+    // Regression guard: the pre-fix driver navigated to
+    // `${backendUrl}/demos/agentic-chat` for every discovered service.
+    // On a starter (no /demos/* routing) that fires a 404 and flips the
+    // row red. We assert the driver never asks for a new page — it
+    // short-circuits on shape BEFORE any page.goto() call.
+    let gotoCalled = false;
+    const scriptedBrowser: E2eBrowser = {
+      async newContext(): Promise<E2eBrowserContext> {
+        return {
+          async newPage(): Promise<E2ePage> {
+            return {
+              async goto() {
+                gotoCalled = true;
+                throw new Error("should not be called on starter shape");
+              },
+              async type() {},
+              async press() {},
+              async waitForSelector() {},
+              async textContent() {
+                return "";
+              },
+              async close() {},
+            };
+          },
+          async close() {},
+        };
+      },
+      async close() {},
+    };
+    const driver = createE2eSmokeDriver({
+      launcher: async () => scriptedBrowser,
+    });
+    await driver.run(baseCtx(), {
+      key: "e2e-smoke:starter-mastra",
+      name: "showcase-starter-mastra",
+      backendUrl: "https://showcase-starter-mastra-production.up.railway.app",
+      shape: "starter",
+    });
+    expect(gotoCalled).toBe(false);
+  });
+
+  it("starter shape: in-band `demos` field is ignored (starters have no /demos/*)", async () => {
+    // Even if an operator accidentally passes demos in the YAML for a
+    // starter, the driver must honour the shape flag and skip — shape
+    // wins over demos.
+    const { browser, state } = makeBrowser([]);
+    const driver = createE2eSmokeDriver({ launcher: async () => browser });
+    const result = await driver.run(baseCtx(), {
+      key: "e2e-smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      backendUrl: "https://showcase-starter-ag2-production.up.railway.app",
+      shape: "starter",
+      demos: ["agentic-chat", "tool-rendering"],
+    });
+    const sig = result.signal as E2eSmokeSignal;
+    expect(sig.l3).toBe("skipped");
+    expect(sig.l4).toBe("skipped");
+    expect(state.contextsOpened).toBe(0);
+  });
+});
+
 describe("e2eSmokeDriver module export", () => {
   it("module-level e2eSmokeDriver has kind === 'e2e_smoke'", () => {
     expect(e2eSmokeDriver.kind).toBe("e2e_smoke");

--- a/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
@@ -454,10 +454,8 @@ describe("e2eSmokeDriver starter shape", () => {
     // Full signal contract — exhaustive field check so a regression that
     // drops any field fails this test. Narrow via the discriminator so
     // TS surfaces missing fields at compile time too.
-    const sig = result.signal as E2eSmokeSignal;
-    expect(sig.shape).toBe("starter");
-    if (sig.shape !== "starter") throw new Error("unreachable");
-    const starterSig: E2eSmokeStarterSignal = sig;
+    const starterSig = result.signal as E2eSmokeStarterSignal;
+    expect(starterSig.shape).toBe("starter");
     expect(starterSig.slug).toBe("starter-ag2");
     expect(starterSig.backendUrl).toBe(
       "https://showcase-starter-ag2-production.up.railway.app",
@@ -465,6 +463,7 @@ describe("e2eSmokeDriver starter shape", () => {
     expect(starterSig.l3).toBe("skipped");
     expect(starterSig.l4).toBe("skipped");
     expect(starterSig.failureSummary).toBe("");
+    expect(starterSig.skipReason).toBe("starter-shape");
     expect(starterSig.note).toBe("starter: no /demos/* routing");
     // errorDesc MUST NOT exist on a green-starter row — alert templates
     // render errorDesc as failure reason and surfacing one on green
@@ -505,7 +504,7 @@ describe("e2eSmokeDriver starter shape", () => {
   });
 
   it("shape-mismatch throws: explicit input.shape disagrees with classifier", async () => {
-    // C1: silent-defaulting at the driver boundary inverts the fix.
+    // Silent-defaulting at the driver boundary inverts the fix.
     // Passing shape='package' with a `showcase-starter-*` name must fail
     // loud so silent drift between discovery and driver is unmissable.
     const { browser } = makeBrowser([{ assistantText: "Hi" }]);

--- a/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
@@ -6,7 +6,9 @@ import {
   type E2eBrowserContext,
   type E2ePage,
   type E2eSmokeLevelSignal,
+  type E2eSmokePackageSignal,
   type E2eSmokeSignal,
+  type E2eSmokeStarterSignal,
 } from "./e2e-smoke.js";
 import { logger } from "../../logger.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
@@ -325,8 +327,9 @@ describe("e2eSmokeDriver error paths", () => {
       backendUrl: "https://x.example.com",
       demos: ["tool-rendering"],
     });
-    const sig = result.signal as E2eSmokeSignal;
+    const sig = result.signal as E2eSmokePackageSignal;
     expect(result.state).toBe("red");
+    expect(sig.shape).toBe("package");
     expect(sig.errorDesc).toBe("launcher-error");
     expect(sig.l3).toBe("red");
     expect(sig.l4).toBe("red");
@@ -343,7 +346,7 @@ describe("e2eSmokeDriver error paths", () => {
       backendUrl: "https://x.example.com",
     });
     expect(result.state).toBe("red");
-    const sig = result.signal as E2eSmokeSignal;
+    const sig = result.signal as E2eSmokePackageSignal;
     expect(sig.failureSummary).toMatch(/ERR_CONNECTION_REFUSED/);
   });
 
@@ -351,8 +354,8 @@ describe("e2eSmokeDriver error paths", () => {
     // Hanging launcher: resolves only when its AbortSignal fires (which
     // it will, from the driver's hard-timeout). Ensures the driver maps
     // the abort into `errorDesc: "timeout"` rather than masquerading as
-    // `launcher-error`. Tests the Procedure 0 fail-loud distinction
-    // between "chromium missing" and "remote stack slow".
+    // `launcher-error` — the user-facing distinction matters: "chromium
+    // missing" and "remote stack slow" need separate alert routing.
     let rejectLauncher: ((err: Error) => void) | undefined;
     const launcher = async (): Promise<E2eBrowser> =>
       await new Promise<E2eBrowser>((_res, rej) => {
@@ -372,7 +375,8 @@ describe("e2eSmokeDriver error paths", () => {
     setTimeout(() => rejectLauncher?.(new Error("launcher aborted")), 60);
     const result = await p;
     expect(result.state).toBe("red");
-    const sig = result.signal as E2eSmokeSignal;
+    const sig = result.signal as E2eSmokePackageSignal;
+    expect(sig.shape).toBe("package");
     expect(sig.errorDesc).toBe("timeout");
     expect(sig.failureSummary).toMatch(/timeout after/);
   });
@@ -433,7 +437,7 @@ describe("e2eSmokeDriver side-emits", () => {
 // registry-lookup path (starters aren't keyed in registry.json).
 
 describe("e2eSmokeDriver starter shape", () => {
-  it("aggregate green-skipped when shape='starter' — L3 and L4 both skipped", async () => {
+  it("aggregate green-skipped when shape='starter' — full signal contract locked in", async () => {
     // The fake browser is never used, but we still wire it in to verify
     // the driver short-circuits BEFORE launching chromium (no newContext
     // calls, no pages opened).
@@ -447,15 +451,73 @@ describe("e2eSmokeDriver starter shape", () => {
       shape: "starter",
     });
     expect(result.state).toBe("green");
+    // Full signal contract — exhaustive field check so a regression that
+    // drops any field fails this test. Narrow via the discriminator so
+    // TS surfaces missing fields at compile time too.
     const sig = result.signal as E2eSmokeSignal;
-    expect(sig.l3).toBe("skipped");
-    expect(sig.l4).toBe("skipped");
+    expect(sig.shape).toBe("starter");
+    if (sig.shape !== "starter") throw new Error("unreachable");
+    const starterSig: E2eSmokeStarterSignal = sig;
+    expect(starterSig.slug).toBe("starter-ag2");
+    expect(starterSig.backendUrl).toBe(
+      "https://showcase-starter-ag2-production.up.railway.app",
+    );
+    expect(starterSig.l3).toBe("skipped");
+    expect(starterSig.l4).toBe("skipped");
+    expect(starterSig.failureSummary).toBe("");
+    expect(starterSig.note).toBe("starter: no /demos/* routing");
+    // errorDesc MUST NOT exist on a green-starter row — alert templates
+    // render errorDesc as failure reason and surfacing one on green
+    // would flap red in downstream views.
+    expect(
+      (starterSig as unknown as { errorDesc?: unknown }).errorDesc,
+    ).toBeUndefined();
     // Zero chromium contexts opened — shape check happens before launch.
     expect(state.contextsOpened).toBe(0);
     // No side-emits written for skipped levels so dashboards don't count
     // them as flaps; operators reading the primary aggregate see the
     // explicit `skipped` state.
     expect(writer.results).toHaveLength(0);
+  });
+
+  it("starter short-circuit runs BEFORE demos resolver — throwing resolver doesn't surface", async () => {
+    // Locks in the ordering: shape check → return, without ever calling
+    // the demos resolver. A refactor that moves the shape check below
+    // the resolver lookup would let registry outages surface as false
+    // reds on starters — this test catches that.
+    const { browser } = makeBrowser([]);
+    const throwingResolver = (): Promise<string[]> => {
+      throw new Error("registry.json missing — should not be called");
+    };
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser,
+      demosResolver: throwingResolver,
+    });
+    const result = await driver.run(baseCtx(), {
+      key: "e2e-smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      backendUrl: "https://showcase-starter-ag2-production.up.railway.app",
+      shape: "starter",
+    });
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eSmokeSignal;
+    expect(sig.shape).toBe("starter");
+  });
+
+  it("shape-mismatch throws: explicit input.shape disagrees with classifier", async () => {
+    // C1: silent-defaulting at the driver boundary inverts the fix.
+    // Passing shape='package' with a `showcase-starter-*` name must fail
+    // loud so silent drift between discovery and driver is unmissable.
+    const { browser } = makeBrowser([{ assistantText: "Hi" }]);
+    const driver = createE2eSmokeDriver({ launcher: async () => browser });
+    await expect(
+      driver.run(baseCtx(), {
+        key: "e2e-smoke:starter-ag2",
+        name: "showcase-starter-ag2",
+        backendUrl: "https://showcase-starter-ag2.up.railway.app",
+        shape: "package",
+      }),
+    ).rejects.toThrow(/Shape mismatch/);
   });
 
   it("starter shape: never navigates to /demos/* (no registry lookup needed)", async () => {

--- a/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
@@ -581,6 +581,68 @@ describe("e2eSmokeDriver starter shape", () => {
   });
 });
 
+// --- Package-shape slug + registry lookup ------------------------------
+//
+// Starters short-circuit before the demosResolver runs, so the package
+// path is the only one that exercises slug-derivation-feeding-registry.
+// A regression that breaks the slug (e.g. leaves `showcase-` on the front)
+// would yield `hasToolRendering === false` silently and skip every L4
+// row. These tests pin the end-to-end flow.
+
+describe("e2eSmokeDriver package shape: deriveSlug + demosResolver", () => {
+  it("calls demosResolver with the stripped slug for a `showcase-<multi-seg>` name", async () => {
+    const resolverCalls: string[] = [];
+    const { browser } = makeBrowser([
+      { assistantText: "Hi" },
+      { assistantText: "San Francisco is sunny." },
+    ]);
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser,
+      demosResolver: async (slug) => {
+        resolverCalls.push(slug);
+        return ["agentic-chat", "tool-rendering"];
+      },
+    });
+    const result = await driver.run(baseCtx(), {
+      key: "e2e-smoke:showcase-langgraph-python",
+      name: "showcase-langgraph-python",
+      backendUrl: "https://x.example.com",
+      shape: "package",
+    });
+    // Regression guard: the slug passed to demosResolver must be the
+    // registry-keyed form (`langgraph-python`), not `showcase-langgraph-
+    // python` and not a double-stripped `starter-<slug>` artefact.
+    expect(resolverCalls).toEqual(["langgraph-python"]);
+    const sig = result.signal as E2eSmokePackageSignal;
+    expect(sig.l4).toBe("green");
+  });
+
+  it("package shape + throwing demosResolver → L4 skipped, driver continues with demos=[]", async () => {
+    // Pins current swallow behavior: the orchestrator deferred changing
+    // it; this test locks the existing contract so a future refactor
+    // can't silently switch to surfacing the throw without an intentional
+    // update here. L3 still runs; L4 is "skipped" because demos=[] ⇒ no
+    // tool-rendering entry.
+    const { browser } = makeBrowser([{ assistantText: "Hi" }]);
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser,
+      demosResolver: async () => {
+        throw new Error("registry.json missing");
+      },
+    });
+    const result = await driver.run(baseCtx(), {
+      key: "e2e-smoke:showcase-langgraph-python",
+      name: "showcase-langgraph-python",
+      backendUrl: "https://x.example.com",
+      shape: "package",
+    });
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eSmokePackageSignal;
+    expect(sig.l3).toBe("green");
+    expect(sig.l4).toBe("skipped");
+  });
+});
+
 describe("e2eSmokeDriver module export", () => {
   it("module-level e2eSmokeDriver has kind === 'e2e_smoke'", () => {
     expect(e2eSmokeDriver.kind).toBe("e2e_smoke");

--- a/showcase/ops/src/probes/drivers/e2e-smoke.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.ts
@@ -3,9 +3,8 @@ import path from "node:path";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
 import {
-  classifyShape,
+  resolveShape,
   showcaseShapeSchema,
-  type ShowcaseServiceShape,
 } from "../discovery/railway-services.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
@@ -111,8 +110,24 @@ export interface E2eSmokeStarterSignal {
   l3: "skipped";
   l4: "skipped";
   failureSummary: "";
+  /**
+   * Enum literal pinning the structural reason the level was skipped.
+   * Separate from `note` so downstream consumers can branch on a stable
+   * discriminator instead of parsing prose. Extend when a new skip
+   * reason lands.
+   */
+  skipReason: "starter-shape";
   /** Human-readable explanation of WHY the level was skipped. Never rendered as a failure reason. */
   note: string;
+  /**
+   * Starter rows MUST NOT carry a failure reason — alert templates
+   * render `errorDesc` as the red-tick summary and surfacing one on a
+   * skipped-green row would flap red in downstream views. `?: never`
+   * turns that invariant into a compile error, so a future path that
+   * sets errorDesc on a starter fails tsc rather than slipping into
+   * prod silently.
+   */
+  errorDesc?: never;
 }
 
 export interface E2eSmokePackageSignal {
@@ -334,7 +349,10 @@ export function createE2eSmokeDriver(
       // Schema already guaranteed at least one is present.
       const backendUrl = (input.backendUrl ?? input.publicUrl)!;
       const slug = deriveSlug(input.key, input.name);
-      const shape = resolveShape(input);
+      const shape = resolveShape(
+        { name: input.name, shape: input.shape },
+        { logger: ctx.logger },
+      );
 
       // Starter short-circuit — runs BEFORE chromium launch AND BEFORE
       // demos resolution so a broken registry / missing chromium image
@@ -351,6 +369,7 @@ export function createE2eSmokeDriver(
             l3: "skipped",
             l4: "skipped",
             failureSummary: "",
+            skipReason: "starter-shape",
             note: "starter: no /demos/* routing",
           },
           observedAt,
@@ -760,27 +779,6 @@ async function runLevel(opts: {
  *      slug cleanly).
  *   3. The whole key as-is (fallback).
  */
-/**
- * Resolve the deployment shape for a driver invocation. Mirrors the
- * smoke driver's resolver: classifier wins when `input.name` is present
- * and throws on explicit-vs-classifier disagreement; honour
- * `input.shape` only when the classifier has no `name` to work with.
- * Fallback is `package` so the legacy Playwright-against-/demos/* path
- * remains the default for hand-authored YAML.
- */
-function resolveShape(input: E2eSmokeDriverInput): ShowcaseServiceShape {
-  if (input.name) {
-    const classified = classifyShape(input.name);
-    if (input.shape && input.shape !== classified) {
-      throw new Error(
-        `Shape mismatch: classifier="${classified}" input="${input.shape}" — check discovery wiring`,
-      );
-    }
-    return classified;
-  }
-  return input.shape ?? "package";
-}
-
 function deriveSlug(key: string, name?: string): string {
   const parts = key.split(":");
   let raw: string;

--- a/showcase/ops/src/probes/drivers/e2e-smoke.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.ts
@@ -2,6 +2,11 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
+import {
+  classifyShape,
+  showcaseShapeSchema,
+  type ShowcaseServiceShape,
+} from "../discovery/railway-services.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -58,11 +63,16 @@ const inputSchema = z
      * Deployment shape tag from the discovery source. Starters are
      * single-app integrations with NO `/demos/*` routing, so L3/L4 is
      * skipped entirely on `shape === "starter"` — they would otherwise
-     * produce 17 × 2 = 34 false-red `chat:<slug>` / `tools:<slug>`
-     * alerts per tick. Package shape (default) keeps the legacy
+     * produce one false-red `chat:<slug>` and one false-red
+     * `tools:<slug>` row per starter per tick. Package shape keeps the
      * Playwright-against-/demos/* behaviour.
+     *
+     * Optional in the schema so static-YAML callers can pre-pin shape
+     * explicitly; when absent in discovery-mode input the driver
+     * reclassifies from `input.name` at run() entry. Explicit values
+     * that disagree with the classifier cause run() to throw.
      */
-    shape: z.enum(["package", "starter"]).optional(),
+    shape: showcaseShapeSchema.optional(),
   })
   .passthrough()
   .refine((v) => !!(v.backendUrl ?? v.publicUrl), {
@@ -73,23 +83,49 @@ const inputSchema = z
 type E2eSmokeDriverInput = z.infer<typeof inputSchema>;
 
 /**
- * Aggregate signal shape for the primary `e2e-smoke:<slug>` result. Each
- * level's outcome is carried so alert templates can render per-level
- * failure detail without round-tripping back to the status store.
+ * Aggregate signal shape for the primary `e2e-smoke:<slug>` result.
+ * Discriminated on `shape` so downstream consumers can exhaustively
+ * switch without guessing which field combinations mean what.
+ *
+ *   - `shape: "starter"` — the driver short-circuited before launching
+ *     chromium; `l3` and `l4` are both literally `"skipped"` and a
+ *     `note` field carries the human-readable reason. Rows are always
+ *     `state: "green"` for this variant, so the signal MUST NOT carry
+ *     an `errorDesc` — alert templates render `errorDesc` as the
+ *     failure reason and surfacing one on a green row would flap red
+ *     in downstream views.
+ *
+ *   - `shape: "package"` — the driver ran Playwright against
+ *     `/demos/*`. `l3` is `green` or `red`; `l4` can also be `skipped`
+ *     when the registry entry has no `tool-rendering` demo. A red row
+ *     may carry an `errorDesc` keyed to the failure class
+ *     (`launcher-error`, `timeout`, `driver-error`, or absent when the
+ *     failure lives in `failureSummary`).
  */
-export interface E2eSmokeSignal {
+export type E2eSmokeSignal = E2eSmokeStarterSignal | E2eSmokePackageSignal;
+
+export interface E2eSmokeStarterSignal {
+  shape: "starter";
+  slug: string;
+  backendUrl: string;
+  l3: "skipped";
+  l4: "skipped";
+  failureSummary: "";
+  /** Human-readable explanation of WHY the level was skipped. Never rendered as a failure reason. */
+  note: string;
+}
+
+export interface E2eSmokePackageSignal {
+  shape: "package";
   slug: string;
   backendUrl: string;
   /**
    * Per-level outcome.
    *   - "green" / "red"  standard probe result
-   *   - "skipped"        the level did not run. For L3 this only
-   *                      happens under `shape === "starter"` (single-app
-   *                      integrations with no `/demos/*` routing). For
-   *                      L4 it also happens when the registry entry has
-   *                      no `tool-rendering` demo.
+   *   - "skipped"        L4 only — set when the registry entry has no
+   *                      `tool-rendering` demo.
    */
-  l3: "green" | "red" | "skipped";
+  l3: "green" | "red";
   l4: "green" | "red" | "skipped";
   failureSummary: string;
   errorDesc?: string;
@@ -298,26 +334,24 @@ export function createE2eSmokeDriver(
       // Schema already guaranteed at least one is present.
       const backendUrl = (input.backendUrl ?? input.publicUrl)!;
       const slug = deriveSlug(input.key, input.name);
+      const shape = resolveShape(input);
 
-      // Starter shape short-circuit: starters are single-app Next.js
-      // integrations mounted at `/` with no `/demos/*` routing. Running
-      // L3/L4 against them would 404 on navigation and emit 34 false-
-      // red `chat:<slug>` / `tools:<slug>` rows per tick. Return an
-      // explicit green-skipped aggregate BEFORE launching chromium so
-      // the whole skip costs milliseconds (no browser process, no
-      // registry lookup, no side-emits). Dashboards see `l3: "skipped"`
-      // / `l4: "skipped"` instead of silently-missing rows.
-      if (input.shape === "starter") {
+      // Starter short-circuit — runs BEFORE chromium launch AND BEFORE
+      // demos resolution so a broken registry / missing chromium image
+      // never contributes a false-red row for a starter. The ordering
+      // here is load-bearing; the test suite locks it in.
+      if (shape === "starter") {
         return {
           key: input.key,
           state: "green",
           signal: {
+            shape: "starter",
             slug,
             backendUrl,
             l3: "skipped",
             l4: "skipped",
             failureSummary: "",
-            errorDesc: "starter: no /demos/* routing",
+            note: "starter: no /demos/* routing",
           },
           observedAt,
         };
@@ -400,6 +434,7 @@ export function createE2eSmokeDriver(
             key: input.key,
             state: "red",
             signal: {
+              shape: "package",
               slug,
               backendUrl,
               l3: "red",
@@ -510,6 +545,7 @@ export function createE2eSmokeDriver(
           key: input.key,
           state: aggregateGreen ? "green" : "red",
           signal: {
+            shape: "package",
             slug,
             backendUrl,
             l3: l3State,
@@ -525,6 +561,7 @@ export function createE2eSmokeDriver(
             key: input.key,
             state: "red",
             signal: {
+              shape: "package",
               slug,
               backendUrl,
               l3: "red",
@@ -541,6 +578,7 @@ export function createE2eSmokeDriver(
           key: input.key,
           state: "red",
           signal: {
+            shape: "package",
             slug,
             backendUrl,
             l3: "red",
@@ -722,6 +760,27 @@ async function runLevel(opts: {
  *      slug cleanly).
  *   3. The whole key as-is (fallback).
  */
+/**
+ * Resolve the deployment shape for a driver invocation. Mirrors the
+ * smoke driver's resolver: classifier wins when `input.name` is present
+ * and throws on explicit-vs-classifier disagreement; honour
+ * `input.shape` only when the classifier has no `name` to work with.
+ * Fallback is `package` so the legacy Playwright-against-/demos/* path
+ * remains the default for hand-authored YAML.
+ */
+function resolveShape(input: E2eSmokeDriverInput): ShowcaseServiceShape {
+  if (input.name) {
+    const classified = classifyShape(input.name);
+    if (input.shape && input.shape !== classified) {
+      throw new Error(
+        `Shape mismatch: classifier="${classified}" input="${input.shape}" — check discovery wiring`,
+      );
+    }
+    return classified;
+  }
+  return input.shape ?? "package";
+}
+
 function deriveSlug(key: string, name?: string): string {
   const parts = key.split(":");
   let raw: string;

--- a/showcase/ops/src/probes/drivers/e2e-smoke.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.ts
@@ -54,6 +54,15 @@ const inputSchema = z
     // usually leave this undefined and let the driver resolve via the
     // registry.
     demos: z.array(z.string()).optional(),
+    /**
+     * Deployment shape tag from the discovery source. Starters are
+     * single-app integrations with NO `/demos/*` routing, so L3/L4 is
+     * skipped entirely on `shape === "starter"` — they would otherwise
+     * produce 17 × 2 = 34 false-red `chat:<slug>` / `tools:<slug>`
+     * alerts per tick. Package shape (default) keeps the legacy
+     * Playwright-against-/demos/* behaviour.
+     */
+    shape: z.enum(["package", "starter"]).optional(),
   })
   .passthrough()
   .refine((v) => !!(v.backendUrl ?? v.publicUrl), {
@@ -71,8 +80,16 @@ type E2eSmokeDriverInput = z.infer<typeof inputSchema>;
 export interface E2eSmokeSignal {
   slug: string;
   backendUrl: string;
-  /** "green" | "red" | "skipped" per level. Skipped L4 = demo not available. */
-  l3: "green" | "red";
+  /**
+   * Per-level outcome.
+   *   - "green" / "red"  standard probe result
+   *   - "skipped"        the level did not run. For L3 this only
+   *                      happens under `shape === "starter"` (single-app
+   *                      integrations with no `/demos/*` routing). For
+   *                      L4 it also happens when the registry entry has
+   *                      no `tool-rendering` demo.
+   */
+  l3: "green" | "red" | "skipped";
   l4: "green" | "red" | "skipped";
   failureSummary: string;
   errorDesc?: string;
@@ -281,6 +298,30 @@ export function createE2eSmokeDriver(
       // Schema already guaranteed at least one is present.
       const backendUrl = (input.backendUrl ?? input.publicUrl)!;
       const slug = deriveSlug(input.key, input.name);
+
+      // Starter shape short-circuit: starters are single-app Next.js
+      // integrations mounted at `/` with no `/demos/*` routing. Running
+      // L3/L4 against them would 404 on navigation and emit 34 false-
+      // red `chat:<slug>` / `tools:<slug>` rows per tick. Return an
+      // explicit green-skipped aggregate BEFORE launching chromium so
+      // the whole skip costs milliseconds (no browser process, no
+      // registry lookup, no side-emits). Dashboards see `l3: "skipped"`
+      // / `l4: "skipped"` instead of silently-missing rows.
+      if (input.shape === "starter") {
+        return {
+          key: input.key,
+          state: "green",
+          signal: {
+            slug,
+            backendUrl,
+            l3: "skipped",
+            l4: "skipped",
+            failureSummary: "",
+            errorDesc: "starter: no /demos/* routing",
+          },
+          observedAt,
+        };
+      }
 
       // Demos resolution: (1) in-band `input.demos`, (2) registry lookup
       // via the injected resolver. A slug with no demos entry gets

--- a/showcase/ops/src/probes/drivers/smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/smoke.test.ts
@@ -670,6 +670,218 @@ describe("smokeDriver", () => {
     );
   });
 
+  // -------------------------------------------------------------------
+  // Starter shape: probes hit `/api/health` instead of `/smoke` + `/health`.
+  // Starters are single-app Next.js integrations deployed from
+  // showcase/starters/*. They expose `/api/health` (returning JSON) but
+  // no `/smoke`, no `/health`, and no `/demos/*`. Without shape branching
+  // every starter registers 51 false red alerts per tick (17 services ×
+  // 3 endpoints).
+  // -------------------------------------------------------------------
+
+  it("starter shape: primary smoke probe hits /api/health, green on 200", async () => {
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      calls.push(href);
+      // Starter only answers /api/health; everything else is 404.
+      if (/\/api\/health\b/.test(href)) {
+        return new Response('{"status":"ok","integration":"ag2"}', {
+          status: 200,
+        });
+      }
+      if (/\/api\/copilotkit/.test(href)) {
+        return new Response('{"error":"bad body"}', { status: 400 });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer, writes } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      publicUrl: "https://showcase-starter-ag2-production.up.railway.app",
+      shape: "starter",
+    });
+    expect(r.state).toBe("green");
+    expect(r.key).toBe("smoke:starter-ag2");
+    // Starter smoke probe MUST hit /api/health — the whole reason for
+    // shape detection. Seeing /smoke here is the primary regression.
+    expect(calls).toContain(
+      "https://showcase-starter-ag2-production.up.railway.app/api/health",
+    );
+    expect(calls).not.toContain(
+      "https://showcase-starter-ag2-production.up.railway.app/smoke",
+    );
+    expect(calls).not.toContain(
+      "https://showcase-starter-ag2-production.up.railway.app/health",
+    );
+    // Health side-emit still produced (mirrors primary) so dashboards
+    // keyed on `health:<slug>` stay populated.
+    const health = writes.find((w) => w.key === "health:starter-ag2");
+    expect(health?.state).toBe("green");
+  });
+
+  it("starter shape: /api/health 503 → primary smoke red with http 503", async () => {
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (/\/api\/health\b/.test(href)) {
+        return new Response('{"status":"degraded"}', { status: 503 });
+      }
+      if (/\/api\/copilotkit/.test(href)) {
+        return new Response("{}", { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer, writes } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      publicUrl: "https://showcase-starter-ag2-production.up.railway.app",
+      shape: "starter",
+    });
+    expect(r.state).toBe("red");
+    expect(r.signal.errorDesc).toContain("503");
+    // The agent side-emit (L2) should still run + succeed.
+    const agent = writes.find((w) => w.key === "agent:starter-ag2");
+    expect(agent?.state).toBe("green");
+  });
+
+  it("starter shape: never probes /smoke (real starters 404 on it)", async () => {
+    // Regression guard: the previous contract fired GET /smoke which
+    // produced 17 false-red smoke alerts the first tick after deploy.
+    // Under the new shape contract, /smoke must NOT be called at all —
+    // the primary probe, the health side-emit, and the agent probe are
+    // all expected to use `/api/health` / `/api/copilotkit/`.
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      calls.push(href);
+      if (/\/api\/health\b/.test(href)) {
+        return new Response('{"status":"ok"}', { status: 200 });
+      }
+      if (/\/api\/copilotkit/.test(href)) {
+        return new Response("{}", { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:starter-mastra",
+      name: "showcase-starter-mastra",
+      publicUrl: "https://showcase-starter-mastra.up.railway.app",
+      shape: "starter",
+    });
+    for (const c of calls) {
+      expect(c).not.toMatch(/\/smoke(\b|\?|$)/);
+      // `/health` without the `/api` prefix must also not appear.
+      expect(c).not.toMatch(/\.app\/health(\b|\?|$)/);
+    }
+  });
+
+  it("package shape (explicit): keeps the legacy /smoke + /health contract", async () => {
+    // Sanity check that the new `shape` field is optional and
+    // backward-compatible: when `shape === "package"` (or omitted), the
+    // driver still hits /smoke + /health exactly like before.
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      calls.push(href);
+      return responseFor(href, {
+        smokeStatus: 200,
+        healthStatus: 200,
+        agentStatus: 200,
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:ag2",
+      name: "showcase-ag2",
+      publicUrl: "https://showcase-ag2.up.railway.app",
+      shape: "package",
+    });
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/smoke");
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/health");
+  });
+
+  // -------------------------------------------------------------------
+  // L2 308 redirect handling: /api/copilotkit/ → /api/copilotkit
+  //
+  // Railway's Next.js edge serves a 308 for the trailing-slash variant.
+  // The previous contract accepted the raw 308 as proof-of-life, which
+  // quietly masked regressions where the redirect target was a 404
+  // (e.g. wrong mount path). Enabling redirect following makes the
+  // probe classify on the FINAL status: 308→200 stays green, 308→400
+  // (runtime rejected the empty body) stays green, but 308→404 flips
+  // red so we actually catch unmounted routes.
+  // -------------------------------------------------------------------
+
+  it("agent probe follows 308 redirects and judges the final response", async () => {
+    const seenPaths: string[] = [];
+    // Simulate Railway edge: 308 with Location, then the real handler.
+    // We can't actually send 308 from a synthetic Response + have fetch
+    // follow — testing the effect via the probe's behaviour after the
+    // redirect lands on a 404 target URL. The driver MUST request with
+    // `redirect: "follow"` so the undici runtime handles the redirect.
+    let sawRedirectOption = false;
+    const fetchImpl: typeof fetch = (async (
+      url: string | URL,
+      init?: RequestInit,
+    ) => {
+      const href = typeof url === "string" ? url : url.toString();
+      seenPaths.push(href);
+      if (/\/api\/copilotkit/.test(href)) {
+        if ((init as RequestInit | undefined)?.redirect === "follow") {
+          sawRedirectOption = true;
+        }
+        // Simulate the post-redirect reply: runtime got our `{}` and
+        // responded with 400. That's a non-404 → proof-of-life → green.
+        return new Response('{"error":"missing fields"}', { status: 400 });
+      }
+      return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer, writes } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    expect(sawRedirectOption).toBe(true);
+    const agent = writes.find((w) => w.key === "agent:mastra")!;
+    expect(agent.state).toBe("green");
+    expect((agent.signal as SmokeDriverSignal).status).toBe(400);
+  });
+
+  it("agent probe red when 308 redirect lands on a 404 (route actually missing)", async () => {
+    const fetchImpl: typeof fetch = (async (
+      url: string | URL,
+      _init?: RequestInit,
+    ) => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (/\/api\/copilotkit/.test(href)) {
+        // Post-redirect reply: edge says "page not found". Under the old
+        // contract the raw 308 was treated as green — this test locks in
+        // that we now see the terminal 404 and flip red.
+        return new Response("<html>not found</html>", { status: 404 });
+      }
+      return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer, writes } = mkWriter();
+    await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    const agent = writes.find((w) => w.key === "agent:mastra")!;
+    expect(agent.state).toBe("red");
+    expect((agent.signal as SmokeDriverSignal).errorDesc).toMatch(
+      /route not mounted|agent endpoint 404/,
+    );
+  });
+
   it("discovery input with trailing `/` on publicUrl strips it before appending paths", async () => {
     const calls: string[] = [];
     const fetchImpl: typeof fetch = (async (url: string | URL) => {

--- a/showcase/ops/src/probes/drivers/smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/smoke.test.ts
@@ -717,12 +717,7 @@ describe("smokeDriver", () => {
     expect(calls).not.toContain(
       "https://showcase-starter-ag2-production.up.railway.app/health",
     );
-    // Contract: smoke and health rows feed separate alert dimensions so
-    // the driver MUST issue TWO independent GETs against /api/health
-    // rather than reusing the first response. Dashboards that correlate
-    // smoke vs health red flips rely on the rows being independent
-    // observations; a shared result would make them byte-identical and
-    // defeat the correlation signal.
+    // Contract: two independent GETs on /api/health — see smoke.ts run() for rationale.
     const healthCalls = calls.filter((c) => c.endsWith("/api/health"));
     expect(healthCalls).toHaveLength(2);
     // Health side-emit still produced (mirrors primary) so dashboards
@@ -965,12 +960,11 @@ describe("smokeDriver", () => {
   });
 
   it("shape-mismatch throws: explicit input.shape disagrees with classifier", async () => {
-    // C1 regression guard: silent-defaulting at the driver boundary
-    // inverts the whole fix. If discovery marks a service as
-    // `showcase-starter-*` (classifier → "starter") but the caller also
-    // pins `shape: "package"`, the driver must fail loud rather than
-    // pick one — silent drift is exactly the failure mode this contract
-    // prevents.
+    // Silent-defaulting at the driver boundary inverts the whole fix.
+    // When discovery marks a service as `showcase-starter-*` (classifier
+    // → "starter") but the caller pins `shape: "package"`, the driver
+    // fails loud rather than pick one — silent drift is the exact
+    // failure mode this contract prevents.
     vi.stubGlobal(
       "fetch",
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),

--- a/showcase/ops/src/probes/drivers/smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/smoke.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
 import { smokeDriver, type SmokeDriverSignal } from "./smoke.js";
 import { logger } from "../../logger.js";
 import type {
@@ -675,8 +677,7 @@ describe("smokeDriver", () => {
   // Starters are single-app Next.js integrations deployed from
   // showcase/starters/*. They expose `/api/health` (returning JSON) but
   // no `/smoke`, no `/health`, and no `/demos/*`. Without shape branching
-  // every starter registers 51 false red alerts per tick (17 services ×
-  // 3 endpoints).
+  // each starter emits one false-red row per probed endpoint per tick.
   // -------------------------------------------------------------------
 
   it("starter shape: primary smoke probe hits /api/health, green on 200", async () => {
@@ -716,10 +717,48 @@ describe("smokeDriver", () => {
     expect(calls).not.toContain(
       "https://showcase-starter-ag2-production.up.railway.app/health",
     );
+    // Contract: smoke and health rows feed separate alert dimensions so
+    // the driver MUST issue TWO independent GETs against /api/health
+    // rather than reusing the first response. Dashboards that correlate
+    // smoke vs health red flips rely on the rows being independent
+    // observations; a shared result would make them byte-identical and
+    // defeat the correlation signal.
+    const healthCalls = calls.filter((c) => c.endsWith("/api/health"));
+    expect(healthCalls).toHaveLength(2);
     // Health side-emit still produced (mirrors primary) so dashboards
     // keyed on `health:<slug>` stay populated.
     const health = writes.find((w) => w.key === "health:starter-ag2");
     expect(health?.state).toBe("green");
+  });
+
+  it("starter shape: /api/health 404 → both smoke:<slug> and health:<slug> flip red", async () => {
+    // Distinct from the 503 case (service answering but degraded): a 404
+    // means the starter's /api/health route is not mounted at all. Both
+    // the primary smoke tick and the health side-emit must flip red so
+    // dashboards keyed on either dimension catch the outage.
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (/\/api\/health\b/.test(href)) {
+        return new Response("", { status: 404 });
+      }
+      if (/\/api\/copilotkit/.test(href)) {
+        return new Response("{}", { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer, writes } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      publicUrl: "https://showcase-starter-ag2-production.up.railway.app",
+      shape: "starter",
+    });
+    expect(r.state).toBe("red");
+    expect(r.signal.errorDesc).toContain("404");
+    const health = writes.find((w) => w.key === "health:starter-ag2");
+    expect(health?.state).toBe("red");
+    expect((health?.signal as SmokeDriverSignal).errorDesc).toContain("404");
   });
 
   it("starter shape: /api/health 503 → primary smoke red with http 503", async () => {
@@ -819,67 +858,179 @@ describe("smokeDriver", () => {
   // red so we actually catch unmounted routes.
   // -------------------------------------------------------------------
 
-  it("agent probe follows 308 redirects and judges the final response", async () => {
-    const seenPaths: string[] = [];
-    // Simulate Railway edge: 308 with Location, then the real handler.
-    // We can't actually send 308 from a synthetic Response + have fetch
-    // follow — testing the effect via the probe's behaviour after the
-    // redirect lands on a 404 target URL. The driver MUST request with
-    // `redirect: "follow"` so the undici runtime handles the redirect.
-    let sawRedirectOption = false;
+  // Real-server 308 tests: stand up an ephemeral http.Server that replies
+  // with a genuine 308 + Location to the first path, then the terminal
+  // status on the redirect target. A regression that drops
+  // `redirect: "follow"` from the agent POST will fail these — the driver
+  // would classify the raw 308 as proof-of-life and miss the final 404.
+  it("agent probe follows a real 308 redirect to a 200 and stays green", async () => {
+    const { url, close } = await startRealRedirectServer({
+      first: { status: 308, locationPath: "/final" },
+      final: { status: 200, body: '{"ok":true}' },
+    });
+    try {
+      // Restore real fetch — we're intentionally talking to a real socket.
+      vi.unstubAllGlobals();
+      const { writer, writes } = mkWriter();
+      await smokeDriver.run(mkCtx(writer), {
+        key: "smoke:mastra",
+        url: `${url}/smoke`,
+      });
+      const agent = writes.find((w) => w.key === "agent:mastra")!;
+      expect(agent.state).toBe("green");
+      expect((agent.signal as SmokeDriverSignal).status).toBe(200);
+    } finally {
+      await close();
+    }
+  });
+
+  it("agent probe follows a real 308 redirect to a 404 and flips red", async () => {
+    const { url, close } = await startRealRedirectServer({
+      first: { status: 308, locationPath: "/final" },
+      final: { status: 404, body: "<html>not found</html>" },
+    });
+    try {
+      vi.unstubAllGlobals();
+      const { writer, writes } = mkWriter();
+      await smokeDriver.run(mkCtx(writer), {
+        key: "smoke:mastra",
+        url: `${url}/smoke`,
+      });
+      const agent = writes.find((w) => w.key === "agent:mastra")!;
+      expect(agent.state).toBe("red");
+      expect((agent.signal as SmokeDriverSignal).errorDesc).toMatch(
+        /route not mounted|agent endpoint 404/,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  // Regression guard for discovery-mode `redirect: "follow"` propagation.
+  // Earlier coverage asserted the option only for static-URL mode; a
+  // refactor could drop the option in the discovery branch without the
+  // original test catching it.
+  it("discovery + package: agent POST carries `redirect: 'follow'`", async () => {
+    let sawRedirect = false;
     const fetchImpl: typeof fetch = (async (
       url: string | URL,
       init?: RequestInit,
     ) => {
       const href = typeof url === "string" ? url : url.toString();
-      seenPaths.push(href);
       if (/\/api\/copilotkit/.test(href)) {
         if ((init as RequestInit | undefined)?.redirect === "follow") {
-          sawRedirectOption = true;
+          sawRedirect = true;
         }
-        // Simulate the post-redirect reply: runtime got our `{}` and
-        // responded with 400. That's a non-404 → proof-of-life → green.
-        return new Response('{"error":"missing fields"}', { status: 400 });
+        return new Response("{}", { status: 200 });
       }
       return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
-    const { writer, writes } = mkWriter();
+    const { writer } = mkWriter();
     await smokeDriver.run(mkCtx(writer), {
-      key: "smoke:mastra",
-      url: "https://x.example/smoke",
+      key: "smoke:ag2",
+      name: "showcase-ag2",
+      publicUrl: "https://showcase-ag2.up.railway.app",
     });
-    expect(sawRedirectOption).toBe(true);
-    const agent = writes.find((w) => w.key === "agent:mastra")!;
-    expect(agent.state).toBe("green");
-    expect((agent.signal as SmokeDriverSignal).status).toBe(400);
+    expect(sawRedirect).toBe(true);
   });
 
-  it("agent probe red when 308 redirect lands on a 404 (route actually missing)", async () => {
+  it("discovery + starter: agent POST carries `redirect: 'follow'`", async () => {
+    let sawRedirect = false;
     const fetchImpl: typeof fetch = (async (
       url: string | URL,
-      _init?: RequestInit,
+      init?: RequestInit,
     ) => {
       const href = typeof url === "string" ? url : url.toString();
       if (/\/api\/copilotkit/.test(href)) {
-        // Post-redirect reply: edge says "page not found". Under the old
-        // contract the raw 308 was treated as green — this test locks in
-        // that we now see the terminal 404 and flip red.
-        return new Response("<html>not found</html>", { status: 404 });
+        if ((init as RequestInit | undefined)?.redirect === "follow") {
+          sawRedirect = true;
+        }
+        return new Response("{}", { status: 200 });
       }
-      return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
+      if (/\/api\/health/.test(href)) {
+        return new Response('{"status":"ok"}', { status: 200 });
+      }
+      return new Response("", { status: 404 });
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
-    const { writer, writes } = mkWriter();
+    const { writer } = mkWriter();
     await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:starter-ag2",
+      name: "showcase-starter-ag2",
+      publicUrl: "https://showcase-starter-ag2.up.railway.app",
+      shape: "starter",
+    });
+    expect(sawRedirect).toBe(true);
+  });
+
+  it("shape-mismatch throws: explicit input.shape disagrees with classifier", async () => {
+    // C1 regression guard: silent-defaulting at the driver boundary
+    // inverts the whole fix. If discovery marks a service as
+    // `showcase-starter-*` (classifier → "starter") but the caller also
+    // pins `shape: "package"`, the driver must fail loud rather than
+    // pick one — silent drift is exactly the failure mode this contract
+    // prevents.
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
+    );
+    const { writer } = mkWriter();
+    await expect(
+      smokeDriver.run(mkCtx(writer), {
+        key: "smoke:starter-ag2",
+        name: "showcase-starter-ag2",
+        publicUrl: "https://showcase-starter-ag2.up.railway.app",
+        shape: "package",
+      }),
+    ).rejects.toThrow(/Shape mismatch/);
+  });
+
+  it("inputSchema rejects `url` + `shape` combo (shape only valid with publicUrl)", () => {
+    const parsed = smokeDriver.inputSchema.safeParse({
       key: "smoke:mastra",
       url: "https://x.example/smoke",
+      shape: "starter",
     });
-    const agent = writes.find((w) => w.key === "agent:mastra")!;
-    expect(agent.state).toBe("red");
-    expect((agent.signal as SmokeDriverSignal).errorDesc).toMatch(
-      /route not mounted|agent endpoint 404/,
-    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("mixed-driver wiring: spread of RailwayServiceInfo carries `shape` through .passthrough() end-to-end", async () => {
+    // Regression guard for the discovery → driver edge: the orchestrator
+    // builds driver input as `{ ...discoveryRecord, key, slug }`. If the
+    // driver schema stops carrying `shape` through `.passthrough()`, the
+    // field would be silently dropped and starters would fall back to
+    // `package` shape — producing the very false-red row flood this
+    // contract exists to prevent.
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      calls.push(href);
+      if (/\/api\/health/.test(href)) {
+        return new Response('{"status":"ok"}', { status: 200 });
+      }
+      if (/\/api\/copilotkit/.test(href)) {
+        return new Response("{}", { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer } = mkWriter();
+    const discoveryRecord = {
+      name: "showcase-starter-ag2",
+      imageRef: "ghcr.io/copilotkit/showcase-starter-ag2:latest",
+      publicUrl: "https://showcase-starter-ag2.up.railway.app",
+      env: { FOO: "bar" },
+      shape: "starter" as const,
+    };
+    await smokeDriver.run(mkCtx(writer), {
+      ...discoveryRecord,
+      key: "smoke:starter-ag2",
+    });
+    for (const c of calls) {
+      expect(c).not.toMatch(/\.app\/smoke(\b|\?|$)/);
+      expect(c).not.toMatch(/\.app\/health(\b|\?|$)/);
+    }
   });
 
   it("discovery input with trailing `/` on publicUrl strips it before appending paths", async () => {
@@ -917,4 +1068,50 @@ describe("smokeDriver", () => {
  */
 function smokeInputSchema_safeParse(input: unknown): { success: boolean } {
   return smokeDriver.inputSchema.safeParse(input);
+}
+
+/**
+ * Stand up an ephemeral HTTP server that answers the first path with a
+ * real 308 redirect (Location header → `/final`) and the terminal path
+ * with the configured status + body. Used to verify that the driver's
+ * agent POST actually follows redirects via `redirect: "follow"` rather
+ * than classifying the raw 308 as proof-of-life.
+ */
+async function startRealRedirectServer(spec: {
+  first: { status: number; locationPath: string };
+  final: { status: number; body: string };
+}): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? "/";
+    if (url === spec.first.locationPath) {
+      res.writeHead(spec.final.status, {
+        "Content-Type": "text/html; charset=utf-8",
+      });
+      res.end(spec.final.body);
+      return;
+    }
+    // First hop — handles the `/api/copilotkit/` POST. Respond 308 with
+    // Location so undici follows to `/final`.
+    if (/\/api\/copilotkit/.test(url)) {
+      res.writeHead(spec.first.status, {
+        Location: spec.first.locationPath,
+      });
+      res.end();
+      return;
+    }
+    // Smoke / health GETs land on `/smoke` / `/health` — respond 200 with
+    // a JSON body so those rows don't accidentally fail.
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end('{"status":"ok"}');
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${addr.port}`;
+  return {
+    url,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
 }

--- a/showcase/ops/src/probes/drivers/smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/smoke.test.ts
@@ -989,6 +989,89 @@ describe("smokeDriver", () => {
     expect(parsed.success).toBe(false);
   });
 
+  // Parse-time invariants — callers that run safeParse in isolation must
+  // get a unified rejection for structural mistakes regardless of which
+  // arm's strictness would otherwise absorb them.
+  it("inputSchema rejects bare `{ key }` (no url, no name+publicUrl)", () => {
+    const parsed = smokeDriver.inputSchema.safeParse({ key: "k" });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("inputSchema rejects `{ key, name }` (discovery missing publicUrl)", () => {
+    const parsed = smokeDriver.inputSchema.safeParse({
+      key: "k",
+      name: "showcase-ag2",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("inputSchema rejects mixed modes `{ key, url, name, publicUrl }`", () => {
+    // Discovery arm's .passthrough() would otherwise absorb the stray
+    // `url` field; the union-level superRefine enforces XOR across the
+    // two modes.
+    const parsed = smokeDriver.inputSchema.safeParse({
+      key: "k",
+      url: "http://x.example/smoke",
+      name: "showcase-ag2",
+      publicUrl: "http://x.example",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  // Item-5 regression guards: the primary `smoke:<slug>` key is rewritten
+  // in discovery mode so YAML key_templates that interpolate `${name}`
+  // (producing `smoke:showcase-ag2`) land on the stripped slug
+  // (`smoke:ag2`) dashboards + alerts are actually keyed on. Static mode
+  // passes the YAML-authored key through verbatim.
+  it("discovery package: `smoke:showcase-ag2` is rewritten to `smoke:ag2`", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
+    );
+    const { writer } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:showcase-ag2",
+      name: "showcase-ag2",
+      publicUrl: "https://showcase-ag2.up.railway.app",
+      shape: "package",
+    });
+    expect(r.key).toBe("smoke:ag2");
+  });
+
+  it("discovery starter: `smoke:showcase-starter-ag2` is rewritten to `smoke:starter-ag2`", async () => {
+    vi.stubGlobal("fetch", (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      if (/\/api\/health/.test(href)) {
+        return new Response('{"status":"ok"}', { status: 200 });
+      }
+      if (/\/api\/copilotkit/.test(href)) {
+        return new Response("{}", { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch);
+    const { writer } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:showcase-starter-ag2",
+      name: "showcase-starter-ag2",
+      publicUrl: "https://showcase-starter-ag2.up.railway.app",
+      shape: "starter",
+    });
+    expect(r.key).toBe("smoke:starter-ag2");
+  });
+
+  it("static mode passes the YAML-authored key through verbatim", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
+    );
+    const { writer } = mkWriter();
+    const r = await smokeDriver.run(mkCtx(writer), {
+      key: "smoke:custom-yaml-key",
+      url: "https://x.example/smoke",
+    });
+    expect(r.key).toBe("smoke:custom-yaml-key");
+  });
+
   it("mixed-driver wiring: spread of RailwayServiceInfo carries `shape` through .passthrough() end-to-end", async () => {
     // Regression guard for the discovery → driver edge: the orchestrator
     // builds driver input as `{ ...discoveryRecord, key, slug }`. If the

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { deriveHealthUrl } from "../smoke.js";
 import {
-  classifyShape,
+  resolveShape,
   showcaseShapeSchema,
   type ShowcaseServiceShape,
 } from "../discovery/railway-services.js";
@@ -65,21 +65,38 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  */
 
 /**
- * Per-target input schema. Two cases: static (`{key, url}`) and discovery
- * (`{key, name, publicUrl, ...}`). `passthrough()` tolerates the extra
- * discovery fields (`imageRef`, `env`) without requiring the schema to
- * enumerate them — the driver only reads the subset it needs and lets the
- * discovery source own the authoritative shape.
+ * Per-target input schema, shaped as a discriminated union on `mode` so
+ * the two call paths (`static` / `discovery`) are type-level distinct.
+ * Each branch carries exactly the fields it needs; the non-null assertion
+ * previously used on `input.url` (static path) and ad-hoc `refine()`s
+ * that expressed `url XOR (name+publicUrl)` + `no shape with url` are
+ * replaced by the discriminator, which `tsc` can narrow directly.
+ *
+ * Both branches keep `mode` optional so existing callers (YAML,
+ * orchestrator, unit tests) that pre-date the discriminator still parse
+ * and run unchanged; `normaliseMode()` at the top of `run()` fills it
+ * in from field presence before any downstream narrowing. The discovery
+ * branch `.passthrough()`s so the orchestrator can spread a full
+ * `RailwayServiceInfo` (`{ name, publicUrl, imageRef, env, shape }`)
+ * into the input without pre-filtering fields.
  */
-const smokeInputSchema = z
+const staticSmokeInputSchema = z
   .object({
+    mode: z.literal("static").optional(),
     key: z.string().min(1),
-    /** Static mode: full `/smoke` URL. Optional in discovery mode — derived from `publicUrl`. */
-    url: z.string().url().optional(),
+    /** Static mode: full `/smoke` URL. */
+    url: z.string().url(),
+  })
+  .strict();
+
+const discoverySmokeInputSchema = z
+  .object({
+    mode: z.literal("discovery").optional(),
+    key: z.string().min(1),
     /** Discovery mode: Railway service name (`showcase-<slug>` or `showcase-starter-<slug>`). */
-    name: z.string().min(1).optional(),
+    name: z.string().min(1),
     /** Discovery mode: `https://<domain>` base URL. The driver appends `/smoke` or `/api/health` per shape. */
-    publicUrl: z.string().optional(),
+    publicUrl: z.string().url(),
     /**
      * Deployment shape tag from the discovery source
      * (`discovery/railway-services.ts`). Controls which URL contract the
@@ -91,28 +108,46 @@ const smokeInputSchema = z
      *                 route; using the legacy contract produces one
      *                 false-red row per starter per endpoint.
      *
-     * Optional in the schema so static-YAML callers can pre-pin shape
-     * explicitly; when absent in discovery-mode input the driver
-     * reclassifies from `input.name` at run() entry. When both `input.name`
-     * and an explicit `input.shape` are present and the classifier
-     * disagrees with the explicit value, the driver throws — silent
-     * drift between the classifier and caller-supplied shape is the
-     * exact failure mode this contract is meant to prevent.
+     * Optional — when absent the driver reclassifies from `name` at
+     * run() entry. When both are present and the classifier disagrees
+     * with the explicit value, the driver throws; silent drift between
+     * the classifier and caller-supplied shape is the exact failure
+     * mode this contract is meant to prevent.
      */
     shape: showcaseShapeSchema.optional(),
   })
-  .passthrough()
-  .refine((v) => v.url || (v.name && v.publicUrl), {
-    message:
-      "smoke driver requires either `url` (static) or `name`+`publicUrl` (discovery)",
-  })
-  .refine((v) => !(v.url && v.shape), {
-    message:
-      "`shape` is not permitted when `url` is set; shape applies only to discovered `publicUrl`",
-    path: ["shape"],
-  });
+  .passthrough();
+
+/**
+ * Raw schema produced by `smokeInputSchema.parse()` / `.safeParse()`.
+ * Both branches leave `mode` optional — `normaliseMode` at the top of
+ * `run()` fills in the discriminator from field presence (`url` ⇒
+ * static, `name+publicUrl` ⇒ discovery) and produces a
+ * `NormalisedSmokeInput` that the rest of the driver narrows against.
+ * The union contract is enforced at parse time; the discriminator is
+ * assigned at execute time.
+ */
+const smokeInputSchema = z.union([
+  staticSmokeInputSchema,
+  discoverySmokeInputSchema,
+]);
 
 type SmokeDriverInput = z.infer<typeof smokeInputSchema>;
+
+/**
+ * Internal, post-normalisation form. `mode` is required here so every
+ * downstream helper narrows by discriminator without a fallback branch.
+ */
+type NormalisedSmokeInput =
+  | { mode: "static"; key: string; url: string }
+  | {
+      mode: "discovery";
+      key: string;
+      name: string;
+      publicUrl: string;
+      shape?: ShowcaseServiceShape;
+      [k: string]: unknown;
+    };
 
 /**
  * Shared signal shape for the smoke, health, and agent ProbeResults.
@@ -135,32 +170,38 @@ export interface SmokeDriverSignal {
 export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
   kind: "smoke",
   inputSchema: smokeInputSchema,
-  async run(ctx, input) {
+  async run(ctx, rawInput) {
+    // Normalise mode at the boundary. Schema-parsed inputs (orchestrator
+    // path) carry `mode` via the union default; tests that hand a raw
+    // object to `driver.run()` omit it. Field presence is the runtime
+    // discriminator: `url` present ⇒ static, `name`+`publicUrl` ⇒
+    // discovery. After this cast the rest of the function narrows via
+    // `input.mode` alone.
+    const input = normaliseMode(rawInput);
     const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
     const timeoutMs = readTimeoutMs(ctx);
     const slug = deriveSlug(input);
-    // Shape resolution: when the discovery record carries a `name`, run
-    // the classifier and use its verdict. If the caller also pinned
-    // `input.shape` explicitly (static-YAML override), fail loud on any
-    // disagreement — a silent default to `package` is exactly what
-    // produces the per-starter false-red row flood that shape detection
-    // is meant to eliminate. When only `input.shape` is present (static
-    // mode with no `name`), honour it verbatim. When neither is present,
-    // fall back to `package` — the only way to hit this branch is a
-    // static-URL call with no shape pinned, which schema-refines above
-    // already guarantee can't also carry a `shape` field.
-    const shape = resolveShape(input);
+    // Shape resolution delegates to the shared resolveShape helper in
+    // `discovery/railway-services.ts` — classifier wins on `name`, throws
+    // on explicit-vs-classifier disagreement, honours explicit `shape`
+    // otherwise. Thread `ctx.logger` so the classifier's audit-warn fires
+    // on the driver path too.
+    const shape = resolveShape(
+      input.mode === "discovery"
+        ? { name: input.name, shape: input.shape }
+        : {},
+      { logger: ctx.logger },
+    );
     const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input, shape);
-    // Primary key for the smoke ProbeResult. In DISCOVERY mode (when
-    // `input.name` is set), `input.key` arrives as `smoke:showcase-ag2`
-    // because the `key_template` in YAML interpolates `${name}` and
-    // the template language has no string-munge function to strip the
-    // prefix. Rewrite to `smoke:<slug>` here so dashboards/alerts that
-    // match on `smoke:ag2` / `smoke:starter-ag2` stay intact under
-    // both static and discovery call paths. In STATIC mode, pass the
-    // YAML-authored key through verbatim so legacy callers keep their
-    // exact `input.key` in the primary result.
-    const primaryKey = input.name ? `smoke:${slug}` : input.key;
+    // Primary key for the smoke ProbeResult. In DISCOVERY mode,
+    // `input.key` arrives as `smoke:showcase-ag2` because the
+    // `key_template` in YAML interpolates `${name}` and the template
+    // language has no string-munge function to strip the prefix.
+    // Rewrite to `smoke:<slug>` here so dashboards/alerts that match on
+    // `smoke:ag2` / `smoke:starter-ag2` stay intact. In STATIC mode,
+    // pass the YAML-authored key through verbatim so legacy callers
+    // keep their exact `input.key` in the primary result.
+    const primaryKey = input.mode === "discovery" ? `smoke:${slug}` : input.key;
 
     // Sequential issue of smoke + health + agent to keep inflight socket
     // count bounded at max_concurrency × 3 — Railway's edge has
@@ -218,6 +259,41 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
     return smokeResult;
   },
 };
+
+/**
+ * Normalise a driver input into the `SmokeDriverInput` discriminated
+ * union. Schema-parsed inputs already carry `mode` via the union
+ * default, but callers that hand a raw object straight to `driver.run()`
+ * (unit tests, ad-hoc integrations) omit it. We detect mode from field
+ * presence: `url` present ⇒ static; `name` + `publicUrl` present ⇒
+ * discovery. When neither matches, throw loud — the previous ad-hoc
+ * `.refine()` guards enforced the same invariant and the discriminated
+ * union needs to preserve that behaviour for unparsed-input callers.
+ */
+function normaliseMode(input: unknown): NormalisedSmokeInput {
+  const raw = input as Record<string, unknown> | null;
+  if (!raw || typeof raw !== "object") {
+    throw new Error("smoke driver: input must be an object");
+  }
+  if (raw.mode === "static" || raw.mode === "discovery") {
+    return raw as NormalisedSmokeInput;
+  }
+  if (typeof raw.url === "string") {
+    return {
+      ...(raw as Record<string, unknown>),
+      mode: "static",
+    } as NormalisedSmokeInput;
+  }
+  if (typeof raw.name === "string" && typeof raw.publicUrl === "string") {
+    return {
+      ...(raw as Record<string, unknown>),
+      mode: "discovery",
+    } as NormalisedSmokeInput;
+  }
+  throw new Error(
+    "smoke driver: input requires either `url` (static) or `name`+`publicUrl` (discovery)",
+  );
+}
 
 /**
  * Write a side-emit ProbeResult through `ctx.writer`. Absent writer is a
@@ -454,29 +530,8 @@ async function probeAgent(opts: {
  * a distinct `health:bare` / `agent:bare` side-tick rather than a
  * blank one.
  */
-/**
- * Resolve the deployment shape for a driver invocation. Classifier wins
- * when `input.name` is present — silent defaulting at the boundary
- * inverts the fix this driver exists to make, so we throw on any
- * explicit-vs-classifier disagreement rather than pick one. When
- * `input.name` is absent, honour `input.shape` verbatim; when both are
- * absent, fall back to `package` (static-URL callers historically).
- */
-function resolveShape(input: SmokeDriverInput): ShowcaseServiceShape {
-  if (input.name) {
-    const classified = classifyShape(input.name);
-    if (input.shape && input.shape !== classified) {
-      throw new Error(
-        `Shape mismatch: classifier="${classified}" input="${input.shape}" — check discovery wiring`,
-      );
-    }
-    return classified;
-  }
-  return input.shape ?? "package";
-}
-
-function deriveSlug(input: SmokeDriverInput): string {
-  if (input.name) {
+function deriveSlug(input: NormalisedSmokeInput): string {
+  if (input.mode === "discovery") {
     const stripped = input.name.replace(/^showcase-/, "");
     if (stripped.length > 0) return stripped;
   }
@@ -513,10 +568,10 @@ interface DerivedUrls {
  * schema extension if needed.
  */
 function deriveUrls(
-  input: SmokeDriverInput,
+  input: NormalisedSmokeInput,
   shape: ShowcaseServiceShape,
 ): DerivedUrls {
-  if (input.publicUrl) {
+  if (input.mode === "discovery") {
     const base = input.publicUrl.replace(/\/$/, "");
     if (shape === "starter") {
       // Starters expose `/api/health` as the canonical liveness route
@@ -537,11 +592,10 @@ function deriveUrls(
       agentUrl: `${base}/api/copilotkit/`,
     };
   }
-  // Static fallback. `url` is guaranteed present by the refine() guard
-  // in `smokeInputSchema` when `publicUrl` is absent. Static mode
-  // predates shape detection and always assumes package shape — the
-  // YAML author already picked concrete URLs.
-  const smokeUrl = input.url!;
+  // Static mode. The discriminated union guarantees `url` is present
+  // here; static mode predates shape detection and always assumes
+  // package shape — the YAML author already picked concrete URLs.
+  const smokeUrl = input.url;
   const healthUrl = deriveHealthUrl(smokeUrl);
   const agentUrl = deriveAgentUrl(smokeUrl);
   return { smokeUrl, healthUrl, agentUrl };

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -73,8 +73,22 @@ const smokeInputSchema = z
     url: z.string().url().optional(),
     /** Discovery mode: Railway service name (`showcase-<slug>` or `showcase-starter-<slug>`). */
     name: z.string().min(1).optional(),
-    /** Discovery mode: `https://<domain>` base URL. The driver appends `/smoke`. */
+    /** Discovery mode: `https://<domain>` base URL. The driver appends `/smoke` or `/api/health` per shape. */
     publicUrl: z.string().optional(),
+    /**
+     * Deployment shape tag from the discovery source
+     * (`discovery/railway-services.ts`). Controls which URL contract the
+     * driver exercises:
+     *
+     *   - `package` (default) → legacy `/smoke` + `/health` + `/api/copilotkit/`.
+     *   - `starter`           → `/api/health` (primary + side-emit) +
+     *                           `/api/copilotkit/`. Starters have no
+     *                           `/smoke` route; using the legacy contract
+     *                           produces 34 false-red alerts per tick.
+     *
+     * Missing → treated as `package` so static-YAML callers keep working.
+     */
+    shape: z.enum(["package", "starter"]).optional(),
   })
   .passthrough()
   .refine((v) => v.url || (v.name && v.publicUrl), {
@@ -109,7 +123,8 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
     const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
     const timeoutMs = readTimeoutMs(ctx);
     const slug = deriveSlug(input);
-    const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input);
+    const shape = input.shape ?? "package";
+    const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input, shape);
     // Primary key for the smoke ProbeResult. In DISCOVERY mode (when
     // `input.name` is set), `input.key` arrives as `smoke:showcase-ag2`
     // because the `key_template` in YAML interpolates `${name}` and
@@ -128,6 +143,14 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
     // Railway, which has historically triggered edge-side rate
     // limiting. Sequential keeps the bound at max_concurrency * 3 = 18 —
     // still well under any edge threshold.
+    //
+    // Starter shape: smoke and health share the same endpoint
+    // (`/api/health`) because starters expose no `/smoke` route. To
+    // keep the probe HTTP count consistent across shapes (2 GETs + 1
+    // POST per tick), we call `/api/health` ONCE and reuse the result
+    // for both the primary `smoke:<slug>` tick and the `health:<slug>`
+    // side-emit — dashboards keyed on either row still populate, and
+    // we don't pay a second round-trip for the same JSON.
     const smokeResult = await probeOne({
       fetchImpl,
       url: smokeUrl,
@@ -138,17 +161,22 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
       method: "GET",
     });
 
-    // Side-emit #1: health tick.
+    // Side-emit #1: health tick. Reuse the smoke result when the two
+    // endpoints coincide (starter shape); otherwise run the classic
+    // second GET against `/health`.
     const healthKey = `health:${slug}`;
-    const healthResult = await probeOne({
-      fetchImpl,
-      url: healthUrl,
-      key: healthKey,
-      slug,
-      timeoutMs,
-      now: ctx.now,
-      method: "GET",
-    });
+    const healthResult =
+      smokeUrl === healthUrl
+        ? { ...smokeResult, key: healthKey }
+        : await probeOne({
+            fetchImpl,
+            url: healthUrl,
+            key: healthKey,
+            slug,
+            timeoutMs,
+            now: ctx.now,
+            method: "GET",
+          });
     await sideEmit(ctx, healthResult, healthKey);
 
     // Side-emit #2: agent endpoint POST. Non-404 2xx-5xx response is
@@ -327,6 +355,14 @@ async function probeAgent(opts: {
       headers: { "Content-Type": "application/json" },
       body: "{}",
       signal: controller.signal,
+      // Railway's Next.js edge serves a 308 for the trailing-slash
+      // variant of `/api/copilotkit/` → `/api/copilotkit`. Without
+      // following, the probe classifies the raw 308 as proof-of-life,
+      // which quietly masks regressions where the redirect target is a
+      // 404 (route actually unmounted). Following means we judge the
+      // FINAL response: a runtime-rejected `{}` payload (400) stays
+      // green, but an unmounted route (final 404) correctly flips red.
+      redirect: "follow",
     });
     const latencyMs = now().getTime() - started;
     const signal: SmokeDriverSignal = {
@@ -434,9 +470,25 @@ interface DerivedUrls {
  * static-mode callers can pass an explicit agent URL in a future
  * schema extension if needed.
  */
-function deriveUrls(input: SmokeDriverInput): DerivedUrls {
+function deriveUrls(
+  input: SmokeDriverInput,
+  shape: "package" | "starter",
+): DerivedUrls {
   if (input.publicUrl) {
     const base = input.publicUrl.replace(/\/$/, "");
+    if (shape === "starter") {
+      // Starters expose `/api/health` as the canonical liveness route
+      // (see `showcase/starters/template/frontend/app/api/health/route.ts`).
+      // There is no `/smoke` and no separate `/health` route — so the
+      // primary smoke probe and the health side-emit both target
+      // `/api/health`. The run() loop re-uses the single GET result
+      // rather than round-tripping twice.
+      return {
+        smokeUrl: `${base}/api/health`,
+        healthUrl: `${base}/api/health`,
+        agentUrl: `${base}/api/copilotkit/`,
+      };
+    }
     return {
       smokeUrl: `${base}/smoke`,
       healthUrl: `${base}/health`,
@@ -444,7 +496,9 @@ function deriveUrls(input: SmokeDriverInput): DerivedUrls {
     };
   }
   // Static fallback. `url` is guaranteed present by the refine() guard
-  // in `smokeInputSchema` when `publicUrl` is absent.
+  // in `smokeInputSchema` when `publicUrl` is absent. Static mode
+  // predates shape detection and always assumes package shape — the
+  // YAML author already picked concrete URLs.
   const smokeUrl = input.url!;
   const healthUrl = deriveHealthUrl(smokeUrl);
   const agentUrl = deriveAgentUrl(smokeUrl);

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 import { deriveHealthUrl } from "../smoke.js";
+import {
+  classifyShape,
+  showcaseShapeSchema,
+  type ShowcaseServiceShape,
+} from "../discovery/railway-services.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -80,20 +85,31 @@ const smokeInputSchema = z
      * (`discovery/railway-services.ts`). Controls which URL contract the
      * driver exercises:
      *
-     *   - `package` (default) → legacy `/smoke` + `/health` + `/api/copilotkit/`.
-     *   - `starter`           → `/api/health` (primary + side-emit) +
-     *                           `/api/copilotkit/`. Starters have no
-     *                           `/smoke` route; using the legacy contract
-     *                           produces 34 false-red alerts per tick.
+     *   - `package` → legacy `/smoke` + `/health` + `/api/copilotkit/`.
+     *   - `starter` → `/api/health` (primary + side-emit) +
+     *                 `/api/copilotkit/`. Starters have no `/smoke`
+     *                 route; using the legacy contract produces one
+     *                 false-red row per starter per endpoint.
      *
-     * Missing → treated as `package` so static-YAML callers keep working.
+     * Optional in the schema so static-YAML callers can pre-pin shape
+     * explicitly; when absent in discovery-mode input the driver
+     * reclassifies from `input.name` at run() entry. When both `input.name`
+     * and an explicit `input.shape` are present and the classifier
+     * disagrees with the explicit value, the driver throws — silent
+     * drift between the classifier and caller-supplied shape is the
+     * exact failure mode this contract is meant to prevent.
      */
-    shape: z.enum(["package", "starter"]).optional(),
+    shape: showcaseShapeSchema.optional(),
   })
   .passthrough()
   .refine((v) => v.url || (v.name && v.publicUrl), {
     message:
       "smoke driver requires either `url` (static) or `name`+`publicUrl` (discovery)",
+  })
+  .refine((v) => !(v.url && v.shape), {
+    message:
+      "`shape` is not permitted when `url` is set; shape applies only to discovered `publicUrl`",
+    path: ["shape"],
   });
 
 type SmokeDriverInput = z.infer<typeof smokeInputSchema>;
@@ -123,7 +139,17 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
     const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
     const timeoutMs = readTimeoutMs(ctx);
     const slug = deriveSlug(input);
-    const shape = input.shape ?? "package";
+    // Shape resolution: when the discovery record carries a `name`, run
+    // the classifier and use its verdict. If the caller also pinned
+    // `input.shape` explicitly (static-YAML override), fail loud on any
+    // disagreement — a silent default to `package` is exactly what
+    // produces the per-starter false-red row flood that shape detection
+    // is meant to eliminate. When only `input.shape` is present (static
+    // mode with no `name`), honour it verbatim. When neither is present,
+    // fall back to `package` — the only way to hit this branch is a
+    // static-URL call with no shape pinned, which schema-refines above
+    // already guarantee can't also carry a `shape` field.
+    const shape = resolveShape(input);
     const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input, shape);
     // Primary key for the smoke ProbeResult. In DISCOVERY mode (when
     // `input.name` is set), `input.key` arrives as `smoke:showcase-ag2`
@@ -136,21 +162,19 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
     // exact `input.key` in the primary result.
     const primaryKey = input.name ? `smoke:${slug}` : input.key;
 
-    // Issue the smoke + health + agent probes SEQUENTIALLY rather than
-    // in parallel. Parallel would cut wall-clock but would triple the
-    // inflight socket count per target; at max_concurrency=6 * 34
-    // services * 3 endpoints that's 612 simultaneous TCP connections to
-    // Railway, which has historically triggered edge-side rate
-    // limiting. Sequential keeps the bound at max_concurrency * 3 = 18 —
-    // still well under any edge threshold.
+    // Sequential issue of smoke + health + agent to keep inflight socket
+    // count bounded at max_concurrency × 3 — Railway's edge has
+    // historically rate-limited at higher parallelism, so we eat the
+    // wall-clock cost to stay well under any edge threshold.
     //
-    // Starter shape: smoke and health share the same endpoint
-    // (`/api/health`) because starters expose no `/smoke` route. To
-    // keep the probe HTTP count consistent across shapes (2 GETs + 1
-    // POST per tick), we call `/api/health` ONCE and reuse the result
-    // for both the primary `smoke:<slug>` tick and the `health:<slug>`
-    // side-emit — dashboards keyed on either row still populate, and
-    // we don't pay a second round-trip for the same JSON.
+    // Starter shape hits the same endpoint (`/api/health`) for both the
+    // primary smoke tick and the health side-emit. We intentionally run
+    // TWO independent GETs rather than reusing the first result: the
+    // `smoke:<slug>` and `health:<slug>` rows feed separate alert
+    // dimensions (`dimension: smoke` vs `dimension: health`) that
+    // dashboards compare for correlation, and a single-GET-reuse would
+    // make the two rows byte-identical and defeat that signal. The extra
+    // round-trip is a cheap liveness check against the same endpoint.
     const smokeResult = await probeOne({
       fetchImpl,
       url: smokeUrl,
@@ -161,22 +185,19 @@ export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
       method: "GET",
     });
 
-    // Side-emit #1: health tick. Reuse the smoke result when the two
-    // endpoints coincide (starter shape); otherwise run the classic
-    // second GET against `/health`.
+    // Side-emit #1: health tick. Always a fresh GET — even when smokeUrl
+    // === healthUrl (starter shape), see the comment block above for why
+    // we do NOT reuse the smoke result.
     const healthKey = `health:${slug}`;
-    const healthResult =
-      smokeUrl === healthUrl
-        ? { ...smokeResult, key: healthKey }
-        : await probeOne({
-            fetchImpl,
-            url: healthUrl,
-            key: healthKey,
-            slug,
-            timeoutMs,
-            now: ctx.now,
-            method: "GET",
-          });
+    const healthResult = await probeOne({
+      fetchImpl,
+      url: healthUrl,
+      key: healthKey,
+      slug,
+      timeoutMs,
+      now: ctx.now,
+      method: "GET",
+    });
     await sideEmit(ctx, healthResult, healthKey);
 
     // Side-emit #2: agent endpoint POST. Non-404 2xx-5xx response is
@@ -333,9 +354,9 @@ async function probeOne(opts: {
  * This matches the acceptance contract of `checkAgentEndpoint` in
  * `showcase/tests/e2e/helpers.ts`: any non-404 response is proof-of-life.
  * We don't GET /info first like the helper does — the helper runs in
- * Playwright where it can afford two round-trips; the probe budget is
- * per-tick tight (3 endpoints × 34 services × sequential) so we keep it
- * to a single POST.
+ * Playwright where it can afford two round-trips; the probe budget per
+ * tick is tight (N services × sequential endpoints) so we keep the agent
+ * check to a single POST.
  */
 async function probeAgent(opts: {
   fetchImpl: typeof fetch;
@@ -433,6 +454,27 @@ async function probeAgent(opts: {
  * a distinct `health:bare` / `agent:bare` side-tick rather than a
  * blank one.
  */
+/**
+ * Resolve the deployment shape for a driver invocation. Classifier wins
+ * when `input.name` is present — silent defaulting at the boundary
+ * inverts the fix this driver exists to make, so we throw on any
+ * explicit-vs-classifier disagreement rather than pick one. When
+ * `input.name` is absent, honour `input.shape` verbatim; when both are
+ * absent, fall back to `package` (static-URL callers historically).
+ */
+function resolveShape(input: SmokeDriverInput): ShowcaseServiceShape {
+  if (input.name) {
+    const classified = classifyShape(input.name);
+    if (input.shape && input.shape !== classified) {
+      throw new Error(
+        `Shape mismatch: classifier="${classified}" input="${input.shape}" — check discovery wiring`,
+      );
+    }
+    return classified;
+  }
+  return input.shape ?? "package";
+}
+
 function deriveSlug(input: SmokeDriverInput): string {
   if (input.name) {
     const stripped = input.name.replace(/^showcase-/, "");
@@ -472,17 +514,17 @@ interface DerivedUrls {
  */
 function deriveUrls(
   input: SmokeDriverInput,
-  shape: "package" | "starter",
+  shape: ShowcaseServiceShape,
 ): DerivedUrls {
   if (input.publicUrl) {
     const base = input.publicUrl.replace(/\/$/, "");
     if (shape === "starter") {
       // Starters expose `/api/health` as the canonical liveness route
-      // (see `showcase/starters/template/frontend/app/api/health/route.ts`).
-      // There is no `/smoke` and no separate `/health` route — so the
-      // primary smoke probe and the health side-emit both target
-      // `/api/health`. The run() loop re-uses the single GET result
-      // rather than round-tripping twice.
+      // (see any starter's `app/api/health/route.ts`). There is no
+      // `/smoke` and no separate `/health` route — both the primary
+      // smoke probe and the health side-emit target `/api/health`. The
+      // two calls are intentionally independent round-trips; see the
+      // run() comment block for why.
       return {
         smokeUrl: `${base}/api/health`,
         healthUrl: `${base}/api/health`,

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -124,19 +124,65 @@ const discoverySmokeInputSchema = z
  * `run()` fills in the discriminator from field presence (`url` ⇒
  * static, `name+publicUrl` ⇒ discovery) and produces a
  * `NormalisedSmokeInput` that the rest of the driver narrows against.
- * The union contract is enforced at parse time; the discriminator is
- * assigned at execute time.
+ *
+ * The union contract is re-asserted at parse time via `.superRefine()`:
+ *   - Exactly one of `(url)` OR `(name + publicUrl)` must be present.
+ *     A caller passing all three gets rejected here, which matters
+ *     because the discovery arm's `.passthrough()` would otherwise let
+ *     the mixed payload through.
+ *   - `shape` is only valid alongside the discovery fields; setting
+ *     `shape` with `url` is a structural mistake (static mode predates
+ *     shape detection and is always package).
+ *
+ * Callers doing `smokeInputSchema.safeParse()` in isolation now see a
+ * unified rejection path for structural invariants regardless of which
+ * arm's strictness caught the bad field.
  */
-const smokeInputSchema = z.union([
-  staticSmokeInputSchema,
-  discoverySmokeInputSchema,
-]);
+const smokeInputSchema = z
+  .union([staticSmokeInputSchema, discoverySmokeInputSchema])
+  .superRefine((val, ctx) => {
+    const raw = val as {
+      url?: unknown;
+      name?: unknown;
+      publicUrl?: unknown;
+      shape?: unknown;
+    };
+    const hasUrl = typeof raw.url === "string";
+    const hasDiscovery =
+      typeof raw.name === "string" && typeof raw.publicUrl === "string";
+    if (hasUrl && hasDiscovery) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "smoke input: pass either `url` (static) OR `name`+`publicUrl` (discovery), not both",
+      });
+    }
+    if (!hasUrl && !hasDiscovery) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "smoke input: requires either `url` (static) or `name`+`publicUrl` (discovery)",
+      });
+    }
+    if (hasUrl && raw.shape !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "smoke input: `shape` is only valid with discovery mode (`name`+`publicUrl`)",
+      });
+    }
+  });
 
 type SmokeDriverInput = z.infer<typeof smokeInputSchema>;
 
 /**
  * Internal, post-normalisation form. `mode` is required here so every
  * downstream helper narrows by discriminator without a fallback branch.
+ * The discovery arm intentionally does NOT carry a `[k: string]: unknown`
+ * index signature: passthrough extras from the raw input are not read
+ * downstream, and keeping them off the type forces `input.url` in a
+ * `mode === "discovery"` branch to be a TS error rather than silently
+ * typechecking as `unknown`.
  */
 type NormalisedSmokeInput =
   | { mode: "static"; key: string; url: string }
@@ -146,7 +192,6 @@ type NormalisedSmokeInput =
       name: string;
       publicUrl: string;
       shape?: ShowcaseServiceShape;
-      [k: string]: unknown;
     };
 
 /**
@@ -275,20 +320,35 @@ function normaliseMode(input: unknown): NormalisedSmokeInput {
   if (!raw || typeof raw !== "object") {
     throw new Error("smoke driver: input must be an object");
   }
-  if (raw.mode === "static" || raw.mode === "discovery") {
-    return raw as NormalisedSmokeInput;
+  // Field presence is the sole discriminator. A caller-supplied `raw.mode`
+  // ("static" / "discovery") is ignored here — a previous early-return
+  // arm trusted `raw.mode` verbatim and let malformed inputs like
+  // `{mode:"static", key:"k"}` (no `url`) slip through. Letting the
+  // field-presence branches classify instead means the two paths are
+  // consistent between schema-parsed and raw inputs, and a bad shape
+  // throws loud rather than coercing.
+  if (typeof raw.key !== "string" || raw.key.length === 0) {
+    throw new Error("smoke driver: input.key is required");
   }
   if (typeof raw.url === "string") {
     return {
-      ...(raw as Record<string, unknown>),
       mode: "static",
-    } as NormalisedSmokeInput;
+      key: raw.key,
+      url: raw.url,
+    };
   }
   if (typeof raw.name === "string" && typeof raw.publicUrl === "string") {
+    const shape =
+      typeof raw.shape === "string"
+        ? (raw.shape as ShowcaseServiceShape)
+        : undefined;
     return {
-      ...(raw as Record<string, unknown>),
       mode: "discovery",
-    } as NormalisedSmokeInput;
+      key: raw.key,
+      name: raw.name,
+      publicUrl: raw.publicUrl,
+      shape,
+    };
   }
   throw new Error(
     "smoke driver: input requires either `url` (static) or `name`+`publicUrl` (discovery)",


### PR DESCRIPTION
## Summary

- Classify Railway showcase services as `package` vs `starter` from the service name and thread a `shape` field through the discovery source; drivers branch on it.
- `drivers/smoke.ts` probes `/api/health` for starters (reusing the result for the health side-emit), `/smoke` + `/health` for packages, and now follows 308 redirects on the `/api/copilotkit/` L2 probe so unmounted routes (308→404) actually flip red.
- `drivers/e2e-smoke.ts` short-circuits with `l3: "skipped"` + `l4: "skipped"` for starters before launching chromium — starters are single-app integrations with no `/demos/*` routing.

## Why

Starters expose a different URL surface than shell-based packages. The current discovery-driven probe contract assumed one shape and was firing false-red alerts on every tick against the 17 deployed starter services:

1. **No `/smoke` route** — L1 primary probe 404s.
2. **Health at `/api/health`, not `/health`** — side-emit 404s.
3. **No `/demos/*` routing** — L3 navigates to `/demos/agentic-chat` and 404s; L4 likewise.
4. **Registry lookup mismatch** — `deriveSlug` strips `showcase-` leaving `starter-<slug>`, which `registry.json` does not key on, so `hasToolRendering` is silently false and L4 never runs.
5. **L2 accepted raw 308** — masked regressions where the redirect target is actually unmounted (final 404).

Next probe tick without this fix would fire **17 × 3 = 51 false-red L1 alerts** plus **17 × 2 = 34 false-red L3/L4 alerts**. Verified against three live starters (`ag2`, `mastra`, `langgraph-python`): all return 200 on `/api/health`, 404 on `/smoke` / `/health` / `/demos/*`, and 308 → 400 on `POST /api/copilotkit/` (runtime rejects the empty body; proof-of-life remains).

Shape is derived from the Railway service name (`showcase-starter-*` → `"starter"`, else `"package"`), so adding a new starter requires no YAML edit — the next tick picks it up automatically.

## Test plan

TDD — 12 new tests written first (verified red against existing code), then implemented against:

- `railway-services.test.ts` (3 new): starter / package / mixed-batch classification of the `shape` field.
- `drivers/smoke.test.ts` (6 new): starter primary GET → `/api/health` green-on-200, starter `/api/health` 503 → red, `/smoke` + `/health` never probed under starter shape, explicit package shape preserves legacy contract, `/api/copilotkit/` POST uses `redirect: "follow"`, followed-redirect-to-404 flips red.
- `drivers/e2e-smoke.test.ts` (3 new): starter shape returns green-skipped aggregate, chromium never launched, `/demos/*` never navigated, in-band `demos` field ignored under starter shape.

Full showcase-ops suite: **716 tests passing** (704 existing + 12 new). Typecheck clean. Build clean.

## Follow-ups

None deferred — L2 308 handling is addressed in this PR alongside the shape split.