### PR TITLE
docs: update top-bar CTA to "Free Developer Access"

### DIFF
--- a/docs/components/react/link-to-copilot-cloud.tsx
+++ b/docs/components/react/link-to-copilot-cloud.tsx
@@ -62,7 +62,7 @@ export function LinkToCopilotCloud({
   return (
     <Link href={href} target="_blank" className={cn} suppressHydrationWarning>
       {asButton ? <CloudIcon className="w-5 h-5 mr-2" /> : null}
-      {children ? children : "Copilot Cloud"}
+      {children ? children : "Free Developer Access"}
     </Link>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Renames the docs top-bar call-to-action from **"Copilot Cloud"** to **"Free Developer Access"** to better reflect the value proposition of the signup flow.

The change touches the default text of the `LinkToCopilotCloud` component. Inline usages that pass explicit children (e.g., "Click here to get your Copilot Cloud API key for free", "navigate to Copilot Cloud", the MCP-servers reference) are unaffected — they keep their existing copy. The navbar nav link (not a CTA) also keeps its "Copilot Cloud" label.

Affected surface: the CTA button in `TopBar` at the top of every docs page.

## Related PRs and Issues

- n/a

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation