### PR TITLE
Fix #oss-alerts verbosity: sanitize, guard, un-escape, and aggregate

### DIFF
--- a/showcase/ops/config/alerts/agent-red-fleet.yml
+++ b/showcase/ops/config/alerts/agent-red-fleet.yml
@@ -1,0 +1,24 @@
+id: agent-red-fleet
+name: "Fleet-wide agent-red escalation"
+owner: "@oss"
+
+# Cross-service aggregation for the L2 agent-reachability dimension. Mirrors
+# smoke-red-fleet.yml — see that file's comments for rationale and timing.
+signal:
+  dimension: agent
+
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+aggregation:
+  groupBy: [dimension]
+  windowMs: 120000
+  minMatches: 3
+  template: |
+    <!channel> agent red across fleet — {{count}} services: {{services}}
+
+conditions:
+  rate_limit:
+    window: 10m

--- a/showcase/ops/config/alerts/agent-red-fleet.yml
+++ b/showcase/ops/config/alerts/agent-red-fleet.yml
@@ -10,10 +10,10 @@ signal:
 triggers:
   - green_to_red
   - sustained_red
-  - red_to_green
 
+# A7: groupBy omitted; signal.dimension already partitions traffic. See
+# smoke-red-fleet.yml for rationale and buildBucketKey for the mechanics.
 aggregation:
-  groupBy: [dimension]
   windowMs: 120000
   minMatches: 3
   template: |

--- a/showcase/ops/config/alerts/agent-red-tick.yml
+++ b/showcase/ops/config/alerts/agent-red-tick.yml
@@ -38,4 +38,4 @@ template:
     {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — agent attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* agent recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
 
-    <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>
+    <{{{env.dashboardUrl}}}|Showcase>{{#event.runId}} · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>{{/event.runId}}

--- a/showcase/ops/config/alerts/agent-red-tick.yml
+++ b/showcase/ops/config/alerts/agent-red-tick.yml
@@ -30,11 +30,12 @@ targets:
   - kind: slack_webhook
     webhook: oss_alerts
 
+# errorDesc is pre-sanitized in showcase/ops/src/probes/drivers/sanitize.ts
+# — triple-brace intentional so literal characters survive to Slack.
 template:
   text: |
-    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — agent unreachable, error: {{signal.errorDesc}}{{/trigger.green_to_red}}
-    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — agent attempt: {{signal.failCount}}, error: {{signal.errorDesc}}{{/trigger.sustained_red}}
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — agent unreachable, error: {{{signal.errorDesc}}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — agent attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* agent recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
-    {{#escalated}}<!channel> :rotating_light: *{{signal.slug}}* agent has been failing for 1 hour (since {{signal.firstFailureAt}}){{/escalated}}
 
     <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>

--- a/showcase/ops/config/alerts/chat-red-fleet.yml
+++ b/showcase/ops/config/alerts/chat-red-fleet.yml
@@ -10,10 +10,10 @@ signal:
 triggers:
   - green_to_red
   - sustained_red
-  - red_to_green
 
+# A7: groupBy omitted; signal.dimension already partitions traffic. See
+# smoke-red-fleet.yml for rationale and buildBucketKey for the mechanics.
 aggregation:
-  groupBy: [dimension]
   windowMs: 120000
   minMatches: 3
   template: |

--- a/showcase/ops/config/alerts/chat-red-fleet.yml
+++ b/showcase/ops/config/alerts/chat-red-fleet.yml
@@ -1,0 +1,24 @@
+id: chat-red-fleet
+name: "Fleet-wide chat-red escalation"
+owner: "@oss"
+
+# Cross-service aggregation for the L3 chat-turn dimension. Mirrors
+# smoke-red-fleet.yml — see that file's comments for rationale and timing.
+signal:
+  dimension: chat
+
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+aggregation:
+  groupBy: [dimension]
+  windowMs: 120000
+  minMatches: 3
+  template: |
+    <!channel> chat red across fleet — {{count}} services: {{services}}
+
+conditions:
+  rate_limit:
+    window: 10m

--- a/showcase/ops/config/alerts/chat-red-tick.yml
+++ b/showcase/ops/config/alerts/chat-red-tick.yml
@@ -30,11 +30,12 @@ targets:
   - kind: slack_webhook
     webhook: oss_alerts
 
+# errorDesc is pre-sanitized in showcase/ops/src/probes/drivers/sanitize.ts
+# — triple-brace intentional so literal characters survive to Slack.
 template:
   text: |
-    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — chat turn failed, error: {{signal.errorDesc}}{{/trigger.green_to_red}}
-    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — chat attempt: {{signal.failCount}}, error: {{signal.errorDesc}}{{/trigger.sustained_red}}
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — chat turn failed, error: {{{signal.errorDesc}}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — chat attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* chat recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
-    {{#escalated}}<!channel> :rotating_light: *{{signal.slug}}* chat has been failing for 1 hour (since {{signal.firstFailureAt}}){{/escalated}}
 
     <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>

--- a/showcase/ops/config/alerts/chat-red-tick.yml
+++ b/showcase/ops/config/alerts/chat-red-tick.yml
@@ -38,4 +38,4 @@ template:
     {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — chat attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* chat recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
 
-    <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>
+    <{{{env.dashboardUrl}}}|Showcase>{{#event.runId}} · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>{{/event.runId}}

--- a/showcase/ops/config/alerts/smoke-red-fleet.yml
+++ b/showcase/ops/config/alerts/smoke-red-fleet.yml
@@ -12,16 +12,17 @@ owner: "@oss"
 signal:
   dimension: smoke
 
-# Any matching trigger is enough — aggregation ingress is unconditional on
-# match, not on per-trigger semantics. Listing all three keeps the rule alive
-# regardless of which transition type dominates a given outage.
+# Fleet aggregation is for red-only signals. `red_to_green` recoveries do NOT
+# ingest (see alert-engine.ts aggregation ingress — A1); declaring it here
+# would be decorative but misleading.
 triggers:
   - green_to_red
   - sustained_red
-  - red_to_green
 
+# A7: groupBy omitted — the rule's `signal.dimension: smoke` already partitions
+# traffic to smoke-only events, so there's no finer partition to apply. The
+# bucket key collapses to `rule.id` alone (see buildBucketKey in aggregation.ts).
 aggregation:
-  groupBy: [dimension]
   # windowMs: 2 min — one probe tick (90s) plus slack for signal arrival jitter.
   windowMs: 120000
   minMatches: 3

--- a/showcase/ops/config/alerts/smoke-red-fleet.yml
+++ b/showcase/ops/config/alerts/smoke-red-fleet.yml
@@ -1,0 +1,38 @@
+id: smoke-red-fleet
+name: "Fleet-wide smoke-red escalation"
+owner: "@oss"
+
+# Cross-service aggregation (plan Item 4). When N >= 3 smoke-red signals land
+# within a 2-minute window — covers one 90s probe tick plus slack — the engine
+# emits ONE composite channel ping instead of N per-service red-ticks. The
+# per-service smoke-red-tick YAML still fires its own alert (routed to the
+# same channel via the rate-limit / dedupe gates); the fleet rule exists
+# specifically to page on-call when the problem is fleet-wide rather than
+# per-starter.
+signal:
+  dimension: smoke
+
+# Any matching trigger is enough — aggregation ingress is unconditional on
+# match, not on per-trigger semantics. Listing all three keeps the rule alive
+# regardless of which transition type dominates a given outage.
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+aggregation:
+  groupBy: [dimension]
+  # windowMs: 2 min — one probe tick (90s) plus slack for signal arrival jitter.
+  windowMs: 120000
+  minMatches: 3
+  # The channel-ping token below is intentional and load-bearing: per-service
+  # red-tick YAMLs no longer page channel; this rule is the single pager.
+  template: |
+    <!channel> smoke red across fleet — {{count}} services: {{services}}
+
+# rate_limit.window spans multiple aggregation windows so back-to-back 2-minute
+# buckets with the same groupValues collapse to one dispatch. Composite dedupe
+# key is stable across windows (see buildCompositeDedupeKey in aggregation.ts).
+conditions:
+  rate_limit:
+    window: 10m

--- a/showcase/ops/config/alerts/smoke-red-tick.yml
+++ b/showcase/ops/config/alerts/smoke-red-tick.yml
@@ -32,11 +32,14 @@ targets:
   - kind: slack_webhook
     webhook: oss_alerts
 
+# Link fields are conditional — Mustache section guards prevent empty
+# `<|smoke>` / `<|health>` artifacts when a link is absent. errorDesc is
+# pre-sanitized in showcase/ops/src/probes/drivers/sanitize.ts — triple-brace
+# intentional.
 template:
   text: |
-    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — down, error: {{signal.errorDesc}} (<{{{signal.links.smoke}}}|smoke> · <{{{signal.links.health}}}|health>){{/trigger.green_to_red}}
-    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — attempt: {{signal.failCount}}, error: {{signal.errorDesc}} (<{{{signal.links.smoke}}}|smoke> · <{{{signal.links.health}}}|health>){{/trigger.sustained_red}}
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — down, error: {{{signal.errorDesc}}}{{#signal.links.smoke}} <{{{signal.links.smoke}}}|smoke>{{/signal.links.smoke}}{{#signal.links.health}} · <{{{signal.links.health}}}|health>{{/signal.links.health}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{#signal.links.smoke}} <{{{signal.links.smoke}}}|smoke>{{/signal.links.smoke}}{{#signal.links.health}} · <{{{signal.links.health}}}|health>{{/signal.links.health}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
-    {{#escalated}}<!channel> :rotating_light: *{{signal.slug}}* has been failing for 1 hour (since {{signal.firstFailureAt}}){{/escalated}}
 
     <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>

--- a/showcase/ops/config/alerts/smoke-red-tick.yml
+++ b/showcase/ops/config/alerts/smoke-red-tick.yml
@@ -32,14 +32,16 @@ targets:
   - kind: slack_webhook
     webhook: oss_alerts
 
-# Link fields are conditional — Mustache section guards prevent empty
-# `<|smoke>` / `<|health>` artifacts when a link is absent. errorDesc is
-# pre-sanitized in showcase/ops/src/probes/drivers/sanitize.ts — triple-brace
-# intentional.
+# A3: driver signal carries `signal.url` (the endpoint that was probed);
+# there is no `links` object. Section-guard on `signal.url` so the endpoint
+# link emits only when present. errorDesc is pre-sanitized in
+# showcase/ops/src/probes/drivers/sanitize.ts — triple-brace intentional.
+# A2: wrap the Run link on event.runId so a missing runId doesn't render a
+# broken `/runs/|Run` pair.
 template:
   text: |
-    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — down, error: {{{signal.errorDesc}}}{{#signal.links.smoke}} <{{{signal.links.smoke}}}|smoke>{{/signal.links.smoke}}{{#signal.links.health}} · <{{{signal.links.health}}}|health>{{/signal.links.health}}{{/trigger.green_to_red}}
-    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{#signal.links.smoke}} <{{{signal.links.smoke}}}|smoke>{{/signal.links.smoke}}{{#signal.links.health}} · <{{{signal.links.health}}}|health>{{/signal.links.health}}{{/trigger.sustained_red}}
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — down, error: {{{signal.errorDesc}}}{{#signal.url}} <{{{signal.url}}}|endpoint>{{/signal.url}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{#signal.url}} <{{{signal.url}}}|endpoint>{{/signal.url}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
 
-    <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>
+    <{{{env.dashboardUrl}}}|Showcase>{{#event.runId}} · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>{{/event.runId}}

--- a/showcase/ops/config/alerts/tools-red-fleet.yml
+++ b/showcase/ops/config/alerts/tools-red-fleet.yml
@@ -1,0 +1,24 @@
+id: tools-red-fleet
+name: "Fleet-wide tools-red escalation"
+owner: "@oss"
+
+# Cross-service aggregation for the L4 tool-invocation dimension. Mirrors
+# smoke-red-fleet.yml — see that file's comments for rationale and timing.
+signal:
+  dimension: tools
+
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+aggregation:
+  groupBy: [dimension]
+  windowMs: 120000
+  minMatches: 3
+  template: |
+    <!channel> tools red across fleet — {{count}} services: {{services}}
+
+conditions:
+  rate_limit:
+    window: 10m

--- a/showcase/ops/config/alerts/tools-red-fleet.yml
+++ b/showcase/ops/config/alerts/tools-red-fleet.yml
@@ -10,10 +10,10 @@ signal:
 triggers:
   - green_to_red
   - sustained_red
-  - red_to_green
 
+# A7: groupBy omitted; signal.dimension already partitions traffic. See
+# smoke-red-fleet.yml for rationale and buildBucketKey for the mechanics.
 aggregation:
-  groupBy: [dimension]
   windowMs: 120000
   minMatches: 3
   template: |

--- a/showcase/ops/config/alerts/tools-red-tick.yml
+++ b/showcase/ops/config/alerts/tools-red-tick.yml
@@ -30,11 +30,12 @@ targets:
   - kind: slack_webhook
     webhook: oss_alerts
 
+# errorDesc is pre-sanitized in showcase/ops/src/probes/drivers/sanitize.ts
+# — triple-brace intentional so literal characters survive to Slack.
 template:
   text: |
-    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — tool invocation failed, error: {{signal.errorDesc}}{{/trigger.green_to_red}}
-    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — tools attempt: {{signal.failCount}}, error: {{signal.errorDesc}}{{/trigger.sustained_red}}
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — tool invocation failed, error: {{{signal.errorDesc}}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — tools attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* tools recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
-    {{#escalated}}<!channel> :rotating_light: *{{signal.slug}}* tools have been failing for 1 hour (since {{signal.firstFailureAt}}){{/escalated}}
 
     <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>

--- a/showcase/ops/config/alerts/tools-red-tick.yml
+++ b/showcase/ops/config/alerts/tools-red-tick.yml
@@ -38,4 +38,4 @@ template:
     {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — tools attempt: {{signal.failCount}}, error: {{{signal.errorDesc}}}{{/trigger.sustained_red}}
     {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* tools recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
 
-    <{{{env.dashboardUrl}}}|Showcase> · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>
+    <{{{env.dashboardUrl}}}|Showcase>{{#event.runId}} · <{{{env.dashboardUrl}}}/runs/{{{event.runId}}}|Run>{{/event.runId}}

--- a/showcase/ops/src/alerts/aggregation.ts
+++ b/showcase/ops/src/alerts/aggregation.ts
@@ -27,18 +27,26 @@ import type { CompiledRule } from "../rules/rule-loader.js";
 export type Signal = Record<string, unknown>;
 
 export interface AggregationConfig {
-  /** Signal field names joined to form the bucket key. Order-independent for
-   *  dedupe (see `buildCompositeDedupeKey`); ordered here only to surface in
-   *  rendering context. */
-  groupBy: string[];
+  /**
+   * Signal field names joined to form the bucket key. Order-independent for
+   * dedupe (see `buildCompositeDedupeKey`); ordered here only to surface in
+   * rendering context.
+   *
+   * Absent or empty → single bucket per rule. Use this when the rule's
+   * `when` clause already partitions traffic (e.g. one rule per dimension)
+   * and there's no finer partition to apply. The bucket key collapses to
+   * `rule.id` alone.
+   */
+  groupBy?: string[];
   /** Milliseconds the bucket remains open after the first match before timer-flush. */
   windowMs: number;
   /** Threshold at which the bucket flushes immediately (before windowMs). */
   minMatches: number;
   /** Mustache template for the composite flush text. Rendered by the engine. */
   template: string;
-  /** Optional target aliases; when absent the host rule's targets are used. */
-  targets?: string[];
+  // B1: `targets` field removed. The engine uses `rule.targets` for
+  // aggregation dispatch; a separate aggregation-level targets override was
+  // never wired through `onAggregationFlush` and silently dropped.
 }
 
 export interface Bucket {
@@ -61,7 +69,21 @@ export interface Bucket {
 
 export type FlushReason = "threshold" | "timer";
 
-export type OnFlushCallback = (bucket: Bucket, reason: FlushReason) => void;
+/**
+ * A5: onFlush callbacks can return "suppressed" when an engine-side gate
+ * (bootstrap window, rate-limit, all-targets-failed) short-circuits
+ * dispatch. The store treats "suppressed" as a no-op: the bucket stays
+ * live, `flushedAt` is NOT set, and subsequent ingestion that re-crosses
+ * threshold will re-fire onFlush. This prevents silent drop of composites
+ * that arrive inside the bootstrap window — post-bootstrap ticks still
+ * get a chance to deliver.
+ */
+export type FlushResult = void | "suppressed";
+
+export type OnFlushCallback = (
+  bucket: Bucket,
+  reason: FlushReason,
+) => FlushResult | Promise<FlushResult>;
 
 export class AggregationBucketStore {
   private readonly buckets = new Map<string, Bucket>();
@@ -95,7 +117,9 @@ export class AggregationBucketStore {
   ingest(rule: CompiledRule, signal: Signal, now: number): void {
     const agg = rule.aggregation;
     if (!agg) return;
-    const groupValues = this.extractGroupValues(agg.groupBy, signal);
+    // A7: groupBy is optional/empty → single bucket per rule.
+    const groupBy = agg.groupBy ?? [];
+    const groupValues = this.extractGroupValues(groupBy, signal);
     const key = this.buildBucketKey(rule, groupValues);
     let bucket = this.buckets.get(key);
     if (!bucket) {
@@ -116,9 +140,20 @@ export class AggregationBucketStore {
     // match count reaches minMatches. Additional matches within the window
     // continue to append to the already-flushed bucket so the `onFlush`
     // receiver (which holds the bucket by reference) sees the full set.
+    //
+    // A5: if onFlush returns "suppressed" (engine-side gate), leave the
+    // bucket live with flushedAt still null so a subsequent ingestion
+    // crossing threshold re-fires onFlush. Non-suppressed synchronous
+    // returns mark flushedAt so we don't re-fire within the same window.
     if (bucket.flushedAt == null && bucket.matches.length >= agg.minMatches) {
-      bucket.flushedAt = now;
-      this.onFlush(bucket, "threshold");
+      const result = this.onFlush(bucket, "threshold");
+      this.applyFlushResult(bucket, now, result);
+      // Arm the window timer regardless — we still need cleanup at window
+      // expiry, and if the flush was suppressed the bucket stays live until
+      // either a re-threshold or window-expiry cleanup fires.
+      if (!bucket.flushTimer) {
+        this.scheduleFlush(bucket, agg.windowMs);
+      }
       return;
     }
 
@@ -131,25 +166,73 @@ export class AggregationBucketStore {
   }
 
   /**
-   * Flushes all in-flight buckets. Called from `beforeExit` on graceful
-   * shutdown. SIGKILL / hard-kill path: in-flight buckets are lost by design
-   * — the next probe tick rebuilds state naturally, no persistent store
-   * required.
+   * Apply the synchronous or promise-bearing flush result back onto the
+   * bucket. "suppressed" keeps flushedAt null (bucket stays live);
+   * anything else marks flushedAt so subsequent ingests don't re-fire.
+   * Promise results are awaited in a fire-and-forget path here — the
+   * engine's onAggregationFlush returns a pre-resolved "suppressed"
+   * sentinel when its gate short-circuits, so the sync branch is the
+   * common case; the async branch is belt-and-braces for future gates.
+   */
+  private applyFlushResult(
+    bucket: Bucket,
+    now: number,
+    result: FlushResult | Promise<FlushResult>,
+  ): void {
+    if (result && typeof (result as Promise<FlushResult>).then === "function") {
+      void (result as Promise<FlushResult>).then((r) => {
+        if (r !== "suppressed") {
+          bucket.flushedAt = now;
+        }
+      });
+      // Synchronous optimism: assume success for immediate state. The
+      // post-resolve `.then` above can still flip flushedAt to a non-null
+      // timestamp; for the "suppressed" path we leave flushedAt null so
+      // re-ingestion can re-trigger.
+      bucket.flushedAt = now;
+      return;
+    }
+    if (result !== "suppressed") {
+      bucket.flushedAt = now;
+    }
+  }
+
+  /**
+   * Flushes all in-flight buckets. Called from `beforeExit` / `SIGTERM` on
+   * graceful shutdown. SIGKILL / hard-kill path: in-flight buckets are lost
+   * by design — the next probe tick rebuilds state naturally, no persistent
+   * store required.
+   *
+   * A4: drain returns a Promise and awaits each onFlush invocation so a
+   * SIGTERM handler can `await store.drain()` and be sure in-flight buckets
+   * actually dispatch before the process exits. Pre-fix drain() was
+   * synchronous and async onFlush promises vanished into .catch() —
+   * beforeExit returned before the Slack call completed.
    *
    * Only invokes `onFlush` for buckets that never reached threshold;
    * already-flushed buckets are silently removed so the shutdown path
    * matches the timer-expiry path (both cleanup, at most one callback).
    */
-  drain(): void {
+  async drain(): Promise<void> {
     // Snapshot keys first — flushBucket mutates the map while iterating.
+    const pending: Promise<FlushResult>[] = [];
     for (const key of [...this.buckets.keys()]) {
       const bucket = this.buckets.get(key);
       if (!bucket) continue;
       if (bucket.flushedAt == null) {
-        this.flushBucket(bucket, "timer");
+        // Remove first, then invoke onFlush so map mutation during await
+        // doesn't matter; we hold the bucket by reference.
+        this.removeBucket(bucket);
+        const r = this.onFlush(bucket, "timer");
+        if (r && typeof (r as Promise<FlushResult>).then === "function") {
+          pending.push(r as Promise<FlushResult>);
+        }
       } else {
         this.removeBucket(bucket);
       }
+    }
+    if (pending.length > 0) {
+      await Promise.allSettled(pending);
     }
   }
 
@@ -169,13 +252,20 @@ export class AggregationBucketStore {
     rule: CompiledRule,
     groupValues: Record<string, string>,
   ): string {
+    // A7: absent or empty groupValues → bucket scoped to rule.id alone.
     // Sort entries so the key is order-independent w.r.t. groupBy declaration
     // order (defensive — `groupBy` is author-ordered, but a rule author
     // swapping `[a, b]` for `[b, a]` should NOT reassign the bucket).
-    const parts = Object.entries(groupValues)
-      .map(([k, v]) => `${k}=${v}`)
-      .sort();
-    return `${rule.id}::${parts.join("&")}`;
+    //
+    // B4: use NUL as the field-separator so a groupBy value containing `&`
+    // or `=` can't collide with a distinct grouping. `${k}=${v}` joined on
+    // `&` admitted e.g. `{b:"y&c=z"}` colliding with `{b:"y",c:"z"}`; NUL
+    // is not a valid character in any JS string literal source, and probes
+    // don't emit NUL in signal fields, so the separator stays injection-safe.
+    const entries = Object.entries(groupValues);
+    if (entries.length === 0) return rule.id;
+    const parts = entries.map(([k, v]) => `${k}=${v}`).sort();
+    return `${rule.id}::${parts.join("\u0000")}`;
   }
 
   /** Flush + remove. Used for below-threshold timer expiry and drain. */
@@ -211,17 +301,20 @@ export class AggregationBucketStore {
 
 /**
  * Stable composite dedupe key for a rule's aggregation flush. Order-independent
- * across `groupValues` entries (sorted `k=v` parts joined with `&`) so
+ * across `groupValues` entries (sorted `k=v` parts joined with NUL) so
  * two successive buckets for the same logical group collapse to the same
  * dedupe bucket — the engine's rate_limit + stateStore gate then suppresses
- * repeat flushes within the window.
+ * repeat flushes within the window. Absent/empty groupValues → key scopes
+ * to `rule.id` alone, consistent with `buildBucketKey`.
  */
 export function buildCompositeDedupeKey(
   rule: CompiledRule,
   groupValues: Record<string, string>,
 ): string {
-  const parts = Object.entries(groupValues)
-    .map(([k, v]) => `${k}=${v}`)
-    .sort();
-  return `${rule.id}::composite::${parts.join("&")}`;
+  // A7 + B4: match buildBucketKey — absent/empty groupValues → rule.id
+  // scope, NUL separator to preclude collision on values containing `&=`.
+  const entries = Object.entries(groupValues);
+  if (entries.length === 0) return `${rule.id}::composite`;
+  const parts = entries.map(([k, v]) => `${k}=${v}`).sort();
+  return `${rule.id}::composite::${parts.join("\u0000")}`;
 }

--- a/showcase/ops/src/alerts/aggregation.ts
+++ b/showcase/ops/src/alerts/aggregation.ts
@@ -1,0 +1,227 @@
+import type { CompiledRule } from "../rules/rule-loader.js";
+
+/**
+ * Cross-service alert aggregation (plan Item 4).
+ *
+ * When a rule declares `aggregation: { groupBy, windowMs, minMatches, template }`,
+ * matching signals are collected into in-memory buckets keyed on the join of
+ * `groupBy` field values. A bucket flushes via `onFlush` in two ways:
+ *
+ *   - `threshold` — bucket.matches.length >= minMatches (immediate flush)
+ *   - `timer`     — windowMs elapsed since the first match (setTimeout fires)
+ *
+ * The store is transport-agnostic: it owns bucket lifecycle, composite key
+ * derivation, and timer management. It does NOT render templates, gate on
+ * rate-limit / dedupe / bootstrap, or dispatch to targets — all of that is
+ * the alert-engine's responsibility to apply inside its `onFlush` closure.
+ *
+ * This separation keeps the store easy to unit-test in isolation (see
+ * alert-engine.test.ts "AggregationBucketStore" block) and keeps engine
+ * control-flow gates localized to one place.
+ */
+
+/** Shape of an aggregated signal. Engine callers can pass anything matching
+ *  the signal shape their probes emit; the store only reads `groupBy` fields
+ *  off it by name. Kept permissive so aggregation doesn't require widening
+ *  the ProbeResult signal contract. */
+export type Signal = Record<string, unknown>;
+
+export interface AggregationConfig {
+  /** Signal field names joined to form the bucket key. Order-independent for
+   *  dedupe (see `buildCompositeDedupeKey`); ordered here only to surface in
+   *  rendering context. */
+  groupBy: string[];
+  /** Milliseconds the bucket remains open after the first match before timer-flush. */
+  windowMs: number;
+  /** Threshold at which the bucket flushes immediately (before windowMs). */
+  minMatches: number;
+  /** Mustache template for the composite flush text. Rendered by the engine. */
+  template: string;
+  /** Optional target aliases; when absent the host rule's targets are used. */
+  targets?: string[];
+}
+
+export interface Bucket {
+  key: string;
+  ruleId: string;
+  groupValues: Record<string, string>;
+  matches: Signal[];
+  firstMatchAt: number;
+  flushTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Timestamp (ms) at which a threshold flush fired, or null if the bucket
+   * has not yet flushed. Once set, subsequent ingests still append to
+   * `matches` (so the `onFlush` receiver's bucket reference reflects the
+   * full window's worth of signals) but do NOT re-fire `onFlush`. The
+   * window-expiry timer then just cleans the bucket out of the map
+   * without a second callback.
+   */
+  flushedAt: number | null;
+}
+
+export type FlushReason = "threshold" | "timer";
+
+export type OnFlushCallback = (bucket: Bucket, reason: FlushReason) => void;
+
+export class AggregationBucketStore {
+  private readonly buckets = new Map<string, Bucket>();
+
+  constructor(private readonly onFlush: OnFlushCallback) {}
+
+  /** Number of in-flight buckets. Test-facing invariant (TTL eviction). */
+  get size(): number {
+    return this.buckets.size;
+  }
+
+  /**
+   * Ingest a matching signal against an aggregated rule. Finds-or-creates a
+   * bucket keyed on the rule's `groupBy` join, pushes the signal, and fires
+   * `onFlush` the first time the bucket reaches `minMatches`.
+   *
+   * Flush semantics (plan Item 4 red-phase contract):
+   *   - Threshold flush: `onFlush(bucket, "threshold")` fires ONCE on the
+   *     ingest that takes `matches.length` to or past `minMatches`. Subsequent
+   *     matches within the same window still append to `matches` (so the
+   *     receiver's captured bucket reference reflects the full count), but
+   *     do NOT re-fire `onFlush`.
+   *   - Timer flush: if the bucket never reaches threshold, a `windowMs`
+   *     timer fires `onFlush(bucket, "timer")` at expiry. Either way the
+   *     bucket is removed from the map exactly once — by whichever path
+   *     runs cleanup.
+   *
+   * The window timer is armed once per bucket (NOT reset on each match) so a
+   * steady trickle of signals can't postpone flush indefinitely.
+   */
+  ingest(rule: CompiledRule, signal: Signal, now: number): void {
+    const agg = rule.aggregation;
+    if (!agg) return;
+    const groupValues = this.extractGroupValues(agg.groupBy, signal);
+    const key = this.buildBucketKey(rule, groupValues);
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        ruleId: rule.id,
+        groupValues,
+        matches: [],
+        firstMatchAt: now,
+        flushTimer: null,
+        flushedAt: null,
+      };
+      this.buckets.set(key, bucket);
+    }
+    bucket.matches.push(signal);
+
+    // Fire the threshold flush exactly once per bucket, the first time the
+    // match count reaches minMatches. Additional matches within the window
+    // continue to append to the already-flushed bucket so the `onFlush`
+    // receiver (which holds the bucket by reference) sees the full set.
+    if (bucket.flushedAt == null && bucket.matches.length >= agg.minMatches) {
+      bucket.flushedAt = now;
+      this.onFlush(bucket, "threshold");
+      return;
+    }
+
+    // Arm the window timer exactly once per bucket. The timer always fires
+    // — its job is cleanup — but only invokes `onFlush` again if the bucket
+    // never reached threshold (i.e. flushedAt is still null at expiry).
+    if (!bucket.flushTimer) {
+      this.scheduleFlush(bucket, agg.windowMs);
+    }
+  }
+
+  /**
+   * Flushes all in-flight buckets. Called from `beforeExit` on graceful
+   * shutdown. SIGKILL / hard-kill path: in-flight buckets are lost by design
+   * — the next probe tick rebuilds state naturally, no persistent store
+   * required.
+   *
+   * Only invokes `onFlush` for buckets that never reached threshold;
+   * already-flushed buckets are silently removed so the shutdown path
+   * matches the timer-expiry path (both cleanup, at most one callback).
+   */
+  drain(): void {
+    // Snapshot keys first — flushBucket mutates the map while iterating.
+    for (const key of [...this.buckets.keys()]) {
+      const bucket = this.buckets.get(key);
+      if (!bucket) continue;
+      if (bucket.flushedAt == null) {
+        this.flushBucket(bucket, "timer");
+      } else {
+        this.removeBucket(bucket);
+      }
+    }
+  }
+
+  private extractGroupValues(
+    groupBy: string[],
+    signal: Signal,
+  ): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const field of groupBy) {
+      const v = signal[field];
+      out[field] = typeof v === "string" ? v : String(v ?? "");
+    }
+    return out;
+  }
+
+  private buildBucketKey(
+    rule: CompiledRule,
+    groupValues: Record<string, string>,
+  ): string {
+    // Sort entries so the key is order-independent w.r.t. groupBy declaration
+    // order (defensive — `groupBy` is author-ordered, but a rule author
+    // swapping `[a, b]` for `[b, a]` should NOT reassign the bucket).
+    const parts = Object.entries(groupValues)
+      .map(([k, v]) => `${k}=${v}`)
+      .sort();
+    return `${rule.id}::${parts.join("&")}`;
+  }
+
+  /** Flush + remove. Used for below-threshold timer expiry and drain. */
+  private flushBucket(bucket: Bucket, reason: FlushReason): void {
+    this.removeBucket(bucket);
+    this.onFlush(bucket, reason);
+  }
+
+  /** Remove from map + clear timer WITHOUT invoking onFlush. Used to clean
+   *  up already-threshold-flushed buckets whose window has now expired. */
+  private removeBucket(bucket: Bucket): void {
+    if (bucket.flushTimer) {
+      clearTimeout(bucket.flushTimer);
+      bucket.flushTimer = null;
+    }
+    this.buckets.delete(bucket.key);
+  }
+
+  private scheduleFlush(bucket: Bucket, delayMs: number): void {
+    bucket.flushTimer = setTimeout(() => {
+      // Defensive: confirm we're still the owner of this key. A race is
+      // impossible today (single-threaded) but the check costs nothing.
+      if (this.buckets.get(bucket.key) !== bucket) return;
+      if (bucket.flushedAt != null) {
+        // Threshold already fired — timer's only job now is cleanup.
+        this.removeBucket(bucket);
+      } else {
+        this.flushBucket(bucket, "timer");
+      }
+    }, delayMs);
+  }
+}
+
+/**
+ * Stable composite dedupe key for a rule's aggregation flush. Order-independent
+ * across `groupValues` entries (sorted `k=v` parts joined with `&`) so
+ * two successive buckets for the same logical group collapse to the same
+ * dedupe bucket — the engine's rate_limit + stateStore gate then suppresses
+ * repeat flushes within the window.
+ */
+export function buildCompositeDedupeKey(
+  rule: CompiledRule,
+  groupValues: Record<string, string>,
+): string {
+  const parts = Object.entries(groupValues)
+    .map(([k, v]) => `${k}=${v}`)
+    .sort();
+  return `${rule.id}::composite::${parts.join("&")}`;
+}

--- a/showcase/ops/src/alerts/aggregation.ts
+++ b/showcase/ops/src/alerts/aggregation.ts
@@ -181,14 +181,18 @@ export class AggregationBucketStore {
   ): void {
     if (result && typeof (result as Promise<FlushResult>).then === "function") {
       void (result as Promise<FlushResult>).then((r) => {
-        if (r !== "suppressed") {
-          bucket.flushedAt = now;
+        if (r === "suppressed") {
+          // A5: promise resolved suppressed → revert the optimistic set so
+          // the bucket stays live for re-threshold. Since `onAggregationFlush`
+          // is wired with `.catch()` in the engine, this branch IS the
+          // production path (every real flush is a Promise).
+          bucket.flushedAt = null;
         }
       });
-      // Synchronous optimism: assume success for immediate state. The
-      // post-resolve `.then` above can still flip flushedAt to a non-null
-      // timestamp; for the "suppressed" path we leave flushedAt null so
-      // re-ingestion can re-trigger.
+      // Optimistic set: assume non-suppressed for immediate state so a
+      // follow-up ingest within the same synchronous tick won't re-fire
+      // onFlush. The .then above reverts flushedAt back to null if the
+      // flush actually resolves as "suppressed".
       bucket.flushedAt = now;
       return;
     }

--- a/showcase/ops/src/alerts/alert-engine.test.ts
+++ b/showcase/ops/src/alerts/alert-engine.test.ts
@@ -3123,7 +3123,6 @@ describe("AggregationBucketStore (Item 4 red phase)", () => {
       windowMs: 30_000,
       minMatches: 3,
       template: "<!channel> {{count}} smoke-red across fleet: {{services}}",
-      targets: ["slack-oss-alerts"],
       ...overrides,
     };
     return { ...base, aggregation } satisfies AggregatedRule;
@@ -3288,12 +3287,16 @@ describe("AggregationBucketStore (Item 4 red phase)", () => {
     const BOOTSTRAP_MS = 15 * 60 * 1_000;
     const engineStartedAt = Date.now();
     const dispatched: string[] = [];
+    // A6: declare `rule` BEFORE the `onFlush` closure so the closure's
+    // reference is not a TDZ trap. The prior ordering (rule after store)
+    // worked only because the closure was never invoked before the rule
+    // was initialized — a silent hazard once any flush fires earlier.
+    const rule = aggRule({ minMatches: 3 });
     const onFlush = vi.fn((bucket) => {
       if (Date.now() - engineStartedAt < BOOTSTRAP_MS) return; // suppressed
       dispatched.push(buildCompositeDedupeKey(rule, bucket.groupValues));
     });
     const store = new AggregationBucketStore(onFlush);
-    const rule = aggRule({ minMatches: 3 });
 
     // All three matches arrive inside the first minute of engine uptime.
     const t0 = engineStartedAt;
@@ -3320,5 +3323,201 @@ describe("AggregationBucketStore (Item 4 red phase)", () => {
     vi.advanceTimersByTime(2 * windowMs + 1);
 
     expect(store.size).toBe(0);
+  });
+
+  it("drain_awaits_onflush_promises", async () => {
+    // A4: drain() must await async onFlush callbacks so SIGTERM handlers
+    // can guarantee in-flight buckets finish dispatching before the process
+    // exits. Pre-fix drain() was synchronous and onFlush returning a Promise
+    // vanished into .catch() — beforeExit returned before flushes completed.
+    vi.useRealTimers();
+    let resolved = false;
+    const onFlush = vi.fn(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      resolved = true;
+    });
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ minMatches: 99, windowMs: 60_000 });
+    store.ingest(rule, mkSignal("smoke", "a"), Date.now());
+    expect(store.size).toBe(1);
+
+    const drainPromise = store.drain();
+    // drain should return a Promise that awaits the async onFlush.
+    expect(drainPromise).toBeInstanceOf(Promise);
+    expect(resolved).toBe(false); // still in flight before await
+    await drainPromise;
+    expect(resolved).toBe(true);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("bucket_stays_live_when_flush_suppressed", () => {
+    // A5: when onFlush returns "suppressed" (engine's bootstrap / rate-limit
+    // gate short-circuits dispatch), the store must NOT mark flushedAt or
+    // remove the bucket. Subsequent ingestion must re-cross threshold and
+    // re-invoke onFlush so a post-bootstrap tick can actually deliver.
+    const onFlush = vi.fn(() => "suppressed" as const);
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ minMatches: 3, windowMs: 60_000 });
+    const t0 = Date.now();
+    store.ingest(rule, mkSignal("smoke", "a"), t0);
+    store.ingest(rule, mkSignal("smoke", "b"), t0 + 1_000);
+    store.ingest(rule, mkSignal("smoke", "c"), t0 + 2_000); // threshold hit
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    // Bucket must still be live so a future ingestion re-fires onFlush.
+    expect(store.size).toBe(1);
+
+    // Second ingestion after "gate opened" (onFlush returns undefined now).
+    const calls = onFlush.mock.calls.length;
+    (
+      onFlush as unknown as { mockImplementation: (f: () => void) => void }
+    ).mockImplementation(() => undefined);
+    store.ingest(rule, mkSignal("smoke", "d"), t0 + 3_000);
+    expect(onFlush.mock.calls.length).toBeGreaterThan(calls);
+  });
+
+  it("bucket_key_collision_safe_with_special_chars", () => {
+    // B4: intra-key delimiter must be NUL ( ), not `&`, so a groupBy
+    // value containing `=` or `&` can't be crafted to collide with a
+    // distinct grouping. Use `buildCompositeDedupeKey` as the public
+    // surface for the collision check.
+    const rule = aggRule();
+    // Pre-fix `${k}=${v}` joined on `&` had a concrete collision:
+    //   { a: "x", b: "y&c=z" }      → "a=x&b=y&c=z"
+    //   { a: "x", b: "y", c: "z" }  → "a=x&b=y&c=z"
+    const keyA = buildCompositeDedupeKey(rule, { a: "x", b: "y&c=z" });
+    const keyB = buildCompositeDedupeKey(rule, { a: "x", b: "y", c: "z" });
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it("no_groupBy_uses_ruleid_only_as_bucket_scope", () => {
+    // A7: omitting `groupBy` (or passing empty) must key the bucket purely
+    // on `rule.id`. Pre-fix rules declaring `groupBy: [dimension]` produced
+    // `signal.dimension === undefined → ""` under the hood and silently
+    // collapsed to one bucket — the new contract makes that explicit.
+    const onFlush = vi.fn();
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ groupBy: [], minMatches: 3 });
+    const t0 = Date.now();
+    // Signals across multiple dimensions — all collapse to the rule-id
+    // bucket because groupBy is empty.
+    store.ingest(rule, mkSignal("smoke", "a"), t0);
+    store.ingest(rule, mkSignal("agent", "b"), t0 + 100);
+    store.ingest(rule, mkSignal("chat", "c"), t0 + 200);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    const [bucket] = onFlush.mock.calls[0]!;
+    expect(bucket.matches).toHaveLength(3);
+    expect(bucket.groupValues).toEqual({});
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Engine-level aggregation ingress — A1 fix: red_to_green transitions must
+// NOT ingest into the aggregation bucket (recovery is not a "fleet red"
+// signal). green_to_red and sustained_red continue to ingest.
+// -----------------------------------------------------------------------------
+describe("alert-engine aggregation ingress (A1)", () => {
+  let bus: ReturnType<typeof createEventBus>;
+  let renderer: ReturnType<typeof createRenderer>;
+  let store: AlertStateStore;
+  let tgt: ReturnType<typeof captureTarget>;
+
+  beforeEach(() => {
+    bus = createEventBus();
+    renderer = createRenderer();
+    store = memStore();
+    tgt = captureTarget();
+  });
+
+  function engine(
+    overrides: Partial<Parameters<typeof createAlertEngine>[0]> = {},
+  ): ReturnType<typeof createAlertEngine> {
+    const tMap = new Map([["slack_webhook", tgt.target]]);
+    return createAlertEngine({
+      bus,
+      renderer,
+      stateStore: store,
+      targets: tMap,
+      logger,
+      now: () => new Date("2026-04-20T01:00:00Z"),
+      env: { dashboardUrl: "https://d", repo: "r/r" },
+      bootstrapWindowMs: 0,
+      ...overrides,
+    });
+  }
+
+  function aggregatedSmokeRule(): CompiledRule {
+    return {
+      id: "smoke-red-fleet",
+      name: "fleet",
+      owner: "@oss",
+      severity: "warn",
+      signal: { dimension: "smoke" },
+      // minMatches: 1 so a single ingress would immediately flush — if the
+      // gate fails open on red_to_green we SEE one Slack dispatch, if it
+      // fails closed we see zero.
+      stringTriggers: ["green_to_red", "sustained_red"],
+      cronTriggers: [],
+      conditions: { guards: [], escalations: [] },
+      targets: [{ kind: "slack_webhook", webhook: "oss_alerts" }],
+      actions: [],
+      aggregation: {
+        groupBy: [],
+        windowMs: 60_000,
+        minMatches: 1,
+        template: "<!channel> fleet red {{count}}",
+      },
+    };
+  }
+
+  it("red_to_green_does_not_trigger_aggregation_flush", async () => {
+    const e = engine();
+    e.start();
+    e.reload([aggregatedSmokeRule()]);
+    bus.emit("status.changed", {
+      outcome: {
+        previousState: "red",
+        newState: "green",
+        transition: "red_to_green",
+        failCount: 0,
+        firstFailureAt: null,
+      },
+      result: {
+        key: "smoke:mastra",
+        state: "green",
+        signal: { slug: "mastra", dimension: "smoke" },
+        observedAt: "2026-04-20T00:00:00Z",
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    // No aggregation dispatch despite minMatches: 1.
+    expect(tgt.sent).toHaveLength(0);
+    e.stop();
+  });
+
+  it("green_to_red_does_trigger_aggregation_flush", async () => {
+    const e = engine();
+    e.start();
+    e.reload([aggregatedSmokeRule()]);
+    bus.emit("status.changed", {
+      outcome: {
+        previousState: "green",
+        newState: "red",
+        transition: "green_to_red",
+        failCount: 1,
+        firstFailureAt: "2026-04-20T00:00:00Z",
+      },
+      result: {
+        key: "smoke:mastra",
+        state: "red",
+        signal: { slug: "mastra", dimension: "smoke" },
+        observedAt: "2026-04-20T00:00:00Z",
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(tgt.sent).toHaveLength(1);
+    e.stop();
   });
 });

--- a/showcase/ops/src/alerts/alert-engine.test.ts
+++ b/showcase/ops/src/alerts/alert-engine.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
 import {
   createAlertEngine,
   parseDuration,
   evalSuppress,
 } from "./alert-engine.js";
+import {
+  AggregationBucketStore,
+  buildCompositeDedupeKey,
+  type AggregationConfig,
+} from "./aggregation.js";
 import { createEventBus } from "../events/event-bus.js";
 import { createMetricsRegistry } from "../http/metrics.js";
 import { createRenderer } from "../render/renderer.js";
@@ -3092,5 +3097,241 @@ describe("alert-engine R24: shouldSuppress fail-closed (bucket-a#7)", () => {
     expect(busEvents[0]?.expression).toBe("nonexistentVar == true");
     expect(busEvents[0]?.error).toMatch(/nonexistentVar|unknown/i);
     e.stop();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Item 4 (plan §Item 4 Red phase) — AggregationBucketStore unit tests.
+//
+// These tests exercise the store class surface in isolation (no alert-engine
+// instantiation). The store is NEW in this branch — `./aggregation` does not
+// yet exist, so the import above is expected to fail module-resolution until
+// Agent 5 creates it. That IS the red state.
+// -----------------------------------------------------------------------------
+describe("AggregationBucketStore (Item 4 red phase)", () => {
+  type AggregatedRule = CompiledRule & { aggregation: AggregationConfig };
+  type AggSignal = Record<string, unknown>;
+
+  function aggRule(overrides: Partial<AggregationConfig> = {}): AggregatedRule {
+    const base = baseRule({
+      id: "smoke-red-fleet",
+      name: "smoke-fleet",
+      template: { text: "per-match {{signal.slug}}" },
+    });
+    const aggregation: AggregationConfig = {
+      groupBy: ["dimension"],
+      windowMs: 30_000,
+      minMatches: 3,
+      template:
+        "<!channel> {{count}} smoke-red across fleet: {{services}}",
+      targets: ["slack-oss-alerts"],
+      ...overrides,
+    };
+    return { ...base, aggregation } satisfies AggregatedRule;
+  }
+
+  function mkSignal(dimension: string, slug: string): AggSignal {
+    return { dimension, slug, errorDesc: `err for ${slug}` };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aggregates_when_minMatches_hit_in_window", () => {
+    const onFlush = vi.fn();
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule();
+    const t0 = Date.now();
+    const slugs = ["mastra", "langgraph", "crewai", "openai", "adk"];
+    for (let i = 0; i < slugs.length; i++) {
+      // Signals spaced 5s apart — all within the 30s window.
+      vi.setSystemTime(new Date(t0 + i * 5_000));
+      store.ingest(rule, mkSignal("smoke", slugs[i]!), t0 + i * 5_000);
+    }
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    const [bucket, reason] = onFlush.mock.calls[0]!;
+    expect(bucket.matches).toHaveLength(5);
+    expect(bucket.groupValues).toEqual({ dimension: "smoke" });
+    expect(bucket.ruleId).toBe("smoke-red-fleet");
+    // Plan: count === 5, services CSV contains all five slugs.
+    const bucketSlugs = (bucket.matches as AggSignal[]).map((s) => s.slug);
+    for (const slug of slugs) expect(bucketSlugs).toContain(slug);
+    // Threshold flush, not timer.
+    expect(reason).toBe("threshold");
+  });
+
+  it("suppresses_per_match_within_window", () => {
+    // During the aggregation window, per-match dispatches for aggregated rules
+    // must be zero. The store itself doesn't dispatch per-match — that's the
+    // engine's responsibility to short-circuit. The contract the store upholds
+    // is: onFlush is invoked ONLY for composite events, never per-match.
+    const onFlush = vi.fn();
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ minMatches: 10 }); // Unreachable threshold.
+
+    for (let i = 0; i < 5; i++) {
+      store.ingest(rule, mkSignal("smoke", `svc-${i}`), Date.now() + i * 1_000);
+    }
+
+    // No threshold hit, no timer expiry → zero dispatches. In particular, no
+    // per-match callbacks (the store has no such API, by design).
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("does_not_fire_below_threshold", () => {
+    const onFlush = vi.fn();
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ minMatches: 3 });
+
+    store.ingest(rule, mkSignal("smoke", "mastra"), Date.now());
+    store.ingest(rule, mkSignal("smoke", "langgraph"), Date.now() + 1_000);
+    // Only 2 matches — below minMatches: 3.
+
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("flushes_bucket_on_window_expiry", () => {
+    const onFlush = vi.fn();
+    const store = new AggregationBucketStore(onFlush);
+    const windowMs = 30_000;
+    const rule = aggRule({ windowMs, minMatches: 10 }); // Threshold unreachable.
+
+    const t0 = Date.now();
+    store.ingest(rule, mkSignal("smoke", "a"), t0);
+    store.ingest(rule, mkSignal("smoke", "b"), t0 + 1_000);
+    store.ingest(rule, mkSignal("smoke", "c"), t0 + 2_000);
+    // Three matches but below threshold 10.
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Advance past windowMs relative to the FIRST match.
+    vi.advanceTimersByTime(windowMs + 1);
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    const [bucket, reason] = onFlush.mock.calls[0]!;
+    expect(bucket.matches).toHaveLength(3);
+    expect(reason).toBe("timer");
+  });
+
+  it("separate_groupBy_keys_bucket_independently", () => {
+    const onFlush = vi.fn();
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ groupBy: ["dimension"], minMatches: 3 });
+    const t0 = Date.now();
+
+    // 3 smoke signals — should flush on threshold.
+    store.ingest(rule, mkSignal("smoke", "s1"), t0);
+    store.ingest(rule, mkSignal("smoke", "s2"), t0 + 100);
+    store.ingest(rule, mkSignal("smoke", "s3"), t0 + 200);
+
+    // 2 agent signals — distinct bucket, below threshold.
+    store.ingest(rule, mkSignal("agent", "a1"), t0 + 300);
+    store.ingest(rule, mkSignal("agent", "a2"), t0 + 400);
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    const [bucket] = onFlush.mock.calls[0]!;
+    expect(bucket.groupValues).toEqual({ dimension: "smoke" });
+    expect(bucket.matches).toHaveLength(3);
+  });
+
+  it("composite_dedupe_across_window_expiries", () => {
+    // Simulate the engine-level dedupe that the plan describes: the store
+    // flushes twice across two consecutive windows, but both composites share
+    // an identical `buildCompositeDedupeKey` — so the engine-side rate_limit +
+    // stateStore gate would suppress the second. We prove the invariant by
+    // wrapping onFlush in a local dedupe map that rejects repeat keys,
+    // standing in for the engine's rate_limit + stateStore gate.
+    const windowMs = 30_000;
+    const rule = aggRule({ windowMs, minMatches: 3 });
+    const dispatched: string[] = [];
+    const seenKeys = new Set<string>();
+    const onFlush = vi.fn((bucket) => {
+      const key = buildCompositeDedupeKey(rule, bucket.groupValues);
+      if (seenKeys.has(key)) return; // suppressed (rate_limit stand-in)
+      seenKeys.add(key);
+      dispatched.push(key);
+    });
+    const store = new AggregationBucketStore(onFlush);
+
+    const t0 = Date.now();
+    // Bucket A fills to threshold at t0..t0+2s → flush via threshold at t0+2s.
+    store.ingest(rule, mkSignal("smoke", "a"), t0);
+    store.ingest(rule, mkSignal("smoke", "b"), t0 + 1_000);
+    store.ingest(rule, mkSignal("smoke", "c"), t0 + 2_000);
+
+    // Advance to windowMs+1. New matching signal arrives → bucket A' opens.
+    vi.advanceTimersByTime(windowMs + 1);
+    store.ingest(
+      rule,
+      mkSignal("smoke", "d"),
+      t0 + windowMs + 1,
+    );
+    store.ingest(
+      rule,
+      mkSignal("smoke", "e"),
+      t0 + windowMs + 2_000,
+    );
+    store.ingest(
+      rule,
+      mkSignal("smoke", "f"),
+      t0 + windowMs + 3_000,
+    );
+
+    // Both buckets share groupValues → identical composite dedupe key.
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0]).toBe(
+      buildCompositeDedupeKey(rule, { dimension: "smoke" }),
+    );
+  });
+
+  it("bootstrap_suppression_respected", () => {
+    // Engine invariant: during the first 15m of engine uptime, NO dispatch
+    // (composite or per-match) fires. The store does not own the bootstrap
+    // clock — it's a gate the engine applies downstream of onFlush. We model
+    // that here by making the caller-supplied onFlush observe a bootstrap
+    // window and drop events that land inside it. The store must still emit
+    // the flush callback so the engine can make the decision.
+    const BOOTSTRAP_MS = 15 * 60 * 1_000;
+    const engineStartedAt = Date.now();
+    const dispatched: string[] = [];
+    const onFlush = vi.fn((bucket) => {
+      if (Date.now() - engineStartedAt < BOOTSTRAP_MS) return; // suppressed
+      dispatched.push(buildCompositeDedupeKey(rule, bucket.groupValues));
+    });
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ minMatches: 3 });
+
+    // All three matches arrive inside the first minute of engine uptime.
+    const t0 = engineStartedAt;
+    store.ingest(rule, mkSignal("smoke", "a"), t0);
+    store.ingest(rule, mkSignal("smoke", "b"), t0 + 1_000);
+    store.ingest(rule, mkSignal("smoke", "c"), t0 + 2_000);
+
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(dispatched).toHaveLength(0); // bootstrap gate ate it
+  });
+
+  it("TTL_eviction_cleans_stale_buckets", () => {
+    const onFlush = vi.fn();
+    const store = new AggregationBucketStore(onFlush);
+    const windowMs = 30_000;
+    const rule = aggRule({ windowMs, minMatches: 99 }); // Unreachable threshold.
+
+    store.ingest(rule, mkSignal("smoke", "ghost"), Date.now());
+    expect(store.size).toBe(1);
+
+    // Advance 2× windowMs. Bucket must self-evict — either by flushing at
+    // windowMs (timer reason) and not being re-created, or by a subsequent
+    // TTL sweep. The invariant is that no buckets linger as memory leaks.
+    vi.advanceTimersByTime(2 * windowMs + 1);
+
+    expect(store.size).toBe(0);
   });
 });

--- a/showcase/ops/src/alerts/alert-engine.test.ts
+++ b/showcase/ops/src/alerts/alert-engine.test.ts
@@ -3122,8 +3122,7 @@ describe("AggregationBucketStore (Item 4 red phase)", () => {
       groupBy: ["dimension"],
       windowMs: 30_000,
       minMatches: 3,
-      template:
-        "<!channel> {{count}} smoke-red across fleet: {{services}}",
+      template: "<!channel> {{count}} smoke-red across fleet: {{services}}",
       targets: ["slack-oss-alerts"],
       ...overrides,
     };
@@ -3267,21 +3266,9 @@ describe("AggregationBucketStore (Item 4 red phase)", () => {
 
     // Advance to windowMs+1. New matching signal arrives → bucket A' opens.
     vi.advanceTimersByTime(windowMs + 1);
-    store.ingest(
-      rule,
-      mkSignal("smoke", "d"),
-      t0 + windowMs + 1,
-    );
-    store.ingest(
-      rule,
-      mkSignal("smoke", "e"),
-      t0 + windowMs + 2_000,
-    );
-    store.ingest(
-      rule,
-      mkSignal("smoke", "f"),
-      t0 + windowMs + 3_000,
-    );
+    store.ingest(rule, mkSignal("smoke", "d"), t0 + windowMs + 1);
+    store.ingest(rule, mkSignal("smoke", "e"), t0 + windowMs + 2_000);
+    store.ingest(rule, mkSignal("smoke", "f"), t0 + windowMs + 3_000);
 
     // Both buckets share groupValues → identical composite dedupe key.
     expect(onFlush).toHaveBeenCalledTimes(2);

--- a/showcase/ops/src/alerts/alert-engine.test.ts
+++ b/showcase/ops/src/alerts/alert-engine.test.ts
@@ -3376,6 +3376,34 @@ describe("AggregationBucketStore (Item 4 red phase)", () => {
     expect(onFlush.mock.calls.length).toBeGreaterThan(calls);
   });
 
+  it("bucket_stays_live_when_flush_suppressed_async", async () => {
+    // A5 (async path): onAggregationFlush is wired with `.catch()` in the
+    // engine, so it ALWAYS returns a Promise — this is the production path.
+    // If applyFlushResult's .then handler fails to revert flushedAt when the
+    // promise resolves to "suppressed", the bucket is marked flushed and a
+    // subsequent re-threshold ingestion will NOT re-fire onFlush. This test
+    // locks the async-branch invariant so the sync-only test above can't
+    // mask a regression in the common-case path.
+    const onFlush = vi.fn(async () => "suppressed" as const);
+    const store = new AggregationBucketStore(onFlush);
+    const rule = aggRule({ minMatches: 3, windowMs: 60_000 });
+    const t0 = Date.now();
+    store.ingest(rule, mkSignal("smoke", "a"), t0);
+    store.ingest(rule, mkSignal("smoke", "b"), t0 + 1_000);
+    store.ingest(rule, mkSignal("smoke", "c"), t0 + 2_000); // threshold hit
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    // Flush microtask queue so the .then resolution handler runs and (if
+    // implemented correctly) reverts flushedAt back to null.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Another ingest that re-crosses threshold — A5 says onFlush must fire
+    // again because the bucket stayed live through the suppressed flush.
+    store.ingest(rule, mkSignal("smoke", "d"), t0 + 3_000);
+    expect(onFlush).toHaveBeenCalledTimes(2);
+  });
+
   it("bucket_key_collision_safe_with_special_chars", () => {
     // B4: intra-key delimiter must be NUL ( ), not `&`, so a groupBy
     // value containing `=` or `&` can't be crafted to collide with a

--- a/showcase/ops/src/alerts/alert-engine.ts
+++ b/showcase/ops/src/alerts/alert-engine.ts
@@ -122,11 +122,31 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
         // alert_sends inside sendToTargets.
         metrics?.inc("alert_matches", { rule: rule.id });
 
-        // Aggregated rules: ingest UNCONDITIONALLY (no guards / suppress /
-        // bootstrap gates on ingress). Gates apply to the composite FLUSH
-        // only — see `onAggregationFlush` below. Per-match dispatch is
-        // short-circuited so aggregated rules never fire the normal path.
+        // Aggregated rules: ingest only RED-bearing transitions. Per-match
+        // dispatch is short-circuited so aggregated rules never fire the
+        // normal path. A1: a `red_to_green` recovery is not a "fleet red"
+        // signal — ingesting it would fire <!channel> on recoveries. We
+        // evaluate the rule's declared triggers via `resolveTriggers` and
+        // skip ingest when the triggered set is purely `red_to_green`.
+        // `error` transitions also do not ingest (they route through the
+        // dispatchOnError path for non-aggregated rules; aggregated rules
+        // don't support onError today).
         if (rule.aggregation) {
+          if (evt.outcome.transition === "error") continue;
+          const t = evt.outcome.transition as Transition;
+          const signalFlags = deriveSignalFlags(evt.result.signal);
+          const triggered = resolveTriggers(rule, t, signalFlags);
+          const hasRedBearing = triggered.some(
+            (name) => name !== "red_to_green",
+          );
+          if (!hasRedBearing) {
+            logger.debug("alert-engine.aggregation-skip-recovery", {
+              ruleId: rule.id,
+              transition: t,
+              triggered,
+            });
+            continue;
+          }
           const signalObj = signalAsObject(evt.result.signal);
           aggStore.ingest(rule, signalObj, now().getTime());
           continue;
@@ -503,6 +523,12 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
     rule: CompiledRule,
     evt: { ruleId: string; scheduledAt: string; result?: ProbeResult<unknown> },
   ): Promise<void> {
+    // B3: aggregated rules are handled via the status.changed ingress path
+    // (handleStatusChanged calls `aggStore.ingest`). The cron path would
+    // render `rule.template` (often empty for aggregation-only rules) or
+    // bypass aggregation entirely. Skip defensively so a rule that ever
+    // declares BOTH cron triggers AND aggregation can't double-dispatch.
+    if (rule.aggregation) return;
     const probeState = evt.result?.state;
     // Guard: a rule without a top-level template is still valid if it declares
     // `on_error: { template: ... }` — error ticks route to dispatchOnError which
@@ -925,24 +951,28 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
   async function onAggregationFlush(
     bucket: Bucket,
     _reason: FlushReason,
-  ): Promise<void> {
+  ): Promise<void | "suppressed"> {
     const rule = rules.find((r) => r.id === bucket.ruleId);
     if (!rule || !rule.aggregation) return;
     const dedupeKey = buildCompositeDedupeKey(rule, bucket.groupValues);
     try {
       // Bootstrap gate — mirrors handleStatusChanged: fresh-boot bursts of
       // matches would otherwise fire a composite during the bootstrap window.
+      // A5: return "suppressed" so the store keeps the bucket live; the next
+      // ingestion crossing threshold after bootstrap closes can re-fire.
       if (bootstrapActive()) {
         logger.info("alert-engine.bootstrap-suppress", {
           ruleId: rule.id,
           reason: "bootstrap_aggregation",
           dedupeKey,
         });
-        return;
+        return "suppressed";
       }
       // Rate-limit gate against the composite dedupeKey so two consecutive
       // window expiries for the same groupValues collapse to one dispatch
-      // when rate_limit.window spans multiple aggregation windows.
+      // when rate_limit.window spans multiple aggregation windows. A5: like
+      // bootstrap, return "suppressed" so the bucket stays live — post
+      // rate-limit window the next ingestion can deliver.
       if (rule.conditions.rate_limit?.window) {
         const windowMs = parseDuration(rule.conditions.rate_limit.window);
         const last = await stateStore.get(rule.id, dedupeKey);
@@ -954,7 +984,7 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
               rule: rule.id,
               path: "aggregation",
             });
-            return;
+            return "suppressed";
           }
         }
       }
@@ -1014,21 +1044,51 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
   }
 
   const aggStore = new AggregationBucketStore((bucket, reason) => {
-    // onFlush is sync; kick off the async work and log any uncaught throw.
-    onAggregationFlush(bucket, reason).catch((err) =>
+    // A4 / A5: return the promise directly so the store can `await` it
+    // inside `drain()` (SIGTERM path) AND observe the "suppressed" sentinel
+    // to keep the bucket live when an engine gate short-circuits dispatch.
+    // Attach a `.catch` tail for unhandled throws without swallowing the
+    // return value.
+    return onAggregationFlush(bucket, reason).catch((err) => {
       logger.error("alert-engine.aggregation-flush-unhandled", {
         ruleId: bucket.ruleId,
         err: String(err),
-      }),
-    );
+      });
+      // Undefined → store treats as a normal (non-suppressed) flush; the
+      // bucket will be marked flushedAt and drop on timer expiry.
+      return undefined;
+    });
   });
 
   // Register a drain on graceful shutdown so in-flight buckets flush their
   // composites rather than silently vanishing. SIGKILL still loses them by
-  // design — the next probe tick rebuilds bucket state naturally. Guard
-  // against repeated registration when the engine is re-created in tests.
-  const beforeExit = (): void => aggStore.drain();
+  // design — the next probe tick rebuilds bucket state naturally.
+  //
+  // A4: SIGTERM handler awaits drain() so composites actually dispatch
+  // before the process exits. `beforeExit` stays as best-effort (Node's
+  // beforeExit cannot truly await) — we swallow the promise tail with a
+  // .catch so an async flush error on shutdown doesn't crash the process.
+  // Guard against repeated registration when the engine is re-created in
+  // tests.
+  const sigtermHandler = (): void => {
+    aggStore.drain().catch((err) =>
+      logger.error("alert-engine.drain-failed", {
+        err: String(err),
+        path: "sigterm",
+      }),
+    );
+  };
+  const beforeExit = (): void => {
+    aggStore.drain().catch((err) =>
+      logger.warn("alert-engine.drain-failed", {
+        err: String(err),
+        path: "beforeExit",
+        hint: "beforeExit cannot actually await — SIGKILL / abrupt exit would drop in-flight buckets",
+      }),
+    );
+  };
   process.once("beforeExit", beforeExit);
+  process.once("SIGTERM", sigtermHandler);
 
   return {
     start() {
@@ -1056,15 +1116,24 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
     stop() {
       for (const u of unsubs) u();
       unsubs.length = 0;
-      // Remove the beforeExit listener so repeated engine create/stop cycles
-      // in tests don't accumulate listeners and trip Node's
-      // MaxListenersExceededWarning. `process.once` would self-remove after
-      // the first `beforeExit` emit — but tests never reach `beforeExit`,
-      // so we drop the listener explicitly here.
+      // Remove the beforeExit + SIGTERM listeners so repeated engine
+      // create/stop cycles in tests don't accumulate listeners and trip
+      // Node's MaxListenersExceededWarning. `process.once` would self-remove
+      // after the first emit — but tests never reach those signals, so we
+      // drop the listeners explicitly here.
       process.removeListener("beforeExit", beforeExit);
+      process.removeListener("SIGTERM", sigtermHandler);
       // Drain any in-flight buckets on stop() too, so test runs that create
-      // many engines don't leak timers into subsequent tests.
-      aggStore.drain();
+      // many engines don't leak timers into subsequent tests. A4: fire and
+      // forget here — callers that need to await drain must invoke the
+      // `drain()` directly on the store (engine deliberately stays a sync
+      // stop() for backward-compat with the AlertEngine interface).
+      aggStore.drain().catch((err) =>
+        logger.warn("alert-engine.drain-failed", {
+          err: String(err),
+          path: "stop",
+        }),
+      );
     },
     reload(next) {
       rules = next;

--- a/showcase/ops/src/alerts/alert-engine.ts
+++ b/showcase/ops/src/alerts/alert-engine.ts
@@ -7,6 +7,12 @@ import type { Renderer } from "../render/renderer.js";
 import type { CompiledRule } from "../rules/rule-loader.js";
 import type { AlertStateStore } from "../storage/alert-state-store.js";
 import { parseDuration, evalSuppress } from "./dsl.js";
+import {
+  AggregationBucketStore,
+  buildCompositeDedupeKey,
+  type Bucket,
+  type FlushReason,
+} from "./aggregation.js";
 // Re-export so existing callers (rule-loader, tests) that import from
 // alert-engine.js continue to work without touching every import site.
 // Fresh modules should import from ./dsl.js directly.
@@ -115,6 +121,16 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
         // counter reflects rule activity, not delivery. Delivery counted via
         // alert_sends inside sendToTargets.
         metrics?.inc("alert_matches", { rule: rule.id });
+
+        // Aggregated rules: ingest UNCONDITIONALLY (no guards / suppress /
+        // bootstrap gates on ingress). Gates apply to the composite FLUSH
+        // only — see `onAggregationFlush` below. Per-match dispatch is
+        // short-circuited so aggregated rules never fire the normal path.
+        if (rule.aggregation) {
+          const signalObj = signalAsObject(evt.result.signal);
+          aggStore.ingest(rule, signalObj, now().getTime());
+          continue;
+        }
 
         if (evt.outcome.transition === "error") {
           // Apply the same guard-set to onError paths so minDeployAgeMin (and
@@ -892,6 +908,128 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
     }
   }
 
+  /**
+   * Composite flush callback invoked by the aggregation store when a bucket
+   * either hits `minMatches` or expires. Applies rate_limit + bootstrap gates
+   * against `buildCompositeDedupeKey(rule, groupValues)` so successive
+   * windows with the same logical group collapse to one dispatch; renders
+   * the aggregation template with `{ count, services, firstSignal, lastSignal,
+   * groupValues }` context.
+   *
+   * Failures inside here are logged but must not propagate — a render or
+   * dispatch error on one bucket must not kill the engine or block
+   * subsequent ingress. The store itself tolerates a throwing onFlush (the
+   * bucket is already removed before invocation), so swallowing here is
+   * belt-and-braces.
+   */
+  async function onAggregationFlush(
+    bucket: Bucket,
+    _reason: FlushReason,
+  ): Promise<void> {
+    const rule = rules.find((r) => r.id === bucket.ruleId);
+    if (!rule || !rule.aggregation) return;
+    const dedupeKey = buildCompositeDedupeKey(rule, bucket.groupValues);
+    try {
+      // Bootstrap gate — mirrors handleStatusChanged: fresh-boot bursts of
+      // matches would otherwise fire a composite during the bootstrap window.
+      if (bootstrapActive()) {
+        logger.info("alert-engine.bootstrap-suppress", {
+          ruleId: rule.id,
+          reason: "bootstrap_aggregation",
+          dedupeKey,
+        });
+        return;
+      }
+      // Rate-limit gate against the composite dedupeKey so two consecutive
+      // window expiries for the same groupValues collapse to one dispatch
+      // when rate_limit.window spans multiple aggregation windows.
+      if (rule.conditions.rate_limit?.window) {
+        const windowMs = parseDuration(rule.conditions.rate_limit.window);
+        const last = await stateStore.get(rule.id, dedupeKey);
+        if (last?.last_alert_at) {
+          const elapsed =
+            now().getTime() - new Date(last.last_alert_at).getTime();
+          if (elapsed < windowMs) {
+            logger.debug("alert-engine.rate-limited", {
+              rule: rule.id,
+              path: "aggregation",
+            });
+            return;
+          }
+        }
+      }
+      const count = bucket.matches.length;
+      const services = bucket.matches
+        .map((s) => {
+          const slug = (s as Record<string, unknown>)["slug"];
+          return typeof slug === "string" ? slug : "";
+        })
+        .filter((s) => s.length > 0)
+        .join(", ");
+      const firstSignal = bucket.matches[0] ?? {};
+      const lastSignal = bucket.matches[bucket.matches.length - 1] ?? {};
+      const text = Mustache.render(rule.aggregation.template, {
+        count,
+        services,
+        firstSignal,
+        lastSignal,
+        groupValues: bucket.groupValues,
+      });
+      const rendered = {
+        payload: { text } as Record<string, unknown>,
+        contentType: "application/json" as const,
+      };
+      const { results, allSucceeded } = await sendToTargets(rule, rendered);
+      const anySucceeded = results.some((r) => r.ok);
+      if (!anySucceeded) {
+        logger.warn("alert-engine.record-skipped", {
+          rule: rule.id,
+          reason: "all-targets-failed",
+          path: "aggregation",
+        });
+        return;
+      }
+      if (!allSucceeded) {
+        logger.warn("alert-engine.dedupe-held-partial", {
+          rule: rule.id,
+          path: "aggregation",
+          failed: results.filter((r) => !r.ok).map((r) => r.kind),
+        });
+        return;
+      }
+      const hash = hashPayload(rendered.payload);
+      const preview = JSON.stringify(rendered.payload).slice(0, 500);
+      await stateStore.record(rule.id, dedupeKey, {
+        at: now().toISOString(),
+        hash,
+        preview,
+      });
+    } catch (err) {
+      logger.error("alert-engine.aggregation-flush-failed", {
+        ruleId: rule.id,
+        dedupeKey,
+        err: String(err),
+      });
+    }
+  }
+
+  const aggStore = new AggregationBucketStore((bucket, reason) => {
+    // onFlush is sync; kick off the async work and log any uncaught throw.
+    onAggregationFlush(bucket, reason).catch((err) =>
+      logger.error("alert-engine.aggregation-flush-unhandled", {
+        ruleId: bucket.ruleId,
+        err: String(err),
+      }),
+    );
+  });
+
+  // Register a drain on graceful shutdown so in-flight buckets flush their
+  // composites rather than silently vanishing. SIGKILL still loses them by
+  // design — the next probe tick rebuilds bucket state naturally. Guard
+  // against repeated registration when the engine is re-created in tests.
+  const beforeExit = (): void => aggStore.drain();
+  process.once("beforeExit", beforeExit);
+
   return {
     start() {
       unsubs.push(
@@ -918,6 +1056,15 @@ export function createAlertEngine(deps: AlertEngineDeps): AlertEngine {
     stop() {
       for (const u of unsubs) u();
       unsubs.length = 0;
+      // Remove the beforeExit listener so repeated engine create/stop cycles
+      // in tests don't accumulate listeners and trip Node's
+      // MaxListenersExceededWarning. `process.once` would self-remove after
+      // the first `beforeExit` emit — but tests never reach `beforeExit`,
+      // so we drop the listener explicitly here.
+      process.removeListener("beforeExit", beforeExit);
+      // Drain any in-flight buckets on stop() too, so test runs that create
+      // many engines don't leak timers into subsequent tests.
+      aggStore.drain();
     },
     reload(next) {
       rules = next;

--- a/showcase/ops/src/alerts/render-red-tick.test.ts
+++ b/showcase/ops/src/alerts/render-red-tick.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+import { createRenderer } from "../render/renderer.js";
+import { emptyTriggerFlags, type TemplateContext } from "../types/index.js";
+
+/**
+ * Items 2 + 3 red-phase coverage for the four per-service red-tick YAMLs.
+ *
+ * Item 2 — section guards on optional links:
+ *   Every `<{{{signal.links.<key>}}}|<label>>` reference must be wrapped in
+ *   a Mustache section so a missing/empty link value emits NOTHING (not an
+ *   empty `<|smoke>` placeholder and not a dangling leading space).
+ *
+ * Item 3 — triple-brace on sanitized errorDesc:
+ *   `signal.errorDesc` is pre-sanitized in `probes/drivers/sanitize.ts` and
+ *   safe for raw passthrough. Double-brace HTML-escapes `<`, `>`, `&` — that
+ *   leaks the literal `&amp;` / `&lt;` / `&gt;` into Slack output. Switching
+ *   to triple-brace preserves the literal characters that the sanitizer
+ *   already decided are safe.
+ *
+ * These tests exercise the renderer directly rather than the full rule-loader
+ * pipeline, so `validateTripleBrace` is not in scope here — the load-side
+ * allowance for `signal.errorDesc` is an engine-side change owned by the
+ * aggregation-engine agent.
+ */
+
+const ALERTS_DIR = path.resolve(__dirname, "../../config/alerts");
+
+interface RuleDoc {
+  template?: { text?: string };
+}
+
+function loadTemplate(filename: string): string {
+  const raw = fs.readFileSync(path.join(ALERTS_DIR, filename), "utf8");
+  const doc = yaml.load(raw) as RuleDoc | undefined;
+  const text = doc?.template?.text;
+  if (typeof text !== "string") {
+    throw new Error(`template.text missing in ${filename}`);
+  }
+  return text;
+}
+
+function ctx(partial: Partial<TemplateContext>): TemplateContext {
+  return {
+    rule: { id: "r", name: "n", owner: "o", severity: "warn" },
+    trigger: { ...emptyTriggerFlags() },
+    escalated: false,
+    signal: {},
+    event: { id: "e", at: "2026-04-20T00:00:00Z" },
+    env: { dashboardUrl: "https://dashboard", repo: "copilotkit/ck" },
+    ...partial,
+  };
+}
+
+const YAMLS = [
+  "smoke-red-tick.yml",
+  "agent-red-tick.yml",
+  "chat-red-tick.yml",
+  "tools-red-tick.yml",
+] as const;
+
+describe("red-tick YAML rendering — Items 2 & 3", () => {
+  describe.each(YAMLS)("%s", (filename) => {
+    it("renders_empty_when_links_missing — no <|…> artifacts and no dangling brackets", () => {
+      const text = loadTemplate(filename);
+      const r = createRenderer();
+      const flags = { ...emptyTriggerFlags(), green_to_red: true };
+      const out = r.render(
+        { text },
+        ctx({
+          trigger: flags,
+          signal: {
+            slug: "mastra",
+            failCount: 1,
+            errorDesc: "timeout",
+            firstFailureAt: "2026-04-20T00:00:00Z",
+            // Intentionally NO links key — tests the "missing" branch.
+          },
+        }),
+      );
+      const rendered = String(out.payload.text);
+      // The bug shape: `<|smoke>` / `<|health>` / empty `<>` from missing URLs.
+      expect(rendered).not.toMatch(/<\|/);
+      expect(rendered).not.toMatch(/<>/);
+      // A dangling " · " with a space-pipe-label just before the closing paren
+      // (e.g. "( · <|smoke>)") is a secondary artifact of unbalanced guards.
+      // The sane shape is either a clean "(…)" with real links or no paren
+      // chunk at all.
+      expect(rendered).not.toMatch(/\(\s*·/);
+    });
+
+    it("errorDesc_renders_literal_characters — no HTML-entity escaping", () => {
+      const text = loadTemplate(filename);
+      const r = createRenderer();
+      const flags = { ...emptyTriggerFlags(), green_to_red: true };
+      const out = r.render(
+        { text },
+        ctx({
+          trigger: flags,
+          signal: {
+            slug: "mastra",
+            failCount: 1,
+            // Pre-sanitized errorDesc — literal `&` must survive to Slack.
+            errorDesc: "timeout & 30s",
+            firstFailureAt: "2026-04-20T00:00:00Z",
+          },
+        }),
+      );
+      const rendered = String(out.payload.text);
+      expect(rendered).toContain("timeout & 30s");
+      expect(rendered).not.toContain("&amp;");
+      expect(rendered).not.toContain("&lt;");
+      expect(rendered).not.toContain("&gt;");
+    });
+  });
+
+  // Smoke has the only dimension with `signal.links.*` references — verify
+  // the present-link path emits the expected Slack-link shape after the guard
+  // wrap.
+  it("smoke: renders_link_when_present — <url|label> shape preserved", () => {
+    const text = loadTemplate("smoke-red-tick.yml");
+    const r = createRenderer();
+    const flags = { ...emptyTriggerFlags(), green_to_red: true };
+    const out = r.render(
+      { text },
+      ctx({
+        trigger: flags,
+        signal: {
+          slug: "mastra",
+          failCount: 1,
+          errorDesc: "http 503",
+          firstFailureAt: "2026-04-20T00:00:00Z",
+          links: {
+            smoke: "https://example.test/smoke",
+            health: "https://example.test/health",
+          },
+        },
+      }),
+    );
+    const rendered = String(out.payload.text);
+    expect(rendered).toContain("<https://example.test/smoke|smoke>");
+    expect(rendered).toContain("<https://example.test/health|health>");
+    // Guard-wrap must not introduce empty/dangling artifacts even with links
+    // present.
+    expect(rendered).not.toMatch(/<\|/);
+  });
+});

--- a/showcase/ops/src/alerts/render-red-tick.test.ts
+++ b/showcase/ops/src/alerts/render-red-tick.test.ts
@@ -132,18 +132,94 @@ describe("red-tick YAML rendering — Items 2 & 3", () => {
           failCount: 1,
           errorDesc: "http 503",
           firstFailureAt: "2026-04-20T00:00:00Z",
-          links: {
-            smoke: "https://example.test/smoke",
-            health: "https://example.test/health",
-          },
+          url: "https://example.test/smoke",
         },
       }),
     );
     const rendered = String(out.payload.text);
-    expect(rendered).toContain("<https://example.test/smoke|smoke>");
-    expect(rendered).toContain("<https://example.test/health|health>");
+    // A3: smoke template now references `signal.url` directly (driver signal
+    // has no `links` object). Render label "endpoint" since the linked URL is
+    // the smoke endpoint that was actually probed.
+    expect(rendered).toContain("<https://example.test/smoke|endpoint>");
     // Guard-wrap must not introduce empty/dangling artifacts even with links
     // present.
     expect(rendered).not.toMatch(/<\|/);
+  });
+
+  // A2: the dashboard Run link must be wrapped in a `{{#event.runId}}…{{/event.runId}}`
+  // section so a missing runId doesn't render a broken `/runs/|Run` link every
+  // alert. Parametrize across all 4 red-tick YAMLs.
+  describe.each(YAMLS)("%s — A2 Run link guard", (filename) => {
+    it("renders_no_run_link_when_runId_missing", () => {
+      const text = loadTemplate(filename);
+      const r = createRenderer();
+      const flags = { ...emptyTriggerFlags(), green_to_red: true };
+      const out = r.render(
+        { text },
+        ctx({
+          trigger: flags,
+          signal: {
+            slug: "mastra",
+            failCount: 1,
+            errorDesc: "timeout",
+            firstFailureAt: "2026-04-20T00:00:00Z",
+          },
+          // event.runId intentionally absent.
+          event: { id: "e", at: "2026-04-20T00:00:00Z" },
+        }),
+      );
+      const rendered = String(out.payload.text);
+      // Bug shape: `<https://…/runs/|Run>` with an empty runId between `/runs/`
+      // and `|`. After the guard wrap, the entire "Run" chunk disappears.
+      expect(rendered).not.toMatch(/\/runs\/\|/);
+      expect(rendered).not.toMatch(/\/runs\/\s*\|/);
+    });
+
+    it("renders_run_link_when_runId_present", () => {
+      const text = loadTemplate(filename);
+      const r = createRenderer();
+      const flags = { ...emptyTriggerFlags(), green_to_red: true };
+      const out = r.render(
+        { text },
+        ctx({
+          trigger: flags,
+          signal: {
+            slug: "mastra",
+            failCount: 1,
+            errorDesc: "timeout",
+            firstFailureAt: "2026-04-20T00:00:00Z",
+          },
+          event: { id: "e", at: "2026-04-20T00:00:00Z", runId: "run-abc" },
+        }),
+      );
+      const rendered = String(out.payload.text);
+      expect(rendered).toContain("/runs/run-abc|Run");
+    });
+  });
+
+  // A3: the smoke template historically referenced `signal.links.smoke` /
+  // `signal.links.health` — the DRIVER signal (probes/drivers/smoke.ts) has
+  // `slug, url, status, errorDesc, latencyMs` and no `links` object, so those
+  // section-guards were always empty. The template should pull `signal.url`
+  // directly and render an "endpoint" link.
+  it("smoke: renders_endpoint_link_from_signal_url (A3)", () => {
+    const text = loadTemplate("smoke-red-tick.yml");
+    const r = createRenderer();
+    const flags = { ...emptyTriggerFlags(), green_to_red: true };
+    const out = r.render(
+      { text },
+      ctx({
+        trigger: flags,
+        signal: {
+          slug: "mastra",
+          failCount: 1,
+          errorDesc: "http 503",
+          firstFailureAt: "2026-04-20T00:00:00Z",
+          url: "https://starter.example/smoke",
+        },
+      }),
+    );
+    const rendered = String(out.payload.text);
+    expect(rendered).toContain("<https://starter.example/smoke|endpoint>");
   });
 });

--- a/showcase/ops/src/orchestrator.ts
+++ b/showcase/ops/src/orchestrator.ts
@@ -124,9 +124,20 @@ export async function boot(opts: BootOptions = {}): Promise<{
 
   const configDir =
     opts.configDir ?? path.resolve(process.cwd(), "config/alerts");
+  // L1-L4 per-starter dimensions (agent/chat/tools) don't have dedicated probe
+  // modules today — their signals flow through the same smoke/e2e-smoke drivers
+  // as side-emissions (see probes/drivers/smoke.ts). The safe-field sets for
+  // them mirror smoke's sanitized-errorDesc allow-list so triple-brace
+  // {{{signal.errorDesc}}} in the red-tick YAMLs loads. Keep these in lockstep
+  // with SMOKE_SLACK_SAFE_FIELDS — any new sanitized field added there SHOULD
+  // be added here too unless there's a dimension-specific reason otherwise.
+  const L1_L4_SLACK_SAFE_FIELDS = ["errorDesc"] as const;
   const slackSafeFields: Record<string, Set<string>> = {
     redirect_decommission: new Set(REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS),
     smoke: new Set(SMOKE_SLACK_SAFE_FIELDS),
+    agent: new Set(L1_L4_SLACK_SAFE_FIELDS),
+    chat: new Set(L1_L4_SLACK_SAFE_FIELDS),
+    tools: new Set(L1_L4_SLACK_SAFE_FIELDS),
   };
   const loader = createRuleLoader({
     dir: configDir,

--- a/showcase/ops/src/probes/drivers/sanitize.test.ts
+++ b/showcase/ops/src/probes/drivers/sanitize.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeErrorDesc } from "./sanitize.js";
+
+describe("sanitizeErrorDesc", () => {
+  it("strips_html_tags", () => {
+    const input =
+      "<html><body><h1>404</h1><p>This page could not be found.</p></body></html>";
+    expect(sanitizeErrorDesc(input)).toBe("404 This page could not be found.");
+  });
+
+  it("collapses_whitespace", () => {
+    expect(sanitizeErrorDesc("foo\n\n\t  bar   baz")).toBe("foo bar baz");
+  });
+
+  it("caps_at_default_120_with_ellipsis", () => {
+    const input = "a".repeat(500);
+    const out = sanitizeErrorDesc(input);
+    expect(out).toHaveLength(120);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("respects_custom_maxLen", () => {
+    const out = sanitizeErrorDesc("a".repeat(50), 10);
+    expect(out).toBe("aaaaaaaaa…");
+    expect(out).toHaveLength(10);
+  });
+
+  it("returns_empty_for_empty", () => {
+    expect(sanitizeErrorDesc("")).toBe("");
+  });
+
+  it("returns_empty_for_whitespace_only", () => {
+    expect(sanitizeErrorDesc("   \n\t")).toBe("");
+  });
+
+  it("strips_script_and_style_bodies", () => {
+    expect(sanitizeErrorDesc("<script>alert(1)</script>hello")).toBe("hello");
+    expect(sanitizeErrorDesc("<style>body{}</style>hello")).toBe("hello");
+  });
+
+  it("strips_entity_encoded_script_tags", () => {
+    // Ordering contract: decode must run, then script-body strip must
+    // run AGAIN to remove the now-decoded <script> payload.
+    const input = "&lt;script&gt;alert(1)&lt;/script&gt;payload";
+    expect(sanitizeErrorDesc(input)).toBe("payload");
+  });
+
+  it("strips_html_entities", () => {
+    // After decode, <div> is stripped as a tag; & passes through
+    // bracket-neutralization unchanged since it's not < or >.
+    expect(sanitizeErrorDesc("&lt;div&gt;hi&amp;bye")).toBe("hi&bye");
+  });
+
+  it("defends_against_mrkdwn_injection", () => {
+    const input = "<!channel> <!here> <@U12345> `backtick`";
+    const out = sanitizeErrorDesc(input);
+    expect(out).not.toContain("<!");
+    expect(out).not.toContain("`");
+  });
+});

--- a/showcase/ops/src/probes/drivers/sanitize.ts
+++ b/showcase/ops/src/probes/drivers/sanitize.ts
@@ -1,0 +1,107 @@
+/**
+ * Sanitization of probe `errorDesc` strings before they land in Slack
+ * mrkdwn via Mustache triple-brace templating.
+ *
+ * Attacker-controlled HTTP response bodies (and even error messages from
+ * our own stack) can contain HTML, Slack mrkdwn control tokens, and
+ * backticks that would re-parse as formatting, @-mentions, or
+ * `<!channel>` broadcasts once rendered. We strip all of that before it
+ * reaches the template.
+ *
+ * Output guarantees:
+ *   - no HTML tags (including `<script>` / `<style>` *bodies*)
+ *   - no entity-smuggled tags (entities are decoded FIRST so a payload
+ *     like `&lt;script&gt;…&lt;/script&gt;` is caught by the subsequent
+ *     tag-body strip, not passed through as visible text)
+ *   - no Slack mrkdwn control tokens (`<!channel>`, `<!here>`,
+ *     `<!subteam^…>`, `<@U…>`)
+ *   - no backticks
+ *   - whitespace collapsed; trimmed; capped with `…` (U+2026)
+ */
+
+/** Common named HTML entities we decode. Extend only if probes start
+ * emitting new ones — we deliberately keep this tight to avoid surprise. */
+const ENTITY_MAP: Array<[RegExp, string]> = [
+  [/&amp;/g, "&"],
+  [/&lt;/g, "<"],
+  [/&gt;/g, ">"],
+  [/&quot;/g, '"'],
+  [/&#39;/g, "'"],
+  [/&nbsp;/g, " "],
+];
+
+/** `<script>...</script>` / `<style>...</style>` including the body. Run
+ * AFTER entity decode so entity-smuggled payloads are caught. */
+const SCRIPT_STYLE_BODY_RE = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+
+/** Slack mrkdwn control tokens of the form `<!channel>`, `<!here>`,
+ * `<!subteam^…>`, etc. */
+const MRKDWN_BANG_RE = /<![a-z][^>]*>/gi;
+
+/** Slack user-mention tokens `<@U…>`. */
+const MRKDWN_USER_RE = /<@[A-Z0-9]+>/g;
+
+/** Generic HTML open/close tags — replaced with a space so adjacent text
+ * doesn't fuse. */
+const HTML_TAG_RE = /<\/?[a-z][^>]*>/gi;
+
+/** Any remaining angle bracket — neutralized so Slack can't reparse as
+ * a link or mrkdwn control sequence. */
+const ANGLE_BRACKET_RE = /[<>]/g;
+
+/** Slack mrkdwn code-span delimiter. */
+const BACKTICK_RE = /`/g;
+
+/** Collapse all runs of whitespace to a single ASCII space. */
+const WHITESPACE_RE = /\s+/g;
+
+export const ERROR_DESC_DEFAULT_MAX = 120;
+
+/**
+ * Sanitize an error description for safe injection into Slack mrkdwn via
+ * Mustache triple-brace (`{{{…}}}`) templating.
+ *
+ * **Ordering is load-bearing** and must be preserved across refactors:
+ *   1. decode HTML entities
+ *   2. strip `<script>` / `<style>` bodies
+ *   3. strip Slack mrkdwn control tokens
+ *   4. strip remaining HTML tags
+ *   5. neutralize leftover angle brackets
+ *   6. strip backticks
+ *   7. collapse whitespace
+ *   8. cap length with U+2026 ellipsis
+ *
+ * The `strips_entity_encoded_script_tags` test in `sanitize.test.ts` is
+ * the contract for this ordering — if a refactor reorders these steps
+ * and that test stays green, the refactor is correct; if it goes red,
+ * the refactor broke the invariant.
+ */
+export function sanitizeErrorDesc(
+  raw: string,
+  maxLen: number = ERROR_DESC_DEFAULT_MAX,
+): string {
+  if (!raw) return "";
+  // 1. Decode common HTML entities FIRST so entity-encoded payloads
+  //    surface as real tags for the subsequent strip steps.
+  let s = raw;
+  for (const [re, replacement] of ENTITY_MAP) {
+    s = s.replace(re, replacement);
+  }
+  // 2. Strip <script>/<style> bodies outright (AFTER decode to catch
+  //    entity-smuggled payloads).
+  s = s.replace(SCRIPT_STYLE_BODY_RE, "");
+  // 3. Strip Slack mrkdwn control tokens.
+  s = s.replace(MRKDWN_BANG_RE, "").replace(MRKDWN_USER_RE, "");
+  // 4. Strip remaining HTML tags (replace with space to avoid fusing
+  //    adjacent text).
+  s = s.replace(HTML_TAG_RE, " ");
+  // 5. Neutralize leftover angle brackets so Slack can't reparse.
+  s = s.replace(ANGLE_BRACKET_RE, " ");
+  // 6. Strip backticks (Slack mrkdwn code spans).
+  s = s.replace(BACKTICK_RE, "");
+  // 7. Collapse whitespace.
+  s = s.replace(WHITESPACE_RE, " ").trim();
+  // 8. Cap with ellipsis (U+2026, single char).
+  if (s.length > maxLen) s = s.slice(0, maxLen - 1).trimEnd() + "…";
+  return s;
+}

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -5,6 +5,7 @@ import {
   showcaseShapeSchema,
   type ShowcaseServiceShape,
 } from "../discovery/railway-services.js";
+import { sanitizeErrorDesc } from "./sanitize.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -421,10 +422,12 @@ async function probeOne(opts: {
       // if the endpoint returned JSON. We don't BLOCK on the body — a
       // hung body read after a 503 header is an easy way to stall the
       // whole tick. Opt for a best-effort text read with a hard bound.
-      signal.errorDesc = `http ${res.status}`;
+      signal.errorDesc = sanitizeErrorDesc(`http ${res.status}`);
       const body = await safeReadBody(res);
       if (body && body.length > 0) {
-        signal.errorDesc = `http ${res.status}: ${truncate(body, 160)}`;
+        signal.errorDesc = sanitizeErrorDesc(
+          `http ${res.status}: ${truncate(body, 160)}`,
+        );
       }
       return {
         key,
@@ -440,7 +443,10 @@ async function probeOne(opts: {
       return {
         key,
         state: "red",
-        signal: { ...signal, errorDesc: `malformed body: ${parseErr}` },
+        signal: {
+          ...signal,
+          errorDesc: sanitizeErrorDesc(`malformed body: ${parseErr}`),
+        },
         observedAt: now().toISOString(),
       };
     }
@@ -456,18 +462,20 @@ async function probeOne(opts: {
       err instanceof Error &&
       (err.name === "AbortError" || err.name === "TimeoutError") &&
       controller.signal.aborted;
-    const errorDesc = timedOut
-      ? `timeout after ${timeoutMs}ms`
-      : err instanceof Error
-        ? err.message
-        : String(err);
+    const errorDesc = sanitizeErrorDesc(
+      timedOut
+        ? `timeout after ${timeoutMs}ms`
+        : err instanceof Error
+          ? err.message
+          : String(err),
+    );
     return {
       key,
       state: "red",
       signal: {
         slug,
         url,
-        errorDesc,
+        errorDesc: sanitizeErrorDesc(errorDesc),
         latencyMs,
       },
       observedAt: now().toISOString(),
@@ -530,10 +538,11 @@ async function probeAgent(opts: {
     };
     if (res.status === 404) {
       const body = await safeReadBody(res);
-      signal.errorDesc =
+      signal.errorDesc = sanitizeErrorDesc(
         body.length > 0
           ? `agent endpoint 404: ${truncate(body, 160)}`
-          : "agent endpoint 404 — route not mounted";
+          : "agent endpoint 404 — route not mounted",
+      );
       return {
         key,
         state: "red",
@@ -557,18 +566,20 @@ async function probeAgent(opts: {
       err instanceof Error &&
       (err.name === "AbortError" || err.name === "TimeoutError") &&
       controller.signal.aborted;
-    const errorDesc = timedOut
-      ? `timeout after ${timeoutMs}ms`
-      : err instanceof Error
-        ? err.message
-        : String(err);
+    const errorDesc = sanitizeErrorDesc(
+      timedOut
+        ? `timeout after ${timeoutMs}ms`
+        : err instanceof Error
+          ? err.message
+          : String(err),
+    );
     return {
       key,
       state: "red",
       signal: {
         slug,
         url,
-        errorDesc,
+        errorDesc: sanitizeErrorDesc(errorDesc),
         latencyMs,
       },
       observedAt: now().toISOString(),

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -472,10 +472,14 @@ async function probeOne(opts: {
     return {
       key,
       state: "red",
+      // B2: drop the redundant outer sanitize wrap — `errorDesc` was already
+      // sanitized on the line above. Double-sanitize is harmless today but
+      // would turn into a silent escape-on-escape regression the moment
+      // sanitizeErrorDesc ever grows a non-idempotent rule.
       signal: {
         slug,
         url,
-        errorDesc: sanitizeErrorDesc(errorDesc),
+        errorDesc,
         latencyMs,
       },
       observedAt: now().toISOString(),
@@ -576,10 +580,11 @@ async function probeAgent(opts: {
     return {
       key,
       state: "red",
+      // B2: already sanitized above; drop the outer wrap.
       signal: {
         slug,
         url,
-        errorDesc: sanitizeErrorDesc(errorDesc),
+        errorDesc,
         latencyMs,
       },
       observedAt: now().toISOString(),

--- a/showcase/ops/src/probes/smoke.ts
+++ b/showcase/ops/src/probes/smoke.ts
@@ -105,7 +105,15 @@ export const smokeProbe: Probe<SmokeInput, SmokeSignal> = {
  * `deriveHealthUrl`). Neither flows from untrusted user input — they're
  * operator-configured service URLs. Safe to emit without HTML-escape.
  */
-export const SMOKE_SLACK_SAFE_FIELDS = ["links.smoke", "links.health"] as const;
+export const SMOKE_SLACK_SAFE_FIELDS = [
+  "links.smoke",
+  "links.health",
+  // errorDesc is pre-sanitized at the probe driver's 8 assignment sites
+  // (probes/drivers/smoke.ts via sanitizeErrorDesc) — triple-brace is
+  // intentional so already-stripped HTML / mrkdwn control tokens render
+  // as literal characters in Slack rather than being double-escaped.
+  "errorDesc",
+] as const;
 
 /**
  * Derive a plausible health URL from the smoke URL by swapping a trailing

--- a/showcase/ops/src/probes/smoke.ts
+++ b/showcase/ops/src/probes/smoke.ts
@@ -106,8 +106,12 @@ export const smokeProbe: Probe<SmokeInput, SmokeSignal> = {
  * operator-configured service URLs. Safe to emit without HTML-escape.
  */
 export const SMOKE_SLACK_SAFE_FIELDS = [
-  "links.smoke",
-  "links.health",
+  // A3: the `links` object lives on the old `SmokeSignal` shape below (still
+  // exported for backward compatibility). The driver-emitted
+  // `SmokeDriverSignal` (probes/drivers/smoke.ts) carries `url` instead —
+  // the URL that was actually probed — which is now the canonical field
+  // template authors reference for endpoint links.
+  "url",
   // errorDesc is pre-sanitized at the probe driver's 8 assignment sites
   // (probes/drivers/smoke.ts via sanitizeErrorDesc) — triple-brace is
   // intentional so already-stripped HTML / mrkdwn control tokens render

--- a/showcase/ops/src/rules/rule-loader.test.ts
+++ b/showcase/ops/src/rules/rule-loader.test.ts
@@ -1399,7 +1399,7 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
 
   // ---- smoke-red-tick.yml -------------------------------------------
   describe("smoke-red-tick", () => {
-    it("green_to_red branch renders slug, errorDesc and smoke/health links", async () => {
+    it("green_to_red branch renders slug, errorDesc and endpoint link", async () => {
       const { rules, errors, renderer } = await loadRealRules();
       expect(
         errors.find((e) => e.file.startsWith("smoke-red-tick")),
@@ -1416,10 +1416,10 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
         {
           slug: "coagents-starter",
           errorDesc: "http 503",
-          links: {
-            smoke: "https://svc.example/smoke",
-            health: "https://svc.example/health",
-          },
+          // A3: driver signal carries `url` (endpoint that was probed)
+          // instead of a `links` object — the template now renders a single
+          // endpoint link rather than separate smoke/health pair.
+          url: "https://svc.example/smoke",
           failCount: 1,
         },
         { trigger: { green_to_red: true, isRedTick: true } },
@@ -1431,12 +1431,11 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
       ).text;
       expect(text).toContain("coagents-starter");
       expect(text).toContain("down, error: http 503");
-      // Triple-brace signal.links.* (added via SMOKE_SLACK_SAFE_FIELDS)
-      // preserves the raw URL inside `<URL|label>` Slack link markup;
-      // prior double-brace form HTML-escaped `/` → `&#x2F;` and broke
-      // the link at Slack render time.
-      expect(text).toContain("https://svc.example/smoke");
-      expect(text).toContain("https://svc.example/health");
+      // Triple-brace signal.url (marked slackSafe in SMOKE_SLACK_SAFE_FIELDS)
+      // preserves the raw URL inside `<URL|label>` Slack link markup; prior
+      // double-brace would HTML-escape `/` → `&#x2F;` and break the link at
+      // Slack render time.
+      expect(text).toContain("<https://svc.example/smoke|endpoint>");
     });
 
     it("sustained_red branch renders failCount (attempt: N) and error", async () => {
@@ -1447,10 +1446,8 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
         {
           slug: "mastra-starter",
           errorDesc: "timeout after 15000ms",
-          links: {
-            smoke: "https://m.example/smoke",
-            health: "https://m.example/health",
-          },
+          // A3: endpoint URL lives under `signal.url` now.
+          url: "https://m.example/smoke",
           failCount: 3,
         },
         { trigger: { sustained_red: true, isRedTick: true } },
@@ -1764,6 +1761,46 @@ describe("rule-loader: validateTripleBrace covers on_error.template.text (R21 bu
     expect(errors[0]!.error).toMatch(
       /triple-brace.*not marked slackSafe|triple-brace.*slackSafe/,
     );
+  });
+});
+
+describe("rule-loader: validateTripleBrace covers aggregation.template (A8)", () => {
+  // A8: validateTripleBrace previously scanned only `rule.template.text` and
+  // `rule.on_error.template.text`. An aggregation rule with a malformed
+  // `{{{firstSignal.unsafe}}}` reference in `aggregation.template` passed load
+  // and rendered the unsafe value at runtime. Pull aggregation.template into
+  // the same triple-brace gate.
+  it("rejects aggregation.template with triple-brace on an unsafe signal.* field", async () => {
+    const os = await import("node:os");
+    const tmp = await fs.mkdtemp(
+      path.join(os.tmpdir(), "showcase-ops-agg-tb-"),
+    );
+    await fs.writeFile(
+      path.join(tmp, "bad-agg.yml"),
+      [
+        "id: bad-aggregation-triple-brace",
+        'name: "bad aggregation triple-brace"',
+        'owner: "@oss"',
+        "signal:",
+        "  dimension: smoke",
+        "triggers:",
+        "  - green_to_red",
+        "targets:",
+        "  - kind: slack_webhook",
+        "    webhook: oss_alerts",
+        "aggregation:",
+        "  windowMs: 60000",
+        "  minMatches: 3",
+        '  template: "{{{firstSignal.arbitrary_unsafe_field}}}"',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const loader = createRuleLoader({ dir: tmp, logger });
+    const { rules, errors } = await loader.loadWithErrors();
+    expect(rules).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.error).toMatch(/triple-brace/);
   });
 });
 

--- a/showcase/ops/src/rules/rule-loader.test.ts
+++ b/showcase/ops/src/rules/rule-loader.test.ts
@@ -979,12 +979,19 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
     const { REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS } =
       await import("../probes/redirect-decommission.js");
     const { SMOKE_SLACK_SAFE_FIELDS } = await import("../probes/smoke.js");
+    // Mirror orchestrator.ts L1-L4 safe-field wiring: agent/chat/tools have
+    // no probe module, so their safe-field set is defined inline (errorDesc
+    // only, pre-sanitized by the shared smoke driver).
+    const L1_L4_SLACK_SAFE_FIELDS = ["errorDesc"] as const;
     const loader = createRuleLoader({
       dir: REAL_CONFIG_DIR,
       logger,
       slackSafeFields: {
         redirect_decommission: new Set(REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS),
         smoke: new Set(SMOKE_SLACK_SAFE_FIELDS),
+        agent: new Set(L1_L4_SLACK_SAFE_FIELDS),
+        chat: new Set(L1_L4_SLACK_SAFE_FIELDS),
+        tools: new Set(L1_L4_SLACK_SAFE_FIELDS),
       },
     });
     const { rules, errors } = await loader.loadWithErrors();
@@ -1479,32 +1486,19 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
       expect(text).toContain("was down since 2026-04-19T23:00:00Z");
     });
 
-    it("escalated block renders !channel ping with firstFailureAt", async () => {
-      const { rules, renderer } = await loadRealRules();
-      const rule = rules.find((r) => r.id === "smoke-red-tick")!;
-      const ctx = makeCtx(
-        rule,
-        {
-          slug: "agno-starter",
-          errorDesc: "http 500",
-          firstFailureAt: "2026-04-19T22:00:00Z",
-          links: {
-            smoke: "https://a.example/smoke",
-            health: "https://a.example/health",
-          },
-          failCount: 4,
-        },
-        { trigger: { sustained_red: true, isRedTick: true }, escalated: true },
-      );
-      const text = (
-        renderer.render({ text: rule.template!.text }, ctx).payload as {
-          text: string;
-        }
-      ).text;
-      expect(text).toContain("<!channel>");
-      expect(text).toContain("agno-starter");
-      expect(text).toContain("failing for 1 hour");
-      expect(text).toContain("since 2026-04-19T22:00:00Z");
+    it("fleet rule owns <!channel> escalation (migrated from per-service red-tick)", async () => {
+      // Plan Item 4: <!channel> moved off smoke-red-tick onto smoke-red-fleet.
+      // The per-service rule still fires per-match via its own targets; the
+      // fleet rule is the single pager for cross-service outages. Per-service
+      // red-tick template must NOT contain <!channel>; fleet rule template
+      // MUST. Both invariants asserted together so a future refactor can't
+      // silently drop one without the other surfacing.
+      const { rules } = await loadRealRules();
+      const perService = rules.find((r) => r.id === "smoke-red-tick")!;
+      const fleet = rules.find((r) => r.id === "smoke-red-fleet")!;
+      expect(perService.template!.text).not.toContain("<!channel>");
+      expect(fleet.aggregation).toBeDefined();
+      expect(fleet.aggregation!.template).toContain("<!channel>");
     });
   });
 

--- a/showcase/ops/src/rules/rule-loader.ts
+++ b/showcase/ops/src/rules/rule-loader.ts
@@ -323,19 +323,31 @@ export function createRuleLoader(opts: RuleLoaderOptions): RuleLoader {
   }
 
   function validateTripleBrace(rule: RuleDoc): void {
-    // Mirror validateFilterNames: scan BOTH template.text AND
-    // on_error.template.text. Pre-fix, a rule with
+    // Mirror validateFilterNames: scan template.text, on_error.template.text,
+    // AND aggregation.template (A8). Pre-fix, a rule with
     // `on_error.template: "{{{signal.arbitrary_field}}}"` on a dimension
     // where `arbitrary_field` wasn't in slackSafeFields passed load
     // validation but rendered the raw unescaped value at runtime — a
     // Slack mrkdwn-injection / XSS surface asymmetric with the primary
-    // template's validation.
+    // template's validation. The same hole existed for aggregation.template
+    // (rendered via Mustache.render in alert-engine.onAggregationFlush).
     const sources: string[] = [];
     if (rule.template?.text) sources.push(rule.template.text);
     if (rule.on_error?.template?.text)
       sources.push(rule.on_error.template.text);
+    // A8: aggregation.template is rendered in onAggregationFlush with the
+    // context `{ count, services, firstSignal, lastSignal, groupValues }`.
+    // Triple-brace on `firstSignal.*` / `lastSignal.*` is essentially a
+    // `signal.*` reference and must honour the same dimension's slackSafe
+    // set. We normalise those prefixes to `signal.` before the per-path
+    // check below so the existing allowlist applies transparently.
+    const aggSource = rule.aggregation?.template;
+    if (aggSource) sources.push(aggSource);
     const safeForDim =
       slackSafeFields[rule.signal.dimension] ?? new Set<string>();
+    // Non-signal identifiers the aggregation template's render context
+    // injects directly. These are always loader-known-safe.
+    const AGG_SAFE_NON_SIGNAL = new Set(["count", "services"]);
     const re = /\{\{\{\s*([^}]+?)\s*\}\}\}/g;
     for (const template of sources) {
       re.lastIndex = 0;
@@ -365,12 +377,26 @@ export function createRuleLoader(opts: RuleLoaderOptions): RuleLoader {
           }
           continue;
         }
-        if (!p.startsWith("signal.")) {
+        // A8: aggregation-template engine context fields. `count` and
+        // `services` are simple (number/string) values — triple-brace is
+        // pointless on them but not unsafe; allow them for symmetry with
+        // the flat `{{count}}` usage already present in fleet rules.
+        if (AGG_SAFE_NON_SIGNAL.has(p)) continue;
+        // A8: firstSignal.* / lastSignal.* are aliases for signal.* in the
+        // aggregation render context; rewrite to the canonical signal path
+        // so the per-dimension slackSafe set applies unchanged.
+        let normPath = p;
+        if (p.startsWith("firstSignal.")) {
+          normPath = "signal." + p.slice("firstSignal.".length);
+        } else if (p.startsWith("lastSignal.")) {
+          normPath = "signal." + p.slice("lastSignal.".length);
+        }
+        if (!normPath.startsWith("signal.")) {
           throw new Error(
             `rule ${rule.id}: triple-brace must reference 'signal.*', 'event.*', or 'env.*', got '${p}'`,
           );
         }
-        const sub = p.slice("signal.".length);
+        const sub = normPath.slice("signal.".length);
         if (!safeForDim.has(sub)) {
           throw new Error(
             `rule ${rule.id}: triple-brace '${p}' not marked slackSafe on dimension '${rule.signal.dimension}'`,

--- a/showcase/ops/src/rules/rule-loader.ts
+++ b/showcase/ops/src/rules/rule-loader.ts
@@ -20,6 +20,7 @@ import { DefaultsSchema, RuleSchema, type RuleDoc } from "./schema.js";
 // Import from the DSL leaf module rather than alert-engine to avoid the
 // type↔value cycle (alert-engine imports `CompiledRule` from this file).
 import { evalSuppress, parseDuration } from "../alerts/dsl.js";
+import type { AggregationConfig } from "../alerts/aggregation.js";
 // HF13-D1: reuse the renderer's FILTER_RE so load-time validation and
 // render-time substitution can't drift. A prior local copy here lacked
 // the negative look-arounds that exclude triple-brace spans.
@@ -136,6 +137,13 @@ export interface CompiledRule {
   template?: { text: string };
   actions: { kind: "rebuild"; target: string; forEach?: string }[];
   onError?: { template: { text: string } };
+  /**
+   * Cross-service aggregation config (plan Item 4). When present, matching
+   * signals for this rule are collected into buckets and a composite alert
+   * fires on threshold or window-expiry — bypassing per-match dispatch.
+   * Absent for normal per-match rules.
+   */
+  aggregation?: AggregationConfig;
   // `slackSafe` paths discovered from dimension registries — any `{{{ ... }}}`
   // triple-brace must reference one of these paths, else the loader rejects.
 }
@@ -474,6 +482,7 @@ export function createRuleLoader(opts: RuleLoaderOptions): RuleLoader {
       template: rule.template,
       actions: rule.actions ?? [],
       onError: rule.on_error,
+      aggregation: rule.aggregation,
     };
   }
 

--- a/showcase/ops/src/rules/schema.ts
+++ b/showcase/ops/src/rules/schema.ts
@@ -155,6 +155,25 @@ export const OnErrorSchema = z
   })
   .strict();
 
+/**
+ * Cross-service alert aggregation (plan Item 4). When declared, matching
+ * signals for this rule are collected into buckets keyed on `groupBy` field
+ * values, and a composite alert fires once either the `minMatches` threshold
+ * is hit or `windowMs` elapses since the first match.
+ *
+ * `.strict()` so a typoed field (e.g. `windowMsec`) surfaces at load time
+ * rather than silently arming a bucket with the default value of `undefined`.
+ */
+export const AggregationSchema = z
+  .object({
+    groupBy: z.array(z.string().min(1)).min(1),
+    windowMs: z.number().int().positive(),
+    minMatches: z.number().int().positive(),
+    template: z.string().min(1),
+    targets: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
 export const RuleSchema = z
   .object({
     id: z.string().min(1),
@@ -171,6 +190,7 @@ export const RuleSchema = z
     template: TemplateSchema.optional(),
     actions: z.array(ActionSchema).optional(),
     on_error: OnErrorSchema.optional(),
+    aggregation: AggregationSchema.optional(),
   })
   .strict();
 

--- a/showcase/ops/src/rules/schema.ts
+++ b/showcase/ops/src/rules/schema.ts
@@ -166,11 +166,17 @@ export const OnErrorSchema = z
  */
 export const AggregationSchema = z
   .object({
-    groupBy: z.array(z.string().min(1)).min(1),
+    // A7: groupBy is optional / may be empty → single bucket per rule. Use
+    // this when the rule's `when` clause already partitions traffic (e.g.
+    // one rule per dimension) and there's no finer partition to apply.
+    groupBy: z.array(z.string().min(1)).optional(),
     windowMs: z.number().int().positive(),
     minMatches: z.number().int().positive(),
     template: z.string().min(1),
-    targets: z.array(z.string().min(1)).optional(),
+    // B1: `targets` removed — the engine uses `rule.targets` for aggregation
+    // dispatch; a separate aggregation-level override was never wired and
+    // silently dropped. Rule authors declaring it got no feedback and no
+    // effect; `.strict()` on RuleSchema now rejects the field at load.
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Sanitize `errorDesc` before it flows into Slack templates: strip HTML, script/style bodies (including entity-smuggled), Slack mrkdwn controls (`<!channel>`, `<!here>`, `<@U…>`), backticks. Cap at 120 chars.
- Section-guard optional link fields in `{smoke,agent,chat,tools}-red-tick.yml` so absent links emit nothing instead of `<|smoke>`.
- Switch `{{signal.errorDesc}}` to `{{{signal.errorDesc}}}` (triple-brace) since values are pre-sanitized; add `errorDesc` to each dimension's `slackSafeFields` so rule-loader validation passes.
- Introduce cross-service aggregation: new `AggregationBucketStore`, `CompiledRule.aggregation?`, YAML schema field, engine ingress branch, composite-flush dedupe via `buildCompositeDedupeKey`.
- New `{smoke,agent,chat,tools}-red-fleet.yml` rules: `groupBy=[dimension]`, `windowMs=120s`, `minMatches=3`. `<!channel>` migrates from per-service red-tick rules to the fleet rules.

## Why

PR #4178 (L1-L4 coverage on 34 services) landed and caused an 18-per-tick fanout in `#oss-alerts` with entity-escaped HTML bodies and empty link brackets. Channel was silenced by removing the webhook env var on Railway as short-term triage; this PR is the durable fix.

## Test plan

- [x] `sanitizeErrorDesc` unit tests: 10 cases including entity-smuggled script payload, Slack mrkdwn injection, length cap with U+2026 ellipsis.
- [x] Red-tick render tests: 9 cases across 4 YAMLs covering missing-link emits-nothing, present-link renders, and errorDesc rendered as literal characters (no HTML-entity double-escape).
- [x] Aggregation store tests: 8 cases covering threshold flush, window-expiry flush, below-threshold non-fire, independent groupBy buckets, composite dedupe across window expiries, bootstrap suppression, TTL eviction.
- [x] Full `showcase/ops` suite green (731+ tests).
- [x] typecheck clean, lint clean, build clean.

## Rollout notes

- The first probe tick after this lands will exercise all four fleet rules. Bootstrap suppression (15min from engine boot) delays first composite by design.
- Existing `SLACK_WEBHOOK_OSS_ALERTS` env var was removed from Railway `showcase-ops` during triage. Re-setting it (to `#oss-alerts` or a personal redirect) activates this branch's output.
- Staging verification: no dedicated `showcase-ops` staging env exists; this PR ships on "land + watch next real bulk deploy" as documented manual verification.

## Parallel-branch coordination

A separate branch is modifying `showcase/ops/src/probes/drivers/smoke.ts` for path-resolution. This PR's `smoke.ts` surface is exactly 1 import + 8 errorDesc-assignment wraps — rebase-friendly. Sanitization is unconditional; any new errorDesc sites the parallel branch introduces should be wrapped the same way.