### PR TITLE
fix(langgraph-python-threads): render canvas state on resume

### DIFF
--- a/examples/integrations/langgraph-python-threads/apps/app/src/App.tsx
+++ b/examples/integrations/langgraph-python-threads/apps/app/src/App.tsx
@@ -1,6 +1,9 @@
 import { useState } from "react";
-import { CopilotKitProvider } from "@copilotkit/react-core/v2";
-import { CopilotChat } from "@copilotkit/react-core/v2";
+import {
+  CopilotChat,
+  CopilotChatConfigurationProvider,
+  CopilotKitProvider,
+} from "@copilotkit/react-core/v2";
 import { ExampleLayout } from "@/components/example-layout";
 import { ExampleCanvas } from "@/components/example-canvas";
 import { ThreadsDrawer } from "@/components/threads-drawer";
@@ -25,16 +28,25 @@ function HomePage() {
         onThreadChange={setThreadId}
       />
       <div className={styles.mainPanel}>
-        <ExampleLayout
-          chatContent={
-            <CopilotChat
-              agentId="default"
-              threadId={threadId}
-              input={{ disclaimer: () => null, className: "pb-6" }}
-            />
-          }
-          appContent={<ExampleCanvas />}
-        />
+        {/*
+          Wrap both the chat and the canvas in one CopilotChatConfigurationProvider
+          so they share the active threadId. `useAgent()` falls back to the
+          provider's threadId when called without an explicit one, which makes
+          the canvas read from the same per-thread agent clone that the chat's
+          /connect replay populates. Without this wrapper, the canvas resolves
+          to the registry agent and never receives STATE_SNAPSHOT events on
+          thread resume.
+        */}
+        <CopilotChatConfigurationProvider agentId="default" threadId={threadId}>
+          <ExampleLayout
+            chatContent={
+              <CopilotChat
+                input={{ disclaimer: () => null, className: "pb-6" }}
+              />
+            }
+            appContent={<ExampleCanvas />}
+          />
+        </CopilotChatConfigurationProvider>
       </div>
     </div>
   );

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { EventType, BaseEvent, RunAgentInput } from "@ag-ui/client";
-import { Observable } from "rxjs";
-import { MockSocket, MockChannel } from "./test-utils";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { RUNTIME_MODE_INTELLIGENCE } from "@copilotkit/shared";
+import type { MockChannel } from "./test-utils";
+import { MockSocket } from "./test-utils";
 
 vi.mock("phoenix", () => ({
   Socket: MockSocket,
@@ -9,6 +12,7 @@ vi.mock("phoenix", () => ({
 
 // Must come after vi.mock so phoenix is mocked when the module is loaded.
 const { IntelligenceAgent } = await import("../intelligence-agent");
+const { ProxiedCopilotRuntimeAgent } = await import("../agent");
 type IntelligenceAgentInstance = InstanceType<typeof IntelligenceAgent>;
 
 let mockFetch: ReturnType<typeof vi.fn>;
@@ -1234,6 +1238,58 @@ describe("IntelligenceAgent", () => {
       expect(getChannel(agent)).toBeNull();
     });
 
+    it("hydrates agent state from bootstrap STATE_SNAPSHOT events through connectAgent", async () => {
+      // Reproduces the shared-state thread-resume case:
+      // on resume, the /connect bootstrap plan replays STATE_SNAPSHOT events
+      // captured during the original run. After connectAgent resolves,
+      // agent.state must reflect the final snapshot — otherwise UI that reads
+      // from agent.state (e.g. todo list) shows empty on resume.
+      const finalSnapshot = {
+        todos: [
+          { id: "1", title: "Read CopilotKit docs", status: "pending" },
+          { id: "2", title: "Build a CopilotKit prototype", status: "pending" },
+          { id: "3", title: "Explore agent state", status: "pending" },
+        ],
+      };
+
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse({
+          mode: "bootstrap",
+          latestEventId: "event-4",
+          events: [
+            {
+              type: EventType.RUN_STARTED,
+              threadId: "thread-1",
+              run_id: "backend-run-1",
+              input: { messages: [] },
+            },
+            // Earlier intermediate snapshot — agent.state must not be stuck here.
+            {
+              type: EventType.STATE_SNAPSHOT,
+              snapshot: {
+                todos: [
+                  { id: "1", title: "Read CopilotKit docs", status: "pending" },
+                ],
+              },
+            },
+            // Final snapshot captured before RUN_FINISHED.
+            {
+              type: EventType.STATE_SNAPSHOT,
+              snapshot: finalSnapshot,
+            },
+            { type: EventType.RUN_FINISHED },
+          ],
+        }),
+      );
+
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+
+      await agent.connectAgent({ runId: "run-1" });
+
+      expect(agent.state).toEqual(finalSnapshot);
+    });
+
     it("does not create a socket for bootstrap-only connect plans", async () => {
       mockFetch.mockResolvedValueOnce(
         await jsonResponse({
@@ -1525,5 +1581,59 @@ describe("IntelligenceAgent", () => {
         last_seen_event_id: null,
       });
     });
+  });
+});
+
+describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
+  // Mirrors the real demo wiring: Vite app → BFF runtime that exposes a
+  // ProxiedCopilotRuntimeAgent in intelligence mode → IntelligenceAgent delegate
+  // talking to the realtime gateway. On thread resume, the delegate's /connect
+  // bootstrap plan replays STATE_SNAPSHOT events captured during the original run;
+  // the proxy bridges delegate.state → proxy.state so useAgent re-renders.
+  it("hydrates proxy state from bootstrap STATE_SNAPSHOT events via the intelligence delegate", async () => {
+    const finalSnapshot = {
+      todos: [
+        { id: "1", title: "Read CopilotKit docs", status: "pending" },
+        { id: "2", title: "Build a CopilotKit prototype", status: "pending" },
+        { id: "3", title: "Explore agent state", status: "pending" },
+      ],
+    };
+
+    mockFetch.mockResolvedValueOnce(
+      await jsonResponse({
+        mode: "bootstrap",
+        latestEventId: "event-4",
+        events: [
+          {
+            type: EventType.RUN_STARTED,
+            threadId: "thread-1",
+            run_id: "backend-run-1",
+            input: { messages: [] },
+          },
+          {
+            type: EventType.STATE_SNAPSHOT,
+            snapshot: {
+              todos: [
+                { id: "1", title: "Read CopilotKit docs", status: "pending" },
+              ],
+            },
+          },
+          { type: EventType.STATE_SNAPSHOT, snapshot: finalSnapshot },
+          { type: EventType.RUN_FINISHED },
+        ],
+      }),
+    );
+
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "http://localhost:4000/api/copilotkit",
+      agentId: "default",
+      runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+      intelligence: { wsUrl: "ws://localhost:4401/client" },
+    });
+    agent.threadId = "thread-1";
+
+    await agent.connectAgent({ runId: "run-1" });
+
+    expect(agent.state).toEqual(finalSnapshot);
   });
 });


### PR DESCRIPTION
## Summary

The `langgraph-python-threads` example's canvas renders "No todos yet" on thread resume even when the agent has persisted todos — the chat correctly shows the prior conversation, but the shared-state view is empty.

Root cause: `<ExampleCanvas>` calls `useAgent()` with no args, which resolves to the registry agent. `<CopilotChat threadId={threadId}>` drives a **per-thread clone**. On resume, the `/connect` bootstrap replay's `STATE_SNAPSHOT` events hydrate the clone — not the registry agent the canvas is reading from.

Fix: wrap `<ExampleLayout>` (both chat and canvas) in a single `<CopilotChatConfigurationProvider agentId="default" threadId={threadId}>`. The canvas's `useAgent()` then inherits the active `threadId` via the existing fallback at `use-agent.tsx:139` and resolves to the same clone. Redundant `agentId`/`threadId` props are removed from `<CopilotChat>` (single source of truth).

## Changes

- `examples/integrations/langgraph-python-threads/apps/app/src/App.tsx` — wrap in `CopilotChatConfigurationProvider`.
- `packages/core/src/__tests__/intelligence-agent.test.ts` — add regression coverage: `connectAgent` with a bootstrap plan containing `STATE_SNAPSHOT` events must leave `agent.state` hydrated (both directly on `IntelligenceAgent` and through `ProxiedCopilotRuntimeAgent` in intelligence mode). These tests already pass — they lock in the replay-pipeline contract the demo depends on.