### PR TITLE
fix(react-core): overlay chat input on scroll area

### DIFF
--- a/examples/v2/react/storybook/stories/CopilotChatView.stories.tsx
+++ b/examples/v2/react/storybook/stories/CopilotChatView.stories.tsx
@@ -62,6 +62,36 @@ export const Default: Story = {
   },
 };
 
+export const PinToSend: Story = {
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "Pin-to-send mode anchors the user's last message at the top of the viewport when they submit. Useful for inspecting how content fades (or doesn't) above the input.",
+      },
+    },
+  },
+  decorators: Default.decorators,
+  render: () => {
+    return (
+      <CopilotKitProvider runtimeUrl="https://copilotkit.ai">
+        <CopilotChatConfigurationProvider threadId="storybook-pin-to-send">
+          <div style={{ height: "100%" }}>
+            <CopilotChatView
+              autoScroll="pin-to-send"
+              messages={pinToSendMessages}
+              onSubmitMessage={(value) => {
+                alert(`Message submitted: ${value}`);
+              }}
+            />
+          </div>
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>
+    );
+  },
+};
+
 export const WithSuggestions: Story = {
   parameters: {
     layout: "fullscreen",
@@ -166,5 +196,103 @@ In this example:
 - \`setCount\` is the function to update the state`,
     timestamp: new Date(),
     role: "assistant" as const,
+  },
+];
+
+// Enough back-and-forth to force scrolling so the feather region above the
+// input is clearly visible in pin-to-send mode.
+const pinToSendMessages = [
+  {
+    id: "u1",
+    role: "user" as const,
+    content: "Give me a quick intro to useEffect.",
+    timestamp: new Date(),
+  },
+  {
+    id: "a1",
+    role: "assistant" as const,
+    content: `\`useEffect\` runs side effects after render. Common uses:
+
+- Data fetching
+- Subscriptions
+- Manual DOM work
+- Timers
+
+It takes a callback and an optional dependency array. If the deps change between renders, the callback re-runs. Return a cleanup function to tear down subscriptions or timers.`,
+    timestamp: new Date(),
+  },
+  {
+    id: "u2",
+    role: "user" as const,
+    content: "Show me a subscription example.",
+    timestamp: new Date(),
+  },
+  {
+    id: "a2",
+    role: "assistant" as const,
+    content: `\`\`\`jsx
+useEffect(() => {
+  const socket = new WebSocket(url);
+  socket.addEventListener("message", onMessage);
+  return () => socket.close();
+}, [url]);
+\`\`\`
+
+The cleanup closes the socket if \`url\` changes or the component unmounts. Without it you'd leak connections on every dependency change.`,
+    timestamp: new Date(),
+  },
+  {
+    id: "u3",
+    role: "user" as const,
+    content: "What about running something only once on mount?",
+    timestamp: new Date(),
+  },
+  {
+    id: "a3",
+    role: "assistant" as const,
+    content: `Pass an empty dependency array:
+
+\`\`\`jsx
+useEffect(() => {
+  analytics.track("page_viewed");
+}, []);
+\`\`\`
+
+With \`[]\`, React runs the effect once after the first render and never again (in production — Strict Mode runs it twice in dev to help surface cleanup bugs).`,
+    timestamp: new Date(),
+  },
+  {
+    id: "u4",
+    role: "user" as const,
+    content:
+      "How do I avoid the stale-closure trap when reading state inside an effect?",
+    timestamp: new Date(),
+  },
+  {
+    id: "a4",
+    role: "assistant" as const,
+    content: `A few options:
+
+1. **Add the value to deps** so the effect re-subscribes with the fresh closure.
+2. **Use a ref** (\`useRef\`) and read \`ref.current\` inside the callback — the ref always sees the latest value.
+3. **Use functional setState** when updating: \`setCount(c => c + 1)\` avoids reading the stale \`count\`.
+
+Dependency arrays are the honest answer — refs are an escape hatch when the value changes too often to re-subscribe on.`,
+    timestamp: new Date(),
+  },
+  {
+    id: "u5",
+    role: "user" as const,
+    content: "Anything to watch out for with async work inside useEffect?",
+    timestamp: new Date(),
+  },
+  {
+    id: "a5",
+    role: "assistant" as const,
+    content: `Two big ones:
+
+1. **The effect itself can't be \`async\`.** Define an inner async function and call it: \`useEffect(() => { (async () => { ... })(); }, [])\`.
+2. **Guard against unmount / stale responses.** If a fetch resolves after the component unmounts (or after a new request starts), you'll either set state on an unmounted component or overwrite newer data with older. An \`ignore\` flag in cleanup, or an \`AbortController\`, handles both.`,
+    timestamp: new Date(),
   },
 ];

--- a/packages/react-core/src/v2/components/chat/CopilotChatAttachmentQueue.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAttachmentQueue.tsx
@@ -21,7 +21,10 @@ export const CopilotChatAttachmentQueue: React.FC<
   if (attachments.length === 0) return null;
 
   return (
-    <div className={cn("cpk:flex cpk:flex-wrap cpk:gap-2 cpk:p-2", className)}>
+    <div
+      data-testid="copilot-attachment-queue"
+      className={cn("cpk:flex cpk:flex-wrap cpk:gap-2 cpk:p-2", className)}
+    >
       {attachments.map((attachment) => {
         const isMedia =
           attachment.type === "image" || attachment.type === "video";

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -239,11 +239,11 @@ export function CopilotChatView({
     onAddFile,
     positioning: "static",
     keyboardHeight: isKeyboardOpen ? keyboardHeight : 0,
-    containerRef: inputContainerRef,
     showDisclaimer: true,
-    // This input is the last flex child of the chat column, so it sits at
-    // the bottom where the license banner would overlap. The welcome-screen
-    // input (below) intentionally omits this flag.
+    // The parent overlay wrapper handles absolute bottom-0 positioning.
+    // `bottomAnchored` still triggers the license-banner offset padding
+    // inside CopilotChatInput. The welcome-screen input (below) intentionally
+    // omits this flag.
     bottomAnchored: true,
     ...(disclaimer !== undefined ? { disclaimer } : {}),
   } as CopilotChatInputProps);
@@ -272,8 +272,9 @@ export function CopilotChatView({
     isResizing,
     children: (
       <div
+        data-testid="copilot-scroll-content"
         style={{
-          paddingBottom: `${hasSuggestions ? 4 : 32}px`,
+          paddingBottom: `${inputContainerHeight + (hasSuggestions ? 4 : 32)}px`,
         }}
       >
         <div className="cpk:max-w-3xl cpk:mx-auto">
@@ -396,17 +397,22 @@ export function CopilotChatView({
       {dragOver && <DropOverlay />}
       {BoundScrollView}
 
-      <div className="cpk:max-w-3xl cpk:mx-auto cpk:w-full">
+      <div
+        ref={inputContainerRef}
+        data-testid="copilot-input-overlay"
+        className="cpk:absolute cpk:bottom-0 cpk:left-0 cpk:right-0 cpk:z-20 cpk:pointer-events-none"
+      >
         {attachments && attachments.length > 0 && (
-          <CopilotChatAttachmentQueue
-            attachments={attachments}
-            onRemoveAttachment={(id) => onRemoveAttachment?.(id)}
-            className="cpk:px-4"
-          />
+          <div className="cpk:max-w-3xl cpk:mx-auto cpk:w-full cpk:pointer-events-auto">
+            <CopilotChatAttachmentQueue
+              attachments={attachments}
+              onRemoveAttachment={(id) => onRemoveAttachment?.(id)}
+              className="cpk:px-4"
+            />
+          </div>
         )}
+        {BoundInput}
       </div>
-
-      {BoundInput}
     </div>
   );
 }

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -6,17 +6,19 @@ import React, {
   useLayoutEffect,
 } from "react";
 import { ScrollElementContext } from "./scroll-element-context";
-import { WithSlots, SlotValue, renderSlot } from "../../lib/slots";
+import type { WithSlots, SlotValue } from "../../lib/slots";
+import { renderSlot } from "../../lib/slots";
 import CopilotChatMessageView from "./CopilotChatMessageView";
-import CopilotChatInput, {
+import type {
   CopilotChatInputProps,
   CopilotChatInputMode,
 } from "./CopilotChatInput";
+import CopilotChatInput from "./CopilotChatInput";
 import CopilotChatSuggestionView, {
   CopilotChatSuggestionViewProps,
 } from "./CopilotChatSuggestionView";
-import { Suggestion } from "@copilotkit/core";
-import { Message } from "@ag-ui/core";
+import type { Suggestion } from "@copilotkit/core";
+import type { Message } from "@ag-ui/core";
 import type { Attachment } from "@copilotkit/shared";
 import { CopilotChatAttachmentQueue } from "./CopilotChatAttachmentQueue";
 import { twMerge } from "tailwind-merge";
@@ -37,29 +39,8 @@ import { normalizeAutoScroll } from "./normalize-auto-scroll";
 import type { AutoScrollMode } from "./normalize-auto-scroll";
 import { usePinToSend } from "../../hooks/use-pin-to-send";
 
-// Height of the feather gradient overlay (h-24 = 6rem = 96px)
-const FEATHER_HEIGHT = 96;
-
-// Pin-to-send uses a softer, shorter feather than pin-to-bottom so readable
-// content isn't obscured (h-12 = 3rem = 48px).
-const PIN_TO_SEND_FEATHER_HEIGHT = 48;
-
-const PinToSendSoftFeather: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
-  className,
-  style,
-  ...props
-}) => (
-  <div
-    className={cn(
-      "cpk:absolute cpk:bottom-0 cpk:left-0 cpk:right-4 cpk:h-12 cpk:pointer-events-none cpk:z-10 cpk:bg-gradient-to-t",
-      "cpk:from-white cpk:to-transparent",
-      "cpk:dark:from-[rgb(33,33,33)]",
-      className,
-    )}
-    style={style}
-    {...props}
-  />
-);
+// Vertical gap between the scroll-to-bottom button and the input container.
+const SCROLL_BUTTON_OFFSET = 16;
 
 // Forward declaration for WelcomeScreen component type
 export type WelcomeScreenProps = WithSlots<
@@ -476,7 +457,6 @@ export namespace CopilotChatView {
             </div>
           </StickToBottom.Content>
 
-          {/* Feather gradient overlay */}
           {BoundFeather}
 
           {/* Scroll to bottom button - hidden during resize */}
@@ -484,7 +464,7 @@ export namespace CopilotChatView {
             <div
               className="cpk:absolute cpk:inset-x-0 cpk:flex cpk:justify-center cpk:z-30 cpk:pointer-events-none"
               style={{
-                bottom: `${inputContainerHeight + FEATHER_HEIGHT + 16}px`,
+                bottom: `${inputContainerHeight + SCROLL_BUTTON_OFFSET}px`,
               }}
             >
               {renderSlot(
@@ -541,21 +521,13 @@ export namespace CopilotChatView {
       topOffset: 16,
     });
 
-    // Pin-to-send uses a SOFTER feather than pin-to-bottom:
-    //   - default: h-24 + from-white via-white to-transparent (fully opaque
-    //     bottom half, aggressive). Good for streaming-to-bottom where
-    //     the edge is always churning.
-    //   - pin-to-send: h-12 + from-white to-transparent (gradual fade,
-    //     no opaque midline). Gives a visual soft edge above the input
-    //     without obscuring otherwise-readable content.
-    // Consumers can still override with the `feather` slot.
-    const BoundFeather = renderSlot(feather, PinToSendSoftFeather, {});
-
-    // Feather and scroll-to-bottom button live OUTSIDE the scroll container.
-    // `position: absolute` children of an `overflow: auto` element are
-    // positioned relative to the scroll *content*, which means they scroll
-    // away with it. Placing them as siblings of the scroll container
+    // The feather and scroll-to-bottom button live OUTSIDE the scroll
+    // container. `position: absolute` children of an `overflow: auto` element
+    // are positioned relative to the scroll *content*, which means they
+    // scroll away with it. Placing them as siblings of the scroll container
     // (inside a `relative` wrapper) keeps them pinned to the viewport bottom.
+    const BoundFeather = renderSlot(feather, CopilotChatView.Feather, {});
+
     return (
       <ScrollElementContext.Provider value={nonAutoScrollEl}>
         <div
@@ -582,14 +554,13 @@ export namespace CopilotChatView {
               style={{ height: 0, flex: "0 0 auto" }}
             />
           </div>
-          {/* Soft feather — pinned to wrapper bottom */}
           {BoundFeather}
           {/* Scroll to bottom button */}
           {showScrollButton && !isResizing && (
             <div
               className="cpk:absolute cpk:inset-x-0 cpk:flex cpk:justify-center cpk:z-30 cpk:pointer-events-none"
               style={{
-                bottom: `${inputContainerHeight + PIN_TO_SEND_FEATHER_HEIGHT + 16}px`,
+                bottom: `${inputContainerHeight + SCROLL_BUTTON_OFFSET}px`,
               }}
             >
               {renderSlot(
@@ -722,7 +693,6 @@ export namespace CopilotChatView {
               {children}
             </div>
 
-            {/* Feather gradient overlay */}
             {BoundFeather}
 
             {/* Scroll to bottom button for manual mode */}
@@ -730,7 +700,7 @@ export namespace CopilotChatView {
               <div
                 className="cpk:absolute cpk:inset-x-0 cpk:flex cpk:justify-center cpk:z-30 cpk:pointer-events-none"
                 style={{
-                  bottom: `${inputContainerHeight + FEATHER_HEIGHT + 16}px`,
+                  bottom: `${inputContainerHeight + SCROLL_BUTTON_OFFSET}px`,
                 }}
               >
                 {renderSlot(
@@ -812,22 +782,14 @@ export namespace CopilotChatView {
     </Button>
   );
 
+  // Default renders an empty div — no visual, but the element is still in the
+  // tree so a slot override of the form `scrollView={{ feather: "my-class" }}`
+  // can apply classes (and any consumer with a full component override gets
+  // the className/style forwarding they expect).
   export const Feather: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
     className,
-    style,
     ...props
-  }) => (
-    <div
-      className={cn(
-        "cpk:absolute cpk:bottom-0 cpk:left-0 cpk:right-4 cpk:h-24 cpk:pointer-events-none cpk:z-10 cpk:bg-gradient-to-t",
-        "cpk:from-white cpk:via-white cpk:to-transparent",
-        "cpk:dark:from-[rgb(33,33,33)] cpk:dark:via-[rgb(33,33,33)]",
-        className,
-      )}
-      style={style}
-      {...props}
-    />
-  );
+  }) => <div className={className} {...props} />;
 
   export const WelcomeMessage: React.FC<
     React.HTMLAttributes<HTMLDivElement>

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.inputOverlay.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.inputOverlay.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { CopilotChatView } from "../CopilotChatView";
+import { LastUserMessageContext } from "../last-user-message-context";
+import type { Attachment } from "@copilotkit/shared";
+
+beforeEach(() => {
+  HTMLElement.prototype.scrollTo = vi.fn();
+});
+
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <CopilotKitProvider>
+    <CopilotChatConfigurationProvider threadId="test-thread">
+      <div style={{ height: 400 }}>{children}</div>
+    </CopilotChatConfigurationProvider>
+  </CopilotKitProvider>
+);
+
+const sampleMessages = [
+  { id: "1", role: "user" as const, content: "Hello" },
+  { id: "2", role: "assistant" as const, content: "Hi there!" },
+];
+
+const sampleAttachments: Attachment[] = [
+  {
+    id: "att-1",
+    type: "document",
+    source: {
+      type: "url",
+      value: "https://example.com/doc.txt",
+      mimeType: "text/plain",
+    },
+    filename: "example.txt",
+    size: 42,
+    status: "ready",
+  },
+];
+
+async function waitForMount(screen: {
+  findByTestId: (id: string) => Promise<HTMLElement>;
+}) {
+  await screen.findByTestId("copilot-message-list");
+}
+
+describe("CopilotChatView input overlay layout", () => {
+  it("renders the input inside an absolute-positioned overlay wrapper on the main view", async () => {
+    const screen = render(
+      <TestWrapper>
+        <LastUserMessageContext.Provider value={{ id: null, sendNonce: 0 }}>
+          <CopilotChatView messages={sampleMessages} />
+        </LastUserMessageContext.Provider>
+      </TestWrapper>,
+    );
+    await waitForMount(screen);
+
+    // getByTestId throws if missing — presence is implicit.
+    const overlay = screen.getByTestId("copilot-input-overlay");
+    // Class-level assertion — the cpk: prefix avoids false positives from
+    // consumer classes. Absolute + bottom-0 is the contract we care about.
+    expect(overlay.className).toMatch(/cpk:absolute/);
+    expect(overlay.className).toMatch(/cpk:bottom-0/);
+
+    // Input (send button) lives inside the overlay, not outside it.
+    const sendButton = screen.getByTestId("copilot-send-button");
+    expect(overlay.contains(sendButton)).toBe(true);
+  });
+
+  it("renders the attachment queue above the input inside the overlay wrapper", async () => {
+    const screen = render(
+      <TestWrapper>
+        <LastUserMessageContext.Provider value={{ id: null, sendNonce: 0 }}>
+          <CopilotChatView
+            messages={sampleMessages}
+            attachments={sampleAttachments}
+          />
+        </LastUserMessageContext.Provider>
+      </TestWrapper>,
+    );
+    await waitForMount(screen);
+
+    const overlay = screen.getByTestId("copilot-input-overlay");
+    const queue = overlay.querySelector(
+      '[data-testid="copilot-attachment-queue"]',
+    );
+    const sendButton = overlay.querySelector(
+      '[data-testid="copilot-send-button"]',
+    );
+
+    expect(queue).not.toBeNull();
+    expect(sendButton).not.toBeNull();
+
+    // DOM order: the attachment queue must appear before the send button
+    // in document order so it renders visually above the pill.
+    const position = queue!.compareDocumentPosition(sendButton!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("does NOT wrap the welcome-screen input in the overlay", async () => {
+    const screen = render(
+      <TestWrapper>
+        <LastUserMessageContext.Provider value={{ id: null, sendNonce: 0 }}>
+          <CopilotChatView messages={[]} />
+        </LastUserMessageContext.Provider>
+      </TestWrapper>,
+    );
+    await screen.findByTestId("copilot-welcome-screen");
+
+    // Welcome screen present → no overlay wrapper exists in this render.
+    expect(screen.queryByTestId("copilot-input-overlay")).toBeNull();
+  });
+
+  it("reserves inputContainerHeight as bottom padding on the scroll content", async () => {
+    // Spy on ResizeObserver so we can trigger a known height. The component
+    // uses ResizeObserver to measure the overlay wrapper; we inject a known
+    // value and assert the scroll content's inline padding-bottom reflects it.
+    const callbacks: Array<{
+      cb: ResizeObserverCallback;
+      target: Element | null;
+    }> = [];
+    const OriginalRO = global.ResizeObserver;
+    class MockResizeObserver {
+      private cb: ResizeObserverCallback;
+      constructor(cb: ResizeObserverCallback) {
+        this.cb = cb;
+      }
+      observe(target: Element) {
+        callbacks.push({ cb: this.cb, target });
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).ResizeObserver = MockResizeObserver as any;
+
+    try {
+      const screen = render(
+        <TestWrapper>
+          <LastUserMessageContext.Provider value={{ id: null, sendNonce: 0 }}>
+            <CopilotChatView messages={sampleMessages} />
+          </LastUserMessageContext.Provider>
+        </TestWrapper>,
+      );
+      await waitForMount(screen);
+
+      const scrollContent = screen.getByTestId("copilot-scroll-content");
+
+      // Simulate the overlay wrapper reporting a content height of 120px.
+      for (const { cb } of callbacks) {
+        cb(
+          [
+            {
+              contentRect: { height: 120 } as DOMRectReadOnly,
+            } as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      }
+
+      // After the resize fires, paddingBottom = 120 (input) + 32 (baseline,
+      // no suggestions) = "152px". The test asserts the formula.
+      await waitFor(() =>
+        expect(scrollContent.style.paddingBottom).toBe("152px"),
+      );
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).ResizeObserver = OriginalRO;
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the guillotine cut where long messages hit the flat top of the chat input and get sliced mid-line. Most visible in `autoScroll=\"pin-to-send\"` mode (where the user reads at their own pace and routinely lingers with a line butted against the input), but applies to all scroll modes.

### The problem

`CopilotChatView` rendered the attachment queue + input as flex siblings beneath the scroll area, so the scroll content stopped at the input's flat rectangular boundary. The previously-shipped feather gradient masked this visually but clashed with host themes whose `--background` didn't match its hard-coded white / near-black — [b621e96ee](https://github.com/CopilotKit/CopilotKit/commit/b621e96ee) defaulted the feather to an empty div, which then revealed the underlying layout bug.

### The fix

Wrap attachments + input in a single absolute-positioned overlay wrapper at the `CopilotChatView` level. The scroll content now fills full height and passes behind the rounded pill, matching ChatGPT's layout. The scroll content's bottom padding reflects the measured overlay height so the last line clears the pill when scrolled to the bottom.

Changes:
- `CopilotChatView.tsx` — replace flex-sibling attachments + input with a single absolute overlay wrapper; move `inputContainerRef` onto the wrapper so the `ResizeObserver` measures the full stack (attachments + pill + disclaimer); add `inputContainerHeight` to scroll-content bottom padding
- `CopilotChatAttachmentQueue.tsx` — add `data-testid=\"copilot-attachment-queue\"` for test hooks
- `CopilotChatView.stories.tsx` — add a `PinToSend` story as manual-verification scaffolding
- New test file `CopilotChatView.inputOverlay.test.tsx` with four tests: overlay wrapper is absolute-positioned, attachments render above the input inside the wrapper, welcome-screen input is NOT wrapped, scroll content reserves `inputContainerHeight` as bottom padding

Not changed:
- `CopilotChatInput.tsx` public API (still accepts `positioning: \"static\" | \"absolute\"`, same `bottomAnchored` flag, same `containerRef`)
- `use-pin-to-send.ts` anchor math
- The `feather` slot itself — still empty-div default from [b621e96ee](https://github.com/CopilotKit/CopilotKit/commit/b621e96ee); hosts who want a themed fade supply their own via `scrollView={{ feather: ... }}`
- Welcome-screen input (stays inline)
- Angular parallel (follow-up if desired)

## Related PRs and Issues

- Builds on [#4158](https://github.com/CopilotKit/CopilotKit/pull/4158) (pin-to-send anchoring/spacer/feather fixes)
- Builds on [b621e96ee](https://github.com/CopilotKit/CopilotKit/commit/b621e96ee) (feather defaulted to empty div)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation

## Test plan

- [x] Unit tests — 4 new tests in `CopilotChatView.inputOverlay.test.tsx` cover overlay structure, attachment ordering, welcome-screen exclusion, and padding formula
- [x] Full `@copilotkit/react-core` suite (1153 tests) passes
- [x] Manual verification in Storybook (`UI/CopilotChatView → Default`, `PinToSend`): content flows cleanly under the pill, last line reachable, no guillotine cut
- [ ] Reviewer: check `WithSuggestions` story (padding formula switches between `+4` and `+32`)
- [ ] Reviewer: check that `scrollView={{ feather: MyFeather }}` override still works (the `slots.e2e` test covers this, but worth a manual sanity check)