### PR TITLE
fix(showcase): rebase-and-retry on capture-previews registry push

### DIFF
--- a/.github/workflows/showcase_capture-previews.yml
+++ b/.github/workflows/showcase_capture-previews.yml
@@ -138,11 +138,28 @@ jobs:
           cd showcase/shell/src/data
           if git diff --quiet registry.json; then
             echo "No registry changes"
-          else
-            git add registry.json
-            git commit -m "Update preview URLs in registry"
-            git push
+            exit 0
           fi
+          git add registry.json
+          git commit -m "Update preview URLs in registry"
+          # Rebase-and-retry loop: the capture job can take ~30 minutes,
+          # during which other commits routinely land on main. Without
+          # this loop, `git push` loses the race and fails with "fetch
+          # first" (observed in runs 24799601181 and 24809331709 on
+          # 2026-04-22). Rebase our single registry commit onto the
+          # latest main and retry; bounded attempts so a persistent
+          # failure still surfaces rather than looping forever.
+          attempts=0
+          max_attempts=5
+          until git push; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge "$max_attempts" ]; then
+              echo "::error::push failed after $max_attempts rebase attempts"
+              exit 1
+            fi
+            echo "push rejected — rebasing onto latest main (attempt $attempts/$max_attempts)"
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
 
       # Slack failure alert. This workflow only runs on main-branch pushes,
       # workflow_run completions, and manual dispatch — all of which


### PR DESCRIPTION
## Summary

Add a bounded rebase-and-retry loop to the `Commit registry updates` step in `.github/workflows/showcase_capture-previews.yml` so the devops-bot push to `main` can recover from concurrent pushes that landed during the capture job.

## Why

The Showcase: Capture Previews workflow failed twice today (runs [24799601181](https://github.com/CopilotKit/CopilotKit/actions/runs/24799601181) at 13:10 PDT and [24809331709](https://github.com/CopilotKit/CopilotKit/actions/runs/24809331709) at 17:23 PDT), both at the `Commit registry updates` step with:

```
! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/CopilotKit/CopilotKit'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

The capture step runs Playwright + ffmpeg against every starter and can take ~30 minutes. During that window, normal PR merges to `main` routinely land, so the auto-generated `Update preview URLs in registry` commit loses the push race. Today's activity (showcase-ops swapover landing a sequence of fixes) made the race visible twice in one afternoon, but the bug is latent under any normal PR cadence.

The fix: if `git push` is rejected, `git pull --rebase` onto the latest branch head and retry. Bounded to 5 attempts so a persistent failure (conflict on `registry.json`, auth issue, etc.) surfaces rather than looping forever. The commit contains only `registry.json` so rebase conflicts should be rare; if one occurs, the loop exits and the job fails loudly.

## Test plan

- [ ] CI runs the workflow on a subsequent `Showcase: Build & Deploy` completion and the registry push lands on the first attempt
- [ ] Next time the capture job races against a concurrent merge, the rebase loop kicks in and the push succeeds rather than exit-1'ing
- [ ] If a persistent push failure occurs (not a race), the job fails after 5 attempts with a clear `::error::push failed after 5 rebase attempts` annotation