### PR TITLE
fix(starters): harden uv install against astral.sh curl|sh pipe-swallow

### DIFF
--- a/examples/integrations/adk/Dockerfile
+++ b/examples/integrations/adk/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/adk/docker/Dockerfile.agent
+++ b/examples/integrations/adk/docker/Dockerfile.agent
@@ -1,11 +1,8 @@
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/examples/integrations/agno/Dockerfile
+++ b/examples/integrations/agno/Dockerfile
@@ -27,8 +27,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/agno/docker/Dockerfile.agent
+++ b/examples/integrations/agno/docker/Dockerfile.agent
@@ -1,11 +1,8 @@
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/examples/integrations/crewai-crews/Dockerfile
+++ b/examples/integrations/crewai-crews/Dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/langgraph-fastapi/Dockerfile
+++ b/examples/integrations/langgraph-fastapi/Dockerfile
@@ -28,8 +28,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/langgraph-fastapi/docker/Dockerfile.agent
+++ b/examples/integrations/langgraph-fastapi/docker/Dockerfile.agent
@@ -2,12 +2,9 @@
 # Mirrors the user experience: uv sync + uv run main.py (same as pnpm dev:agent).
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/examples/integrations/langgraph-python-threads/Dockerfile
+++ b/examples/integrations/langgraph-python-threads/Dockerfile
@@ -24,8 +24,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/langgraph-python-threads/docker/Dockerfile.agent
+++ b/examples/integrations/langgraph-python-threads/docker/Dockerfile.agent
@@ -2,12 +2,9 @@
 # Mirrors the user experience: uv sync + langgraph dev (same as npm run dev:agent).
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/examples/integrations/langgraph-python/Dockerfile
+++ b/examples/integrations/langgraph-python/Dockerfile
@@ -30,8 +30,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/langgraph-python/docker/Dockerfile.agent
+++ b/examples/integrations/langgraph-python/docker/Dockerfile.agent
@@ -2,12 +2,9 @@
 # Mirrors the user experience: uv sync + langgraph dev (same as npm run dev:agent).
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/examples/integrations/llamaindex/Dockerfile
+++ b/examples/integrations/llamaindex/Dockerfile
@@ -27,8 +27,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/llamaindex/docker/Dockerfile.agent
+++ b/examples/integrations/llamaindex/docker/Dockerfile.agent
@@ -1,11 +1,8 @@
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/examples/integrations/ms-agent-framework-python/Dockerfile
+++ b/examples/integrations/ms-agent-framework-python/Dockerfile
@@ -24,8 +24,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/ms-agent-framework-python/docker/Dockerfile.agent
+++ b/examples/integrations/ms-agent-framework-python/docker/Dockerfile.agent
@@ -1,11 +1,9 @@
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-ENV PATH="/root/.local/bin:$PATH"
 ENV PYTHONPATH=/app/src
 
 WORKDIR /app

--- a/examples/integrations/pydantic-ai/Dockerfile
+++ b/examples/integrations/pydantic-ai/Dockerfile
@@ -27,8 +27,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/pydantic-ai/docker/Dockerfile.agent
+++ b/examples/integrations/pydantic-ai/docker/Dockerfile.agent
@@ -1,11 +1,9 @@
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-ENV PATH="/root/.local/bin:$PATH"
 ENV PYTHONPATH=/app/src
 
 WORKDIR /app

--- a/examples/integrations/strands-python/Dockerfile
+++ b/examples/integrations/strands-python/Dockerfile
@@ -27,8 +27,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ENV PATH="/root/.local/bin:$PATH"
 

--- a/examples/integrations/strands-python/docker/Dockerfile.agent
+++ b/examples/integrations/strands-python/docker/Dockerfile.agent
@@ -1,11 +1,8 @@
 FROM python:3.12-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.local/bin:$PATH"
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/examples/showcases/scene-creator/agent/Dockerfile
+++ b/examples/showcases/scene-creator/agent/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.12-slim
 WORKDIR /app
 
-# Install build dependencies and uv
-RUN apt-get update && apt-get install -y curl gcc && rm -rf /var/lib/apt/lists/*
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:${PATH}"
+# Install build dependencies
+RUN apt-get update && apt-get install -y gcc && rm -rf /var/lib/apt/lists/*
+
+# Install uv by copying from the official image (avoids curl|sh pipe-swallow bug
+# where a 5xx on astral.sh silently produces an exit-0 layer with no uv binary).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 # Copy dependency files
 COPY requirements.txt pyproject.toml /app/


### PR DESCRIPTION
## Summary

Replace `RUN curl -LsSf https://astral.sh/uv/install.sh | sh` across 20 starter Dockerfiles with `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/` to eliminate a latent pipe-swallow bug.

- 9 `examples/integrations/*/docker/Dockerfile.agent`
- 10 `examples/integrations/*/Dockerfile` (adk, agno, crewai-crews, langgraph-fastapi, langgraph-python, langgraph-python-threads, llamaindex, ms-agent-framework-python, pydantic-ai, strands-python)
- 1 `examples/showcases/scene-creator/agent/Dockerfile`

All 20 use the uv image COPY pattern — no `pipefail` fallbacks were needed.

## Why

When astral.sh returns a 5xx, `curl -LsSf` fails with no stdout, but the piped `sh` sees empty stdin and exits 0. The Docker layer "succeeds" with no `uv` binary installed, and the next `RUN uv sync` then crashes with `uv: not found` (exit 127). The root failure mode is invisible in logs — you only see the downstream symptom.

This already bit the agno starter today in CI run `24809910399` when astral.sh had a transient outage. Upstream is fine now, so this is a **latent-bug cleanup, not a hotfix** — the intent is to make future astral.sh outages a non-event.

The COPY-from-image pattern is uv's own recommended production pattern (see https://docs.astral.sh/uv/guides/integration/docker/): cache-friendly, no network call at build time, no pipe to swallow.

## Test plan

- [x] `grep -rln 'astral.sh/uv/install.sh' --include='Dockerfile*' .` returns zero matches on this branch
- [x] Local `docker build -f examples/integrations/agno/docker/Dockerfile.agent examples/integrations/agno/agent` builds cleanly end-to-end (uv binary present, `uv sync` completes)
- [ ] CI starter smoke / showcase deploy jobs build all 20 Dockerfiles successfully