### PR TITLE
fix(showcase-ops): correct Railway GQL query for service discovery

### DIFF
--- a/showcase/ops/src/probes/discovery/railway-services.test.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.test.ts
@@ -453,6 +453,71 @@ describe("railwayServicesSource", () => {
     expect(out[0].env).toEqual({});
   });
 
+  // -----------------------------------------------------------------
+  // Regression: Railway's current schema does NOT accept the
+  // `environmentId` argument on `Service.serviceInstances`. Sending it
+  // raises a GraphQL validation error (observed in production:
+  //   "Unknown argument \"environmentId\" on field
+  //    \"Service.serviceInstances\"")
+  // which surfaces as a 400 and blocks every discovery tick. The source
+  // MUST filter instances by environment client-side instead of passing
+  // an argument to the field.
+  // -----------------------------------------------------------------
+  it("omits environmentId arg from Service.serviceInstances selection to match current Railway schema", async () => {
+    // Simulate Railway's actual behaviour: reject any query that passes
+    // `environmentId` as an argument to `serviceInstances`, accept the
+    // arg-less form. Under the pre-fix code this queue runs the 400
+    // branch and the source throws a backend error; under the fix it
+    // runs the 200 branch and returns the service list.
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      const raw = (init as RequestInit | undefined)?.body as string | undefined;
+      const parsed = raw
+        ? (JSON.parse(raw) as { query: string })
+        : { query: "" };
+      // Project-level query: validate shape against live Railway schema.
+      if (parsed.query.includes("query project")) {
+        if (/serviceInstances\s*\(/.test(parsed.query)) {
+          return new Response(
+            JSON.stringify({
+              errors: [
+                {
+                  message:
+                    'Unknown argument "environmentId" on field "Service.serviceInstances".',
+                  extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                },
+              ],
+            }),
+            {
+              status: 400,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        return new Response(
+          JSON.stringify(
+            railwayProjectResponse([
+              {
+                id: "s-1",
+                name: "showcase-a",
+                image: "ghcr.io/copilotkit/showcase-a:latest",
+                domain: "showcase-a.up.railway.app",
+              },
+            ]),
+          ),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      // Variables round-trip.
+      return new Response(JSON.stringify({ data: { variables: {} } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const out = await railwayServicesSource.enumerate(makeCtx(fetchImpl), {});
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("showcase-a");
+  });
+
   it("throws DiscoverySourceBackendError on 200 envelope with graphql errors[]", async () => {
     // Railway can return HTTP 200 with { errors: [...] } for invalid
     // queries or permission errors. These must surface as a backend

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -261,14 +261,21 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
     // Project-level query: fetch all services with their instance image
     // refs + domains in one round-trip. A failure here aborts the tick —
     // we can't synthesize targets without the service list.
+    //
+    // Note: `serviceInstances` on `Service` takes NO arguments in the
+    // current Railway schema — passing `environmentId` there raises
+    // `Unknown argument "environmentId" on field "Service.serviceInstances"`
+    // and 400s the whole tick. We fetch every instance and filter by
+    // environment client-side below (the loop that finds
+    // `environmentId === environmentId`).
     const projectRaw = await gql<unknown>(
-      `query project($id: String!, $envId: String!) {
+      `query project($id: String!) {
         project(id: $id) {
           services {
             edges { node {
               id
               name
-              serviceInstances(environmentId: $envId) {
+              serviceInstances {
                 edges { node {
                   environmentId
                   source { image }
@@ -279,7 +286,7 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
           }
         }
       }`,
-      { id: projectId, envId: environmentId },
+      { id: projectId },
     );
     const parsedProject = ProjectServicesSchema.safeParse(projectRaw);
     if (!parsedProject.success) {


### PR DESCRIPTION
## Summary

The `railway-services` DiscoverySource in `showcase/ops` passed `environmentId` as an argument to `Service.serviceInstances` in its project-level GraphQL query. Railway's current schema does not accept that argument — every discovery tick 400'd with:

```
railway gql 400: Unknown argument "environmentId" on field "Service.serviceInstances".
```

Result: no probes ticked, PocketBase stopped receiving fresh rows, alert pipeline starved of data.

Fix: drop the invalid field argument. The returned `serviceInstances.edges` are already filtered by `environmentId` client-side a few lines down (`svc.serviceInstances.edges.find((e) => e.node.environmentId === environmentId)`), so there is no semantic change — the argument was dead weight that tripped GraphQL validation.

## Why

- Blocks `railway-services` from enumerating anything, which blocks every downstream probe that fans out across Railway services (image-drift, smoke, e2e-smoke, redirect-decom).
- Unblocks the fresh-redeploy of showcase-ops that carries the #4180 merge — that PR's fix is in the running image but never reachable because no probes tick.

## Verification

Introspection confirmed the current shape of `Service.serviceInstances`:

- `Query { project(id: String!) }` exists and returns `Project`
- `Project.services` paginates to `ServiceEdge { node: Service }`
- `Service.serviceInstances` accepts no field arguments
- `ServiceInstance.environmentId` is present, so client-side filtering is correct

Direct `curl` against `backboard.railway.com/graphql/v2` with the fixed query returned 41 services for the CopilotKit showcase project, matching the expected ~35 (17 starters + 17 packages + shell + aimock + a few infra services).

## Test plan

New test: `omits environmentId arg from Service.serviceInstances selection to match current Railway schema`

- Mocks a Railway endpoint that rejects any query whose `serviceInstances` call includes parenthesised arguments with the production 400 error body, and accepts the arg-less form.
- Red on pre-fix code: `DiscoverySourceBackendError: railway gql 400: {"errors":[{"message":"Unknown argument \"environmentId\" on field \"Service.serviceInstances\".",...}]}`
- Green after fix; full suite 743/743.

- [x] `pnpm --filter @copilotkit/showcase-ops typecheck`
- [x] `pnpm --filter @copilotkit/showcase-ops test` (743 passed, was 742 + 1 new regression test)
- [x] `pnpm format`
- [x] `oxlint` clean on touched files (one pre-existing unused-import warning left alone — not in this diff)