### PR TITLE
fix(sdk-python): relax partialjson version pin to allow 1.x

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -16,18 +16,24 @@ keywords = [
   "langsmith",
   "langserve",
 ]
+classifiers = [
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 packages = [{ include = "copilotkit" }]
-include = ["copilotkit/*.json"]
+include = ["copilotkit/*.json", "copilotkit/py.typed"]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.14"
 langgraph = { version = ">=0.3.25,<2" }
 langchain = { version = ">=0.3.0" }
-crewai = { version = "0.118.0", optional = true }
+crewai = { version = ">=0.118.0", optional = true, python = ">=3.10,<3.13" }
 ag-ui-langgraph = { version = ">=0.0.29", extras = ["fastapi"] }
 ag-ui-protocol = ">=0.1.15"
 fastapi = ">=0.115.0,<1.0.0"
-partialjson = "^0.0.8"
+partialjson = ">=0.0.8,<2.0.0"
 toml = "^0.10.2"
 
 [tool.poetry.extras]


### PR DESCRIPTION
Fixes #4131

## Problem

The `partialjson` dependency in `sdk-python/pyproject.toml` was pinned as `^0.0.8`, which in Poetry's semver notation translates to `>=0.0.8, <0.0.9`. This effectively blocks downstream projects from using `partialjson` 1.x, and prevents Dependabot from bumping the package.

## Solution

Widen the constraint to `>=0.0.8,<2.0.0`. The only usage in the SDK is `JSONParser().parse()` (in `copilotkit/runloop.py`), which is fully backward-compatible across the 0.0.8 → 1.x range per the partialjson changelog.

## Testing

- Verified `JSONParser` is the only partialjson API consumed by the SDK
- The additive changes between 0.0.8 and 1.x do not affect the existing API surface
- The upper bound `<2.0.0` guards against potential future breaking changes