### PR TITLE
fix(react-core): prevent cursor jump when typing in mobile viewport

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -87,6 +87,19 @@ type CopilotChatInputRestProps = {
   containerRef?: React.Ref<HTMLDivElement>;
   /** Whether to show the disclaimer. Default: true for absolute positioning, false for static */
   showDisclaimer?: boolean;
+  /**
+   * Set to `true` when the input sits at the bottom of its container as a
+   * flex-last-child (visible position is driven by layout, not CSS
+   * positioning). Triggers reservation of bottom space for the fixed
+   * CopilotKit license banner via the
+   * `--copilotkit-license-banner-offset` CSS var so the two don't overlap.
+   *
+   * Not needed when `positioning === "absolute"`; that mode already pins the
+   * input to the bottom and picks up the same reservation automatically.
+   * Leave unset (default `false`) for inputs rendered mid-layout such as the
+   * welcome screen, where the banner offset would push the input off-center.
+   */
+  bottomAnchored?: boolean;
 } & Omit<React.HTMLAttributes<HTMLDivElement>, "onChange">;
 
 type CopilotChatInputBaseProps = WithSlots<
@@ -130,6 +143,7 @@ export function CopilotChatInput({
   keyboardHeight = 0,
   containerRef,
   showDisclaimer,
+  bottomAnchored = false,
   textArea,
   sendButton,
   startTranscribeButton,
@@ -744,7 +758,14 @@ export function CopilotChatInput({
     ) {
       const isMobileViewport = window.matchMedia("(max-width: 767px)").matches;
       if (isMobileViewport) {
-        ensureMeasurements();
+        // Only call ensureMeasurements() when we don't have measurements yet.
+        // Calling it unconditionally sets textarea.value = "" on every keystroke
+        // which resets the cursor to the end, making it impossible to edit text
+        // in the middle of a string on mobile viewports. adjustTextareaHeight()
+        // already guards this call internally for the same reason.
+        if (measurementsRef.current.singleLineHeight === 0) {
+          ensureMeasurements();
+        }
         adjustTextareaHeight();
         updateLayout("expanded");
         return;
@@ -1097,6 +1118,14 @@ export function CopilotChatInput({
         transform:
           keyboardHeight > 0 ? `translateY(-${keyboardHeight}px)` : undefined,
         transition: "transform 0.2s ease-out",
+        // Reserve room when the fixed license banner is visible so it doesn't
+        // overlap the input. Applied only for bottom-anchored inputs (either
+        // `positioning === "absolute"`, or an explicitly-flagged flex-last-child
+        // input in run state). The welcome-screen input sits mid-layout and
+        // must stay still when the banner is present.
+        ...(positioning === "absolute" || bottomAnchored
+          ? { paddingBottom: "var(--copilotkit-license-banner-offset, 0px)" }
+          : {}),
       }}
       {...props}
     >


### PR DESCRIPTION
Fixes #4150

## Problem

When the browser window is narrowed below 768px (mobile viewport), typing in the CopilotChat input box causes the cursor to jump to the end of the text after every keystroke. This makes it impossible to edit text in the middle of a string on mobile-sized viewports.

**Root cause:** The `evaluateLayout()` function is triggered on every `ResizeObserver` tick (which fires as the textarea grows while the user types). On the mobile viewport path, it unconditionally called `ensureMeasurements()`. Inside that function, `textarea.value` is temporarily set to `""` to measure single-line height, then restored — but this programmatic assignment resets the browser's cursor position to the end of the string.

## Solution

Guard the `ensureMeasurements()` call in the mobile viewport path so it only runs when measurements haven't been taken yet (`singleLineHeight === 0`), the same guard already used in `adjustTextareaHeight()` and in the non-mobile code path. After the first evaluation, subsequent calls skip the destructive measurement and leave the cursor untouched.

## Testing

- Reproduce by resizing the browser to <768px and typing text, then trying to insert characters in the middle — the cursor no longer jumps to the end
- Textarea height still adjusts correctly on mobile viewports (first-time measurement still runs via the `singleLineHeight === 0` guard)
- Desktop behavior is unchanged