### PR TITLE
fix(core): forward credentials on REST transport in ProxiedCopilotRuntimeAgent

### DIFF
--- a/.changeset/forward-credentials-rest-transport.md
+++ b/.changeset/forward-credentials-rest-transport.md
@@ -1,0 +1,14 @@
+---
+"@copilotkit/core": patch
+---
+
+fix: forward credentials on REST transport in ProxiedCopilotRuntimeAgent
+
+The REST transport (default `/agent/:id/connect` and `/agent/:id/run` paths)
+inherited `requestInit` from `HttpAgent`, which does not include the agent's
+`credentials` field. As a result, cookies were dropped on cross-origin
+requests even when `credentials` was configured on the provider. Override
+`requestInit` in `ProxiedCopilotRuntimeAgent` so the REST paths honor the
+configured credentials, matching the single-route transport behavior.
+
+Fixes #4198.

--- a/packages/core/src/__tests__/core-credentials.test.ts
+++ b/packages/core/src/__tests__/core-credentials.test.ts
@@ -1,6 +1,39 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CopilotKitCore } from "../core";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
 import { waitForCondition } from "./test-utils";
+
+const encoder = new TextEncoder();
+
+function createSseResponse(): Response {
+  const stream = new ReadableStream({
+    start(controller) {
+      const events = [
+        {
+          type: "RUN_STARTED",
+          threadId: "test-thread",
+          runId: "test-run",
+        },
+        {
+          type: "RUN_FINISHED",
+          threadId: "test-thread",
+          runId: "test-run",
+          result: { newMessages: [] },
+        },
+      ];
+      const payload = events
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join("");
+      controller.enqueue(encoder.encode(payload));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
 
 describe("CopilotKitCore credentials", () => {
   const originalFetch = global.fetch;
@@ -160,5 +193,60 @@ describe("CopilotKitCore credentials", () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://runtime.example"); // Single endpoint, no /info suffix
     expect(init.credentials).toBe("include");
+  });
+
+  it("forwards credentials to fetch on REST transport run requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createSseResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "rest-agent",
+      transport: "rest",
+      credentials: "include",
+    });
+
+    await agent.runAgent({});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://runtime.example/agent/rest-agent/run");
+    expect(init.credentials).toBe("include");
+  });
+
+  it("forwards credentials to fetch on REST transport connect requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createSseResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "rest-agent",
+      transport: "rest",
+      credentials: "same-origin",
+    });
+
+    await agent.connectAgent({});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://runtime.example/agent/rest-agent/connect");
+    expect(init.credentials).toBe("same-origin");
+  });
+
+  it("omits credentials on REST transport when not configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createSseResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "rest-agent",
+      transport: "rest",
+    });
+
+    await agent.runAgent({});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.credentials).toBeUndefined();
   });
 });

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -130,6 +130,14 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     }
   }
 
+  override requestInit(input: RunAgentInput): RequestInit {
+    const baseInit = super.requestInit(input);
+    return {
+      ...baseInit,
+      ...(this.credentials ? { credentials: this.credentials } : {}),
+    };
+  }
+
   get capabilities(): AgentCapabilities | undefined {
     return this._capabilities;
   }


### PR DESCRIPTION
## Summary

Fixes #4198.

`HttpAgent.requestInit()` from `@ag-ui/client` returns `{ method, headers, body, signal }` and does **not** include `credentials`. `ProxiedCopilotRuntimeAgent` declares `credentials?: RequestCredentials` and correctly spreads it inside `createSingleRouteRequestInit` (single-route transport), but the default REST transport — `#connectViaHttp` (`/agent/:id/connect`) and `#runViaHttp` (`/agent/:id/run` via `super.run`) — calls the inherited `this.requestInit(input)` and drops `credentials`. As a result, cookies are lost on cross-origin requests even when `<CopilotKitProvider credentials="include">` is set.

This PR adds a `requestInit` override on `ProxiedCopilotRuntimeAgent` that mirrors the existing pattern in `createSingleRouteRequestInit`: take the base init from `super.requestInit(input)` and spread `this.credentials` on top when configured. Behavior is unchanged when `credentials` is not set.

```ts
override requestInit(input: RunAgentInput): RequestInit {
  const baseInit = super.requestInit(input);
  return {
    ...baseInit,
    ...(this.credentials ? { credentials: this.credentials } : {}),
  };
}
```

### Related prior work

- #3141 — original bug report (assignment side)
- #3839 — fixed `applyCredentialsToAgent` on every registration path but didn't address the consumption side on the REST transport, which is what this PR does.

## Test plan

Added three tests in `packages/core/src/__tests__/core-credentials.test.ts` (mirroring the existing `core-credentials.test.ts` / `proxied-runtime-transport.test.ts` mocking conventions):

- [x] REST transport `runAgent` forwards `credentials: "include"` to `fetch`
- [x] REST transport `connectAgent` forwards `credentials: "same-origin"` to `fetch`
- [x] REST transport `runAgent` omits `credentials` when not configured

All 399 tests in `@copilotkit/core` pass locally. `pnpm -F @copilotkit/core build` succeeds.