### PR TITLE
fix(showcase-ops): correct e2e_smoke key_template (underscore not hyphen)

### DIFF
--- a/showcase/ops/config/probes/e2e-smoke.yml
+++ b/showcase/ops/config/probes/e2e-smoke.yml
@@ -53,4 +53,4 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
-  key_template: "e2e-smoke:${name}"
+  key_template: "e2e_smoke:${name}"


### PR DESCRIPTION
## Summary

One-line YAML fix aligning the `e2e-smoke` probe's emitted key prefix with the rest of the system.

- `showcase/ops/config/probes/e2e-smoke.yml` line 56: `key_template: "e2e-smoke:${name}"` -> `key_template: "e2e_smoke:${name}"`.

## Why

Every other reference in showcase-ops uses the underscore form:
- `kind: e2e_smoke` (same file, line 39)
- `DIMENSIONS` enum (zod schema — `e2e_smoke`)
- Alert rules filter on `dimension: e2e_smoke`

The YAML key_template was the lone hyphen holdout, so the producer wrote `e2e-smoke:<slug>` rows while the dashboard filtered for `e2e_smoke`. PB currently has 17 orphan hyphen rows and zero matches on the dashboard.

Driver code is untouched: `deriveSlug` splits on `:` regardless of prefix, so no test changes required. All 788 showcase-ops tests pass. Typecheck and build are clean.

## Test plan

- [x] `pnpm --filter @copilotkit/showcase-ops test` — 788/788 green
- [x] `pnpm --filter @copilotkit/showcase-ops typecheck` — clean
- [x] `pnpm --filter @copilotkit/showcase-ops build` — clean
- [x] `oxfmt --check` on edited file — clean
- [x] `oxlint showcase/ops/` — 0 errors (108 pre-existing warnings unrelated)
- [ ] Post-deploy: confirm new `e2e_smoke:<slug>` rows appear in PB, hyphen rows go stale