### PR TITLE
feat(showcase-dashboard): add filter bar and tighten visual density

### DIFF
--- a/showcase/shell-dashboard/src/app/globals.css
+++ b/showcase/shell-dashboard/src/app/globals.css
@@ -3,15 +3,19 @@
 :root {
   --bg: #ffffff;
   --bg-surface: #ffffff;
+  --bg-alt: #fafbfc;
   --bg-muted: #f7f8fa;
   --bg-hover: #f1f3f6;
+  --bg-danger: #fef2f2;
   --border: #e4e7ec;
   --border-strong: #d0d5dd;
   --text: #101828;
   --text-secondary: #475467;
   --text-muted: #98a2b3;
+  --text-faint: #d0d5dd;
   --accent: #2563eb;
   --accent-hover: #1d4ed8;
+  --accent-light: #eff6ff;
   --ok: #059669;
   --amber: #d97706;
   --danger: #dc2626;

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -102,8 +102,7 @@ function DashboardInner() {
     // "where is this feature supported"). When an integration matches,
     // narrow columns but keep all features ("what's in this integration").
     const featureMatch = feats.filter(
-      (f) =>
-        f.name.toLowerCase().includes(q) || f.id.toLowerCase().includes(q),
+      (f) => f.name.toLowerCase().includes(q) || f.id.toLowerCase().includes(q),
     );
     const integrationMatch = ints.filter(
       (i) =>

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -2,9 +2,17 @@
 // Feature matrix: one row per feature × integration. Each feature's
 // `kind` (primary | testing) determines its visual grouping.
 // "testing"-kind features render muted and skip the docs row.
+import { Suspense, useMemo } from "react";
 import { FeatureGrid, type CellContext } from "@/components/feature-grid";
 import { CellStatus, urlsFor } from "@/components/cell-pieces";
 import { CommandCell } from "@/components/command-cell";
+import { FilterBar } from "@/components/filter-bar";
+import { useFilterState } from "@/hooks/useFilterState";
+import {
+  getFeatureCategories,
+  getFeatures,
+  getIntegrations,
+} from "@/lib/registry";
 
 function Cell(ctx: CellContext) {
   const isTesting = ctx.feature.kind === "testing";
@@ -47,9 +55,96 @@ function Cell(ctx: CellContext) {
 }
 
 export default function Page() {
+  // `useSearchParams()` inside `useFilterState` requires a Suspense boundary
+  // under Next.js 15 static rendering, otherwise the page bails out of
+  // prerender. Scope the boundary here so the rest of the chrome can SSR.
+  return (
+    <Suspense fallback={null}>
+      <DashboardInner />
+    </Suspense>
+  );
+}
+
+function DashboardInner() {
+  const filters = useFilterState();
+  const allIntegrations = useMemo(() => getIntegrations(), []);
+  const allFeatures = useMemo(() => getFeatures(), []);
+  const featureCategories = useMemo(() => getFeatureCategories(), []);
+
+  // Narrow integrations + features by the non-status filters here so the
+  // matrix only receives the subset it needs to render. The "only green"
+  // filter runs inside FeatureGrid itself because it depends on live status.
+  const { visibleIntegrations, visibleFeatures } = useMemo(() => {
+    const q = filters.q.trim().toLowerCase();
+    const ints = allIntegrations.filter((i) => {
+      if (filters.languages.length && !filters.languages.includes(i.language))
+        return false;
+      if (
+        filters.integrationCategories.length &&
+        !filters.integrationCategories.includes(i.category)
+      )
+        return false;
+      return true;
+    });
+    const feats = allFeatures.filter((f) => {
+      if (
+        filters.featureCategories.length &&
+        !filters.featureCategories.includes(f.category)
+      )
+        return false;
+      return true;
+    });
+
+    if (!q) return { visibleIntegrations: ints, visibleFeatures: feats };
+
+    // Search hits EITHER a feature name OR an integration name. When a
+    // feature matches, narrow rows but keep all columns (so you can scan
+    // "where is this feature supported"). When an integration matches,
+    // narrow columns but keep all features ("what's in this integration").
+    const featureMatch = feats.filter(
+      (f) =>
+        f.name.toLowerCase().includes(q) || f.id.toLowerCase().includes(q),
+    );
+    const integrationMatch = ints.filter(
+      (i) =>
+        i.name.toLowerCase().includes(q) || i.slug.toLowerCase().includes(q),
+    );
+    return {
+      visibleIntegrations:
+        integrationMatch.length > 0 ? integrationMatch : ints,
+      visibleFeatures: featureMatch.length > 0 ? featureMatch : feats,
+    };
+  }, [
+    allIntegrations,
+    allFeatures,
+    filters.q,
+    filters.languages,
+    filters.integrationCategories,
+    filters.featureCategories,
+  ]);
+
   return (
     <>
-      <FeatureGrid title="Feature Matrix" renderCell={Cell} minColWidth={260} />
+      <FilterBar
+        integrations={allIntegrations}
+        featureCategories={featureCategories}
+        state={filters}
+        actions={filters}
+        summary={{
+          visibleFeatures: visibleFeatures.length,
+          totalFeatures: allFeatures.length,
+          visibleIntegrations: visibleIntegrations.length,
+          totalIntegrations: allIntegrations.length,
+        }}
+      />
+      <FeatureGrid
+        title="Feature Matrix"
+        renderCell={Cell}
+        minColWidth={200}
+        integrations={visibleIntegrations}
+        features={visibleFeatures}
+        onlyGreen={filters.onlyGreen}
+      />
       <Legend />
     </>
   );
@@ -62,54 +157,55 @@ function Legend() {
   // here are informational copy, not live-derived. If the probes'
   // "degraded" cutoff changes, update this Legend too (C5 F11).
   return (
-    <div className="px-8 pb-8 mt-4 flex flex-wrap gap-x-6 gap-y-2 text-xs text-[var(--text-muted)]">
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--text-secondary)]">testing</span>
-        rows are muted &amp; hide docs (primary feature = has docs)
+    <details className="px-8 pb-8 text-xs text-[var(--text-muted)]">
+      <summary className="cursor-pointer select-none text-[var(--text-secondary)] hover:text-[var(--text)]">
+        Legend
+      </summary>
+      <div className="mt-3 flex flex-wrap gap-x-6 gap-y-2">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--text-secondary)]">testing</span>
+          rows are muted &amp; hide docs (primary feature = has docs)
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--ok)]">docs-og ✓</span>/
+          <span className="text-[var(--danger)]">docs-shell ✗</span>
+          doc link present / missing
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--accent)] font-medium">Demo ↗</span>/
+          <span className="text-[var(--accent)] font-medium">Code {"</>"}</span>
+          open hosted preview / source
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--ok)]">E2E ✓</span>/
+          <span className="text-[var(--amber)]">amber</span>/
+          <span className="text-[var(--danger)]">✗</span>
+          end-to-end (green &lt;6h · amber older · red fail/none)
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--ok)]">Smoke ✓</span>
+          smoke test, same color rules
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--ok)]">QA 3d</span>
+          days since human QA (green &lt;7d · amber &lt;30d · red older/never)
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="inline-flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-full bg-[var(--ok)]" />
+            Hosted
+          </span>
+          dot = live probe, click = open hosted URL
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--text-muted)]">?</span>
+          live data not yet received (probe pending)
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[var(--text-muted)]">—</span>
+          supported, no demo yet
+        </div>
       </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--ok)]">docs-og ✓</span>/
-        <span className="text-[var(--danger)]">docs-shell ✗</span>
-        doc link present / missing
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--accent)] font-medium">Demo ↗</span>/
-        <span className="text-[var(--accent)] font-medium">Code {"</>"}</span>
-        open hosted preview / source
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--ok)]">E2E ✓</span>/
-        <span className="text-[var(--amber)]">amber</span>/
-        <span className="text-[var(--danger)]">✗</span>
-        end-to-end (green &lt;6h · amber older · red fail/none)
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--ok)]">Smoke ✓</span>
-        smoke test, same color rules
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--ok)]">QA 3d</span>
-        days since human QA (green &lt;7d · amber &lt;30d · red older/never)
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="inline-flex items-center gap-1">
-          <span className="inline-block w-2 h-2 rounded-full bg-[var(--ok)]" />
-          Hosted
-        </span>
-        dot = live probe, click = open hosted URL
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--text-muted)]">?</span>
-        live data not yet received (probe pending)
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--text-muted)]">—</span>
-        supported, no demo yet
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[var(--danger)]">✗</span>
-        not supported
-      </div>
-    </div>
+    </details>
   );
 }

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -144,20 +144,35 @@ export function FeatureGrid({
   title,
   subtitle,
   renderCell,
-  minColWidth = 220,
+  minColWidth = 200,
+  integrations: integrationsProp,
+  features: featuresProp,
+  onlyGreen = false,
 }: {
   title: string;
   subtitle?: string;
   renderCell: CellRenderer;
   minColWidth?: number;
+  /** Pre-filtered integrations. Falls back to the full registry when omitted. */
+  integrations?: Integration[];
+  /** Pre-filtered features. Falls back to the full registry when omitted. */
+  features?: Feature[];
+  /**
+   * Hide any feature row where at least one visible integration has a non-green
+   * rollup (red / amber / gray / error) for that feature. Evaluated after live
+   * status resolves so it reacts to the SSE stream.
+   */
+  onlyGreen?: boolean;
 }) {
   const shellUrl = resolveShellUrl();
   // `getIntegrations()` / `getFeatures()` call `.sort()` / array spread on
   // every invocation, returning a fresh array identity. Memoize once per
   // mount so downstream `useMemo`s keyed on these arrays don't identity-
   // invalidate every render (C5 F9).
-  const integrations = useMemo(() => getIntegrations(), []);
-  const features = useMemo(() => getFeatures(), []);
+  const allIntegrations = useMemo(() => getIntegrations(), []);
+  const allFeatures = useMemo(() => getFeatures(), []);
+  const integrations = integrationsProp ?? allIntegrations;
+  const features = featuresProp ?? allFeatures;
   const categories = useMemo(() => getFeatureCategories(), []);
 
   // One subscription per dimension — each resolves into `rows` that we
@@ -192,33 +207,54 @@ export function FeatureGrid({
     return out;
   }, [integrations, features, liveStatus, connection]);
 
+  // When `onlyGreen` is on, a feature is visible only if EVERY integration
+  // that has a demo for it rolls up green. Integrations without a demo for
+  // the feature are treated as N/A (they don't sabotage the row), but a row
+  // with zero green cells across the visible integrations is still hidden —
+  // "fully green" means "something is green and nothing is failing".
+  const greenVisible = useMemo(() => {
+    if (!onlyGreen) return features;
+    return features.filter((f) => {
+      let sawGreen = false;
+      for (const i of integrations) {
+        const hasDemo = i.demos.some((d) => d.id === f.id);
+        if (!hasDemo) continue;
+        const cell = resolveCell(liveStatus, i.slug, f.id, { connection });
+        if (cell.rollup !== "green") return false;
+        sawGreen = true;
+      }
+      return sawGreen;
+    });
+  }, [onlyGreen, features, integrations, liveStatus, connection]);
+
   const featuresByCategory = categories
     .map((cat) => ({
       ...cat,
-      features: features.filter((f) => f.category === cat.id),
+      features: greenVisible.filter((f) => f.category === cat.id),
     }))
     .filter((cat) => cat.features.length > 0);
 
+  const hasVisibleRows = featuresByCategory.length > 0;
+
   return (
-    <div className="p-8 max-w-[100vw]">
-      <header className="mb-6">
-        <div className="flex items-center gap-3">
-          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
-          <LiveIndicator status={connection} />
-        </div>
-        <p className="mt-1 text-sm text-[var(--text-secondary)]">
-          {subtitle ? <>{subtitle} · </> : null}
-          {features.length} features × {integrations.length} integrations.
-        </p>
+    <div className="px-8 pt-4 pb-6 max-w-[100vw]">
+      <header className="mb-3 flex items-center gap-3">
+        <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+        <LiveIndicator status={connection} />
+        {subtitle && (
+          <span className="text-xs text-[var(--text-secondary)]">
+            {subtitle}
+          </span>
+        )}
       </header>
 
       {connection === "error" && <OfflineBanner />}
 
-      <div className="overflow-auto rounded-lg border border-[var(--border)] bg-[var(--bg-surface)]">
-        <table className="border-collapse text-sm">
+      <div className="overflow-auto rounded-md border border-[var(--border)] bg-[var(--bg-surface)]">
+        <table className="border-collapse text-[12px]">
           <thead>
             <tr>
-              <th className="sticky left-0 top-0 z-30 bg-[var(--bg-muted)] px-4 py-3 text-left min-w-[260px] border-b border-[var(--border)]">
+              <th className="sticky left-0 top-0 z-30 bg-[var(--bg-muted)] px-3 py-2 text-left min-w-[220px] border-b border-[var(--border)]">
                 <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
                   Feature
                 </span>
@@ -239,42 +275,38 @@ export function FeatureGrid({
                 return (
                   <th
                     key={integration.slug}
-                    className="sticky top-0 z-20 bg-[var(--bg-muted)] px-3 py-3 text-left border-b border-l border-[var(--border)] font-normal"
+                    className="sticky top-0 z-20 bg-[var(--bg-muted)] px-2.5 py-2 text-left border-b border-l border-[var(--border)] font-normal"
                     style={{ minWidth: `${minColWidth}px` }}
                   >
-                    <div className="text-xs font-semibold text-[var(--text)]">
+                    <div className="text-[12px] font-semibold text-[var(--text)] leading-tight">
                       {integration.name}
                     </div>
-                    <div className="mt-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
-                      {integration.language}
-                    </div>
-                    <div
-                      className="mt-1 text-[10px] tabular-nums text-[var(--text-muted)]"
-                      title={tallyTitle}
-                    >
-                      {tally.unknown ? (
-                        <span className="text-[var(--text-muted)]">
-                          ? offline
-                        </span>
-                      ) : (
-                        <>
-                          <span className="text-[var(--ok)]">
-                            ✓ {tally.green}
-                          </span>
-                          <span className="mx-1 text-[var(--text-muted)]">
-                            ·
-                          </span>
-                          <span className="text-[var(--amber)]">
-                            ~ {tally.amber}
-                          </span>
-                          <span className="mx-1 text-[var(--text-muted)]">
-                            ·
-                          </span>
-                          <span className="text-[var(--danger)]">
-                            ✗ {tally.red}
-                          </span>
-                        </>
-                      )}
+                    <div className="mt-0.5 flex items-center gap-2 text-[10px] text-[var(--text-muted)]">
+                      <span className="uppercase tracking-wider">
+                        {integration.language}
+                      </span>
+                      <span
+                        className="tabular-nums"
+                        title={tallyTitle}
+                      >
+                        {tally.unknown ? (
+                          "? offline"
+                        ) : (
+                          <>
+                            <span className="text-[var(--ok)]">
+                              {tally.green}
+                            </span>
+                            <span className="mx-0.5">/</span>
+                            <span className="text-[var(--amber)]">
+                              {tally.amber}
+                            </span>
+                            <span className="mx-0.5">/</span>
+                            <span className="text-[var(--danger)]">
+                              {tally.red}
+                            </span>
+                          </>
+                        )}
+                      </span>
                     </div>
                   </th>
                 );
@@ -282,12 +314,22 @@ export function FeatureGrid({
             </tr>
           </thead>
           <tbody>
+            {!hasVisibleRows && (
+              <tr>
+                <td
+                  colSpan={integrations.length + 1}
+                  className="px-6 py-10 text-center text-xs text-[var(--text-muted)]"
+                >
+                  No features match the current filters.
+                </td>
+              </tr>
+            )}
             {featuresByCategory.map((cat) => (
               <Fragment key={cat.id}>
                 <tr>
                   <td
                     colSpan={integrations.length + 1}
-                    className="sticky left-0 px-4 pt-5 pb-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)] bg-[var(--bg-surface)]"
+                    className="sticky left-0 px-3 pt-3 pb-1 text-[9.5px] font-medium uppercase tracking-wider text-[var(--text-muted)] bg-[var(--bg-surface)]"
                   >
                     {cat.name}
                   </td>
@@ -297,9 +339,9 @@ export function FeatureGrid({
                   return (
                     <tr
                       key={feature.id}
-                      className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+                      className="odd:bg-[var(--bg-alt)] hover:bg-[var(--bg-hover)]"
                     >
-                      <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-2 border-r border-[var(--border)] align-top">
+                      <td className="sticky left-0 z-10 bg-inherit px-3 py-1.5 border-r border-t border-[var(--border)] align-top">
                         <div
                           className={
                             testing
@@ -323,7 +365,7 @@ export function FeatureGrid({
                         return (
                           <td
                             key={integration.slug}
-                            className="border-l border-[var(--border)] px-3 py-2 align-top text-left"
+                            className="border-l border-t border-[var(--border)] px-2.5 py-1.5 align-top text-left"
                           >
                             {demo ? (
                               renderCell({
@@ -339,10 +381,10 @@ export function FeatureGrid({
                               })
                             ) : (
                               <div
-                                className="text-center text-base text-[var(--danger)]"
-                                title="No demo"
+                                className="text-center text-sm text-[var(--text-faint)]"
+                                title="No demo for this feature"
                               >
-                                ✗
+                                —
                               </div>
                             )}
                           </td>

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -285,10 +285,7 @@ export function FeatureGrid({
                       <span className="uppercase tracking-wider">
                         {integration.language}
                       </span>
-                      <span
-                        className="tabular-nums"
-                        title={tallyTitle}
-                      >
+                      <span className="tabular-nums" title={tallyTitle}>
                         {tally.unknown ? (
                           "? offline"
                         ) : (

--- a/showcase/shell-dashboard/src/components/filter-bar.tsx
+++ b/showcase/shell-dashboard/src/components/filter-bar.tsx
@@ -27,7 +27,12 @@ interface FilterBarProps {
   state: FilterState;
   actions: FilterActions;
   /** Counts after current filters for the result summary. */
-  summary: { visibleFeatures: number; totalFeatures: number; visibleIntegrations: number; totalIntegrations: number };
+  summary: {
+    visibleFeatures: number;
+    totalFeatures: number;
+    visibleIntegrations: number;
+    totalIntegrations: number;
+  };
 }
 
 export function FilterBar({
@@ -94,9 +99,7 @@ export function FilterBar({
           options={featureCategories.map((c) => c.id)}
           selected={state.featureCategories}
           onToggle={actions.toggleFeatureCategory}
-          labelFor={(v) =>
-            featureCategories.find((c) => c.id === v)?.name ?? v
-          }
+          labelFor={(v) => featureCategories.find((c) => c.id === v)?.name ?? v}
         />
 
         <label className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] select-none cursor-pointer">
@@ -111,7 +114,9 @@ export function FilterBar({
 
         <div className="ml-auto flex items-center gap-3 text-[11px] text-[var(--text-muted)] tabular-nums">
           <span>
-            {summary.visibleFeatures}/{summary.totalFeatures} features · {summary.visibleIntegrations}/{summary.totalIntegrations} integrations
+            {summary.visibleFeatures}/{summary.totalFeatures} features ·{" "}
+            {summary.visibleIntegrations}/{summary.totalIntegrations}{" "}
+            integrations
           </span>
           {hasAnyFilter && (
             <button

--- a/showcase/shell-dashboard/src/components/filter-bar.tsx
+++ b/showcase/shell-dashboard/src/components/filter-bar.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useMemo } from "react";
+import type { FilterActions, FilterState } from "@/hooks/useFilterState";
+import type { FeatureCategory, Integration } from "@/lib/registry";
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  python: "Python",
+  typescript: "TypeScript",
+  dotnet: ".NET",
+  java: "Java",
+};
+
+const INTEGRATION_CATEGORY_LABELS: Record<string, string> = {
+  popular: "Most Popular",
+  "agent-framework": "Agent Frameworks",
+  "enterprise-platform": "Enterprise",
+  "provider-sdk": "Provider SDKs",
+  protocol: "Protocols",
+  emerging: "Emerging",
+  starter: "Starter",
+};
+
+interface FilterBarProps {
+  integrations: Integration[];
+  featureCategories: FeatureCategory[];
+  state: FilterState;
+  actions: FilterActions;
+  /** Counts after current filters for the result summary. */
+  summary: { visibleFeatures: number; totalFeatures: number; visibleIntegrations: number; totalIntegrations: number };
+}
+
+export function FilterBar({
+  integrations,
+  featureCategories,
+  state,
+  actions,
+  summary,
+}: FilterBarProps) {
+  // Unique language + integration-category axes derived from the actual data
+  // (not hard-coded) — so adding a new language to the registry surfaces a
+  // pill automatically without a code change.
+  const { languages, integrationCategories } = useMemo(() => {
+    const langs = new Set<string>();
+    const cats = new Set<string>();
+    for (const i of integrations) {
+      if (i.language) langs.add(i.language);
+      if (i.category) cats.add(i.category);
+    }
+    return {
+      languages: [...langs].sort(),
+      integrationCategories: [...cats].sort(),
+    };
+  }, [integrations]);
+
+  const hasAnyFilter =
+    state.q.length > 0 ||
+    state.languages.length > 0 ||
+    state.integrationCategories.length > 0 ||
+    state.featureCategories.length > 0 ||
+    state.onlyGreen;
+
+  return (
+    <div className="sticky top-0 z-40 border-b border-[var(--border)] bg-[var(--bg)] px-8 py-3 backdrop-blur">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        <div className="flex items-center gap-2">
+          <input
+            type="search"
+            placeholder="Search features or integrations…"
+            value={state.q}
+            onChange={(e) => actions.setSearch(e.target.value)}
+            className="h-7 w-64 rounded-md border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-[12px] text-[var(--text)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none"
+          />
+        </div>
+
+        <PillGroup
+          label="Language"
+          options={languages}
+          selected={state.languages}
+          onToggle={actions.toggleLanguage}
+          labelFor={(v) => LANGUAGE_LABELS[v] ?? v}
+        />
+
+        <PillGroup
+          label="Integration"
+          options={integrationCategories}
+          selected={state.integrationCategories}
+          onToggle={actions.toggleIntegrationCategory}
+          labelFor={(v) => INTEGRATION_CATEGORY_LABELS[v] ?? v}
+        />
+
+        <PillGroup
+          label="Feature"
+          options={featureCategories.map((c) => c.id)}
+          selected={state.featureCategories}
+          onToggle={actions.toggleFeatureCategory}
+          labelFor={(v) =>
+            featureCategories.find((c) => c.id === v)?.name ?? v
+          }
+        />
+
+        <label className="flex items-center gap-1.5 text-[11px] text-[var(--text-secondary)] select-none cursor-pointer">
+          <input
+            type="checkbox"
+            checked={state.onlyGreen}
+            onChange={(e) => actions.setOnlyGreen(e.target.checked)}
+            className="h-3.5 w-3.5 accent-[var(--ok)] cursor-pointer"
+          />
+          Only fully green
+        </label>
+
+        <div className="ml-auto flex items-center gap-3 text-[11px] text-[var(--text-muted)] tabular-nums">
+          <span>
+            {summary.visibleFeatures}/{summary.totalFeatures} features · {summary.visibleIntegrations}/{summary.totalIntegrations} integrations
+          </span>
+          {hasAnyFilter && (
+            <button
+              type="button"
+              onClick={actions.clearAll}
+              className="rounded border border-[var(--border)] px-2 py-0.5 text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--text-muted)]"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PillGroup({
+  label,
+  options,
+  selected,
+  onToggle,
+  labelFor,
+}: {
+  label: string;
+  options: string[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  labelFor: (value: string) => string;
+}) {
+  if (options.length === 0) return null;
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+        {label}
+      </span>
+      <div className="flex flex-wrap gap-1">
+        {options.map((opt) => {
+          const on = selected.includes(opt);
+          return (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => onToggle(opt)}
+              className={
+                on
+                  ? "rounded-full border px-2 py-0.5 text-[10.5px] border-[var(--accent)] bg-[var(--accent-light)] text-[var(--accent)]"
+                  : "rounded-full border px-2 py-0.5 text-[10.5px] border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text)] hover:border-[var(--text-muted)]"
+              }
+              aria-pressed={on}
+            >
+              {labelFor(opt)}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/showcase/shell-dashboard/src/hooks/useFilterState.ts
+++ b/showcase/shell-dashboard/src/hooks/useFilterState.ts
@@ -55,7 +55,11 @@ export function useFilterState(): FilterState & FilterActions {
   );
 
   const write = useCallback(
-    (next: Partial<Record<"q" | "lang" | "ic" | "fc" | "green", string | null>>) => {
+    (
+      next: Partial<
+        Record<"q" | "lang" | "ic" | "fc" | "green", string | null>
+      >,
+    ) => {
       const sp = new URLSearchParams(params.toString());
       for (const [k, v] of Object.entries(next)) {
         if (v === null || v === "" || v === undefined) sp.delete(k);
@@ -67,7 +71,10 @@ export function useFilterState(): FilterState & FilterActions {
     [params, router],
   );
 
-  const setSearch = useCallback((q: string) => write({ q: q || null }), [write]);
+  const setSearch = useCallback(
+    (q: string) => write({ q: q || null }),
+    [write],
+  );
 
   const toggleLanguage = useCallback(
     (lang: string) =>

--- a/showcase/shell-dashboard/src/hooks/useFilterState.ts
+++ b/showcase/shell-dashboard/src/hooks/useFilterState.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export interface FilterState {
+  /** Free-text search across integration + feature names. Empty = no filter. */
+  q: string;
+  /** Selected languages; empty array = show all. */
+  languages: string[];
+  /** Selected integration categories; empty = show all. */
+  integrationCategories: string[];
+  /** Selected feature categories; empty = show all. */
+  featureCategories: string[];
+  /** When true, hide any feature row that has any non-green cell among visible integrations. */
+  onlyGreen: boolean;
+}
+
+export interface FilterActions {
+  setSearch: (q: string) => void;
+  toggleLanguage: (lang: string) => void;
+  toggleIntegrationCategory: (cat: string) => void;
+  toggleFeatureCategory: (cat: string) => void;
+  setOnlyGreen: (on: boolean) => void;
+  clearAll: () => void;
+}
+
+function parseList(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function toggle(list: string[], value: string): string[] {
+  return list.includes(value)
+    ? list.filter((v) => v !== value)
+    : [...list, value];
+}
+
+export function useFilterState(): FilterState & FilterActions {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const state: FilterState = useMemo(
+    () => ({
+      q: params.get("q") ?? "",
+      languages: parseList(params.get("lang")),
+      integrationCategories: parseList(params.get("ic")),
+      featureCategories: parseList(params.get("fc")),
+      onlyGreen: params.get("green") === "1",
+    }),
+    [params],
+  );
+
+  const write = useCallback(
+    (next: Partial<Record<"q" | "lang" | "ic" | "fc" | "green", string | null>>) => {
+      const sp = new URLSearchParams(params.toString());
+      for (const [k, v] of Object.entries(next)) {
+        if (v === null || v === "" || v === undefined) sp.delete(k);
+        else sp.set(k, v);
+      }
+      const qs = sp.toString();
+      router.replace(qs ? `?${qs}` : "?", { scroll: false });
+    },
+    [params, router],
+  );
+
+  const setSearch = useCallback((q: string) => write({ q: q || null }), [write]);
+
+  const toggleLanguage = useCallback(
+    (lang: string) =>
+      write({ lang: toggle(state.languages, lang).join(",") || null }),
+    [state.languages, write],
+  );
+
+  const toggleIntegrationCategory = useCallback(
+    (cat: string) =>
+      write({ ic: toggle(state.integrationCategories, cat).join(",") || null }),
+    [state.integrationCategories, write],
+  );
+
+  const toggleFeatureCategory = useCallback(
+    (cat: string) =>
+      write({ fc: toggle(state.featureCategories, cat).join(",") || null }),
+    [state.featureCategories, write],
+  );
+
+  const setOnlyGreen = useCallback(
+    (on: boolean) => write({ green: on ? "1" : null }),
+    [write],
+  );
+
+  const clearAll = useCallback(() => {
+    router.replace("?", { scroll: false });
+  }, [router]);
+
+  return {
+    ...state,
+    setSearch,
+    toggleLanguage,
+    toggleIntegrationCategory,
+    toggleFeatureCategory,
+    setOnlyGreen,
+    clearAll,
+  };
+}

--- a/showcase/shell/src/data/registry.json
+++ b/showcase/shell/src/data/registry.json
@@ -366,11 +366,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -420,18 +416,14 @@
           "id": "cli-start",
           "name": "CLI Start Command",
           "description": "Copy-paste command to clone the canonical starter",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "command": "npx copilotkit@latest init --framework langgraph-python"
         },
         {
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat.mp4",
           "highlight": [
@@ -444,9 +436,7 @@
           "id": "chat-customization-css",
           "name": "Chat Customization (CSS)",
           "description": "Default CopilotChat re-themed via CopilotKitCSSProperties",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-customization-css",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-customization-css.mp4",
           "highlight": [
@@ -460,9 +450,7 @@
           "id": "tool-rendering-default-catchall",
           "name": "Tool Rendering (Default Catch-all)",
           "description": "Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-default-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-default-catchall.mp4",
           "highlight": [
@@ -475,9 +463,7 @@
           "id": "tool-rendering-custom-catchall",
           "name": "Tool Rendering (Custom Catch-all)",
           "description": "Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-custom-catchall",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-custom-catchall.mp4",
           "highlight": [
@@ -491,9 +477,7 @@
           "id": "frontend-tools",
           "name": "Frontend Tools (In-App Actions)",
           "description": "Agent invokes client-side handlers registered with useFrontendTool",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools.mp4",
           "highlight": [
@@ -506,9 +490,7 @@
           "id": "frontend-tools-async",
           "name": "Frontend Tools (Async)",
           "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/frontend-tools-async",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_frontend-tools-async.mp4",
           "highlight": [
@@ -522,9 +504,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
           "description": "Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-chat.mp4",
           "highlight": [
@@ -538,9 +518,7 @@
           "id": "hitl-in-app",
           "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
           "description": "Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl-in-app",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_hitl-in-app.mp4",
           "highlight": [
@@ -554,9 +532,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Custom per-tool renderers (WeatherCard, FlightListCard) plus a wildcard catch-all for every other tool",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering.mp4",
           "highlight": [
@@ -571,9 +547,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-tool-based.mp4",
           "highlight": [
@@ -587,9 +561,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Canonical agent-state-driven Gen UI — the agent plans a live step list and emits it via copilotkit_emit_state; the frontend renders it with the v1 useCoAgentStateRender hook",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-agent.mp4",
           "highlight": [
@@ -603,9 +575,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-read-write.mp4",
           "highlight": [
@@ -620,9 +590,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_shared-state-streaming.mp4",
           "highlight": [
@@ -636,9 +604,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_subagents.mp4",
           "highlight": [
@@ -652,9 +618,7 @@
           "id": "prebuilt-sidebar",
           "name": "Pre-Built: Sidebar",
           "description": "Docked sidebar chat via <CopilotSidebar />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-sidebar",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-sidebar.mp4",
           "highlight": [
@@ -667,9 +631,7 @@
           "id": "prebuilt-popup",
           "name": "Pre-Built: Popup",
           "description": "Floating popup chat via <CopilotPopup />",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/prebuilt-popup",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_prebuilt-popup.mp4",
           "highlight": [
@@ -682,9 +644,7 @@
           "id": "chat-slots",
           "name": "Chat Customization (Slots)",
           "description": "Customize CopilotChat via its slot system",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/chat-slots",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_chat-slots.mp4",
           "highlight": [
@@ -698,9 +658,7 @@
           "id": "headless-simple",
           "name": "Headless Chat (Simple)",
           "description": "Minimal custom chat surface built on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-simple",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-simple.mp4",
           "highlight": [
@@ -713,9 +671,7 @@
           "id": "headless-complete",
           "name": "Headless Chat (Complete)",
           "description": "Full chat implementation built from scratch on useAgent",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/headless-complete",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_headless-complete.mp4",
           "highlight": [
@@ -730,9 +686,7 @@
           "id": "agentic-chat-reasoning",
           "name": "Reasoning",
           "description": "Visible reasoning/thinking chain alongside the final answer",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/agentic-chat-reasoning",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_agentic-chat-reasoning.mp4",
           "highlight": [
@@ -746,9 +700,7 @@
           "id": "gen-ui-interrupt",
           "name": "In-Chat HITL (useInterrupt — low-level primitive)",
           "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-interrupt",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_gen-ui-interrupt.mp4",
           "highlight": [
@@ -762,9 +714,7 @@
           "id": "declarative-gen-ui",
           "name": "Declarative Generative UI (A2UI)",
           "description": "Canonical A2UI BYOC — custom catalog (Card/StatusBadge/Metric/InfoRow/PrimaryButton) wired via a2ui.catalog on the provider; runtime injects the render_a2ui tool automatically",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/declarative-gen-ui",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_declarative-gen-ui.mp4",
           "highlight": [
@@ -780,9 +730,7 @@
           "id": "a2ui-fixed-schema",
           "name": "Declarative Generative UI (A2UI — Fixed Schema)",
           "description": "A2UI rendering against a known client-side schema",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/a2ui-fixed-schema",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_a2ui-fixed-schema.mp4",
           "highlight": [
@@ -800,9 +748,7 @@
           "id": "mcp-apps",
           "name": "MCP Apps",
           "description": "MCP server-driven UI via activity renderers",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/mcp-apps",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_mcp-apps.mp4",
           "highlight": [
@@ -815,9 +761,7 @@
           "id": "interrupt-headless",
           "name": "Headless Interrupt (testing)",
           "description": "Resolve langgraph interrupts from a plain button grid — no chat, no useInterrupt render prop",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/interrupt-headless",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_interrupt-headless.mp4",
           "highlight": [
@@ -830,9 +774,7 @@
           "id": "readonly-state-agent-context",
           "name": "Readonly State (Agent Context)",
           "description": "Frontend provides read-only context to the agent via useAgentContext",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/readonly-state-agent-context",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_readonly-state-agent-context.mp4",
           "highlight": [
@@ -845,9 +787,7 @@
           "id": "reasoning-default-render",
           "name": "Reasoning (Default Render)",
           "description": "Built-in CopilotChatReasoningMessage renders without a custom slot",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/reasoning-default-render",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_reasoning-default-render.mp4",
           "highlight": [
@@ -860,9 +800,7 @@
           "id": "tool-rendering-reasoning-chain",
           "name": "Tool Rendering + Reasoning Chain (testing)",
           "description": "Sequential tool calls with reasoning tokens rendered side-by-side",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/tool-rendering-reasoning-chain",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_tool-rendering-reasoning-chain.mp4",
           "highlight": [
@@ -877,9 +815,7 @@
           "id": "beautiful-chat",
           "name": "Beautiful Chat",
           "description": "Canonical polished starter chat — brand fonts, theme tokens, suggestion pills",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/beautiful-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-python_beautiful-chat.mp4",
           "highlight": [
@@ -1042,11 +978,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1074,9 +1006,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_agentic-chat.mp4"
         },
@@ -1084,9 +1014,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_hitl-in-chat.mp4"
         },
@@ -1094,9 +1022,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_tool-rendering.mp4"
         },
@@ -1104,9 +1030,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-tool-based.mp4"
         },
@@ -1114,9 +1038,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_gen-ui-agent.mp4"
         },
@@ -1124,9 +1046,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-read-write.mp4"
         },
@@ -1134,9 +1054,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_shared-state-streaming.mp4"
         },
@@ -1144,9 +1062,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-typescript_subagents.mp4"
         }
@@ -1206,11 +1122,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "LangGraph Platform",
         "url": "https://langsmith.com"
@@ -1238,9 +1150,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_agentic-chat.mp4"
         },
@@ -1248,9 +1158,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_tool-rendering.mp4"
         },
@@ -1258,9 +1166,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_hitl-in-chat.mp4"
         },
@@ -1268,9 +1174,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-tool-based.mp4"
         },
@@ -1278,9 +1182,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_gen-ui-agent.mp4"
         },
@@ -1288,9 +1190,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-read-write.mp4"
         },
@@ -1298,9 +1198,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_shared-state-streaming.mp4"
         },
@@ -1308,9 +1206,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langgraph-fastapi_subagents.mp4"
         }
@@ -1370,11 +1266,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/google-adk",
         "name": "Sales Dashboard",
@@ -1398,9 +1290,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_agentic-chat.mp4"
         },
@@ -1408,9 +1298,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_hitl-in-chat.mp4"
         },
@@ -1418,9 +1306,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_tool-rendering.mp4"
         },
@@ -1428,9 +1314,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-tool-based.mp4"
         },
@@ -1438,9 +1322,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_gen-ui-agent.mp4"
         },
@@ -1448,9 +1330,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-read-write.mp4"
         },
@@ -1458,9 +1338,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_shared-state-streaming.mp4"
         },
@@ -1468,9 +1346,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/google-adk_subagents.mp4"
         }
@@ -1530,11 +1406,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "Mastra Cloud",
         "url": "https://mastra.ai/cloud"
@@ -1562,9 +1434,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_agentic-chat.mp4"
         },
@@ -1572,9 +1442,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_hitl-in-chat.mp4"
         },
@@ -1582,9 +1450,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_tool-rendering.mp4"
         },
@@ -1592,9 +1458,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-tool-based.mp4"
         },
@@ -1602,9 +1466,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_gen-ui-agent.mp4"
         },
@@ -1612,9 +1474,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-read-write.mp4"
         },
@@ -1622,9 +1482,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_shared-state-streaming.mp4"
         },
@@ -1632,9 +1490,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/mastra_subagents.mp4"
         }
@@ -1694,11 +1550,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "managed_platform": {
         "name": "CrewAI Enterprise",
         "url": "https://crewai.com/amp"
@@ -1726,9 +1578,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_agentic-chat.mp4"
         },
@@ -1736,9 +1586,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_hitl-in-chat.mp4"
         },
@@ -1746,9 +1594,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_tool-rendering.mp4"
         },
@@ -1756,9 +1602,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-tool-based.mp4"
         },
@@ -1766,9 +1610,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_gen-ui-agent.mp4"
         },
@@ -1776,9 +1618,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-read-write.mp4"
         },
@@ -1786,9 +1626,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_shared-state-streaming.mp4"
         },
@@ -1796,9 +1634,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/crewai-crews_subagents.mp4"
         }
@@ -1858,11 +1694,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/pydantic-ai",
         "name": "Sales Dashboard",
@@ -1886,9 +1718,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_agentic-chat.mp4"
         },
@@ -1896,9 +1726,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_hitl-in-chat.mp4"
         },
@@ -1906,9 +1734,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_tool-rendering.mp4"
         },
@@ -1916,9 +1742,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-tool-based.mp4"
         },
@@ -1926,9 +1750,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_gen-ui-agent.mp4"
         },
@@ -1936,9 +1758,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-read-write.mp4"
         },
@@ -1946,9 +1766,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_shared-state-streaming.mp4"
         },
@@ -1956,9 +1774,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/pydantic-ai_subagents.mp4"
         }
@@ -2018,11 +1834,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2038,9 +1850,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_agentic-chat.mp4"
         },
@@ -2048,9 +1858,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_hitl-in-chat.mp4"
         },
@@ -2058,9 +1866,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_tool-rendering.mp4"
         },
@@ -2068,9 +1874,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-tool-based.mp4"
         },
@@ -2078,9 +1882,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_gen-ui-agent.mp4"
         },
@@ -2088,9 +1890,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-read-write.mp4"
         },
@@ -2098,9 +1898,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_shared-state-streaming.mp4"
         },
@@ -2108,9 +1906,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-python_subagents.mp4"
         }
@@ -2178,11 +1974,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2198,9 +1990,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_agentic-chat.mp4"
         },
@@ -2208,9 +1998,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_hitl-in-chat.mp4"
         },
@@ -2218,9 +2006,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_tool-rendering.mp4"
         },
@@ -2228,9 +2014,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-tool-based.mp4"
         },
@@ -2238,9 +2022,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_gen-ui-agent.mp4"
         },
@@ -2248,9 +2030,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-read-write.mp4"
         },
@@ -2258,9 +2038,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_shared-state-streaming.mp4"
         },
@@ -2268,9 +2046,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/claude-sdk-typescript_subagents.mp4"
         }
@@ -2338,11 +2114,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/agno",
         "name": "Sales Dashboard",
@@ -2366,9 +2138,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_agentic-chat.mp4"
         },
@@ -2376,9 +2146,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_hitl-in-chat.mp4"
         },
@@ -2386,9 +2154,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_tool-rendering.mp4"
         },
@@ -2396,9 +2162,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-tool-based.mp4"
         },
@@ -2406,9 +2170,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_gen-ui-agent.mp4"
         },
@@ -2416,9 +2178,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-read-write.mp4"
         },
@@ -2426,9 +2186,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_shared-state-streaming.mp4"
         },
@@ -2436,9 +2194,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/agno_subagents.mp4"
         }
@@ -2502,11 +2258,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -2522,9 +2274,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_agentic-chat.mp4"
         },
@@ -2532,9 +2282,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_hitl-in-chat.mp4"
         },
@@ -2542,9 +2290,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_tool-rendering.mp4"
         },
@@ -2552,9 +2298,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-tool-based.mp4"
         },
@@ -2562,9 +2306,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_gen-ui-agent.mp4"
         },
@@ -2572,9 +2314,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-read-write.mp4"
         },
@@ -2582,9 +2322,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_shared-state-streaming.mp4"
         },
@@ -2592,9 +2330,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ag2_subagents.mp4"
         }
@@ -2666,11 +2402,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/llamaindex",
         "name": "Sales Dashboard",
@@ -2694,9 +2426,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_agentic-chat.mp4"
         },
@@ -2704,9 +2434,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_hitl-in-chat.mp4"
         },
@@ -2714,9 +2442,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_tool-rendering.mp4"
         },
@@ -2724,9 +2450,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-tool-based.mp4"
         },
@@ -2734,9 +2458,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_gen-ui-agent.mp4"
         },
@@ -2744,9 +2466,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-read-write.mp4"
         },
@@ -2754,9 +2474,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_shared-state-streaming.mp4"
         },
@@ -2764,9 +2482,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/llamaindex_subagents.mp4"
         }
@@ -2830,11 +2546,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/strands",
         "name": "Sales Dashboard",
@@ -2858,9 +2570,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_agentic-chat.mp4"
         },
@@ -2868,9 +2578,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_hitl-in-chat.mp4"
         },
@@ -2878,9 +2586,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_tool-rendering.mp4"
         },
@@ -2888,9 +2594,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-tool-based.mp4"
         },
@@ -2898,9 +2602,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_gen-ui-agent.mp4"
         },
@@ -2908,9 +2610,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-read-write.mp4"
         },
@@ -2918,9 +2618,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_shared-state-streaming.mp4"
         },
@@ -2928,9 +2626,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/strands_subagents.mp4"
         }
@@ -2990,11 +2686,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3010,9 +2702,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_agentic-chat.mp4"
         },
@@ -3020,9 +2710,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_hitl-in-chat.mp4"
         },
@@ -3030,9 +2718,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_tool-rendering.mp4"
         },
@@ -3040,9 +2726,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-tool-based.mp4"
         },
@@ -3050,9 +2734,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_gen-ui-agent.mp4"
         },
@@ -3060,9 +2742,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-read-write.mp4"
         },
@@ -3070,9 +2750,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_shared-state-streaming.mp4"
         },
@@ -3080,9 +2758,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/langroid_subagents.mp4"
         }
@@ -3117,11 +2793,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-python",
         "name": "Sales Dashboard",
@@ -3145,9 +2817,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_agentic-chat.mp4"
         },
@@ -3155,9 +2825,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_hitl-in-chat.mp4"
         },
@@ -3165,9 +2833,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_tool-rendering.mp4"
         },
@@ -3175,9 +2841,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-tool-based.mp4"
         },
@@ -3185,9 +2849,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_gen-ui-agent.mp4"
         },
@@ -3195,9 +2857,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-read-write.mp4"
         },
@@ -3205,9 +2865,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_shared-state-streaming.mp4"
         },
@@ -3215,9 +2873,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-python_subagents.mp4"
         }
@@ -3277,11 +2933,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "starter": {
         "path": "showcase/starters/ms-agent-dotnet",
         "name": "Sales Dashboard",
@@ -3305,9 +2957,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_agentic-chat.mp4"
         },
@@ -3315,9 +2965,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_hitl-in-chat.mp4"
         },
@@ -3325,9 +2973,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_tool-rendering.mp4"
         },
@@ -3335,9 +2981,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-tool-based.mp4"
         },
@@ -3345,9 +2989,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_gen-ui-agent.mp4"
         },
@@ -3355,9 +2997,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-read-write.mp4"
         },
@@ -3365,9 +3005,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_shared-state-streaming.mp4"
         },
@@ -3375,9 +3013,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/ms-agent-dotnet_subagents.mp4"
         }
@@ -3437,11 +3073,7 @@
         "a2ui-fixed-schema",
         "a2ui-dynamic-schema"
       ],
-      "interaction_modalities": [
-        "sidebar",
-        "embedded",
-        "chat"
-      ],
+      "interaction_modalities": ["sidebar", "embedded", "chat"],
       "features": [
         "agentic-chat",
         "hitl-in-chat",
@@ -3457,9 +3089,7 @@
           "id": "agentic-chat",
           "name": "Agentic Chat",
           "description": "Natural conversation with frontend tool execution",
-          "tags": [
-            "chat-ui"
-          ],
+          "tags": ["chat-ui"],
           "route": "/demos/agentic-chat",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_agentic-chat.mp4"
         },
@@ -3467,9 +3097,7 @@
           "id": "hitl-in-chat",
           "name": "In-Chat Human in the Loop",
           "description": "User approves agent actions before execution",
-          "tags": [
-            "interactivity"
-          ],
+          "tags": ["interactivity"],
           "route": "/demos/hitl",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_hitl-in-chat.mp4"
         },
@@ -3477,9 +3105,7 @@
           "id": "tool-rendering",
           "name": "Tool Rendering",
           "description": "Backend agent tools rendered as UI components",
-          "tags": [
-            "agent-capabilities"
-          ],
+          "tags": ["agent-capabilities"],
           "route": "/demos/tool-rendering",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_tool-rendering.mp4"
         },
@@ -3487,9 +3113,7 @@
           "id": "gen-ui-tool-based",
           "name": "Tool-Based Generative UI",
           "description": "Agent uses tools to trigger UI generation",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-tool-based",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-tool-based.mp4"
         },
@@ -3497,9 +3121,7 @@
           "id": "gen-ui-agent",
           "name": "Agentic Generative UI",
           "description": "Long-running agent tasks with generated UI",
-          "tags": [
-            "generative-ui"
-          ],
+          "tags": ["generative-ui"],
           "route": "/demos/gen-ui-agent",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_gen-ui-agent.mp4"
         },
@@ -3507,9 +3129,7 @@
           "id": "shared-state-read-write",
           "name": "Shared State (Read + Write)",
           "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-read-write",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-read-write.mp4"
         },
@@ -3517,9 +3137,7 @@
           "id": "shared-state-streaming",
           "name": "State Streaming",
           "description": "Per-token state delta streaming from agent to UI",
-          "tags": [
-            "agent-state"
-          ],
+          "tags": ["agent-state"],
           "route": "/demos/shared-state-streaming",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_shared-state-streaming.mp4"
         },
@@ -3527,9 +3145,7 @@
           "id": "subagents",
           "name": "Sub-Agents",
           "description": "Multiple agents with visible task delegation",
-          "tags": [
-            "multi-agent"
-          ],
+          "tags": ["multi-agent"],
           "route": "/demos/subagents",
           "animated_preview_url": "https://github.com/CopilotKit/CopilotKit/releases/download/showcase-previews/spring-ai_subagents.mp4"
         }


### PR DESCRIPTION
## Summary

The feature matrix on the showcase dashboard was hard to scan — ~30 integrations × ~30 features overflowed the viewport with no way to narrow the view, every cell had the same visual weight, and the legend dominated the bottom of the page.

This PR adds a sticky filter bar above the matrix and does a visual polish pass on the table itself. No changes to data, schemas, or live-status logic.

## Filter bar

Sticky at the top of the page, above the table:

- **Search** — free-text across integration + feature names/slugs. Matches either axis: a feature hit narrows rows, an integration hit narrows columns, so you can use it for both "where is feature X supported" and "what's in integration Y".
- **Language pills** (Python / TypeScript / .NET / Java) — multi-select; empty = all.
- **Integration category pills** (Popular / Agent Frameworks / Enterprise / Emerging / etc.) — multi-select; empty = all.
- **Feature category pills** (Chat & UI / Gen UI / Agent State / …) — multi-select; empty = all.
- **"Only fully green" toggle** — hides any feature row with a non-green cell among the currently visible integrations. Evaluated against the live SSE rollup, so it reacts to the stream. Integrations without a demo for the feature are treated as N/A (they don't sabotage the row), and a row with zero green cells is still hidden — "fully green" means "something is green and nothing is failing".
- **Live counts + Clear** — right side shows `N/total features · M/total integrations`; Clear resets all filters.

Filter state is encoded in URL params (`q`, `lang`, `ic`, `fc`, `green=1`) so views are shareable and survive reloads.

Options for language / integration-category pills are derived from the registry, not hardcoded, so adding a new language (e.g. `rust`) surfaces a pill automatically.

## Visual polish

Kept the matrix layout, tightened the density:

- Tighter cell padding (`px-2.5 py-1.5`), smaller column headers, hairline row borders.
- Subtle row zebra via a new `--bg-alt` token.
- Category divider rows shrunk from `pt-5 pb-1.5` to `pt-3 pb-1`.
- No-demo cells render `—` (muted gray) instead of red `✗` — missing is not an error; reserve red for actual failures.
- Column-header tally collapses from `✓ 3 · ~ 1 · ✗ 0` to a compact `3/1/0` triple.
- Legend becomes a collapsible `<details>` at the bottom so the initial page view isn't dominated by legend copy.

## Backward compat

`FeatureGrid`'s existing exports (`LiveIndicator`, `computeColumnTally`, `CellContext`, `CellRenderer`) are unchanged. The component now accepts three optional props (`integrations`, `features`, `onlyGreen`) that fall back to the full registry when omitted, so existing consumers / unit tests work without modification.

## Test plan

- [x] Dev server (`npx next dev --port 3012`) — verified:
  - Search narrowing rows when a feature matches, cols when an integration matches.
  - Language / integration-category / feature-category pills each narrow independently; combining them narrows further.
  - "Only fully green" hides rows that have red/amber cells in the live data.
  - Clear button resets all URL params and restores the full matrix.
  - URL params survive reload (shareable links).
  - Zebra, tighter padding, smaller headers, muted `—` cells.
- [x] Pre-commit hooks (`check-binaries`, `test-and-check-packages` including dashboard's vitest + 1149 upstream tests, `commitlint`) all pass.