### PR TITLE
fix: align package-shape probe URLs with actual Next.js API routes

### DIFF
--- a/showcase/ops/src/probes/drivers/smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/smoke.test.ts
@@ -646,8 +646,8 @@ describe("smokeDriver", () => {
     expect(writes.map((w) => w.key).sort()).toEqual(
       ["agent:ag2", "health:ag2"].sort(),
     );
-    expect(calls).toContain("https://showcase-ag2.up.railway.app/smoke");
-    expect(calls).toContain("https://showcase-ag2.up.railway.app/health");
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/api/smoke");
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/api/health");
     expect(calls).toContain(
       "https://showcase-ag2.up.railway.app/api/copilotkit/",
     );
@@ -815,10 +815,7 @@ describe("smokeDriver", () => {
     }
   });
 
-  it("package shape (explicit): keeps the legacy /smoke + /health contract", async () => {
-    // Sanity check that the new `shape` field is optional and
-    // backward-compatible: when `shape === "package"` (or omitted), the
-    // driver still hits /smoke + /health exactly like before.
+  it("package shape (explicit): hits /api/smoke + /api/health", async () => {
     const calls: string[] = [];
     const fetchImpl: typeof fetch = (async (url: string | URL) => {
       const href = typeof url === "string" ? url : url.toString();
@@ -837,8 +834,8 @@ describe("smokeDriver", () => {
       publicUrl: "https://showcase-ag2.up.railway.app",
       shape: "package",
     });
-    expect(calls).toContain("https://showcase-ag2.up.railway.app/smoke");
-    expect(calls).toContain("https://showcase-ag2.up.railway.app/health");
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/api/smoke");
+    expect(calls).toContain("https://showcase-ag2.up.railway.app/api/health");
   });
 
   // -------------------------------------------------------------------

--- a/showcase/ops/src/probes/drivers/smoke.ts
+++ b/showcase/ops/src/probes/drivers/smoke.ts
@@ -41,8 +41,8 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  * behaviour contained to this file.
  *
  * Input shapes: the driver accepts TWO inputs.
- *   - Static YAML: `{ key, url }`. `url` is the `/smoke` endpoint; the
- *     derived /health + agent URLs come from path manipulation.
+ *   - Static YAML: `{ key, url }`. `url` is the `/api/smoke` endpoint;
+ *     the derived /api/health + agent URLs come from path manipulation.
  *   - Discovery: `{ key, name, imageRef, publicUrl, env }`. The smoke
  *     URL is `${publicUrl}/smoke`; slug is `name` with the `showcase-`
  *     prefix stripped (`showcase-ag2` → `ag2`, `showcase-starter-ag2`
@@ -103,7 +103,7 @@ const discoverySmokeInputSchema = z
      * (`discovery/railway-services.ts`). Controls which URL contract the
      * driver exercises:
      *
-     *   - `package` → legacy `/smoke` + `/health` + `/api/copilotkit/`.
+     *   - `package` → `/api/smoke` + `/api/health` + `/api/copilotkit/`.
      *   - `starter` → `/api/health` (primary + side-emit) +
      *                 `/api/copilotkit/`. Starters have no `/smoke`
      *                 route; using the legacy contract produces one
@@ -627,8 +627,8 @@ interface DerivedUrls {
 /**
  * Derive the three per-target URLs from the input shape.
  *
- *   - Discovery mode (`publicUrl` present): smoke = `${publicUrl}/smoke`,
- *     health = `${publicUrl}/health`, agent = `${publicUrl}/api/copilotkit/`.
+ *   - Discovery mode (`publicUrl` present): smoke = `${publicUrl}/api/smoke`,
+ *     health = `${publicUrl}/api/health`, agent = `${publicUrl}/api/copilotkit/`.
  *     The trailing slash on the agent path mirrors the runtime router's
  *     expectation — CopilotKit Hono routes are mounted at
  *     `/api/copilotkit/` with a trailing slash in every showcase.
@@ -663,8 +663,8 @@ function deriveUrls(
       };
     }
     return {
-      smokeUrl: `${base}/smoke`,
-      healthUrl: `${base}/health`,
+      smokeUrl: `${base}/api/smoke`,
+      healthUrl: `${base}/api/health`,
       agentUrl: `${base}/api/copilotkit/`,
     };
   }
@@ -688,7 +688,9 @@ function deriveUrls(
 function deriveAgentUrl(url: string): string {
   try {
     const u = new URL(url);
-    if (/\/smoke\/?$/.test(u.pathname)) {
+    if (/\/api\/smoke\/?$/.test(u.pathname)) {
+      u.pathname = u.pathname.replace(/\/api\/smoke\/?$/, "/api/copilotkit/");
+    } else if (/\/smoke\/?$/.test(u.pathname)) {
       u.pathname = u.pathname.replace(/\/smoke\/?$/, "/api/copilotkit/");
     } else {
       u.pathname = u.pathname.replace(/\/$/, "") + "/api/copilotkit/";


### PR DESCRIPTION
## Summary

- Showcase packages serve health/smoke at `/api/health` and `/api/smoke`
  (Next.js app router convention), but the smoke probe driver was hitting
  bare `/smoke` and `/health` for the package shape, causing 17/17
  false-red rows every tick for both `smoke:<pkg>` and `health:<pkg>`.
- Update `deriveUrls` in the smoke probe driver so package-shape
  discovery uses `/api/smoke` and `/api/health`, matching what starters
  already do for `/api/health`.
- Fix `deriveAgentUrl` to handle `/api/smoke` path prefix correctly.
- Update tests to assert the corrected URL paths.

All 17 packages already had `/api/health` and `/api/smoke` route files;
the issue was purely in the probe driver's URL construction for the
package shape.

## Test plan

- [x] `pnpm --filter @copilotkit/showcase-ops test` passes (788/788)
- [ ] CI green
- [ ] After deploy, PB `smoke:<package>` and `health:<package>` rows
      turn green for all 17 packages