### PR TITLE
fix(a2ui): document id="root" entry-point requirement in generation guidelines

### DIFF
--- a/packages/shared/src/a2ui-prompts.ts
+++ b/packages/shared/src/a2ui-prompts.ts
@@ -27,6 +27,11 @@ CRITICAL: You MUST call the render_a2ui tool with ALL of these arguments:
   component names or use names not in the schema.
 
 COMPONENT ID RULES:
+- Exactly one component MUST have id="root". This is the surface's entry
+  point — the renderer begins at "root" and walks the child/children tree
+  from there. Every other component must be reachable from "root". If no
+  component has id="root", the surface renders an empty loading placeholder
+  and none of your components will be shown.
 - Every component ID must be unique within the surface.
 - A component MUST NOT reference itself as child/children. This causes a
   circular dependency error. For example, if a component has id="avatar",

--- a/sdk-python/copilotkit/a2ui.py
+++ b/sdk-python/copilotkit/a2ui.py
@@ -117,6 +117,11 @@ CRITICAL: You MUST call the render_a2ui tool with ALL of these arguments:
 - every component must have the "component" field specifying the component type (e.g. "Text", "Image", "Row", "Column", "List", "Button", etc.)
 
 COMPONENT ID RULES:
+- Exactly one component MUST have id="root". This is the surface's entry
+  point — the renderer begins at "root" and walks the child/children tree
+  from there. Every other component must be reachable from "root". If no
+  component has id="root", the surface renders an empty loading placeholder
+  and none of your components will be shown.
 - Every component ID must be unique within the surface.
 - A component MUST NOT reference itself as child/children. This causes a
   circular dependency error. For example, if a component has id="avatar",


### PR DESCRIPTION
## Summary

Stacked on top of #4216 — that PR patches the `langgraph-python-threads` demo's tool docstring so the sub-LLM learns about the `id: "root"` requirement. This PR lands the fix in the upstream prompt so every A2UI-enabled consumer picks it up, not just that one demo.

## Why

The A2UI React renderer always starts rendering at the component with `id: "root"` ([`A2uiSurface.tsx:152`](packages/a2ui-renderer/src/react-renderer/a2ui-react/A2uiSurface.tsx)):

```tsx
export const A2uiSurface: React.FC<{...}> = ({ surface }) => {
  // The root component always has ID 'root' and base path '/'
  return <DeferredChild surface={surface} id="root" basePath="/" />;
};
```

If no component has that ID, `DeferredChild` returns its shimmer placeholder, so the surface silently renders as a ~30px-tall empty box no matter how many components were sent. No error, no warning — just a loading spinner that never resolves. In the `Sales Dashboard (A2UI Dynamic)` demo this manifests as the \"empty white square\" bug that kicked off this stack.

Fixed-schema demos survive because their JSON schemas hard-code a component with `id: "root"`. Dynamic demos have been relying on the LLM guessing — sometimes right, often wrong — because the guideline strings shipped to the sub-LLM never stated the rule.

## What this PR does

Adds a bullet to the `COMPONENT ID RULES` section of both guideline strings:

- `packages/shared/src/a2ui-prompts.ts` → `A2UI_DEFAULT_GENERATION_GUIDELINES` (injected into agent context by `A2UICatalogContext` in `@copilotkit/react-core` for every A2UI-enabled app).
- `sdk-python/copilotkit/a2ui.py` → `DEFAULT_GENERATION_GUIDELINES` (used by the Python SDK's `a2ui.a2ui_prompt()` helper).

Identical wording in both:

> Exactly one component MUST have id=\"root\". This is the surface's entry point — the renderer begins at \"root\" and walks the child/children tree from there. Every other component must be reachable from \"root\". If no component has id=\"root\", the surface renders an empty loading placeholder and none of your components will be shown.

No demo code changes needed. The context flow (`addContext` → AG-UI state → demo's `generate_a2ui`) forwards the updated string verbatim.

## Test plan

- [x] Confirmed locally that restoring the equivalent instruction to a demo tool docstring (via the stacked PR #4216) makes the *Sales Dashboard (A2UI Dynamic)* demo render correctly. Same instruction flowing from the shared guidelines should produce the same outcome for any A2UI-enabled consumer.
- [ ] Reviewer to sanity-check that the guideline strings aren't asserted verbatim in any test snapshots (grep found none).

## Possible follow-ups (not in scope)

- Make the renderer emit a warning / fallback UI when `componentsModel.get("root")` is missing but other components exist, instead of an infinite shimmer — would turn a silent failure into a loud one.
- Once this ships and consumers pull in the new `@copilotkit/shared` / `copilotkit` versions, the per-demo docstring restored in #4216 becomes belt-and-braces and can be trimmed if desired.