### PR TITLE
fix: unblock verify-image-refs for aimock + ops drift

### DIFF
--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -145,8 +145,7 @@ export function validateImage(
     };
   }
   const expected =
-    IMAGE_OVERRIDES[serviceName] ??
-    `ghcr.io/copilotkit/${serviceName}:latest`;
+    IMAGE_OVERRIDES[serviceName] ?? `ghcr.io/copilotkit/${serviceName}:latest`;
   if (image !== expected) {
     return {
       service: serviceName,

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -33,12 +33,25 @@ const SHOWCASE = {
 
 // Canonical shape: ghcr.io/copilotkit/<name>:latest where <name> is the
 // service name itself. This single pattern covers showcase-<slug>,
-// showcase-starter-<slug>, showcase-aimock, showcase-pocketbase,
-// showcase-ops, and any future showcase-* service. Enforcing identity
-// between Railway service name and image name (modulo the ghcr.io/copilotkit/
-// prefix and :latest tag) is the invariant — if these ever drift apart we
-// want to know.
-const IMAGE_SHAPE = /^ghcr\.io\/copilotkit\/showcase-[a-z0-9-]+:latest$/;
+// showcase-starter-<slug>, showcase-pocketbase, showcase-ops, and any
+// future showcase-* service. Enforcing identity between Railway service
+// name and image name (modulo the ghcr.io/copilotkit/ prefix and :latest
+// tag) is the invariant — if these ever drift apart we want to know.
+//
+// The regex accepts both `showcase-*` and bare `<name>` images to
+// accommodate services like aimock whose wrapper was eliminated — the
+// Railway service is still named `showcase-aimock` but the image is now
+// `ghcr.io/copilotkit/aimock:latest`.
+const IMAGE_SHAPE = /^ghcr\.io\/copilotkit\/[a-z0-9-]+:latest$/;
+
+// Services whose GHCR image name intentionally differs from the Railway
+// service name. After the aimock wrapper elimination (PR #128), Railway
+// pulls `ghcr.io/copilotkit/aimock:latest` directly instead of the old
+// `showcase-aimock` wrapper image. The verify job must accept this
+// divergence rather than requiring image === service name.
+const IMAGE_OVERRIDES: Record<string, string> = {
+  "showcase-aimock": "ghcr.io/copilotkit/aimock:latest",
+};
 
 function getToken(): string {
   if (process.env.RAILWAY_TOKEN) return process.env.RAILWAY_TOKEN;
@@ -128,10 +141,12 @@ export function validateImage(
     return {
       service: serviceName,
       image,
-      reason: `does not match canonical shape ^ghcr\\.io/copilotkit/showcase-[a-z0-9-]+:latest$`,
+      reason: `does not match canonical shape ^ghcr\\.io/copilotkit/[a-z0-9-]+:latest$`,
     };
   }
-  const expected = `ghcr.io/copilotkit/${serviceName}:latest`;
+  const expected =
+    IMAGE_OVERRIDES[serviceName] ??
+    `ghcr.io/copilotkit/${serviceName}:latest`;
   if (image !== expected) {
     return {
       service: serviceName,


### PR DESCRIPTION
## Summary

The `verify-image-refs` job has been failing on every main push, blocking all showcase deploys. Two services drifted from expected state:

- **showcase-aimock** — wrapper elimination (PR #128) changed the canonical image from `ghcr.io/copilotkit/showcase-aimock:latest` to `ghcr.io/copilotkit/aimock:latest`. The verify script's regex required a `showcase-` prefix and enforced `image === ghcr.io/copilotkit/{serviceName}:latest`, both of which reject the new direct-pull image name.
- **showcase-ops** — Railway was pinned to `ghcr.io/copilotkit/showcase-ops:3add284` (a commit SHA tag) instead of `:latest`.

## Changes

**Workflow code** (`showcase/scripts/verify-railway-image-refs.ts`):
- Relaxed `IMAGE_SHAPE` regex from `showcase-[a-z0-9-]+` to `[a-z0-9-]+` to accept non-showcase-prefixed images
- Added `IMAGE_OVERRIDES` map so `showcase-aimock` expects `ghcr.io/copilotkit/aimock:latest` instead of the default convention

**Railway config** (out-of-band mutation, not in diff):
- Updated `showcase-ops` source.image from `:3add284` to `:latest` via `serviceInstanceUpdate`

## Verification

Ran `verify-railway-image-refs.ts` locally after both changes — all 41 services pass.

## Test plan

- [ ] CI `verify-image-refs` job passes on this PR
- [ ] Merge to main, confirm next showcase deploy completes without verify-image-refs gate failure