### PR TITLE
fix(showcase/starters): increase mastra watchdog grace to 360s

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -650,6 +650,8 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  * `mastra` starters spawn `mastra dev`, which runs a tsx-based build +
  * Mastra server boot on first request and was observed restart-looping
  * on Railway starting 04-20 18:18 UTC — same kill-loop shape as langgraph.
+ * Cold-start observed at ~280s; 180s grace + 90s strike budget = 270s was
+ * not enough, so mastra uses 360s grace (total budget 450s).
  *
  * `claude-sdk-typescript` starters spawn `tsx agent/index.ts` which
  * performs a full tsx type-strip + @anthropic-ai/claude-agent-sdk init;
@@ -663,7 +665,7 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  */
 function getWatchdogGraceSeconds(fw: FrameworkDef): number {
   if (fw.slug.startsWith("langgraph-")) return 180;
-  if (fw.slug === "mastra") return 180;
+  if (fw.slug === "mastra") return 360;
   if (fw.slug === "claude-sdk-typescript") return 180;
   return 0;
 }

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -58,7 +58,7 @@ fi
 # per-framework ceiling) before the strike counter is armed. See
 # getWatchdogGraceSeconds() for the mapping.
 (
-  GRACE=180
+  GRACE=360
   echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
   ELAPSED=0
   while [ $ELAPSED -lt $GRACE ]; do
@@ -96,7 +96,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 180s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 360s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."


### PR DESCRIPTION
## Summary

- Mastra agent cold-start takes ~280s on Railway. The previous 180s
  watchdog grace + 90s strike budget (3x30s) = 270s total, causing
  the agent to be SIGKILL'd ~10s before it becomes ready.
- Increases mastra's grace period from 180s to 360s (total budget
  450s), giving safe margin over observed startup time.
- Regenerated `showcase/starters/mastra/entrypoint.sh` to reflect
  the new grace value.

## Other starters' watchdog grace periods

| Framework | Grace (s) | Total budget (s) |
|-----------|-----------|-------------------|
| langgraph-* | 180 | 270 |
| mastra | 360 (was 180) | 450 |
| claude-sdk-typescript | 180 | 270 |
| all others | 0 | 90 |

## Test plan

- [x] Regenerated starters via `npx tsx generate-starters.ts`
- [x] Verified `showcase/starters/mastra/entrypoint.sh` now has
      `GRACE=360`
- [x] No other starters affected by regeneration
- [ ] Mastra starter image will auto-rebuild via `showcase_deploy.yml`
      and Railway auto-updates will pull the new image