### PR TITLE
fix(showcase/starters): increase mastra watchdog grace to 600s

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -665,7 +665,7 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  */
 function getWatchdogGraceSeconds(fw: FrameworkDef): number {
   if (fw.slug.startsWith("langgraph-")) return 180;
-  if (fw.slug === "mastra") return 360;
+  if (fw.slug === "mastra") return 600;
   if (fw.slug === "claude-sdk-typescript") return 180;
   return 0;
 }

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -58,7 +58,7 @@ fi
 # per-framework ceiling) before the strike counter is armed. See
 # getWatchdogGraceSeconds() for the mapping.
 (
-  GRACE=360
+  GRACE=600
   echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
   ELAPSED=0
   while [ $ELAPSED -lt $GRACE ]; do
@@ -96,7 +96,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 360s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 600s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."


### PR DESCRIPTION
## Summary

- Increase mastra watchdog startup grace from 360s to 600s in `getWatchdogGraceSeconds()`
- Regenerated mastra entrypoint.sh to reflect the new value
- Cold-start observed at ~450s; 360s grace + 90s strike = 450s total budget (zero margin). 600s grace gives 240s headroom.

## Test plan

- [ ] Deploy mastra showcase starter and verify cold-start completes without watchdog kill
- [ ] Confirm `GRACE=600` in generated `showcase/starters/mastra/entrypoint.sh`