### PR TITLE
fix(showcase/starters): reduce mastra watchdog grace 180s to 30s

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -663,7 +663,9 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  */
 function getWatchdogGraceSeconds(fw: FrameworkDef): number {
   if (fw.slug.startsWith("langgraph-")) return 180;
-  if (fw.slug === "mastra") return 180;
+  // mastra: pre-built via `mastra build` at image time → `node` boot is <10s.
+  // 30s is ample for the pre-compiled bundle to bind its port.
+  if (fw.slug === "mastra") return 30;
   if (fw.slug === "claude-sdk-typescript") return 180;
   return 0;
 }

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -58,7 +58,7 @@ fi
 # per-framework ceiling) before the strike counter is armed. See
 # getWatchdogGraceSeconds() for the mapping.
 (
-  GRACE=180
+  GRACE=30
   echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
   ELAPSED=0
   while [ $ELAPSED -lt $GRACE ]; do
@@ -96,7 +96,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 180s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 30s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."


### PR DESCRIPTION
## Summary

- Reduces mastra starter watchdog grace from 180s to 30s in
  `getWatchdogGraceSeconds()` and regenerates the starter
- The mastra starter already builds at image time via `mastra build`
  (landed in #4133) and boots via `node .mastra/output/index.mjs`,
  so startup is <10s — 180s grace was ~6x longer than needed

## Test plan

- [x] `generate-starters.test.ts` passes (266 tests)
- [x] `--check --slug mastra` confirms no drift
- [ ] Deploy to Railway and observe agent healthy within 30s grace