### PR TITLE
fix(showcase/starters): mastra watchdog probes /health not /api

### DIFF
--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -606,13 +606,12 @@ fi`;
  *   * claude-sdk-typescript -> /health (express app.get("/health"))
  *   * ms-agent-dotnet -> /health (app.MapGet("/health", ...))
  *   * spring-ai -> /health (custom @GetMapping in AgentController)
- *   * mastra -> /api (mastra dev serves its REST surface at /api; no
- *                      dedicated health endpoint, but /api returns 200 once
- *                      the dev server is ready)
+ *   * mastra -> /health (Mastra pre-built server exposes GET /health
+ *                        returning {"success":true} with HTTP 200)
  */
 function getAgentHealthPath(fw: FrameworkDef): string {
   if (fw.slug.startsWith("langgraph-")) return "/ok";
-  if (fw.slug === "mastra") return "/api";
+  if (fw.slug === "mastra") return "/health";
   return "/health";
 }
 
@@ -647,11 +646,8 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  * 58bbebe8-7a94-4f99-b6e4-ffcbb4eb78b9. 180s is the observed upper bound
  * across cold-start samples plus a safety margin.
  *
- * `mastra` starters spawn `mastra dev`, which runs a tsx-based build +
- * Mastra server boot on first request and was observed restart-looping
- * on Railway starting 04-20 18:18 UTC — same kill-loop shape as langgraph.
- * Cold-start observed at ~280s; 180s grace + 90s strike budget = 270s was
- * not enough, so mastra uses 360s grace (total budget 450s).
+ * `mastra` starters use the pre-built Mastra server, which starts in ~2s
+ * locally. 30s grace is generous margin for Railway cold containers.
  *
  * `claude-sdk-typescript` starters spawn `tsx agent/index.ts` which
  * performs a full tsx type-strip + @anthropic-ai/claude-agent-sdk init;
@@ -665,7 +661,7 @@ function getAgentHealthPath(fw: FrameworkDef): string {
  */
 function getWatchdogGraceSeconds(fw: FrameworkDef): number {
   if (fw.slug.startsWith("langgraph-")) return 180;
-  if (fw.slug === "mastra") return 600;
+  if (fw.slug === "mastra") return 30;
   if (fw.slug === "claude-sdk-typescript") return 180;
   return 0;
 }

--- a/showcase/starters/mastra/entrypoint.sh
+++ b/showcase/starters/mastra/entrypoint.sh
@@ -58,7 +58,7 @@ fi
 # per-framework ceiling) before the strike counter is armed. See
 # getWatchdogGraceSeconds() for the mapping.
 (
-  GRACE=600
+  GRACE=30
   echo "[watchdog] Startup grace: waiting up to ${GRACE}s for first successful health probe before arming strike counter"
   ELAPSED=0
   while [ $ELAPSED -lt $GRACE ]; do
@@ -66,7 +66,7 @@ fi
       # Agent died during startup — wait -n in the main shell will handle it.
       exit 0
     fi
-    if curl -fsS --max-time 5 http://127.0.0.1:8123/api > /dev/null 2>&1; then
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
       echo "[watchdog] Agent healthy after ${ELAPSED}s — arming strike counter"
       break
     fi
@@ -82,7 +82,7 @@ fi
       # Agent already dead — wait -n in the main shell will handle it.
       break
     fi
-    if curl -fsS --max-time 5 http://127.0.0.1:8123/api > /dev/null 2>&1; then
+    if curl -fsS --max-time 5 http://127.0.0.1:8123/health > /dev/null 2>&1; then
       FAILS=0
     else
       FAILS=$((FAILS + 1))
@@ -96,7 +96,7 @@ fi
   done
 ) &
 WATCHDOG_PID=$!
-echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/api, startup grace 600s)"
+echo "[entrypoint] Watchdog started (PID: $WATCHDOG_PID, probing http://127.0.0.1:8123/health, startup grace 30s)"
 
 echo "========================================="
 echo "[entrypoint] Starting Next.js frontend on port ${PORT:-10000}..."


### PR DESCRIPTION
## Summary

- **getAgentHealthPath()**: mastra changed from `/api` to `/health` -- the
  Mastra pre-built server returns 404 on `/api`; the correct endpoint is
  `GET /health` (HTTP 200 `{"success":true}`)
- **getWatchdogGraceSeconds()**: mastra grace reduced from 600s to 30s --
  the agent starts in ~2s locally; 30s is generous margin for Railway
- Regenerated `showcase/starters/mastra/entrypoint.sh` to propagate both
  changes

## Why

The watchdog was probing `/api`, never seeing success, and killing the
mastra agent after the full 600s grace period. Every container restart
burned 10 minutes before the agent was killed and restarted.

## Test plan

- [x] `vitest run generate-starters.test.ts` -- 266/266 pass
- [x] Verified regenerated entrypoint.sh contains `/health` and `GRACE=30`