### PR TITLE
fix(showcase/tests): sync deployed flags with registry

### DIFF
--- a/showcase/tests/e2e/integration-smoke.spec.ts
+++ b/showcase/tests/e2e/integration-smoke.spec.ts
@@ -137,7 +137,7 @@ const INTEGRATIONS: Integration[] = [
     name: "Claude Agent SDK (Python)",
     backendUrl: "https://showcase-claude-sdk-python-production.up.railway.app",
     backendType: "ag-ui",
-    deployed: false,
+    deployed: true,
     demos: [
       "agentic-chat",
       "tool-rendering",
@@ -151,7 +151,7 @@ const INTEGRATIONS: Integration[] = [
     backendUrl:
       "https://showcase-claude-sdk-typescript-production.up.railway.app",
     backendType: "ag-ui",
-    deployed: false,
+    deployed: true,
     demos: [
       "agentic-chat",
       "tool-rendering",
@@ -229,7 +229,7 @@ const INTEGRATIONS: Integration[] = [
     name: "Langroid",
     backendUrl: "https://showcase-langroid-production.up.railway.app",
     backendType: "ag-ui",
-    deployed: false,
+    deployed: true,
     demos: [
       "agentic-chat",
       "tool-rendering",
@@ -268,7 +268,7 @@ const INTEGRATIONS: Integration[] = [
     name: "Spring AI",
     backendUrl: "https://showcase-spring-ai-production.up.railway.app",
     backendType: "ag-ui",
-    deployed: false,
+    deployed: true,
     demos: [
       "agentic-chat",
       "tool-rendering",


### PR DESCRIPTION
## Summary

- Syncs `deployed` flags in `integration-smoke.spec.ts` INTEGRATIONS array with the source-of-truth `registry.json`
- 4 integrations were stale `deployed: false` but `true` in registry: **claude-sdk-python**, **claude-sdk-typescript**, **langroid**, **spring-ai**
- These integrations were silently skipped by the smoke suite

## Test plan

- [x] `npx prettier --check` passes
- [x] `npx playwright test --list` shows all 17 integrations in every test level
- [ ] CI green