### PR TITLE
fix(showcase-ops): replace :last-of-type with querySelectorAll index in e2e-smoke driver

### DIFF
--- a/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.test.ts
@@ -68,6 +68,12 @@ function makePage(script: PageScript = {}): E2ePage {
       }
       return "";
     },
+    async evaluate<R>(fn: () => R): Promise<R> {
+      // The evaluate() call in the driver reads the last assistant
+      // message's textContent via querySelectorAll. In the fake we
+      // return the same assistantText the old textContent path used.
+      return (script.assistantText ?? "") as unknown as R;
+    },
     async close() {
       /* no-op */
     },
@@ -211,23 +217,23 @@ describe("e2eSmokeDriver L3 (chat)", () => {
   it("polls for non-empty textContent when initial read is empty (streaming race)", async () => {
     // Simulates the race condition where CopilotKit renders the
     // assistant-message container before tokens stream in. The first
-    // two textContent reads return "" (container visible but empty);
+    // two evaluate() reads return "" (container visible but empty);
     // the third returns real text. The driver must poll and eventually
     // read the text rather than reporting "empty assistant response".
-    let textContentCalls = 0;
+    let evaluateCalls = 0;
     const delayedPage: E2ePage = {
       async goto() {},
       async type() {},
       async press() {},
       async waitForSelector() {},
-      async textContent(sel) {
-        if (sel === '[data-testid="copilot-assistant-message"]:last-of-type') {
-          textContentCalls++;
-          // First two calls return empty (tokens not yet streamed).
-          if (textContentCalls <= 2) return "";
-          return "Hello! Nice to meet you.";
-        }
+      async textContent() {
         return "";
+      },
+      async evaluate<R>(): Promise<R> {
+        evaluateCalls++;
+        // First two calls return empty (tokens not yet streamed).
+        if (evaluateCalls <= 2) return "" as unknown as R;
+        return "Hello! Nice to meet you." as unknown as R;
       },
       async close() {},
     };
@@ -257,7 +263,7 @@ describe("e2eSmokeDriver L3 (chat)", () => {
     const chatSig = chat?.signal as E2eSmokeLevelSignal;
     expect(chatSig.responseText).toBe("Hello! Nice to meet you.");
     // Must have polled more than once.
-    expect(textContentCalls).toBeGreaterThan(1);
+    expect(evaluateCalls).toBeGreaterThan(1);
   });
 
   it("falls back to body scraping when the assistant selector never resolves", async () => {
@@ -596,6 +602,9 @@ describe("e2eSmokeDriver starter shape", () => {
               async waitForSelector() {},
               async textContent() {
                 return "";
+              },
+              async evaluate<R>(): Promise<R> {
+                return "" as unknown as R;
               },
               async close() {},
             };

--- a/showcase/ops/src/probes/drivers/e2e-smoke.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.ts
@@ -182,6 +182,13 @@ export interface E2ePage {
     opts?: { timeout?: number; state?: "visible" },
   ): Promise<unknown>;
   textContent(selector: string): Promise<string | null>;
+  /**
+   * Run a function in the browser page context. Used for DOM reads that
+   * must NOT auto-wait (Playwright's `page.textContent(selector)` waits
+   * up to 30 s for the selector to match; `evaluate` returns immediately
+   * with whatever the DOM currently holds).
+   */
+  evaluate<R>(fn: () => R): Promise<R>;
   close(): Promise<void>;
 }
 
@@ -285,6 +292,7 @@ const defaultLauncher: E2eBrowserLauncher = async (): Promise<E2eBrowser> => {
             press: (sel, key, opts) => page.press(sel, key, opts),
             waitForSelector: (sel, opts) => page.waitForSelector(sel, opts),
             textContent: (sel) => page.textContent(sel),
+            evaluate: <R>(fn: () => R) => page.evaluate(fn),
             close: () => page.close(),
           };
         },
@@ -714,13 +722,56 @@ async function runLevel(opts: {
       // stream in (starts as ""). Slower integrations (ms-agent-dotnet:
       // extra network hop) need time for the first token to arrive. Poll
       // for non-empty textContent instead of reading once.
+      //
+      // IMPORTANT: we use `page.evaluate()` instead of
+      // `page.textContent(selector)` for two reasons:
+      //
+      //   1. CSS `:last-of-type` is unreliable here. CopilotKit often
+      //      renders a trailing <div> (streaming indicator, input area)
+      //      after the assistant-message <div>. `:last-of-type` selects
+      //      the last element of a given TAG TYPE among siblings, so it
+      //      matches the trailing <div> — not the assistant message.
+      //      The compound selector
+      //      `[data-testid="copilot-assistant-message"]:last-of-type`
+      //      then matches ZERO elements.
+      //
+      //   2. Playwright's `page.textContent(selector)` auto-waits up to
+      //      30 s for the selector to match. When the selector matches
+      //      nothing (see #1), each poll iteration blocks for 30 s and
+      //      then throws — making the 500 ms poll interval meaningless.
+      //      Two failed polls exhaust the entire textPollTimeoutMs
+      //      budget, and the outer catch swallows the timeout, returning
+      //      empty text → false-red.
+      //
+      // `page.evaluate()` runs synchronously in the browser context,
+      // returns immediately with whatever the DOM currently holds, and
+      // uses `querySelectorAll` to find the last matching element by
+      // index rather than by CSS pseudo-selector.
       let raw = "";
       const pollEnd = Date.now() + textPollTimeoutMs;
       while (Date.now() < pollEnd) {
+        // The callback executes in the browser where `document` exists.
+        // TypeScript's Node-only `lib` doesn't include DOM types, so we
+        // access `document` via `globalThis` to avoid a compile error
+        // without polluting the project-wide tsconfig with `"dom"`.
         raw =
-          (await page.textContent(
-            '[data-testid="copilot-assistant-message"]:last-of-type',
-          )) ?? "";
+          (await page.evaluate(() => {
+            // `document` lives in the browser context where this callback
+            // runs. The server-side tsconfig intentionally excludes DOM
+            // types, so we reach it via a type-erased indirection.
+            const win = globalThis as unknown as {
+              document: {
+                querySelectorAll(
+                  sel: string,
+                ): ArrayLike<{ textContent: string | null }>;
+              };
+            };
+            const msgs = win.document.querySelectorAll(
+              '[data-testid="copilot-assistant-message"]',
+            );
+            if (msgs.length === 0) return "";
+            return msgs[msgs.length - 1]!.textContent ?? "";
+          })) ?? "";
         if (raw.trim().length > 0) break;
         await new Promise((r) => setTimeout(r, 500));
       }


### PR DESCRIPTION
## Summary

- Replace CSS `:last-of-type` selector with `page.evaluate()` + `querySelectorAll` index-based lookup for reading the last assistant message in the e2e-smoke probe driver
- `:last-of-type` matches the last `<div>` among siblings, not the last element with `data-testid="copilot-assistant-message"` -- a trailing `<div>` causes zero matches and Playwright auto-waits 30s per call, exhausting the timeout budget
- `page.evaluate()` returns immediately with current DOM state, avoiding the 30s auto-wait trap entirely

## Test plan

- [x] 823/823 showcase-ops tests pass locally
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Build succeeds (`tsc -p tsconfig.build.json`)
- [x] Updated streaming-race test to exercise the new `evaluate()` path
- [ ] Post-deploy: `e2e_smoke:showcase-ag2` and `tools:ag2` flip green on next tick