### PR TITLE
fix: prevent ag2 infinite tool-call loop and agno request timeouts

### DIFF
--- a/showcase/packages/ag2/src/agents/agent.py
+++ b/showcase/packages/ag2/src/agents/agent.py
@@ -148,6 +148,12 @@ agent = ConversableAgent(
     ),
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
     human_input_mode="NEVER",
+    # Guard against infinite tool-call loops: AG2's ConversableAgent with
+    # human_input_mode="NEVER" will keep executing tool calls indefinitely
+    # if the LLM keeps requesting them.  Without this limit the agent floods
+    # Railway's log stream (500 logs/sec rate-limit), becomes unresponsive
+    # to health probes, and gets killed by the watchdog.
+    max_consecutive_auto_reply=15,
     functions=[
         get_weather,
         query_data,

--- a/showcase/packages/agno/src/agents/main.py
+++ b/showcase/packages/agno/src/agents/main.py
@@ -173,7 +173,11 @@ def generate_a2ui(context: str):
 
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    # Raise the HTTP timeout so requests routed through aimock don't time out
+    # under normal load.  The default httpx timeout is too short when aimock
+    # is proxying to the upstream LLM — observed "Request timed out" errors
+    # that crash the agent run and trigger watchdog restarts.
+    model=OpenAIChat(id="gpt-4o", timeout=120),
     tools=[
         get_weather,
         query_data,
@@ -184,6 +188,8 @@ agent = Agent(
         search_flights,
         generate_a2ui,
     ],
+    # Prevent runaway tool-call loops — same guard as the ag2 package.
+    tool_call_limit=15,
     description="You are a helpful sales assistant for the CopilotKit showcase demos.",
     instructions="""
         SALES PIPELINE:

--- a/showcase/starters/ag2/agent/agent.py
+++ b/showcase/starters/ag2/agent/agent.py
@@ -138,6 +138,12 @@ agent = ConversableAgent(
     ),
     llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
     human_input_mode="NEVER",
+    # Guard against infinite tool-call loops: AG2's ConversableAgent with
+    # human_input_mode="NEVER" will keep executing tool calls indefinitely
+    # if the LLM keeps requesting them.  Without this limit the agent floods
+    # Railway's log stream (500 logs/sec rate-limit), becomes unresponsive
+    # to health probes, and gets killed by the watchdog.
+    max_consecutive_auto_reply=15,
     functions=[
         get_weather,
         query_data,

--- a/showcase/starters/agno/agent/main.py
+++ b/showcase/starters/agno/agent/main.py
@@ -157,7 +157,11 @@ def generate_a2ui(context: str):
     return json.dumps({"error": "LLM did not call render_a2ui"})
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    # Raise the HTTP timeout so requests routed through aimock don't time out
+    # under normal load.  The default httpx timeout is too short when aimock
+    # is proxying to the upstream LLM — observed "Request timed out" errors
+    # that crash the agent run and trigger watchdog restarts.
+    model=OpenAIChat(id="gpt-4o", timeout=120),
     tools=[
         get_weather,
         query_data,
@@ -168,6 +172,8 @@ agent = Agent(
         search_flights,
         generate_a2ui,
     ],
+    # Prevent runaway tool-call loops — same guard as the ag2 package.
+    tool_call_limit=15,
     description="You are a helpful sales assistant for the CopilotKit showcase demos.",
     instructions="""
         SALES PIPELINE:


### PR DESCRIPTION
## Summary

- **ag2**: Add `max_consecutive_auto_reply=15` to `ConversableAgent` to prevent infinite tool-call loops that flood Railway's log stream at 500+ logs/sec and starve health probes
- **agno**: Raise `OpenAIChat` timeout from default to 120s (aimock proxy latency) and add `tool_call_limit=15` safety net

## Root Cause

**ag2 (9/12 ticks 503)**: AG2's `ConversableAgent` with `human_input_mode="NEVER"` has no built-in turn limit. When the LLM enters a repetitive tool-call pattern (observed: hundreds of `get_weather(Tokyo)` calls per second), the agent loops indefinitely. This generates 500+ log lines/sec hitting Railway's rate limit, the agent becomes unresponsive to health probes, the watchdog kills it after 90s, and the container restarts. Cycle repeats.

**agno (3/12 ticks 503)**: The agno `OpenAIChat` model uses httpx's default timeout, which is too short when requests route through the aimock proxy under load. Observed `"Error in Agent run: Request timed out."` in logs followed by agent restart. Less frequent than ag2 because it only happens under concurrent load.

## Test plan

- [ ] Deploy ag2 and agno via CI (push to main triggers showcase_deploy)
- [ ] Monitor health for 30 min post-deploy: `curl showcase-ag2-production.up.railway.app/api/health`
- [ ] Verify Railway logs no longer show rate-limit messages or infinite tool-call output
- [ ] Verify watchdog kill events drop to zero