### PR TITLE
fix(showcase): wire build-time env vars + flatten table alignment

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -224,7 +224,7 @@ jobs:
             {"dispatch_name":"starter-spring-ai","filter_key":"starter_spring_ai","context":"showcase/starters/spring-ai","image":"showcase-starter-spring-ai","railway_id":"3559ece3-7ba3-41ac-b24c-1f780133ec58","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"starter-strands","filter_key":"starter_strands","context":"showcase/starters/strands","image":"showcase-starter-strands","railway_id":"06db2bb8-e15d-4c6a-97ad-e14777c92d9f","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
             {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"}
           ]'
 
@@ -338,6 +338,12 @@ jobs:
           if [ -n "${{ matrix.service.build_args_sha }}" ]; then
             ARGS="COMMIT_SHA=${{ matrix.service.build_args_sha }}"
             ARGS="${ARGS}"$'\n'"BRANCH=${{ matrix.service.build_args_branch }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_pb_url }}" ]; then
+            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POCKETBASE_URL=${{ matrix.service.build_args_pb_url }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_shell_url }}" ]; then
+            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SHELL_URL=${{ matrix.service.build_args_shell_url }}"
           fi
           # Use delimiter to safely pass multiline value
           echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT

--- a/showcase/shell-dashboard/Dockerfile
+++ b/showcase/shell-dashboard/Dockerfile
@@ -28,10 +28,12 @@ COPY showcase/shell-dashboard/ ./shell-dashboard/
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 ENV NEXT_PUBLIC_BRANCH=${BRANCH}
 
-# Shell URL is inlined by Next.js at build time (NEXT_PUBLIC_*). Must be
-# provided as a build arg — a runtime env var on Railway is too late.
+# NEXT_PUBLIC_* vars are inlined by Next.js at build time. Must be
+# provided as Docker build args — runtime env vars on Railway are too late.
 ARG NEXT_PUBLIC_SHELL_URL
 ENV NEXT_PUBLIC_SHELL_URL=${NEXT_PUBLIC_SHELL_URL}
+ARG NEXT_PUBLIC_POCKETBASE_URL
+ENV NEXT_PUBLIC_POCKETBASE_URL=${NEXT_PUBLIC_POCKETBASE_URL}
 
 # Generate registry + docs status, then build Next.js
 RUN cd scripts && node node_modules/tsx/dist/cli.mjs generate-registry.ts \

--- a/showcase/shell-dashboard/package-lock.json
+++ b/showcase/shell-dashboard/package-lock.json
@@ -21,7 +21,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
-        "@vitejs/plugin-react": "^6.0.1",
+        "@vitejs/plugin-react": "^5.2.0",
         "jsdom": "^29.0.2",
         "postcss": "^8.5.0",
         "tailwindcss": "^4.0.0",
@@ -107,12 +107,178 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -123,9 +289,80 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -134,6 +371,54 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1748,9 +2033,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
-      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2136,6 +2421,51 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2182,29 +2512,24 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
-      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.7"
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "vite": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rolldown/plugin-babel": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        }
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2365,6 +2690,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2373,6 +2711,40 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2460,6 +2832,24 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -2494,6 +2884,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -2571,6 +2968,16 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2622,6 +3029,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2689,8 +3106,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.0.2",
@@ -2731,6 +3147,32 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -3042,6 +3484,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3140,6 +3589,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -3226,7 +3682,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3326,6 +3781,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -3720,6 +4185,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
@@ -3969,6 +4465,13 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/showcase/shell-dashboard/src/components/__tests__/collapsible-category.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/collapsible-category.test.tsx
@@ -1,9 +1,15 @@
 /**
  * Unit tests for CollapsibleCategory — expand/collapse, localStorage persist.
+ * Tests both the legacy CollapsibleCategory wrapper and the new
+ * useCollapsible hook + CategoryHeaderRow component.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
-import { CollapsibleCategory } from "../collapsible-category";
+import { render, fireEvent, renderHook, act } from "@testing-library/react";
+import {
+  CollapsibleCategory,
+  CategoryHeaderRow,
+  useCollapsible,
+} from "../collapsible-category";
 
 // Mock localStorage
 const storageMap = new Map<string, string>();
@@ -22,7 +28,7 @@ beforeEach(() => {
   });
 });
 
-describe("CollapsibleCategory", () => {
+describe("CollapsibleCategory (legacy wrapper)", () => {
   it("renders children when defaultOpen is true", () => {
     const { getByText } = render(
       <CollapsibleCategory name="Core" count="10/38" defaultOpen>
@@ -107,5 +113,104 @@ describe("CollapsibleCategory", () => {
     );
     const chevron = getByTestId("collapsible-chevron");
     expect(chevron).toBeDefined();
+  });
+});
+
+describe("useCollapsible hook", () => {
+  it("returns isOpen=true when defaultOpen and no localStorage", () => {
+    const { result } = renderHook(() =>
+      useCollapsible({ name: "HookTest", defaultOpen: true }),
+    );
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("returns isOpen=false when defaultOpen=false and no localStorage", () => {
+    const { result } = renderHook(() =>
+      useCollapsible({ name: "HookTest", defaultOpen: false }),
+    );
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("toggle flips state and persists to localStorage", () => {
+    const { result } = renderHook(() =>
+      useCollapsible({ name: "HookToggle", defaultOpen: true }),
+    );
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.toggle());
+    expect(result.current.isOpen).toBe(false);
+    expect(storageMap.get("dashboard-collapse-HookToggle")).toBe("collapsed");
+
+    act(() => result.current.toggle());
+    expect(result.current.isOpen).toBe(true);
+    expect(storageMap.get("dashboard-collapse-HookToggle")).toBe("expanded");
+  });
+
+  it("reads initial state from localStorage", () => {
+    storageMap.set("dashboard-collapse-Stored", "collapsed");
+    const { result } = renderHook(() =>
+      useCollapsible({ name: "Stored", defaultOpen: true }),
+    );
+    expect(result.current.isOpen).toBe(false);
+  });
+});
+
+describe("CategoryHeaderRow", () => {
+  it("renders name, count, and chevron inside a <tr>", () => {
+    const onToggle = vi.fn();
+    const { getByText, getByTestId } = render(
+      <table>
+        <tbody>
+          <CategoryHeaderRow
+            name="Chat & UI"
+            count="5/10"
+            colSpan={4}
+            isOpen={true}
+            onToggle={onToggle}
+          />
+        </tbody>
+      </table>,
+    );
+    expect(getByText("Chat & UI")).toBeDefined();
+    expect(getByText("5/10")).toBeDefined();
+    expect(getByTestId("collapsible-chevron")).toBeDefined();
+  });
+
+  it("calls onToggle when clicked", () => {
+    const onToggle = vi.fn();
+    const { getByTestId } = render(
+      <table>
+        <tbody>
+          <CategoryHeaderRow
+            name="Platform"
+            count="2/4"
+            colSpan={4}
+            isOpen={true}
+            onToggle={onToggle}
+          />
+        </tbody>
+      </table>,
+    );
+    fireEvent.click(getByTestId("collapsible-header"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets correct colSpan on the td", () => {
+    const { getByTestId } = render(
+      <table>
+        <tbody>
+          <CategoryHeaderRow
+            name="Core"
+            count="1/2"
+            colSpan={5}
+            isOpen={false}
+            onToggle={() => {}}
+          />
+        </tbody>
+      </table>,
+    );
+    const tr = getByTestId("collapsible-category");
+    const td = tr.querySelector("td");
+    expect(td?.getAttribute("colspan")).toBe("5");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -2,15 +2,18 @@
 /**
  * CellMatrix — 38-feature x 17-integration grid.
  *
- * Rows grouped by FeatureCategory using CollapsibleCategory.
+ * Rows grouped by FeatureCategory with collapsible category separators.
  * Integration columns auto-sorted by parity tier (reference first,
  * then at_parity, partial, minimal, not_wired), alphabetical within tier.
  * Each cell renders a DepthChip.
+ *
+ * Uses a single flat <table> — category headers and feature rows are
+ * sibling <tr> elements sharing the same column structure.
  */
 import { useMemo } from "react";
 import { DepthChip } from "./depth-chip";
 import { IntegrationHeader } from "./integration-header";
-import { CollapsibleCategory } from "./collapsible-category";
+import { useCollapsible, CategoryHeaderRow } from "./collapsible-category";
 import { deriveDepth, type CatalogCell } from "./depth-utils";
 import type { ParityTier } from "./parity-badge";
 import type { FilterMode } from "./filter-chips";
@@ -56,6 +59,102 @@ function sortIntegrations(integrations: IntegrationInfo[]): IntegrationInfo[] {
     return a.name.localeCompare(b.name);
   });
 }
+
+/* ------------------------------------------------------------------ */
+/*  CategorySection — one collapsible group of feature rows            */
+/* ------------------------------------------------------------------ */
+
+interface CategorySectionProps {
+  cat: FeatureCategory & { features: FeatureInfo[] };
+  visibleIntegrations: IntegrationInfo[];
+  cellIndex: Map<string, CatalogCell>;
+  liveStatus: LiveStatusMap;
+  defaultOpen: boolean;
+  filter: FilterMode;
+  filterFeatureRow: (featureId: string) => boolean;
+}
+
+function CategorySection({
+  cat,
+  visibleIntegrations,
+  cellIndex,
+  liveStatus,
+  defaultOpen,
+  filter,
+  filterFeatureRow,
+}: CategorySectionProps) {
+  const { isOpen, toggle } = useCollapsible({
+    name: cat.name,
+    defaultOpen,
+  });
+
+  const wiredInCat = cat.features.reduce((acc, f) => {
+    return (
+      acc +
+      visibleIntegrations.filter((int) => {
+        const cell = cellIndex.get(`${int.slug}/${f.id}`);
+        return cell?.status === "wired";
+      }).length
+    );
+  }, 0);
+  const totalInCat = cat.features.length * visibleIntegrations.length;
+
+  const visibleFeatures = cat.features.filter((f) => filterFeatureRow(f.id));
+  const displayFeatures =
+    filter === "all" || filter === "reference" ? cat.features : visibleFeatures;
+
+  return (
+    <>
+      <CategoryHeaderRow
+        name={cat.name}
+        count={`${wiredInCat}/${totalInCat}`}
+        colSpan={visibleIntegrations.length + 1}
+        isOpen={isOpen}
+        onToggle={toggle}
+      />
+      {isOpen &&
+        displayFeatures.map((feature) => (
+          <tr
+            key={feature.id}
+            className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+          >
+            <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-1.5 border-r border-[var(--border)] align-middle min-w-[200px]">
+              <span
+                className="text-xs text-[var(--text)]"
+                title={feature.name}
+              >
+                {feature.name}
+              </span>
+            </td>
+            {visibleIntegrations.map((int) => {
+              const cell = cellIndex.get(`${int.slug}/${feature.id}`);
+              const cellStatus = cell?.status ?? "unshipped";
+              const depth = cell
+                ? deriveDepth(cell, liveStatus)
+                : { achieved: 0, isRegression: false };
+
+              return (
+                <td
+                  key={int.slug}
+                  className="border-l border-[var(--border)] px-3 py-1.5 align-middle text-center"
+                >
+                  <DepthChip
+                    depth={depth.achieved as 0 | 1 | 2 | 3 | 4}
+                    status={cellStatus}
+                    regression={depth.isRegression}
+                  />
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  CellMatrix                                                         */
+/* ------------------------------------------------------------------ */
 
 export function CellMatrix({
   cells,
@@ -153,73 +252,17 @@ export function CellMatrix({
             );
             if (visibleFeatures.length === 0 && filter !== "all") return null;
 
-            // Count wired cells in this category for the count label
-            const wiredInCat = cat.features.reduce((acc, f) => {
-              return (
-                acc +
-                visibleIntegrations.filter((int) => {
-                  const cell = cellIndex.get(`${int.slug}/${f.id}`);
-                  return cell?.status === "wired";
-                }).length
-              );
-            }, 0);
-            const totalInCat = cat.features.length * visibleIntegrations.length;
-
             return (
-              <tr key={cat.id}>
-                <td colSpan={visibleIntegrations.length + 1} className="p-0">
-                  <CollapsibleCategory
-                    name={cat.name}
-                    count={`${wiredInCat}/${totalInCat}`}
-                    defaultOpen={defaultOpenCategories.has(cat.id)}
-                  >
-                    <table className="border-collapse text-sm w-full">
-                      <tbody>
-                        {(filter === "all" || filter === "reference"
-                          ? cat.features
-                          : visibleFeatures
-                        ).map((feature) => (
-                          <tr
-                            key={feature.id}
-                            className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
-                          >
-                            <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-1.5 border-r border-[var(--border)] align-middle min-w-[200px]">
-                              <span
-                                className="text-xs text-[var(--text)]"
-                                title={feature.name}
-                              >
-                                {feature.name}
-                              </span>
-                            </td>
-                            {visibleIntegrations.map((int) => {
-                              const cell = cellIndex.get(
-                                `${int.slug}/${feature.id}`,
-                              );
-                              const cellStatus = cell?.status ?? "unshipped";
-                              const depth = cell
-                                ? deriveDepth(cell, liveStatus)
-                                : { achieved: 0, isRegression: false };
-
-                              return (
-                                <td
-                                  key={int.slug}
-                                  className="border-l border-[var(--border)] px-3 py-1.5 align-middle text-center"
-                                >
-                                  <DepthChip
-                                    depth={depth.achieved as 0 | 1 | 2 | 3 | 4}
-                                    status={cellStatus}
-                                    regression={depth.isRegression}
-                                  />
-                                </td>
-                              );
-                            })}
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </CollapsibleCategory>
-                </td>
-              </tr>
+              <CategorySection
+                key={cat.id}
+                cat={cat}
+                visibleIntegrations={visibleIntegrations}
+                cellIndex={cellIndex}
+                liveStatus={liveStatus}
+                defaultOpen={defaultOpenCategories.has(cat.id)}
+                filter={filter}
+                filterFeatureRow={filterFeatureRow}
+              />
             );
           })}
         </tbody>

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -14,7 +14,8 @@ import { useMemo } from "react";
 import { DepthChip } from "./depth-chip";
 import { IntegrationHeader } from "./integration-header";
 import { useCollapsible, CategoryHeaderRow } from "./collapsible-category";
-import { deriveDepth, type CatalogCell } from "./depth-utils";
+import { deriveDepth } from "./depth-utils";
+import type { CatalogCell } from "./depth-utils";
 import type { ParityTier } from "./parity-badge";
 import type { FilterMode } from "./filter-chips";
 import type { LiveStatusMap } from "@/lib/live-status";
@@ -119,10 +120,7 @@ function CategorySection({
             className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
           >
             <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-1.5 border-r border-[var(--border)] align-middle min-w-[200px]">
-              <span
-                className="text-xs text-[var(--text)]"
-                title={feature.name}
-              >
+              <span className="text-xs text-[var(--text)]" title={feature.name}>
                 {feature.name}
               </span>
             </td>

--- a/showcase/shell-dashboard/src/components/collapsible-category.tsx
+++ b/showcase/shell-dashboard/src/components/collapsible-category.tsx
@@ -1,18 +1,16 @@
 "use client";
 /**
- * CollapsibleCategory — wraps content with expand/collapse header.
+ * CollapsibleCategory — headless hook + header-row component for
+ * flat table layouts with expand/collapse per category.
  *
  * Collapse state is persisted in localStorage using the key
  * `dashboard-collapse-{name}`.
  */
 import { useState } from "react";
 
-export interface CollapsibleCategoryProps {
-  name: string;
-  count: string;
-  defaultOpen: boolean;
-  children: React.ReactNode;
-}
+/* ------------------------------------------------------------------ */
+/*  localStorage helpers                                               */
+/* ------------------------------------------------------------------ */
 
 function readStorage(name: string, fallback: boolean): boolean {
   try {
@@ -36,19 +34,110 @@ function writeStorage(name: string, open: boolean): void {
   }
 }
 
+/* ------------------------------------------------------------------ */
+/*  useCollapsible hook                                                */
+/* ------------------------------------------------------------------ */
+
+export interface UseCollapsibleOptions {
+  name: string;
+  defaultOpen: boolean;
+}
+
+export interface UseCollapsibleReturn {
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+/**
+ * Headless hook for collapse state with localStorage persistence.
+ */
+export function useCollapsible({
+  name,
+  defaultOpen,
+}: UseCollapsibleOptions): UseCollapsibleReturn {
+  const [isOpen, setIsOpen] = useState(() => readStorage(name, defaultOpen));
+
+  const toggle = () => {
+    const next = !isOpen;
+    setIsOpen(next);
+    writeStorage(name, next);
+  };
+
+  return { isOpen, toggle };
+}
+
+/* ------------------------------------------------------------------ */
+/*  CategoryHeaderRow — renders the clickable <tr> separator           */
+/* ------------------------------------------------------------------ */
+
+export interface CategoryHeaderRowProps {
+  name: string;
+  count: string;
+  colSpan: number;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * A `<tr>` that spans the full table width and acts as a collapsible
+ * category separator. Renders a chevron, category name, and count.
+ */
+export function CategoryHeaderRow({
+  name,
+  count,
+  colSpan,
+  isOpen,
+  onToggle,
+}: CategoryHeaderRowProps) {
+  return (
+    <tr data-testid="collapsible-category">
+      <td colSpan={colSpan} className="p-0">
+        <button
+          type="button"
+          data-testid="collapsible-header"
+          onClick={onToggle}
+          className="w-full flex items-center gap-2 px-4 py-2 text-left bg-[var(--bg-muted)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
+        >
+          <span
+            data-testid="collapsible-chevron"
+            className={`inline-block text-[10px] text-[var(--text-muted)] transition-transform duration-200 ${isOpen ? "rotate-90" : "rotate-0"}`}
+          >
+            &#9654;
+          </span>
+          <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+            {name}
+          </span>
+          <span className="text-[10px] tabular-nums text-[var(--text-muted)]">
+            {count}
+          </span>
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Legacy wrapper (backward compat for tests / other consumers)       */
+/* ------------------------------------------------------------------ */
+
+export interface CollapsibleCategoryProps {
+  name: string;
+  count: string;
+  defaultOpen: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Legacy wrapper that renders a `<div>` with collapse behavior.
+ * Prefer useCollapsible + CategoryHeaderRow for flat table layouts.
+ */
 export function CollapsibleCategory({
   name,
   count,
   defaultOpen,
   children,
 }: CollapsibleCategoryProps) {
-  const [open, setOpen] = useState(() => readStorage(name, defaultOpen));
-
-  const toggle = () => {
-    const next = !open;
-    setOpen(next);
-    writeStorage(name, next);
-  };
+  const { isOpen, toggle } = useCollapsible({ name, defaultOpen });
 
   return (
     <div data-testid="collapsible-category">
@@ -60,7 +149,7 @@ export function CollapsibleCategory({
       >
         <span
           data-testid="collapsible-chevron"
-          className={`inline-block text-[10px] text-[var(--text-muted)] transition-transform duration-200 ${open ? "rotate-90" : "rotate-0"}`}
+          className={`inline-block text-[10px] text-[var(--text-muted)] transition-transform duration-200 ${isOpen ? "rotate-90" : "rotate-0"}`}
         >
           &#9654;
         </span>
@@ -71,7 +160,7 @@ export function CollapsibleCategory({
           {count}
         </span>
       </button>
-      {open && children}
+      {isOpen && children}
     </div>
   );
 }

--- a/showcase/shell-dashboard/src/components/parity-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/parity-matrix.tsx
@@ -4,13 +4,16 @@
  *
  * The reference integration's depth appears as a frozen first column
  * labeled "Ref Depth" regardless of alphabetical position. Each cell
- * shows a DepthChip colored by parity tier. Same CollapsibleCategory
+ * shows a DepthChip colored by parity tier. Same collapsible category
  * grouping as CellMatrix.
+ *
+ * Uses a single flat <table> — category headers and feature rows are
+ * sibling <tr> elements sharing the same column structure.
  */
 import { useMemo } from "react";
 import { DepthChip } from "./depth-chip";
 import { IntegrationHeader } from "./integration-header";
-import { CollapsibleCategory } from "./collapsible-category";
+import { useCollapsible, CategoryHeaderRow } from "./collapsible-category";
 import { deriveDepth, type CatalogCell } from "./depth-utils";
 import type { ParityTier } from "./parity-badge";
 import type { LiveStatusMap } from "@/lib/live-status";
@@ -54,6 +57,113 @@ function sortIntegrations(integrations: IntegrationInfo[]): IntegrationInfo[] {
     return a.name.localeCompare(b.name);
   });
 }
+
+/* ------------------------------------------------------------------ */
+/*  CategorySection — one collapsible group of feature rows            */
+/* ------------------------------------------------------------------ */
+
+interface ParityCategorySectionProps {
+  cat: FeatureCategory & { features: FeatureInfo[] };
+  nonRefIntegrations: IntegrationInfo[];
+  sortedIntegrations: IntegrationInfo[];
+  cellIndex: Map<string, CatalogCell>;
+  liveStatus: LiveStatusMap;
+  defaultOpen: boolean;
+  referenceSlug: string;
+}
+
+function ParityCategorySection({
+  cat,
+  nonRefIntegrations,
+  sortedIntegrations,
+  cellIndex,
+  liveStatus,
+  defaultOpen,
+  referenceSlug,
+}: ParityCategorySectionProps) {
+  const { isOpen, toggle } = useCollapsible({
+    name: cat.name,
+    defaultOpen,
+  });
+
+  const wiredInCat = cat.features.reduce((acc, f) => {
+    return (
+      acc +
+      sortedIntegrations.filter((int) => {
+        const cell = cellIndex.get(`${int.slug}/${f.id}`);
+        return cell?.status === "wired";
+      }).length
+    );
+  }, 0);
+  const totalInCat = cat.features.length * sortedIntegrations.length;
+
+  // colSpan = Feature col + Ref Depth col + non-ref integration cols
+  const colSpan = nonRefIntegrations.length + 2;
+
+  return (
+    <>
+      <CategoryHeaderRow
+        name={cat.name}
+        count={`${wiredInCat}/${totalInCat}`}
+        colSpan={colSpan}
+        isOpen={isOpen}
+        onToggle={toggle}
+      />
+      {isOpen &&
+        cat.features.map((feature) => {
+          const refCell = cellIndex.get(`${referenceSlug}/${feature.id}`);
+          const refStatus = refCell?.status ?? "unshipped";
+          const refDepth = refCell
+            ? deriveDepth(refCell, liveStatus)
+            : { achieved: 0, isRegression: false };
+
+          return (
+            <tr
+              key={feature.id}
+              className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+            >
+              <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-1.5 border-r border-[var(--border)] align-middle min-w-[200px]">
+                <span className="text-xs text-[var(--text)]">
+                  {feature.name}
+                </span>
+              </td>
+              <td className="border-l border-[var(--border)] px-3 py-1.5 align-middle text-center bg-purple-900/5">
+                <DepthChip
+                  depth={refDepth.achieved as 0 | 1 | 2 | 3 | 4}
+                  status={refStatus}
+                  regression={refDepth.isRegression}
+                />
+              </td>
+              {nonRefIntegrations.map((int) => {
+                const cell = cellIndex.get(`${int.slug}/${feature.id}`);
+                const cellStatus = cell?.status ?? "unshipped";
+                const depth = cell
+                  ? deriveDepth(cell, liveStatus)
+                  : { achieved: 0, isRegression: false };
+
+                return (
+                  <td
+                    key={int.slug}
+                    className="border-l border-[var(--border)] px-3 py-1.5 align-middle text-center"
+                  >
+                    <DepthChip
+                      depth={depth.achieved as 0 | 1 | 2 | 3 | 4}
+                      status={cellStatus}
+                      regression={depth.isRegression}
+                    />
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ParityMatrix                                                       */
+/* ------------------------------------------------------------------ */
 
 export function ParityMatrix({
   cells,
@@ -125,88 +235,18 @@ export function ParityMatrix({
           </tr>
         </thead>
         <tbody>
-          {featuresByCategory.map((cat) => {
-            const wiredInCat = cat.features.reduce((acc, f) => {
-              return (
-                acc +
-                sortedIntegrations.filter((int) => {
-                  const cell = cellIndex.get(`${int.slug}/${f.id}`);
-                  return cell?.status === "wired";
-                }).length
-              );
-            }, 0);
-            const totalInCat = cat.features.length * sortedIntegrations.length;
-
-            return (
-              <tr key={cat.id}>
-                <td colSpan={nonRefIntegrations.length + 2} className="p-0">
-                  <CollapsibleCategory
-                    name={cat.name}
-                    count={`${wiredInCat}/${totalInCat}`}
-                    defaultOpen={defaultOpenCategories.has(cat.id)}
-                  >
-                    <table className="border-collapse text-sm w-full">
-                      <tbody>
-                        {cat.features.map((feature) => {
-                          const refCell = cellIndex.get(
-                            `${referenceSlug}/${feature.id}`,
-                          );
-                          const refStatus = refCell?.status ?? "unshipped";
-                          const refDepth = refCell
-                            ? deriveDepth(refCell, liveStatus)
-                            : { achieved: 0, isRegression: false };
-
-                          return (
-                            <tr
-                              key={feature.id}
-                              className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
-                            >
-                              <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-1.5 border-r border-[var(--border)] align-middle min-w-[200px]">
-                                <span className="text-xs text-[var(--text)]">
-                                  {feature.name}
-                                </span>
-                              </td>
-                              <td className="border-l border-[var(--border)] px-3 py-1.5 align-middle text-center bg-purple-900/5">
-                                <DepthChip
-                                  depth={refDepth.achieved as 0 | 1 | 2 | 3 | 4}
-                                  status={refStatus}
-                                  regression={refDepth.isRegression}
-                                />
-                              </td>
-                              {nonRefIntegrations.map((int) => {
-                                const cell = cellIndex.get(
-                                  `${int.slug}/${feature.id}`,
-                                );
-                                const cellStatus = cell?.status ?? "unshipped";
-                                const depth = cell
-                                  ? deriveDepth(cell, liveStatus)
-                                  : { achieved: 0, isRegression: false };
-
-                                return (
-                                  <td
-                                    key={int.slug}
-                                    className="border-l border-[var(--border)] px-3 py-1.5 align-middle text-center"
-                                  >
-                                    <DepthChip
-                                      depth={
-                                        depth.achieved as 0 | 1 | 2 | 3 | 4
-                                      }
-                                      status={cellStatus}
-                                      regression={depth.isRegression}
-                                    />
-                                  </td>
-                                );
-                              })}
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </CollapsibleCategory>
-                </td>
-              </tr>
-            );
-          })}
+          {featuresByCategory.map((cat) => (
+            <ParityCategorySection
+              key={cat.id}
+              cat={cat}
+              nonRefIntegrations={nonRefIntegrations}
+              sortedIntegrations={sortedIntegrations}
+              cellIndex={cellIndex}
+              liveStatus={liveStatus}
+              defaultOpen={defaultOpenCategories.has(cat.id)}
+              referenceSlug={referenceSlug}
+            />
+          ))}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary

Batched fix for three dashboard issues found during post-deploy verification:

1. **PB URL not baked into build** — `NEXT_PUBLIC_POCKETBASE_URL` was never declared as a Docker `ARG` or passed in `showcase_deploy.yml`. Every deploy produced a bundle where `pbIsMisconfigured = true`, showing "dashboard unavailable" on all tabs. Adds the ARG to Dockerfile and the build arg to the CI matrix.

2. **Column misalignment** — Cell and Parity matrix tables used nested `<table>` inside `colSpan` cells, causing data columns to float independently of headers. Replaced with flat `<tr>` siblings using a `useCollapsible` hook.

3. **Lockfile mismatch** — `package-lock.json` still pinned `@vitejs/plugin-react@6.0.1` after the `package.json` downgrade to `^5.2.0` in PR #4241. Regenerated.

## Test plan
- [x] Local Docker build with `--build-arg NEXT_PUBLIC_POCKETBASE_URL=...` — passes
- [x] Vitest: 130/130 tests pass (alignment fix tests included)
- [ ] CI: showcase_deploy workflow builds with env vars
- [ ] Live: dashboard.showcase.copilotkit.ai tabs show real PB data