### PR TITLE
fix(showcase): use single PB subscription to prevent SSE connection race

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -11,19 +11,11 @@ import { TabShell, type TabDef } from "@/components/tab-shell";
 import { CellsView } from "@/components/cells-view";
 import { ParityView } from "@/components/parity-view";
 import { useLiveStatus } from "@/hooks/useLiveStatus";
-import { mergeRowsToMap, type ConnectionStatus } from "@/lib/live-status";
+import { mergeRowsToMap } from "@/lib/live-status";
 import catalog from "@/data/catalog.json";
 import type { CatalogData } from "@/data/catalog-types";
 
 const catalogData = catalog as unknown as CatalogData;
-
-function aggregateConnection(
-  ...statuses: ConnectionStatus[]
-): ConnectionStatus {
-  if (statuses.some((s) => s === "error")) return "error";
-  if (statuses.some((s) => s === "connecting")) return "connecting";
-  return "live";
-}
 
 function Cell(ctx: CellContext) {
   const isTesting = ctx.feature.kind === "testing";
@@ -66,47 +58,17 @@ function Cell(ctx: CellContext) {
 }
 
 export default function Page() {
-  // Seven subscriptions shared across all tabs (lifted from FeatureGrid).
-  // Six are the Phase 3 originals; "e2e" is new for D3 per-cell data.
-  const smoke = useLiveStatus("smoke");
-  const health = useLiveStatus("health");
-  const e2eSmoke = useLiveStatus("e2e_smoke");
-  const agent = useLiveStatus("agent");
-  const chat = useLiveStatus("chat");
-  const tools = useLiveStatus("tools");
-  const e2e = useLiveStatus("e2e");
+  // Single subscription for ALL dimensions — no filter. Avoids the 7-way
+  // SSE race that caused PB subscribe 400s when 7 hooks competed for the
+  // single PB SDK realtime connection during hydration.
+  const allStatus = useLiveStatus();
 
   const liveStatus = useMemo(
-    () =>
-      mergeRowsToMap(
-        smoke.rows,
-        health.rows,
-        e2eSmoke.rows,
-        agent.rows,
-        chat.rows,
-        tools.rows,
-        e2e.rows,
-      ),
-    [
-      smoke.rows,
-      health.rows,
-      e2eSmoke.rows,
-      agent.rows,
-      chat.rows,
-      tools.rows,
-      e2e.rows,
-    ],
+    () => mergeRowsToMap(allStatus.rows),
+    [allStatus.rows],
   );
 
-  const connection = aggregateConnection(
-    smoke.status,
-    health.status,
-    e2eSmoke.status,
-    agent.status,
-    chat.status,
-    tools.status,
-    e2e.status,
-  );
+  const connection = allStatus.status;
 
   const tabs: TabDef[] = useMemo(
     () => [


### PR DESCRIPTION
## Summary

Fixes the "dashboard unavailable" banner that appeared on all dashboard tabs after fresh deploys.

**Root cause:** Seven concurrent `useLiveStatus()` hooks each opened their own PocketBase SSE connection during React hydration. The PB SDK multiplexes subscriptions over a single EventSource, but the concurrent `subscribe()` calls raced the initial SSE handshake — some `POST /api/realtime` calls fired before the `clientId` was available, returning HTTP 400. After 3 retry attempts, the affected hooks set `connection="error"`, triggering the offline banner.

**Fix:** Replace 7 per-dimension hooks with a single `useLiveStatus()` call (no dimension filter). All status rows are fetched in one subscription. The existing `keyFor()` lookups filter by dimension implicitly at the component level. This:
- Eliminates the 7-way SSE race condition
- Reduces PB connections from 7 to 1
- Removes the `aggregateConnection` helper (no longer needed)

## Test plan
- [x] Verified live at dashboard.showcase.copilotkit.ai via Playwright:
  - Zero "unavailable" banners across all 4 tabs
  - Coverage: 170 green L1-L4 chips
  - Cells: 48 D4 + 96 D2 + 128 unshipped chips, stats correct
  - Parity: 62 D4 + 192 D2 + 256 unshipped, Ref Depth column present
  - Packages: 17 D4 depth chips, all L1-L4 green
- [x] Docker build passes locally with PB URL build arg