### PR TITLE
feat(showcase-ops): widen e2e-demos probe to all integrations

### DIFF
--- a/showcase/ops/config/probes/e2e-demos.yml
+++ b/showcase/ops/config/probes/e2e-demos.yml
@@ -122,19 +122,16 @@
 kind: e2e_demos
 id: e2e-demos
 schedule: "0 */6 * * *"
-timeout_ms: 600000
-max_concurrency: 1
+timeout_ms: 900000
+max_concurrency: 2
 discovery:
   source: railway-services
   filter:
-    # Wave 1 scope: matches only `showcase-langgraph-python`. The
-    # prefix is unique — `-typescript` / `-fastapi` siblings do NOT
-    # start with `-python`. Widen by relaxing to `"showcase-"` when
-    # additional packages' E2E routes land; the infra excludes below
-    # already drop the non-demo services from the fan-out. The driver
+    # Full fleet scope: matches all `showcase-*` Railway services.
+    # The infra excludes below drop non-demo services. The driver
     # strips the `showcase-` prefix internally to derive the slug
-    # used in side-emit keys (`e2e:langgraph-python/<featureId>`).
-    namePrefix: "showcase-langgraph-python"
+    # used in side-emit keys (`e2e:<slug>/<featureId>`).
+    namePrefix: "showcase-"
     # Infra exclude list — inert at Wave 1 scope (the tight prefix
     # already drops them) but authored up-front so a future scope
     # widening doesn't accidentally fan out to these non-demo


### PR DESCRIPTION
## Summary

Two fixes:

1. **Widen e2e-demos probe to all integrations** — relaxes the `namePrefix` filter from `"showcase-langgraph-python"` (Wave 1) to `"showcase-"` (full fleet). All 17 integrations now get per-demo D3 structural checks. Also bumps `max_concurrency` to 2 and `timeout_ms` to 900s.

2. **Fix starter deployed smoke CI** — the test imports `registry.json` which is now gitignored (since PR #4236). Adds a generate-registry step before the Playwright run. Fixes the repeating "Starter Deployed Smoke Test Failed — job-level error" alerts in #oss-alerts.

## Test plan
- [ ] Next e2e-demos tick produces `e2e:<slug>/<featureId>` rows for all integrations
- [ ] Starter deployed smoke CI run passes (no more "Cannot find module" error)