### PR TITLE
fix(ci): generate registry.json before starter deployed smoke tests

### DIFF
--- a/.github/workflows/test_smoke-starter-deployed.yml
+++ b/.github/workflows/test_smoke-starter-deployed.yml
@@ -69,6 +69,10 @@ jobs:
         run: npm ci
         working-directory: showcase/tests
 
+      - name: Generate registry data
+        run: |
+          cd showcase/scripts && npm ci && node node_modules/tsx/dist/cli.mjs generate-registry.ts
+
       - name: Install Playwright
         working-directory: showcase/tests
         run: npx playwright install chromium --with-deps


### PR DESCRIPTION
## Summary

Fixes the repeating "Starter Deployed Smoke Test Failed — 0 failure(s) — job-level error" alerts in #oss-alerts.

**Root cause:** `integration-smoke.spec.ts` imports `registry.json`, which is now gitignored (generated at build time, removed from tracking in PR #4236). The CI workflow didn't run the generator before tests, so the import fails with "Cannot find module."

**Fix:** Add a `generate-registry` step before the Playwright test run.

## Test plan
- [ ] Next scheduled run (or manual dispatch) passes without "Cannot find module" error
- [ ] #oss-alerts stops receiving "job-level error" messages