### PR TITLE
fix(showcase/langgraph-python): lazy-init voice runtime to unblock Railway deploys

### DIFF
--- a/showcase/packages/langgraph-python/src/app/api/copilotkit-voice/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/copilotkit-voice/route.ts
@@ -35,34 +35,40 @@ const voiceDemoAgent = new LangGraphAgent({
   langsmithApiKey: process.env.LANGSMITH_API_KEY || "",
 });
 
-// Construct the OpenAI client lazily so the bundle can be built even when
-// OPENAI_API_KEY is not set at build time. Whisper calls only fire when the
-// user triggers transcription at runtime on Railway.
-const transcriptionService = new TranscriptionServiceOpenAI({
-  openai: new OpenAI({ apiKey: process.env.OPENAI_API_KEY }),
-});
-
-const runtime = new CopilotRuntime({
-  // @ts-ignore -- see main route.ts: published CopilotRuntime agents type
-  // wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain
-  // Records; fixed in source, pending release.
-  agents: {
-    // The page mounts <CopilotKit agent="voice-demo">; resolve that to the
-    // neutral sample_agent graph.
-    "voice-demo": voiceDemoAgent,
-    // useAgent() with no args defaults to "default"; alias so any internal
-    // default-agent lookups resolve against the same graph.
-    default: voiceDemoAgent,
-  },
-  transcriptionService,
-});
+// Construct the OpenAI client + runtime lazily on first request so the
+// Next.js build step (which imports and page-data-collects every route
+// module) can complete even when OPENAI_API_KEY is not set in the Docker
+// build context. Whisper calls only fire when the user triggers
+// transcription at runtime on Railway, where the env var is set.
+let cachedRuntime: CopilotRuntime | null = null;
+function getRuntime(): CopilotRuntime {
+  if (cachedRuntime) return cachedRuntime;
+  const transcriptionService = new TranscriptionServiceOpenAI({
+    openai: new OpenAI({ apiKey: process.env.OPENAI_API_KEY }),
+  });
+  cachedRuntime = new CopilotRuntime({
+    // @ts-ignore -- see main route.ts: published CopilotRuntime agents type
+    // wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain
+    // Records; fixed in source, pending release.
+    agents: {
+      // The page mounts <CopilotKit agent="voice-demo">; resolve that to
+      // the neutral sample_agent graph.
+      "voice-demo": voiceDemoAgent,
+      // useAgent() with no args defaults to "default"; alias so any internal
+      // default-agent lookups resolve against the same graph.
+      default: voiceDemoAgent,
+    },
+    transcriptionService,
+  });
+  return cachedRuntime;
+}
 
 export const POST = async (req: NextRequest) => {
   try {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-voice",
       serviceAdapter: new ExperimentalEmptyAdapter(),
-      runtime,
+      runtime: getRuntime(),
     });
     return await handleRequest(req);
   } catch (error: unknown) {


### PR DESCRIPTION
## Problem

Every \`showcase-langgraph-python\` deploy has been **failing** since #4224 (voice demo) merged:

\`\`\`
[Error: Failed to collect page data for /api/copilotkit-voice]
Missing credentials. Please pass an \`apiKey\`, or set the \`OPENAI_API_KEY\` environment variable.
Error: failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1
\`\`\`

Root cause: the voice route was instantiating \`new OpenAI({ apiKey: process.env.OPENAI_API_KEY })\` at module scope. Next.js runs route modules at build time to collect page/route data, and the Docker build context does **not** have \`OPENAI_API_KEY\` set (only the running container does), so the SDK's constructor throws and the build fails.

## Fix

Wrap the \`OpenAI\` + \`TranscriptionServiceOpenAI\` + \`CopilotRuntime\` construction in a \`getRuntime()\` function that runs on the first request. Cached after first call so there's no per-request cost.

Affects only \`/api/copilotkit-voice\`. Runtime behavior is unchanged; this is a pure build-time-safety fix. The comment on the original code already said "construct lazily" — the code just didn't match the comment.

## Why this blocks everything

Railway auto-deploys on every push to \`main\` under \`showcase/**\`. While this route fails \`npm run build\`, the langgraph-python container can't be pushed to Railway, which means:

- Voice, multimodal, auth, agent-config, byoc-hashbrown, byoc-json-render demos all ship nothing new to Railway — every merge since #4224 has been failing the deploy.
- The dashboard at \`dashboard.showcase.copilotkit.ai\` won't reflect any of Waves 2b-4b until this lands.

## Test plan

- [ ] Validate Showcase CI passes
- [ ] Container builds locally with \`docker build\` (or CI build job) when \`OPENAI_API_KEY\` is unset in the build context
- [ ] Post-merge: \`showcase_deploy.yml\` run for \`langgraph-python\` succeeds
- [ ] Post-deploy: \`/api/copilotkit-voice\` responds normally (first-request init still works)