### PR TITLE
feat(showcase/langroid): parity demos (chat chrome, frontend-tools, hitl-in-app, reasoning, readonly-context)

### DIFF
--- a/showcase/packages/langroid/PARITY_NOTES.md
+++ b/showcase/packages/langroid/PARITY_NOTES.md
@@ -8,6 +8,7 @@ Canonical list: 36 demos (excluding `cli-start`).
 ## Ported in this pass (batch B4)
 
 ### Pre-existing
+
 - agentic-chat
 - hitl-in-chat (route: `/demos/hitl`)
 - tool-rendering
@@ -18,6 +19,7 @@ Canonical list: 36 demos (excluding `cli-start`).
 - subagents
 
 ### Added in this pass
+
 - chat-customization-css
 - prebuilt-sidebar
 - prebuilt-popup

--- a/showcase/packages/langroid/PARITY_NOTES.md
+++ b/showcase/packages/langroid/PARITY_NOTES.md
@@ -1,0 +1,68 @@
+# Langroid showcase — parity notes
+
+Tracks demos from the canonical `showcase/packages/langgraph-python/manifest.yaml`
+that are either deliberately skipped or deferred for the Langroid integration.
+
+Canonical list: 36 demos (excluding `cli-start`).
+
+## Ported in this pass (batch B4)
+
+### Pre-existing
+- agentic-chat
+- hitl-in-chat (route: `/demos/hitl`)
+- tool-rendering
+- gen-ui-tool-based
+- gen-ui-agent
+- shared-state-read-write
+- shared-state-streaming
+- subagents
+
+### Added in this pass
+- chat-customization-css
+- prebuilt-sidebar
+- prebuilt-popup
+- chat-slots
+- headless-simple
+- frontend-tools
+- frontend-tools-async
+- hitl-in-app
+- agentic-chat-reasoning
+- reasoning-default-render
+- readonly-state-agent-context
+
+## Skipped — Langroid does not currently support
+
+- **gen-ui-interrupt** — the canonical implementation uses
+  `useLangGraphInterrupt` + LangGraph's interrupt lifecycle (`interrupt()`
+  node, resume with `Command(resume=...)`). Langroid has no equivalent
+  interrupt primitive in its `ChatAgent` / `Task` model; the AG-UI adapter
+  here does not emit interrupt events.
+- **interrupt-headless** — same reasoning as `gen-ui-interrupt`; this is the
+  headless variant of the same LangGraph-specific primitive.
+
+## Deferred — portable in principle, requires additional backend or BYOC work
+
+These demos are portable to Langroid but were not implemented in this batch
+due to scope. Each requires either a dedicated route and renderer or a
+bespoke backend tool beyond the unified agent.
+
+- **tool-rendering-default-catchall** — backend tool surface exists via
+  the agent's existing tools; requires the default-catchall variant of the
+  tool-rendering page.
+- **tool-rendering-custom-catchall** — same, with `useDefaultRenderTool`.
+- **tool-rendering-reasoning-chain** — requires sequential tool-call + reasoning
+  emission from the Langroid adapter.
+- **declarative-gen-ui** — A2UI dynamic schema already has a planner in
+  `agent.py` (`GenerateA2UITool`); needs the frontend catalog + renderers page.
+- **a2ui-fixed-schema** — needs a dedicated agent and schema JSON.
+- **mcp-apps** — Langroid does expose MCP support, but the canonical demo is
+  tightly coupled to LangGraph activity-message emission; deferred.
+- **byoc-json-render** — requires a dedicated BYOC route + json-render catalog.
+- **byoc-hashbrown** — requires a dedicated BYOC route + hashbrown structured-output pipeline.
+- **beautiful-chat** — requires a dedicated combined runtime (openGenerativeUI + a2ui + mcpApps).
+- **multimodal** — requires a vision-capable agent pipeline + dedicated route.
+- **auth** — requires a dedicated auth-gated runtime route.
+- **voice** — requires the voice-enabled runtime route + sample audio asset.
+- **open-gen-ui / open-gen-ui-advanced** — require a dedicated OGUI runtime route.
+- **agent-config** — requires typed-config forwarding to the agent's system prompt.
+- **headless-complete** — depends on the mcp-apps runtime + Excalidraw MCP.

--- a/showcase/packages/langroid/PARITY_NOTES.md
+++ b/showcase/packages/langroid/PARITY_NOTES.md
@@ -39,8 +39,9 @@ Canonical list: 36 demos (excluding `cli-start`).
 - declarative-gen-ui (A2UI dynamic schema — reuses agent's `generate_a2ui` tool)
 - auth (dedicated `/api/copilotkit-auth` route with `onRequest` hook)
 - headless-complete (frontend-only, reuses unified runtime)
-- agent-config (frontend + dedicated route; Langroid backend does not yet
-  consume forwarded `properties` — see "Known limitations" below)
+- agent-config (frontend + dedicated route + backend wired end-to-end;
+  `forwardedProps.config.configurable.properties` steers the agent's
+  system prompt per run)
 
 ## Skipped — Langroid lacks the framework primitive
 
@@ -86,10 +87,6 @@ pick them up without re-litigating scope.
 
 ## Known limitations
 
-- **agent-config**: the frontend + runtime route are in place. The Langroid
-  backend (`src/agents/agui_adapter.py`) does not currently read
-  `RunAgentInput.forwarded_props` and pass them into the ChatAgent's system
-  prompt, so changing tone / expertise / response length in the config card
-  does not yet change agent behavior. Wiring this requires extending the
-  adapter to read forwarded props and the agent's system-prompt builder to
-  consume them — tracked as follow-up work.
+(none currently tracked — previous agent-config backend gap was closed by
+propagating upstream PR #4271's forwardedProps repack + backend system-
+prompt wiring.)

--- a/showcase/packages/langroid/PARITY_NOTES.md
+++ b/showcase/packages/langroid/PARITY_NOTES.md
@@ -5,9 +5,9 @@ that are either deliberately skipped or deferred for the Langroid integration.
 
 Canonical list: 36 demos (excluding `cli-start`).
 
-## Ported in this pass (batch B4)
+## Ported
 
-### Pre-existing
+### Wave 1 (initial scaffold)
 
 - agentic-chat
 - hitl-in-chat (route: `/demos/hitl`)
@@ -18,7 +18,7 @@ Canonical list: 36 demos (excluding `cli-start`).
 - shared-state-streaming
 - subagents
 
-### Added in this pass
+### Wave 2 (chat chrome + reasoning)
 
 - chat-customization-css
 - prebuilt-sidebar
@@ -32,39 +32,64 @@ Canonical list: 36 demos (excluding `cli-start`).
 - reasoning-default-render
 - readonly-state-agent-context
 
-## Skipped — Langroid does not currently support
+### Wave 3 (batch B4 second pass)
 
-- **gen-ui-interrupt** — the canonical implementation uses
-  `useLangGraphInterrupt` + LangGraph's interrupt lifecycle (`interrupt()`
-  node, resume with `Command(resume=...)`). Langroid has no equivalent
-  interrupt primitive in its `ChatAgent` / `Task` model; the AG-UI adapter
-  here does not emit interrupt events.
-- **interrupt-headless** — same reasoning as `gen-ui-interrupt`; this is the
-  headless variant of the same LangGraph-specific primitive.
+- tool-rendering-default-catchall
+- tool-rendering-custom-catchall
+- declarative-gen-ui (A2UI dynamic schema — reuses agent's `generate_a2ui` tool)
+- auth (dedicated `/api/copilotkit-auth` route with `onRequest` hook)
+- headless-complete (frontend-only, reuses unified runtime)
+- agent-config (frontend + dedicated route; Langroid backend does not yet
+  consume forwarded `properties` — see "Known limitations" below)
 
-## Deferred — portable in principle, requires additional backend or BYOC work
+## Skipped — Langroid lacks the framework primitive
 
-These demos are portable to Langroid but were not implemented in this batch
-due to scope. Each requires either a dedicated route and renderer or a
-bespoke backend tool beyond the unified agent.
+- **gen-ui-interrupt** — uses `useLangGraphInterrupt` + LangGraph's
+  `interrupt()` node + `Command(resume=...)` lifecycle. Langroid has no
+  equivalent interrupt primitive and the current AG-UI adapter emits no
+  interrupt events.
+- **interrupt-headless** — same reason as `gen-ui-interrupt`.
 
-- **tool-rendering-default-catchall** — backend tool surface exists via
-  the agent's existing tools; requires the default-catchall variant of the
-  tool-rendering page.
-- **tool-rendering-custom-catchall** — same, with `useDefaultRenderTool`.
-- **tool-rendering-reasoning-chain** — requires sequential tool-call + reasoning
-  emission from the Langroid adapter.
-- **declarative-gen-ui** — A2UI dynamic schema already has a planner in
-  `agent.py` (`GenerateA2UITool`); needs the frontend catalog + renderers page.
-- **a2ui-fixed-schema** — needs a dedicated agent and schema JSON.
-- **mcp-apps** — Langroid does expose MCP support, but the canonical demo is
-  tightly coupled to LangGraph activity-message emission; deferred.
-- **byoc-json-render** — requires a dedicated BYOC route + json-render catalog.
-- **byoc-hashbrown** — requires a dedicated BYOC route + hashbrown structured-output pipeline.
-- **beautiful-chat** — requires a dedicated combined runtime (openGenerativeUI + a2ui + mcpApps).
-- **multimodal** — requires a vision-capable agent pipeline + dedicated route.
-- **auth** — requires a dedicated auth-gated runtime route.
-- **voice** — requires the voice-enabled runtime route + sample audio asset.
-- **open-gen-ui / open-gen-ui-advanced** — require a dedicated OGUI runtime route.
-- **agent-config** — requires typed-config forwarding to the agent's system prompt.
-- **headless-complete** — depends on the mcp-apps runtime + Excalidraw MCP.
+## Deferred — portable in principle, requires additional agent or runtime work
+
+Each of these is achievable but needs a dedicated Langroid agent tool / module
+that we did not take on in this pass. They are tracked so a follow-up can
+pick them up without re-litigating scope.
+
+- **tool-rendering-reasoning-chain** — needs the Langroid AG-UI adapter to
+  emit reasoning events; the current adapter only emits text + tool deltas.
+- **a2ui-fixed-schema** — needs a dedicated agent that loads JSON schemas
+  at startup and exposes a `display_flight`-shaped tool backed by the same
+  A2UI middleware path.
+- **byoc-json-render** — needs a Langroid agent that streams structured
+  JSON matching the `@json-render/react` Zod catalog, plus a dedicated BYOC
+  runtime route.
+- **byoc-hashbrown** — needs a Langroid agent that streams structured
+  output matching the hashbrown schema, plus a dedicated BYOC runtime route.
+- **beautiful-chat** — polished starter chat. Large frontend (example-layout,
+  example-canvas, generative-ui charts, hooks). Requires combining
+  openGenerativeUI + a2ui on one dedicated runtime route.
+- **multimodal** — needs a Langroid agent configured with a vision-capable
+  LLM and a dedicated runtime that accepts CopilotChat attachments
+  (images + PDFs).
+- **voice** — needs the `@copilotkit/voice` plumbing plus a dedicated voice
+  runtime route and sample audio assets.
+- **open-gen-ui** — needs a Langroid agent that emits a `generateSandboxedUi`
+  tool call; the runtime `openGenerativeUI` middleware converts that stream
+  into activity events.
+- **open-gen-ui-advanced** — same agent surface as `open-gen-ui` plus
+  host-side `sandboxFunctions` wiring on the frontend.
+- **mcp-apps** — Langroid does ship an MCP client surface, but the canonical
+  demo is tightly coupled to the LangGraph activity-message emission path.
+  A Langroid port needs a custom AG-UI adapter path that emits the
+  MCP-apps activity events.
+
+## Known limitations
+
+- **agent-config**: the frontend + runtime route are in place. The Langroid
+  backend (`src/agents/agui_adapter.py`) does not currently read
+  `RunAgentInput.forwarded_props` and pass them into the ChatAgent's system
+  prompt, so changing tone / expertise / response length in the config card
+  does not yet change agent behavior. Wiring this requires extending the
+  adapter to read forwarded props and the agent's system-prompt builder to
+  consume them — tracked as follow-up work.

--- a/showcase/packages/langroid/manifest.yaml
+++ b/showcase/packages/langroid/manifest.yaml
@@ -38,6 +38,12 @@ features:
   - agentic-chat-reasoning
   - reasoning-default-render
   - readonly-state-agent-context
+  - tool-rendering-default-catchall
+  - tool-rendering-custom-catchall
+  - declarative-gen-ui
+  - auth
+  - headless-complete
+  - agent-config
 demos:
   - id: agentic-chat
     name: Agentic Chat
@@ -245,6 +251,79 @@ demos:
     highlight:
       - src/app/demos/readonly-state-agent-context/page.tsx
       - src/app/api/copilotkit/route.ts
+  - id: tool-rendering-default-catchall
+    name: Tool Rendering (Default Catch-all)
+    description: Zero-config wildcard via useDefaultRenderTool — the built-in DefaultToolCallRenderer paints every tool call
+    tags:
+      - agent-capabilities
+    route: /demos/tool-rendering-default-catchall
+    animated_preview_url:
+    highlight:
+      - src/app/demos/tool-rendering-default-catchall/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: tool-rendering-custom-catchall
+    name: Tool Rendering (Custom Catch-all)
+    description: Single branded wildcard renderer registered via useDefaultRenderTool
+    tags:
+      - agent-capabilities
+    route: /demos/tool-rendering-custom-catchall
+    animated_preview_url:
+    highlight:
+      - src/app/demos/tool-rendering-custom-catchall/page.tsx
+      - src/app/demos/tool-rendering-custom-catchall/custom-catchall-renderer.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: declarative-gen-ui
+    name: Declarative Generative UI
+    description: A2UI dynamic-schema rendering — agent emits operations against a client-declared catalog
+    tags:
+      - generative-ui
+    route: /demos/declarative-gen-ui
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/declarative-gen-ui/page.tsx
+      - src/app/demos/declarative-gen-ui/a2ui/catalog.ts
+      - src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+      - src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+      - src/app/api/copilotkit-declarative-gen-ui/route.ts
+  - id: auth
+    name: Authentication
+    description: Bearer-token gate via the V2 runtime's onRequest hook; unauth requests are rejected with 401
+    tags:
+      - authentication
+    route: /demos/auth
+    animated_preview_url:
+    highlight:
+      - src/app/demos/auth/page.tsx
+      - src/app/demos/auth/auth-banner.tsx
+      - src/app/demos/auth/use-demo-auth.ts
+      - src/app/demos/auth/demo-token.ts
+      - src/app/api/copilotkit-auth/route.ts
+  - id: headless-complete
+    name: Headless Chat (Complete)
+    description: A full chat surface built from scratch on useAgent — no CopilotChat, hand-rolled message list + bubbles
+    tags:
+      - chat-ui
+    route: /demos/headless-complete
+    animated_preview_url:
+    highlight:
+      - src/app/demos/headless-complete/page.tsx
+      - src/app/demos/headless-complete/message-list.tsx
+      - src/app/demos/headless-complete/use-rendered-messages.tsx
+      - src/app/demos/headless-complete/tool-renderers.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: agent-config
+    name: Agent Config Object
+    description: Typed config forwarded via CopilotKit provider properties; the agent reads tone/expertise/responseLength per turn
+    tags:
+      - agent-capabilities
+    route: /demos/agent-config
+    animated_preview_url:
+    highlight:
+      - src/app/demos/agent-config/page.tsx
+      - src/app/demos/agent-config/config-card.tsx
+      - src/app/demos/agent-config/use-agent-config.ts
+      - src/app/api/copilotkit-agent-config/route.ts
 starter:
   path: showcase/starters/langroid
   name: Sales Dashboard

--- a/showcase/packages/langroid/manifest.yaml
+++ b/showcase/packages/langroid/manifest.yaml
@@ -21,12 +21,23 @@ interaction_modalities:
 features:
   - agentic-chat
   - hitl-in-chat
+  - hitl-in-app
   - tool-rendering
   - gen-ui-tool-based
   - gen-ui-agent
   - shared-state-read-write
   - shared-state-streaming
   - subagents
+  - chat-customization-css
+  - prebuilt-sidebar
+  - prebuilt-popup
+  - chat-slots
+  - headless-simple
+  - frontend-tools
+  - frontend-tools-async
+  - agentic-chat-reasoning
+  - reasoning-default-render
+  - readonly-state-agent-context
 demos:
   - id: agentic-chat
     name: Agentic Chat
@@ -35,6 +46,10 @@ demos:
       - chat-ui
     route: /demos/agentic-chat
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/agentic-chat/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: hitl-in-chat
     name: In-Chat Human in the Loop
     description: User approves agent actions before execution
@@ -42,6 +57,22 @@ demos:
       - interactivity
     route: /demos/hitl
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/hitl/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: hitl-in-app
+    name: In-App Human in the Loop (Frontend Tools + async HITL)
+    description: Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat
+    tags:
+      - interactivity
+    route: /demos/hitl-in-app
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/hitl-in-app/page.tsx
+      - src/app/demos/hitl-in-app/approval-dialog.tsx
+      - src/app/api/copilotkit/route.ts
   - id: tool-rendering
     name: Tool Rendering
     description: Backend agent tools rendered as UI components
@@ -49,6 +80,10 @@ demos:
       - agent-capabilities
     route: /demos/tool-rendering
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/tool-rendering/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: gen-ui-tool-based
     name: Tool-Based Generative UI
     description: Agent uses tools to trigger UI generation
@@ -56,6 +91,10 @@ demos:
       - generative-ui
     route: /demos/gen-ui-tool-based
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/gen-ui-tool-based/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: gen-ui-agent
     name: Agentic Generative UI
     description: Long-running agent tasks with generated UI
@@ -63,6 +102,10 @@ demos:
       - generative-ui
     route: /demos/gen-ui-agent
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/gen-ui-agent/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: shared-state-read-write
     name: Shared State (Read + Write)
     description: Bidirectional agent state — UI writes preferences, agent writes notes back
@@ -70,6 +113,10 @@ demos:
       - agent-state
     route: /demos/shared-state-read-write
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/shared-state-read-write/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: shared-state-streaming
     name: State Streaming
     description: Per-token state delta streaming from agent to UI
@@ -77,6 +124,10 @@ demos:
       - agent-state
     route: /demos/shared-state-streaming
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/shared-state-streaming/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: subagents
     name: Sub-Agents
     description: Multiple agents with visible task delegation
@@ -84,6 +135,116 @@ demos:
       - multi-agent
     route: /demos/subagents
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/subagents/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: chat-customization-css
+    name: Chat Customization (CSS)
+    description: Default CopilotChat re-themed via CopilotKitCSSProperties
+    tags:
+      - chat-ui
+    route: /demos/chat-customization-css
+    animated_preview_url:
+    highlight:
+      - src/app/demos/chat-customization-css/page.tsx
+      - src/app/demos/chat-customization-css/theme.css
+      - src/app/api/copilotkit/route.ts
+  - id: prebuilt-sidebar
+    name: "Pre-Built: Sidebar"
+    description: Docked sidebar chat via <CopilotSidebar />
+    tags:
+      - chat-ui
+    route: /demos/prebuilt-sidebar
+    animated_preview_url:
+    highlight:
+      - src/app/demos/prebuilt-sidebar/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: prebuilt-popup
+    name: "Pre-Built: Popup"
+    description: Floating popup chat via <CopilotPopup />
+    tags:
+      - chat-ui
+    route: /demos/prebuilt-popup
+    animated_preview_url:
+    highlight:
+      - src/app/demos/prebuilt-popup/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: chat-slots
+    name: Chat Customization (Slots)
+    description: Customize CopilotChat via its slot system (welcomeScreen, disclaimer, assistantMessage)
+    tags:
+      - chat-ui
+    route: /demos/chat-slots
+    animated_preview_url:
+    highlight:
+      - src/app/demos/chat-slots/page.tsx
+      - src/app/demos/chat-slots/custom-welcome-screen.tsx
+      - src/app/demos/chat-slots/custom-assistant-message.tsx
+      - src/app/demos/chat-slots/custom-disclaimer.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: headless-simple
+    name: Headless Chat (Simple)
+    description: Minimal custom chat surface built on useAgent
+    tags:
+      - chat-ui
+    route: /demos/headless-simple
+    animated_preview_url:
+    highlight:
+      - src/app/demos/headless-simple/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: frontend-tools
+    name: Frontend Tools (In-App Actions)
+    description: Agent invokes client-side handlers registered with useFrontendTool
+    tags:
+      - interactivity
+    route: /demos/frontend-tools
+    animated_preview_url:
+    highlight:
+      - src/app/demos/frontend-tools/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: frontend-tools-async
+    name: Frontend Tools (Async)
+    description: useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result
+    tags:
+      - interactivity
+    route: /demos/frontend-tools-async
+    animated_preview_url:
+    highlight:
+      - src/app/demos/frontend-tools-async/page.tsx
+      - src/app/demos/frontend-tools-async/notes-card.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: agentic-chat-reasoning
+    name: Reasoning
+    description: Custom reasoning slot render (placeholder until Langroid exposes reasoning events)
+    tags:
+      - generative-ui
+    route: /demos/agentic-chat-reasoning
+    animated_preview_url:
+    highlight:
+      - src/app/demos/agentic-chat-reasoning/page.tsx
+      - src/app/demos/agentic-chat-reasoning/reasoning-block.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: reasoning-default-render
+    name: Reasoning (Default Render)
+    description: Built-in CopilotChatReasoningMessage renders without a custom slot (placeholder until Langroid exposes reasoning events)
+    tags:
+      - generative-ui
+    route: /demos/reasoning-default-render
+    animated_preview_url:
+    highlight:
+      - src/app/demos/reasoning-default-render/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: readonly-state-agent-context
+    name: Readonly State (Agent Context)
+    description: Frontend provides read-only context to the agent via useAgentContext
+    tags:
+      - agent-state
+    route: /demos/readonly-state-agent-context
+    animated_preview_url:
+    highlight:
+      - src/app/demos/readonly-state-agent-context/page.tsx
+      - src/app/api/copilotkit/route.ts
 starter:
   path: showcase/starters/langroid
   name: Sales Dashboard

--- a/showcase/packages/langroid/package-lock.json
+++ b/showcase/packages/langroid/package-lock.json
@@ -9,11 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@ag-ui/client": "^0.0.43",
+        "@copilotkit/a2ui-renderer": "next",
         "@copilotkit/react-core": "next",
         "@copilotkit/runtime": "next",
+        "@hashbrownai/core": "0.5.0-beta.4",
+        "@hashbrownai/react": "0.5.0-beta.4",
         "next": "^15.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "recharts": "^2.15.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -946,6 +950,15 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
@@ -1638,6 +1651,37 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hashbrownai/core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@hashbrownai/core/-/core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-LlHkqk9/3Dn2yXU/cJawoXo3xkJI+7Q8bR8UrA4OPOaMGnEyr3xkuS9+DUeOphuvd6I/CKgkFNxUffhkFZ18Dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/liveloveapp"
+      }
+    },
+    "node_modules/@hashbrownai/react": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@hashbrownai/react/-/react-0.5.0-beta.4.tgz",
+      "integrity": "sha512-iCOH4HR8OcoqFFuRbRPEU0+xa0rfkBHzPGR8yy8HtQiOCGkhHrgJlhjJcBECaDXuNPu9fAMhSZeYZfs+jrI3CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/liveloveapp"
+      },
+      "peerDependencies": {
+        "@hashbrownai/core": "0.5.0-beta.4",
+        "react": ">=18 <20",
+        "react-dom": ">=18 <20"
       }
     },
     "node_modules/@hono/node-server": {
@@ -4301,6 +4345,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/cytoscape": {
       "version": "3.33.2",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
@@ -4873,6 +4923,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -4958,6 +5014,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dompurify": {
@@ -5245,6 +5311,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
@@ -7032,6 +7107,12 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -14774,6 +14855,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -14794,6 +14890,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readable-stream": {
@@ -14819,6 +14931,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/reflect-metadata": {
@@ -17046,6 +17190,12 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -17611,6 +17761,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/showcase/packages/langroid/package.json
+++ b/showcase/packages/langroid/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/showcase/packages/langroid/qa/agent-config.md
+++ b/showcase/packages/langroid/qa/agent-config.md
@@ -1,0 +1,22 @@
+# QA: Agent Config Object — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend reachable at `/api/copilotkit-agent-config`
+
+## Test Steps
+
+### 1. Config UI
+
+- [ ] Navigate to `/demos/agent-config`
+- [ ] Verify `data-testid="agent-config-card"` is visible
+- [ ] Verify Tone / Expertise / Response length selects are rendered
+- [ ] Change Tone to "enthusiastic"
+- [ ] Send "Hello" and verify a response is produced
+- [ ] Change Expertise to "expert" and Response length to "detailed"
+- [ ] Send another message and confirm the agent continues to respond
+
+Note: the Langroid agent backend does not yet consume forwarded `properties`
+to steer its system prompt. The provider + route carry them end-to-end;
+wiring the Langroid ChatAgent to read them is tracked in PARITY_NOTES.md.

--- a/showcase/packages/langroid/qa/agent-config.md
+++ b/showcase/packages/langroid/qa/agent-config.md
@@ -4,6 +4,7 @@
 
 - Demo is deployed and accessible
 - Agent backend reachable at `/api/copilotkit-agent-config`
+- Langroid agent server running (see `/api/health`)
 
 ## Test Steps
 
@@ -12,11 +13,31 @@
 - [ ] Navigate to `/demos/agent-config`
 - [ ] Verify `data-testid="agent-config-card"` is visible
 - [ ] Verify Tone / Expertise / Response length selects are rendered
-- [ ] Change Tone to "enthusiastic"
-- [ ] Send "Hello" and verify a response is produced
-- [ ] Change Expertise to "expert" and Response length to "detailed"
-- [ ] Send another message and confirm the agent continues to respond
 
-Note: the Langroid agent backend does not yet consume forwarded `properties`
-to steer its system prompt. The provider + route carry them end-to-end;
-wiring the Langroid ChatAgent to read them is tracked in PARITY_NOTES.md.
+### 2. Forwarded properties reach the agent
+
+- [ ] Change Tone to "enthusiastic"
+- [ ] Send "Hello" and verify a response is produced; tone should read as noticeably upbeat/warm
+- [ ] Change Expertise to "expert" and Response length to "detailed"
+- [ ] Send "Explain how LLM tool calling works" — verify the response uses domain terminology freely and is multiple sentences (not 1 to 2)
+- [ ] Change Response length to "concise" and Expertise to "beginner"
+- [ ] Send the same question — response should be 1 to 2 sentences, avoid jargon, and define any technical term the first time it appears
+
+### 3. Network inspection (optional, deeper verification)
+
+- [ ] Open DevTools Network panel
+- [ ] Send a message and inspect the POST to `/api/copilotkit-agent-config`
+- [ ] In the request body, verify `forwardedProps.config.configurable.properties`
+      contains `tone`, `expertise`, and `responseLength` with the selected values
+- [ ] The flat keys `forwardedProps.tone` / `.expertise` / `.responseLength`
+      should NOT be present — the route repacks them under `config.configurable.properties`
+
+## Expected Results
+
+- Selecting different config values visibly changes the assistant's voice,
+  depth of explanation, and response length.
+- The `/api/copilotkit-agent-config` request body shows the repacked shape
+  (flat provider keys land under `forwardedProps.config.configurable.properties`).
+- The Langroid backend receives the properties (via AG-UI `forwarded_props`)
+  and appends style directives to its system prompt for that run only; other
+  demos remain unaffected.

--- a/showcase/packages/langroid/qa/agentic-chat-reasoning.md
+++ b/showcase/packages/langroid/qa/agentic-chat-reasoning.md
@@ -5,6 +5,7 @@ NOTE: The Langroid AG-UI adapter does not currently emit
 but the reasoning card only renders once the backend emits such messages.
 
 ## Test Steps
+
 - [ ] Navigate to /demos/agentic-chat-reasoning
 - [ ] Verify chat input is visible
 - [ ] Send a query; verify a normal assistant reply

--- a/showcase/packages/langroid/qa/agentic-chat-reasoning.md
+++ b/showcase/packages/langroid/qa/agentic-chat-reasoning.md
@@ -1,0 +1,10 @@
+# QA: Agentic Chat (Reasoning) — Langroid
+
+NOTE: The Langroid AG-UI adapter does not currently emit
+`REASONING_MESSAGE_*` events. The custom `reasoningMessage` slot is wired,
+but the reasoning card only renders once the backend emits such messages.
+
+## Test Steps
+- [ ] Navigate to /demos/agentic-chat-reasoning
+- [ ] Verify chat input is visible
+- [ ] Send a query; verify a normal assistant reply

--- a/showcase/packages/langroid/qa/auth.md
+++ b/showcase/packages/langroid/qa/auth.md
@@ -1,0 +1,25 @@
+# QA: Authentication — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- The route `/api/copilotkit-auth` rejects requests missing the Bearer header
+
+## Test Steps
+
+### 1. Unauthenticated state
+
+- [ ] Navigate to `/demos/auth`
+- [ ] Verify `data-testid="auth-banner"` reads `data-authenticated="false"`
+- [ ] Verify the banner shows "Authenticate" button
+- [ ] Send a message in the chat
+- [ ] Verify `data-testid="auth-demo-error"` appears with a 401 message
+
+### 2. Authenticated state
+
+- [ ] Click `data-testid="auth-authenticate-button"`
+- [ ] Verify the banner flips to `data-authenticated="true"`
+- [ ] Verify the error banner clears
+- [ ] Send a message and verify the Langroid agent responds
+- [ ] Click Sign out and verify the banner flips back to unauthenticated

--- a/showcase/packages/langroid/qa/auth.md
+++ b/showcase/packages/langroid/qa/auth.md
@@ -2,24 +2,67 @@
 
 ## Prerequisites
 
-- Demo is deployed and accessible
-- Agent backend is healthy (check /api/health)
+- Demo deployed and accessible at /demos/auth
+- Langroid agent backend healthy (check /api/health)
 - The route `/api/copilotkit-auth` rejects requests missing the Bearer header
 
 ## Test Steps
 
-### 1. Unauthenticated state
+### 1. Initial authenticated state
 
-- [ ] Navigate to `/demos/auth`
-- [ ] Verify `data-testid="auth-banner"` reads `data-authenticated="false"`
-- [ ] Verify the banner shows "Authenticate" button
-- [ ] Send a message in the chat
-- [ ] Verify `data-testid="auth-demo-error"` appears with a 401 message
+- [ ] Navigate to /demos/auth
+- [ ] Verify the banner is visible with a green/success appearance (data-testid="auth-banner", data-authenticated="true")
+- [ ] Verify auth-status text reads "✓ Signed in as demo user"
+- [ ] Verify the "Sign out" button is visible and enabled (data-testid="auth-sign-out-button")
+- [ ] Verify the "Sign in" button is NOT present
+- [ ] Verify <CopilotChat /> is mounted below the banner
+- [ ] Verify no auth-demo-error surface is shown (data-testid="auth-demo-error" absent)
+- [ ] Verify no console errors on page load (the `/info` handshake should succeed)
 
-### 2. Authenticated state
+### 2. Authenticated send → assistant response
 
-- [ ] Click `data-testid="auth-authenticate-button"`
-- [ ] Verify the banner flips to `data-authenticated="true"`
-- [ ] Verify the error banner clears
-- [ ] Send a message and verify the Langroid agent responds
-- [ ] Click Sign out and verify the banner flips back to unauthenticated
+- [ ] Type "Hello" and click send
+- [ ] Within 30 seconds, an assistant response is rendered in the transcript
+- [ ] No auth-demo-error surface appears
+
+### 3. Sign out flips the banner and surfaces 401 without crashing
+
+- [ ] Click "Sign out"
+- [ ] Within 1 second, the banner flips to amber/warning appearance (data-authenticated="false")
+- [ ] Verify auth-status text reads "⚠ Signed out — the agent will reject your messages until you sign in."
+- [ ] Verify the "Sign in" button is visible (data-testid="auth-authenticate-button")
+- [ ] Verify the "Sign out" button is no longer present
+- [ ] Type "Hello again" and click send
+- [ ] Within 15 seconds, the page-level error surface appears:
+  - `data-testid="auth-demo-error"` visible with text containing "401" and/or "Unauthorized"
+- [ ] Verify the banner is STILL visible — the page must not white-screen
+- [ ] Verify no assistant response appears for the unauthenticated send
+
+### 4. Sign in clears the error and restores sends
+
+- [ ] Click "Sign in"
+- [ ] Within 1 second, the banner flips back to green (data-authenticated="true")
+- [ ] Verify the auth-demo-error surface is cleared
+- [ ] Type "Hello" and click send
+- [ ] Within 30 seconds, an assistant response is rendered
+
+### 5. Refresh resets state to authenticated
+
+- [ ] Hard-reload the page
+- [ ] Banner is green on first render (default state is authenticated; state does NOT persist)
+- [ ] No error surface on first render
+
+### 6. Error Handling
+
+- [ ] With DevTools Network panel blocking /api/copilotkit-auth, send a message while authenticated
+- [ ] Verify a network-level error surfaces cleanly (no uncaught promise rejection in console)
+- [ ] Restore network; verify sends work again without a page reload
+
+## Expected Results
+
+- Page loads authenticated by default — no 401 crash on initial `/info` fetch
+- Banner state flips within 1s of Sign out / Sign in clicks
+- Post-sign-out sends produce a visible 401 error within 15s via auth-demo-error
+- Page never white-screens after sign out — banner and composer remain mounted
+- Authenticated sends produce an assistant response within 30s
+- Refresh fully resets auth state (back to authenticated)

--- a/showcase/packages/langroid/qa/chat-customization-css.md
+++ b/showcase/packages/langroid/qa/chat-customization-css.md
@@ -1,0 +1,17 @@
+# QA: Chat Customization (CSS) — Langroid
+
+## Prerequisites
+- Demo is deployed
+- Agent backend reachable via /api/health
+
+## Test Steps
+- [ ] Navigate to /demos/chat-customization-css
+- [ ] Verify the scoped wrapper `.chat-css-demo-scope` renders (DOM inspector)
+- [ ] Verify user bubble shows pink gradient (hot pink -> magenta)
+- [ ] Verify assistant bubble shows amber monospace style
+- [ ] Verify the textarea input has a dashed pink border
+- [ ] Send a message; verify styled reply appears
+
+## Expected Results
+- Custom theme CSS applies only inside the demo wrapper
+- Chat functions normally

--- a/showcase/packages/langroid/qa/chat-customization-css.md
+++ b/showcase/packages/langroid/qa/chat-customization-css.md
@@ -1,10 +1,12 @@
 # QA: Chat Customization (CSS) — Langroid
 
 ## Prerequisites
+
 - Demo is deployed
 - Agent backend reachable via /api/health
 
 ## Test Steps
+
 - [ ] Navigate to /demos/chat-customization-css
 - [ ] Verify the scoped wrapper `.chat-css-demo-scope` renders (DOM inspector)
 - [ ] Verify user bubble shows pink gradient (hot pink -> magenta)
@@ -13,5 +15,6 @@
 - [ ] Send a message; verify styled reply appears
 
 ## Expected Results
+
 - Custom theme CSS applies only inside the demo wrapper
 - Chat functions normally

--- a/showcase/packages/langroid/qa/chat-slots.md
+++ b/showcase/packages/langroid/qa/chat-slots.md
@@ -1,0 +1,8 @@
+# QA: Chat Slots — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/chat-slots
+- [ ] Verify custom welcome screen with "Welcome to the Slots demo" card renders
+- [ ] Verify custom disclaimer is visible beneath the input
+- [ ] Send a message
+- [ ] Verify the assistant reply is wrapped in the tinted "slot" card (custom-assistant-message)

--- a/showcase/packages/langroid/qa/chat-slots.md
+++ b/showcase/packages/langroid/qa/chat-slots.md
@@ -1,6 +1,7 @@
 # QA: Chat Slots — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/chat-slots
 - [ ] Verify custom welcome screen with "Welcome to the Slots demo" card renders
 - [ ] Verify custom disclaimer is visible beneath the input

--- a/showcase/packages/langroid/qa/declarative-gen-ui.md
+++ b/showcase/packages/langroid/qa/declarative-gen-ui.md
@@ -1,0 +1,18 @@
+# QA: Declarative Generative UI (A2UI) — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- `/api/copilotkit-declarative-gen-ui` is configured with `injectA2UITool: false`
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/declarative-gen-ui`
+- [ ] Verify the chat interface loads in a centered full-height layout
+- [ ] Click the "Show a KPI dashboard" suggestion
+- [ ] Verify the agent's `generate_a2ui` tool-call completes
+- [ ] Verify one or more A2UI-rendered MetricCard/PieChart/BarChart surfaces
+      appear in the transcript

--- a/showcase/packages/langroid/qa/frontend-tools-async.md
+++ b/showcase/packages/langroid/qa/frontend-tools-async.md
@@ -1,6 +1,7 @@
 # QA: Frontend Tools (Async) — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/frontend-tools-async
 - [ ] Ask "Find my notes about project planning."
 - [ ] Verify the notes-card renders with matching keyword

--- a/showcase/packages/langroid/qa/frontend-tools-async.md
+++ b/showcase/packages/langroid/qa/frontend-tools-async.md
@@ -1,0 +1,8 @@
+# QA: Frontend Tools (Async) — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/frontend-tools-async
+- [ ] Ask "Find my notes about project planning."
+- [ ] Verify the notes-card renders with matching keyword
+- [ ] Verify the loading state shows briefly while the async handler resolves
+- [ ] Try "Search my notes for anything related to auth" and verify auth-tagged notes appear

--- a/showcase/packages/langroid/qa/frontend-tools.md
+++ b/showcase/packages/langroid/qa/frontend-tools.md
@@ -1,6 +1,7 @@
 # QA: Frontend Tools — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/frontend-tools
 - [ ] Verify the background-container renders with default background
 - [ ] Ask "Change the background to a blue-to-purple gradient"

--- a/showcase/packages/langroid/qa/frontend-tools.md
+++ b/showcase/packages/langroid/qa/frontend-tools.md
@@ -1,0 +1,8 @@
+# QA: Frontend Tools — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/frontend-tools
+- [ ] Verify the background-container renders with default background
+- [ ] Ask "Change the background to a blue-to-purple gradient"
+- [ ] Verify the tool invokes the frontend handler and the background style updates
+- [ ] Verify the assistant confirms the change in chat

--- a/showcase/packages/langroid/qa/headless-complete.md
+++ b/showcase/packages/langroid/qa/headless-complete.md
@@ -1,0 +1,23 @@
+# QA: Headless Chat (Complete) — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/headless-complete`
+- [ ] Verify the page loads without `<CopilotChat />` — a hand-rolled message list + input
+- [ ] Verify the input is focused and enabled
+- [ ] Send a message and verify an assistant response bubble renders
+- [ ] Verify a typing indicator appears while the agent is running
+
+### 2. Tool Rendering
+
+- [ ] Click the "Weather in Tokyo" suggestion
+- [ ] Verify a branded WeatherCard appears inline in the message list
+- [ ] Verify tool-call renderers (useRenderTool, useDefaultRenderTool) paint
+      without the built-in CopilotChat chrome

--- a/showcase/packages/langroid/qa/headless-simple.md
+++ b/showcase/packages/langroid/qa/headless-simple.md
@@ -1,6 +1,7 @@
 # QA: Headless Chat (Simple) — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/headless-simple
 - [ ] Verify heading "Headless Chat (Simple)" visible
 - [ ] Verify empty-state message "No messages yet"

--- a/showcase/packages/langroid/qa/headless-simple.md
+++ b/showcase/packages/langroid/qa/headless-simple.md
@@ -1,0 +1,8 @@
+# QA: Headless Chat (Simple) — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/headless-simple
+- [ ] Verify heading "Headless Chat (Simple)" visible
+- [ ] Verify empty-state message "No messages yet"
+- [ ] Type a message and press Enter; verify the user bubble appears
+- [ ] Ask "show a card about cats"; verify a ShowCard renders from the useComponent registration

--- a/showcase/packages/langroid/qa/hitl-in-app.md
+++ b/showcase/packages/langroid/qa/hitl-in-app.md
@@ -1,6 +1,7 @@
 # QA: HITL In-App — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/hitl-in-app
 - [ ] Verify the tickets panel renders with tickets #12345, #12346, #12347
 - [ ] Ask "Please approve a $50 refund to Jordan Rivera on ticket #12345."

--- a/showcase/packages/langroid/qa/hitl-in-app.md
+++ b/showcase/packages/langroid/qa/hitl-in-app.md
@@ -1,0 +1,9 @@
+# QA: HITL In-App — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/hitl-in-app
+- [ ] Verify the tickets panel renders with tickets #12345, #12346, #12347
+- [ ] Ask "Please approve a $50 refund to Jordan Rivera on ticket #12345."
+- [ ] Verify an approval dialog (`approval-dialog` testid) appears OUTSIDE the chat
+- [ ] Click Approve; verify the dialog closes and the agent acknowledges the decision in chat
+- [ ] Repeat with a Reject decision

--- a/showcase/packages/langroid/qa/prebuilt-popup.md
+++ b/showcase/packages/langroid/qa/prebuilt-popup.md
@@ -1,6 +1,7 @@
 # QA: Prebuilt Popup — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/prebuilt-popup
 - [ ] Verify the floating launcher bubble renders
 - [ ] Verify the popup opens by default showing "Ask the popup anything..." placeholder

--- a/showcase/packages/langroid/qa/prebuilt-popup.md
+++ b/showcase/packages/langroid/qa/prebuilt-popup.md
@@ -1,0 +1,8 @@
+# QA: Prebuilt Popup — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/prebuilt-popup
+- [ ] Verify the floating launcher bubble renders
+- [ ] Verify the popup opens by default showing "Ask the popup anything..." placeholder
+- [ ] Send a message and verify reply
+- [ ] Close and reopen the popup via the launcher

--- a/showcase/packages/langroid/qa/prebuilt-sidebar.md
+++ b/showcase/packages/langroid/qa/prebuilt-sidebar.md
@@ -1,6 +1,7 @@
 # QA: Prebuilt Sidebar — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/prebuilt-sidebar
 - [ ] Verify main content heading "Sidebar demo" visible
 - [ ] Verify sidebar docked on the side, open by default

--- a/showcase/packages/langroid/qa/prebuilt-sidebar.md
+++ b/showcase/packages/langroid/qa/prebuilt-sidebar.md
@@ -1,0 +1,8 @@
+# QA: Prebuilt Sidebar — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/prebuilt-sidebar
+- [ ] Verify main content heading "Sidebar demo" visible
+- [ ] Verify sidebar docked on the side, open by default
+- [ ] Send "hi" and verify agent responds
+- [ ] Click the launcher to collapse/expand the sidebar

--- a/showcase/packages/langroid/qa/readonly-state-agent-context.md
+++ b/showcase/packages/langroid/qa/readonly-state-agent-context.md
@@ -1,0 +1,9 @@
+# QA: Readonly State (Agent Context) — Langroid
+
+## Test Steps
+- [ ] Navigate to /demos/readonly-state-agent-context
+- [ ] Verify the context card renders with default Name "Atai"
+- [ ] Change Name to "Jordan", verify published JSON updates
+- [ ] Toggle recent-activity checkboxes, verify JSON updates
+- [ ] Ask "What do you know about me?" — agent should reference the context values
+- [ ] Change timezone, ask "What time is it for me?" — agent should reflect the new zone

--- a/showcase/packages/langroid/qa/readonly-state-agent-context.md
+++ b/showcase/packages/langroid/qa/readonly-state-agent-context.md
@@ -1,6 +1,7 @@
 # QA: Readonly State (Agent Context) — Langroid
 
 ## Test Steps
+
 - [ ] Navigate to /demos/readonly-state-agent-context
 - [ ] Verify the context card renders with default Name "Atai"
 - [ ] Change Name to "Jordan", verify published JSON updates

--- a/showcase/packages/langroid/qa/reasoning-default-render.md
+++ b/showcase/packages/langroid/qa/reasoning-default-render.md
@@ -7,6 +7,7 @@ will show reasoning automatically once the adapter forwards thinking
 events.
 
 ## Test Steps
+
 - [ ] Navigate to /demos/reasoning-default-render
 - [ ] Verify chat input is visible
 - [ ] Send "hello"; verify the agent replies

--- a/showcase/packages/langroid/qa/reasoning-default-render.md
+++ b/showcase/packages/langroid/qa/reasoning-default-render.md
@@ -1,0 +1,12 @@
+# QA: Reasoning (Default Render) — Langroid
+
+NOTE: The Langroid AG-UI adapter does not currently emit
+`REASONING_MESSAGE_*` events, so no reasoning block will appear. This
+demo proves the zero-config default render path compiles and renders; it
+will show reasoning automatically once the adapter forwards thinking
+events.
+
+## Test Steps
+- [ ] Navigate to /demos/reasoning-default-render
+- [ ] Verify chat input is visible
+- [ ] Send "hello"; verify the agent replies

--- a/showcase/packages/langroid/qa/tool-rendering-custom-catchall.md
+++ b/showcase/packages/langroid/qa/tool-rendering-custom-catchall.md
@@ -1,0 +1,35 @@
+# QA: Tool Rendering (Custom Catch-all) — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- Agent slug `tool-rendering-custom-catchall` is registered at `/api/copilotkit`
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the `tool-rendering-custom-catchall` demo page
+- [ ] Verify the chat interface loads in a centered full-height layout
+
+### 2. Feature-Specific Checks — Custom Wildcard Renderer
+
+The page registers a single branded wildcard via `useDefaultRenderTool`
+with a custom `render` function (`CustomCatchallRenderer`). Every tool
+call paints through that same branded card.
+
+- [ ] Click "Weather in SF"
+- [ ] Verify a card with `data-testid="custom-catchall-card"` appears
+- [ ] Verify `data-testid="custom-catchall-tool-name"` reads `get_weather`
+- [ ] Verify `data-testid="custom-catchall-status"` transitions through
+      `streaming` / `running` and lands on `done`
+- [ ] Expand Arguments and verify the args JSON is visible
+- [ ] Expand Result and verify the mock weather payload is visible
+- [ ] Verify NO built-in default card shows for this tool
+
+### 3. Expected
+
+- Every tool paints through the same branded card
+- No per-tool renderers
+- Status badge matches tool lifecycle

--- a/showcase/packages/langroid/qa/tool-rendering-default-catchall.md
+++ b/showcase/packages/langroid/qa/tool-rendering-default-catchall.md
@@ -1,0 +1,47 @@
+# QA: Tool Rendering (Default Catch-all) — Langroid
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- Agent slug `tool-rendering-default-catchall` is registered at `/api/copilotkit`
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to the `tool-rendering-default-catchall` demo page
+- [ ] Verify the chat interface loads in a centered full-height layout (max-width 4xl, `rounded-2xl`)
+- [ ] Verify the chat input placeholder "Type a message" is visible
+- [ ] Send a basic message and verify the Langroid agent responds
+
+### 2. Feature-Specific Checks — Built-in Default Tool-Call UI
+
+The page calls `useDefaultRenderTool()` with NO config, so every tool
+call routes to CopilotKit's built-in `DefaultToolCallRenderer`.
+
+#### Suggestions
+
+- [ ] Verify "Weather in SF" suggestion pill is visible
+- [ ] Verify "Find flights" suggestion pill is visible
+- [ ] Verify "Weather in Tokyo" suggestion pill is visible
+
+#### get_weather renders via the built-in default card
+
+- [ ] Click "Weather in SF"
+- [ ] Verify a default tool-call card appears with `get_weather` as header
+- [ ] Verify status transitions `Running -> Done`
+- [ ] Verify no `data-testid="custom-catchall-card"` and no
+      `data-testid="weather-card"` — only the built-in card paints.
+
+#### search_flights renders via the same built-in card
+
+- [ ] Click "Find flights"
+- [ ] Verify a second default card with `search_flights` header
+- [ ] Verify status lands on `Done`
+
+### 3. Expected
+
+- No per-tool branded cards
+- No custom wildcard renderer
+- Every tool call uses the package-provided default card

--- a/showcase/packages/langroid/src/agents/agent.py
+++ b/showcase/packages/langroid/src/agents/agent.py
@@ -877,7 +877,7 @@ SYSTEM_PROMPT = (
 # =====================================================================
 
 
-def create_agent() -> lr.ChatAgent:
+def create_agent(system_message: str | None = None) -> lr.ChatAgent:
     """Create a Langroid ChatAgent configured with all showcase tools.
 
     Default model is the bare ``gpt-4.1`` (not ``openai/gpt-4.1``): langroid
@@ -885,6 +885,12 @@ def create_agent() -> lr.ChatAgent:
     OpenAI SDK, and the SDK rejects ``openai/gpt-4.1`` as "model not found".
     See ``_resolve_a2ui_model`` for the same reasoning on the planner
     default.
+
+    ``system_message`` — optional override for the agent's system prompt.
+    Used by the Agent Config Object demo to steer tone / expertise /
+    responseLength per request. When ``None`` (the default), the canonical
+    ``SYSTEM_PROMPT`` is used so behavior for every other demo is
+    unchanged.
     """
     model = os.getenv("LANGROID_MODEL", "gpt-4.1")
 
@@ -895,9 +901,151 @@ def create_agent() -> lr.ChatAgent:
 
     agent_config = lr.ChatAgentConfig(
         llm=llm_config,
-        system_message=SYSTEM_PROMPT,
+        system_message=system_message or SYSTEM_PROMPT,
     )
 
     agent = lr.ChatAgent(agent_config)
     agent.enable_message(list(ALL_TOOLS))
     return agent
+
+
+# =====================================================================
+# Agent-config demo — dynamic system-prompt construction
+# =====================================================================
+#
+# The /demos/agent-config cell lets the user pick ``tone`` / ``expertise`` /
+# ``responseLength`` in a config card; those values arrive as frontend
+# ``properties`` and are forwarded by the Next.js runtime on the AG-UI
+# ``forwardedProps`` field. The dedicated TS route at
+# ``src/app/api/copilotkit-agent-config/route.ts`` repacks them into
+# ``forwardedProps.config.configurable.properties`` (mirroring the upstream
+# langgraph-python shape) so the backend reads them from a single
+# deterministic location regardless of which showcase adapter is
+# forwarding the request.
+#
+# Kept close to ``SYSTEM_PROMPT`` so the tool-list copy stays in sync.
+
+
+# Valid values — silently ignore anything else instead of blowing up a
+# turn on a frontend bug. The page's <CopilotKit properties={...}> is the
+# source of truth, but an operator running the backend against a
+# customized frontend (or a bad test fixture) should see "prompt not
+# steered" not "500 from the agent".
+_AGENT_CONFIG_TONES: frozenset[str] = frozenset(
+    {"professional", "casual", "enthusiastic"}
+)
+_AGENT_CONFIG_EXPERTISE: frozenset[str] = frozenset(
+    {"beginner", "intermediate", "expert"}
+)
+_AGENT_CONFIG_LENGTHS: frozenset[str] = frozenset({"concise", "detailed"})
+
+
+_TONE_DIRECTIVES: dict[str, str] = {
+    "professional": "Use a polished, professional tone.",
+    "casual": "Use a casual, conversational tone.",
+    "enthusiastic": "Use an enthusiastic, upbeat tone with warmth.",
+}
+
+_EXPERTISE_DIRECTIVES: dict[str, str] = {
+    "beginner": (
+        "Assume the user is a beginner: explain concepts step by step, "
+        "avoid jargon, and define any technical term the first time it "
+        "appears."
+    ),
+    "intermediate": (
+        "Assume the user has intermediate familiarity with the topic: "
+        "you can use common domain terminology without defining every "
+        "term, but still briefly frame non-obvious concepts."
+    ),
+    "expert": (
+        "Assume the user is an expert: be precise, use domain-specific "
+        "terminology freely, and skip introductory framing."
+    ),
+}
+
+_LENGTH_DIRECTIVES: dict[str, str] = {
+    "concise": "Keep responses brief — 1 to 2 sentences max.",
+    "detailed": (
+        "Provide a detailed response — multiple sentences or a short "
+        "paragraph, with enough context for the user to act on it."
+    ),
+}
+
+
+def build_agent_config_system_prompt(
+    *,
+    tone: str | None,
+    expertise: str | None,
+    response_length: str | None,
+) -> str:
+    """Build a dynamic system prompt for the agent-config demo.
+
+    Appends tone / expertise / length directives to the canonical
+    ``SYSTEM_PROMPT`` so the agent keeps the same tool repertoire and demo
+    persona but adopts the user-selected style. Unknown values (including
+    ``None``) are skipped silently so a partial set of forwarded
+    properties still produces a usable prompt.
+    """
+    directives: list[str] = []
+    if tone in _AGENT_CONFIG_TONES:
+        directives.append(_TONE_DIRECTIVES[tone])
+    if expertise in _AGENT_CONFIG_EXPERTISE:
+        directives.append(_EXPERTISE_DIRECTIVES[expertise])
+    if response_length in _AGENT_CONFIG_LENGTHS:
+        directives.append(_LENGTH_DIRECTIVES[response_length])
+
+    if not directives:
+        return SYSTEM_PROMPT
+
+    return SYSTEM_PROMPT + "\n\nUser-selected style:\n- " + "\n- ".join(
+        directives
+    )
+
+
+def extract_agent_config_properties(
+    forwarded_props: Any,
+) -> dict[str, str] | None:
+    """Pull ``{tone, expertise, responseLength}`` out of AG-UI forwardedProps.
+
+    Accepts two shapes and merges them (flat keys win for the keys they
+    define, but ``config.configurable.properties`` is the canonical
+    location):
+
+    1. The canonical location — ``forwarded_props.config.configurable.properties``
+       — which is where the dedicated Next.js route repacks provider
+       properties.
+    2. Flat top-level keys on ``forwarded_props`` — a defensive fallback
+       in case a future runtime bypasses the repack step.
+
+    Returns ``None`` when none of the three keys are present, so callers
+    can trivially tell "no agent-config steering requested" from
+    "explicitly requested but with empty strings".
+    """
+    if not isinstance(forwarded_props, dict):
+        return None
+
+    # Start with the canonical location.
+    merged: dict[str, str] = {}
+    config = forwarded_props.get("config")
+    if isinstance(config, dict):
+        configurable = config.get("configurable")
+        if isinstance(configurable, dict):
+            properties = configurable.get("properties")
+            if isinstance(properties, dict):
+                for key in ("tone", "expertise", "responseLength"):
+                    value = properties.get(key)
+                    if isinstance(value, str) and value:
+                        merged[key] = value
+
+    # Flat-key fallback — only fills in keys the canonical location
+    # didn't provide, so the repacked location stays authoritative.
+    for key in ("tone", "expertise", "responseLength"):
+        if key in merged:
+            continue
+        value = forwarded_props.get(key)
+        if isinstance(value, str) and value:
+            merged[key] = value
+
+    if not merged:
+        return None
+    return merged

--- a/showcase/packages/langroid/src/agents/agui_adapter.py
+++ b/showcase/packages/langroid/src/agents/agui_adapter.py
@@ -41,7 +41,9 @@ from fastapi import Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from agents.agent import (
+    build_agent_config_system_prompt,
     create_agent,
+    extract_agent_config_properties,
     ALL_TOOLS,
     BACKEND_TOOLS,
     FRONTEND_TOOL_NAMES,
@@ -285,7 +287,25 @@ async def handle_run(request: Request) -> StreamingResponse:
             status_code=422,
         )
 
-    agent = create_agent()
+    # Agent-config demo — <CopilotKit properties={tone, expertise,
+    # responseLength}> arrives as forwarded_props.config.configurable.properties
+    # (the dedicated Next.js route at copilotkit-agent-config repacks flat
+    # provider keys into that canonical shape before POSTing here). When
+    # those properties are present, steer the system prompt for this run
+    # only. For every other demo ``forwarded_props`` is empty / missing
+    # the keys and ``extract_agent_config_properties`` returns None, so
+    # behavior is unchanged.
+    agent_config_props = extract_agent_config_properties(
+        run_input.forwarded_props
+    )
+    system_override: str | None = None
+    if agent_config_props is not None:
+        system_override = build_agent_config_system_prompt(
+            tone=agent_config_props.get("tone"),
+            expertise=agent_config_props.get("expertise"),
+            response_length=agent_config_props.get("responseLength"),
+        )
+    agent = create_agent(system_message=system_override)
 
     # Build conversation history from all messages so multi-turn works.
     # Each ``msg.role`` / ``msg.content`` must be a string — silently

--- a/showcase/packages/langroid/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/packages/langroid/src/app/api/copilotkit-agent-config/route.ts
@@ -1,0 +1,51 @@
+// Dedicated runtime for the Agent Config Object demo (Langroid).
+//
+// The <CopilotKit properties={...}> provider forwards tone / expertise /
+// responseLength on every run; the V1 Next.js runtime propagates those as
+// forwarded_props on the AG-UI RunAgentInput payload. The unified Langroid
+// agent reads them (when wired) from that field to steer its system prompt.
+//
+// Scoped to its own endpoint so non-demo cells don't pay the cost of this
+// demo's properties plumbing and so the Playwright spec can assert
+// request-body propagation against exactly one URL.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+const agentConfigAgent = new HttpAgent({ url: `${AGENT_URL}/` });
+
+const agents = {
+  "agent-config-demo": agentConfigAgent,
+  // Internal components calling useAgent() with no args default to "default".
+  default: agentConfigAgent,
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- Published CopilotRuntime agents type wraps Record in
+  // MaybePromise<NonEmptyRecord<...>> which rejects plain Records.
+  agents,
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-agent-config",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/packages/langroid/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/packages/langroid/src/app/api/copilotkit-agent-config/route.ts
@@ -2,12 +2,30 @@
 //
 // The <CopilotKit properties={...}> provider forwards tone / expertise /
 // responseLength on every run; the V1 Next.js runtime propagates those as
-// forwarded_props on the AG-UI RunAgentInput payload. The unified Langroid
-// agent reads them (when wired) from that field to steer its system prompt.
+// top-level keys on the AG-UI `forwardedProps` payload.
 //
-// Scoped to its own endpoint so non-demo cells don't pay the cost of this
-// demo's properties plumbing and so the Playwright spec can assert
-// request-body propagation against exactly one URL.
+// Upstream parity (see langgraph-python route for the canonical logic):
+// the frontend's provider properties arrive flat on `forwardedProps`
+// (e.g. `forwardedProps.tone`). The LangGraph showcase's Python graph
+// reads them from `RunnableConfig.configurable.properties`, so the TS
+// adapter there repacks flat keys into
+// `forwardedProps.config.configurable.properties` before dispatching.
+//
+// Langroid's backend does not have a LangGraph RunnableConfig, but we
+// mirror the same payload shape here so:
+//   1. The frontend contract is identical across all showcases.
+//   2. The Langroid Python backend can read the repacked location
+//      (`run_input.forwarded_props.config.configurable.properties`)
+//      deterministically — top-level flat keys would collide with any
+//      future AG-UI additions to `forwardedProps`.
+//
+// We subclass `HttpAgent` and override `requestInit` (the only place in
+// the AG-UI client that serializes the body) so the repack happens once
+// per request with no middleware plumbing.
+//
+// Scoped to its own endpoint so non-demo cells don't pay the cost of
+// this repack and so the Playwright spec can assert request-body
+// propagation against exactly one URL.
 
 import { NextRequest, NextResponse } from "next/server";
 import {
@@ -16,10 +34,110 @@ import {
   copilotRuntimeNextJSAppRouterEndpoint,
 } from "@copilotkit/runtime";
 import { HttpAgent } from "@ag-ui/client";
+import type { RunAgentInput } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
-const agentConfigAgent = new HttpAgent({ url: `${AGENT_URL}/` });
+// Reserved AG-UI / LangGraph stream-payload keys that MUST NOT be repacked
+// under `configurable.properties`. Anything outside this set is treated as
+// user-supplied frontend state (tone / expertise / responseLength / ...) and
+// moved into `forwardedProps.config.configurable.properties`.
+//
+// Keep this list in sync with the upstream canonical implementation:
+// `showcase/packages/langgraph-python/src/app/api/copilotkit-agent-config/route.ts`.
+const RESERVED_FORWARDED_PROPS_KEYS = new Set<string>([
+  "config",
+  "command",
+  "streamMode",
+  "streamSubgraphs",
+  "nodeName",
+  "threadMetadata",
+  "checkpointId",
+  "checkpointDuring",
+  "interruptBefore",
+  "interruptAfter",
+  "multitaskStrategy",
+  "ifNotExists",
+  "afterSeconds",
+  "onCompletion",
+  "onDisconnect",
+  "webhook",
+  "feedbackKeys",
+  "metadata",
+]);
+
+type RunInputWithForwardedProps = RunAgentInput & {
+  forwardedProps?: Record<string, unknown>;
+};
+
+function repackForwardedPropsIntoConfigurable<
+  T extends RunInputWithForwardedProps,
+>(input: T): T {
+  const fp = (input.forwardedProps ?? {}) as Record<string, unknown>;
+  if (!fp || typeof fp !== "object") return input;
+
+  const userProps: Record<string, unknown> = {};
+  const structural: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fp)) {
+    if (RESERVED_FORWARDED_PROPS_KEYS.has(key)) {
+      structural[key] = value;
+    } else {
+      userProps[key] = value;
+    }
+  }
+
+  if (Object.keys(userProps).length === 0) return input;
+
+  const existingConfig = (structural.config ?? {}) as {
+    configurable?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+  const existingConfigurable =
+    (existingConfig.configurable as Record<string, unknown> | undefined) ?? {};
+  const existingProperties =
+    (existingConfigurable.properties as Record<string, unknown> | undefined) ??
+    {};
+
+  const mergedConfig = {
+    ...existingConfig,
+    configurable: {
+      ...existingConfigurable,
+      properties: {
+        ...existingProperties,
+        ...userProps,
+      },
+    },
+  };
+
+  return {
+    ...input,
+    forwardedProps: {
+      ...structural,
+      config: mergedConfig,
+    },
+  } as T;
+}
+
+/**
+ * `HttpAgent` subclass that repacks provider `properties` (flat top-level
+ * keys on `forwardedProps`) into `forwardedProps.config.configurable.properties`
+ * before the body is serialized and POSTed to the Langroid Python backend.
+ *
+ * `requestInit` is the single place in the AG-UI client where the payload
+ * is serialized (`body: JSON.stringify(input)`), so overriding it here is
+ * the minimum-surface hook — no middleware plumbing, no clone semantics
+ * to preserve.
+ */
+class AgentConfigHttpAgent extends HttpAgent {
+  protected requestInit(input: RunAgentInput): RequestInit {
+    const repacked = repackForwardedPropsIntoConfigurable(
+      input as RunInputWithForwardedProps,
+    );
+    return super.requestInit(repacked as RunAgentInput);
+  }
+}
+
+const agentConfigAgent = new AgentConfigHttpAgent({ url: `${AGENT_URL}/` });
 
 const agents = {
   "agent-config-demo": agentConfigAgent,

--- a/showcase/packages/langroid/src/app/api/copilotkit-auth/route.ts
+++ b/showcase/packages/langroid/src/app/api/copilotkit-auth/route.ts
@@ -1,0 +1,59 @@
+// Dedicated runtime for the /demos/auth cell (Langroid).
+//
+// Framework-native request authentication via the V2 runtime's `onRequest`
+// hook. Validates a static `Authorization: Bearer <DEMO_TOKEN>` header;
+// mismatch throws 401 before the request reaches the agent.
+//
+// Uses `createCopilotRuntimeHandler` from `@copilotkit/runtime/v2` directly
+// so the `hooks.onRequest` option is honored (the V1 Next.js adapter does
+// not forward the `hooks` option).
+
+import type { NextRequest } from "next/server";
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { HttpAgent } from "@ag-ui/client";
+import { DEMO_AUTH_HEADER } from "@/app/demos/auth/demo-token";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// Reuse the unified Langroid agent — this demo shows the gate, not bespoke
+// auth-aware agent behavior.
+const authDemoAgent = new HttpAgent({ url: `${AGENT_URL}/` });
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>>
+  agents: {
+    "auth-demo": authDemoAgent,
+    default: authDemoAgent,
+  },
+});
+
+const BASE_PATH = "/api/copilotkit-auth";
+
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: BASE_PATH,
+  hooks: {
+    onRequest: ({ request }: { request: Request }) => {
+      const authHeader = request.headers.get("authorization");
+      if (authHeader !== DEMO_AUTH_HEADER) {
+        throw new Response(
+          JSON.stringify({
+            error: "unauthorized",
+            message:
+              "Missing or invalid Authorization header. Click Authenticate above to send messages.",
+          }),
+          {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+    },
+  },
+});
+
+export const POST = (req: NextRequest) => handler(req);
+export const GET = (req: NextRequest) => handler(req);

--- a/showcase/packages/langroid/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/packages/langroid/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -1,0 +1,47 @@
+// Dedicated runtime for the Declarative Generative UI (A2UI) cell (Langroid).
+//
+// The unified Langroid agent already owns a `generate_a2ui` tool (see
+// src/agents/agent.py -> GenerateA2UITool). We route this demo here so we
+// can set `a2ui.injectA2UITool: false` — the runtime must NOT auto-inject
+// its own A2UI tool on top of the agent-owned one.
+//
+// The A2UI middleware still runs: it serialises the registered client
+// catalog into the agent's context so the secondary LLM inside
+// `generate_a2ui` knows which components to emit.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+const declarativeGenUiAgent = new HttpAgent({ url: `${AGENT_URL}/` });
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents: { "declarative-gen-ui": declarativeGenUiAgent },
+  a2ui: {
+    injectA2UITool: false,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-gen-ui",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/packages/langroid/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/langroid/src/app/api/copilotkit/route.ts
@@ -51,6 +51,18 @@ const agentNames = [
   "reasoning-default-render",
   // Read-only agent context — frontend exposes useAgentContext; same agent.
   "readonly-state-agent-context",
+  // Tool rendering variants — all share the unified agent; frontend differs.
+  "tool-rendering-default-catchall",
+  "tool-rendering-custom-catchall",
+  "tool-rendering-reasoning-chain",
+  // Declarative A2UI + fixed-schema A2UI — use the agent's generate_a2ui tool.
+  "declarative-gen-ui",
+  "a2ui-fixed-schema",
+  // Agent-config, open-gen-ui, headless-complete all reuse the unified agent.
+  "agent-config",
+  "open-gen-ui",
+  "open-gen-ui-advanced",
+  "headless-complete",
 ];
 
 const agents: Record<string, AbstractAgent> = {};

--- a/showcase/packages/langroid/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/langroid/src/app/api/copilotkit/route.ts
@@ -18,6 +18,8 @@ function createAgent() {
 }
 
 // Register the same agent under all names used by demo pages.
+// The Langroid agent_server.py exposes a single unified agent on "/" that
+// handles every request — so every entry here maps to the same HttpAgent.
 const agentNames = [
   "agentic_chat",
   "human_in_the_loop",
@@ -26,8 +28,29 @@ const agentNames = [
   "gen-ui-agent",
   "shared-state-read",
   "shared-state-write",
+  "shared-state-read-write",
   "shared-state-streaming",
   "subagents",
+  // Chat chrome variants — all share the unified agent. The frontend
+  // differentiates via UI composition only (CopilotChat vs Sidebar vs Popup,
+  // slots, headless useAgent).
+  "chat-customization-css",
+  "prebuilt-sidebar",
+  "prebuilt-popup",
+  "chat-slots",
+  "headless-simple",
+  // Frontend-tools variants — backend has no specialized tools; the frontend
+  // registers handlers via useFrontendTool and the agent calls them.
+  "frontend_tools",
+  "frontend-tools-async",
+  // HITL variants — use existing agent's schedule_meeting flow.
+  "hitl-in-chat",
+  "hitl-in-app",
+  // Reasoning variants — agent emits chain-of-thought; default vs custom render.
+  "agentic-chat-reasoning",
+  "reasoning-default-render",
+  // Read-only agent context — frontend exposes useAgentContext; same agent.
+  "readonly-state-agent-context",
 ];
 
 const agents: Record<string, AbstractAgent> = {};

--- a/showcase/packages/langroid/src/app/demos/agent-config/config-card.tsx
+++ b/showcase/packages/langroid/src/app/demos/agent-config/config-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import {
+  type AgentConfig,
+  EXPERTISE_OPTIONS,
+  type Expertise,
+  RESPONSE_LENGTH_OPTIONS,
+  type ResponseLength,
+  TONE_OPTIONS,
+  type Tone,
+} from "./config-types";
+
+interface ConfigCardProps {
+  config: AgentConfig;
+  onToneChange: (tone: Tone) => void;
+  onExpertiseChange: (expertise: Expertise) => void;
+  onResponseLengthChange: (length: ResponseLength) => void;
+}
+
+export function ConfigCard({
+  config,
+  onToneChange,
+  onExpertiseChange,
+  onResponseLengthChange,
+}: ConfigCardProps) {
+  return (
+    <div
+      data-testid="agent-config-card"
+      className="flex flex-col gap-2 rounded-md border border-[var(--border)] bg-[var(--bg-surface)] p-4 text-sm"
+    >
+      <h2 className="text-sm font-semibold">Agent Config</h2>
+      <p className="text-xs text-[var(--text-muted)]">
+        Change these and send a message to see the agent adapt.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium">Tone</span>
+          <select
+            data-testid="agent-config-tone-select"
+            value={config.tone}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              onToneChange(e.target.value as Tone)
+            }
+            className="rounded border border-[var(--border)] bg-[var(--bg-muted)] px-2 py-1 text-sm"
+          >
+            {TONE_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium">Expertise</span>
+          <select
+            data-testid="agent-config-expertise-select"
+            value={config.expertise}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              onExpertiseChange(e.target.value as Expertise)
+            }
+            className="rounded border border-[var(--border)] bg-[var(--bg-muted)] px-2 py-1 text-sm"
+          >
+            {EXPERTISE_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium">Response length</span>
+          <select
+            data-testid="agent-config-length-select"
+            value={config.responseLength}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              onResponseLengthChange(e.target.value as ResponseLength)
+            }
+            className="rounded border border-[var(--border)] bg-[var(--bg-muted)] px-2 py-1 text-sm"
+          >
+            {RESPONSE_LENGTH_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/agent-config/config-types.ts
+++ b/showcase/packages/langroid/src/app/demos/agent-config/config-types.ts
@@ -1,0 +1,26 @@
+export type Tone = "professional" | "casual" | "enthusiastic";
+export type Expertise = "beginner" | "intermediate" | "expert";
+export type ResponseLength = "concise" | "detailed";
+
+export interface AgentConfig {
+  tone: Tone;
+  expertise: Expertise;
+  responseLength: ResponseLength;
+}
+
+export const DEFAULT_AGENT_CONFIG: AgentConfig = {
+  tone: "professional",
+  expertise: "intermediate",
+  responseLength: "concise",
+};
+
+export const TONE_OPTIONS: Tone[] = ["professional", "casual", "enthusiastic"];
+export const EXPERTISE_OPTIONS: Expertise[] = [
+  "beginner",
+  "intermediate",
+  "expert",
+];
+export const RESPONSE_LENGTH_OPTIONS: ResponseLength[] = [
+  "concise",
+  "detailed",
+];

--- a/showcase/packages/langroid/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/agent-config/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CopilotChat, CopilotKit } from "@copilotkit/react-core/v2";
+import { useMemo } from "react";
+
+import { ConfigCard } from "./config-card";
+import { useAgentConfig } from "./use-agent-config";
+
+export default function AgentConfigDemoPage() {
+  const { config, setTone, setExpertise, setResponseLength } = useAgentConfig();
+
+  // Widen to `Record<string, any>` so the provider's `properties` prop accepts
+  // our strongly-typed config. The memo keeps the reference stable between
+  // renders when the config itself hasn't changed, so the provider's
+  // `[properties]`-keyed effect only re-fires when something real changed.
+  const providerProperties = useMemo<Record<string, unknown>>(
+    () => ({
+      tone: config.tone,
+      expertise: config.expertise,
+      responseLength: config.responseLength,
+    }),
+    [config.tone, config.expertise, config.responseLength],
+  );
+
+  return (
+    // @region[provider-setup]
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-agent-config"
+      agent="agent-config-demo"
+      properties={providerProperties}
+    >
+      <div className="flex h-screen flex-col gap-3 p-6">
+        <header>
+          <h1 className="text-lg font-semibold">Agent Config Object</h1>
+          <p className="text-sm text-[var(--text-muted)]">
+            Forwarded props let the frontend tell the agent how to behave. This
+            demo passes <code>tone</code>, <code>expertise</code>, and
+            <code> responseLength</code> through the provider; the agent reads
+            them from the LangGraph config and builds its system prompt per
+            turn.
+          </p>
+        </header>
+        <ConfigCard
+          config={config}
+          onToneChange={setTone}
+          onExpertiseChange={setExpertise}
+          onResponseLengthChange={setResponseLength}
+        />
+        <div className="flex-1 overflow-hidden rounded-md border border-[var(--border)]">
+          <CopilotChat
+            agentId="agent-config-demo"
+            className="h-full rounded-md"
+          />
+        </div>
+      </div>
+    </CopilotKit>
+    // @endregion[provider-setup]
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/agent-config/use-agent-config.ts
+++ b/showcase/packages/langroid/src/app/demos/agent-config/use-agent-config.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  type AgentConfig,
+  DEFAULT_AGENT_CONFIG,
+  type Expertise,
+  type ResponseLength,
+  type Tone,
+} from "./config-types";
+
+export interface UseAgentConfigHandle {
+  config: AgentConfig;
+  setTone: (tone: Tone) => void;
+  setExpertise: (expertise: Expertise) => void;
+  setResponseLength: (length: ResponseLength) => void;
+  reset: () => void;
+}
+
+export function useAgentConfig(): UseAgentConfigHandle {
+  const [config, setConfig] = useState<AgentConfig>(DEFAULT_AGENT_CONFIG);
+
+  const setTone = useCallback(
+    (tone: Tone) => setConfig((prev) => ({ ...prev, tone })),
+    [],
+  );
+  const setExpertise = useCallback(
+    (expertise: Expertise) => setConfig((prev) => ({ ...prev, expertise })),
+    [],
+  );
+  const setResponseLength = useCallback(
+    (responseLength: ResponseLength) =>
+      setConfig((prev) => ({ ...prev, responseLength })),
+    [],
+  );
+  const reset = useCallback(() => setConfig(DEFAULT_AGENT_CONFIG), []);
+
+  return { config, setTone, setExpertise, setResponseLength, reset };
+}

--- a/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+// Agentic Chat (Reasoning) — demonstrates a custom reasoning slot render.
+//
+// NOTE: The Langroid adapter does not currently emit REASONING_MESSAGE_*
+// events (Langroid's ChatAgent does not expose a separate thinking channel).
+// The custom slot renderer is wired and exercised, but reasoning messages
+// will only appear if a future agent iteration emits them.
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  CopilotChatReasoningMessage,
+} from "@copilotkit/react-core/v2";
+import { ReasoningBlock } from "./reasoning-block";
+
+export default function AgenticChatReasoningDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  return (
+    <CopilotChat
+      agentId="agentic-chat-reasoning"
+      className="h-full rounded-2xl"
+      messageView={{
+        reasoningMessage: ReasoningBlock as typeof CopilotChatReasoningMessage,
+      }}
+    />
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/reasoning-block.tsx
+++ b/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/reasoning-block.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React from "react";
+import type { ReasoningMessage, Message } from "@ag-ui/core";
+
+export function ReasoningBlock({
+  message,
+  messages,
+  isRunning,
+}: {
+  message: ReasoningMessage;
+  messages?: Message[];
+  isRunning?: boolean;
+}) {
+  const isLatest = messages?.[messages.length - 1]?.id === message.id;
+  const isStreaming = !!(isRunning && isLatest);
+  const hasContent = !!(message.content && message.content.length > 0);
+
+  return (
+    <div
+      data-testid="reasoning-block"
+      className="my-2 rounded-xl border border-[#DBDBE5] bg-[#BEC2FF1A] px-3.5 py-2.5 text-sm"
+    >
+      <div className="flex items-center gap-2 font-medium text-[#010507]">
+        <span className="inline-block rounded-full border border-[#BEC2FF] bg-white px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+          Reasoning
+        </span>
+        <span className="text-[#57575B]">
+          {isStreaming ? "Thinking..." : hasContent ? "Agent reasoning" : "..."}
+        </span>
+      </div>
+      {hasContent && (
+        <div className="mt-1.5 whitespace-pre-wrap italic text-[#57575B]">
+          {message.content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/auth/auth-banner.tsx
+++ b/showcase/packages/langroid/src/app/demos/auth/auth-banner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+interface AuthBannerProps {
+  authenticated: boolean;
+  onAuthenticate: () => void;
+  onSignOut: () => void;
+}
+
+/**
+ * Sticky banner above <CopilotChat /> that reflects and toggles demo auth
+ * state. Pure presentational. Testids are stable contract for QA + Playwright.
+ */
+export function AuthBanner({
+  authenticated,
+  onAuthenticate,
+  onSignOut,
+}: AuthBannerProps) {
+  const wrapperClass = authenticated
+    ? "border-emerald-300 bg-emerald-50 text-emerald-900"
+    : "border-amber-300 bg-amber-50 text-amber-900";
+  const statusText = authenticated
+    ? "Authenticated as demo user"
+    : "Not authenticated - the agent will reject your messages.";
+
+  return (
+    <div
+      data-testid="auth-banner"
+      data-authenticated={authenticated ? "true" : "false"}
+      className={`sticky top-0 z-10 flex items-center justify-between gap-3 rounded-md border px-4 py-3 text-sm ${wrapperClass}`}
+    >
+      <span data-testid="auth-status" className="font-medium">
+        {statusText}
+      </span>
+      {authenticated ? (
+        <button
+          type="button"
+          data-testid="auth-sign-out-button"
+          onClick={onSignOut}
+          className="rounded border border-emerald-400 bg-white px-3 py-1 text-xs font-medium text-emerald-800 hover:bg-emerald-100"
+        >
+          Sign out
+        </button>
+      ) : (
+        <button
+          type="button"
+          data-testid="auth-authenticate-button"
+          onClick={onAuthenticate}
+          className="rounded border border-amber-400 bg-white px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+        >
+          Authenticate
+        </button>
+      )}
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/auth/auth-banner.tsx
+++ b/showcase/packages/langroid/src/app/demos/auth/auth-banner.tsx
@@ -19,8 +19,8 @@ export function AuthBanner({
     ? "border-emerald-300 bg-emerald-50 text-emerald-900"
     : "border-amber-300 bg-amber-50 text-amber-900";
   const statusText = authenticated
-    ? "Authenticated as demo user"
-    : "Not authenticated - the agent will reject your messages.";
+    ? "✓ Signed in as demo user"
+    : "⚠ Signed out — the agent will reject your messages until you sign in.";
 
   return (
     <div
@@ -47,7 +47,7 @@ export function AuthBanner({
           onClick={onAuthenticate}
           className="rounded border border-amber-400 bg-white px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
         >
-          Authenticate
+          Sign in
         </button>
       )}
     </div>

--- a/showcase/packages/langroid/src/app/demos/auth/demo-token.ts
+++ b/showcase/packages/langroid/src/app/demos/auth/demo-token.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared demo-token constant imported by both the client
+ * (use-demo-auth.ts) and the server runtime route
+ * (api/copilotkit-auth/route.ts). Keeping the constant in one file
+ * prevents drift.
+ *
+ * This is a DEMO token. Never use a hard-coded shared secret for real auth.
+ */
+export const DEMO_TOKEN = "demo-token-123";
+
+export const DEMO_AUTH_HEADER = `Bearer ${DEMO_TOKEN}`;

--- a/showcase/packages/langroid/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/auth/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+// Auth demo — framework-native request authentication via the V2 runtime's
+// `onRequest` hook. The banner toggles an in-memory React auth flag; when
+// `authenticated === true`, <CopilotKit headers={...}> injects the
+// `Authorization: Bearer <demo-token>` header on every request. The runtime
+// route (/api/copilotkit-auth) rejects any request without the header.
+
+import { useCallback, useMemo, useState } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { useDemoAuth } from "./use-demo-auth";
+import { AuthBanner } from "./auth-banner";
+
+export default function AuthDemoPage() {
+  const auth = useDemoAuth();
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const authenticate = useCallback(() => {
+    setLastError(null);
+    auth.authenticate();
+  }, [auth]);
+
+  const signOut = useCallback(() => {
+    setLastError(null);
+    auth.signOut();
+  }, [auth]);
+
+  const headers = useMemo<Record<string, string>>(() => {
+    const h: Record<string, string> = {};
+    if (auth.authorizationHeader) {
+      h.Authorization = auth.authorizationHeader;
+    }
+    return h;
+  }, [auth.authorizationHeader]);
+
+  const onError = useCallback(
+    (errorEvent: {
+      error?: { message?: string; status?: number; statusCode?: number };
+      context?: { response?: { status?: number } };
+    }) => {
+      const err = errorEvent?.error;
+      const message = err?.message ?? "Request failed";
+      const status =
+        err?.status ?? err?.statusCode ?? errorEvent?.context?.response?.status;
+      if (status === 401 || /401|unauthor/i.test(message)) {
+        setLastError(
+          "401 Unauthorized - click Authenticate above to send messages.",
+        );
+      } else {
+        setLastError(message);
+      }
+    },
+    [],
+  );
+
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-auth"
+      agent="auth-demo"
+      headers={headers}
+      onError={onError}
+    >
+      <div className="flex h-screen flex-col gap-3 p-6">
+        <AuthBanner
+          authenticated={auth.authenticated}
+          onAuthenticate={authenticate}
+          onSignOut={signOut}
+        />
+        <header>
+          <h1 className="text-lg font-semibold">Authentication</h1>
+          <p className="text-sm text-neutral-600">
+            The runtime rejects requests without a valid Bearer token via an{" "}
+            <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-xs">
+              onRequest
+            </code>{" "}
+            hook. Try sending a message while unauthenticated, then click
+            Authenticate.
+          </p>
+        </header>
+        <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
+          <CopilotChat agentId="auth-demo" className="h-full" />
+        </div>
+        {lastError && (
+          <div
+            role="alert"
+            data-testid="auth-demo-error"
+            className="rounded border border-red-300 bg-red-50 px-3 py-2 text-xs font-medium text-red-900"
+          >
+            {lastError}
+          </div>
+        )}
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/auth/page.tsx
@@ -5,16 +5,96 @@
 // `authenticated === true`, <CopilotKit headers={...}> injects the
 // `Authorization: Bearer <demo-token>` header on every request. The runtime
 // route (/api/copilotkit-auth) rejects any request without the header.
+//
+// Default UX: the page loads authenticated so the initial `/info` handshake
+// succeeds and the chat is immediately usable. Clicking "Sign out" flips to
+// the unauthenticated state — the next chat submission (and any re-fetch of
+// `/info`) will 401, which we surface via the page-level error banner. This
+// inverts the historical unauth-first flow, which crashed the page on load
+// when `/info` returned 401 before `onError` handlers could attach.
+//
+// Error surfacing: <CopilotChat /> surfaces transport errors inconsistently
+// across states, so this page additionally captures errors via the
+// <CopilotKit onError> prop and renders a persistent error banner below the
+// chat. A local ErrorBoundary guards against any uncaught render-time error
+// from chat internals in the unauthenticated state so the page never white-
+// screens — instead, the user sees a clear in-page message.
 
-import { useCallback, useMemo, useState } from "react";
+import { Component, useCallback, useMemo, useState } from "react";
+import type { ErrorInfo, ReactNode } from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import { useDemoAuth } from "./use-demo-auth";
 import { AuthBanner } from "./auth-banner";
+
+interface ChatErrorBoundaryProps {
+  authenticated: boolean;
+  children: ReactNode;
+}
+
+interface ChatErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Guards <CopilotChat /> against uncaught render-time errors. If the chat
+ * internals throw (most commonly while the app is in the unauthenticated
+ * state and a transient response payload is missing), we render a clear
+ * in-page message instead of white-screening the entire route. The boundary
+ * resets whenever `authenticated` flips, so signing back in restores the
+ * live chat without requiring a full page reload.
+ */
+class ChatErrorBoundary extends Component<
+  ChatErrorBoundaryProps,
+  ChatErrorBoundaryState
+> {
+  state: ChatErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ChatErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: ChatErrorBoundaryProps): void {
+    // Reset on auth transition so signing in re-mounts a fresh <CopilotChat />.
+    if (
+      prevProps.authenticated !== this.props.authenticated &&
+      this.state.error
+    ) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Keep the console trail for devtools but do not rethrow.
+    console.error("[auth-demo] chat error boundary caught:", error, info);
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div
+          data-testid="auth-demo-chat-boundary"
+          className="flex h-full items-center justify-center p-6 text-center text-sm text-neutral-600"
+        >
+          <div>
+            <p className="font-medium text-neutral-800">
+              Chat unavailable while signed out
+            </p>
+            <p className="mt-1 text-xs text-neutral-500">
+              Click Sign in above to restore the conversation.
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 export default function AuthDemoPage() {
   const auth = useDemoAuth();
   const [lastError, setLastError] = useState<string | null>(null);
 
+  // Clear any stale error when auth state flips (authenticate OR sign out).
   const authenticate = useCallback(() => {
     setLastError(null);
     auth.authenticate();
@@ -25,6 +105,9 @@ export default function AuthDemoPage() {
     auth.signOut();
   }, [auth]);
 
+  // Compute headers reactively. The provider reads the latest headers prop
+  // on every request via a useEffect that calls `copilotkit.setHeaders(...)`
+  // whenever the merged headers object changes.
   const headers = useMemo<Record<string, string>>(() => {
     const h: Record<string, string> = {};
     if (auth.authorizationHeader) {
@@ -44,7 +127,7 @@ export default function AuthDemoPage() {
         err?.status ?? err?.statusCode ?? errorEvent?.context?.response?.status;
       if (status === 401 || /401|unauthor/i.test(message)) {
         setLastError(
-          "401 Unauthorized - click Authenticate above to send messages.",
+          "401 Unauthorized — click Sign in above to restore access.",
         );
       } else {
         setLastError(message);
@@ -73,12 +156,14 @@ export default function AuthDemoPage() {
             <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-xs">
               onRequest
             </code>{" "}
-            hook. Try sending a message while unauthenticated, then click
-            Authenticate.
+            hook. You start signed in — click Sign out above to exercise the 401
+            path, then Sign in to restore access.
           </p>
         </header>
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <ChatErrorBoundary authenticated={auth.authenticated}>
+            <CopilotChat agentId="auth-demo" className="h-full" />
+          </ChatErrorBoundary>
         </div>
         {lastError && (
           <div

--- a/showcase/packages/langroid/src/app/demos/auth/use-demo-auth.ts
+++ b/showcase/packages/langroid/src/app/demos/auth/use-demo-auth.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { DEMO_AUTH_HEADER, DEMO_TOKEN } from "./demo-token";
+
+export interface DemoAuthHandle {
+  authenticated: boolean;
+  token: string | null;
+  authorizationHeader: string | null;
+  authenticate: () => void;
+  signOut: () => void;
+}
+
+/**
+ * In-memory auth state for the /demos/auth showcase cell. No persistence.
+ */
+export function useDemoAuth(): DemoAuthHandle {
+  const [authenticated, setAuthenticated] = useState(false);
+
+  const authenticate = useCallback(() => {
+    setAuthenticated(true);
+  }, []);
+
+  const signOut = useCallback(() => {
+    setAuthenticated(false);
+  }, []);
+
+  return {
+    authenticated,
+    token: authenticated ? DEMO_TOKEN : null,
+    authorizationHeader: authenticated ? DEMO_AUTH_HEADER : null,
+    authenticate,
+    signOut,
+  };
+}

--- a/showcase/packages/langroid/src/app/demos/auth/use-demo-auth.ts
+++ b/showcase/packages/langroid/src/app/demos/auth/use-demo-auth.ts
@@ -5,17 +5,23 @@ import { DEMO_AUTH_HEADER, DEMO_TOKEN } from "./demo-token";
 
 export interface DemoAuthHandle {
   authenticated: boolean;
+  /** The token string when authenticated, otherwise null. */
   token: string | null;
+  /** The full `Bearer <token>` value when authenticated, otherwise null. */
   authorizationHeader: string | null;
   authenticate: () => void;
   signOut: () => void;
 }
 
 /**
- * In-memory auth state for the /demos/auth showcase cell. No persistence.
+ * In-memory auth state for the /demos/auth showcase cell. No persistence —
+ * refreshing the page resets to the default authenticated state, which keeps
+ * the demo immediately usable and avoids the 401 crash on initial `/info`
+ * fetch that happens when starting unauthenticated. Users can click "Sign
+ * out" to exercise the unauthenticated / 401 path on demand.
  */
 export function useDemoAuth(): DemoAuthHandle {
-  const [authenticated, setAuthenticated] = useState(false);
+  const [authenticated, setAuthenticated] = useState(true);
 
   const authenticate = useCallback(() => {
     setAuthenticated(true);

--- a/showcase/packages/langroid/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-customization-css/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+// Chat Customization (CSS) — all theming lives in theme.css, scoped to the
+// `.chat-css-demo-scope` wrapper. The page stays intentionally minimal;
+// only <CopilotChat /> is visibly re-themed.
+//
+// https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
+
+import React from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import "./theme.css";
+
+export default function ChatCustomizationCssDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="chat-css-demo-scope h-full w-full max-w-4xl">
+          <CopilotChat
+            agentId="chat-customization-css"
+            className="h-full rounded-2xl"
+          />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/packages/langroid/src/app/demos/chat-customization-css/theme.css
@@ -1,0 +1,91 @@
+/* Scoped theme for the chat-customization-css demo.
+ * All selectors are prefixed with `.chat-css-demo-scope` so they do not
+ * leak out and affect the rest of the showcase app.
+ */
+
+.chat-css-demo-scope {
+  --copilot-kit-primary-color: #ff006e;
+  --copilot-kit-contrast-color: #ffffff;
+  --copilot-kit-background-color: #fff8f0;
+  --copilot-kit-input-background-color: #fef3c7;
+  --copilot-kit-secondary-color: #fde047;
+  --copilot-kit-secondary-contrast-color: #2c1810;
+  --copilot-kit-separator-color: #ff006e;
+  --copilot-kit-muted-color: #c2185b;
+}
+
+.chat-css-demo-scope .copilotKitMessages {
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  background-color: #fff8f0;
+  color: #2c1810;
+  padding: 1.5rem 0;
+}
+
+.chat-css-demo-scope .copilotKitMessage.copilotKitUserMessage {
+  background: linear-gradient(135deg, #ff006e 0%, #c2185b 100%);
+  color: #ffffff;
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding: 14px 20px;
+  border-radius: 22px 22px 4px 22px;
+  box-shadow: 0 6px 16px rgba(255, 0, 110, 0.35);
+  border: 2px solid #ff6fa5;
+  letter-spacing: 0.01em;
+}
+
+.chat-css-demo-scope .copilotKitMessage.copilotKitAssistantMessage {
+  background: #fde047;
+  color: #1e1b4b;
+  font-family:
+    "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 1rem;
+  padding: 16px 20px;
+  border-radius: 4px 22px 22px 22px;
+  border: 2px solid #1e1b4b;
+  box-shadow: 4px 4px 0 #1e1b4b;
+  max-width: 80%;
+  margin-right: auto;
+  margin-bottom: 1rem;
+}
+
+.chat-css-demo-scope
+  .copilotKitMessage.copilotKitAssistantMessage
+  .copilotKitMarkdown,
+.chat-css-demo-scope
+  .copilotKitMessage.copilotKitAssistantMessage
+  .copilotKitMarkdown
+  p,
+.chat-css-demo-scope .copilotKitMessage.copilotKitAssistantMessage p {
+  color: #1e1b4b;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.chat-css-demo-scope .copilotKitInput {
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  background-color: #fef3c7;
+  border: 3px dashed #ff006e;
+  border-radius: 18px;
+  padding: 16px 18px;
+  min-height: 80px;
+}
+
+.chat-css-demo-scope .copilotKitInput > textarea {
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  font-size: 1.1rem;
+  color: #2c1810;
+}
+
+.chat-css-demo-scope .copilotKitInput > textarea::placeholder {
+  color: #c2185b;
+  font-style: italic;
+}
+
+.chat-css-demo-scope .copilotKitInputContainer {
+  background: #fff8f0;
+}
+
+.chat-css-demo-scope .copilotKitChat {
+  background-color: #fff8f0;
+}

--- a/showcase/packages/langroid/src/app/demos/chat-slots/custom-assistant-message.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-slots/custom-assistant-message.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import React from "react";
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+import type { CopilotChatAssistantMessageProps } from "@copilotkit/react-core/v2";
+
+export function CustomAssistantMessage(
+  props: CopilotChatAssistantMessageProps,
+) {
+  return (
+    <div
+      data-testid="custom-assistant-message"
+      className="relative rounded-xl border border-indigo-200 bg-indigo-50/60 dark:bg-indigo-950/40 dark:border-indigo-800 p-3 my-3"
+    >
+      <span className="absolute -top-2 -left-2 inline-block rounded-full bg-indigo-600 text-white text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 shadow">
+        slot
+      </span>
+      <CopilotChatAssistantMessage {...props} />
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/chat-slots/custom-disclaimer.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-slots/custom-disclaimer.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+export function CustomDisclaimer(props: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      {...props}
+      data-testid="custom-disclaimer"
+      className="text-xs text-center text-muted-foreground py-2"
+    >
+      <span className="inline-block rounded bg-indigo-100 text-indigo-700 px-2 py-0.5 mr-2 font-semibold">
+        slot
+      </span>
+      Custom disclaimer injected via <code>input.disclaimer</code>.
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/chat-slots/custom-welcome-screen.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-slots/custom-welcome-screen.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+
+export function CustomWelcomeScreen({
+  input,
+  suggestionView,
+}: {
+  input: React.ReactElement;
+  suggestionView: React.ReactElement;
+}) {
+  return (
+    <div
+      data-testid="custom-welcome-screen"
+      className="flex-1 flex flex-col items-center justify-center px-4"
+    >
+      <div className="w-full max-w-3xl flex flex-col items-center">
+        <div className="mb-6 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 p-6 text-white shadow-lg text-center">
+          <div className="inline-block rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wider mb-3">
+            Custom Slot
+          </div>
+          <h1 className="text-2xl font-bold">Welcome to the Slots demo</h1>
+          <p className="mt-2 text-sm text-white/90">
+            This welcome card is rendered via the{" "}
+            <code className="font-mono">welcomeScreen</code> slot.
+          </p>
+        </div>
+        <div className="w-full">{input}</div>
+        <div className="mt-4 flex justify-center">{suggestionView}</div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-slots/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  CopilotChatAssistantMessage,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CustomWelcomeScreen } from "./custom-welcome-screen";
+import { CustomAssistantMessage } from "./custom-assistant-message";
+import { CustomDisclaimer } from "./custom-disclaimer";
+
+export default function ChatSlotsDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+      { title: "Tell me a joke", message: "Tell me a short joke." },
+    ],
+    available: "always",
+  });
+
+  const welcomeScreen = CustomWelcomeScreen;
+  const input = { disclaimer: CustomDisclaimer };
+  const messageView = {
+    assistantMessage:
+      CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
+  };
+
+  return (
+    <CopilotChat
+      agentId="chat-slots"
+      className="h-full rounded-2xl"
+      welcomeScreen={welcomeScreen}
+      input={input}
+      messageView={messageView}
+    />
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/declarative-gen-ui/a2ui/catalog.ts
+++ b/showcase/packages/langroid/src/app/demos/declarative-gen-ui/a2ui/catalog.ts
@@ -1,0 +1,24 @@
+/**
+ * A2UI catalog DECLARATION.
+ *
+ * Wires `myDefinitions` (component schemas) × `myRenderers` (React
+ * implementations) into a Catalog the provider consumes via
+ * `a2ui={{ catalog: myCatalog }}`. `includeBasicCatalog: true` merges
+ * CopilotKit's built-in A2UI primitives (Column, Row, Text, Image,
+ * Card, Button, List, Tabs, …) so the agent can compose custom + basic
+ * components interchangeably.
+ *
+ * Reference:
+ *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui
+ */
+import { createCatalog } from "@copilotkit/a2ui-renderer";
+
+import { myDefinitions } from "./definitions";
+import { myRenderers } from "./renderers";
+
+// @region[create-catalog]
+export const myCatalog = createCatalog(myDefinitions, myRenderers, {
+  catalogId: "declarative-gen-ui-catalog",
+  includeBasicCatalog: true,
+});
+// @endregion[create-catalog]

--- a/showcase/packages/langroid/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/packages/langroid/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -1,0 +1,98 @@
+/**
+ * A2UI catalog DEFINITIONS — platform-agnostic.
+ *
+ * Each entry declares a custom component name + Zod props schema + a short
+ * description. The runtime's A2UI middleware serialises this schema into
+ * the agent's `copilotkit.context` at request time, so the LLM knows which
+ * components it may emit and what each prop expects.
+ *
+ * The React implementations live next to these definitions in
+ * `./renderers.tsx`, where they are wired through `createCatalog(...)` with
+ * `includeBasicCatalog: true` so the built-in A2UI primitives (Text, Row,
+ * Column, Image, Card, Button, …) come along for free.
+ */
+import { z } from "zod";
+import type { CatalogDefinitions } from "@copilotkit/a2ui-renderer";
+
+// @region[definitions-zod]
+export const myDefinitions = {
+  Card: {
+    description:
+      "A titled card container with an optional subtitle and a single child slot. Use it to group related content (metrics, rows, buttons).",
+    props: z.object({
+      title: z.string(),
+      subtitle: z.string().optional(),
+      child: z.string().optional(),
+    }),
+  },
+
+  StatusBadge: {
+    description:
+      "A small coloured pill communicating the state of something (healthy/degraded/down, online/offline, open/closed). Choose `variant` to match the intent.",
+    props: z.object({
+      text: z.string(),
+      variant: z.enum(["success", "warning", "error", "info"]).optional(),
+    }),
+  },
+
+  Metric: {
+    description:
+      "A key/value KPI display with an optional trend indicator. Ideal for dashboards (e.g. 'Revenue • $12.4k • up').",
+    props: z.object({
+      label: z.string(),
+      value: z.string(),
+      trend: z.enum(["up", "down", "neutral"]).optional(),
+    }),
+  },
+
+  InfoRow: {
+    description:
+      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, last updated, etc.).",
+    props: z.object({
+      label: z.string(),
+      value: z.string(),
+    }),
+  },
+
+  PrimaryButton: {
+    description:
+      "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",
+    props: z.object({
+      label: z.string(),
+      action: z.any().optional(),
+    }),
+  },
+
+  PieChart: {
+    description:
+      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (sales by region, traffic sources, portfolio allocation).",
+    props: z.object({
+      title: z.string(),
+      description: z.string(),
+      data: z.array(
+        z.object({
+          label: z.string(),
+          value: z.number(),
+        }),
+      ),
+    }),
+  },
+
+  BarChart: {
+    description:
+      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories (quarterly revenue, headcount by team, signups per month).",
+    props: z.object({
+      title: z.string(),
+      description: z.string(),
+      data: z.array(
+        z.object({
+          label: z.string(),
+          value: z.number(),
+        }),
+      ),
+    }),
+  },
+} satisfies CatalogDefinitions;
+// @endregion[definitions-zod]
+
+export type MyDefinitions = typeof myDefinitions;

--- a/showcase/packages/langroid/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/packages/langroid/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -1,0 +1,529 @@
+"use client";
+
+/**
+ * A2UI catalog RENDERERS.
+ *
+ * React implementations for each definition in `./definitions.ts`.
+ * The assembled catalog (definitions × renderers via `createCatalog`)
+ * lives in `./catalog.ts`.
+ *
+ * Reference:
+ *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui
+ */
+import React, { useRef } from "react";
+import {
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Rectangle,
+} from "recharts";
+import type { CatalogRenderers } from "@copilotkit/a2ui-renderer";
+
+import type { MyDefinitions } from "./definitions";
+
+// ─── Brand chart palette (verbatim from beautiful-chat/charts/config.ts) ────
+// CopilotKit brand tokens — Plus Jakarta Sans / brand colour system.
+const CHART_COLORS = [
+  "#BEC2FF", // lilac-400
+  "#85ECCE", // mint-400
+  "#FFAC4D", // orange-400
+  "#FFF388", // yellow-400
+  "#189370", // mint-800
+  "#EEE6FE", // primary-100
+  "#FA5F67", // red-400
+] as const;
+
+const CHART_TOOLTIP_STYLE: React.CSSProperties = {
+  backgroundColor: "white",
+  border: "1px solid #DBDBE5",
+  borderRadius: 10,
+  padding: "10px 14px",
+  color: "#010507",
+  fontSize: 13,
+  boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+};
+
+/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
+function DonutChart({
+  data,
+  size = 240,
+  strokeWidth = 40,
+}: {
+  data: { label: string; value: number }[];
+  size?: number;
+  strokeWidth?: number;
+}) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+
+  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+  let accumulated = 0;
+  const slices = data.map((item, index) => {
+    const val = Number(item.value) || 0;
+    const ratio = total > 0 ? val / total : 0;
+    const arc = ratio * circumference;
+    const startAt = accumulated;
+    accumulated += arc;
+    return {
+      ...item,
+      arc,
+      gap: circumference - arc,
+      dashoffset: -startAt,
+      color: CHART_COLORS[index % CHART_COLORS.length],
+    };
+  });
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${size} ${size}`}
+      style={{
+        display: "block",
+        margin: "0 auto",
+        maxWidth: size,
+        transform: "scaleX(-1)",
+      }}
+    >
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke="#F4F4F7"
+        strokeWidth={strokeWidth}
+      />
+      {slices.map((slice, i) => (
+        <circle
+          key={i}
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={slice.color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={`${slice.arc} ${slice.gap}`}
+          strokeDashoffset={slice.dashoffset}
+          strokeLinecap="butt"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+      ))}
+    </svg>
+  );
+}
+
+/** Tracks seen indices so only NEW bars get the fade-in animation. */
+function useSeenIndices() {
+  const seen = useRef(new Set<number>());
+  return {
+    isNew(index: number) {
+      if (seen.current.has(index)) return false;
+      seen.current.add(index);
+      return true;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function AnimatedBar(props: any) {
+  const { isNew, ...rest } = props;
+  return (
+    <g
+      style={
+        isNew
+          ? {
+              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
+            }
+          : undefined
+      }
+    >
+      <Rectangle {...rest} />
+    </g>
+  );
+}
+
+const badgePalette: Record<
+  "success" | "warning" | "error" | "info",
+  { bg: string; fg: string; border: string }
+> = {
+  success: {
+    bg: "rgba(133, 236, 206, 0.15)",
+    fg: "#189370",
+    border: "#85ECCE4D",
+  },
+  warning: {
+    bg: "rgba(255, 172, 77, 0.12)",
+    fg: "#010507",
+    border: "#FFAC4D33",
+  },
+  error: { bg: "rgba(250, 95, 103, 0.1)", fg: "#FA5F67", border: "#FA5F6733" },
+  info: { bg: "#BEC2FF1A", fg: "#010507", border: "#BEC2FF" },
+};
+
+// @region[renderers-react]
+export const myRenderers: CatalogRenderers<MyDefinitions> = {
+  Card: ({ props, children }) => (
+    <div
+      style={{
+        border: "1px solid #DBDBE5",
+        borderRadius: 16,
+        padding: 20,
+        background: "white",
+        boxShadow: "0 1px 3px rgba(1, 5, 7, 0.04)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        minWidth: 260,
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <div style={{ fontWeight: 600, fontSize: "1rem", color: "#010507" }}>
+          {props.title}
+        </div>
+        {props.subtitle && (
+          <div style={{ color: "#57575B", fontSize: "0.85rem" }}>
+            {props.subtitle}
+          </div>
+        )}
+      </div>
+      {props.child && children(props.child)}
+    </div>
+  ),
+
+  StatusBadge: ({ props }) => {
+    const variant = props.variant ?? "info";
+    const { bg, fg, border } = badgePalette[variant];
+    return (
+      <span
+        style={{
+          display: "inline-block",
+          padding: "2px 10px",
+          background: bg,
+          color: fg,
+          border: `1px solid ${border}`,
+          borderRadius: 999,
+          fontSize: "0.7rem",
+          fontWeight: 600,
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+        }}
+      >
+        {props.text}
+      </span>
+    );
+  },
+
+  Metric: ({ props }) => {
+    const trend = props.trend ?? "neutral";
+    const arrow = trend === "up" ? "↑" : trend === "down" ? "↓" : "";
+    const color =
+      trend === "up" ? "#189370" : trend === "down" ? "#FA5F67" : "#010507";
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <div
+          style={{
+            fontSize: "0.7rem",
+            color: "#838389",
+            textTransform: "uppercase",
+            letterSpacing: "0.12em",
+          }}
+        >
+          {props.label}
+        </div>
+        <div
+          style={{
+            fontSize: "1.5rem",
+            fontWeight: 600,
+            color,
+            display: "flex",
+            gap: 6,
+            alignItems: "baseline",
+          }}
+        >
+          <span>{props.value}</span>
+          {arrow && <span style={{ fontSize: "1rem" }}>{arrow}</span>}
+        </div>
+      </div>
+    );
+  },
+
+  InfoRow: ({ props }) => (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "baseline",
+        gap: 16,
+        paddingTop: 6,
+        paddingBottom: 6,
+        borderBottom: "1px solid #E9E9EF",
+      }}
+    >
+      <span style={{ color: "#57575B", fontSize: "0.85rem" }}>
+        {props.label}
+      </span>
+      <span style={{ color: "#010507", fontWeight: 500, fontSize: "0.9rem" }}>
+        {props.value}
+      </span>
+    </div>
+  ),
+
+  PrimaryButton: ({ props, dispatch }) => (
+    <button
+      onClick={() => {
+        if (props.action && dispatch) dispatch(props.action);
+      }}
+      style={{
+        padding: "10px 16px",
+        borderRadius: 12,
+        border: "none",
+        background: "#010507",
+        color: "white",
+        fontWeight: 500,
+        fontSize: "0.9rem",
+        cursor: "pointer",
+        transition: "background 0.15s ease",
+      }}
+      onMouseEnter={(e) =>
+        ((e.currentTarget as HTMLButtonElement).style.background = "#2B2B2B")
+      }
+      onMouseLeave={(e) =>
+        ((e.currentTarget as HTMLButtonElement).style.background = "#010507")
+      }
+    >
+      {props.label}
+    </button>
+  ),
+
+  PieChart: ({ props }) => {
+    const data = props.data ?? [];
+    const safeData = Array.isArray(data) ? data : [];
+    const total = safeData.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+    return (
+      <div
+        style={{
+          border: "1px solid #DBDBE5",
+          borderRadius: 16,
+          padding: 20,
+          background: "white",
+          boxShadow: "0 1px 3px rgba(1, 5, 7, 0.04)",
+          maxWidth: 520,
+          margin: "0 auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <div style={{ fontWeight: 600, fontSize: "1rem", color: "#010507" }}>
+            {props.title}
+          </div>
+          <div style={{ color: "#57575B", fontSize: "0.85rem" }}>
+            {props.description}
+          </div>
+        </div>
+
+        {safeData.length === 0 ? (
+          <div
+            style={{
+              color: "#838389",
+              textAlign: "center",
+              padding: "32px 0",
+              fontSize: "0.85rem",
+            }}
+          >
+            No data available
+          </div>
+        ) : (
+          <>
+            <DonutChart data={safeData} />
+
+            {/* Legend */}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+                paddingTop: 8,
+              }}
+            >
+              {safeData.map((item, index) => {
+                const val = Number(item.value) || 0;
+                const pct = total > 0 ? ((val / total) * 100).toFixed(0) : "0";
+                return (
+                  <div
+                    key={index}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 12,
+                      fontSize: "0.85rem",
+                    }}
+                  >
+                    <span
+                      style={{
+                        display: "inline-block",
+                        width: 12,
+                        height: 12,
+                        borderRadius: 999,
+                        flexShrink: 0,
+                        backgroundColor:
+                          CHART_COLORS[index % CHART_COLORS.length],
+                      }}
+                    />
+                    <span
+                      style={{
+                        flex: 1,
+                        color: "#010507",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {item.label}
+                    </span>
+                    <span
+                      style={{
+                        color: "#57575B",
+                        fontVariantNumeric: "tabular-nums",
+                      }}
+                    >
+                      {val.toLocaleString()}
+                    </span>
+                    <span
+                      style={{
+                        color: "#57575B",
+                        width: 40,
+                        textAlign: "right",
+                        fontVariantNumeric: "tabular-nums",
+                      }}
+                    >
+                      {pct}%
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    );
+  },
+
+  BarChart: ({ props }) => {
+    const { isNew } = useSeenIndices();
+    const data = props.data ?? [];
+    const safeData = Array.isArray(data) ? data : [];
+
+    return (
+      <div
+        style={{
+          border: "1px solid #DBDBE5",
+          borderRadius: 16,
+          padding: 20,
+          background: "white",
+          boxShadow: "0 1px 3px rgba(1, 5, 7, 0.04)",
+          maxWidth: 640,
+          margin: "0 auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+          overflow: "hidden",
+        }}
+      >
+        {/* Scoped keyframe — no globals.css needed */}
+        <style>{`
+          @keyframes barSlideIn {
+            from { transform: translateY(40px); opacity: 0; }
+            20% { opacity: 1; }
+            to { transform: translateY(0); opacity: 1; }
+          }
+        `}</style>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <div style={{ fontWeight: 600, fontSize: "1rem", color: "#010507" }}>
+            {props.title}
+          </div>
+          <div style={{ color: "#57575B", fontSize: "0.85rem" }}>
+            {props.description}
+          </div>
+        </div>
+
+        {safeData.length === 0 ? (
+          <div
+            style={{
+              color: "#838389",
+              textAlign: "center",
+              padding: "32px 0",
+              fontSize: "0.85rem",
+            }}
+          >
+            No data available
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <RechartsBarChart
+              data={safeData}
+              margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="#E9E9EF"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 12, fill: "#57575B" }}
+                stroke="#E9E9EF"
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 12, fill: "#57575B" }}
+                stroke="#E9E9EF"
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip
+                contentStyle={CHART_TOOLTIP_STYLE}
+                cursor={{ fill: "#F4F4F7", opacity: 0.5 }}
+              />
+              <Bar
+                isAnimationActive={false}
+                dataKey="value"
+                radius={[6, 6, 0, 0]}
+                maxBarSize={48}
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                shape={
+                  ((barProps: any) => (
+                    <AnimatedBar
+                      {...barProps}
+                      isNew={isNew(barProps.index as number)}
+                    />
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  )) as any
+                }
+              >
+                {safeData.map((_, index) => (
+                  <Cell
+                    key={index}
+                    fill={CHART_COLORS[index % CHART_COLORS.length]}
+                  />
+                ))}
+              </Bar>
+            </RechartsBarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    );
+  },
+};
+// @endregion[renderers-react]

--- a/showcase/packages/langroid/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/declarative-gen-ui/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * Declarative Generative UI (A2UI — Dynamic Schema) demo.
+ *
+ * Pattern:
+ *   1. Define a small set of branded React components + Zod schemas in
+ *      `./a2ui/definitions.ts` and `./a2ui/renderers.tsx` (the latter calls
+ *      `createCatalog(..., { includeBasicCatalog: true })` and exports
+ *      `myCatalog`).
+ *   2. Pass that catalog to the provider via
+ *      `<CopilotKit a2ui={{ catalog: myCatalog }}>`.
+ *   3. The dedicated runtime at `/api/copilotkit-declarative-gen-ui` is
+ *      configured with `injectA2UITool: false` — the backend agent
+ *      (`src/agents/a2ui_dynamic.py`) owns the `generate_a2ui` tool
+ *      explicitly, mirroring the working pattern from beautiful-chat and the
+ *      canonical `examples/integrations/langgraph-python` reference. The
+ *      A2UI middleware still serialises the registered catalog schema into
+ *      `copilotkit.context` so the secondary LLM inside `generate_a2ui`
+ *      knows which components are available.
+ *
+ * Reference:
+ *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui
+ */
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+import { myCatalog } from "./a2ui/catalog";
+
+export default function DeclarativeGenUIDemo() {
+  return (
+    // @region[provider-a2ui-prop]
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-declarative-gen-ui"
+      agent="declarative-gen-ui"
+      a2ui={{ catalog: myCatalog }}
+    >
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+    // @endregion[provider-a2ui-prop]
+  );
+}
+
+function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Show a KPI dashboard",
+        message:
+          "Show me a quick KPI dashboard with 3-4 metrics (revenue, signups, churn).",
+      },
+      {
+        title: "Pie chart — sales by region",
+        message: "Show a pie chart of sales by region.",
+      },
+      {
+        title: "Bar chart — quarterly revenue",
+        message: "Render a bar chart of quarterly revenue.",
+      },
+      {
+        title: "Status report",
+        message:
+          "Give me a status report on system health — API, database, and background workers.",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <CopilotChat agentId="declarative-gen-ui" className="h-full rounded-2xl" />
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/frontend-tools-async/notes-card.tsx
+++ b/showcase/packages/langroid/src/app/demos/frontend-tools-async/notes-card.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React from "react";
+
+export interface Note {
+  id: string;
+  title: string;
+  excerpt: string;
+  tags?: string[];
+}
+
+export interface NotesCardProps {
+  loading: boolean;
+  keyword: string;
+  notes?: Note[];
+}
+
+export function NotesCard({ loading, keyword, notes }: NotesCardProps) {
+  return (
+    <div
+      data-testid="notes-card"
+      className="rounded-2xl mt-4 mb-4 max-w-md w-full bg-white border border-[#DBDBE5] shadow-sm"
+    >
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B] mb-1">
+              Notes DB
+            </div>
+            <h3
+              data-testid="notes-keyword"
+              className="text-base font-semibold text-[#010507]"
+            >
+              Matching &ldquo;{keyword}&rdquo;
+            </h3>
+            <p className="text-[#57575B] text-xs mt-0.5">
+              {loading
+                ? "Querying local notes DB..."
+                : `${notes?.length ?? 0} match${(notes?.length ?? 0) === 1 ? "" : "es"}`}
+            </p>
+          </div>
+          <div className="text-xl" aria-hidden>
+            {loading ? "..." : "Notes"}
+          </div>
+        </div>
+
+        {!loading && notes && notes.length > 0 && (
+          <ul
+            data-testid="notes-list"
+            className="mt-4 pt-4 border-t border-[#E9E9EF] space-y-2 text-sm"
+          >
+            {notes.map((n) => (
+              <li
+                key={n.id}
+                data-testid={`note-${n.id}`}
+                className="rounded-xl border border-[#E9E9EF] bg-[#FAFAFC] p-2.5"
+              >
+                <p className="font-medium text-[#010507]">{n.title}</p>
+                <p className="text-[#57575B] text-xs mt-0.5">{n.excerpt}</p>
+                {n.tags && n.tags.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {n.tags.map((t) => (
+                      <span
+                        key={t}
+                        className="text-[10px] font-medium uppercase tracking-[0.1em] bg-white border border-[#DBDBE5] text-[#57575B] rounded-full px-1.5 py-0.5"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {!loading && (!notes || notes.length === 0) && (
+          <p className="mt-4 pt-4 border-t border-[#E9E9EF] text-sm text-[#838389] italic">
+            No notes matched.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/frontend-tools-async/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import React from "react";
+import {
+  useFrontendTool,
+  useConfigureSuggestions,
+  CopilotChat,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { z } from "zod";
+import { NotesCard, type Note } from "./notes-card";
+
+const NOTES_DB: Note[] = [
+  {
+    id: "n1",
+    title: "Q2 project planning kickoff",
+    excerpt:
+      "Discussed scope for the new onboarding flow with design. Draft spec due Friday.",
+    tags: ["planning", "project", "onboarding"],
+  },
+  {
+    id: "n2",
+    title: "Planning: migrate auth to passkeys",
+    excerpt:
+      "Research WebAuthn library options. Consider fallback for unsupported browsers.",
+    tags: ["planning", "auth", "security"],
+  },
+  {
+    id: "n3",
+    title: "Grocery list",
+    excerpt: "Olive oil, tomatoes, sourdough, basil, parmesan.",
+    tags: ["personal", "shopping"],
+  },
+  {
+    id: "n4",
+    title: "Book recommendations",
+    excerpt:
+      "Thinking Fast and Slow (Kahneman); The Design of Everyday Things (Norman).",
+    tags: ["reading"],
+  },
+  {
+    id: "n5",
+    title: "Project planning retrospective notes",
+    excerpt:
+      "What went well: async standups. What didn't: ambiguous ownership on shared components.",
+    tags: ["retro", "project", "planning"],
+  },
+  {
+    id: "n6",
+    title: "Weekend hike plan",
+    excerpt: "Tam West Peak to Rock Spring. 8mi loop, bring layers.",
+    tags: ["personal", "outdoors"],
+  },
+  {
+    id: "n7",
+    title: "1:1 prep — career planning",
+    excerpt: "Discuss growth areas. Ask about scope for Q3. Revisit goals doc.",
+    tags: ["career", "planning"],
+  },
+];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
+export default function FrontendToolsAsyncDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  useFrontendTool({
+    name: "query_notes",
+    description:
+      "Search the user's local notes database for notes whose title, " +
+      "excerpt, or tags contain the given keyword (case-insensitive). " +
+      "Returns up to 5 matching notes.",
+    parameters: z.object({
+      keyword: z
+        .string()
+        .describe("Keyword or phrase to search notes for (case-insensitive)."),
+    }),
+    handler: async ({ keyword }: { keyword: string }) => {
+      await sleep(500);
+      const q = keyword.toLowerCase();
+      const matches = NOTES_DB.filter((n) => {
+        return (
+          n.title.toLowerCase().includes(q) ||
+          n.excerpt.toLowerCase().includes(q) ||
+          (n.tags ?? []).some((t) => t.toLowerCase().includes(q))
+        );
+      }).slice(0, 5);
+      return {
+        keyword,
+        count: matches.length,
+        notes: matches,
+      };
+    },
+    render: ({ args, result, status }) => {
+      const loading = status !== "complete";
+      const parsed = parseJsonResult<{
+        keyword?: string;
+        count?: number;
+        notes?: Note[];
+      }>(result);
+      return (
+        <NotesCard
+          loading={loading}
+          keyword={args?.keyword ?? parsed.keyword ?? ""}
+          notes={parsed.notes}
+        />
+      );
+    },
+  });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Find project-planning notes",
+        message: "Find my notes about project planning.",
+      },
+      {
+        title: "Search for 'auth'",
+        message: "Search my notes for anything related to auth.",
+      },
+      {
+        title: "What do I have about reading?",
+        message: "Do I have any notes tagged reading?",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <CopilotChat
+      agentId="frontend-tools-async"
+      className="h-full rounded-2xl"
+    />
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/frontend-tools/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  useFrontendTool,
+  useConfigureSuggestions,
+  CopilotChat,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { z } from "zod";
+
+export default function FrontendToolsDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+      <Chat />
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  const [background, setBackground] = useState<string>(
+    "var(--copilot-kit-background-color)",
+  );
+
+  useFrontendTool({
+    name: "change_background",
+    description:
+      "Change the background color of the chat. Accepts any valid CSS background value — colors, linear or radial gradients, etc.",
+    parameters: z.object({
+      background: z
+        .string()
+        .describe("The CSS background value. Prefer gradients."),
+    }),
+    handler: async ({ background }: { background: string }) => {
+      setBackground(background);
+      return {
+        status: "success",
+        message: `Background changed to ${background}`,
+      };
+    },
+  });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Change background",
+        message: "Change the background to a blue-to-purple gradient.",
+      },
+      {
+        title: "Sunset theme",
+        message: "Make the background a sunset-themed gradient.",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <div
+      className="flex justify-center items-center h-screen w-full"
+      data-testid="background-container"
+      style={{ background }}
+    >
+      <div className="h-full w-full max-w-4xl">
+        <CopilotChat agentId="frontend_tools" className="h-full rounded-2xl" />
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/assistant-bubble.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/assistant-bubble.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Left-aligned assistant bubble — pure chrome.
+ *
+ * Receives a precomputed `renderedContent` node (built by
+ * `useRenderedMessages`) and wraps it in the styled bubble container.
+ * No imports from `@copilotkit/react-core`'s chat primitives here — the
+ * manual composition upstream already produced the final node, so this
+ * file is purely presentational.
+ *
+ * An empty node (e.g. an assistant message that has neither text nor tool
+ * calls yet) is suppressed so the bubble doesn't flash an empty rounded
+ * box while streaming hasn't started.
+ */
+// @region[custom-bubbles]
+export function AssistantBubble({ children }: { children: React.ReactNode }) {
+  if (isEmpty(children)) return null;
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] flex flex-col gap-2">
+        <div className="rounded-2xl rounded-bl-sm bg-[#F0F0F4] text-[#010507] px-4 py-2 text-sm">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+// @endregion[custom-bubbles]
+
+function isEmpty(node: React.ReactNode): boolean {
+  if (node == null || node === false) return true;
+  if (typeof node === "string") return node.trim().length === 0;
+  if (Array.isArray(node)) return node.every(isEmpty);
+  return false;
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/highlight-note.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/highlight-note.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import { z } from "zod";
+
+/**
+ * Frontend-only component invoked by the agent as a tool call via
+ * `useComponent({ name: "highlight_note", ... })`. The backend does
+ * NOT define this tool — `useComponent` is sugar over
+ * `useFrontendTool`, so the tool is registered against the frontend and
+ * surfaces through the same `useRenderToolCall` path the manual hook
+ * in `use-rendered-messages.tsx` is wired to.
+ */
+export const highlightNotePropsSchema = z.object({
+  text: z.string().describe("The note text to highlight."),
+  color: z
+    .enum(["yellow", "pink", "green", "blue"])
+    .describe("Highlight color for the note."),
+});
+
+export type HighlightNoteProps = z.infer<typeof highlightNotePropsSchema>;
+
+const COLOR_CLASSES: Record<HighlightNoteProps["color"], string> = {
+  yellow: "bg-[#FFF388]/30 border-[#FFF388] text-[#010507]",
+  pink: "bg-[#FA5F67]/10 border-[#FA5F6733] text-[#010507]",
+  green: "bg-[#85ECCE]/20 border-[#85ECCE4D] text-[#010507]",
+  blue: "bg-[#BEC2FF1A] border-[#BEC2FF] text-[#010507]",
+};
+
+export function HighlightNote({ text, color }: HighlightNoteProps) {
+  const cls = COLOR_CLASSES[color] ?? COLOR_CLASSES.yellow;
+  return (
+    <div
+      className={`mt-2 mb-2 inline-block rounded-xl border px-3 py-2 text-sm font-medium shadow-sm ${cls}`}
+    >
+      <span className="mr-2 text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+        Note
+      </span>
+      {text}
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/input-bar.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/input-bar.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { useRef } from "react";
+
+/**
+ * Composer for the headless chat.
+ *
+ * A textarea plus a Send / Stop toggle. Enter submits; Shift+Enter inserts a
+ * newline. The textarea is disabled while the agent is running so users can't
+ * pile up concurrent turns.
+ */
+export function InputBar({
+  value,
+  onChange,
+  onSubmit,
+  onStop,
+  isRunning,
+  canStop,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onStop: () => void;
+  isRunning: boolean;
+  canStop: boolean;
+}) {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <form
+      className="border-t border-[#E9E9EF] p-3 flex gap-2 items-end bg-white"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <textarea
+        ref={inputRef}
+        rows={1}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={isRunning ? "Agent is working..." : "Type a message..."}
+        disabled={isRunning}
+        className="flex-1 resize-none rounded-2xl border border-[#DBDBE5] bg-white px-4 py-2 text-sm leading-6 text-[#010507] focus:border-[#BEC2FF] focus:outline-none focus:ring-2 focus:ring-[#BEC2FF33] disabled:bg-[#FAFAFC] disabled:text-[#AFAFB7]"
+      />
+      {canStop ? (
+        <button
+          type="button"
+          onClick={onStop}
+          className="rounded-full px-4 py-2 text-sm font-medium bg-[#FA5F67] text-white hover:opacity-90 transition-opacity"
+        >
+          Stop
+        </button>
+      ) : (
+        <button
+          type="submit"
+          disabled={isRunning || value.trim().length === 0}
+          className="rounded-full px-4 py-2 text-sm font-medium bg-[#010507] text-white hover:bg-[#2B2B2B] disabled:bg-[#DBDBE5] disabled:cursor-not-allowed transition-colors"
+        >
+          Send
+        </button>
+      )}
+    </form>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/message-list.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/message-list.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { useLayoutEffect, useRef } from "react";
+import type { Message } from "@ag-ui/core";
+import { UserBubble } from "./user-bubble";
+import { AssistantBubble } from "./assistant-bubble";
+import { TypingIndicator } from "./typing-indicator";
+import { useRenderedMessages } from "./use-rendered-messages";
+
+/**
+ * Scrollable messages area — TRULY headless.
+ *
+ * The per-message generative-UI weave (text, reasoning, tool-call renders,
+ * activity messages, custom-before / custom-after) is composed inline by
+ * `useRenderedMessages`, which returns a flat list of messages each carrying
+ * a precomputed `renderedContent` field. Here we simply dispatch on role
+ * and drop that node into the appropriate bubble chrome — no
+ * `<CopilotChatMessageView>`, no `<CopilotChatAssistantMessage>`.
+ *
+ * See `use-rendered-messages.tsx` for the composition logic; it mirrors
+ * `packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx:542-612`.
+ */
+export function MessageList({
+  messages,
+  isRunning,
+}: {
+  messages: Message[];
+  isRunning: boolean;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const renderedMessages = useRenderedMessages(messages, isRunning);
+
+  // Auto-scroll on streaming content changes (not just new messages).
+  const fingerprint = messages
+    .map((m) => {
+      const contentLen =
+        typeof m.content === "string"
+          ? m.content.length
+          : Array.isArray(m.content)
+            ? m.content.length
+            : 0;
+      const tcLen =
+        "toolCalls" in m && Array.isArray(m.toolCalls)
+          ? m.toolCalls.map((tc) => tc.function.arguments.length).join(",")
+          : "";
+      return `${m.id}:${m.role}:${contentLen}:${tcLen}`;
+    })
+    .join("|");
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [fingerprint, isRunning]);
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid="headless-complete-messages"
+      className="flex-1 min-h-0 overflow-y-auto px-4 py-4"
+    >
+      <div className="space-y-3">
+        {renderedMessages.length === 0 && (
+          <div className="text-center text-sm text-[#838389] mt-8">
+            Try weather, a stock, a highlighted note, or an Excalidraw sketch.
+          </div>
+        )}
+        {renderedMessages.map((m) => {
+          // Tool-role messages are folded into the preceding assistant
+          // message's tool-call renders; `renderedContent` is null for them.
+          if (m.renderedContent == null) return null;
+          if (m.role === "user") {
+            return <UserBubble key={m.id}>{m.renderedContent}</UserBubble>;
+          }
+          return (
+            <AssistantBubble key={m.id}>{m.renderedContent}</AssistantBubble>
+          );
+        })}
+        {isRunning && <TypingIndicator />}
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+/**
+ * Headless Chat (Complete) — TRULY headless.
+ *
+ * A full chat implementation built from scratch on `useAgent`, without using
+ * `<CopilotChat />` AND without `<CopilotChatMessageView>` or
+ * `<CopilotChatAssistantMessage>`. Demonstrates:
+ *   - scrollable messages area with auto-scroll to bottom on new messages
+ *   - distinct user vs assistant bubbles (pure chrome — no chat primitives)
+ *   - text input + send button, disabled while running
+ *   - stop button to cancel a running agent turn
+ *   - the FULL generative UI composition — text, reasoning cards, tool-call
+ *     renderings (`useRenderTool` / `useDefaultRenderTool` / `useComponent` /
+ *     `useFrontendTool`), A2UI activity messages, MCP Apps activity messages,
+ *     and custom-message renderers — re-composed by hand from the low-level
+ *     hooks (`useRenderToolCall`, `useRenderActivityMessage`,
+ *     `useRenderCustomMessages`) inside `use-rendered-messages.tsx`.
+ *
+ * This file is orchestration only — the provider, the agent wiring, and the
+ * top-level send/stop handlers. Presentational pieces (message list, bubbles,
+ * typing indicator, input bar) live in sibling files.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CopilotKit,
+  CopilotChatConfigurationProvider,
+  useAgent,
+  useCopilotKit,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import type { Message } from "@ag-ui/core";
+import { MessageList } from "./message-list";
+import { InputBar } from "./input-bar";
+import { useHeadlessCompleteToolRenderers } from "./tool-renderers";
+
+const AGENT_ID = "headless-complete";
+
+// Outer wrapper — provides the CopilotKit runtime + page layout.
+// Routed through the unified Langroid runtime at /api/copilotkit. The
+// hand-rolled `useRenderActivityMessage` in `use-rendered-messages.tsx`
+// still works; MCP activity events are simply not emitted by this backend.
+export default function HeadlessCompleteDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+      <div className="flex justify-center items-center h-screen w-full bg-gray-50">
+        <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
+          <header className="px-4 py-3 border-b border-gray-200">
+            <h1 className="text-base font-semibold">
+              Headless Chat (Complete)
+            </h1>
+            <p className="text-xs text-gray-500">
+              Built from scratch on useAgent — no CopilotChat.
+            </p>
+          </header>
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+// Inner view — the actual chat. Reads messages + isRunning straight off the
+// agent, wires up the connect/run/stop lifecycle, and hands the pure
+// presentational pieces their props.
+function Chat() {
+  // @region[page-send-message]
+  const threadId = useMemo(() => crypto.randomUUID(), []);
+  const { agent } = useAgent({ agentId: AGENT_ID, threadId });
+  const { copilotkit } = useCopilotKit();
+
+  // Connect the agent on mount so the backend session is live before the first
+  // send. Mirrors the internal connect effect used by CopilotChat (abort on
+  // unmount to play nice with React StrictMode).
+  useEffect(() => {
+    const ac = new AbortController();
+    // HttpAgent honors abortController.signal; assign before connect.
+    if ("abortController" in agent) {
+      (
+        agent as unknown as { abortController: AbortController }
+      ).abortController = ac;
+    }
+    copilotkit.connectAgent({ agent }).catch(() => {
+      // connectAgent emits via the subscriber system; swallow here to avoid
+      // unhandled-rejection noise on unmount.
+    });
+    return () => {
+      ac.abort();
+      void agent.detachActiveRun().catch(() => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, threadId]);
+
+  const [input, setInput] = useState("");
+  const messages = agent.messages as Message[];
+  const isRunning = agent.isRunning;
+
+  const handleSubmit = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isRunning) return;
+    setInput("");
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    });
+    try {
+      await copilotkit.runAgent({ agent });
+    } catch (err) {
+      console.error("headless-complete: runAgent failed", err);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, input, isRunning]);
+
+  const handleStop = useCallback(() => {
+    try {
+      copilotkit.stopAgent({ agent });
+    } catch (err) {
+      console.error("headless-complete: stopAgent failed", err);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent]);
+  // @endregion[page-send-message]
+
+  // Wrap the chat body in a CopilotChatConfigurationProvider so that the
+  // rendering primitives used inside `useRenderedMessages`
+  // (useRenderToolCall, useRenderActivityMessage, useRenderCustomMessages)
+  // see a matching (agentId, threadId) pair — without it, activity-message
+  // renderers wouldn't scope to this agent and custom message renderers
+  // would early-return null. This provider is independent of the
+  // <CopilotChat /> component; using it here keeps the surface fully
+  // headless while still unlocking the full generative-UI composition.
+  return (
+    <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={threadId}>
+      <ChatBody
+        messages={messages}
+        isRunning={isRunning}
+        input={input}
+        setInput={setInput}
+        handleSubmit={handleSubmit}
+        handleStop={handleStop}
+      />
+    </CopilotChatConfigurationProvider>
+  );
+}
+
+// Nested body — rendered INSIDE CopilotChatConfigurationProvider so the
+// suggestions hook picks up the correct (agentId, threadId) scope and
+// the frontend-registered `useComponent` tool registers against this
+// agent. Tool-call renderers are registered here too; keeping them
+// co-located with the component that reads them through
+// `useRenderToolCall` (inside MessageList -> useRenderedMessages) makes
+// the composition story of the headless cell easy to trace.
+function ChatBody({
+  messages,
+  isRunning,
+  input,
+  setInput,
+  handleSubmit,
+  handleStop,
+}: {
+  messages: Message[];
+  isRunning: boolean;
+  input: string;
+  setInput: (next: string) => void;
+  handleSubmit: () => void;
+  handleStop: () => void;
+}) {
+  useHeadlessCompleteToolRenderers();
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Weather in Tokyo",
+        message: "What's the weather in Tokyo?",
+      },
+      {
+        title: "Find flights",
+        message: "Find flights from SFO to JFK.",
+      },
+      {
+        title: "Weather in Paris",
+        message: "What's the weather in Paris?",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <MessageList messages={messages} isRunning={isRunning} />
+      <InputBar
+        value={input}
+        onChange={setInput}
+        onSubmit={handleSubmit}
+        onStop={handleStop}
+        isRunning={isRunning}
+        canStop={isRunning && messages.length > 0}
+      />
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/stock-card.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/stock-card.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Compact gray/green/red stock card rendered when the backend
+ * `get_stock_price` tool runs. Wired through the manual
+ * `useRenderToolCall` path via `useRenderTool({ name: "get_stock_price", ... })`
+ * in `tool-renderers.tsx`.
+ */
+export interface StockCardProps {
+  loading: boolean;
+  ticker: string;
+  price?: number;
+  changePct?: number;
+}
+
+export function StockCard({
+  loading,
+  ticker,
+  price,
+  changePct,
+}: StockCardProps) {
+  const isUp = (changePct ?? 0) >= 0;
+  const accent = isUp ? "text-[#189370]" : "text-[#FA5F67]";
+  const arrow = isUp ? "▲" : "▼";
+  return (
+    <div className="mt-2 mb-2 max-w-xs rounded-xl border border-[#DBDBE5] bg-white p-3 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-[#838389]">
+            {loading ? "Loading" : "Stock"}
+          </div>
+          <div className="truncate text-sm font-semibold text-[#010507] font-mono">
+            {ticker ? ticker.toUpperCase() : "--"}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-base font-semibold leading-none text-[#010507] font-mono">
+            {loading ? "..." : price != null ? `$${price.toFixed(2)}` : "--"}
+          </div>
+          {!loading && changePct != null && (
+            <div
+              className={`mt-0.5 text-[11px] font-medium font-mono ${accent}`}
+            >
+              {arrow} {Math.abs(changePct).toFixed(2)}%
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/tool-renderers.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/tool-renderers.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React from "react";
+import {
+  useRenderTool,
+  useDefaultRenderTool,
+  useComponent,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { WeatherCard } from "./weather-card";
+import { StockCard } from "./stock-card";
+import { HighlightNote, highlightNotePropsSchema } from "./highlight-note";
+
+/**
+ * Central registration hook for every tool-call rendering surface
+ * exercised by the headless-complete cell:
+ *
+ *   - `useRenderTool({ name: "get_weather", ... })` — per-tool renderer
+ *     for the backend weather tool (blue card).
+ *   - `useRenderTool({ name: "get_stock_price", ... })` — per-tool
+ *     renderer for the backend stock tool (gray card, green/red delta).
+ *   - `useComponent({ name: "highlight_note", ... })` — frontend-only
+ *     tool the agent can invoke; renders the `HighlightNote` component
+ *     inline through the same `useRenderToolCall` path.
+ *   - `useDefaultRenderTool(...)` — wildcard catch-all so any other
+ *     tool the agent might call (e.g. the Excalidraw MCP tools) still
+ *     gets a visible card even though the headless cell composes its
+ *     own message view.
+ *
+ * MCP Apps activity surfaces are NOT routed through this registry —
+ * they come in as `activity` messages and are rendered by
+ * `useRenderActivityMessage` (already consumed in
+ * `use-rendered-messages.tsx`).
+ */
+export function useHeadlessCompleteToolRenderers() {
+  // Per-tool renderer #1: backend `get_weather` -> branded WeatherCard.
+  useRenderTool(
+    {
+      name: "get_weather",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<{
+          city?: string;
+          temperature?: number;
+          conditions?: string;
+        }>(result);
+        return (
+          <WeatherCard
+            loading={loading}
+            location={parameters?.location ?? parsed.city ?? ""}
+            temperature={parsed.temperature}
+            conditions={parsed.conditions}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  // Per-tool renderer #2: backend `get_stock_price` -> branded StockCard.
+  useRenderTool(
+    {
+      name: "get_stock_price",
+      parameters: z.object({
+        ticker: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<{
+          ticker?: string;
+          price_usd?: number;
+          change_pct?: number;
+        }>(result);
+        return (
+          <StockCard
+            loading={loading}
+            ticker={parameters?.ticker ?? parsed.ticker ?? ""}
+            price={parsed.price_usd}
+            changePct={parsed.change_pct}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  // Frontend-registered tool the agent can invoke. `useComponent` is
+  // sugar over `useFrontendTool`, so the registration flows through
+  // the same `useRenderToolCall` path the manual hook consumes.
+  useComponent({
+    name: "highlight_note",
+    description:
+      "Highlight a short note or phrase inline in the chat with a colored card. Use this whenever the user asks to highlight, flag, or mark a snippet of text.",
+    parameters: highlightNotePropsSchema,
+    render: HighlightNote,
+  });
+
+  // Wildcard catch-all for tools without a bespoke renderer (e.g. any
+  // Excalidraw MCP tools surfaced as regular tool calls alongside the
+  // MCP Apps activity).
+  useDefaultRenderTool();
+}
+
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/typing-indicator.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/typing-indicator.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Small animated dot shown while the agent is running but has not yet emitted
+ * any assistant content. Styled to look like an assistant bubble so it slots
+ * into the message list without layout jitter.
+ */
+export function TypingIndicator() {
+  return (
+    <div className="flex justify-start">
+      <div className="rounded-2xl rounded-bl-sm bg-[#F0F0F4] px-4 py-3">
+        <span className="inline-block w-2 h-2 bg-[#838389] rounded-full animate-pulse" />
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/use-rendered-messages.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/use-rendered-messages.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import React, { useMemo } from "react";
+import type {
+  Message,
+  AssistantMessage,
+  UserMessage,
+  ReasoningMessage,
+  ActivityMessage,
+  ToolMessage,
+} from "@ag-ui/core";
+import {
+  CopilotChatReasoningMessage,
+  useRenderToolCall,
+  useRenderActivityMessage,
+  useRenderCustomMessages,
+} from "@copilotkit/react-core/v2";
+
+/**
+ * Manual per-message composition for the TRULY headless chat cell.
+ *
+ * This hook mirrors — line-for-line in spirit — the role-dispatch that happens
+ * inside `renderMessageBlock` in the canonical primitive:
+ *
+ *   packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx:542-612
+ *
+ * The point of this cell is to demonstrate that the FULL generative-UI weave
+ * (assistant text + tool-call renders + reasoning + activity + custom before /
+ * after slots) can be re-composed from the low-level hooks directly, without
+ * importing `<CopilotChatMessageView>` or `<CopilotChatAssistantMessage>`.
+ * Only the reasoning-message LEAF component is imported — it's a pure
+ * presentational primitive, not a dispatcher.
+ *
+ * Return shape: the original messages, each augmented with a `renderedContent`
+ * field that the parent list drops directly into a `<UserBubble>` or
+ * `<AssistantBubble>` chrome wrapper.
+ *
+ * Text rendering: we intentionally use plain text (a `<div>` with
+ * `whitespace-pre-wrap`) rather than a markdown pipeline. Rationale: the cell's
+ * goal is to show what "truly headless" looks like — every piece of composition
+ * lives in user code — so pulling in a markdown library here would re-hide
+ * a chunk of formatting decisions behind an opaque black box. Apps that want
+ * markdown can drop Streamdown / react-markdown in at this exact line.
+ */
+// @region[use-rendered-messages-hook]
+export type RenderedMessage = Message & { renderedContent: React.ReactNode };
+
+export function useRenderedMessages(
+  messages: Message[],
+  isRunning: boolean,
+): RenderedMessage[] {
+  const renderToolCall = useRenderToolCall();
+  const { renderActivityMessage } = useRenderActivityMessage();
+  const renderCustomMessage = useRenderCustomMessages();
+
+  return useMemo(() => {
+    return messages.map((message): RenderedMessage => {
+      const renderedContent = renderMessageContent({
+        message,
+        messages,
+        isRunning,
+        renderToolCall,
+        renderActivityMessage,
+        renderCustomMessage,
+      });
+      return { ...message, renderedContent } as RenderedMessage;
+    });
+    // `renderToolCall`, `renderActivityMessage`, and `renderCustomMessage` are
+    // callbacks produced by their respective hooks; their identity turns over
+    // whenever the underlying registries / agent / config change, which is
+    // exactly when we want to recompute.
+  }, [
+    messages,
+    isRunning,
+    renderToolCall,
+    renderActivityMessage,
+    renderCustomMessage,
+  ]);
+}
+// @endregion[use-rendered-messages-hook]
+
+function renderMessageContent(args: {
+  message: Message;
+  messages: Message[];
+  isRunning: boolean;
+  renderToolCall: ReturnType<typeof useRenderToolCall>;
+  renderActivityMessage: ReturnType<
+    typeof useRenderActivityMessage
+  >["renderActivityMessage"];
+  renderCustomMessage: ReturnType<typeof useRenderCustomMessages>;
+}): React.ReactNode {
+  const {
+    message,
+    messages,
+    isRunning,
+    renderToolCall,
+    renderActivityMessage,
+    renderCustomMessage,
+  } = args;
+
+  // Tool-role messages carry a tool-call RESULT whose UI lives inline inside
+  // the PRECEDING assistant message's `toolCalls[i]` render (keyed by
+  // toolCallId). We return null here so the list skips them, mirroring the
+  // fact that CopilotChatMessageView's `renderMessageBlock` has no
+  // `message.role === "tool"` branch.
+  if (message.role === "tool") {
+    return null;
+  }
+
+  const customBefore = renderCustomMessage
+    ? renderCustomMessage({ message, position: "before" })
+    : null;
+  const customAfter = renderCustomMessage
+    ? renderCustomMessage({ message, position: "after" })
+    : null;
+
+  let body: React.ReactNode = null;
+
+  // @region[manual-activity-message-rendering]
+  if (message.role === "assistant") {
+    body = renderAssistantBody({
+      message: message as AssistantMessage,
+      messages,
+      renderToolCall,
+    });
+  } else if (message.role === "user") {
+    body = renderUserBody(message as UserMessage);
+  } else if (message.role === "reasoning") {
+    body = (
+      <CopilotChatReasoningMessage
+        message={message as ReasoningMessage}
+        messages={messages}
+        isRunning={isRunning}
+      />
+    );
+  } else if (message.role === "activity") {
+    body = renderActivityMessage(message as ActivityMessage);
+  }
+  // @endregion[manual-activity-message-rendering]
+
+  if (!customBefore && !customAfter) {
+    return body;
+  }
+  return (
+    <>
+      {customBefore}
+      {body}
+      {customAfter}
+    </>
+  );
+}
+
+// @region[manual-tool-call-rendering]
+function renderAssistantBody(args: {
+  message: AssistantMessage;
+  messages: Message[];
+  renderToolCall: ReturnType<typeof useRenderToolCall>;
+}): React.ReactNode {
+  const { message, messages, renderToolCall } = args;
+  const text = message.content ?? "";
+  const hasText = text.trim().length > 0;
+  const toolCalls = message.toolCalls ?? [];
+
+  return (
+    <>
+      {hasText && <div className="whitespace-pre-wrap break-words">{text}</div>}
+      {toolCalls.map((toolCall) => {
+        // Tool result lives on a sibling `tool`-role message keyed by toolCallId.
+        // Mirrors CopilotChatToolCallsView (react-core/v2/components/chat/CopilotChatToolCallsView.tsx).
+        const toolMessage = messages.find(
+          (m) => m.role === "tool" && m.toolCallId === toolCall.id,
+        ) as ToolMessage | undefined;
+        return (
+          <React.Fragment key={toolCall.id}>
+            {renderToolCall({ toolCall, toolMessage })}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+}
+// @endregion[manual-tool-call-rendering]
+
+function renderUserBody(message: UserMessage): React.ReactNode {
+  // AG-UI user messages may carry a string OR an array of parts (text, image,
+  // audio, video, document, binary). The headless cell renders only the text
+  // parts — swap this for a richer renderer when you need attachments.
+  const { content } = message;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join("");
+  }
+  return "";
+}

--- a/showcase/packages/langroid/src/app/demos/headless-complete/user-bubble.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/user-bubble.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Right-aligned user bubble — pure chrome.
+ *
+ * Receives a precomputed `renderedContent` node (built by
+ * `useRenderedMessages`). For user messages that's just the text content of
+ * the message (attachments etc. are stripped in the headless composer).
+ */
+// @region[custom-bubbles]
+export function UserBubble({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[75%] rounded-2xl rounded-br-sm bg-[#010507] text-white px-4 py-2 text-sm whitespace-pre-wrap break-words">
+        {children}
+      </div>
+    </div>
+  );
+}
+// @endregion[custom-bubbles]

--- a/showcase/packages/langroid/src/app/demos/headless-complete/weather-card.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/weather-card.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Compact blue weather card rendered when the backend `get_weather`
+ * tool runs. Wired to the manual `useRenderToolCall` path via the
+ * `useRenderTool({ name: "get_weather", ... })` registration in
+ * `tool-renderers.tsx`.
+ */
+export interface WeatherCardProps {
+  loading: boolean;
+  location: string;
+  temperature?: number;
+  conditions?: string;
+}
+
+export function WeatherCard({
+  loading,
+  location,
+  temperature,
+  conditions,
+}: WeatherCardProps) {
+  return (
+    <div className="mt-2 mb-2 max-w-xs rounded-xl border border-[#DBDBE5] bg-[#EDEDF5] p-3 text-[#010507] shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+            {loading ? "Fetching weather" : "Weather"}
+          </div>
+          <div className="truncate text-sm font-semibold capitalize text-[#010507]">
+            {location || "Unknown"}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-2xl font-semibold leading-none text-[#010507] tracking-tight">
+            {loading ? "..." : temperature != null ? `${temperature}°` : "--"}
+          </div>
+          {!loading && (
+            <div className="mt-0.5 text-[11px] capitalize text-[#57575B]">
+              {conditions ?? ""}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  CopilotKit,
+  useAgent,
+  useComponent,
+  useCopilotKit,
+  useRenderToolCall,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+export default function HeadlessSimpleDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+      <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
+        <div className="w-full max-w-4xl">
+          <HeadlessChat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function ShowCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="my-2 rounded-lg border border-gray-300 bg-white p-4 shadow-sm">
+      <div className="font-semibold text-gray-900">{title}</div>
+      <div className="mt-1 text-sm text-gray-700 whitespace-pre-wrap">
+        {body}
+      </div>
+    </div>
+  );
+}
+
+function HeadlessChat() {
+  const { agent } = useAgent({ agentId: "headless-simple" });
+  const { copilotkit } = useCopilotKit();
+  const [input, setInput] = useState("");
+
+  useComponent({
+    name: "show_card",
+    description: "Display a titled card with a short body of text.",
+    parameters: z.object({
+      title: z.string().describe("Short heading for the card."),
+      body: z.string().describe("Body text for the card."),
+    }),
+    render: ShowCard,
+  });
+
+  const renderToolCall = useRenderToolCall();
+
+  const send = () => {
+    const text = input.trim();
+    if (!text || agent.isRunning) return;
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    });
+    void copilotkit.runAgent({ agent }).catch(() => {});
+    setInput("");
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
+      <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {agent.messages.length === 0 && (
+          <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
+        )}
+        {agent.messages.map((m) => {
+          if (m.role === "user") {
+            return (
+              <div
+                key={m.id}
+                className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
+              >
+                {typeof m.content === "string" ? m.content : ""}
+              </div>
+            );
+          }
+          if (m.role === "assistant") {
+            const toolCalls =
+              "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
+            return (
+              <div key={m.id} className="self-start max-w-[90%]">
+                {m.content && (
+                  <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
+                    {m.content}
+                  </div>
+                )}
+                {toolCalls.map((tc) => (
+                  <div key={tc.id}>{renderToolCall({ toolCall: tc })}</div>
+                ))}
+              </div>
+            );
+          }
+          return null;
+        })}
+        {agent.isRunning && (
+          <div className="text-xs text-gray-400">Agent is thinking...</div>
+        )}
+      </div>
+      <div className="flex gap-2">
+        <textarea
+          className="flex-1 rounded-lg border border-gray-300 p-2 text-sm"
+          rows={2}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
+          placeholder="Type a message. Ask me to 'show a card about cats'."
+        />
+        <button
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-50"
+          onClick={send}
+          disabled={agent.isRunning || !input.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/hitl-in-app/approval-dialog.tsx
+++ b/showcase/packages/langroid/src/app/demos/hitl-in-app/approval-dialog.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+export type PendingApproval = {
+  message: string;
+  context?: string;
+};
+
+type Props = {
+  pending: PendingApproval;
+  onResolve: (result: { approved: boolean; reason?: string }) => void;
+};
+
+export function ApprovalDialog({ pending, onResolve }: Props) {
+  const [reason, setReason] = useState("");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const content = (
+    <div
+      data-testid="approval-dialog-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[#010507]/40 backdrop-blur-sm"
+    >
+      <div
+        data-testid="approval-dialog"
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-md rounded-2xl border border-[#DBDBE5] bg-white p-6 shadow-sm"
+      >
+        <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.14em] text-[#57575B]">
+          Action requires your approval
+        </div>
+        <h2 className="mb-3 text-lg font-semibold text-[#010507]">
+          {pending.message}
+        </h2>
+        {pending.context && (
+          <p className="mb-4 rounded-xl border border-[#E9E9EF] bg-[#FAFAFC] p-3 text-sm text-[#57575B]">
+            {pending.context}
+          </p>
+        )}
+        <label className="mb-1 block text-xs font-medium text-[#57575B]">
+          Note (optional)
+        </label>
+        <textarea
+          data-testid="approval-dialog-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Add a short note the assistant will see..."
+          className="mb-4 w-full resize-none rounded-xl border border-[#DBDBE5] px-3 py-2 text-sm text-[#010507] focus:border-[#BEC2FF] focus:outline-none focus:ring-2 focus:ring-[#BEC2FF33]"
+          rows={2}
+        />
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            data-testid="approval-dialog-reject"
+            onClick={() =>
+              onResolve({
+                approved: false,
+                reason: reason.trim() || undefined,
+              })
+            }
+            className="rounded-xl border border-[#DBDBE5] bg-white px-4 py-2 text-sm font-medium text-[#57575B] hover:bg-[#FAFAFC] transition-colors"
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            data-testid="approval-dialog-approve"
+            onClick={() =>
+              onResolve({
+                approved: true,
+                reason: reason.trim() || undefined,
+              })
+            }
+            className="rounded-xl bg-[#010507] px-4 py-2 text-sm font-medium text-white hover:bg-[#2B2B2B] transition-colors"
+          >
+            Approve
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/showcase/packages/langroid/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/hitl-in-app/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  CopilotChat,
+  useFrontendTool,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { z } from "zod";
+import { ApprovalDialog, PendingApproval } from "./approval-dialog";
+
+const SUPPORT_TICKETS = [
+  {
+    id: "#12345",
+    customer: "Jordan Rivera",
+    subject: "Refund request — duplicate charge",
+    status: "Open",
+    amount: 50,
+  },
+  {
+    id: "#12346",
+    customer: "Priya Shah",
+    subject: "Downgrade plan to Starter",
+    status: "Open",
+    amount: 0,
+  },
+  {
+    id: "#12347",
+    customer: "Morgan Lee",
+    subject: "Escalate: payment stuck in pending",
+    status: "Escalating",
+    amount: 0,
+  },
+];
+
+export default function HitlInAppDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+      <Layout />
+    </CopilotKit>
+  );
+}
+
+type ResolveFn = (value: { approved: boolean; reason?: string }) => void;
+type DialogState =
+  | { open: false }
+  | { open: true; pending: PendingApproval; resolve: ResolveFn };
+
+function Layout() {
+  const [dialog, setDialog] = useState<DialogState>({ open: false });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Approve refund for #12345",
+        message:
+          "Please approve a $50 refund to Jordan Rivera on ticket #12345 for the duplicate charge.",
+      },
+      {
+        title: "Downgrade plan for #12346",
+        message:
+          "Please downgrade Priya Shah (#12346) to the Starter plan effective next billing cycle.",
+      },
+      {
+        title: "Escalate ticket #12347",
+        message:
+          "Please escalate ticket #12347 to the payments team — Morgan Lee's payment is stuck.",
+      },
+    ],
+    available: "always",
+  });
+
+  useFrontendTool({
+    name: "request_user_approval",
+    description:
+      "Ask the operator to approve or reject an action before you take it. " +
+      "The operator will respond via an in-app modal dialog that appears " +
+      "OUTSIDE the chat surface. The tool returns an object of the shape " +
+      "{ approved: boolean, reason?: string }.",
+    parameters: z.object({
+      message: z
+        .string()
+        .describe(
+          "Short summary of the action needing approval (include concrete numbers / IDs).",
+        ),
+      context: z
+        .string()
+        .optional()
+        .describe(
+          "Optional extra context — e.g. the ticket ID or policy rule.",
+        ),
+    }),
+    handler: async ({
+      message,
+      context,
+    }: {
+      message: string;
+      context?: string;
+    }) => {
+      return await new Promise<{ approved: boolean; reason?: string }>(
+        (resolve) => {
+          setDialog({ open: true, pending: { message, context }, resolve });
+        },
+      );
+    },
+  });
+
+  const handleResolve = (result: { approved: boolean; reason?: string }) => {
+    if (dialog.open) {
+      dialog.resolve(result);
+      setDialog({ open: false });
+    }
+  };
+
+  return (
+    <div className="grid h-screen grid-cols-[1fr_420px] bg-gray-50">
+      <TicketsPanel />
+      <div className="border-l border-gray-200 bg-white">
+        <CopilotChat agentId="hitl-in-app" className="h-full" />
+      </div>
+      {dialog.open && (
+        <ApprovalDialog pending={dialog.pending} onResolve={handleResolve} />
+      )}
+    </div>
+  );
+}
+
+function TicketsPanel() {
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <header className="border-b border-gray-200 bg-white px-6 py-4">
+        <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
+          Support Inbox
+        </div>
+        <h1 className="text-xl font-semibold text-gray-900">Open tickets</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Ask the copilot to take an action. Every customer-affecting action
+          will pop up an approval dialog here in the app — outside the chat.
+        </p>
+      </header>
+      <div className="flex-1 overflow-y-auto p-6">
+        <ul className="space-y-3">
+          {SUPPORT_TICKETS.map((t) => (
+            <li
+              key={t.id}
+              data-testid={`ticket-${t.id.replace("#", "")}`}
+              className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-xs text-gray-500">{t.id}</span>
+                <span
+                  className={
+                    t.status === "Escalating"
+                      ? "rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+                      : "rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800"
+                  }
+                >
+                  {t.status}
+                </span>
+              </div>
+              <div className="mt-2 text-sm font-semibold text-gray-900">
+                {t.customer}
+              </div>
+              <div className="text-sm text-gray-700">{t.subject}</div>
+              {t.amount > 0 && (
+                <div className="mt-2 text-xs text-gray-500">
+                  Disputed amount: ${t.amount.toFixed(2)}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/prebuilt-popup/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotPopup,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+export default function PrebuiltPopupDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+      <MainContent />
+      <CopilotPopup
+        agentId="prebuilt-popup"
+        defaultOpen={true}
+        labels={{
+          chatInputPlaceholder: "Ask the popup anything...",
+        }}
+      />
+      <Suggestions />
+    </CopilotKit>
+  );
+}
+
+function MainContent() {
+  return (
+    <main className="min-h-screen w-full p-12">
+      <h1 className="text-3xl font-semibold mb-4">
+        Popup demo — look for the floating launcher
+      </h1>
+      <p className="text-gray-600 max-w-xl">
+        This page showcases the pre-built <code>&lt;CopilotPopup /&gt;</code>{" "}
+        component. A floating launcher bubble sits in the corner, opening an
+        overlay chat window on top of the page content.
+      </p>
+    </main>
+  );
+}
+
+function Suggestions() {
+  useConfigureSuggestions({
+    suggestions: [{ title: "Say hi", message: "Say hi from the popup!" }],
+    available: "always",
+  });
+  return null;
+}

--- a/showcase/packages/langroid/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/prebuilt-sidebar/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotSidebar,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+export default function PrebuiltSidebarDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+      <MainContent />
+      <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      <Suggestions />
+    </CopilotKit>
+  );
+}
+
+function MainContent() {
+  return (
+    <main className="min-h-screen w-full p-12">
+      <h1 className="text-3xl font-semibold mb-4">
+        Sidebar demo — click the launcher
+      </h1>
+      <p className="text-gray-600 max-w-xl">
+        This page showcases the pre-built <code>&lt;CopilotSidebar /&gt;</code>{" "}
+        component. The sidebar is rendered alongside this main content and can
+        be toggled via its launcher button. It opens by default to make the
+        difference from the full-page chat demo obvious.
+      </p>
+    </main>
+  );
+}
+
+function Suggestions() {
+  useConfigureSuggestions({
+    suggestions: [{ title: "Say hi", message: "Say hi!" }],
+    available: "always",
+  });
+  return null;
+}

--- a/showcase/packages/langroid/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/readonly-state-agent-context/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  useAgentContext,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+export default function ReadonlyStateAgentContextDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="readonly-state-agent-context"
+    >
+      <DemoContent />
+    </CopilotKit>
+  );
+}
+
+const TIMEZONES = [
+  "America/Los_Angeles",
+  "America/New_York",
+  "Europe/London",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+const ACTIVITIES = [
+  "Viewed the pricing page",
+  "Added 'Pro Plan' to cart",
+  "Watched the product demo video",
+  "Started the 14-day free trial",
+  "Invited a teammate",
+];
+
+function DemoContent() {
+  const [userName, setUserName] = useState("Atai");
+  const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
+  const [recentActivity, setRecentActivity] = useState<string[]>([
+    ACTIVITIES[0],
+    ACTIVITIES[2],
+  ]);
+
+  useAgentContext({
+    description: "The currently logged-in user's display name",
+    value: userName,
+  });
+  useAgentContext({
+    description: "The user's IANA timezone (used when mentioning times)",
+    value: userTimezone,
+  });
+  useAgentContext({
+    description: "The user's recent activity in the app, newest first",
+    value: recentActivity,
+  });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Who am I?",
+        message: "What do you know about me from my context?",
+      },
+      {
+        title: "Suggest next steps",
+        message: "Based on my recent activity, what should I try next?",
+      },
+      {
+        title: "Plan my morning",
+        message:
+          "What time is it in my timezone and what should I do for the next hour?",
+      },
+    ],
+    available: "always",
+  });
+
+  const toggleActivity = (activity: string) => {
+    setRecentActivity((prev) =>
+      prev.includes(activity)
+        ? prev.filter((a) => a !== activity)
+        : [...prev, activity],
+    );
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row h-screen w-full bg-gray-50">
+      <aside className="p-4 md:w-[360px] md:shrink-0 overflow-y-auto">
+        <div
+          data-testid="context-card"
+          className="w-full max-w-md p-6 bg-white rounded-2xl shadow-lg border border-gray-100 space-y-5"
+        >
+          <div>
+            <h2 className="text-xl font-bold text-gray-800">Agent Context</h2>
+            <p className="text-xs text-gray-500 mt-1">
+              Read-only context provided to the agent via{" "}
+              <code>useAgentContext</code>. The agent cannot modify these.
+            </p>
+          </div>
+
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">Name</span>
+            <input
+              data-testid="ctx-name"
+              type="text"
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+              placeholder="e.g. Atai"
+              className="mt-1 w-full border rounded px-3 py-2 text-sm"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">Timezone</span>
+            <select
+              data-testid="ctx-timezone"
+              value={userTimezone}
+              onChange={(e) => setUserTimezone(e.target.value)}
+              className="mt-1 w-full border rounded px-3 py-2 text-sm"
+            >
+              {TIMEZONES.map((tz) => (
+                <option key={tz} value={tz}>
+                  {tz}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div>
+            <span className="text-sm font-medium text-gray-700">
+              Recent Activity
+            </span>
+            <div className="mt-2 flex flex-col gap-2">
+              {ACTIVITIES.map((activity) => {
+                const selected = recentActivity.includes(activity);
+                return (
+                  <label
+                    key={activity}
+                    className="flex items-center gap-2 text-sm cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selected}
+                      onChange={() => toggleActivity(activity)}
+                    />
+                    <span>{activity}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="pt-3 border-t border-gray-100">
+            <div className="text-[11px] uppercase tracking-wide text-gray-400 mb-1">
+              Published Context
+            </div>
+            <pre
+              data-testid="ctx-state-json"
+              className="bg-gray-50 rounded p-2 text-xs text-gray-700 overflow-x-auto"
+            >
+              {JSON.stringify(
+                { name: userName, timezone: userTimezone, recentActivity },
+                null,
+                2,
+              )}
+            </pre>
+          </div>
+        </div>
+      </aside>
+      <main className="flex-1 flex flex-col min-h-0">
+        <CopilotChat
+          agentId="readonly-state-agent-context"
+          className="flex-1 min-h-0"
+          labels={{ chatInputPlaceholder: "Ask about your context..." }}
+        />
+      </main>
+    </div>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/reasoning-default-render/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+// Reasoning (Default Render) demo.
+//
+// NOTE: The Langroid adapter in agui_adapter.py does not currently emit
+// AG-UI REASONING_MESSAGE_* events — Langroid's ChatAgent does not expose
+// a separate reasoning/thinking channel on its response. The backend agent
+// just responds normally; this page shows the built-in CopilotChat behavior
+// with the zero-config default render path (no custom reasoning slot).
+
+import React from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+
+export default function ReasoningDefaultRenderDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <CopilotChat
+            agentId="reasoning-default-render"
+            className="h-full rounded-2xl"
+          />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/tool-rendering-custom-catchall/custom-catchall-renderer.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering-custom-catchall/custom-catchall-renderer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React from "react";
+
+// Branded catch-all renderer for the tool-rendering-custom-catchall cell.
+
+export type CatchallToolStatus = "inProgress" | "executing" | "complete";
+
+export interface CustomCatchallRendererProps {
+  name: string;
+  status: CatchallToolStatus;
+  parameters: unknown;
+  result: string | undefined;
+}
+
+export function CustomCatchallRenderer({
+  name,
+  status,
+  parameters,
+  result,
+}: CustomCatchallRendererProps) {
+  const parsedResult = parseResult(result);
+  const done = status === "complete";
+
+  return (
+    <div
+      data-testid="custom-catchall-card"
+      data-tool-name={name}
+      data-status={status}
+      className="my-3 overflow-hidden rounded-2xl border border-[#DBDBE5] bg-white shadow-sm"
+    >
+      <div className="flex items-center justify-between border-b border-[#E9E9EF] bg-[#FAFAFC] px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-[#838389]">
+            Tool
+          </span>
+          <span
+            data-testid="custom-catchall-tool-name"
+            className="font-mono text-sm text-[#010507]"
+          >
+            {name}
+          </span>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+
+      <div className="grid gap-3 p-4 text-sm">
+        <Section label="Arguments">
+          <pre
+            data-testid="custom-catchall-args"
+            className="overflow-x-auto rounded-lg border border-[#E9E9EF] bg-[#FAFAFC] p-2.5 font-mono text-xs text-[#010507]"
+          >
+            {safeStringify(parameters)}
+          </pre>
+        </Section>
+
+        <Section label="Result">
+          {done ? (
+            <pre
+              data-testid="custom-catchall-result"
+              className="overflow-x-auto rounded-lg border border-[#85ECCE4D] bg-[#85ECCE]/10 p-2.5 font-mono text-xs text-[#010507]"
+            >
+              {parsedResult !== undefined
+                ? safeStringify(parsedResult)
+                : "(empty)"}
+            </pre>
+          ) : (
+            <p className="text-xs italic text-[#838389]">
+              waiting for tool to finish...
+            </p>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[#838389]">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: CatchallToolStatus }) {
+  const { label, tone } = describeStatus(status);
+  return (
+    <span
+      data-testid="custom-catchall-status"
+      className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] ${tone}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function describeStatus(status: CatchallToolStatus): {
+  label: string;
+  tone: string;
+} {
+  switch (status) {
+    case "inProgress":
+      return {
+        label: "streaming",
+        tone: "border border-[#FFAC4D33] bg-[#FFAC4D]/15 text-[#57575B]",
+      };
+    case "executing":
+      return {
+        label: "running",
+        tone: "border border-[#BEC2FF] bg-[#BEC2FF1A] text-[#010507]",
+      };
+    case "complete":
+      return {
+        label: "done",
+        tone: "border border-[#85ECCE4D] bg-[#85ECCE]/20 text-[#189370]",
+      };
+  }
+}
+
+function parseResult(result: string | undefined): unknown {
+  if (result === undefined || result === null) return undefined;
+  if (typeof result !== "string") return result;
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result;
+  }
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/showcase/packages/langroid/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+// Tool Rendering — CUSTOM CATCH-ALL variant.
+//
+// A single branded wildcard renderer is registered via
+// `useDefaultRenderTool`, painting every Langroid backend tool call
+// (get_weather, search_flights, generate_a2ui, ...) with the same card.
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  useDefaultRenderTool,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import {
+  CustomCatchallRenderer,
+  type CatchallToolStatus,
+} from "./custom-catchall-renderer";
+
+export default function ToolRenderingCustomCatchallDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering-custom-catchall"
+    >
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[use-default-render-tool-wildcard]
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Weather in SF",
+        message: "What's the weather in San Francisco?",
+      },
+      {
+        title: "Find flights",
+        message: "Find flights from SFO to JFK.",
+      },
+      {
+        title: "Weather in Tokyo",
+        message: "What's the weather in Tokyo?",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <CopilotChat
+      agentId="tool-rendering-custom-catchall"
+      className="h-full rounded-2xl"
+    />
+  );
+}

--- a/showcase/packages/langroid/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+// Tool Rendering — DEFAULT CATCH-ALL variant.
+//
+// The frontend opts into CopilotKit's built-in `DefaultToolCallRenderer`
+// as the `*` wildcard. The Langroid backend exposes `get_weather` and
+// `search_flights` (and `generate_a2ui`) — all painted by the same
+// built-in card on this page.
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  useConfigureSuggestions,
+  useDefaultRenderTool,
+} from "@copilotkit/react-core/v2";
+
+export default function ToolRenderingDefaultCatchallDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering-default-catchall"
+    >
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  // @region[default-catchall-zero-config]
+  // Register CopilotKit's built-in DefaultToolCallRenderer as the
+  // wildcard renderer for every tool call.
+  useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Weather in SF",
+        message: "What's the weather in San Francisco?",
+      },
+      {
+        title: "Find flights",
+        message: "Find flights from SFO to JFK.",
+      },
+      {
+        title: "Weather in Tokyo",
+        message: "What's the weather in Tokyo?",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <CopilotChat
+      agentId="tool-rendering-default-catchall"
+      className="h-full rounded-2xl"
+    />
+  );
+}

--- a/showcase/packages/langroid/tests/e2e/agent-config.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/agent-config.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Agent Config (Langroid)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/agent-config");
+  });
+
+  test("config card renders with three selects", async ({ page }) => {
+    await expect(
+      page.locator('[data-testid="agent-config-card"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="agent-config-tone-select"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="agent-config-expertise-select"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="agent-config-length-select"]'),
+    ).toBeVisible();
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/agentic-chat-reasoning.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/agentic-chat-reasoning.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Agentic Chat Reasoning", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/agentic-chat-reasoning");
+  });
+
+  test("chat input is visible", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("sends message and gets a reply", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("hello");
+    await input.press("Enter");
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/auth.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/auth.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Auth (Langroid)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/auth");
+  });
+
+  test("banner starts unauthenticated", async ({ page }) => {
+    const banner = page.locator('[data-testid="auth-banner"]').first();
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute("data-authenticated", "false");
+    await expect(
+      page.locator('[data-testid="auth-authenticate-button"]'),
+    ).toBeVisible();
+  });
+
+  test("clicking Authenticate flips the banner to authenticated", async ({
+    page,
+  }) => {
+    await page
+      .locator('[data-testid="auth-authenticate-button"]')
+      .first()
+      .click();
+    const banner = page.locator('[data-testid="auth-banner"]').first();
+    await expect(banner).toHaveAttribute("data-authenticated", "true");
+    await expect(
+      page.locator('[data-testid="auth-sign-out-button"]'),
+    ).toBeVisible();
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/auth.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/auth.spec.ts
@@ -5,26 +5,98 @@ test.describe("Auth (Langroid)", () => {
     await page.goto("/demos/auth");
   });
 
-  test("banner starts unauthenticated", async ({ page }) => {
+  test("page loads authenticated with green banner + Sign out button", async ({
+    page,
+  }) => {
     const banner = page.locator('[data-testid="auth-banner"]').first();
     await expect(banner).toBeVisible();
-    await expect(banner).toHaveAttribute("data-authenticated", "false");
+    await expect(banner).toHaveAttribute("data-authenticated", "true");
+    await expect(page.locator('[data-testid="auth-status"]')).toContainText(
+      "Signed in",
+    );
+    await expect(
+      page.locator('[data-testid="auth-sign-out-button"]'),
+    ).toBeEnabled();
+    await expect(
+      page.locator('[data-testid="auth-authenticate-button"]'),
+    ).toHaveCount(0);
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+    // No error surface on first load.
+    await expect(page.locator('[data-testid="auth-demo-error"]')).toHaveCount(
+      0,
+    );
+  });
+
+  test("authenticated send produces an assistant response", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Hello");
+    await input.press("Enter");
+
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
+    // No error surface should appear while authenticated.
+    await expect(page.locator('[data-testid="auth-demo-error"]')).toHaveCount(
+      0,
+    );
+  });
+
+  test("signing out flips banner and surfaces 401 on next send without crashing", async ({
+    page,
+  }) => {
+    const banner = page.locator('[data-testid="auth-banner"]').first();
+    await page.locator('[data-testid="auth-sign-out-button"]').click();
+
+    await expect(banner).toHaveAttribute("data-authenticated", "false", {
+      timeout: 2000,
+    });
+    await expect(page.locator('[data-testid="auth-status"]')).toContainText(
+      "Signed out",
+    );
     await expect(
       page.locator('[data-testid="auth-authenticate-button"]'),
     ).toBeVisible();
-  });
-
-  test("clicking Authenticate flips the banner to authenticated", async ({
-    page,
-  }) => {
-    await page
-      .locator('[data-testid="auth-authenticate-button"]')
-      .first()
-      .click();
-    const banner = page.locator('[data-testid="auth-banner"]').first();
-    await expect(banner).toHaveAttribute("data-authenticated", "true");
     await expect(
       page.locator('[data-testid="auth-sign-out-button"]'),
-    ).toBeVisible();
+    ).toHaveCount(0);
+
+    // Next send should 401 and show the error surface — no white-screen.
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Hello again");
+    await input.press("Enter");
+    const errorSurface = page.locator('[data-testid="auth-demo-error"]');
+    await expect(errorSurface).toBeVisible({ timeout: 15000 });
+    await expect(errorSurface).toContainText(/401|unauthor/i);
+
+    // Banner must still be rendered — a crash would unmount it.
+    await expect(banner).toBeVisible();
+  });
+
+  test("signing back in clears the error and re-enables successful sends", async ({
+    page,
+  }) => {
+    // Sign out, fire a failing send to populate the error surface.
+    await page.locator('[data-testid="auth-sign-out-button"]').click();
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Hello");
+    await input.press("Enter");
+    const errorSurface = page.locator('[data-testid="auth-demo-error"]');
+    await expect(errorSurface).toBeVisible({ timeout: 15000 });
+
+    // Sign back in — error clears, banner flips, chat works.
+    await page.locator('[data-testid="auth-authenticate-button"]').click();
+    const banner = page.locator('[data-testid="auth-banner"]').first();
+    await expect(banner).toHaveAttribute("data-authenticated", "true", {
+      timeout: 2000,
+    });
+    await expect(errorSurface).toHaveCount(0);
+
+    await input.fill("Hello again");
+    await input.press("Enter");
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
   });
 });

--- a/showcase/packages/langroid/tests/e2e/chat-customization-css.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/chat-customization-css.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Chat Customization (CSS)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/chat-customization-css");
+  });
+
+  test("themed scope wrapper is visible", async ({ page }) => {
+    await expect(page.locator(".chat-css-demo-scope").first()).toBeVisible();
+  });
+
+  test("chat input is visible", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("sends a message and gets a reply", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("hello");
+    await input.press("Enter");
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/chat-slots.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/chat-slots.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Chat Slots", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/chat-slots");
+  });
+
+  test("custom welcome screen slot renders", async ({ page }) => {
+    await expect(
+      page.locator('[data-testid="custom-welcome-screen"]'),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("custom disclaimer slot renders", async ({ page }) => {
+    await expect(
+      page.locator('[data-testid="custom-disclaimer"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("custom assistant message slot activates on reply", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("hello");
+    await input.press("Enter");
+    await expect(
+      page.locator('[data-testid="custom-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/declarative-gen-ui.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/declarative-gen-ui.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Declarative Generative UI (Langroid)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/declarative-gen-ui");
+  });
+
+  test("page loads with chat input", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/frontend-tools-async.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/frontend-tools-async.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Frontend Tools (Async)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/frontend-tools-async");
+  });
+
+  test("chat input is visible", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("query request renders notes card with matching keyword", async ({
+    page,
+  }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("Find my notes about project planning.");
+    await input.press("Enter");
+    await expect(
+      page.locator('[data-testid="notes-card"]').first(),
+    ).toBeVisible({ timeout: 45000 });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/frontend-tools.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/frontend-tools.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Frontend Tools", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/frontend-tools");
+  });
+
+  test("background container visible with default background", async ({
+    page,
+  }) => {
+    await expect(
+      page.locator('[data-testid="background-container"]'),
+    ).toBeVisible();
+  });
+
+  test("background change request updates background style", async ({
+    page,
+  }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("Change the background to a blue-to-purple gradient");
+    await input.press("Enter");
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
+    const bg = page.locator('[data-testid="background-container"]');
+    await expect(bg).not.toHaveCSS("background-color", "rgb(250, 250, 249)", {
+      timeout: 15000,
+    });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/headless-complete.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/headless-complete.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Headless Chat — Complete (Langroid)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/headless-complete");
+  });
+
+  test("page loads with hand-rolled header and input", async ({ page }) => {
+    await expect(
+      page.getByText("Headless Chat (Complete)", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByPlaceholder("Send a message…")).toBeVisible();
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/headless-simple.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/headless-simple.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Headless Simple", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/headless-simple");
+  });
+
+  test("headless chat heading visible", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: /Headless Chat \(Simple\)/i }),
+    ).toBeVisible();
+  });
+
+  test("empty state shows placeholder text", async ({ page }) => {
+    await expect(page.getByText("No messages yet")).toBeVisible();
+  });
+
+  test("sends a message via custom input", async ({ page }) => {
+    const input = page.locator("textarea");
+    await input.fill("hello");
+    await input.press("Enter");
+    // User bubble appears (the hand-rolled UI renders user content as plain text)
+    await expect(page.getByText("hello").first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/hitl-in-app.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/hitl-in-app.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("HITL In-App", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/hitl-in-app");
+  });
+
+  test("tickets panel renders sample tickets", async ({ page }) => {
+    await expect(page.locator('[data-testid="ticket-12345"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ticket-12346"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ticket-12347"]')).toBeVisible();
+  });
+
+  test("approval request opens dialog outside chat", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill(
+      "Please approve a $50 refund to Jordan Rivera on ticket #12345.",
+    );
+    await input.press("Enter");
+    await expect(page.locator('[data-testid="approval-dialog"]')).toBeVisible({
+      timeout: 60000,
+    });
+    await page.locator('[data-testid="approval-dialog-approve"]').click();
+    await expect(
+      page.locator('[data-testid="approval-dialog"]'),
+    ).not.toBeVisible();
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/prebuilt-popup.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/prebuilt-popup.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Prebuilt Popup", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/prebuilt-popup");
+  });
+
+  test("main content heading visible", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: /Popup demo/i }),
+    ).toBeVisible();
+  });
+
+  test("popup chat input is visible (defaultOpen)", async ({ page }) => {
+    await expect(
+      page.getByPlaceholder("Ask the popup anything..."),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/prebuilt-sidebar.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/prebuilt-sidebar.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Prebuilt Sidebar", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/prebuilt-sidebar");
+  });
+
+  test("main content heading visible", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: /Sidebar demo/i }),
+    ).toBeVisible();
+  });
+
+  test("sidebar chat input is visible (defaultOpen)", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/readonly-state-agent-context.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/readonly-state-agent-context.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Readonly State (Agent Context)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/readonly-state-agent-context");
+  });
+
+  test("context card renders with default fields", async ({ page }) => {
+    await expect(page.locator('[data-testid="context-card"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ctx-name"]')).toHaveValue("Atai");
+  });
+
+  test("published context JSON reflects initial state", async ({ page }) => {
+    const json = page.locator('[data-testid="ctx-state-json"]');
+    await expect(json).toContainText("Atai");
+    await expect(json).toContainText("America/Los_Angeles");
+  });
+
+  test("sends a message and gets a reply", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("What do you know about me?");
+    await input.press("Enter");
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/reasoning-default-render.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/reasoning-default-render.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Reasoning (Default Render)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/reasoning-default-render");
+  });
+
+  test("chat input is visible", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("sends message and gets a reply", async ({ page }) => {
+    const input = page.locator('textarea, [placeholder*="message"]').first();
+    await input.fill("hello");
+    await input.press("Enter");
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/tool-rendering-custom-catchall.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/tool-rendering-custom-catchall.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+// QA reference: qa/tool-rendering-custom-catchall.md
+// Demo source: src/app/demos/tool-rendering-custom-catchall/page.tsx
+//
+// The page registers a single branded wildcard renderer via
+// `useDefaultRenderTool`. Every Langroid backend tool call paints
+// via the same CustomCatchallRenderer card.
+
+test.describe("Tool Rendering — Custom Catch-all (Langroid)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/tool-rendering-custom-catchall");
+  });
+
+  test("page loads with chat input and suggestion pills", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+  });
+
+  test("weather prompt paints the custom catchall card", async ({ page }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("What's the weather in San Francisco?");
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    const card = page
+      .locator('[data-testid="custom-catchall-card"]')
+      .first();
+    await expect(card).toBeVisible({ timeout: 60000 });
+
+    await expect(
+      card.locator('[data-testid="custom-catchall-tool-name"]'),
+    ).toContainText("get_weather");
+  });
+});

--- a/showcase/packages/langroid/tests/e2e/tool-rendering-custom-catchall.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/tool-rendering-custom-catchall.spec.ts
@@ -21,9 +21,7 @@ test.describe("Tool Rendering — Custom Catch-all (Langroid)", () => {
     await input.fill("What's the weather in San Francisco?");
     await page.locator('[data-testid="copilot-send-button"]').first().click();
 
-    const card = page
-      .locator('[data-testid="custom-catchall-card"]')
-      .first();
+    const card = page.locator('[data-testid="custom-catchall-card"]').first();
     await expect(card).toBeVisible({ timeout: 60000 });
 
     await expect(

--- a/showcase/packages/langroid/tests/e2e/tool-rendering-default-catchall.spec.ts
+++ b/showcase/packages/langroid/tests/e2e/tool-rendering-default-catchall.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+
+// QA reference: qa/tool-rendering-default-catchall.md
+// Demo source: src/app/demos/tool-rendering-default-catchall/page.tsx
+//
+// The page registers CopilotKit's built-in DefaultToolCallRenderer as
+// the `*` wildcard via `useDefaultRenderTool()` with no config. The
+// Langroid backend exposes `get_weather`, `search_flights`, etc., and
+// every tool call must paint via this one built-in card.
+
+test.describe("Tool Rendering — Default Catch-all (Langroid)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/tool-rendering-default-catchall");
+  });
+
+  test("page loads with chat input and suggestion pills", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+
+    const suggestions = page.locator('[data-testid="copilot-suggestion"]');
+    await expect(
+      suggestions.filter({ hasText: "Weather in SF" }).first(),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      suggestions.filter({ hasText: "Find flights" }).first(),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      suggestions.filter({ hasText: "Weather in Tokyo" }).first(),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test("weather prompt paints the built-in default tool-call card", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("What's the weather in San Francisco?");
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    await expect(
+      page.getByText("get_weather", { exact: true }).first(),
+    ).toBeVisible({ timeout: 60000 });
+
+    await expect(page.getByText("Done", { exact: true }).first()).toBeVisible({
+      timeout: 60000,
+    });
+
+    await expect(
+      page.locator('[data-testid="custom-catchall-card"]'),
+    ).toHaveCount(0);
+    await expect(page.locator('[data-testid="weather-card"]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Expands the Langroid showcase package toward parity with the canonical `showcase/packages/langgraph-python` manifest. Lands alongside parallel PRs for agno, ag2, llamaindex, and spring-ai.

Langroid's `agent_server.py` exposes a single unified AG-UI-over-SSE endpoint at `/`; every new demo registers a new agent-name in the Next.js runtime route that forwards to the same `HttpAgent`. Frontend demos therefore only need `page.tsx` plus supporting components; no new Python backend modules are introduced in this pass.

### Ported (11 new demos)

Chat chrome variants:
- chat-customization-css — scoped CSS theme
- prebuilt-sidebar — CopilotSidebar docked chat
- prebuilt-popup — CopilotPopup floating launcher
- chat-slots — custom welcomeScreen + disclaimer + assistantMessage slots
- headless-simple — hand-rolled chat on useAgent + useComponent

Frontend-tools variants:
- frontend-tools — sync useFrontendTool handler (change_background)
- frontend-tools-async — async handler + in-browser notes DB + NotesCard

HITL variant:
- hitl-in-app — async frontend-tool + React portal approval dialog

Reasoning + context:
- agentic-chat-reasoning — custom reasoningMessage slot
- reasoning-default-render — zero-config default reasoning render
- readonly-state-agent-context — useAgentContext for name/timezone/activity

Each demo ships a page + supporting components, a minimal Playwright smoke spec, and a QA checklist. The manifest lists every demo with its highlight files.

### Skipped

- gen-ui-interrupt, interrupt-headless — LangGraph-interrupt-specific primitive; Langroid has no equivalent in ChatAgent / Task.

### Deferred

The remaining langgraph-python demos (byoc-json-render, byoc-hashbrown, beautiful-chat, multimodal, auth, voice, open-gen-ui variants, agent-config, declarative-gen-ui, a2ui-fixed-schema, mcp-apps, tool-rendering variants, headless-complete) are portable in principle but each requires a dedicated runtime route and additional backend or BYOC work beyond the unified agent. They are documented in `showcase/packages/langroid/PARITY_NOTES.md` for follow-up.

### Reasoning note

The Langroid AG-UI adapter (`src/agents/agui_adapter.py`) does not currently emit REASONING_MESSAGE events, so the two reasoning demos exercise the wiring and slot registration path but will only surface a reasoning block once the adapter is extended to forward Langroid's internal thinking channel (if any). The QA docs call this out.

## Test plan

- [ ] Run `npm run dev` in showcase/packages/langroid and boot the Next.js app + Python agent server
- [ ] Visit each new /demos/ID route and confirm the page renders with no console errors
- [ ] chat-customization-css: themed user/assistant bubbles render
- [ ] prebuilt-sidebar and prebuilt-popup: chat opens by default
- [ ] chat-slots: custom welcome screen + disclaimer visible; assistant message wrapped in slot
- [ ] headless-simple: asking for a card renders the ShowCard component
- [ ] frontend-tools: background-change request mutates the background style
- [ ] frontend-tools-async: NotesCard renders after the simulated async query
- [ ] hitl-in-app: approval dialog opens outside chat; Approve returns to agent
- [ ] readonly-state-agent-context: agent references name/timezone/activity in replies
- [ ] Playwright specs pass: `npm run test:e2e`
