### PR TITLE
feat(showcase/claude-sdk-python): bring closer to parity with langgraph-python (frontend-only demos)

### DIFF
--- a/showcase/packages/claude-sdk-python/PARITY_NOTES.md
+++ b/showcase/packages/claude-sdk-python/PARITY_NOTES.md
@@ -1,0 +1,37 @@
+# Parity Notes
+
+Baseline: `showcase/packages/langgraph-python/`.
+
+This package currently ports the frontend-only demos whose agent behavior is fully satisfied by the shared default Claude backend in `src/agents/agent.py`. The demos below are deliberately out of scope for this pass and left for a follow-up.
+
+## Ported in this pass
+
+- `cli-start` — manifest-only entry with the framework-slug init command.
+- `prebuilt-sidebar` — default `<CopilotSidebar />` against the shared agent.
+- `prebuilt-popup` — default `<CopilotPopup />` against the shared agent.
+- `chat-slots` — custom `welcomeScreen`, `input.disclaimer`, `messageView.assistantMessage` slots.
+- `chat-customization-css` — scoped CSS variable and class overrides.
+- `headless-simple` — `useAgent` + `useComponent` minimal custom chat surface.
+
+## Skipped demos
+
+### Require langgraph-specific primitives (no Claude Agent SDK equivalent)
+
+- `gen-ui-interrupt` — relies on langgraph's `interrupt()` primitive that pauses the graph and resumes on a client-side response. Claude Agent SDK does not expose an equivalent graph-interrupt API.
+- `interrupt-headless` — same reason; this is a headless surface for resolving a langgraph interrupt.
+
+### Require infrastructure not yet present in this package
+
+- `beautiful-chat` — 28 supporting files (layout, canvas, generative UI charts, hooks, theme CSS, showcase config, A2UI catalog). Porting requires significant surface-area review that did not fit this pass. Skeleton to be added in a follow-up.
+- `mcp-apps` — MCP client driving UI via activity renderers. Claude Agent SDK supports MCP clients, but the langgraph-python demo relies on the CopilotKit runtime wiring through a dedicated `/api/copilotkit-mcp-apps/route.ts` plus agent-side MCP client glue that did not fit this pass.
+- `agentic-chat-reasoning`, `reasoning-default-render`, `tool-rendering-reasoning-chain` — require streaming Claude extended-thinking (reasoning) blocks as distinct AG-UI message parts. The current `src/agents/agent.py` AG-UI bridge does not translate Anthropic `thinking` content blocks; adding it correctly requires new event types and a thinking-aware message buffer. Follow-up.
+- `declarative-gen-ui` — A2UI BYOC catalog wired via `a2ui.catalog` on the provider plus agent-side `render_a2ui` tool injection. Possible on this package but pulls in the full A2UI renderer stack and multi-file catalog/definitions/renderers — deferred to the A2UI follow-up.
+- `a2ui-fixed-schema` — fixed-schema A2UI with two JSON schemas (flights + booked) and a per-demo catalog. Same A2UI follow-up as above.
+- `frontend-tools`, `frontend-tools-async` — each needs a dedicated demo agent and supporting frontend surface (notes-card etc.). The default agent already exposes `change_background` as a frontend tool but the standalone demos were not ported to keep the pass focused.
+- `hitl-in-app` — needs an app-level approval modal plus an async `useFrontendTool` handler that awaits the modal's resolution. Supporting component (approval-dialog.tsx) plus wiring was deferred.
+- `readonly-state-agent-context` — frontend provides read-only context to the agent via `useAgentContext`. Trivial on the frontend, but the reference uses a dedicated agent and a dedicated support component; deferred.
+- `open-gen-ui`, `open-gen-ui-advanced` — open-ended generative UI with sandbox iframe and an OGUI route. Multi-file surface deferred.
+- `tool-rendering-default-catchall`, `tool-rendering-custom-catchall` — focused variants on top of the existing tool-rendering demo. The default agent already exposes backend tools; adding these would only cost a new `page.tsx` and a custom renderer each, but they are deferred to a follow-up that also touches `tool-rendering-reasoning-chain`.
+- `headless-complete` — full-from-scratch chat (message-list, use-rendered-messages, etc.). Multi-file frontend; deferred.
+
+Follow-ups should pick these up in groups: (1) reasoning/thinking plumbing in `agent.py`, (2) A2UI catalog demos, (3) tool-rendering variants, (4) frontend-tools + HITL-in-app, (5) mcp-apps, (6) beautiful-chat, (7) headless-complete.

--- a/showcase/packages/claude-sdk-python/PARITY_NOTES.md
+++ b/showcase/packages/claude-sdk-python/PARITY_NOTES.md
@@ -7,6 +7,43 @@ Claude backend in `src/agents/agent.py`, plus dedicated ogui / headless
 surfaces. The demos below are deliberately out of scope for this pass and
 left for a follow-up.
 
+## New demos (post-PR #4271)
+
+- `byoc-json-render` — dedicated `/byoc-json-render` agent endpoint emits
+  a JSON spec; frontend renders via `<JSONUIProvider>` + `<Renderer />`
+  against a Zod catalog (MetricCard, BarChart, PieChart). Includes the
+  `<JSONUIProvider>` fix from PR #4271 and the `defineRegistry`
+  children-forwarding fix for MetricCard.
+- `byoc-hashbrown` — dedicated `/byoc-hashbrown` agent endpoint emits
+  the hashbrown JSON envelope `{ui: [{metric: {props: {...}}}, ...]}`
+  (NOT XML — the #4271 fix). Frontend parses via `useJsonParser` +
+  `useUiKit` with MetricCard / PieChart / BarChart / DealCard / Markdown.
+- `multimodal` — dedicated `/multimodal` agent endpoint with
+  `convert_part_for_claude` that translates AG-UI `image` / `document`
+  parts into Claude's native Messages API shape. PDFs flatten to text
+  via `pypdf`. **No legacy-binary shim required** — that shim is
+  specific to the `@ag-ui/langgraph@0.0.27` converter and is not needed
+  when HttpAgent forwards modern parts to the Claude Agent SDK backend.
+- `voice` — dedicated `/api/copilotkit-voice` runtime with a
+  `GuardedOpenAITranscriptionService` that reports a typed 401 when
+  `OPENAI_API_KEY` is missing (vs a silent 503). Transcription service
+  is written onto the V2 runtime instance directly to work around the
+  V1 wrapper silently dropping the service. Backend reuses the shared
+  Claude agent.
+- `agent-config` — dedicated `/agent-config` agent endpoint that reads
+  `tone` / `expertise` / `responseLength` off
+  `forwarded_props.config.configurable.properties` and builds the
+  system prompt per turn. Frontend route subclasses `HttpAgent` to
+  repack provider `properties` into the nested configurable shape so
+  the wire format matches the langgraph-python reference exactly.
+- `auth` — dedicated `/api/copilotkit-auth` route uses
+  `createCopilotRuntimeHandler` from `@copilotkit/runtime/v2` directly
+  so the `onRequest` hook actually fires (V1 adapter drops hooks).
+  Bearer-token gate returns 401 on mismatch. Includes the #4271
+  defaults fix: `useDemoAuth` defaults to signed-in, plus
+  `ChatErrorBoundary` so the page never white-screens on auth
+  transitions.
+
 ## Ported
 
 ### Initial pass (B2)

--- a/showcase/packages/claude-sdk-python/PARITY_NOTES.md
+++ b/showcase/packages/claude-sdk-python/PARITY_NOTES.md
@@ -2,9 +2,14 @@
 
 Baseline: `showcase/packages/langgraph-python/`.
 
-This package currently ports the frontend-only demos whose agent behavior is fully satisfied by the shared default Claude backend in `src/agents/agent.py`. The demos below are deliberately out of scope for this pass and left for a follow-up.
+This package ports the frontend-composition demos satisfied by the shared
+Claude backend in `src/agents/agent.py`, plus dedicated ogui / headless
+surfaces. The demos below are deliberately out of scope for this pass and
+left for a follow-up.
 
-## Ported in this pass
+## Ported
+
+### Initial pass (B2)
 
 - `cli-start` — manifest-only entry with the framework-slug init command.
 - `prebuilt-sidebar` — default `<CopilotSidebar />` against the shared agent.
@@ -13,25 +18,68 @@ This package currently ports the frontend-only demos whose agent behavior is ful
 - `chat-customization-css` — scoped CSS variable and class overrides.
 - `headless-simple` — `useAgent` + `useComponent` minimal custom chat surface.
 
-## Skipped demos
+### Follow-up pass (B2')
+
+- `frontend-tools` — `useFrontendTool` with sync handler (change_background).
+- `frontend-tools-async` — `useFrontendTool` with async handler (query_notes).
+- `hitl-in-app` — async `useFrontendTool` HITL; `fixed inset-0` overlay
+  (not `createPortal`) to avoid pulling in `@types/react-dom`.
+- `readonly-state-agent-context` — `useAgentContext` read-only context.
+- `tool-rendering-default-catchall` — zero-renderer built-in default.
+- `tool-rendering-custom-catchall` — `useDefaultRenderTool` wildcard.
+- `open-gen-ui` — minimal open-ended generative UI (dedicated
+  `/api/copilotkit-ogui` route with `openGenerativeUI` flag).
+- `open-gen-ui-advanced` — OGUI with frontend sandbox functions
+  (evaluateExpression, notifyHost).
+- `headless-complete` — full custom chat surface built on `useAgent`,
+  with per-tool renderers, frontend component, and wildcard catch-all.
+  Points to the shared `/api/copilotkit` route (the reference points at
+  `/api/copilotkit-mcp-apps`; this package doesn't port mcp-apps — the
+  Excalidraw-MCP suggestion will surface as a catch-all tool card).
+
+## Skipped
 
 ### Require langgraph-specific primitives (no Claude Agent SDK equivalent)
 
-- `gen-ui-interrupt` — relies on langgraph's `interrupt()` primitive that pauses the graph and resumes on a client-side response. Claude Agent SDK does not expose an equivalent graph-interrupt API.
-- `interrupt-headless` — same reason; this is a headless surface for resolving a langgraph interrupt.
+- `gen-ui-interrupt` — relies on langgraph's `interrupt()` primitive that
+  pauses the graph and resumes on a client-side response. Claude Agent SDK
+  does not expose an equivalent graph-interrupt API.
+- `interrupt-headless` — same reason; this is a headless surface for
+  resolving a langgraph interrupt.
 
-### Require infrastructure not yet present in this package
+### Require streaming Claude extended-thinking plumbing
 
-- `beautiful-chat` — 28 supporting files (layout, canvas, generative UI charts, hooks, theme CSS, showcase config, A2UI catalog). Porting requires significant surface-area review that did not fit this pass. Skeleton to be added in a follow-up.
-- `mcp-apps` — MCP client driving UI via activity renderers. Claude Agent SDK supports MCP clients, but the langgraph-python demo relies on the CopilotKit runtime wiring through a dedicated `/api/copilotkit-mcp-apps/route.ts` plus agent-side MCP client glue that did not fit this pass.
-- `agentic-chat-reasoning`, `reasoning-default-render`, `tool-rendering-reasoning-chain` — require streaming Claude extended-thinking (reasoning) blocks as distinct AG-UI message parts. The current `src/agents/agent.py` AG-UI bridge does not translate Anthropic `thinking` content blocks; adding it correctly requires new event types and a thinking-aware message buffer. Follow-up.
-- `declarative-gen-ui` — A2UI BYOC catalog wired via `a2ui.catalog` on the provider plus agent-side `render_a2ui` tool injection. Possible on this package but pulls in the full A2UI renderer stack and multi-file catalog/definitions/renderers — deferred to the A2UI follow-up.
-- `a2ui-fixed-schema` — fixed-schema A2UI with two JSON schemas (flights + booked) and a per-demo catalog. Same A2UI follow-up as above.
-- `frontend-tools`, `frontend-tools-async` — each needs a dedicated demo agent and supporting frontend surface (notes-card etc.). The default agent already exposes `change_background` as a frontend tool but the standalone demos were not ported to keep the pass focused.
-- `hitl-in-app` — needs an app-level approval modal plus an async `useFrontendTool` handler that awaits the modal's resolution. Supporting component (approval-dialog.tsx) plus wiring was deferred.
-- `readonly-state-agent-context` — frontend provides read-only context to the agent via `useAgentContext`. Trivial on the frontend, but the reference uses a dedicated agent and a dedicated support component; deferred.
-- `open-gen-ui`, `open-gen-ui-advanced` — open-ended generative UI with sandbox iframe and an OGUI route. Multi-file surface deferred.
-- `tool-rendering-default-catchall`, `tool-rendering-custom-catchall` — focused variants on top of the existing tool-rendering demo. The default agent already exposes backend tools; adding these would only cost a new `page.tsx` and a custom renderer each, but they are deferred to a follow-up that also touches `tool-rendering-reasoning-chain`.
-- `headless-complete` — full-from-scratch chat (message-list, use-rendered-messages, etc.). Multi-file frontend; deferred.
+- `agentic-chat-reasoning`, `reasoning-default-render`,
+  `tool-rendering-reasoning-chain` — require streaming Claude extended-
+  thinking (reasoning) blocks as distinct AG-UI message parts. The current
+  `src/agents/agent.py` AG-UI bridge does not translate Anthropic
+  `thinking` content blocks; adding it correctly requires new event types
+  and a thinking-aware message buffer. Follow-up.
 
-Follow-ups should pick these up in groups: (1) reasoning/thinking plumbing in `agent.py`, (2) A2UI catalog demos, (3) tool-rendering variants, (4) frontend-tools + HITL-in-app, (5) mcp-apps, (6) beautiful-chat, (7) headless-complete.
+### Deferred — larger-scope multi-file surfaces
+
+These are feasible on this package but each pulls in substantial
+multi-file frontend infrastructure (catalogs, renderers, MCP client
+glue, theme pipelines) that did not fit this pass. Left for dedicated
+follow-up commits.
+
+- `declarative-gen-ui` — A2UI BYOC catalog (Card/StatusBadge/Metric/
+  InfoRow/PrimaryButton) wired via `a2ui.catalog` on the provider.
+- `a2ui-fixed-schema` — fixed-schema A2UI with two JSON schemas
+  (flights + booked) and a per-demo catalog.
+- `mcp-apps` — MCP server-driven UI via activity renderers. Claude Agent
+  SDK supports MCP clients, but the langgraph-python reference relies on
+  CopilotKit runtime wiring through a dedicated
+  `/api/copilotkit-mcp-apps/route.ts` plus agent-side MCP client glue.
+- `beautiful-chat` — 28+ supporting files (layout, canvas, generative UI
+  charts, hooks, theme CSS, showcase config, A2UI catalog). Porting
+  requires significant surface-area review that did not fit this pass.
+
+## Follow-up buckets
+
+- Reasoning / extended-thinking plumbing in `agent.py` (unlocks
+  `agentic-chat-reasoning`, `reasoning-default-render`,
+  `tool-rendering-reasoning-chain`).
+- A2UI catalog demos (unlocks `declarative-gen-ui`, `a2ui-fixed-schema`).
+- MCP client integration (unlocks `mcp-apps`).
+- Beautiful-chat infrastructure port.

--- a/showcase/packages/claude-sdk-python/manifest.yaml
+++ b/showcase/packages/claude-sdk-python/manifest.yaml
@@ -22,6 +22,7 @@ interaction_modalities:
   - embedded
   - chat
 features:
+  - cli-start
   - agentic-chat
   - hitl-in-chat
   - tool-rendering
@@ -30,7 +31,18 @@ features:
   - shared-state-read-write
   - shared-state-streaming
   - subagents
+  - prebuilt-sidebar
+  - prebuilt-popup
+  - chat-slots
+  - chat-customization-css
+  - headless-simple
 demos:
+  - id: cli-start
+    name: CLI Start Command
+    description: Copy-paste command to clone the canonical starter
+    tags:
+      - chat-ui
+    command: "npx copilotkit@latest init --framework claude-sdk-python"
   - id: agentic-chat
     name: Agentic Chat
     description: Natural conversation with frontend tool execution
@@ -87,6 +99,63 @@ demos:
       - multi-agent
     route: /demos/subagents
     animated_preview_url:
+  - id: prebuilt-sidebar
+    name: "Pre-Built: Sidebar"
+    description: Docked sidebar chat via <CopilotSidebar />
+    tags:
+      - chat-ui
+    route: /demos/prebuilt-sidebar
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/prebuilt-sidebar/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: prebuilt-popup
+    name: "Pre-Built: Popup"
+    description: Floating popup chat via <CopilotPopup />
+    tags:
+      - chat-ui
+    route: /demos/prebuilt-popup
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/prebuilt-popup/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: chat-slots
+    name: Chat Customization (Slots)
+    description: Customize CopilotChat via its slot system
+    tags:
+      - chat-ui
+    route: /demos/chat-slots
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/chat-slots/page.tsx
+      - src/app/demos/chat-slots/custom-welcome-screen.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: chat-customization-css
+    name: Chat Customization (CSS)
+    description: Default CopilotChat re-themed via CopilotKitCSSProperties
+    tags:
+      - chat-ui
+    route: /demos/chat-customization-css
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/chat-customization-css/page.tsx
+      - src/app/demos/chat-customization-css/theme.css
+      - src/app/api/copilotkit/route.ts
+  - id: headless-simple
+    name: Headless Chat (Simple)
+    description: Minimal custom chat surface built on useAgent
+    tags:
+      - chat-ui
+    route: /demos/headless-simple
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/headless-simple/page.tsx
+      - src/app/api/copilotkit/route.ts
 starter:
   path: showcase/starters/claude-sdk-python
   name: Sales Dashboard

--- a/showcase/packages/claude-sdk-python/manifest.yaml
+++ b/showcase/packages/claude-sdk-python/manifest.yaml
@@ -25,17 +25,26 @@ features:
   - cli-start
   - agentic-chat
   - hitl-in-chat
+  - hitl-in-app
   - tool-rendering
+  - tool-rendering-default-catchall
+  - tool-rendering-custom-catchall
   - gen-ui-tool-based
   - gen-ui-agent
   - shared-state-read-write
   - shared-state-streaming
+  - readonly-state-agent-context
   - subagents
   - prebuilt-sidebar
   - prebuilt-popup
   - chat-slots
   - chat-customization-css
   - headless-simple
+  - headless-complete
+  - frontend-tools
+  - frontend-tools-async
+  - open-gen-ui
+  - open-gen-ui-advanced
 demos:
   - id: cli-start
     name: CLI Start Command
@@ -156,6 +165,112 @@ demos:
       - src/agents/agent.py
       - src/app/demos/headless-simple/page.tsx
       - src/app/api/copilotkit/route.ts
+  - id: headless-complete
+    name: Headless Chat (Complete)
+    description: Full chat implementation built from scratch on useAgent
+    tags:
+      - chat-ui
+    route: /demos/headless-complete
+    animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/headless-complete/page.tsx
+      - src/app/demos/headless-complete/message-list.tsx
+      - src/app/demos/headless-complete/use-rendered-messages.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: frontend-tools
+    name: Frontend Tools (In-App Actions)
+    description: Agent invokes client-side handlers registered with useFrontendTool
+    tags:
+      - interactivity
+    route: /demos/frontend-tools
+    animated_preview_url:
+    highlight:
+      - src/agents/frontend_tools.py
+      - src/app/demos/frontend-tools/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: frontend-tools-async
+    name: Frontend Tools (Async)
+    description: useFrontendTool with an async handler — agent awaits a client-side async operation (simulated notes DB query) and uses the returned result
+    tags:
+      - interactivity
+    route: /demos/frontend-tools-async
+    animated_preview_url:
+    highlight:
+      - src/agents/frontend_tools_async.py
+      - src/app/demos/frontend-tools-async/page.tsx
+      - src/app/demos/frontend-tools-async/notes-card.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: hitl-in-app
+    name: In-App Human in the Loop (Frontend Tools + async HITL)
+    description: Agent requests approval via useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision
+    tags:
+      - interactivity
+    route: /demos/hitl-in-app
+    animated_preview_url:
+    highlight:
+      - src/agents/hitl_in_app.py
+      - src/app/demos/hitl-in-app/page.tsx
+      - src/app/demos/hitl-in-app/approval-dialog.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: readonly-state-agent-context
+    name: Readonly State (Agent Context)
+    description: Frontend provides read-only context to the agent via useAgentContext
+    tags:
+      - agent-state
+    route: /demos/readonly-state-agent-context
+    animated_preview_url:
+    highlight:
+      - src/agents/readonly_state_agent_context.py
+      - src/app/demos/readonly-state-agent-context/page.tsx
+      - src/app/api/copilotkit/route.ts
+  - id: tool-rendering-default-catchall
+    name: Tool Rendering (Default Catch-all)
+    description: Out-of-the-box tool rendering — backend defines the tools; the frontend adds zero custom renderers and relies on CopilotKit's built-in default UI
+    tags:
+      - generative-ui
+    route: /demos/tool-rendering-default-catchall
+    animated_preview_url:
+    highlight:
+      - src/app/demos/tool-rendering-default-catchall/page.tsx
+      - src/agents/agent.py
+      - src/app/api/copilotkit/route.ts
+  - id: tool-rendering-custom-catchall
+    name: Tool Rendering (Custom Catch-all)
+    description: Single branded wildcard renderer via useDefaultRenderTool — the same app-designed card paints every tool call
+    tags:
+      - generative-ui
+    route: /demos/tool-rendering-custom-catchall
+    animated_preview_url:
+    highlight:
+      - src/app/demos/tool-rendering-custom-catchall/page.tsx
+      - src/app/demos/tool-rendering-custom-catchall/custom-catchall-renderer.tsx
+      - src/agents/agent.py
+      - src/app/api/copilotkit/route.ts
+  - id: open-gen-ui
+    name: Fully Open-Ended Generative UI
+    description: Agent generates UI from an arbitrary component library
+    tags:
+      - generative-ui
+    route: /demos/open-gen-ui
+    animated_preview_url:
+    highlight:
+      - src/agents/open_gen_ui_agent.py
+      - src/app/demos/open-gen-ui/page.tsx
+      - src/app/api/copilotkit-ogui/route.ts
+  - id: open-gen-ui-advanced
+    name: "Open-Ended Gen UI (Advanced: with frontend function calling)"
+    description: Agent-authored UI that can invoke frontend sandbox functions from inside the iframe
+    tags:
+      - generative-ui
+    route: /demos/open-gen-ui-advanced
+    animated_preview_url:
+    highlight:
+      - src/agents/open_gen_ui_advanced_agent.py
+      - src/app/demos/open-gen-ui-advanced/page.tsx
+      - src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+      - src/app/demos/open-gen-ui-advanced/suggestions.ts
+      - src/app/api/copilotkit-ogui/route.ts
 starter:
   path: showcase/starters/claude-sdk-python
   name: Sales Dashboard

--- a/showcase/packages/claude-sdk-python/manifest.yaml
+++ b/showcase/packages/claude-sdk-python/manifest.yaml
@@ -45,6 +45,12 @@ features:
   - frontend-tools-async
   - open-gen-ui
   - open-gen-ui-advanced
+  - byoc-json-render
+  - byoc-hashbrown
+  - multimodal
+  - voice
+  - agent-config
+  - auth
 demos:
   - id: cli-start
     name: CLI Start Command
@@ -271,6 +277,81 @@ demos:
       - src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
       - src/app/demos/open-gen-ui-advanced/suggestions.ts
       - src/app/api/copilotkit-ogui/route.ts
+  - id: byoc-json-render
+    name: "BYOC: json-render"
+    description: Agent emits a JSON spec; `@json-render/react` renders it against a Zod catalog of MetricCard, BarChart, PieChart
+    tags:
+      - generative-ui
+    route: /demos/byoc-json-render
+    animated_preview_url:
+    highlight:
+      - src/agents/byoc_json_render_agent.py
+      - src/app/demos/byoc-json-render/page.tsx
+      - src/app/demos/byoc-json-render/json-render-renderer.tsx
+      - src/app/demos/byoc-json-render/registry.tsx
+      - src/app/demos/byoc-json-render/catalog.ts
+      - src/app/api/copilotkit-byoc-json-render/route.ts
+  - id: byoc-hashbrown
+    name: "BYOC: Hashbrown"
+    description: Streaming structured output via `@hashbrownai/react` — agent emits a catalog-constrained JSON envelope that renders progressively
+    tags:
+      - generative-ui
+    route: /demos/byoc-hashbrown
+    animated_preview_url:
+    highlight:
+      - src/agents/byoc_hashbrown_agent.py
+      - src/app/demos/byoc-hashbrown/page.tsx
+      - src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
+      - src/app/api/copilotkit-byoc-hashbrown/route.ts
+  - id: multimodal
+    name: Multimodal Attachments
+    description: Image + PDF attachments routed through Claude's native vision + pypdf text flattening
+    tags:
+      - interactivity
+    route: /demos/multimodal
+    animated_preview_url:
+    highlight:
+      - src/agents/multimodal_agent.py
+      - src/app/demos/multimodal/page.tsx
+      - src/app/demos/multimodal/sample-attachment-buttons.tsx
+      - src/app/api/copilotkit-multimodal/route.ts
+  - id: voice
+    name: Voice Input
+    description: Audio transcription wired on a per-demo runtime with a guarded OpenAI Whisper service that maps missing keys to 401
+    tags:
+      - chat-ui
+    route: /demos/voice
+    animated_preview_url:
+    highlight:
+      - src/app/demos/voice/page.tsx
+      - src/app/demos/voice/sample-audio-button.tsx
+      - src/app/api/copilotkit-voice/route.ts
+  - id: agent-config
+    name: Agent Config Object
+    description: Forwarded props (tone / expertise / responseLength) flow from the provider into the agent's system prompt via `forwardedProps.config.configurable.properties`
+    tags:
+      - agent-capabilities
+    route: /demos/agent-config
+    animated_preview_url:
+    highlight:
+      - src/agents/agent_config_agent.py
+      - src/app/demos/agent-config/page.tsx
+      - src/app/demos/agent-config/config-card.tsx
+      - src/app/demos/agent-config/use-agent-config.ts
+      - src/app/api/copilotkit-agent-config/route.ts
+  - id: auth
+    name: Authentication
+    description: Framework-native request auth via the V2 runtime's `onRequest` hook; missing bearer token returns 401
+    tags:
+      - agent-capabilities
+    route: /demos/auth
+    animated_preview_url:
+    highlight:
+      - src/app/demos/auth/page.tsx
+      - src/app/demos/auth/auth-banner.tsx
+      - src/app/demos/auth/use-demo-auth.ts
+      - src/app/demos/auth/demo-token.ts
+      - src/app/api/copilotkit-auth/route.ts
 starter:
   path: showcase/starters/claude-sdk-python
   name: Sales Dashboard

--- a/showcase/packages/claude-sdk-python/package-lock.json
+++ b/showcase/packages/claude-sdk-python/package-lock.json
@@ -9,12 +9,20 @@
       "version": "0.1.0",
       "dependencies": {
         "@ag-ui/client": "^0.0.43",
+        "@copilotkit/a2ui-renderer": "next",
         "@copilotkit/react-core": "next",
         "@copilotkit/runtime": "next",
+        "@copilotkit/voice": "next",
+        "@hashbrownai/core": "0.5.0-beta.4",
+        "@hashbrownai/react": "0.5.0-beta.4",
+        "@json-render/core": "0.18.0",
+        "@json-render/react": "0.18.0",
         "next": "^15.0.0",
+        "openai": "^5.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "zod": "^3.24.0"
+        "recharts": "^2.15.0",
+        "zod": "^4.0.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.50.0",
@@ -92,6 +100,7 @@
     },
     "../../../node_modules/.pnpm/@types+react@19.2.7/node_modules/@types/react": {
       "version": "19.2.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -535,13 +544,6 @@
         "node": ">=14.17"
       }
     },
-    "../../../node_modules/.pnpm/zod@3.25.76/node_modules/zod": {
-      "version": "3.25.76",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
@@ -568,6 +570,15 @@
         "zod-to-json-schema": "^3.25.1"
       }
     },
+    "node_modules/@a2ui/web_core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@ag-ui/a2ui-middleware": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.4.tgz",
@@ -590,6 +601,15 @@
       "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
       "dependencies": {
         "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@ag-ui/encoder": {
@@ -672,6 +692,15 @@
         "openai": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@ag-ui/langgraph/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@ag-ui/mcp-apps-middleware": {
@@ -946,6 +975,15 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
@@ -1017,6 +1055,15 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/@copilotkit/a2ui-renderer/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@copilotkit/core": {
       "version": "1.55.2-next.1",
       "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.55.2-next.1.tgz",
@@ -1060,6 +1107,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@copilotkit/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@copilotkit/license-verifier": {
@@ -1134,6 +1190,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@copilotkit/react-core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@copilotkit/runtime": {
@@ -1269,6 +1334,54 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/@copilotkit/runtime/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@copilotkit/shared": {
       "version": "1.55.2-next.1",
       "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.55.2-next.1.tgz",
@@ -1320,6 +1433,27 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/@copilotkit/shared/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@copilotkit/voice": {
+      "version": "1.55.2-next.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/voice/-/voice-1.55.2-next.1.tgz",
+      "integrity": "sha512-hhRDrUjrBkVKcr/qLLnHOUKQYp76a7PlIgEvDBlJi0lp20RtKG0U1YKaBN4er3KMf1R64VLyP5qaXbId7EHHOQ==",
+      "dependencies": {
+        "@copilotkit/runtime": "1.55.2-next.1",
+        "openai": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@copilotkit/web-inspector": {
       "version": "1.55.2-next.1",
       "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.55.2-next.1.tgz",
@@ -1363,6 +1497,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@copilotkit/web-inspector/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@envelop/core": {
@@ -1640,6 +1783,37 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@hashbrownai/core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@hashbrownai/core/-/core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-LlHkqk9/3Dn2yXU/cJawoXo3xkJI+7Q8bR8UrA4OPOaMGnEyr3xkuS9+DUeOphuvd6I/CKgkFNxUffhkFZ18Dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/liveloveapp"
+      }
+    },
+    "node_modules/@hashbrownai/react": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@hashbrownai/react/-/react-0.5.0-beta.4.tgz",
+      "integrity": "sha512-iCOH4HR8OcoqFFuRbRPEU0+xa0rfkBHzPGR8yy8HtQiOCGkhHrgJlhjJcBECaDXuNPu9fAMhSZeYZfs+jrI3CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/liveloveapp"
+      },
+      "peerDependencies": {
+        "@hashbrownai/core": "0.5.0-beta.4",
+        "react": ">=18 <20",
+        "react-dom": ">=18 <20"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -1675,41 +1849,28 @@
       "integrity": "sha512-My7EHJvN4DNBqefZivTHiivz7auiAl49QixQeYQT48dItkBvMr/WwcQPzUb3RP9CXEZXnMPKOatPlZ/MOjI34g==",
       "license": "Apache-2.0"
     },
-    "node_modules/@langchain/core": {
-      "version": "1.1.39",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.39.tgz",
-      "integrity": "sha512-DP9c7TREy6iA7HnywstmUAsNyJNYTFpRg2yBfQ+6H0l1HnvQzei9GsQ36GeOLxgRaD3vm9K8urCcawSC7yQpCw==",
-      "license": "MIT",
-      "peer": true,
+    "node_modules/@json-render/core": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@json-render/core/-/core-0.18.0.tgz",
+      "integrity": "sha512-zm0K9cgxZLGshw5TmdKe3Xc6fpjbONdlj3v+Er+HhCYZ9fSJpv32d9VzQds4bDW36vPfdieAOcsPR9+EcTff7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cfworker/json-schema": "^4.0.2",
-        "@standard-schema/spec": "^1.1.0",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
-        "js-tiktoken": "^1.0.12",
-        "langsmith": ">=0.5.0 <1.0.0",
-        "mustache": "^4.2.0",
-        "p-queue": "^6.6.2",
-        "uuid": "^11.1.0",
-        "zod": "^3.25.76 || ^4"
+        "zod": "^4.3.6"
       },
-      "engines": {
-        "node": ">=20"
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
-    "node_modules/@langchain/core/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
+    "node_modules/@json-render/react": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@json-render/react/-/react-0.18.0.tgz",
+      "integrity": "sha512-rT0hJ9mK2BGfLxZ/ztS4UF1XqAz/o+FNtFgii7hea7VjD4u0wJYyRphe4a5DetS/dSMZFECXkmida+xi3wKl9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-render/core": "0.18.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
       }
     },
     "node_modules/@langchain/langgraph": {
@@ -4301,6 +4462,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/cytoscape": {
       "version": "3.33.2",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
@@ -4873,6 +5040,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -4958,6 +5131,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dompurify": {
@@ -5245,6 +5428,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
@@ -7032,6 +7224,12 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -14271,19 +14469,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "version": "5.23.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
+      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
       "bin": {
         "openai": "bin/cli"
       },
@@ -14298,15 +14487,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/p-finally": {
@@ -14774,6 +14954,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -14794,6 +14989,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readable-stream": {
@@ -14819,6 +15030,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/reflect-metadata": {
@@ -17046,6 +17289,12 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -17613,6 +17862,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -17746,8 +18017,13 @@
       }
     },
     "node_modules/zod": {
-      "resolved": "../../../node_modules/.pnpm/zod@3.25.76/node_modules/zod",
-      "link": true
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",

--- a/showcase/packages/claude-sdk-python/package.json
+++ b/showcase/packages/claude-sdk-python/package.json
@@ -14,13 +14,17 @@
     "@copilotkit/a2ui-renderer": "next",
     "@copilotkit/react-core": "next",
     "@copilotkit/runtime": "next",
+    "@copilotkit/voice": "next",
     "@hashbrownai/core": "0.5.0-beta.4",
     "@hashbrownai/react": "0.5.0-beta.4",
+    "@json-render/core": "0.18.0",
+    "@json-render/react": "0.18.0",
     "next": "^15.0.0",
+    "openai": "^5.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^2.15.0",
-    "zod": "^3.24.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",

--- a/showcase/packages/claude-sdk-python/public/demo-audio/README.md
+++ b/showcase/packages/claude-sdk-python/public/demo-audio/README.md
@@ -1,0 +1,18 @@
+# Voice demo audio
+
+Drop a small (<100KB) WAV file named `sample.wav` in this directory. The voice
+demo (`/demos/voice`) fetches it client-side and POSTs to the transcription
+endpoint so the flow works without mic permissions.
+
+Expected content: an audio clip speaking the phrase
+**"What is the weather in Tokyo?"** — the demo caption advertises that phrase
+to the user, and the bundled QA checklist + E2E spec assert the transcribed
+text contains "weather" and/or "Tokyo".
+
+Generate locally, for example:
+
+- macOS: `say -o sample.aiff "What is the weather in Tokyo?" && ffmpeg -i sample.aiff -ar 16000 -ac 1 sample.wav`
+- Linux: `espeak-ng -w sample.wav "What is the weather in Tokyo?"`
+- Windows: PowerShell `System.Speech.Synthesis.SpeechSynthesizer` → `SetOutputToWaveFile`
+
+Target: 16kHz mono, 3-5s duration, <100KB.

--- a/showcase/packages/claude-sdk-python/public/demo-audio/sample.wav
+++ b/showcase/packages/claude-sdk-python/public/demo-audio/sample.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd4aa7b049f1c3e324dfd15af4068d7f8fbf2eae1dd044df270dddc5f38a5c57
+size 87078

--- a/showcase/packages/claude-sdk-python/public/demo-files/README.md
+++ b/showcase/packages/claude-sdk-python/public/demo-files/README.md
@@ -1,0 +1,22 @@
+# Demo Files — Multimodal Demo
+
+This directory bundles sample files referenced by the `/demos/multimodal` page.
+
+Required files (must be committed as binaries; see `.gitattributes` at repo root):
+
+- `sample.png` — a small (< 50 KB) PNG that the "Try with sample image" button
+  injects into the chat. A CopilotKit logo or other recognizable brand mark
+  works well so the vision-capable agent has something to describe.
+- `sample.pdf` — a small (< 50 KB) one-page PDF that the "Try with sample PDF"
+  button injects. The content must mention "CopilotKit" so E2E soft
+  assertions hold (e.g. a one-page export of the CopilotKit quickstart).
+
+The page at `src/app/demos/multimodal/page.tsx` fetches these via the public
+path (`/demo-files/sample.png`, `/demo-files/sample.pdf`), wraps the fetched
+blob in a `File`, and routes it through the same `AttachmentsConfig.onUpload`
+callback the paperclip button uses — so the sample path exercises the exact
+same queueing code as a real user upload.
+
+If these files are missing, the demo page still renders but the sample
+buttons will surface a fetch error. The paperclip / drag-and-drop paths
+continue to work without them.

--- a/showcase/packages/claude-sdk-python/public/demo-files/sample.pdf
+++ b/showcase/packages/claude-sdk-python/public/demo-files/sample.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3da2afae36a1a81fd2c02f15e54bfc38b6c22e41655c31a5b54ff1e0e3daab41
+size 2486

--- a/showcase/packages/claude-sdk-python/public/demo-files/sample.png
+++ b/showcase/packages/claude-sdk-python/public/demo-files/sample.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01aa5681de99461247543e9215c1e4da3242e26b2bee11593fcdbe209672d973
+size 10083

--- a/showcase/packages/claude-sdk-python/qa/agent-config.md
+++ b/showcase/packages/claude-sdk-python/qa/agent-config.md
@@ -1,0 +1,52 @@
+# QA: Agent Config Object — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- `ANTHROPIC_API_KEY` is set on the deployment
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/agent-config`
+- [ ] Verify the config card renders with three select inputs:
+      `agent-config-tone-select`, `agent-config-expertise-select`,
+      `agent-config-length-select`
+- [ ] Verify the chat surface is visible below the config card
+
+### 2. Feature-Specific Checks
+
+#### Tone
+
+- [ ] Set tone to `professional`, send "Tell me about Paris"
+- [ ] Verify Claude's reply avoids emoji and exclamation marks
+- [ ] Change tone to `enthusiastic`, send the same prompt
+- [ ] Verify the next reply is noticeably more upbeat
+
+#### Expertise
+
+- [ ] Set expertise to `beginner`, ask "Explain quantum entanglement"
+- [ ] Verify the reply defines jargon and uses an analogy
+- [ ] Switch to `expert` and ask again
+- [ ] Verify the reply uses precise terminology and skips basics
+
+#### Response length
+
+- [ ] Set responseLength to `concise` and ask anything open-ended
+- [ ] Verify the reply is at most 3 sentences
+- [ ] Switch to `detailed`
+- [ ] Verify the reply spans multiple paragraphs
+
+### 3. Error Handling
+
+- [ ] Send a message without changing any config first — verify the
+      default (professional / intermediate / concise) behaviour holds
+- [ ] No console errors during normal usage
+
+## Expected Results
+
+- Config changes take effect on the NEXT message (not retroactively).
+- `forwardedProps` reaches the backend via
+  `forwarded_props.config.configurable.properties`.

--- a/showcase/packages/claude-sdk-python/qa/auth.md
+++ b/showcase/packages/claude-sdk-python/qa/auth.md
@@ -1,0 +1,48 @@
+# QA: Authentication — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- `ANTHROPIC_API_KEY` is set on the deployment
+
+## Test Steps
+
+### 1. Basic Functionality (happy path — start signed in)
+
+- [ ] Navigate to `/demos/auth`
+- [ ] Verify the auth banner renders with
+      `data-authenticated="true"`
+- [ ] Verify the status reads "✓ Signed in as demo user"
+- [ ] Verify the "Sign out" button is visible
+- [ ] Send "Hello" and verify Claude responds
+
+### 2. Sign-out path
+
+- [ ] Click "Sign out"
+- [ ] Verify the banner flips to amber with
+      `data-authenticated="false"`
+- [ ] Verify the button now reads "Sign in"
+- [ ] Attempt to send a message
+- [ ] Verify the error banner (`data-testid="auth-demo-error"`)
+      renders with "401 Unauthorized" text
+- [ ] Verify no white-screen and no uncaught React errors (the
+      ChatErrorBoundary catches any render-time crash from chat
+      internals in the unauth state and renders
+      `data-testid="auth-demo-chat-boundary"`)
+
+### 3. Sign-in recovery
+
+- [ ] Click "Sign in"
+- [ ] Verify the banner flips back to green
+- [ ] Verify the error banner clears
+- [ ] Send a message and verify Claude replies again
+
+### 4. Error Handling
+
+- [ ] No console errors during normal usage.
+
+## Expected Results
+
+- Runtime rejects un-bearer'd requests with HTTP 401.
+- Page never white-screens, even during auth transitions.

--- a/showcase/packages/claude-sdk-python/qa/byoc-hashbrown.md
+++ b/showcase/packages/claude-sdk-python/qa/byoc-hashbrown.md
@@ -1,0 +1,49 @@
+# QA: BYOC hashbrown — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- `ANTHROPIC_API_KEY` is set on the deployment
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/byoc-hashbrown`
+- [ ] Verify the header "BYOC: Hashbrown" renders
+- [ ] Verify the description paragraph mentions `@hashbrownai/react`
+
+### 2. Feature-Specific Checks
+
+#### Q4 Sales Summary (mixed catalog)
+
+- [ ] Send "Show me a Q4 sales summary" (or click a suggestion)
+- [ ] Verify a `data-testid="metric-card"` renders with a formatted value
+- [ ] Verify a `data-testid="pie-chart"` renders with at least three
+      legend rows
+- [ ] Verify a `data-testid="bar-chart"` renders with at least three
+      columns
+- [ ] Verify at least one Markdown heading renders inline
+
+#### Deal card
+
+- [ ] Ask "Show me a sample deal in the negotiation stage"
+- [ ] Verify a `data-testid="hashbrown-deal-card"` renders with a stage
+      badge
+
+### 3. Streaming behaviour
+
+- [ ] Observe components progressively appear as Claude streams the
+      JSON envelope — no full-refresh flash at the end of streaming
+
+### 4. Error Handling
+
+- [ ] No console errors during normal usage.
+- [ ] No hashbrown schema-validation errors logged.
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 15 seconds
+- Backend emits the JSON envelope (`{ui: [...]}`), NEVER XML

--- a/showcase/packages/claude-sdk-python/qa/byoc-json-render.md
+++ b/showcase/packages/claude-sdk-python/qa/byoc-json-render.md
@@ -1,0 +1,59 @@
+# QA: BYOC json-render — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- `ANTHROPIC_API_KEY` is set on the deployment
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/byoc-json-render`
+- [ ] Verify the chat surface loads inside the centered 4xl container
+- [ ] Verify the three suggestion pills are visible:
+      "Sales dashboard", "Revenue by category", "Expense trend"
+
+### 2. Feature-Specific Checks
+
+#### Sales dashboard (MetricCard + BarChart)
+
+- [ ] Click the "Sales dashboard" suggestion pill
+- [ ] Verify a `data-testid="metric-card"` element renders with a label
+      and a dollar-formatted value
+- [ ] Verify a `data-testid="bar-chart"` element renders inside the same
+      `data-testid="json-render-root"` wrapper
+
+#### Revenue by category (PieChart)
+
+- [ ] Click "Revenue by category"
+- [ ] Verify a `data-testid="pie-chart"` element renders with at least
+      three legend rows
+
+#### Expense trend (BarChart)
+
+- [ ] Click "Expense trend"
+- [ ] Verify `data-testid="bar-chart"` renders with three months of data
+
+### 3. Streaming behaviour
+
+- [ ] Observe the raw JSON streaming into the chat bubble briefly while
+      the model emits the spec
+- [ ] Verify the catalog components swap in cleanly once the JSON
+      becomes valid — no flicker, no duplicate render
+
+### 4. Error Handling
+
+- [ ] Ask a free-form question that has nothing to do with dashboards
+      (e.g. "What is 2+2?"). The agent should still reply with a JSON
+      spec — it may emit a single MetricCard — and the page must NOT
+      white-screen.
+- [ ] No console errors during normal usage.
+
+## Expected Results
+
+- Chat loads within 3 seconds
+- Agent responds within 15 seconds (Claude opus)
+- Components render from the json-render catalog wrapped in a single
+  `<JSONUIProvider>` (no missing-provider crashes)

--- a/showcase/packages/claude-sdk-python/qa/chat-customization-css.md
+++ b/showcase/packages/claude-sdk-python/qa/chat-customization-css.md
@@ -1,0 +1,39 @@
+# QA: Chat Customization (CSS) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/chat-customization-css`
+- [ ] Verify the chat loads inside the `.chat-css-demo-scope` wrapper
+- [ ] Send a basic message
+- [ ] Verify the agent responds
+
+### 2. Feature-Specific Checks
+
+#### Theme Application
+
+- [ ] Verify user message bubbles render with the hot-pink gradient
+- [ ] Verify assistant message bubbles render with the amber background and monospace font
+- [ ] Verify the input area shows a dashed pink border
+- [ ] Verify the input placeholder color is pink italic
+
+#### Variable Overrides
+
+- [ ] Inspect the `.chat-css-demo-scope` element and verify CopilotKit CSS variables are overridden (e.g. `--copilot-kit-primary-color: #ff006e`)
+- [ ] Verify the customization does not leak outside the scoped container
+
+### 3. Error Handling
+
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Page loads within 3 seconds
+- Theme is applied only inside `.chat-css-demo-scope`
+- Agent responds within 10 seconds

--- a/showcase/packages/claude-sdk-python/qa/chat-slots.md
+++ b/showcase/packages/claude-sdk-python/qa/chat-slots.md
@@ -1,0 +1,44 @@
+# QA: Chat Slots — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/chat-slots`
+- [ ] Verify the custom welcome screen (`data-testid="custom-welcome-screen"`) is visible
+- [ ] Verify the welcome card shows "Welcome to the Slots demo"
+- [ ] Verify the suggestion pills ("Write a sonnet", "Tell me a joke") are visible
+
+### 2. Feature-Specific Checks
+
+#### Welcome Slot
+
+- [ ] Confirm the gradient welcome card wraps the default input + suggestions
+- [ ] Verify the "Custom Slot" pill is visible above the headline
+
+#### Disclaimer Slot
+
+- [ ] After sending a message, verify the custom disclaimer (`data-testid="custom-disclaimer"`) is visible
+- [ ] Verify the disclaimer text contains "Custom disclaimer injected via"
+
+#### Assistant Message Slot
+
+- [ ] Send a basic message
+- [ ] Wait for the agent response
+- [ ] Verify the assistant message is wrapped by the custom slot (`data-testid="custom-assistant-message"`)
+- [ ] Verify the "slot" badge is visible on the assistant message
+
+### 3. Error Handling
+
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Page loads within 3 seconds
+- All three slot overrides (welcome, disclaimer, assistantMessage) render as custom components
+- Agent responds within 10 seconds

--- a/showcase/packages/claude-sdk-python/qa/cli-start.md
+++ b/showcase/packages/claude-sdk-python/qa/cli-start.md
@@ -1,0 +1,22 @@
+# QA: CLI Start Command — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- None (manifest-only demo — no hosted route)
+
+## Test Steps
+
+### 1. Manifest
+
+- [ ] Verify the `cli-start` entry exists in `manifest.yaml` under `demos:`
+- [ ] Verify the `command` field reads `npx copilotkit@latest init --framework claude-sdk-python`
+- [ ] Verify `cli-start` is listed in the `features:` array
+
+### 2. Expected Behavior
+
+- [ ] Running the command in a fresh directory scaffolds the Claude Agent SDK (Python) starter
+
+## Expected Results
+
+- Manifest entry validates against the showcase schema
+- Command matches the canonical framework slug

--- a/showcase/packages/claude-sdk-python/qa/frontend-tools-async.md
+++ b/showcase/packages/claude-sdk-python/qa/frontend-tools-async.md
@@ -1,0 +1,33 @@
+# QA: Frontend Tools (Async) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/frontend-tools-async`
+- [ ] Verify the chat renders
+- [ ] Click the "Find project-planning notes" suggestion
+- [ ] Verify a NotesCard appears briefly in loading state ("Querying local notes DB...")
+- [ ] After ~500ms, verify the card shows matching notes (Q2 kickoff, migrate auth to passkeys, retrospective notes, career planning)
+
+### 2. Feature-Specific Checks
+
+- [ ] Search for "auth" — verify the "migrate auth to passkeys" note is returned
+- [ ] Ask "Do I have notes tagged reading?" — verify the Book recommendations note appears
+- [ ] Search for "nonsense-keyword-no-match" — verify "No notes matched." empty state
+
+### 3. Error Handling
+
+- [ ] Verify no console errors during search
+- [ ] Verify the loading state transitions to complete within a few seconds
+
+## Expected Results
+
+- NotesCard with `data-testid="notes-card"` displays matching notes
+- Each note rendered with `data-testid="note-<id>"` and tags

--- a/showcase/packages/claude-sdk-python/qa/frontend-tools.md
+++ b/showcase/packages/claude-sdk-python/qa/frontend-tools.md
@@ -1,0 +1,32 @@
+# QA: Frontend Tools — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/frontend-tools`
+- [ ] Verify a chat surface renders in the centered card
+- [ ] Send a message: "Change the background to a blue-to-purple gradient."
+- [ ] Verify the agent calls the `change_background` frontend tool
+- [ ] Verify the page background updates to the requested gradient
+
+### 2. Feature-Specific Checks
+
+- [ ] Click the "Sunset theme" suggestion — background changes to a sunset gradient
+- [ ] Ask "Change the background back to default." — background resets
+- [ ] Verify no errors in the console
+
+### 3. Error Handling
+
+- [ ] Verify the chat remains usable after multiple background changes
+
+## Expected Results
+
+- Background element with `data-testid="background-container"` reflects the CSS background value returned by the tool handler
+- Agent calls the tool and produces a short confirmation message

--- a/showcase/packages/claude-sdk-python/qa/headless-complete.md
+++ b/showcase/packages/claude-sdk-python/qa/headless-complete.md
@@ -1,0 +1,33 @@
+# QA: Headless Chat (Complete) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/headless-complete`
+- [ ] Verify the custom chat surface renders (header, scrollable list, input bar)
+- [ ] Verify NO `<CopilotChat />` imports are visible (all chrome is custom)
+- [ ] Send "Hello" — verify the user bubble + assistant bubble render
+
+### 2. Generative UI Weave
+
+- [ ] Click the "Weather in Tokyo" suggestion — verify the WeatherCard renders inline
+- [ ] Click the "Highlight a note" suggestion — verify the HighlightNote component renders
+- [ ] Try a message that triggers other tools — verify the catch-all tool card renders
+
+### 3. Lifecycle
+
+- [ ] During agent response, verify the Send button swaps to Stop
+- [ ] Click Stop — verify the agent cancels cleanly
+- [ ] Verify no console errors after stop
+
+## Expected Results
+
+- Messages area with `data-testid="headless-complete-messages"` scrolls automatically
+- Input disabled while running; Send button disabled when empty

--- a/showcase/packages/claude-sdk-python/qa/headless-simple.md
+++ b/showcase/packages/claude-sdk-python/qa/headless-simple.md
@@ -1,0 +1,41 @@
+# QA: Headless Chat (Simple) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/headless-simple`
+- [ ] Verify the heading "Headless Chat (Simple)" is visible
+- [ ] Verify the placeholder text "No messages yet. Say hi!" is displayed
+- [ ] Type a message into the textarea
+- [ ] Click Send (or press Enter)
+- [ ] Verify the user bubble appears immediately on the right
+- [ ] Verify the agent responds with a text bubble on the left
+
+### 2. Feature-Specific Checks
+
+#### useAgent / useComponent
+
+- [ ] Ask "Show me a card about cats"
+- [ ] Verify the ShowCard component renders with a title and body
+
+#### Running state
+
+- [ ] While the agent is replying, verify "Agent is thinking..." appears below the message list
+- [ ] Verify the Send button is disabled while the agent is running
+
+### 3. Error Handling
+
+- [ ] Verify sending an empty message does nothing
+- [ ] Verify no console errors during normal usage
+
+## Expected Results
+
+- Page loads within 3 seconds
+- Agent responds within 10 seconds
+- ShowCard renders when the agent calls `show_card`

--- a/showcase/packages/claude-sdk-python/qa/hitl-in-app.md
+++ b/showcase/packages/claude-sdk-python/qa/hitl-in-app.md
@@ -1,0 +1,38 @@
+# QA: In-App HITL — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/hitl-in-app`
+- [ ] Verify the Support Inbox renders three tickets (#12345, #12346, #12347)
+- [ ] Verify the chat surface renders on the right
+
+### 2. Approval Flow
+
+- [ ] Click the "Approve refund for #12345" suggestion
+- [ ] Verify a modal dialog appears with the action summary
+- [ ] Click "Approve" — verify the dialog closes and the agent confirms
+
+### 3. Rejection Flow
+
+- [ ] Click the "Downgrade plan for #12346" suggestion
+- [ ] Verify the modal appears
+- [ ] Add a note "Customer needs to stay on current plan"
+- [ ] Click "Reject" — verify the agent acknowledges the rejection
+
+### 4. Error Handling
+
+- [ ] Verify no console errors during the approval/rejection flows
+- [ ] Verify the modal blocks interaction with the chat until resolved
+
+## Expected Results
+
+- Modal uses `fixed inset-0` overlay rather than a portal (to avoid @types/react-dom)
+- Agent accurately reflects the approve/reject outcome

--- a/showcase/packages/claude-sdk-python/qa/multimodal.md
+++ b/showcase/packages/claude-sdk-python/qa/multimodal.md
@@ -1,0 +1,57 @@
+# QA: Multimodal Attachments — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- `ANTHROPIC_API_KEY` is set on the deployment
+- `pypdf` is installed in the backend environment (listed in
+  `requirements.txt`)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/multimodal`
+- [ ] Verify the "Multimodal attachments" header renders
+- [ ] Verify the bundled-samples row shows "Try with sample image" and
+      "Try with sample PDF" buttons
+- [ ] Verify the paperclip button is visible on the chat composer
+
+### 2. Feature-Specific Checks
+
+#### Sample image
+
+- [ ] Click "Try with sample image" — the button should flip to
+      "Loading…" briefly
+- [ ] Verify the CopilotChat attachment strip shows a pending
+      `sample.png` chip
+- [ ] Type "What's in this image?" and send
+- [ ] Verify Claude's reply references concrete visual details (e.g.
+      colors, objects) from the bundled PNG
+
+#### Sample PDF
+
+- [ ] Click "Try with sample PDF"
+- [ ] Verify the `sample.pdf` chip appears
+- [ ] Type "Summarise this document" and send
+- [ ] Verify Claude replies with a short summary of the PDF's actual
+      content (not a generic "I cannot read PDFs" reply)
+
+### 3. LFS-pointer guard
+
+- [ ] If the deployment accidentally ships a Git LFS pointer instead of
+      the real binary, clicking a sample button should surface
+      `data-testid="multimodal-sample-error"` with an actionable message
+
+### 4. Error Handling
+
+- [ ] No console errors during normal usage.
+- [ ] Upload a file over 10 MB and verify the attachment is rejected
+      with a visible toast.
+
+## Expected Results
+
+- Image replies reference real visual details (not generic).
+- PDF replies reference document-specific content.
+- No silent dropping of attachments.

--- a/showcase/packages/claude-sdk-python/qa/open-gen-ui-advanced.md
+++ b/showcase/packages/claude-sdk-python/qa/open-gen-ui-advanced.md
@@ -1,0 +1,38 @@
+# QA: Open-Ended Generative UI (Advanced) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/open-gen-ui-advanced`
+- [ ] Click the "Calculator (calls evaluateExpression)" suggestion
+- [ ] Verify an iframe renders with a calculator UI (no <form>, only <button type='button'>)
+
+### 2. Sandbox-Function Round-Trip
+
+- [ ] In the calculator, enter "12 * (3 + 4.5)" and press "="
+- [ ] Verify the display updates with the host-evaluated result
+- [ ] Open devtools console — verify `[open-gen-ui/advanced] evaluateExpression` log appears
+
+### 3. notifyHost
+
+- [ ] Try the "Ping the host (calls notifyHost)" suggestion
+- [ ] Click the button in the rendered card
+- [ ] Verify `[open-gen-ui/advanced] notifyHost:` log in the host console
+- [ ] Verify the card updates with a confirmation showing `receivedAt`
+
+### 4. Error Handling
+
+- [ ] Verify no CORS/CSP errors from the sandbox
+- [ ] Verify evaluateExpression rejects non-arithmetic input safely
+
+## Expected Results
+
+- Sandbox -> host calls via Websandbox.connection.remote work end-to-end
+- Handler return values are visible inside the iframe UI

--- a/showcase/packages/claude-sdk-python/qa/open-gen-ui-advanced.md
+++ b/showcase/packages/claude-sdk-python/qa/open-gen-ui-advanced.md
@@ -16,7 +16,7 @@
 
 ### 2. Sandbox-Function Round-Trip
 
-- [ ] In the calculator, enter "12 * (3 + 4.5)" and press "="
+- [ ] In the calculator, enter "12 \* (3 + 4.5)" and press "="
 - [ ] Verify the display updates with the host-evaluated result
 - [ ] Open devtools console — verify `[open-gen-ui/advanced] evaluateExpression` log appears
 

--- a/showcase/packages/claude-sdk-python/qa/open-gen-ui.md
+++ b/showcase/packages/claude-sdk-python/qa/open-gen-ui.md
@@ -1,0 +1,33 @@
+# QA: Open-Ended Generative UI — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/open-gen-ui`
+- [ ] Verify the chat renders with minimal suggestions visible
+- [ ] Click the "3D axis visualization (model airplane)" suggestion
+- [ ] Verify a sandboxed iframe appears with the generated visualization
+
+### 2. Feature-Specific Checks
+
+- [ ] Verify the iframe contains SVG-based content (not div-stacks)
+- [ ] Try the "Quicksort visualization" suggestion — verify an animated bar sort renders
+- [ ] Verify the visualization is self-running (no user interaction needed)
+
+### 3. Error Handling
+
+- [ ] Verify no CORS/CSP errors in the console
+- [ ] Verify the sandbox iframe renders within the chat turn
+
+## Expected Results
+
+- Agent calls `generateSandboxedUi` once per turn
+- The runtime's OpenGenerativeUIMiddleware converts the call into activity events
+- The built-in renderer mounts the agent-authored HTML inside a sandbox

--- a/showcase/packages/claude-sdk-python/qa/prebuilt-popup.md
+++ b/showcase/packages/claude-sdk-python/qa/prebuilt-popup.md
@@ -1,0 +1,41 @@
+# QA: Pre-Built Popup — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/prebuilt-popup`
+- [ ] Verify the main content heading "Popup demo — look for the floating launcher" is visible
+- [ ] Verify `<CopilotPopup />` opens by default (popup overlay is visible)
+- [ ] Verify the chat input placeholder reads "Ask the popup anything..."
+- [ ] Send a basic message (e.g. "Say hi from the popup!")
+- [ ] Verify the agent responds in the popup
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify the "Say hi" suggestion button is visible inside the popup
+- [ ] Click the suggestion and verify it sends the message
+
+#### Popup Toggle
+
+- [ ] Close the popup via its toggle/launcher
+- [ ] Verify the floating launcher bubble remains on the page
+- [ ] Reopen the popup and verify the conversation is preserved
+
+### 3. Error Handling
+
+- [ ] Verify no console errors during normal usage
+- [ ] Verify closing/opening the popup does not break the chat state
+
+## Expected Results
+
+- Page loads within 3 seconds
+- Popup opens with floating launcher
+- Agent responds within 10 seconds

--- a/showcase/packages/claude-sdk-python/qa/prebuilt-sidebar.md
+++ b/showcase/packages/claude-sdk-python/qa/prebuilt-sidebar.md
@@ -1,0 +1,40 @@
+# QA: Pre-Built Sidebar — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/prebuilt-sidebar`
+- [ ] Verify the main content heading "Sidebar demo — click the launcher" is visible
+- [ ] Verify `<CopilotSidebar />` opens by default (sidebar is visible)
+- [ ] Verify the sidebar has a chat input
+- [ ] Send a basic message (e.g. "Say hi")
+- [ ] Verify the agent responds in the sidebar
+
+### 2. Feature-Specific Checks
+
+#### Suggestions
+
+- [ ] Verify the "Say hi" suggestion button is visible inside the sidebar
+- [ ] Click the suggestion and verify it sends the message
+
+#### Sidebar Toggle
+
+- [ ] Close the sidebar via its toggle/launcher
+- [ ] Reopen the sidebar and verify the conversation is preserved
+
+### 3. Error Handling
+
+- [ ] Verify no console errors during normal usage
+- [ ] Verify closing/opening the sidebar does not break the chat state
+
+## Expected Results
+
+- Page loads within 3 seconds
+- Sidebar renders with launcher
+- Agent responds within 10 seconds

--- a/showcase/packages/claude-sdk-python/qa/readonly-state-agent-context.md
+++ b/showcase/packages/claude-sdk-python/qa/readonly-state-agent-context.md
@@ -1,0 +1,33 @@
+# QA: Readonly State (Agent Context) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/readonly-state-agent-context`
+- [ ] Verify the Agent Context card renders with Name, Timezone, Recent Activity controls
+- [ ] Verify the published context JSON pre is visible
+
+### 2. Context Wiring
+
+- [ ] Edit the Name input to "Dana"
+- [ ] Click the "Who am I?" suggestion
+- [ ] Verify the agent greets "Dana" in its reply
+- [ ] Change the timezone to "Asia/Tokyo"
+- [ ] Click "Plan my morning" — verify the agent references Tokyo time
+
+### 3. Error Handling
+
+- [ ] Verify no console errors on context updates
+- [ ] Verify the chat remains usable after multiple context changes
+
+## Expected Results
+
+- Agent references the current Name, Timezone, and Recent Activity
+- The context card cannot be modified by the agent (agent has no write tools)

--- a/showcase/packages/claude-sdk-python/qa/tool-rendering-custom-catchall.md
+++ b/showcase/packages/claude-sdk-python/qa/tool-rendering-custom-catchall.md
@@ -1,0 +1,30 @@
+# QA: Tool Rendering (Custom Catch-all) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/tool-rendering-custom-catchall`
+- [ ] Verify the chat renders
+- [ ] Click "Weather in SF" — verify the agent calls `get_weather`
+- [ ] Verify the BRANDED `CustomCatchallRenderer` card appears (not the default)
+
+### 2. Feature-Specific Checks
+
+- [ ] Verify `data-testid="custom-catchall-card"` renders with the tool name
+- [ ] Verify status pill transitions: streaming → running → done
+- [ ] Try "Find flights" — verify the same branded card renders
+
+### 3. Error Handling
+
+- [ ] Verify no console errors
+
+## Expected Results
+
+- Every tool call renders via the custom `CustomCatchallRenderer`, including tool name, arguments pre, and result pre

--- a/showcase/packages/claude-sdk-python/qa/tool-rendering-default-catchall.md
+++ b/showcase/packages/claude-sdk-python/qa/tool-rendering-default-catchall.md
@@ -1,0 +1,29 @@
+# QA: Tool Rendering (Default Catch-all) — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy
+- ANTHROPIC_API_KEY is set
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/tool-rendering-default-catchall`
+- [ ] Verify the chat renders
+- [ ] Click "Weather in SF" — verify the agent calls `get_weather`
+- [ ] Verify the BUILT-IN `DefaultToolCallRenderer` card appears inline
+
+### 2. Feature-Specific Checks
+
+- [ ] Verify the tool-call card shows the tool name, status pill (Running → Done), and Arguments/Result sections
+- [ ] Try "Find flights" — verify multiple tool calls render
+
+### 3. Error Handling
+
+- [ ] Verify no console errors during tool calls
+
+## Expected Results
+
+- CopilotKit's package-provided default tool card renders every tool call (no custom renderers)

--- a/showcase/packages/claude-sdk-python/qa/voice.md
+++ b/showcase/packages/claude-sdk-python/qa/voice.md
@@ -1,0 +1,53 @@
+# QA: Voice input — Claude Agent SDK (Python)
+
+## Prerequisites
+
+- Demo is deployed and accessible
+- Agent backend is healthy (check /api/health)
+- `ANTHROPIC_API_KEY` is set on the deployment (for chat replies)
+- `OPENAI_API_KEY` is set on the Next.js runtime (for Whisper
+  transcription). If it is not, the mic button still renders but
+  clicking it (or clicking "Play sample") will return a clean 401.
+
+## Test Steps
+
+### 1. Basic Functionality
+
+- [ ] Navigate to `/demos/voice`
+- [ ] Verify the "Voice input" header renders
+- [ ] Verify the mic button is visible on the chat composer
+- [ ] Verify the "Play sample" button renders next to a caption
+      matching `SAMPLE_LABEL` (e.g. "What is the weather in Tokyo?")
+
+### 2. Feature-Specific Checks
+
+#### Play sample
+
+- [ ] Click "Play sample"
+- [ ] Verify the button flips to "Transcribing…" briefly
+- [ ] Verify the composer's textarea is populated with the transcribed
+      text
+- [ ] Press send and verify Claude replies to the transcribed prompt
+
+#### Mic button (manual)
+
+- [ ] Click the mic button, allow microphone access, speak a short
+      sentence, click again
+- [ ] Verify the textarea is populated with the transcription
+- [ ] Press send and verify Claude replies
+
+### 3. Misconfigured deployment
+
+- [ ] With `OPENAI_API_KEY` unset, click "Play sample"
+- [ ] Verify the error slot renders "Error — see console"
+- [ ] Verify the network response is HTTP 401, not 500/503
+
+### 4. Error Handling
+
+- [ ] No console errors during normal usage (other than the expected
+      401 when `OPENAI_API_KEY` is missing).
+
+## Expected Results
+
+- Mic button always visible (transcription service is always mounted).
+- Missing `OPENAI_API_KEY` manifests as 401, not silent failure.

--- a/showcase/packages/claude-sdk-python/requirements.txt
+++ b/showcase/packages/claude-sdk-python/requirements.txt
@@ -3,3 +3,6 @@ ag-ui-protocol>=0.1.14
 fastapi>=0.115.0
 uvicorn>=0.34.0
 python-dotenv>=1.0.1
+# Used by the multimodal demo to flatten PDFs to text so the model can
+# read them without depending on Claude's PDF beta.
+pypdf>=4.0.0

--- a/showcase/packages/claude-sdk-python/src/agent_server.py
+++ b/showcase/packages/claude-sdk-python/src/agent_server.py
@@ -3,17 +3,134 @@ Agent Server for Claude Agent SDK (Python)
 
 FastAPI server that hosts the Claude agent backend via AG-UI protocol.
 The Next.js CopilotKit runtime proxies requests here.
+
+Endpoints:
+  POST /                           — default shared Claude agent (sales
+                                      assistant). Used by most demos.
+  POST /byoc-json-render           — BYOC json-render demo: emits a
+                                      single JSON spec.
+  POST /byoc-hashbrown             — BYOC hashbrown demo: emits
+                                      hashbrown UI envelope JSON.
+  POST /multimodal                 — vision + PDF support for the
+                                      multimodal demo.
+  POST /agent-config               — reads tone/expertise/responseLength
+                                      from ``forwarded_props`` for the
+                                      agent-config demo.
+
+Each dedicated endpoint reuses the shared AG-UI <-> Anthropic streaming
+plumbing in ``agents.agent`` but swaps the system prompt and/or tool set
+as the demo requires.
 """
 
+from __future__ import annotations
+
 import os
+from collections.abc import AsyncIterator
 
 import uvicorn
-from agents.agent import create_app
+from ag_ui.core import RunAgentInput
 from dotenv import load_dotenv
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+
+from agents.agent import create_app, run_agent
+from agents.agent_config_agent import build_system_prompt, read_properties
+from agents.byoc_hashbrown_agent import BYOC_HASHBROWN_SYSTEM_PROMPT
+from agents.byoc_json_render_agent import BYOC_JSON_RENDER_SYSTEM_PROMPT
+from agents.multimodal_agent import SYSTEM_PROMPT as MULTIMODAL_SYSTEM_PROMPT
+from agents.multimodal_agent import convert_part_for_claude
 
 load_dotenv()
 
+
+def _stream_agent_response(
+    input_data: RunAgentInput,
+    *,
+    system_prompt_override: str | None = None,
+    disable_tools: bool = False,
+    preprocess_user_parts: callable | None = None,
+) -> StreamingResponse:
+    """Wrap ``run_agent`` in a StreamingResponse with demo-specific overrides.
+
+    The shared ``run_agent`` in ``agents.agent`` accepts keyword overrides
+    that let per-demo endpoints swap the system prompt or tool registry
+    without duplicating the streaming loop.
+    """
+
+    async def event_stream() -> AsyncIterator[str]:
+        async for chunk in run_agent(
+            input_data,
+            system_prompt_override=system_prompt_override,
+            disable_tools=disable_tools,
+            preprocess_user_parts=preprocess_user_parts,
+        ):
+            yield chunk
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 app = create_app()
+
+# Tighten CORS: the dedicated endpoints share the same CORS policy as the
+# default route, which `create_app` already opens up with `*`. No extra
+# middleware needed here.
+
+
+@app.post("/byoc-json-render")
+async def byoc_json_render_endpoint(request: Request) -> StreamingResponse:
+    body = await request.json()
+    input_data = RunAgentInput(**body)
+    return _stream_agent_response(
+        input_data,
+        system_prompt_override=BYOC_JSON_RENDER_SYSTEM_PROMPT,
+        disable_tools=True,
+    )
+
+
+@app.post("/byoc-hashbrown")
+async def byoc_hashbrown_endpoint(request: Request) -> StreamingResponse:
+    body = await request.json()
+    input_data = RunAgentInput(**body)
+    return _stream_agent_response(
+        input_data,
+        system_prompt_override=BYOC_HASHBROWN_SYSTEM_PROMPT,
+        disable_tools=True,
+    )
+
+
+@app.post("/multimodal")
+async def multimodal_endpoint(request: Request) -> StreamingResponse:
+    body = await request.json()
+    input_data = RunAgentInput(**body)
+    return _stream_agent_response(
+        input_data,
+        system_prompt_override=MULTIMODAL_SYSTEM_PROMPT,
+        disable_tools=True,
+        preprocess_user_parts=convert_part_for_claude,
+    )
+
+
+@app.post("/agent-config")
+async def agent_config_endpoint(request: Request) -> StreamingResponse:
+    body = await request.json()
+    input_data = RunAgentInput(**body)
+    props = read_properties(input_data.forwarded_props)
+    system_prompt = build_system_prompt(
+        props["tone"], props["expertise"], props["response_length"]
+    )
+    return _stream_agent_response(
+        input_data,
+        system_prompt_override=system_prompt,
+        disable_tools=True,
+    )
 
 
 def main() -> None:

--- a/showcase/packages/claude-sdk-python/src/agents/agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/agent.py
@@ -363,8 +363,30 @@ def _execute_tool(name: str, tool_input: dict[str, Any], state: AgentState, conv
     return f"Unknown tool: {name}", None
 
 
-async def run_agent(input_data: RunAgentInput) -> AsyncIterator[str]:
-    """Run the Claude agent and yield AG-UI SSE events."""
+async def run_agent(
+    input_data: RunAgentInput,
+    *,
+    system_prompt_override: str | None = None,
+    disable_tools: bool = False,
+    preprocess_user_parts: Any = None,
+) -> AsyncIterator[str]:
+    """Run the Claude agent and yield AG-UI SSE events.
+
+    Keyword arguments let dedicated demo endpoints reuse this streaming
+    loop with targeted overrides:
+
+    - ``system_prompt_override`` — replace the shared ``SYSTEM_PROMPT``
+      (e.g. BYOC demos emit a JSON envelope, so the sales-assistant
+      prompt is irrelevant).
+    - ``disable_tools`` — run the model with no tool schemas. Useful for
+      BYOC / pure-text demos where tool calls would derail the output.
+    - ``preprocess_user_parts`` — a ``callable(part) -> part`` applied to
+      each content part of every user message before they are sent to
+      Claude. Used by the multimodal demo to convert AG-UI
+      ``image``/``document`` parts into Claude's Messages API shape
+      (``{"type": "image", "source": {...}}``) and to flatten PDFs to
+      text via ``pypdf``.
+    """
     encoder = EventEncoder()
     client = anthropic.AsyncAnthropic(api_key=os.getenv("ANTHROPIC_API_KEY", ""))
 
@@ -373,31 +395,59 @@ async def run_agent(input_data: RunAgentInput) -> AsyncIterator[str]:
     if input_data.state and isinstance(input_data.state, dict):
         state = AgentState(**input_data.state)
 
-    # Convert AG-UI messages to Anthropic format
+    # Convert AG-UI messages to Anthropic format. When a preprocessor is
+    # supplied we preserve the structured content list (image blocks,
+    # document text, etc.) — otherwise we collapse to a flat string for
+    # the text-only happy path used by most demos.
     messages: list[dict[str, Any]] = []
     for msg in (input_data.messages or []):
         role = msg.role.value if hasattr(msg.role, "value") else str(msg.role)
-        if role in ("user", "assistant"):
-            content = ""
-            if hasattr(msg, "content"):
-                if isinstance(msg.content, str):
-                    content = msg.content
-                elif isinstance(msg.content, list):
-                    parts = []
-                    for part in msg.content:
-                        if hasattr(part, "text"):
-                            parts.append(part.text)
-                        elif isinstance(part, dict) and "text" in part:
-                            parts.append(part["text"])
-                    content = "".join(parts)
-            if content:
-                messages.append({"role": role, "content": content})
+        if role not in ("user", "assistant"):
+            continue
+
+        raw_content = getattr(msg, "content", None)
+
+        if preprocess_user_parts is not None and role == "user" and isinstance(raw_content, list):
+            converted_parts: list[Any] = []
+            for part in raw_content:
+                # AG-UI emits pydantic models; normalise to a plain dict
+                # before handing to the converter so the demo-specific
+                # code can rely on ``.get(...)`` semantics.
+                if hasattr(part, "model_dump"):
+                    part_dict = part.model_dump()
+                elif isinstance(part, dict):
+                    part_dict = part
+                else:
+                    part_dict = part
+                converted = preprocess_user_parts(part_dict)
+                if converted is not None:
+                    converted_parts.append(converted)
+            if converted_parts:
+                messages.append({"role": role, "content": converted_parts})
+            continue
+
+        content = ""
+        if isinstance(raw_content, str):
+            content = raw_content
+        elif isinstance(raw_content, list):
+            parts = []
+            for part in raw_content:
+                if hasattr(part, "text"):
+                    parts.append(part.text)
+                elif isinstance(part, dict) and "text" in part:
+                    parts.append(part["text"])
+            content = "".join(parts)
+        if content:
+            messages.append({"role": role, "content": content})
 
     # Inject sales pipeline state into system prompt if state exists
-    system = SYSTEM_PROMPT
-    if state.todos:
-        todos_json = json.dumps(state.todos, indent=2)
-        system = f"{SYSTEM_PROMPT}\n\nCurrent sales pipeline:\n{todos_json}"
+    if system_prompt_override is not None:
+        system = system_prompt_override
+    else:
+        system = SYSTEM_PROMPT
+        if state.todos:
+            todos_json = json.dumps(state.todos, indent=2)
+            system = f"{SYSTEM_PROMPT}\n\nCurrent sales pipeline:\n{todos_json}"
 
     thread_id = input_data.thread_id or "default"
     run_id = input_data.run_id or "run-1"
@@ -416,14 +466,20 @@ async def run_agent(input_data: RunAgentInput) -> AsyncIterator[str]:
             role="assistant",
         ))
 
-        # Stream Claude response
-        async with client.messages.stream(
-            model=os.getenv("ANTHROPIC_MODEL", "claude-opus-4-5"),
-            max_tokens=4096,
-            system=system,
-            messages=messages,
-            tools=TOOLS,  # type: ignore[arg-type]
-        ) as stream:
+        # Stream Claude response. BYOC / multimodal demos opt out of the
+        # shared sales-assistant tool schemas so the model replies as pure
+        # text (or structured JSON for BYOC) rather than chasing tool
+        # calls.
+        stream_kwargs: dict[str, Any] = {
+            "model": os.getenv("ANTHROPIC_MODEL", "claude-opus-4-5"),
+            "max_tokens": 4096,
+            "system": system,
+            "messages": messages,
+        }
+        if not disable_tools:
+            stream_kwargs["tools"] = TOOLS  # type: ignore[assignment]
+
+        async with client.messages.stream(**stream_kwargs) as stream:
             current_tool_id: str | None = None
             current_tool_name: str | None = None
             current_tool_args = ""

--- a/showcase/packages/claude-sdk-python/src/agents/agent_config_agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/agent_config_agent.py
@@ -1,0 +1,123 @@
+"""Claude Agent SDK backing the Agent Config Object demo.
+
+Reads three forwarded properties — tone, expertise, responseLength — from
+the AG-UI run's ``forwarded_props`` (which the dedicated runtime route at
+``/api/copilotkit-agent-config`` repacks from the CopilotKit provider's
+``properties`` prop) and builds the system prompt dynamically per turn.
+
+The companion Next.js route
+(``src/app/api/copilotkit-agent-config/route.ts``) ensures the frontend's
+``<CopilotKitProvider properties={{tone, expertise, responseLength}}>``
+values reach the AG-UI ``forwardedProps`` field on the request body, from
+which this backend reads them.
+
+Unlike the langgraph-python reference — which routes through
+``RunnableConfig["configurable"]["properties"]`` inside a LangGraph node
+— Claude Agent SDK here reads the values directly off the AG-UI run
+input's ``forwardedProps`` / ``forwarded_props`` envelope before
+constructing the system prompt.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+Tone = Literal["professional", "casual", "enthusiastic"]
+Expertise = Literal["beginner", "intermediate", "expert"]
+ResponseLength = Literal["concise", "detailed"]
+
+DEFAULT_TONE: Tone = "professional"
+DEFAULT_EXPERTISE: Expertise = "intermediate"
+DEFAULT_RESPONSE_LENGTH: ResponseLength = "concise"
+
+VALID_TONES: set[str] = {"professional", "casual", "enthusiastic"}
+VALID_EXPERTISE: set[str] = {"beginner", "intermediate", "expert"}
+VALID_RESPONSE_LENGTHS: set[str] = {"concise", "detailed"}
+
+
+def read_properties(forwarded_props: Any) -> dict[str, str]:
+    """Read the three config axes with defensive defaults.
+
+    ``forwarded_props`` may arrive as either the raw top-level dict (when
+    the Next.js route forwards provider ``properties`` straight through)
+    or nested under ``config.configurable.properties`` (the LangGraph
+    convention the shared runtime route adopts for compatibility). We
+    accept both shapes — unknown values fall back to the defaults; the
+    function never raises.
+    """
+    if not isinstance(forwarded_props, dict):
+        forwarded_props = {}
+
+    # Prefer the nested shape (mirrors the langgraph-python convention
+    # the dedicated route repacks into) but fall back to top-level keys
+    # so the demo still works if a caller forwards properties directly.
+    nested = (
+        (forwarded_props.get("config") or {}).get("configurable") or {}
+    ).get("properties") or {}
+    props = nested if isinstance(nested, dict) and nested else forwarded_props
+
+    tone = props.get("tone", DEFAULT_TONE)
+    expertise = props.get("expertise", DEFAULT_EXPERTISE)
+    response_length = props.get("responseLength", DEFAULT_RESPONSE_LENGTH)
+
+    if tone not in VALID_TONES:
+        tone = DEFAULT_TONE
+    if expertise not in VALID_EXPERTISE:
+        expertise = DEFAULT_EXPERTISE
+    if response_length not in VALID_RESPONSE_LENGTHS:
+        response_length = DEFAULT_RESPONSE_LENGTH
+
+    return {
+        "tone": tone,
+        "expertise": expertise,
+        "response_length": response_length,
+    }
+
+
+def build_system_prompt(tone: str, expertise: str, response_length: str) -> str:
+    """Compose the system prompt from the three axes."""
+    tone_rules = {
+        "professional": (
+            "Use neutral, precise language. No emoji. Short sentences."
+        ),
+        "casual": (
+            "Use friendly, conversational language. Contractions OK. "
+            "Light humor welcome."
+        ),
+        "enthusiastic": (
+            "Use upbeat, energetic language. Exclamation points OK. Emoji OK."
+        ),
+    }
+    expertise_rules = {
+        "beginner": "Assume no prior knowledge. Define jargon. Use analogies.",
+        "intermediate": (
+            "Assume common terms are understood; explain specialized terms."
+        ),
+        "expert": (
+            "Assume technical fluency. Use precise terminology. Skip basics."
+        ),
+    }
+    length_rules = {
+        "concise": "Respond in 1-3 sentences.",
+        "detailed": (
+            "Respond in multiple paragraphs with examples where relevant."
+        ),
+    }
+    return (
+        "You are a helpful assistant.\n\n"
+        f"Tone: {tone_rules[tone]}\n"
+        f"Expertise level: {expertise_rules[expertise]}\n"
+        f"Response length: {length_rules[response_length]}"
+    )
+
+
+__all__ = [
+    "DEFAULT_TONE",
+    "DEFAULT_EXPERTISE",
+    "DEFAULT_RESPONSE_LENGTH",
+    "VALID_TONES",
+    "VALID_EXPERTISE",
+    "VALID_RESPONSE_LENGTHS",
+    "read_properties",
+    "build_system_prompt",
+]

--- a/showcase/packages/claude-sdk-python/src/agents/byoc_hashbrown_agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/byoc_hashbrown_agent.py
@@ -1,0 +1,85 @@
+"""Claude Agent SDK backing the byoc-hashbrown demo.
+
+Emits hashbrown-shaped structured output consumed by
+``@hashbrownai/react``'s ``useJsonParser`` + ``useUiKit`` on the frontend.
+
+Wire format
+-----------
+``useJsonParser(content, kit.schema)`` expects a streaming JSON object
+literal matching ``kit.schema`` — NOT the ``<ui>...</ui>`` XML-style
+examples visible inside ``useUiKit({ examples })``. Those XML examples
+are hashbrown's prompt DSL used when hashbrown drives the LLM directly
+(e.g. ``useUiChat``). Because this demo drives the LLM via Claude
+instead, the backend must mirror hashbrown's schema wire format::
+
+    {
+      "ui": [
+        { "metric":   { "props": { "label": "...", "value": "..." } } },
+        { "pieChart": { "props": { "title": "...", "data": "[{...}]" } } },
+        { "barChart": { "props": { "title": "...", "data": "[{...}]" } } },
+        { "dealCard": { "props": { "title": "...", "stage": "prospect", "value": 100000 } } },
+        { "Markdown": { "props": { "children": "## heading\\nbody" } } }
+      ]
+    }
+
+Every node is a single-key object ``{tagName: {props: {...}}}``. The tag
+names and prop schemas match ``useSalesDashboardKit()`` in the ported
+``hashbrown-renderer.tsx``. ``pieChart`` and ``barChart`` receive ``data``
+as a JSON-encoded string to keep the schema stable under partial
+streaming (PR #4252 rationale).
+"""
+
+BYOC_HASHBROWN_SYSTEM_PROMPT = """\
+You are a sales analytics assistant that replies by emitting a single JSON
+object consumed by a streaming JSON parser on the frontend.
+
+ALWAYS respond with a single JSON object of the form:
+
+{
+  "ui": [
+    { <componentName>: { "props": { ... } } },
+    ...
+  ]
+}
+
+Do NOT wrap the response in code fences. Do NOT include any preface or
+explanation outside the JSON object. The response MUST be valid JSON.
+
+Available components and their prop schemas:
+
+- "metric": { "props": { "label": string, "value": string } }
+    A KPI card. `value` is a pre-formatted string like "$1.2M" or "248".
+
+- "pieChart": { "props": { "title": string, "data": string } }
+    A donut chart. `data` is a JSON-encoded STRING (embedded JSON) of an
+    array of {label, value} objects with at least 3 segments, e.g.
+    "data": "[{\\"label\\":\\"Enterprise\\",\\"value\\":600000}]".
+
+- "barChart": { "props": { "title": string, "data": string } }
+    A vertical bar chart. `data` is a JSON-encoded STRING of an array of
+    {label, value} objects with at least 3 bars, typically time-ordered.
+
+- "dealCard": { "props": { "title": string, "stage": string, "value": number } }
+    A single sales deal. `stage` MUST be one of: "prospect", "qualified",
+    "proposal", "negotiation", "closed-won", "closed-lost". `value` is a
+    raw number (no currency symbol or comma).
+
+- "Markdown": { "props": { "children": string } }
+    Short explanatory text. Use for section headings and brief summaries.
+    Standard markdown is supported in `children`.
+
+Rules:
+- Always produce plausible sample data when the user asks for a dashboard or
+  chart — do not refuse for lack of data.
+- Prefer 3-6 rows of data in charts; keep labels short.
+- Use "Markdown" for short headings or linking sentences between visual
+  components. Do not emit long prose.
+- Do not emit components that are not listed above.
+- `data` props on charts MUST be a JSON STRING — escape inner quotes.
+
+Example response (sales dashboard):
+{"ui":[{"Markdown":{"props":{"children":"## Q4 Sales Summary"}}},{"metric":{"props":{"label":"Total Revenue","value":"$1.2M"}}},{"metric":{"props":{"label":"New Customers","value":"248"}}},{"pieChart":{"props":{"title":"Revenue by Segment","data":"[{\\"label\\":\\"Enterprise\\",\\"value\\":600000},{\\"label\\":\\"SMB\\",\\"value\\":400000},{\\"label\\":\\"Startup\\",\\"value\\":200000}]"}}},{"barChart":{"props":{"title":"Monthly Revenue","data":"[{\\"label\\":\\"Oct\\",\\"value\\":350000},{\\"label\\":\\"Nov\\",\\"value\\":400000},{\\"label\\":\\"Dec\\",\\"value\\":450000}]"}}}]}
+"""
+
+
+__all__ = ["BYOC_HASHBROWN_SYSTEM_PROMPT"]

--- a/showcase/packages/claude-sdk-python/src/agents/byoc_json_render_agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/byoc_json_render_agent.py
@@ -1,0 +1,155 @@
+"""Claude Agent SDK backing the BYOC json-render demo.
+
+Emits a single JSON object shaped like ``@json-render/react``'s flat spec
+format (``{ root, elements }``) so the frontend can feed it directly into
+``<Renderer />`` against a Zod-validated catalog of three components —
+MetricCard, BarChart, PieChart.
+
+Wire format
+-----------
+The agent streams a plain JSON text block (no tool calls, no XML). The
+frontend's `JsonRenderAssistantMessage` slot parses the streaming content
+and renders the catalog components when the JSON becomes valid.
+
+Scenario mirrors the langgraph-python reference exactly — same catalog
+shapes, same example responses — so the two BYOC rows are directly
+comparable across frameworks. The only substantive difference is the
+underlying LLM provider.
+"""
+
+from textwrap import dedent
+
+# System prompt pulled into the dedicated endpoint in agent_server.py.
+# Kept verbatim from the langgraph-python reference so behaviour matches
+# across frameworks.
+BYOC_JSON_RENDER_SYSTEM_PROMPT = dedent(
+    """
+    You are a sales-dashboard UI generator for a BYOC json-render demo.
+
+    When the user asks for a UI, respond with **exactly one JSON object** and
+    nothing else — no prose, no markdown fences, no leading explanation. The
+    object must match this schema (the "flat element map" format consumed by
+    `@json-render/react`):
+
+    {
+      "root": "<id of the root element>",
+      "elements": {
+        "<id>": {
+          "type": "<component name>",
+          "props": { ... component-specific props ... },
+          "children": [ "<id>", ... ]
+        },
+        ...
+      }
+    }
+
+    Available components (use each name verbatim as "type"):
+
+    - MetricCard
+      props: { "label": string, "value": string, "trend": string | null }
+      Example trend strings: "+12% vs last quarter", "-3% vs last month", null.
+
+    - BarChart
+      props: {
+        "title": string,
+        "description": string | null,
+        "data": [ { "label": string, "value": number }, ... ]
+      }
+
+    - PieChart
+      props: {
+        "title": string,
+        "description": string | null,
+        "data": [ { "label": string, "value": number }, ... ]
+      }
+
+    Rules:
+
+    1. Output **only** valid JSON. No markdown code fences. No text outside
+       the object.
+    2. Every id referenced in `root` or any `children` array must be a key
+       in `elements`.
+    3. For a multi-component dashboard, use a root MetricCard and list the
+       charts in its `children` array, OR pick any element as root and list
+       the others as its children. Do not emit orphan elements.
+    4. Use realistic sales-domain values (revenue, pipeline, conversion,
+       categories, months) — the demo is a sales dashboard.
+    5. `children` is optional but when present must be an array of strings.
+    6. Never invent component types outside the three listed above.
+
+    ### Worked example — "Show me the sales dashboard with metrics and a revenue chart"
+
+    {
+      "root": "revenue-metric",
+      "elements": {
+        "revenue-metric": {
+          "type": "MetricCard",
+          "props": {
+            "label": "Revenue (Q3)",
+            "value": "$1.24M",
+            "trend": "+18% vs Q2"
+          },
+          "children": ["revenue-bar"]
+        },
+        "revenue-bar": {
+          "type": "BarChart",
+          "props": {
+            "title": "Monthly revenue",
+            "description": "Revenue by month across Q3",
+            "data": [
+              { "label": "Jul", "value": 380000 },
+              { "label": "Aug", "value": 410000 },
+              { "label": "Sep", "value": 450000 }
+            ]
+          }
+        }
+      }
+    }
+
+    ### Worked example — "Break down revenue by category as a pie chart"
+
+    {
+      "root": "category-pie",
+      "elements": {
+        "category-pie": {
+          "type": "PieChart",
+          "props": {
+            "title": "Revenue by category",
+            "description": "Share of total revenue by product category",
+            "data": [
+              { "label": "Enterprise", "value": 540000 },
+              { "label": "SMB", "value": 310000 },
+              { "label": "Self-serve", "value": 220000 },
+              { "label": "Partner", "value": 170000 }
+            ]
+          }
+        }
+      }
+    }
+
+    ### Worked example — "Show me monthly expenses as a bar chart"
+
+    {
+      "root": "expense-bar",
+      "elements": {
+        "expense-bar": {
+          "type": "BarChart",
+          "props": {
+            "title": "Monthly expenses",
+            "description": "Operating expenses by month",
+            "data": [
+              { "label": "Jul", "value": 210000 },
+              { "label": "Aug", "value": 225000 },
+              { "label": "Sep", "value": 240000 }
+            ]
+          }
+        }
+      }
+    }
+
+    Respond with the JSON object only.
+    """
+).strip()
+
+
+__all__ = ["BYOC_JSON_RENDER_SYSTEM_PROMPT"]

--- a/showcase/packages/claude-sdk-python/src/agents/frontend_tools.py
+++ b/showcase/packages/claude-sdk-python/src/agents/frontend_tools.py
@@ -1,0 +1,23 @@
+"""Claude Agent SDK backing the Frontend Tools demo.
+
+The demo illustrates `useFrontendTool` with a sync handler. The frontend
+registers a `change_background` tool; CopilotKit forwards its schema to
+the agent at runtime and the handler executes in the browser.
+
+The shared Claude backend in `src/agents/agent.py` already accepts
+frontend-registered tool schemas via AG-UI message forwarding, so this
+module is documentation-only — there is no separate Python graph to
+mount for this cell. The agent instance served by `agent_server.py`
+handles the `frontend-tools` agent name via the route.ts registration.
+"""
+
+# The demo shares the default Claude agent (see src/agents/agent.py).
+# This module exists so the manifest's `highlight` paths can point to a
+# per-demo Python reference, mirroring the langgraph-python layout.
+
+SYSTEM_PROMPT_HINT = (
+    "You are a helpful assistant. The frontend has registered a "
+    "`change_background` tool via `useFrontendTool`. When the user asks "
+    "to change the background, call that tool with a CSS-valid background "
+    "value (prefer gradients)."
+)

--- a/showcase/packages/claude-sdk-python/src/agents/frontend_tools_async.py
+++ b/showcase/packages/claude-sdk-python/src/agents/frontend_tools_async.py
@@ -1,0 +1,22 @@
+"""Claude Agent SDK backing the Frontend Tools (Async) demo.
+
+This cell demonstrates `useFrontendTool` with an ASYNC handler. The
+frontend registers a `query_notes` tool whose handler awaits a simulated
+client-side DB query (500ms latency) and returns matching notes. The
+agent uses the returned result to summarize what it found.
+
+Like the sibling `frontend_tools` cell, the backend registers no tools
+of its own — CopilotKit forwards the frontend tool schema(s) to the
+agent at runtime, and the handler executes in the browser. The shared
+Claude backend in `src/agents/agent.py` handles all demo routes.
+"""
+
+SYSTEM_PROMPT_HINT = (
+    "You are a helpful assistant that can search the user's personal notes. "
+    "When the user asks about their notes, call the `query_notes` tool with "
+    "a concise keyword extracted from their request. The tool is provided "
+    "by the frontend at runtime and runs entirely in the user's browser — "
+    "you do not need to implement it yourself. After the tool returns, "
+    "summarize the matching notes clearly and concisely. If no notes match, "
+    "say so plainly and offer to try a different keyword."
+)

--- a/showcase/packages/claude-sdk-python/src/agents/hitl_in_app.py
+++ b/showcase/packages/claude-sdk-python/src/agents/hitl_in_app.py
@@ -1,0 +1,32 @@
+"""Claude Agent SDK backing the In-App HITL (frontend-tool + popup) demo.
+
+The agent is a support assistant that processes customer-care requests
+(refunds, account changes, escalations). Any action that materially
+affects a customer MUST be confirmed by the human operator via the
+frontend-provided `request_user_approval` tool.
+
+The tool is defined on the frontend via `useFrontendTool` with an async
+handler that opens a modal dialog OUTSIDE the chat surface. The handler
+awaits the user's decision and resolves with
+`{"approved": bool, "reason": str}`. The agent treats that result as
+authoritative: if `approved` is `True`, continue; otherwise, stop and
+explain the decision back to the user.
+
+The shared Claude backend in `src/agents/agent.py` handles this demo
+via the `hitl-in-app` agent name registered in the copilotkit route.
+This module exists so the manifest's `highlight` path references a
+per-demo Python reference, mirroring the langgraph-python layout.
+"""
+
+SYSTEM_PROMPT_HINT = (
+    "You are a support operations copilot working alongside a human operator "
+    "inside an internal support console. Whenever the operator asks you to "
+    "take an action that affects a customer — for example: issuing a refund, "
+    "updating a customer's plan, cancelling a subscription, escalating a "
+    "ticket, or sending an apology credit — you MUST first call the "
+    "frontend-provided `request_user_approval` tool to obtain the operator's "
+    "explicit consent. The tool returns an object of the shape "
+    "{'approved': bool, 'reason': str | null}. If approved, confirm in one "
+    "short sentence; if rejected, acknowledge in one short sentence and "
+    "reflect the operator's reason back to them. Do NOT retry."
+)

--- a/showcase/packages/claude-sdk-python/src/agents/multimodal_agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/multimodal_agent.py
@@ -1,0 +1,196 @@
+"""Multimodal Claude agent — accepts image + document (PDF) attachments.
+
+Scoped to the ``/demos/multimodal`` cell so other demos keep their cheaper
+text-only model defaults.
+
+Wire format the agent sees
+==========================
+Attachments arrive here after travelling through:
+
+  CopilotChat  →  AG-UI message content parts  →  /api/copilotkit-multimodal
+              →  HttpAgent (this Python backend)
+
+Claude's Messages API supports image content parts natively (``{ "type":
+"image", "source": {...} }``). The AG-UI message content parts use the
+modern ``{ type: "image" | "document", source: { type: "data" | "url",
+value, mimeType } }`` shape (what CopilotChat emits today). We convert
+each attachment in-process:
+
+- ``image/*`` parts become Claude image blocks (base64 inline), forwarded
+  to the vision-capable model unchanged.
+- ``application/pdf`` parts are flattened to text via ``pypdf`` and sent
+  as a ``text`` block prefixed with ``[Attached document]``. Claude
+  recent models also support PDFs natively as ``document`` blocks, but
+  ``pypdf`` keeps the demo provider-agnostic and avoids counting against
+  PDF beta access.
+- Anything else falls through as-is.
+
+References:
+- packages/runtime/src/agent/converters/tanstack.ts (modern AG-UI parts)
+- langgraph-python multimodal_agent.py (baseline pattern; the legacy
+  ``binary`` shim is not needed here because HttpAgent forwards modern
+  parts through without rewriting them).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from typing import Any
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+SYSTEM_PROMPT = (
+    "You are a helpful assistant. The user may attach images or documents "
+    "(PDFs). When they do, analyze the attachment carefully and answer the "
+    "user's question. If no attachment is present, answer the text question "
+    "normally. Keep responses concise (1-3 sentences) unless asked to go deep."
+)
+
+
+def _extract_pdf_text(b64_payload: str) -> str:
+    """Decode an inline-base64 PDF and extract its text.
+
+    Returns an empty string if decoding or extraction fails — callers must
+    treat the extracted text as best-effort. Any exception here is logged
+    and swallowed so one malformed attachment does not tank the whole
+    user turn.
+    """
+    try:
+        raw = base64.b64decode(b64_payload, validate=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[multimodal_agent] base64 decode failed: {exc}")
+        return ""
+
+    try:
+        # Lazy import — keep the module importable even when pypdf is
+        # missing; only needed when a PDF actually arrives.
+        from pypdf import PdfReader  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - defensive
+        print(
+            "[multimodal_agent] pypdf not installed — PDF text extraction "
+            f"unavailable: {exc}",
+        )
+        return ""
+
+    try:
+        reader = PdfReader(io.BytesIO(raw))
+        pages = [page.extract_text() or "" for page in reader.pages]
+        return "\n\n".join(pages).strip()
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[multimodal_agent] pypdf extraction failed: {exc}")
+        return ""
+
+
+def _source_to_base64(source: dict[str, Any]) -> str | None:
+    """Pull base64 bytes out of an AG-UI ``source`` field.
+
+    Supports both ``{type: "data", value: "<base64>"}`` and
+    ``{type: "url", value: "data:...;base64,..."}`` shapes. Returns
+    ``None`` for network URLs — Claude's native image block supports
+    remote URLs, but PDFs must be inlined for ``pypdf``.
+    """
+    src_type = source.get("type")
+    value = source.get("value")
+    if not isinstance(value, str):
+        return None
+    if src_type == "data":
+        return value
+    if src_type == "url":
+        if value.startswith("data:"):
+            _, _, payload = value.partition(",")
+            return payload
+    return None
+
+
+def convert_part_for_claude(part: Any) -> Any:
+    """Translate an AG-UI content part into the Claude Messages API shape.
+
+    Pass-through for parts we don't recognise — Claude will ignore or
+    reject unknown shapes, which is better than silently dropping an
+    attachment the user actually sent.
+    """
+    if isinstance(part, str):
+        return {"type": "text", "text": part}
+
+    if not isinstance(part, dict):
+        return part
+
+    part_type = part.get("type")
+
+    if part_type == "text":
+        return {"type": "text", "text": part.get("text", "")}
+
+    # Modern AG-UI image part → Claude image block (base64 inline).
+    if part_type == "image":
+        source = part.get("source") or {}
+        mime = source.get("mimeType") or "image/png"
+        b64 = _source_to_base64(source)
+        if b64:
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": mime,
+                    "data": b64,
+                },
+            }
+        url_value = source.get("value")
+        if isinstance(url_value, str) and url_value.startswith("http"):
+            return {
+                "type": "image",
+                "source": {"type": "url", "url": url_value},
+            }
+        return {"type": "text", "text": "[Attached image could not be decoded.]"}
+
+    # Modern AG-UI document part → flatten PDFs to text for a
+    # provider-agnostic demo. Non-PDF documents become a placeholder so
+    # the model can tell the user the attachment was unsupported.
+    if part_type == "document":
+        source = part.get("source") or {}
+        mime = (source.get("mimeType") or "").lower()
+        b64 = _source_to_base64(source)
+        if "pdf" in mime and b64:
+            text = _extract_pdf_text(b64)
+            if text:
+                return {"type": "text", "text": f"[Attached document]\n{text}"}
+            return {
+                "type": "text",
+                "text": "[Attached document: PDF could not be read.]",
+            }
+        return {
+            "type": "text",
+            "text": f"[Attached document: unsupported type {mime or 'unknown'}.]",
+        }
+
+    # Legacy ``binary`` shape (defensive: if any adapter in the chain
+    # still rewrites to it, handle it here instead of dropping).
+    if part_type == "binary":
+        mime = (part.get("mimeType") or "").lower()
+        data = part.get("data")
+        if isinstance(data, str) and mime.startswith("image/"):
+            return {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": mime,
+                    "data": data,
+                },
+            }
+        if isinstance(data, str) and "pdf" in mime:
+            text = _extract_pdf_text(data)
+            if text:
+                return {"type": "text", "text": f"[Attached document]\n{text}"}
+            return {
+                "type": "text",
+                "text": "[Attached document: PDF could not be read.]",
+            }
+        return part
+
+    return part
+
+
+__all__ = ["SYSTEM_PROMPT", "convert_part_for_claude"]

--- a/showcase/packages/claude-sdk-python/src/agents/open_gen_ui_advanced_agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/open_gen_ui_advanced_agent.py
@@ -1,0 +1,26 @@
+"""Claude Agent SDK backing the Open-Ended Generative UI (Advanced) demo.
+
+This is the "advanced" variant of the Open Generative UI demo. The key
+distinguishing feature: the agent-authored, sandboxed UI can invoke
+frontend-registered **sandbox functions** — functions the app defines
+on the host page (see `src/app/demos/open-gen-ui-advanced/sandbox-functions.ts`)
+and makes callable from inside the iframe via
+`await Websandbox.connection.remote.<name>(args)`.
+
+The shared Claude backend in `src/agents/agent.py` handles this demo
+via the `open-gen-ui-advanced` agent name registered in the ogui route.
+This module exists so the manifest's `highlight` path references a
+per-demo Python reference, mirroring the langgraph-python layout.
+"""
+
+SYSTEM_PROMPT_HINT = (
+    "You are a UI-generating assistant for the Open Generative UI "
+    "(Advanced) demo. On every user turn you MUST call the "
+    "`generateSandboxedUi` frontend tool exactly once. The generated UI "
+    "must be INTERACTIVE and must invoke the available host-side sandbox "
+    "functions described in your agent context in response to user "
+    "interactions. Call host functions with "
+    "`await Websandbox.connection.remote.<functionName>(args)`. Do NOT "
+    "use <form> or type='submit' — the sandbox blocks form submissions; "
+    "use <button type='button'> wired with addEventListener('click')."
+)

--- a/showcase/packages/claude-sdk-python/src/agents/open_gen_ui_agent.py
+++ b/showcase/packages/claude-sdk-python/src/agents/open_gen_ui_agent.py
@@ -1,0 +1,32 @@
+"""Claude Agent SDK backing the Open-Ended Generative UI (minimal) demo.
+
+The simplest possible example that exercises the open-ended generative UI
+pipeline. All the interesting work happens outside the agent:
+
+- CopilotKit merges the frontend-registered `generateSandboxedUi` tool
+  (auto-registered by `CopilotKitProvider` when the runtime has
+  `openGenerativeUI` enabled) into the agent's tool list. The LLM then
+  sees the tool via the normal AG-UI flow.
+- When the LLM calls `generateSandboxedUi`, the runtime's
+  `OpenGenerativeUIMiddleware` (enabled via `openGenerativeUI` on the
+  runtime — see `src/app/api/copilotkit-ogui/route.ts`) converts that
+  streaming tool call into `open-generative-ui` activity events that the
+  built-in renderer mounts inside a sandboxed iframe.
+
+This is the minimal variant: no sandbox functions, no app-side tools.
+The shared Claude backend in `src/agents/agent.py` handles this demo
+via the `open-gen-ui` agent name registered in the ogui route. This
+module exists so the manifest's `highlight` path references a per-demo
+Python reference, mirroring the langgraph-python layout.
+"""
+
+SYSTEM_PROMPT_HINT = (
+    "You are a UI-generating assistant for an Open Generative UI demo "
+    "focused on intricate, educational visualisations. On every user "
+    "turn you MUST call the `generateSandboxedUi` frontend tool exactly "
+    "once. Design a visually polished, self-contained HTML + CSS + SVG "
+    "widget that teaches the requested concept. Use inline SVG (or "
+    "<canvas>) for geometric content — no stacks of <div>s. Keep your "
+    "own chat message brief (1 sentence); the rendered visualisation is "
+    "the real output."
+)

--- a/showcase/packages/claude-sdk-python/src/agents/readonly_state_agent_context.py
+++ b/showcase/packages/claude-sdk-python/src/agents/readonly_state_agent_context.py
@@ -1,0 +1,23 @@
+"""Claude Agent SDK backing the Readonly State (Agent Context) demo.
+
+Demonstrates the `useAgentContext` hook from @copilotkit/react-core/v2:
+the frontend provides READ-ONLY context *to* the agent. The UI cannot
+be edited by the agent, but the agent reads this context on every turn
+via the CopilotKit runtime, which routes the context entries into the
+model's message history.
+
+The shared Claude backend in `src/agents/agent.py` handles this demo via
+the `readonly-state-agent-context` agent name registered in the
+copilotkit route. This module exists so the manifest's `highlight` path
+references a per-demo Python reference, mirroring the langgraph-python
+layout.
+"""
+
+SYSTEM_PROMPT_HINT = (
+    "You are a helpful, concise assistant. The frontend may provide "
+    "read-only context about the user (e.g. name, timezone, recent "
+    "activity) via the `useAgentContext` hook. Always consult that "
+    "context when it is relevant — address the user by name if known, "
+    "respect their timezone when mentioning times, and reference "
+    "recent activity when it helps you answer. Keep responses short."
+)

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-agent-config/route.ts
@@ -1,0 +1,169 @@
+// Dedicated runtime for the Agent Config Object demo.
+//
+// The CopilotKit provider on the frontend (src/app/demos/agent-config/page.tsx)
+// forwards `{tone, expertise, responseLength}` via <CopilotKit properties={...}>.
+// The runtime takes those provider `properties` and attaches them as
+// top-level keys on the AG-UI run's `forwardedProps` envelope.
+//
+// This route subclasses the `HttpAgent` so it can intercept each run and
+// repack the non-structural forwardedProps keys into
+// `forwardedProps.config.configurable.properties` — the same shape the
+// langgraph-python reference uses (and the agent-config Python backend
+// accepts both shapes defensively; see
+// src/agents/agent_config_agent.py :: `read_properties`). Repacking
+// keeps the wire format consistent across frameworks so the Python
+// backend can be compared directly against the LangGraph reference.
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// Shape of the AG-UI run input we care about. We avoid a direct import
+// of `RunAgentInput` from `@ag-ui/client` so this route has no
+// additional peer-dep on internal AG-UI packages — the field we touch
+// (`forwardedProps`) is part of the stable AG-UI protocol contract.
+type RunInputWithForwardedProps = {
+  forwardedProps?: Record<string, unknown> | undefined;
+  [k: string]: unknown;
+};
+
+// Keys on `forwardedProps` that should NOT be repacked into
+// `configurable.properties`. These mirror the reserved list from
+// `@ag-ui/langgraph` so a future refactor that aliases this route to
+// the langgraph shape remains drop-in compatible.
+const RESERVED_FORWARDED_PROPS_KEYS = new Set<string>([
+  "config",
+  "command",
+  "streamMode",
+  "streamSubgraphs",
+  "nodeName",
+  "threadMetadata",
+  "checkpointId",
+  "checkpointDuring",
+  "interruptBefore",
+  "interruptAfter",
+  "multitaskStrategy",
+  "ifNotExists",
+  "afterSeconds",
+  "onCompletion",
+  "onDisconnect",
+  "webhook",
+  "feedbackKeys",
+  "metadata",
+]);
+
+/**
+ * HttpAgent subclass that repacks the CopilotKit provider's `properties`
+ * (which arrive as top-level keys on `forwardedProps`) into
+ * `forwardedProps.config.configurable.properties` so the Python backend
+ * can read them from a stable location regardless of which framework
+ * (Claude Agent SDK, LangGraph, etc.) drives the agent.
+ *
+ * The backend's `read_properties` (src/agents/agent_config_agent.py)
+ * accepts both the nested shape and the flat top-level shape for
+ * resilience — but we standardise on the nested shape at this boundary
+ * so the wire format matches the langgraph-python reference and
+ * Playwright specs can assert against a consistent payload shape.
+ */
+class AgentConfigHttpAgent extends HttpAgent {
+  run(
+    input: Parameters<HttpAgent["run"]>[0],
+  ): ReturnType<HttpAgent["run"]> {
+    const repacked = repackForwardedPropsIntoConfigurable(
+      input as unknown as RunInputWithForwardedProps,
+    );
+    return super.run(repacked as Parameters<HttpAgent["run"]>[0]);
+  }
+}
+
+function repackForwardedPropsIntoConfigurable<
+  T extends RunInputWithForwardedProps,
+>(input: T): T {
+  const fp = (input.forwardedProps ?? {}) as Record<string, unknown>;
+  if (!fp || typeof fp !== "object") return input;
+
+  const userProps: Record<string, unknown> = {};
+  const structural: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fp)) {
+    if (RESERVED_FORWARDED_PROPS_KEYS.has(key)) {
+      structural[key] = value;
+    } else {
+      userProps[key] = value;
+    }
+  }
+
+  if (Object.keys(userProps).length === 0) return input;
+
+  const existingConfig = (structural.config ?? {}) as {
+    configurable?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+  const existingConfigurable =
+    (existingConfig.configurable as Record<string, unknown> | undefined) ?? {};
+  const existingProperties =
+    (existingConfigurable.properties as Record<string, unknown> | undefined) ??
+    {};
+
+  const mergedConfig = {
+    ...existingConfig,
+    configurable: {
+      ...existingConfigurable,
+      properties: {
+        ...existingProperties,
+        ...userProps,
+      },
+    },
+  };
+
+  return {
+    ...input,
+    forwardedProps: {
+      ...structural,
+      config: mergedConfig,
+    },
+  } as T;
+}
+
+function createAgent(): AbstractAgent {
+  // @ts-ignore -- dangling @ag-ui/client symlink in some install
+  // topologies causes tsc to lose the HttpAgent constructor signature.
+  // At runtime the constructor takes `{ url: string }` and works fine;
+  // the other routes in this package silence the same symptom with
+  // `@ts-ignore` on the CopilotRuntime `agents` property (see
+  // src/app/api/copilotkit/route.ts).
+  return new AgentConfigHttpAgent({
+    url: `${AGENT_URL}/agent-config`,
+  });
+}
+
+const agents: Record<string, AbstractAgent> = {
+  "agent-config-demo": createAgent(),
+  default: createAgent(),
+};
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-agent-config",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- see main route.ts
+        agents,
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-agent-config/route.ts
@@ -73,9 +73,7 @@ const RESERVED_FORWARDED_PROPS_KEYS = new Set<string>([
  * Playwright specs can assert against a consistent payload shape.
  */
 class AgentConfigHttpAgent extends HttpAgent {
-  run(
-    input: Parameters<HttpAgent["run"]>[0],
-  ): ReturnType<HttpAgent["run"]> {
+  run(input: Parameters<HttpAgent["run"]>[0]): ReturnType<HttpAgent["run"]> {
     const repacked = repackForwardedPropsIntoConfigurable(
       input as unknown as RunInputWithForwardedProps,
     );

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-auth/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-auth/route.ts
@@ -1,0 +1,79 @@
+// Dedicated runtime for the /demos/auth cell.
+//
+// Demonstrates framework-native request authentication via the V2
+// runtime's `onRequest` hook, which runs before routing and can
+// short-circuit the request by throwing a Response. We validate a
+// static `Authorization: Bearer <DEMO_TOKEN>` header; mismatch throws
+// 401 before the request reaches the agent.
+//
+// Implementation note: the V1 Next.js adapter
+// (`copilotRuntimeNextJSAppRouterEndpoint`) does NOT forward the
+// `hooks` option to the V2 fetch handler. To get `onRequest` wired,
+// this route uses `createCopilotRuntimeHandler` from
+// `@copilotkit/runtime/v2` directly — the framework-agnostic fetch
+// handler that returns a plain `(Request) => Promise<Response>`, which
+// composes cleanly with a Next.js App Router route export.
+//
+// References:
+// - packages/runtime/src/v2/runtime/core/hooks.ts (onRequest semantics)
+// - packages/runtime/src/v2/runtime/__tests__/hooks.test.ts (throw
+//   Response pattern)
+
+import type { NextRequest } from "next/server";
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+import { DEMO_AUTH_HEADER } from "@/app/demos/auth/demo-token";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// Reuse the neutral shared Claude agent for the authenticated path.
+// The point of this demo is the gate mechanism, not per-user agent
+// branching — authenticated users get the same behaviour as any other
+// neutral demo.
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/` });
+}
+
+const agents: Record<string, AbstractAgent> = {
+  "auth-demo": createAgent(),
+  // Fallback: useAgent() with no args resolves "default" — alias to
+  // the same agent so hooks in the demo page resolve cleanly.
+  default: createAgent(),
+};
+
+const runtime = new CopilotRuntime({ agents });
+
+const BASE_PATH = "/api/copilotkit-auth";
+
+// Framework-agnostic fetch handler with the auth gate wired up.
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: BASE_PATH,
+  hooks: {
+    onRequest: ({ request }) => {
+      const authHeader = request.headers.get("authorization");
+      if (authHeader !== DEMO_AUTH_HEADER) {
+        // Throwing a Response short-circuits the pipeline. The runtime
+        // maps thrown Responses to the HTTP response verbatim.
+        throw new Response(
+          JSON.stringify({
+            error: "unauthorized",
+            message:
+              "Missing or invalid Authorization header. Click Authenticate above to send messages.",
+          }),
+          {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+    },
+  },
+});
+
+// Next.js App Router bindings.
+export const POST = (req: NextRequest) => handler(req);
+export const GET = (req: NextRequest) => handler(req);

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -1,0 +1,47 @@
+// Dedicated runtime for the byoc-hashbrown demo.
+//
+// The backing Python agent (see src/agent_server.py `/byoc-hashbrown`)
+// has a system prompt tuned to emit the hashbrown JSON envelope
+// `{ui: [{tagName: {props: {...}}}, ...]}` — see
+// `src/agents/byoc_hashbrown_agent.py` for the full schema. Keeping
+// that prompt off the shared `/api/copilotkit` runtime is load-bearing
+// because the other demos share the sales-assistant prompt.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/byoc-hashbrown` });
+}
+
+const agents: Record<string, AbstractAgent> = {
+  "byoc-hashbrown-demo": createAgent(),
+  default: createAgent(),
+};
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-byoc-hashbrown",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- see main route.ts
+        agents,
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -1,0 +1,54 @@
+// Dedicated runtime for the BYOC json-render demo.
+//
+// Isolated from `/api/copilotkit` because the backing agent has a very
+// different system prompt (single JSON object, no tools) and bleeding
+// that prompt into the shared runtime would break every other demo that
+// shares the default Claude backend.
+//
+// The Python agent server (see src/agent_server.py) exposes a dedicated
+// `/byoc-json-render` endpoint that reuses the shared AG-UI streaming
+// loop but swaps in the json-render system prompt and disables tools.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/byoc-json-render` });
+}
+
+// The demo page mounts <CopilotKit agent="byoc_json_render">; resolve
+// that to this dedicated agent + expose a `default` alias in case any
+// internal `useAgent()` call falls back to the default slug.
+const agents: Record<string, AbstractAgent> = {
+  byoc_json_render: createAgent(),
+  default: createAgent(),
+};
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-byoc-json-render",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- see main route.ts: CopilotRuntime agents type is
+        // stricter than a plain Record but fixed in source, pending
+        // release.
+        agents,
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-multimodal/route.ts
@@ -1,0 +1,54 @@
+// Dedicated runtime for the Multimodal Attachments demo.
+//
+// Scoped to its own endpoint + its own Python backend route
+// (`/multimodal`) so the vision-capable Claude model and PDF-flatten
+// middleware stay out of the other demos' code paths. The page at
+// src/app/demos/multimodal/page.tsx mounts
+// <CopilotKit agent="multimodal-demo"> against this URL.
+//
+// Note: unlike the langgraph-python reference, this runtime does NOT
+// need an `onRunInitialized` legacy-binary shim. Claude's Messages API
+// accepts the modern AG-UI `{type: "image" | "document", source: {...}}`
+// shape natively once the backend converts it (see
+// src/agents/multimodal_agent.py :: `convert_part_for_claude`). The
+// legacy rewrite that langgraph-python needs is entirely a
+// @ag-ui/langgraph converter concern and is not required here.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/multimodal` });
+}
+
+const agents: Record<string, AbstractAgent> = {
+  "multimodal-demo": createAgent(),
+  default: createAgent(),
+};
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-multimodal",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- see main route.ts
+        agents,
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+// Dedicated runtime for the Open Generative UI demos.
+// Isolated here because the `openGenerativeUI` runtime flag sets
+// `openGenerativeUIEnabled: true` globally on the probe response, which
+// causes the CopilotKit provider's setTools effect to wipe per-demo
+// `useFrontendTool`/`useComponent` registrations in the default runtime.
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/` });
+}
+
+const agentNames = ["open-gen-ui", "open-gen-ui-advanced"];
+const agents: Record<string, AbstractAgent> = {};
+for (const name of agentNames) {
+  agents[name] = createAgent();
+}
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-ogui",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      // Server-side config is identical for minimal and advanced cells —
+      // the advanced behaviour (sandbox -> host function calls) is wired
+      // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
+      // the provider. The single `openGenerativeUI` flag below turns on
+      // Open Generative UI for the listed agent(s); the runtime middleware
+      // converts each agent's streamed `generateSandboxedUi` tool call into
+      // `open-generative-ui` activity events.
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- see main route.ts
+        agents,
+        openGenerativeUI: {
+          agents: ["open-gen-ui", "open-gen-ui-advanced"],
+        },
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const err = error as Error;
+    return NextResponse.json(
+      { error: err.message, stack: err.stack },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit-voice/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit-voice/route.ts
@@ -1,0 +1,143 @@
+// Dedicated runtime for the Voice demo.
+//
+// This is the only demo that needs `transcriptionService` mounted on
+// the V2 runtime — its presence flips `audioFileTranscriptionEnabled:
+// true` on the runtime-info response, which is what makes the
+// CopilotChat composer render its mic button. Mounting transcription on
+// the shared `/api/copilotkit` route would make every other demo grow a
+// mic button too; scoping it here keeps the affordance exactly where
+// the demo promises it.
+//
+// The underlying graph is the same neutral Claude backend other chat
+// demos use — voice is an input-modality concern, not an agent-behavior
+// concern. So the HttpAgent here points back at the shared `/` endpoint
+// on the Python server, not a dedicated one.
+//
+// Two non-obvious things this file does (mirroring the langgraph-python
+// reference route, which has the same framework-agnostic concerns):
+//
+// 1. It bypasses the V1 `CopilotRuntime` wrapper's silent drop of
+//    `transcriptionService` by writing the service onto the V2 runtime
+//    instance directly. See
+//    `packages/runtime/src/lib/runtime/copilot-runtime.ts` — the V1
+//    constructor explicitly does not forward `transcriptionService` to
+//    the V2 runtime. Until that is unblocked upstream, per-demo routes
+//    that need transcription must reach through `.instance`.
+//
+// 2. It always mounts a transcription service (so `/info` advertises
+//    the mic-capable state) but the service returns a deterministic,
+//    human-readable error when `OPENAI_API_KEY` is not set on the
+//    deployment. The runtime's error categorizer maps messages
+//    containing "api key" to `AUTH_FAILED` → HTTP 401, which is the
+//    intended 4xx path for a misconfigured deployment — much better
+//    than a silent 503 through the provider-error fallback.
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+import { TranscriptionService } from "@copilotkit/runtime/v2";
+import type { TranscribeFileOptions } from "@copilotkit/runtime/v2";
+import { TranscriptionServiceOpenAI } from "@copilotkit/voice";
+import OpenAI from "openai";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/` });
+}
+
+/**
+ * Transcription service wrapper that reports a clean, typed auth error
+ * when `OPENAI_API_KEY` is not configured.
+ *
+ * See file header note #2 for why this is the preferred error surface.
+ */
+class GuardedOpenAITranscriptionService extends TranscriptionService {
+  private delegate: TranscriptionServiceOpenAI | null;
+
+  constructor() {
+    super();
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (apiKey) {
+      this.delegate = new TranscriptionServiceOpenAI({
+        openai: new OpenAI({ apiKey }),
+      });
+    } else {
+      this.delegate = null;
+    }
+  }
+
+  async transcribeFile(options: TranscribeFileOptions): Promise<string> {
+    if (!this.delegate) {
+      // Message contains "api key" so the runtime's categorizer maps
+      // it to AUTH_FAILED → HTTP 401 with a readable body.
+      throw new Error(
+        "OPENAI_API_KEY not configured for this deployment (api key missing). " +
+          "Set OPENAI_API_KEY to enable voice transcription.",
+      );
+    }
+    return this.delegate.transcribeFile(options);
+  }
+}
+
+// Lazily construct the runtime + transcription service on first
+// request. Next.js build-time page-data collection imports every route
+// module; deferring construction keeps OPENAI_API_KEY out of the build
+// context and makes Docker builds in CI work even when the key is only
+// available at runtime.
+let cachedRuntime: CopilotRuntime | null = null;
+function getRuntime(): CopilotRuntime {
+  if (cachedRuntime) return cachedRuntime;
+
+  const agent = createAgent();
+  const agents: Record<string, AbstractAgent> = {
+    "voice-demo": agent,
+    // useAgent() with no args defaults to "default"; alias so internal
+    // default-agent lookups resolve against the same graph.
+    default: agent,
+  };
+
+  const runtime = new CopilotRuntime({
+    // @ts-ignore -- see main route.ts
+    agents,
+  });
+
+  // V1 CopilotRuntime drops `transcriptionService` on the floor — write
+  // it onto the V2 runtime instance directly.
+  const v2Instance = runtime.instance as unknown as {
+    transcriptionService?: TranscriptionService;
+  };
+  v2Instance.transcriptionService = new GuardedOpenAITranscriptionService();
+
+  cachedRuntime = runtime;
+  return cachedRuntime;
+}
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-voice",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: getRuntime(),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    return NextResponse.json(
+      { error: e.message, stack: e.stack },
+      { status: 500 },
+    );
+  }
+};
+
+// The V2 runtime client tries `GET {runtimeUrl}/info` first and falls
+// back to single-route POST on failure. Exporting GET here keeps the
+// 405 we'd otherwise return from being treated as a server error in
+// logs; the V2 auto-detect ignores the 405 and moves on to the working
+// POST path.
+export const GET = POST;

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit/route.ts
@@ -28,6 +28,11 @@ const agentNames = [
   "shared-state-write",
   "shared-state-streaming",
   "subagents",
+  "prebuilt-sidebar",
+  "prebuilt-popup",
+  "chat-slots",
+  "chat-customization-css",
+  "headless-simple",
 ];
 
 const agents: Record<string, AbstractAgent> = {};

--- a/showcase/packages/claude-sdk-python/src/app/api/copilotkit/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/copilotkit/route.ts
@@ -22,6 +22,8 @@ const agentNames = [
   "agentic_chat",
   "human_in_the_loop",
   "tool-rendering",
+  "tool-rendering-default-catchall",
+  "tool-rendering-custom-catchall",
   "gen-ui-tool-based",
   "gen-ui-agent",
   "shared-state-read",
@@ -33,6 +35,11 @@ const agentNames = [
   "chat-slots",
   "chat-customization-css",
   "headless-simple",
+  "frontend-tools",
+  "frontend-tools-async",
+  "hitl-in-app",
+  "readonly-state-agent-context",
+  "headless-complete",
 ];
 
 const agents: Record<string, AbstractAgent> = {};

--- a/showcase/packages/claude-sdk-python/src/app/demos/agent-config/config-card.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/agent-config/config-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import {
+  type AgentConfig,
+  EXPERTISE_OPTIONS,
+  type Expertise,
+  RESPONSE_LENGTH_OPTIONS,
+  type ResponseLength,
+  TONE_OPTIONS,
+  type Tone,
+} from "./config-types";
+
+interface ConfigCardProps {
+  config: AgentConfig;
+  onToneChange: (tone: Tone) => void;
+  onExpertiseChange: (expertise: Expertise) => void;
+  onResponseLengthChange: (length: ResponseLength) => void;
+}
+
+export function ConfigCard({
+  config,
+  onToneChange,
+  onExpertiseChange,
+  onResponseLengthChange,
+}: ConfigCardProps) {
+  return (
+    <div
+      data-testid="agent-config-card"
+      className="flex flex-col gap-2 rounded-md border border-[var(--border)] bg-[var(--bg-surface)] p-4 text-sm"
+    >
+      <h2 className="text-sm font-semibold">Agent Config</h2>
+      <p className="text-xs text-[var(--text-muted)]">
+        Change these and send a message to see the agent adapt.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium">Tone</span>
+          <select
+            data-testid="agent-config-tone-select"
+            value={config.tone}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              onToneChange(e.target.value as Tone)
+            }
+            className="rounded border border-[var(--border)] bg-[var(--bg-muted)] px-2 py-1 text-sm"
+          >
+            {TONE_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium">Expertise</span>
+          <select
+            data-testid="agent-config-expertise-select"
+            value={config.expertise}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              onExpertiseChange(e.target.value as Expertise)
+            }
+            className="rounded border border-[var(--border)] bg-[var(--bg-muted)] px-2 py-1 text-sm"
+          >
+            {EXPERTISE_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium">Response length</span>
+          <select
+            data-testid="agent-config-length-select"
+            value={config.responseLength}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              onResponseLengthChange(e.target.value as ResponseLength)
+            }
+            className="rounded border border-[var(--border)] bg-[var(--bg-muted)] px-2 py-1 text-sm"
+          >
+            {RESPONSE_LENGTH_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/agent-config/config-types.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/agent-config/config-types.ts
@@ -1,0 +1,26 @@
+export type Tone = "professional" | "casual" | "enthusiastic";
+export type Expertise = "beginner" | "intermediate" | "expert";
+export type ResponseLength = "concise" | "detailed";
+
+export interface AgentConfig {
+  tone: Tone;
+  expertise: Expertise;
+  responseLength: ResponseLength;
+}
+
+export const DEFAULT_AGENT_CONFIG: AgentConfig = {
+  tone: "professional",
+  expertise: "intermediate",
+  responseLength: "concise",
+};
+
+export const TONE_OPTIONS: Tone[] = ["professional", "casual", "enthusiastic"];
+export const EXPERTISE_OPTIONS: Expertise[] = [
+  "beginner",
+  "intermediate",
+  "expert",
+];
+export const RESPONSE_LENGTH_OPTIONS: ResponseLength[] = [
+  "concise",
+  "detailed",
+];

--- a/showcase/packages/claude-sdk-python/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/agent-config/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CopilotChat, CopilotKit } from "@copilotkit/react-core/v2";
+import { useMemo } from "react";
+
+import { ConfigCard } from "./config-card";
+import { useAgentConfig } from "./use-agent-config";
+
+export default function AgentConfigDemoPage() {
+  const { config, setTone, setExpertise, setResponseLength } = useAgentConfig();
+
+  // Widen to `Record<string, any>` so the provider's `properties` prop accepts
+  // our strongly-typed config. The memo keeps the reference stable between
+  // renders when the config itself hasn't changed, so the provider's
+  // `[properties]`-keyed effect only re-fires when something real changed.
+  const providerProperties = useMemo<Record<string, unknown>>(
+    () => ({
+      tone: config.tone,
+      expertise: config.expertise,
+      responseLength: config.responseLength,
+    }),
+    [config.tone, config.expertise, config.responseLength],
+  );
+
+  return (
+    // @region[provider-setup]
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-agent-config"
+      agent="agent-config-demo"
+      properties={providerProperties}
+    >
+      <div className="flex h-screen flex-col gap-3 p-6">
+        <header>
+          <h1 className="text-lg font-semibold">Agent Config Object</h1>
+          <p className="text-sm text-[var(--text-muted)]">
+            Forwarded props let the frontend tell the agent how to behave. This
+            demo passes <code>tone</code>, <code>expertise</code>, and
+            <code> responseLength</code> through the provider; the agent reads
+            them from the LangGraph config and builds its system prompt per
+            turn.
+          </p>
+        </header>
+        <ConfigCard
+          config={config}
+          onToneChange={setTone}
+          onExpertiseChange={setExpertise}
+          onResponseLengthChange={setResponseLength}
+        />
+        <div className="flex-1 overflow-hidden rounded-md border border-[var(--border)]">
+          <CopilotChat
+            agentId="agent-config-demo"
+            className="h-full rounded-md"
+          />
+        </div>
+      </div>
+    </CopilotKit>
+    // @endregion[provider-setup]
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/agent-config/use-agent-config.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/agent-config/use-agent-config.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  type AgentConfig,
+  DEFAULT_AGENT_CONFIG,
+  type Expertise,
+  type ResponseLength,
+  type Tone,
+} from "./config-types";
+
+export interface UseAgentConfigHandle {
+  config: AgentConfig;
+  setTone: (tone: Tone) => void;
+  setExpertise: (expertise: Expertise) => void;
+  setResponseLength: (length: ResponseLength) => void;
+  reset: () => void;
+}
+
+export function useAgentConfig(): UseAgentConfigHandle {
+  const [config, setConfig] = useState<AgentConfig>(DEFAULT_AGENT_CONFIG);
+
+  const setTone = useCallback(
+    (tone: Tone) => setConfig((prev) => ({ ...prev, tone })),
+    [],
+  );
+  const setExpertise = useCallback(
+    (expertise: Expertise) => setConfig((prev) => ({ ...prev, expertise })),
+    [],
+  );
+  const setResponseLength = useCallback(
+    (responseLength: ResponseLength) =>
+      setConfig((prev) => ({ ...prev, responseLength })),
+    [],
+  );
+  const reset = useCallback(() => setConfig(DEFAULT_AGENT_CONFIG), []);
+
+  return { config, setTone, setExpertise, setResponseLength, reset };
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/auth/auth-banner.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/auth/auth-banner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+interface AuthBannerProps {
+  authenticated: boolean;
+  onAuthenticate: () => void;
+  onSignOut: () => void;
+}
+
+/**
+ * Sticky banner above <CopilotChat /> that reflects and toggles demo auth
+ * state. Pure presentational — owns no state itself. Testids are stable
+ * contract for QA + Playwright specs.
+ */
+export function AuthBanner({
+  authenticated,
+  onAuthenticate,
+  onSignOut,
+}: AuthBannerProps) {
+  const wrapperClass = authenticated
+    ? "border-emerald-300 bg-emerald-50 text-emerald-900"
+    : "border-amber-300 bg-amber-50 text-amber-900";
+  const statusText = authenticated
+    ? "✓ Signed in as demo user"
+    : "⚠ Signed out — the agent will reject your messages until you sign in.";
+
+  return (
+    <div
+      data-testid="auth-banner"
+      data-authenticated={authenticated ? "true" : "false"}
+      className={`sticky top-0 z-10 flex items-center justify-between gap-3 rounded-md border px-4 py-3 text-sm ${wrapperClass}`}
+    >
+      <span data-testid="auth-status" className="font-medium">
+        {statusText}
+      </span>
+      {authenticated ? (
+        <button
+          type="button"
+          data-testid="auth-sign-out-button"
+          onClick={onSignOut}
+          className="rounded border border-emerald-400 bg-white px-3 py-1 text-xs font-medium text-emerald-800 hover:bg-emerald-100"
+        >
+          Sign out
+        </button>
+      ) : (
+        <button
+          type="button"
+          data-testid="auth-authenticate-button"
+          onClick={onAuthenticate}
+          className="rounded border border-amber-400 bg-white px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+        >
+          Sign in
+        </button>
+      )}
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/auth/demo-token.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/auth/demo-token.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared demo-token constant imported by both the client
+ * (use-demo-auth.ts) and the server runtime route
+ * (api/copilotkit-auth/route.ts). Keeping the constant in one file
+ * prevents drift: changing the token in one place changes it everywhere.
+ *
+ * This is a DEMO token. Never use a hard-coded shared secret for real auth.
+ */
+export const DEMO_TOKEN = "demo-token-123";
+
+export const DEMO_AUTH_HEADER = `Bearer ${DEMO_TOKEN}`;

--- a/showcase/packages/claude-sdk-python/src/app/demos/auth/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/auth/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+// Auth demo — framework-native request authentication via the V2 runtime's
+// `onRequest` hook. The banner toggles an in-memory React auth flag; when
+// `authenticated === true`, <CopilotKit headers={...}> injects the
+// `Authorization: Bearer <demo-token>` header on every request. The runtime
+// route (/api/copilotkit-auth) rejects any request without the header.
+//
+// Default UX: the page loads authenticated so the initial `/info` handshake
+// succeeds and the chat is immediately usable. Clicking "Sign out" flips to
+// the unauthenticated state — the next chat submission (and any re-fetch of
+// `/info`) will 401, which we surface via the page-level error banner. This
+// inverts the historical unauth-first flow, which crashed the page on load
+// when `/info` returned 401 before `onError` handlers could attach.
+//
+// Error surfacing: <CopilotChat /> surfaces transport errors inconsistently
+// across states, so this page additionally captures errors via the
+// <CopilotKit onError> prop and renders a persistent error banner below the
+// chat. A local ErrorBoundary guards against any uncaught render-time error
+// from chat internals in the unauthenticated state so the page never white-
+// screens — instead, the user sees a clear in-page message.
+
+import { Component, useCallback, useMemo, useState } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { useDemoAuth } from "./use-demo-auth";
+import { AuthBanner } from "./auth-banner";
+
+interface ChatErrorBoundaryProps {
+  authenticated: boolean;
+  children: ReactNode;
+}
+
+interface ChatErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Guards <CopilotChat /> against uncaught render-time errors. If the chat
+ * internals throw (most commonly while the app is in the unauthenticated
+ * state and a transient response payload is missing), we render a clear
+ * in-page message instead of white-screening the entire route. The boundary
+ * resets whenever `authenticated` flips, so signing back in restores the
+ * live chat without requiring a full page reload.
+ */
+class ChatErrorBoundary extends Component<
+  ChatErrorBoundaryProps,
+  ChatErrorBoundaryState
+> {
+  state: ChatErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ChatErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: ChatErrorBoundaryProps): void {
+    // Reset on auth transition so signing in re-mounts a fresh <CopilotChat />.
+    if (
+      prevProps.authenticated !== this.props.authenticated &&
+      this.state.error
+    ) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Keep the console trail for devtools but do not rethrow.
+    console.error("[auth-demo] chat error boundary caught:", error, info);
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div
+          data-testid="auth-demo-chat-boundary"
+          className="flex h-full items-center justify-center p-6 text-center text-sm text-neutral-600"
+        >
+          <div>
+            <p className="font-medium text-neutral-800">
+              Chat unavailable while signed out
+            </p>
+            <p className="mt-1 text-xs text-neutral-500">
+              Click Sign in above to restore the conversation.
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default function AuthDemoPage() {
+  const auth = useDemoAuth();
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  // Clear any stale error when auth state flips (authenticate OR sign out).
+  const authenticate = useCallback(() => {
+    setLastError(null);
+    auth.authenticate();
+  }, [auth]);
+
+  const signOut = useCallback(() => {
+    setLastError(null);
+    auth.signOut();
+  }, [auth]);
+
+  // Compute headers reactively. The provider reads the latest headers prop
+  // on every request via a useEffect that calls `copilotkit.setHeaders(...)`
+  // whenever the merged headers object changes.
+  const headers = useMemo<Record<string, string>>(() => {
+    const h: Record<string, string> = {};
+    if (auth.authorizationHeader) {
+      h.Authorization = auth.authorizationHeader;
+    }
+    return h;
+  }, [auth.authorizationHeader]);
+
+  const onError = useCallback(
+    (errorEvent: {
+      error?: { message?: string; status?: number; statusCode?: number };
+      context?: { response?: { status?: number } };
+    }) => {
+      const err = errorEvent?.error;
+      const message = err?.message ?? "Request failed";
+      const status =
+        err?.status ?? err?.statusCode ?? errorEvent?.context?.response?.status;
+      if (status === 401 || /401|unauthor/i.test(message)) {
+        setLastError(
+          "401 Unauthorized — click Sign in above to restore access.",
+        );
+      } else {
+        setLastError(message);
+      }
+    },
+    [],
+  );
+
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-auth"
+      agent="auth-demo"
+      headers={headers}
+      onError={onError}
+    >
+      <div className="flex h-screen flex-col gap-3 p-6">
+        <AuthBanner
+          authenticated={auth.authenticated}
+          onAuthenticate={authenticate}
+          onSignOut={signOut}
+        />
+        <header>
+          <h1 className="text-lg font-semibold">Authentication</h1>
+          <p className="text-sm text-neutral-600">
+            The runtime rejects requests without a valid Bearer token via an{" "}
+            <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-xs">
+              onRequest
+            </code>{" "}
+            hook. You start signed in — click Sign out above to exercise the 401
+            path, then Sign in to restore access.
+          </p>
+        </header>
+        <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
+          <ChatErrorBoundary authenticated={auth.authenticated}>
+            <CopilotChat agentId="auth-demo" className="h-full" />
+          </ChatErrorBoundary>
+        </div>
+        {lastError && (
+          <div
+            role="alert"
+            data-testid="auth-demo-error"
+            className="rounded border border-red-300 bg-red-50 px-3 py-2 text-xs font-medium text-red-900"
+          >
+            {lastError}
+          </div>
+        )}
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/auth/use-demo-auth.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/auth/use-demo-auth.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { DEMO_AUTH_HEADER, DEMO_TOKEN } from "./demo-token";
+
+export interface DemoAuthHandle {
+  authenticated: boolean;
+  /** The token string when authenticated, otherwise null. */
+  token: string | null;
+  /** The full `Bearer <token>` value when authenticated, otherwise null. */
+  authorizationHeader: string | null;
+  authenticate: () => void;
+  signOut: () => void;
+}
+
+/**
+ * In-memory auth state for the /demos/auth showcase cell. No persistence —
+ * refreshing the page resets to the default authenticated state, which keeps
+ * the demo immediately usable and avoids the 401 crash on initial `/info`
+ * fetch that happens when starting unauthenticated. Users can click "Sign
+ * out" to exercise the unauthenticated / 401 path on demand.
+ */
+export function useDemoAuth(): DemoAuthHandle {
+  const [authenticated, setAuthenticated] = useState(true);
+
+  const authenticate = useCallback(() => {
+    setAuthenticated(true);
+  }, []);
+
+  const signOut = useCallback(() => {
+    setAuthenticated(false);
+  }, []);
+
+  return {
+    authenticated,
+    token: authenticated ? DEMO_TOKEN : null,
+    authorizationHeader: authenticated ? DEMO_AUTH_HEADER : null,
+    authenticate,
+    signOut,
+  };
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/charts/bar-chart.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/charts/bar-chart.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+/**
+ * BarChart ported from showcase/starters/template/frontend/components/charts/bar-chart.tsx
+ * for the byoc-hashbrown demo (Wave 4a).
+ *
+ * Adds data-testid="bar-chart" on the top-level container for E2E coverage.
+ */
+import { useRef } from "react";
+import {
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Rectangle,
+} from "recharts";
+import { z } from "zod";
+import { CHART_COLORS, CHART_CONFIG } from "./chart-config";
+
+export const BarChartProps = z.object({
+  title: z.string().describe("Chart title"),
+  description: z.string().describe("Brief description or subtitle"),
+  data: z.array(
+    z.object({
+      label: z.string(),
+      value: z.number(),
+    }),
+  ),
+});
+
+type BarChartPropsType = z.infer<typeof BarChartProps>;
+
+/** Tracks seen indices so only NEW bars get the fade-in animation. */
+function useSeenIndices() {
+  const seen = useRef(new Set<number>());
+  return {
+    isNew(index: number) {
+      if (seen.current.has(index)) return false;
+      seen.current.add(index);
+      return true;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function AnimatedBar(props: any) {
+  const { isNew, ...rest } = props;
+  return (
+    <g
+      style={
+        isNew
+          ? {
+              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
+            }
+          : undefined
+      }
+    >
+      <Rectangle {...rest} />
+    </g>
+  );
+}
+
+export function BarChart({ title, description, data }: BarChartPropsType) {
+  const { isNew } = useSeenIndices();
+
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return (
+      <div
+        data-testid="bar-chart"
+        className="max-w-2xl mx-auto my-4 rounded-lg border border-[var(--border)] bg-[var(--card)]"
+      >
+        <div className="p-6">
+          <div className="flex items-center gap-2">
+            <svg
+              className="h-4 w-4 text-[var(--muted-foreground)]"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="20" x2="18" y2="10" />
+              <line x1="12" y1="20" x2="12" y2="4" />
+              <line x1="6" y1="20" x2="6" y2="14" />
+            </svg>
+            <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+              {title}
+            </h3>
+          </div>
+          <p className="text-sm text-[var(--muted-foreground)]">
+            {description}
+          </p>
+        </div>
+        <div className="p-6 pt-0">
+          <p className="text-[var(--muted-foreground)] text-center py-8 text-sm">
+            No data available
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="bar-chart"
+      className="max-w-2xl mx-auto my-4 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]"
+    >
+      {/* Scoped keyframe -- no globals.css needed */}
+      <style>{`
+        @keyframes barSlideIn {
+          from { transform: translateY(40px); opacity: 0; }
+          20% { opacity: 1; }
+          to { transform: translateY(0); opacity: 1; }
+        }
+      `}</style>
+      <div className="p-6 pb-2">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center justify-center h-6 w-6 rounded-md bg-[var(--secondary)]">
+            <svg
+              className="h-3.5 w-3.5 text-[var(--muted-foreground)]"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="20" x2="18" y2="10" />
+              <line x1="12" y1="20" x2="12" y2="4" />
+              <line x1="6" y1="20" x2="6" y2="14" />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+            {title}
+          </h3>
+        </div>
+        <p className="text-sm text-[var(--muted-foreground)]">{description}</p>
+      </div>
+      <div className="p-6 pt-2">
+        <ResponsiveContainer width="100%" height={280}>
+          <RechartsBarChart
+            data={data}
+            margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--border)"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              stroke="var(--border)"
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              stroke="var(--border)"
+              tickLine={false}
+              axisLine={false}
+            />
+            <Tooltip
+              contentStyle={CHART_CONFIG.tooltipStyle}
+              cursor={{ fill: "var(--secondary)", opacity: 0.5 }}
+            />
+            <Bar
+              isAnimationActive={false}
+              dataKey="value"
+              radius={[6, 6, 0, 0]}
+              maxBarSize={48}
+              shape={(props: unknown) => {
+                const p = props as Record<string, unknown>;
+                return <AnimatedBar {...p} isNew={isNew(p.index as number)} />;
+              }}
+            >
+              {data.map((_, index) => (
+                <Cell
+                  key={index}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                />
+              ))}
+            </Bar>
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/charts/chart-config.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/charts/chart-config.ts
@@ -1,0 +1,28 @@
+/**
+ * CopilotKit brand chart palette -- Plus Jakarta Sans / brand color system.
+ *
+ * Ported verbatim from showcase/starters/template/frontend/components/charts/chart-config.ts
+ * for the byoc-hashbrown demo (Wave 4a).
+ */
+export const CHART_COLORS = [
+  "#BEC2FF", // lilac-400
+  "#85ECCE", // mint-400
+  "#FFAC4D", // orange-400
+  "#FFF388", // yellow-400
+  "#189370", // mint-800
+  "#EEE6FE", // primary-100
+  "#FA5F67", // red-400
+] as const;
+
+export const CHART_CONFIG = {
+  tooltipStyle: {
+    backgroundColor: "var(--card)",
+    border: "1px solid var(--border)",
+    borderRadius: "10px",
+    padding: "10px 14px",
+    color: "var(--foreground)",
+    fontSize: "13px",
+    fontFamily: "var(--font-body)",
+    boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+  },
+};

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/charts/pie-chart.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/charts/pie-chart.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+/**
+ * PieChart ported from showcase/starters/template/frontend/components/charts/pie-chart.tsx
+ * for the byoc-hashbrown demo (Wave 4a).
+ *
+ * Adds data-testid="pie-chart" on the top-level container for E2E coverage.
+ */
+import { z } from "zod";
+import { CHART_COLORS } from "./chart-config";
+
+export const PieChartProps = z.object({
+  title: z.string().describe("Chart title"),
+  description: z.string().describe("Brief description or subtitle"),
+  data: z.array(
+    z.object({
+      label: z.string(),
+      value: z.number(),
+    }),
+  ),
+});
+
+type PieChartPropsType = z.infer<typeof PieChartProps>;
+
+/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
+function DonutChart({
+  data,
+  size = 240,
+  strokeWidth = 40,
+}: {
+  data: { label: string; value: number }[];
+  size?: number;
+  strokeWidth?: number;
+}) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+
+  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+  // Calculate each slice's arc length and starting position
+  let accumulated = 0;
+  const slices = data.map((item, index) => {
+    const val = Number(item.value) || 0;
+    const ratio = total > 0 ? val / total : 0;
+    const arc = ratio * circumference;
+    const startAt = accumulated;
+    accumulated += arc;
+    return {
+      ...item,
+      arc,
+      gap: circumference - arc,
+      // Negative dashoffset shifts the dash forward (clockwise) to the correct position
+      dashoffset: -startAt,
+      color: CHART_COLORS[index % CHART_COLORS.length],
+    };
+  });
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${size} ${size}`}
+      className="block mx-auto"
+      style={{ maxWidth: size, transform: "scaleX(-1)" }}
+    >
+      {/* Background ring */}
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke="var(--secondary)"
+        strokeWidth={strokeWidth}
+      />
+      {/* Data slices */}
+      {slices.map((slice, i) => (
+        <circle
+          key={i}
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={slice.color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={`${slice.arc} ${slice.gap}`}
+          strokeDashoffset={slice.dashoffset}
+          strokeLinecap="butt"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export function PieChart({ title, description, data }: PieChartPropsType) {
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return (
+      <div
+        data-testid="pie-chart"
+        className="max-w-lg mx-auto my-4 rounded-lg border border-[var(--border)] bg-[var(--card)]"
+      >
+        <div className="p-6 pb-0">
+          <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+            {title}
+          </h3>
+          <p className="text-sm text-[var(--muted-foreground)]">
+            {description}
+          </p>
+        </div>
+        <div className="p-6">
+          <p className="text-[var(--muted-foreground)] text-center py-8 text-sm">
+            No data available
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+  return (
+    <div
+      data-testid="pie-chart"
+      className="max-w-lg mx-auto my-4 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]"
+    >
+      <div className="p-6 pb-0">
+        <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+          {title}
+        </h3>
+        <p className="text-sm text-[var(--muted-foreground)]">{description}</p>
+      </div>
+      <div className="p-6 pt-4">
+        <DonutChart data={data} />
+
+        {/* Legend */}
+        <div className="space-y-2 pt-4">
+          {data.map((item, index) => {
+            const val = Number(item.value) || 0;
+            const pct = total > 0 ? ((val / total) * 100).toFixed(0) : 0;
+            return (
+              <div
+                key={index}
+                className="flex items-center gap-3 text-sm transition-opacity duration-300 ease-out"
+                style={{ opacity: 1 }}
+              >
+                <span
+                  className="inline-block h-3 w-3 rounded-full shrink-0"
+                  style={{
+                    backgroundColor: CHART_COLORS[index % CHART_COLORS.length],
+                  }}
+                />
+                <span className="flex-1 text-[var(--foreground)] truncate">
+                  {item.label}
+                </span>
+                <span className="text-[var(--muted-foreground)] tabular-nums">
+                  {val.toLocaleString()}
+                </span>
+                <span className="text-[var(--muted-foreground)] text-sm w-10 text-right tabular-nums">
+                  {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+/**
+ * HashBrown message renderer for the byoc-hashbrown demo (Wave 4a).
+ *
+ * Ported from showcase/starters/template/frontend/components/renderers/hashbrown/index.tsx
+ * with these adjustments:
+ * - MetricCard lives in ./metric-card (extracted module).
+ * - Charts live under ./charts/ (co-located in the demo).
+ * - SalesStage type lives in ./types.
+ *
+ * Registers MetricCard + PieChart + BarChart + DealCard + Markdown against the
+ * hashbrown schema via `@hashbrownai/react`'s `useUiKit`. Renders assistant
+ * messages through `useJsonParser` for progressive JSON→UI streaming.
+ *
+ * Wire format
+ * -----------
+ * `useJsonParser(content, kit.schema)` parses a streaming JSON object of the
+ * shape produced by `createUiKit(...).schema`:
+ *
+ *   {
+ *     "ui": [
+ *       { "metric":   { "props": { "label": "...", "value": "..." } } },
+ *       { "pieChart": { "props": { "title": "...", "data": "[{...}]" } } },
+ *       { "Markdown": { "props": { "children": "..." } } }
+ *     ]
+ *   }
+ *
+ * The `useUiKit({ examples: ... })` `<ui>` JSX is hashbrown's prompt DSL used
+ * when hashbrown drives the LLM directly (e.g. `useUiChat`). Because this
+ * demo drives the LLM via langgraph, the backend agent
+ * (`src/agents/byoc_hashbrown_agent.py`) is responsible for emitting the JSON
+ * shape shown above.
+ *
+ * Consume the renderer like this in a page:
+ *
+ *   <HashBrownDashboard>
+ *     <CopilotChat RenderMessage={useHashBrownMessageRenderer()} />
+ *   </HashBrownDashboard>
+ */
+import React, { memo } from "react";
+import { s, prompt } from "@hashbrownai/core";
+import {
+  exposeComponent,
+  exposeMarkdown,
+  useUiKit,
+  useJsonParser,
+} from "@hashbrownai/react";
+import { PieChart } from "./charts/pie-chart";
+import { BarChart } from "./charts/bar-chart";
+import { MetricCard } from "./metric-card";
+import type { SalesStage } from "./types";
+
+/**
+ * The underlying PieChart / BarChart components take `data` as a real
+ * array, but hashbrown's build-time validator (0.5.0-beta.4) rejects
+ * example prompts whose JSX attribute values don't match the schema
+ * type — i.e. `data='[{"label":"A","value":1}]'` (string) doesn't pass
+ * an `s.streaming.array(...)` schema. And since the LLM streams JSON as
+ * text anyway, modeling `data` as a string prop and parsing inside the
+ * component is the path the example syntax naturally supports.
+ *
+ * These wrappers accept `data: string`, JSON-parse it, and render the
+ * real chart. Defensive — silently render nothing if parse fails mid-
+ * stream (hashbrown feeds partial tokens while streaming).
+ */
+type ChartSlice = { label: string; value: number };
+
+function parseChartData(data: string): ChartSlice[] | null {
+  try {
+    const parsed = JSON.parse(data);
+    if (!Array.isArray(parsed)) return null;
+    return parsed as ChartSlice[];
+  } catch {
+    return null;
+  }
+}
+
+function PieChartWithStringData({
+  title,
+  data,
+}: {
+  title: string;
+  data: string;
+}) {
+  const parsed = parseChartData(data);
+  if (!parsed) return null;
+  return <PieChart title={title} description="" data={parsed} />;
+}
+
+function BarChartWithStringData({
+  title,
+  data,
+}: {
+  title: string;
+  data: string;
+}) {
+  const parsed = parseChartData(data);
+  if (!parsed) return null;
+  return <BarChart title={title} description="" data={parsed} />;
+}
+
+/**
+ * Minimal local types for the CopilotChat RenderMessage slot + AG-UI
+ * assistant message shape. These mirror `RenderMessageProps` from
+ * `@copilotkit/react-ui` and `AssistantMessage` from `@ag-ui/core`, inlined
+ * to avoid adding those packages as direct dependencies of langgraph-python
+ * (they come in transitively via `@copilotkit/react-core`).
+ *
+ * Only the fields the renderer reads are declared.
+ */
+interface LocalAssistantMessage {
+  role: "assistant";
+  content?: string;
+}
+
+interface LocalChatMessage {
+  role: string;
+  content?: string;
+}
+
+interface LocalRenderMessageProps {
+  message: LocalChatMessage;
+}
+
+// ---------------------------------------------------------------------------
+// Standalone DealCard for the kit (flat props, no SalesTodo dependency)
+// ---------------------------------------------------------------------------
+
+interface HashBrownDealCardProps {
+  title: string;
+  stage: SalesStage;
+  value: number;
+  assignee?: string;
+  dueDate?: string;
+}
+
+const STAGE_COLORS: Record<SalesStage, string> = {
+  prospect: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  qualified:
+    "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+  proposal: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
+  negotiation:
+    "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+  "closed-won":
+    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  "closed-lost": "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+};
+
+function DealCardComponent({
+  title,
+  stage,
+  value,
+  assignee,
+  dueDate,
+}: HashBrownDealCardProps) {
+  const badgeClass =
+    STAGE_COLORS[stage] ??
+    "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200";
+
+  return (
+    <div
+      data-testid="hashbrown-deal-card"
+      className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4"
+    >
+      <h3 className="text-sm font-semibold leading-snug text-[var(--foreground)]">
+        {title}
+      </h3>
+      <div className="mt-2 flex items-center gap-2 flex-wrap">
+        <span
+          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${badgeClass}`}
+        >
+          {stage}
+        </span>
+        <span className="text-sm font-semibold text-[var(--foreground)]">
+          ${(value ?? 0).toLocaleString()}
+        </span>
+      </div>
+      <div className="mt-2 flex items-center gap-3 text-xs text-[var(--muted-foreground)]">
+        {assignee && <span>{assignee}</span>}
+        {dueDate && <span>Due {dueDate}</span>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Kit definition
+// ---------------------------------------------------------------------------
+
+export function useSalesDashboardKit() {
+  return useUiKit({
+    examples: prompt`
+      # Mixing components and Markdown:
+      <ui>
+        <Markdown children="## Q4 Sales Summary" />
+        <metric label="Total Revenue" value="$1.2M" />
+        <Markdown children="Revenue breakdown by segment:" />
+        <pieChart title="Revenue by Segment" data='[{"label":"Enterprise","value":600000},{"label":"SMB","value":400000},{"label":"Startup","value":200000}]' />
+        <barChart title="Monthly Trend" data='[{"label":"Oct","value":350000},{"label":"Nov","value":400000},{"label":"Dec","value":450000}]' />
+        <dealCard title="Acme Corp Renewal" stage="negotiation" value="250000" />
+      </ui>
+
+      Hint: use Markdown for explanatory text between visual components.
+      Hint: always include title and data for charts. Data is a JSON-encoded
+      array of {label, value} objects as a string.
+    `,
+    components: [
+      exposeMarkdown(),
+      exposeComponent(MetricCard, {
+        name: "metric",
+        description: "A KPI metric card with label, value, and optional trend",
+        // Note on "optional" props: @hashbrownai/core@0.5.0-beta.4 dropped
+        // the `.optional()` chain in favor of treating component prop schemas
+        // as Partial at the exposeComponent layer. We omit optional keys from
+        // the schema and surface their existence to the LLM via the
+        // `examples` prompt above and the natural-language `description`.
+        props: {
+          label: s.string("The metric label/name"),
+          value: s.string("The metric value (formatted)"),
+        },
+      }),
+      exposeComponent(PieChartWithStringData, {
+        name: "pieChart",
+        description:
+          "A donut/pie chart. `data` is a JSON-encoded string of an " +
+          "array of {label, value} segments, e.g. " +
+          '\'[{"label":"A","value":1}]\'.',
+        props: {
+          title: s.string("Chart title"),
+          data: s.string("JSON array of {label, value} segments"),
+        },
+      }),
+      exposeComponent(BarChartWithStringData, {
+        name: "barChart",
+        description:
+          "A vertical bar chart. `data` is a JSON-encoded string of an " +
+          "array of {label, value} bars, e.g. " +
+          '\'[{"label":"A","value":1}]\'.',
+        props: {
+          title: s.string("Chart title"),
+          data: s.string("JSON array of {label, value} bars"),
+        },
+      }),
+      exposeComponent(DealCardComponent, {
+        name: "dealCard",
+        description: "A sales deal card showing pipeline stage and value",
+        props: {
+          title: s.string("Deal title"),
+          stage: s.enumeration("Pipeline stage", [
+            "prospect",
+            "qualified",
+            "proposal",
+            "negotiation",
+            "closed-won",
+            "closed-lost",
+          ]),
+          value: s.number("Deal value in dollars"),
+        },
+      }),
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Custom message renderer
+// ---------------------------------------------------------------------------
+
+const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
+  message,
+  kit,
+}: {
+  message: LocalAssistantMessage;
+  kit: ReturnType<typeof useSalesDashboardKit>;
+}) {
+  const { value } = useJsonParser(message.content ?? "", kit.schema);
+
+  if (!value) return null;
+
+  return (
+    <div className="mt-2 flex w-full justify-start">
+      <div className="w-full px-1 py-1">{kit.render(value)}</div>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Exported dashboard provider + renderer hook
+// ---------------------------------------------------------------------------
+
+export interface HashBrownDashboardProps {
+  /**
+   * Optional custom wrapper for the assistant message area.
+   * Defaults to rendering messages inline.
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Provider that instantiates the HashBrown kit ONCE and shares it via context.
+ * Both the dashboard layout and message renderer consume the same kit instance.
+ *
+ * The kit registers MetricCard, PieChart, BarChart, DealCard, and Markdown
+ * components. Agent context forwarding for output_schema is omitted because
+ * the npm-published react-core may not export useAgentContext yet.
+ */
+const HashBrownKitContext = React.createContext<ReturnType<
+  typeof useSalesDashboardKit
+> | null>(null);
+
+function useHashBrownKit() {
+  const kit = React.useContext(HashBrownKitContext);
+  if (!kit)
+    throw new Error("useHashBrownKit must be used within HashBrownDashboard");
+  return kit;
+}
+
+export function HashBrownDashboard({ children }: HashBrownDashboardProps) {
+  const kit = useSalesDashboardKit();
+
+  // Note: Agent context forwarding (useAgentContext) for output_schema is
+  // omitted because the npm-published react-core may not export it yet.
+
+  return (
+    <HashBrownKitContext.Provider value={kit}>
+      {children}
+    </HashBrownKitContext.Provider>
+  );
+}
+
+/**
+ * Stable message renderer component that consumes the kit from context.
+ * Defined at module level to avoid unstable function identity.
+ */
+function HashBrownRenderMessage({ message }: LocalRenderMessageProps) {
+  const kit = useHashBrownKit();
+  if (message.role === "assistant") {
+    return (
+      <AssistantMessageRenderer
+        message={message as LocalAssistantMessage}
+        kit={kit}
+      />
+    );
+  }
+  return null;
+}
+
+/**
+ * Returns the stable HashBrownRenderMessage component.
+ * Must be used within a HashBrownDashboard provider.
+ */
+export function useHashBrownMessageRenderer() {
+  return HashBrownRenderMessage;
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/metric-card.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/metric-card.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * MetricCard for the byoc-hashbrown demo (Wave 4a).
+ *
+ * Extracted from showcase/starters/template/frontend/components/renderers/hashbrown/index.tsx
+ * so the hashbrown-renderer can import it as its own module.
+ */
+import React from "react";
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+  trend?: string;
+}
+
+export function MetricCard({ label, value, trend }: MetricCardProps) {
+  const isPositive =
+    trend?.startsWith("+") || trend?.toLowerCase().includes("up");
+  const isNegative =
+    trend?.startsWith("-") || trend?.toLowerCase().includes("down");
+  const trendColor = isPositive
+    ? "text-green-600 dark:text-green-400"
+    : isNegative
+      ? "text-red-600 dark:text-red-400"
+      : "text-[var(--muted-foreground)]";
+
+  return (
+    <div
+      data-testid="metric-card"
+      className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4"
+    >
+      <p className="text-xs text-[var(--muted-foreground)] uppercase tracking-wider font-medium">
+        {label}
+      </p>
+      <p className="text-2xl font-bold text-[var(--foreground)] mt-1">
+        {value}
+      </p>
+      {trend && (
+        <p data-testid="metric-trend" className={`text-sm mt-1 ${trendColor}`}>
+          {trend}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * byoc-hashbrown demo page (Wave 4a).
+ *
+ * Dedicated single-mode demo that ports the starter's hashbrown renderer
+ * onto a langgraph-python agent. Streaming structured output from the agent
+ * (`byoc_hashbrown_agent`) is parsed progressively by `@hashbrownai/react`'s
+ * `useJsonParser` + `useUiKit` and rendered with MetricCard + PieChart +
+ * BarChart from `./charts/`.
+ *
+ * Layout:
+ * - Header with title + short description.
+ * - Chat composer with pre-seeded suggestion pills (via
+ *   `useConfigureSuggestions`). Clicking a pill sends the canned prompt.
+ * - Assistant messages are routed through `HashBrownAssistantMessage` via
+ *   `<CopilotChat messageView={{ assistantMessage: ... }} />`.
+ *
+ * Runtime: dedicated endpoint `/api/copilotkit-byoc-hashbrown` with its own
+ * agent — no bleed into the default runtime.
+ */
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  CopilotChatAssistantMessage,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import {
+  HashBrownDashboard,
+  useHashBrownMessageRenderer,
+} from "./hashbrown-renderer";
+import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
+
+export default function ByocHashbrownDemoPage() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-byoc-hashbrown"
+      agent="byoc-hashbrown-demo"
+    >
+      <HashBrownDashboard>
+        <div className="flex h-screen flex-col gap-3 p-6">
+          <header>
+            <h1 className="text-lg font-semibold">BYOC: Hashbrown</h1>
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Streaming structured output via <code>@hashbrownai/react</code>.
+              The agent emits a catalog- constrained UI envelope that renders
+              progressively as data streams.
+            </p>
+          </header>
+          <div className="flex-1 overflow-hidden rounded-md border border-[var(--border)]">
+            <ChatBody />
+          </div>
+        </div>
+      </HashBrownDashboard>
+    </CopilotKit>
+  );
+}
+
+function ChatBody() {
+  // Pre-seed the composer with canonical prompts that steer the agent toward
+  // hashbrown-shaped output. `useConfigureSuggestions` renders pills inside
+  // the CopilotChat composer; clicking a pill sends its `message` directly.
+  useConfigureSuggestions({
+    suggestions: BYOC_HASHBROWN_SUGGESTIONS.map((s) => ({
+      title: s.label,
+      message: s.prompt,
+      // E2E testid-friendly class — Playwright targets visible text, but we
+      // keep a class hook in case we need finer-grained selectors later.
+      className: `byoc-hashbrown-suggestion-${s.label
+        .toLowerCase()
+        .replace(/\s+/g, "-")}`,
+    })),
+    available: "always",
+  });
+
+  // Resolve the memoized HashBrownRenderMessage component from the kit
+  // provider. It consumes the shared kit via context (see
+  // hashbrown-renderer.tsx) and renders assistant messages as a progressively
+  // assembled UI catalog.
+  const HashBrownMessage = useHashBrownMessageRenderer();
+
+  return (
+    <CopilotChat
+      className="h-full"
+      messageView={{
+        // `HashBrownMessage` matches the RenderMessage slot shape ({ message })
+        // but the v2 assistantMessage slot expects CopilotChatAssistantMessage's
+        // wider props. The cast is intentional — the renderer reads only
+        // `message`, exactly like the starter's page does with `RenderMessage`
+        // on CopilotSidebar.
+        assistantMessage:
+          HashBrownMessage as unknown as typeof CopilotChatAssistantMessage,
+      }}
+    />
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/suggestions.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/suggestions.ts
@@ -1,0 +1,32 @@
+/**
+ * Pre-seeded suggestion prompts for the byoc-hashbrown demo (Wave 4a).
+ *
+ * Each prompt is tuned to steer the agent toward emitting hashbrown-shaped
+ * structured output that the ported renderer (MetricCard + PieChart +
+ * BarChart) can progressively assemble via `@hashbrownai/react`'s `useUiKit`
+ * + `useJsonParser`.
+ */
+export interface Suggestion {
+  /** Short label rendered on the pill + used in data-testid suffix. */
+  label: string;
+  /** Full prompt sent to the agent when the pill is clicked. */
+  prompt: string;
+}
+
+export const BYOC_HASHBROWN_SUGGESTIONS: Suggestion[] = [
+  {
+    label: "Sales dashboard",
+    prompt:
+      "Show me a Q4 sales dashboard. Include a total-revenue metric card (with trend), a pie chart of revenue by segment, and a bar chart of monthly revenue trend.",
+  },
+  {
+    label: "Revenue by category",
+    prompt:
+      "Break down Q4 revenue by product category as a pie chart. Include at least four segments with realistic sample values.",
+  },
+  {
+    label: "Expense trend",
+    prompt:
+      "Show me monthly operating expenses for the last six months as a bar chart with one bar per month.",
+  },
+];

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/types.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Local types for the byoc-hashbrown demo (Wave 4a).
+ *
+ * Ported subset from showcase/starters/template/frontend/types.ts — only the
+ * domain types the hashbrown renderer's DealCard needs.
+ */
+export const SALES_STAGES = [
+  "prospect",
+  "qualified",
+  "proposal",
+  "negotiation",
+  "closed-won",
+  "closed-lost",
+] as const;
+
+export type SalesStage = (typeof SALES_STAGES)[number];

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/catalog.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/catalog.ts
@@ -1,0 +1,55 @@
+/**
+ * json-render catalog for the byoc-json-render demo.
+ *
+ * Reuses the prebuilt React schema exposed by `@json-render/react/schema`
+ * (flat element tree: `{ root, elements }`) because the React renderer
+ * we ship is `@json-render/react`'s `<Renderer />`, which expects that
+ * exact shape.
+ *
+ * Declares three components (MetricCard, BarChart, PieChart) matching
+ * the byoc-hashbrown catalog so the two BYOC demos are directly
+ * comparable. No actions — this is a read-only rendering demo.
+ */
+
+import { defineCatalog } from "@json-render/core";
+import { schema } from "@json-render/react/schema";
+import { z } from "zod";
+
+/** Numeric data point used by both bar and pie charts. */
+const dataPoint = z.object({
+  label: z.string(),
+  value: z.number(),
+});
+
+export const catalog = defineCatalog(schema, {
+  components: {
+    MetricCard: {
+      props: z.object({
+        label: z.string(),
+        value: z.string(),
+        trend: z.string().nullable(),
+      }),
+      description:
+        "A labelled metric (single number) with an optional trend subtitle",
+    },
+    BarChart: {
+      props: z.object({
+        title: z.string(),
+        description: z.string().nullable(),
+        data: z.array(dataPoint),
+      }),
+      description:
+        "A vertical bar chart for comparing discrete values side by side",
+    },
+    PieChart: {
+      props: z.object({
+        title: z.string(),
+        description: z.string().nullable(),
+        data: z.array(dataPoint),
+      }),
+      description:
+        "A donut-style pie chart for breaking a total down into category slices",
+    },
+  },
+  actions: {},
+});

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/charts/bar-chart.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/charts/bar-chart.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useRef } from "react";
+import {
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Rectangle,
+} from "recharts";
+import { CHART_COLORS, CHART_CONFIG } from "./chart-config";
+
+export interface BarChartDatum {
+  label: string;
+  value: number;
+}
+
+export interface BarChartComponentProps {
+  title: string;
+  /** Optional subtitle — json-render catalog emits a nullable string. */
+  description?: string | null;
+  data: BarChartDatum[];
+}
+
+/** Tracks seen indices so only NEW bars get the fade-in animation. */
+function useSeenIndices() {
+  const seen = useRef(new Set<number>());
+  return {
+    isNew(index: number) {
+      if (seen.current.has(index)) return false;
+      seen.current.add(index);
+      return true;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function AnimatedBar(props: any) {
+  const { isNew, ...rest } = props;
+  return (
+    <g
+      style={
+        isNew
+          ? {
+              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
+            }
+          : undefined
+      }
+    >
+      <Rectangle {...rest} />
+    </g>
+  );
+}
+
+export function BarChart({ title, description, data }: BarChartComponentProps) {
+  const { isNew } = useSeenIndices();
+
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return (
+      <div
+        data-testid="bar-chart"
+        className="max-w-2xl mx-auto my-4 rounded-lg border border-[var(--border)] bg-[var(--card)]"
+      >
+        <div className="p-6">
+          <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+            {title}
+          </h3>
+          {description ? (
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        <div className="p-6 pt-0">
+          <p className="text-[var(--muted-foreground)] text-center py-8 text-sm">
+            No data available
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="bar-chart"
+      className="max-w-2xl mx-auto my-4 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]"
+    >
+      <style>{`
+        @keyframes barSlideIn {
+          from { transform: translateY(40px); opacity: 0; }
+          20% { opacity: 1; }
+          to { transform: translateY(0); opacity: 1; }
+        }
+      `}</style>
+      <div className="p-6 pb-2">
+        <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+          {title}
+        </h3>
+        {description ? (
+          <p className="text-sm text-[var(--muted-foreground)]">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      <div className="p-6 pt-2">
+        <ResponsiveContainer width="100%" height={280}>
+          <RechartsBarChart
+            data={data}
+            margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--border)"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              stroke="var(--border)"
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              stroke="var(--border)"
+              tickLine={false}
+              axisLine={false}
+            />
+            <Tooltip
+              contentStyle={CHART_CONFIG.tooltipStyle}
+              cursor={{ fill: "var(--secondary)", opacity: 0.5 }}
+            />
+            <Bar
+              isAnimationActive={false}
+              dataKey="value"
+              radius={[6, 6, 0, 0]}
+              maxBarSize={48}
+              shape={(props: unknown) => {
+                const p = props as Record<string, unknown>;
+                return <AnimatedBar {...p} isNew={isNew(p.index as number)} />;
+              }}
+            >
+              {data.map((_, index) => (
+                <Cell
+                  key={index}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                />
+              ))}
+            </Bar>
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/charts/chart-config.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/charts/chart-config.ts
@@ -1,0 +1,27 @@
+/**
+ * CopilotKit brand chart palette. Ported verbatim from the byoc-hashbrown
+ * demo (which ported it from `showcase/starters/template/frontend/components/charts/chart-config.ts`)
+ * so the two BYOC rows use the same colors.
+ */
+export const CHART_COLORS = [
+  "#BEC2FF", // lilac-400
+  "#85ECCE", // mint-400
+  "#FFAC4D", // orange-400
+  "#FFF388", // yellow-400
+  "#189370", // mint-800
+  "#EEE6FE", // primary-100
+  "#FA5F67", // red-400
+] as const;
+
+export const CHART_CONFIG = {
+  tooltipStyle: {
+    backgroundColor: "var(--card)",
+    border: "1px solid var(--border)",
+    borderRadius: "10px",
+    padding: "10px 14px",
+    color: "var(--foreground)",
+    fontSize: "13px",
+    fontFamily: "var(--font-body)",
+    boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+  },
+};

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/charts/pie-chart.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/charts/pie-chart.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { CHART_COLORS } from "./chart-config";
+
+export interface PieChartDatum {
+  label: string;
+  value: number;
+}
+
+export interface PieChartComponentProps {
+  title: string;
+  /** Optional subtitle — json-render catalog emits a nullable string. */
+  description?: string | null;
+  data: PieChartDatum[];
+}
+
+/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
+function DonutChart({
+  data,
+  size = 240,
+  strokeWidth = 40,
+}: {
+  data: PieChartDatum[];
+  size?: number;
+  strokeWidth?: number;
+}) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+
+  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+  let accumulated = 0;
+  const slices = data.map((item, index) => {
+    const val = Number(item.value) || 0;
+    const ratio = total > 0 ? val / total : 0;
+    const arc = ratio * circumference;
+    const startAt = accumulated;
+    accumulated += arc;
+    return {
+      ...item,
+      arc,
+      gap: circumference - arc,
+      dashoffset: -startAt,
+      color: CHART_COLORS[index % CHART_COLORS.length],
+    };
+  });
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${size} ${size}`}
+      className="block mx-auto"
+      style={{ maxWidth: size, transform: "scaleX(-1)" }}
+    >
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke="var(--secondary)"
+        strokeWidth={strokeWidth}
+      />
+      {slices.map((slice, i) => (
+        <circle
+          key={i}
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={slice.color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={`${slice.arc} ${slice.gap}`}
+          strokeDashoffset={slice.dashoffset}
+          strokeLinecap="butt"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export function PieChart({ title, description, data }: PieChartComponentProps) {
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return (
+      <div
+        data-testid="pie-chart"
+        className="max-w-lg mx-auto my-4 rounded-lg border border-[var(--border)] bg-[var(--card)]"
+      >
+        <div className="p-6 pb-0">
+          <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+            {title}
+          </h3>
+          {description ? (
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        <div className="p-6">
+          <p className="text-[var(--muted-foreground)] text-center py-8 text-sm">
+            No data available
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+
+  return (
+    <div
+      data-testid="pie-chart"
+      className="max-w-lg mx-auto my-4 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]"
+    >
+      <div className="p-6 pb-0">
+        <h3 className="text-lg font-semibold leading-none tracking-tight text-[var(--foreground)]">
+          {title}
+        </h3>
+        {description ? (
+          <p className="text-sm text-[var(--muted-foreground)]">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      <div className="p-6 pt-4">
+        <DonutChart data={data} />
+        <div className="space-y-2 pt-4">
+          {data.map((item, index) => {
+            const val = Number(item.value) || 0;
+            const pct = total > 0 ? ((val / total) * 100).toFixed(0) : 0;
+            return (
+              <div
+                key={index}
+                className="flex items-center gap-3 text-sm transition-opacity duration-300 ease-out"
+                style={{ opacity: 1 }}
+              >
+                <span
+                  className="inline-block h-3 w-3 rounded-full shrink-0"
+                  style={{
+                    backgroundColor: CHART_COLORS[index % CHART_COLORS.length],
+                  }}
+                />
+                <span className="flex-1 text-[var(--foreground)] truncate">
+                  {item.label}
+                </span>
+                <span className="text-[var(--muted-foreground)] tabular-nums">
+                  {val.toLocaleString()}
+                </span>
+                <span className="text-[var(--muted-foreground)] text-sm w-10 text-right tabular-nums">
+                  {pct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/json-render-renderer.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/json-render-renderer.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+/**
+ * Custom `messageView.assistantMessage` slot that renders the agent's
+ * structured-JSON output through `@json-render/react`.
+ *
+ * The langgraph-python `byoc_json_render_agent` emits a single JSON object
+ * shaped like `@json-render/react`'s flat spec format:
+ *
+ * ```json
+ * {
+ *   "root": "<id>",
+ *   "elements": {
+ *     "<id>": { "type": "MetricCard" | "BarChart" | "PieChart", "props": { ... } }
+ *   }
+ * }
+ * ```
+ *
+ * While the agent streams, the content is often a partial/invalid JSON
+ * string — we fall back to the default CopilotChatAssistantMessage which
+ * shows the raw streaming text. Once the content parses AND every
+ * referenced element type is in the catalog, we swap to the json-render
+ * Renderer + our catalog-backed registry (see `registry.tsx`).
+ *
+ * Streaming-model decision (R2 in the spec): `@json-render/core`'s
+ * SpecStream compiler consumes JSONL patches, but our agent emits a
+ * single JSON object, not patches. We buffer until the content is valid
+ * JSON, then render — losing progressive in-JSON rendering but gaining
+ * correct behaviour against the agent's actual output shape.
+ */
+
+import React, { useMemo } from "react";
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+import type { CopilotChatAssistantMessageProps } from "@copilotkit/react-core/v2";
+import { JSONUIProvider, Renderer } from "@json-render/react";
+import { registry } from "./registry";
+import type { JsonRenderSpec } from "./types";
+
+// Allowed component types per the catalog (see ./catalog.ts). Kept in sync
+// manually rather than derived from the catalog object, because the agent
+// output may contain stray tokens while streaming and we want a defensive
+// allowlist here too.
+const ALLOWED_TYPES = new Set(["MetricCard", "BarChart", "PieChart"]);
+
+export function JsonRenderAssistantMessage(
+  props: CopilotChatAssistantMessageProps,
+) {
+  const content =
+    typeof props.message.content === "string" ? props.message.content : "";
+
+  const parseResult = useMemo(() => parseSpec(content), [content]);
+
+  // Still streaming or not valid spec yet — fall through to the default
+  // assistant-message chrome (renders the raw text via Streamdown). This
+  // keeps the bubble visually consistent during streaming, and if the
+  // agent replied with plain text (e.g. an unprompted free-form answer)
+  // we still render it sensibly.
+  if (!parseResult.ok) {
+    return <CopilotChatAssistantMessage {...props} />;
+  }
+
+  // Valid spec — render via json-render. `<Renderer />` alone does not
+  // set up the StateProvider / VisibilityProvider / ActionProvider /
+  // ValidationProvider contexts its `ElementRenderer` requires (it would
+  // crash with `useVisibility must be used within a VisibilityProvider`).
+  // `JSONUIProvider` wires all four in one; we don't use actions or
+  // state here, so defaults are fine.
+  return (
+    <div data-testid="json-render-root" className="w-full">
+      <JSONUIProvider registry={registry}>
+        <Renderer
+          spec={
+            parseResult.spec as unknown as Parameters<
+              typeof Renderer
+            >[0]["spec"]
+          }
+          registry={registry}
+        />
+      </JSONUIProvider>
+    </div>
+  );
+}
+
+interface ParseOk {
+  ok: true;
+  spec: JsonRenderSpec;
+}
+
+interface ParseFail {
+  ok: false;
+  reason: "empty" | "invalid-json" | "wrong-shape" | "unknown-type";
+}
+
+type ParseResult = ParseOk | ParseFail;
+
+/**
+ * Parse the assistant message content into a json-render spec.
+ *
+ * Tolerates:
+ * - code-fenced JSON (```json ... ```)
+ * - leading/trailing prose around the JSON object
+ * - partial streams (returns `invalid-json` silently)
+ */
+function parseSpec(raw: string): ParseResult {
+  if (!raw || !raw.trim()) return { ok: false, reason: "empty" };
+
+  const jsonText = extractJsonObject(raw);
+  if (!jsonText) return { ok: false, reason: "invalid-json" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return { ok: false, reason: "invalid-json" };
+  }
+
+  if (!isRecord(parsed)) return { ok: false, reason: "wrong-shape" };
+  const root = (parsed as { root?: unknown }).root;
+  const elements = (parsed as { elements?: unknown }).elements;
+  if (typeof root !== "string" || !isRecord(elements)) {
+    return { ok: false, reason: "wrong-shape" };
+  }
+  if (!(root in (elements as Record<string, unknown>))) {
+    return { ok: false, reason: "wrong-shape" };
+  }
+
+  for (const [, el] of Object.entries(elements as Record<string, unknown>)) {
+    if (!isRecord(el)) return { ok: false, reason: "wrong-shape" };
+    const type = (el as { type?: unknown }).type;
+    if (typeof type !== "string" || !ALLOWED_TYPES.has(type)) {
+      return { ok: false, reason: "unknown-type" };
+    }
+    const elProps = (el as { props?: unknown }).props;
+    if (elProps !== undefined && !isRecord(elProps)) {
+      return { ok: false, reason: "wrong-shape" };
+    }
+  }
+
+  return { ok: true, spec: parsed as unknown as JsonRenderSpec };
+}
+
+/** Strip code fences and find the first balanced JSON object. */
+function extractJsonObject(raw: string): string | null {
+  const fenceMatch = /```(?:json)?\s*([\s\S]*?)```/i.exec(raw);
+  const candidate = (fenceMatch ? fenceMatch[1] : raw).trim();
+  if (!candidate) return null;
+
+  const start = candidate.indexOf("{");
+  if (start === -1) return null;
+
+  // Walk balanced braces, respecting strings and escapes.
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < candidate.length; i++) {
+    const ch = candidate[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return candidate.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/metric-card.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/metric-card.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { MetricCardTrendDirection } from "./types";
+
+export interface MetricCardComponentProps {
+  label: string;
+  value: string;
+  /** Optional trend copy, e.g. "+12% vs last quarter". */
+  trend?: string | null;
+  /** Optional trend direction hint, drives the colored badge. */
+  trendDirection?: MetricCardTrendDirection | null;
+}
+
+/**
+ * Presentational metric card used by the json-render catalog.
+ *
+ * The component is intentionally self-contained — the catalog shape
+ * (`{ label, value, trend }`) mirrors Wave 4a's hashbrown MetricCard
+ * so the two BYOC demos are directly comparable.
+ */
+export function MetricCard({
+  label,
+  value,
+  trend,
+  trendDirection,
+}: MetricCardComponentProps) {
+  const resolvedDirection =
+    trendDirection ?? inferTrendDirection(trend ?? null);
+
+  return (
+    <div
+      data-testid="metric-card"
+      className="max-w-xs mx-auto my-3 rounded-lg border border-[var(--border)] bg-[var(--card)] p-5"
+    >
+      <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+        {label}
+      </div>
+      <div className="mt-1 text-3xl font-semibold tabular-nums text-[var(--foreground)]">
+        {value}
+      </div>
+      {trend ? (
+        <div
+          className={`mt-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${badgeClass(
+            resolvedDirection,
+          )}`}
+        >
+          {trend}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function inferTrendDirection(trend: string | null): MetricCardTrendDirection {
+  if (!trend) return "neutral";
+  const normalized = trend.trim();
+  if (normalized.startsWith("+")) return "up";
+  if (normalized.startsWith("-") || normalized.startsWith("−")) {
+    return "down";
+  }
+  return "neutral";
+}
+
+function badgeClass(direction: MetricCardTrendDirection): string {
+  switch (direction) {
+    case "up":
+      return "bg-[color-mix(in_oklab,var(--primary)_15%,transparent)] text-[var(--primary)]";
+    case "down":
+      return "bg-[color-mix(in_oklab,var(--destructive)_15%,transparent)] text-[var(--destructive)]";
+    case "neutral":
+    default:
+      return "bg-[var(--secondary)] text-[var(--muted-foreground)]";
+  }
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * BYOC json-render demo.
+ *
+ * Scenario: user asks for a sales-dashboard-style UI; the LangGraph agent
+ * emits a JSON spec shaped like `{ root, elements }`, and `@json-render/react`
+ * renders it against a Zod-validated catalog of three components
+ * (MetricCard, BarChart, PieChart).
+ *
+ * Structurally mirrors Wave 4a's hashbrown demo so the two dashboard rows
+ * are directly comparable — the only substantive difference is the message
+ * renderer (this file swaps in `JsonRenderAssistantMessage`).
+ */
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  CopilotChatAssistantMessage,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { JsonRenderAssistantMessage } from "./json-render-renderer";
+import { BYOC_JSON_RENDER_SUGGESTIONS } from "./suggestions";
+
+const AGENT_ID = "byoc_json_render";
+
+export default function ByocJsonRenderDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  useConfigureSuggestions({
+    suggestions: BYOC_JSON_RENDER_SUGGESTIONS.map((s) => ({
+      title: s.label,
+      message: s.prompt,
+    })),
+    available: "always",
+  });
+
+  // `messageView.assistantMessage` replaces CopilotChat's default assistant
+  // bubble. The cast mirrors the pattern used in `demos/chat-slots/page.tsx`
+  // — the slot's prop shape is identical to `CopilotChatAssistantMessage`'s,
+  // but TypeScript can't prove that through the WithSlots indirection.
+  const messageView = {
+    assistantMessage:
+      JsonRenderAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
+  };
+
+  return (
+    <CopilotChat
+      agentId={AGENT_ID}
+      className="h-full rounded-2xl"
+      messageView={messageView}
+    />
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/registry.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/registry.tsx
@@ -1,0 +1,52 @@
+/**
+ * Bridges the byoc-json-render catalog to concrete React components.
+ *
+ * `defineRegistry` returns a `registry` object that `@json-render/react`'s
+ * `<Renderer />` consumes. Each entry is a component function receiving
+ * `{ props, children }` — props are already validated + typed by the Zod
+ * schemas declared in `./catalog.ts`.
+ *
+ * Factored out of `json-render-renderer.tsx` so the registry is built
+ * exactly once at module scope (`defineRegistry` snapshots the catalog
+ * reference; rebuilding it per render would churn `<Renderer />`'s
+ * internal memoization unnecessarily).
+ */
+
+import { defineRegistry } from "@json-render/react";
+import { catalog } from "./catalog";
+import { MetricCard } from "./metric-card";
+import { BarChart } from "./charts/bar-chart";
+import { PieChart } from "./charts/pie-chart";
+
+export const { registry } = defineRegistry(catalog, {
+  components: {
+    // The agent's system prompt includes a worked example where a MetricCard
+    // is the root of a sales dashboard with a BarChart nested in its
+    // `children` array. Forward `children` through so that multi-component
+    // dashboards render as one wrapped block rather than dropping the chart.
+    MetricCard: ({ props, children }) => (
+      <div className="flex w-full flex-col items-stretch gap-3">
+        <MetricCard
+          label={props.label}
+          value={props.value}
+          trend={props.trend}
+        />
+        {children}
+      </div>
+    ),
+    BarChart: ({ props }) => (
+      <BarChart
+        title={props.title}
+        description={props.description}
+        data={props.data}
+      />
+    ),
+    PieChart: ({ props }) => (
+      <PieChart
+        title={props.title}
+        description={props.description}
+        data={props.data}
+      />
+    ),
+  },
+});

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/suggestions.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/suggestions.ts
@@ -1,0 +1,28 @@
+/**
+ * Suggestion prompts for the byoc-json-render demo.
+ *
+ * These match the byoc-hashbrown demo's prompts verbatim so the two
+ * demos can be compared side-by-side.
+ */
+
+export interface Suggestion {
+  /** Short label shown on the pill. */
+  label: string;
+  /** Full prompt text sent to the agent when the pill is clicked. */
+  prompt: string;
+}
+
+export const BYOC_JSON_RENDER_SUGGESTIONS: Suggestion[] = [
+  {
+    label: "Sales dashboard",
+    prompt: "Show me the sales dashboard with metrics and a revenue chart",
+  },
+  {
+    label: "Revenue by category",
+    prompt: "Break down revenue by category as a pie chart",
+  },
+  {
+    label: "Expense trend",
+    prompt: "Show me monthly expenses as a bar chart",
+  },
+];

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/types.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared types for the byoc-json-render demo catalog.
+ *
+ * Mirrors the byoc-hashbrown catalog shape so the two BYOC demos are
+ * directly comparable; the difference is purely in the rendering
+ * technology.
+ */
+
+export type MetricCardTrendDirection = "up" | "down" | "neutral";
+
+/**
+ * Shape of the streaming JSON spec emitted by the agent. Matches
+ * `@json-render/react`'s Spec contract: a flat `elements` map keyed by
+ * id, with one designated `root` id.
+ */
+export interface JsonRenderElement {
+  type: string;
+  props: Record<string, unknown>;
+  children?: string[];
+}
+
+export interface JsonRenderSpec {
+  root: string;
+  elements: Record<string, JsonRenderElement>;
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+// Chat Customization (CSS) — all theming lives in theme.css, scoped to the
+// `.chat-css-demo-scope` wrapper. The page stays intentionally minimal;
+// only <CopilotChat /> is visibly re-themed.
+//
+// https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
+
+import React from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
+import "./theme.css";
+// @endregion[theme-css-import]
+
+export default function ChatCustomizationCssDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="chat-css-demo-scope h-full w-full max-w-4xl">
+          <CopilotChat
+            agentId="chat-customization-css"
+            className="h-full rounded-2xl"
+          />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/theme.css
@@ -1,0 +1,102 @@
+/* Scoped theme for the chat-customization-css demo.
+ * All selectors are prefixed with `.chat-css-demo-scope` so they do not
+ * leak out and affect the rest of the showcase app.
+ *
+ * Targets the CopilotKit built-in classes documented at
+ * https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
+ */
+
+/* @region[css-variables] */
+/* CopilotKit CSS variable overrides (accent colors, etc.) */
+.chat-css-demo-scope {
+  --copilot-kit-primary-color: #ff006e;
+  --copilot-kit-contrast-color: #ffffff;
+  --copilot-kit-background-color: #fff8f0;
+  --copilot-kit-input-background-color: #fef3c7;
+  --copilot-kit-secondary-color: #fde047;
+  --copilot-kit-secondary-contrast-color: #2c1810;
+  --copilot-kit-separator-color: #ff006e;
+  --copilot-kit-muted-color: #c2185b;
+}
+/* @endregion[css-variables] */
+
+/* Messages container – swap the font for the entire chat */
+.chat-css-demo-scope .copilotKitMessages {
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  background-color: #fff8f0;
+  color: #2c1810;
+  padding: 1.5rem 0;
+}
+
+/* User message bubble – hot pink, bold white serif text, large */
+.chat-css-demo-scope .copilotKitMessage.copilotKitUserMessage {
+  background: linear-gradient(135deg, #ff006e 0%, #c2185b 100%);
+  color: #ffffff;
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding: 14px 20px;
+  border-radius: 22px 22px 4px 22px;
+  box-shadow: 0 6px 16px rgba(255, 0, 110, 0.35);
+  border: 2px solid #ff6fa5;
+  letter-spacing: 0.01em;
+}
+
+/* Assistant message bubble – amber, monospace, boxy, dark text */
+.chat-css-demo-scope .copilotKitMessage.copilotKitAssistantMessage {
+  background: #fde047;
+  color: #1e1b4b;
+  font-family:
+    "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 1rem;
+  padding: 16px 20px;
+  border-radius: 4px 22px 22px 22px;
+  border: 2px solid #1e1b4b;
+  box-shadow: 4px 4px 0 #1e1b4b;
+  max-width: 80%;
+  margin-right: auto;
+  margin-bottom: 1rem;
+}
+
+/* Make markdown inside assistant bubble inherit our theme */
+.chat-css-demo-scope
+  .copilotKitMessage.copilotKitAssistantMessage
+  .copilotKitMarkdown,
+.chat-css-demo-scope
+  .copilotKitMessage.copilotKitAssistantMessage
+  .copilotKitMarkdown
+  p,
+.chat-css-demo-scope .copilotKitMessage.copilotKitAssistantMessage p {
+  color: #1e1b4b;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+/* Input area – themed border and font */
+.chat-css-demo-scope .copilotKitInput {
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  background-color: #fef3c7;
+  border: 3px dashed #ff006e;
+  border-radius: 18px;
+  padding: 16px 18px;
+  min-height: 80px;
+}
+
+.chat-css-demo-scope .copilotKitInput > textarea {
+  font-family: "Georgia", "Cambria", "Times New Roman", serif;
+  font-size: 1.1rem;
+  color: #2c1810;
+}
+
+.chat-css-demo-scope .copilotKitInput > textarea::placeholder {
+  color: #c2185b;
+  font-style: italic;
+}
+
+.chat-css-demo-scope .copilotKitInputContainer {
+  background: #fff8f0;
+}
+
+.chat-css-demo-scope .copilotKitChat {
+  background-color: #fff8f0;
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/custom-assistant-message.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/custom-assistant-message.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+import type { CopilotChatAssistantMessageProps } from "@copilotkit/react-core/v2";
+
+// Custom assistantMessage sub-slot of messageView — wraps the default assistant
+// message in a visibly tinted card with a corner "slot" badge, proving the slot
+// override is active during the in-chat message flow (not just the welcome screen).
+export function CustomAssistantMessage(
+  props: CopilotChatAssistantMessageProps,
+) {
+  return (
+    <div
+      data-testid="custom-assistant-message"
+      className="relative rounded-xl border border-indigo-200 bg-indigo-50/60 dark:bg-indigo-950/40 dark:border-indigo-800 p-3 my-3"
+    >
+      <span className="absolute -top-2 -left-2 inline-block rounded-full bg-indigo-600 text-white text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 shadow">
+        slot
+      </span>
+      <CopilotChatAssistantMessage {...props} />
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/custom-disclaimer.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/custom-disclaimer.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+
+// Custom disclaimer sub-slot of the input — visibly tagged so reviewers can
+// tell the slot is in use even once the welcome screen is dismissed.
+export function CustomDisclaimer(props: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      {...props}
+      data-testid="custom-disclaimer"
+      className="text-xs text-center text-muted-foreground py-2"
+    >
+      <span className="inline-block rounded bg-indigo-100 text-indigo-700 px-2 py-0.5 mr-2 font-semibold">
+        slot
+      </span>
+      Custom disclaimer injected via <code>input.disclaimer</code>.
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/custom-welcome-screen.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/custom-welcome-screen.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React from "react";
+
+// Custom welcomeScreen slot — a visibly distinct gradient card wrapping the
+// default input + suggestions props passed in by CopilotChatView.
+export function CustomWelcomeScreen({
+  input,
+  suggestionView,
+}: {
+  input: React.ReactElement;
+  suggestionView: React.ReactElement;
+}) {
+  return (
+    <div
+      data-testid="custom-welcome-screen"
+      className="flex-1 flex flex-col items-center justify-center px-4"
+    >
+      <div className="w-full max-w-3xl flex flex-col items-center">
+        <div className="mb-6 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 p-6 text-white shadow-lg text-center">
+          <div className="inline-block rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wider mb-3">
+            Custom Slot
+          </div>
+          <h1 className="text-2xl font-bold">Welcome to the Slots demo</h1>
+          <p className="mt-2 text-sm text-white/90">
+            This welcome card is rendered via the{" "}
+            <code className="font-mono">welcomeScreen</code> slot.
+          </p>
+        </div>
+        <div className="w-full">{input}</div>
+        <div className="mt-4 flex justify-center">{suggestionView}</div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  CopilotChatAssistantMessage,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CustomWelcomeScreen } from "./custom-welcome-screen";
+import { CustomAssistantMessage } from "./custom-assistant-message";
+import { CustomDisclaimer } from "./custom-disclaimer";
+
+// Outer layer — provider + layout chrome.
+export default function ChatSlotsDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+// The actual view — just the chat, with two slot overrides.
+function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+      { title: "Tell me a joke", message: "Tell me a short joke." },
+    ],
+    available: "always",
+  });
+
+  // Each slot is wired in as a prop on <CopilotChat>. Extracting the
+  // overrides up here keeps the JSX readable and gives the docs something
+  // to point at with `@region` markers for the slot system guide.
+  // @region[register-welcome-slot]
+  const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
+  const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
+  const messageView = {
+    assistantMessage:
+      CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
+  };
+  // @endregion[register-assistant-message-slot]
+
+  return (
+    <CopilotChat
+      agentId="chat-slots"
+      className="h-full rounded-2xl"
+      welcomeScreen={welcomeScreen}
+      input={input}
+      messageView={messageView}
+    />
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/notes-card.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/notes-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React from "react";
+
+export interface Note {
+  id: string;
+  title: string;
+  excerpt: string;
+  tags?: string[];
+}
+
+export interface NotesCardProps {
+  loading: boolean;
+  keyword: string;
+  notes?: Note[];
+}
+
+/**
+ * Branded card rendering the client-side "notes DB query" result.
+ * Mirrors the per-tool render path used by other tool-rendering cells —
+ * but the `notes` array is awaited from an async handler living entirely
+ * in the browser (no backend tool involved).
+ */
+export function NotesCard({ loading, keyword, notes }: NotesCardProps) {
+  return (
+    <div
+      data-testid="notes-card"
+      className="rounded-2xl mt-4 mb-4 max-w-md w-full bg-white border border-[#DBDBE5] shadow-sm"
+    >
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B] mb-1">
+              Notes DB
+            </div>
+            <h3
+              data-testid="notes-keyword"
+              className="text-base font-semibold text-[#010507]"
+            >
+              Matching &ldquo;{keyword}&rdquo;
+            </h3>
+            <p className="text-[#57575B] text-xs mt-0.5">
+              {loading
+                ? "Querying local notes DB..."
+                : `${notes?.length ?? 0} match${(notes?.length ?? 0) === 1 ? "" : "es"}`}
+            </p>
+          </div>
+          <div className="text-xl" aria-hidden>
+            {loading ? "..." : "📓"}
+          </div>
+        </div>
+
+        {!loading && notes && notes.length > 0 && (
+          <ul
+            data-testid="notes-list"
+            className="mt-4 pt-4 border-t border-[#E9E9EF] space-y-2 text-sm"
+          >
+            {notes.map((n) => (
+              <li
+                key={n.id}
+                data-testid={`note-${n.id}`}
+                className="rounded-xl border border-[#E9E9EF] bg-[#FAFAFC] p-2.5"
+              >
+                <p className="font-medium text-[#010507]">{n.title}</p>
+                <p className="text-[#57575B] text-xs mt-0.5">{n.excerpt}</p>
+                {n.tags && n.tags.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {n.tags.map((t) => (
+                      <span
+                        key={t}
+                        className="text-[10px] font-medium uppercase tracking-[0.1em] bg-white border border-[#DBDBE5] text-[#57575B] rounded-full px-1.5 py-0.5"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {!loading && (!notes || notes.length === 0) && (
+          <p className="mt-4 pt-4 border-t border-[#E9E9EF] text-sm text-[#838389] italic">
+            No notes matched.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import React from "react";
+import {
+  useFrontendTool,
+  useConfigureSuggestions,
+  CopilotChat,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { z } from "zod";
+import { NotesCard, type Note } from "./notes-card";
+
+// Fake client-side "notes database" — populated inline for demo. The async
+// handler awaits a 500ms simulated DB round-trip so the async frontend-tool
+// path is exercised faithfully.
+const NOTES_DB: Note[] = [
+  {
+    id: "n1",
+    title: "Q2 project planning kickoff",
+    excerpt:
+      "Discussed scope for the new onboarding flow with design. Draft spec due Friday.",
+    tags: ["planning", "project", "onboarding"],
+  },
+  {
+    id: "n2",
+    title: "Planning: migrate auth to passkeys",
+    excerpt:
+      "Research WebAuthn library options. Consider fallback for unsupported browsers.",
+    tags: ["planning", "auth", "security"],
+  },
+  {
+    id: "n3",
+    title: "Grocery list",
+    excerpt: "Olive oil, tomatoes, sourdough, basil, parmesan.",
+    tags: ["personal", "shopping"],
+  },
+  {
+    id: "n4",
+    title: "Book recommendations",
+    excerpt:
+      "Thinking Fast and Slow (Kahneman); The Design of Everyday Things (Norman).",
+    tags: ["reading"],
+  },
+  {
+    id: "n5",
+    title: "Project planning retrospective notes",
+    excerpt:
+      "What went well: async standups. What didn't: ambiguous ownership on shared components.",
+    tags: ["retro", "project", "planning"],
+  },
+  {
+    id: "n6",
+    title: "Weekend hike plan",
+    excerpt: "Tam West Peak → Rock Spring. 8mi loop, bring layers.",
+    tags: ["personal", "outdoors"],
+  },
+  {
+    id: "n7",
+    title: "1:1 prep — career planning",
+    excerpt: "Discuss growth areas. Ask about scope for Q3. Revisit goals doc.",
+    tags: ["career", "planning"],
+  },
+];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
+export default function FrontendToolsAsyncDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  useFrontendTool({
+    name: "query_notes",
+    description:
+      "Search the user's local notes database for notes whose title, " +
+      "excerpt, or tags contain the given keyword (case-insensitive). " +
+      "Returns up to 5 matching notes.",
+    parameters: z.object({
+      keyword: z
+        .string()
+        .describe("Keyword or phrase to search notes for (case-insensitive)."),
+    }),
+    handler: async ({ keyword }: { keyword: string }) => {
+      await sleep(500);
+      const q = keyword.toLowerCase();
+      const matches = NOTES_DB.filter((n) => {
+        return (
+          n.title.toLowerCase().includes(q) ||
+          n.excerpt.toLowerCase().includes(q) ||
+          (n.tags ?? []).some((t) => t.toLowerCase().includes(q))
+        );
+      }).slice(0, 5);
+      return {
+        keyword,
+        count: matches.length,
+        notes: matches,
+      };
+    },
+    render: ({ args, result, status }) => {
+      const loading = status !== "complete";
+      const parsed = parseJsonResult<{
+        keyword?: string;
+        count?: number;
+        notes?: Note[];
+      }>(result);
+      return (
+        <NotesCard
+          loading={loading}
+          keyword={args?.keyword ?? parsed.keyword ?? ""}
+          notes={parsed.notes}
+        />
+      );
+    },
+  });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Find project-planning notes",
+        message: "Find my notes about project planning.",
+      },
+      {
+        title: "Search for 'auth'",
+        message: "Search my notes for anything related to auth.",
+      },
+      {
+        title: "What do I have about reading?",
+        message: "Do I have any notes tagged reading?",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <CopilotChat
+      agentId="frontend-tools-async"
+      className="h-full rounded-2xl"
+    />
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  useFrontendTool,
+  useConfigureSuggestions,
+  CopilotChat,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { z } from "zod";
+
+export default function FrontendToolsDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools">
+      <Chat />
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  const [background, setBackground] = useState<string>(
+    "var(--copilot-kit-background-color)",
+  );
+
+  useFrontendTool({
+    name: "change_background",
+    description:
+      "Change the background color of the chat. Accepts any valid CSS background value — colors, linear or radial gradients, etc.",
+    parameters: z.object({
+      background: z
+        .string()
+        .describe("The CSS background value. Prefer gradients."),
+    }),
+    handler: async ({ background }: { background: string }) => {
+      setBackground(background);
+      return {
+        status: "success",
+        message: `Background changed to ${background}`,
+      };
+    },
+  });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Change background",
+        message: "Change the background to a blue-to-purple gradient.",
+      },
+      {
+        title: "Sunset theme",
+        message: "Make the background a sunset-themed gradient.",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <div
+      className="flex justify-center items-center h-screen w-full"
+      data-testid="background-container"
+      style={{ background }}
+    >
+      <div className="h-full w-full max-w-4xl">
+        <CopilotChat agentId="frontend-tools" className="h-full rounded-2xl" />
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/assistant-bubble.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/assistant-bubble.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Left-aligned assistant bubble — pure chrome.
+ *
+ * Receives a precomputed `renderedContent` node (built by
+ * `useRenderedMessages`) and wraps it in the styled bubble container.
+ * No imports from `@copilotkit/react-core`'s chat primitives here — the
+ * manual composition upstream already produced the final node, so this
+ * file is purely presentational.
+ *
+ * An empty node (e.g. an assistant message that has neither text nor tool
+ * calls yet) is suppressed so the bubble doesn't flash an empty rounded
+ * box while streaming hasn't started.
+ */
+// @region[custom-bubbles]
+export function AssistantBubble({ children }: { children: React.ReactNode }) {
+  if (isEmpty(children)) return null;
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] flex flex-col gap-2">
+        <div className="rounded-2xl rounded-bl-sm bg-[#F0F0F4] text-[#010507] px-4 py-2 text-sm">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+// @endregion[custom-bubbles]
+
+function isEmpty(node: React.ReactNode): boolean {
+  if (node == null || node === false) return true;
+  if (typeof node === "string") return node.trim().length === 0;
+  if (Array.isArray(node)) return node.every(isEmpty);
+  return false;
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/highlight-note.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/highlight-note.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import { z } from "zod";
+
+/**
+ * Frontend-only component invoked by the agent as a tool call via
+ * `useComponent({ name: "highlight_note", ... })`. The backend does
+ * NOT define this tool — `useComponent` is sugar over
+ * `useFrontendTool`, so the tool is registered against the frontend and
+ * surfaces through the same `useRenderToolCall` path the manual hook
+ * in `use-rendered-messages.tsx` is wired to.
+ */
+export const highlightNotePropsSchema = z.object({
+  text: z.string().describe("The note text to highlight."),
+  color: z
+    .enum(["yellow", "pink", "green", "blue"])
+    .describe("Highlight color for the note."),
+});
+
+export type HighlightNoteProps = z.infer<typeof highlightNotePropsSchema>;
+
+const COLOR_CLASSES: Record<HighlightNoteProps["color"], string> = {
+  yellow: "bg-[#FFF388]/30 border-[#FFF388] text-[#010507]",
+  pink: "bg-[#FA5F67]/10 border-[#FA5F6733] text-[#010507]",
+  green: "bg-[#85ECCE]/20 border-[#85ECCE4D] text-[#010507]",
+  blue: "bg-[#BEC2FF1A] border-[#BEC2FF] text-[#010507]",
+};
+
+export function HighlightNote({ text, color }: HighlightNoteProps) {
+  const cls = COLOR_CLASSES[color] ?? COLOR_CLASSES.yellow;
+  return (
+    <div
+      className={`mt-2 mb-2 inline-block rounded-xl border px-3 py-2 text-sm font-medium shadow-sm ${cls}`}
+    >
+      <span className="mr-2 text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+        Note
+      </span>
+      {text}
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/input-bar.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/input-bar.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { useRef } from "react";
+
+/**
+ * Composer for the headless chat.
+ *
+ * A textarea plus a Send / Stop toggle. Enter submits; Shift+Enter inserts a
+ * newline. The textarea is disabled while the agent is running so users can't
+ * pile up concurrent turns.
+ */
+export function InputBar({
+  value,
+  onChange,
+  onSubmit,
+  onStop,
+  isRunning,
+  canStop,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onStop: () => void;
+  isRunning: boolean;
+  canStop: boolean;
+}) {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <form
+      className="border-t border-[#E9E9EF] p-3 flex gap-2 items-end bg-white"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <textarea
+        ref={inputRef}
+        rows={1}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={isRunning ? "Agent is working..." : "Type a message..."}
+        disabled={isRunning}
+        className="flex-1 resize-none rounded-2xl border border-[#DBDBE5] bg-white px-4 py-2 text-sm leading-6 text-[#010507] focus:border-[#BEC2FF] focus:outline-none focus:ring-2 focus:ring-[#BEC2FF33] disabled:bg-[#FAFAFC] disabled:text-[#AFAFB7]"
+      />
+      {canStop ? (
+        <button
+          type="button"
+          onClick={onStop}
+          className="rounded-full px-4 py-2 text-sm font-medium bg-[#FA5F67] text-white hover:opacity-90 transition-opacity"
+        >
+          Stop
+        </button>
+      ) : (
+        <button
+          type="submit"
+          disabled={isRunning || value.trim().length === 0}
+          className="rounded-full px-4 py-2 text-sm font-medium bg-[#010507] text-white hover:bg-[#2B2B2B] disabled:bg-[#DBDBE5] disabled:cursor-not-allowed transition-colors"
+        >
+          Send
+        </button>
+      )}
+    </form>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/message-list.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/message-list.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { useLayoutEffect, useRef } from "react";
+import type { Message } from "@ag-ui/core";
+import { UserBubble } from "./user-bubble";
+import { AssistantBubble } from "./assistant-bubble";
+import { TypingIndicator } from "./typing-indicator";
+import { useRenderedMessages } from "./use-rendered-messages";
+
+/**
+ * Scrollable messages area — TRULY headless.
+ *
+ * The per-message generative-UI weave (text, reasoning, tool-call renders,
+ * activity messages, custom-before / custom-after) is composed inline by
+ * `useRenderedMessages`, which returns a flat list of messages each carrying
+ * a precomputed `renderedContent` field. Here we simply dispatch on role
+ * and drop that node into the appropriate bubble chrome — no
+ * `<CopilotChatMessageView>`, no `<CopilotChatAssistantMessage>`.
+ *
+ * See `use-rendered-messages.tsx` for the composition logic; it mirrors
+ * `packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx:542-612`.
+ */
+export function MessageList({
+  messages,
+  isRunning,
+}: {
+  messages: Message[];
+  isRunning: boolean;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const renderedMessages = useRenderedMessages(messages, isRunning);
+
+  // Auto-scroll on streaming content changes (not just new messages).
+  const fingerprint = messages
+    .map((m) => {
+      const contentLen =
+        typeof m.content === "string"
+          ? m.content.length
+          : Array.isArray(m.content)
+            ? m.content.length
+            : 0;
+      const tcLen =
+        "toolCalls" in m && Array.isArray(m.toolCalls)
+          ? m.toolCalls.map((tc) => tc.function.arguments.length).join(",")
+          : "";
+      return `${m.id}:${m.role}:${contentLen}:${tcLen}`;
+    })
+    .join("|");
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [fingerprint, isRunning]);
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid="headless-complete-messages"
+      className="flex-1 min-h-0 overflow-y-auto px-4 py-4"
+    >
+      <div className="space-y-3">
+        {renderedMessages.length === 0 && (
+          <div className="text-center text-sm text-[#838389] mt-8">
+            Try weather, a stock, a highlighted note, or an Excalidraw sketch.
+          </div>
+        )}
+        {renderedMessages.map((m) => {
+          // Tool-role messages are folded into the preceding assistant
+          // message's tool-call renders; `renderedContent` is null for them.
+          if (m.renderedContent == null) return null;
+          if (m.role === "user") {
+            return <UserBubble key={m.id}>{m.renderedContent}</UserBubble>;
+          }
+          return (
+            <AssistantBubble key={m.id}>{m.renderedContent}</AssistantBubble>
+          );
+        })}
+        {isRunning && <TypingIndicator />}
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+/**
+ * Headless Chat (Complete) — TRULY headless.
+ *
+ * A full chat implementation built from scratch on `useAgent`, without using
+ * `<CopilotChat />` AND without `<CopilotChatMessageView>` or
+ * `<CopilotChatAssistantMessage>`. Demonstrates:
+ *   - scrollable messages area with auto-scroll to bottom on new messages
+ *   - distinct user vs assistant bubbles (pure chrome — no chat primitives)
+ *   - text input + send button, disabled while running
+ *   - stop button to cancel a running agent turn
+ *   - the FULL generative UI composition — text, tool-call renderings, and
+ *     frontend-component renderers — re-composed by hand from the low-level
+ *     hooks inside `use-rendered-messages.tsx`.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CopilotChatConfigurationProvider,
+  useAgent,
+  useCopilotKit,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import type { Message } from "@ag-ui/core";
+import { MessageList } from "./message-list";
+import { InputBar } from "./input-bar";
+import { useHeadlessCompleteToolRenderers } from "./tool-renderers";
+
+const AGENT_ID = "headless-complete";
+
+export default function HeadlessCompleteDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+      <div className="flex justify-center items-center h-screen w-full bg-gray-50">
+        <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
+          <header className="px-4 py-3 border-b border-gray-200">
+            <h1 className="text-base font-semibold">
+              Headless Chat (Complete)
+            </h1>
+            <p className="text-xs text-gray-500">
+              Built from scratch on useAgent — no CopilotChat.
+            </p>
+          </header>
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  const threadId = useMemo(() => crypto.randomUUID(), []);
+  const { agent } = useAgent({ agentId: AGENT_ID, threadId });
+  const { copilotkit } = useCopilotKit();
+
+  useEffect(() => {
+    const ac = new AbortController();
+    if ("abortController" in agent) {
+      (
+        agent as unknown as { abortController: AbortController }
+      ).abortController = ac;
+    }
+    copilotkit.connectAgent({ agent }).catch(() => {
+      // connectAgent emits via the subscriber system; swallow here
+    });
+    return () => {
+      ac.abort();
+      void agent.detachActiveRun().catch(() => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, threadId]);
+
+  const [input, setInput] = useState("");
+  const messages = agent.messages as Message[];
+  const isRunning = agent.isRunning;
+
+  const handleSubmit = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isRunning) return;
+    setInput("");
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    });
+    try {
+      await copilotkit.runAgent({ agent });
+    } catch (err) {
+      console.error("headless-complete: runAgent failed", err);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, input, isRunning]);
+
+  const handleStop = useCallback(() => {
+    try {
+      copilotkit.stopAgent({ agent });
+    } catch (err) {
+      console.error("headless-complete: stopAgent failed", err);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent]);
+
+  return (
+    <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={threadId}>
+      <ChatBody
+        messages={messages}
+        isRunning={isRunning}
+        input={input}
+        setInput={setInput}
+        handleSubmit={handleSubmit}
+        handleStop={handleStop}
+      />
+    </CopilotChatConfigurationProvider>
+  );
+}
+
+function ChatBody({
+  messages,
+  isRunning,
+  input,
+  setInput,
+  handleSubmit,
+  handleStop,
+}: {
+  messages: Message[];
+  isRunning: boolean;
+  input: string;
+  setInput: (next: string) => void;
+  handleSubmit: () => void;
+  handleStop: () => void;
+}) {
+  useHeadlessCompleteToolRenderers();
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Weather in Tokyo",
+        message: "What's the weather in Tokyo?",
+      },
+      {
+        title: "Sales pipeline",
+        message: "Show me the current sales pipeline.",
+      },
+      {
+        title: "Highlight a note",
+        message: "Highlight 'meeting at 3pm' in yellow.",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <MessageList messages={messages} isRunning={isRunning} />
+      <InputBar
+        value={input}
+        onChange={setInput}
+        onSubmit={handleSubmit}
+        onStop={handleStop}
+        isRunning={isRunning}
+        canStop={isRunning && messages.length > 0}
+      />
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/stock-card.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/stock-card.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Compact gray/green/red stock card rendered when the backend
+ * `get_stock_price` tool runs. Wired through the manual
+ * `useRenderToolCall` path via `useRenderTool({ name: "get_stock_price", ... })`
+ * in `tool-renderers.tsx`.
+ */
+export interface StockCardProps {
+  loading: boolean;
+  ticker: string;
+  price?: number;
+  changePct?: number;
+}
+
+export function StockCard({
+  loading,
+  ticker,
+  price,
+  changePct,
+}: StockCardProps) {
+  const isUp = (changePct ?? 0) >= 0;
+  const accent = isUp ? "text-[#189370]" : "text-[#FA5F67]";
+  const arrow = isUp ? "▲" : "▼";
+  return (
+    <div className="mt-2 mb-2 max-w-xs rounded-xl border border-[#DBDBE5] bg-white p-3 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-[#838389]">
+            {loading ? "Loading" : "Stock"}
+          </div>
+          <div className="truncate text-sm font-semibold text-[#010507] font-mono">
+            {ticker ? ticker.toUpperCase() : "--"}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-base font-semibold leading-none text-[#010507] font-mono">
+            {loading ? "..." : price != null ? `$${price.toFixed(2)}` : "--"}
+          </div>
+          {!loading && changePct != null && (
+            <div
+              className={`mt-0.5 text-[11px] font-medium font-mono ${accent}`}
+            >
+              {arrow} {Math.abs(changePct).toFixed(2)}%
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/tool-renderers.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/tool-renderers.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React from "react";
+import {
+  useRenderTool,
+  useDefaultRenderTool,
+  useComponent,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { WeatherCard } from "./weather-card";
+import { StockCard } from "./stock-card";
+import { HighlightNote, highlightNotePropsSchema } from "./highlight-note";
+
+/**
+ * Central registration hook for every tool-call rendering surface
+ * exercised by the headless-complete cell:
+ *
+ *   - `useRenderTool({ name: "get_weather", ... })` — per-tool renderer
+ *     for the backend weather tool (blue card).
+ *   - `useRenderTool({ name: "get_stock_price", ... })` — per-tool
+ *     renderer for the backend stock tool (gray card, green/red delta).
+ *   - `useComponent({ name: "highlight_note", ... })` — frontend-only
+ *     tool the agent can invoke; renders the `HighlightNote` component
+ *     inline through the same `useRenderToolCall` path.
+ *   - `useDefaultRenderTool(...)` — wildcard catch-all so any other
+ *     tool the agent might call (e.g. the Excalidraw MCP tools) still
+ *     gets a visible card even though the headless cell composes its
+ *     own message view.
+ *
+ * MCP Apps activity surfaces are NOT routed through this registry —
+ * they come in as `activity` messages and are rendered by
+ * `useRenderActivityMessage` (already consumed in
+ * `use-rendered-messages.tsx`).
+ */
+export function useHeadlessCompleteToolRenderers() {
+  // Per-tool renderer #1: backend `get_weather` -> branded WeatherCard.
+  useRenderTool(
+    {
+      name: "get_weather",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<{
+          city?: string;
+          temperature?: number;
+          conditions?: string;
+        }>(result);
+        return (
+          <WeatherCard
+            loading={loading}
+            location={parameters?.location ?? parsed.city ?? ""}
+            temperature={parsed.temperature}
+            conditions={parsed.conditions}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  // Per-tool renderer #2: backend `get_stock_price` -> branded StockCard.
+  useRenderTool(
+    {
+      name: "get_stock_price",
+      parameters: z.object({
+        ticker: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<{
+          ticker?: string;
+          price_usd?: number;
+          change_pct?: number;
+        }>(result);
+        return (
+          <StockCard
+            loading={loading}
+            ticker={parameters?.ticker ?? parsed.ticker ?? ""}
+            price={parsed.price_usd}
+            changePct={parsed.change_pct}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  // Frontend-registered tool the agent can invoke. `useComponent` is
+  // sugar over `useFrontendTool`, so the registration flows through
+  // the same `useRenderToolCall` path the manual hook consumes.
+  useComponent({
+    name: "highlight_note",
+    description:
+      "Highlight a short note or phrase inline in the chat with a colored card. Use this whenever the user asks to highlight, flag, or mark a snippet of text.",
+    parameters: highlightNotePropsSchema,
+    render: HighlightNote,
+  });
+
+  // Wildcard catch-all for tools without a bespoke renderer (e.g. any
+  // Excalidraw MCP tools surfaced as regular tool calls alongside the
+  // MCP Apps activity).
+  useDefaultRenderTool();
+}
+
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/typing-indicator.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/typing-indicator.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Small animated dot shown while the agent is running but has not yet emitted
+ * any assistant content. Styled to look like an assistant bubble so it slots
+ * into the message list without layout jitter.
+ */
+export function TypingIndicator() {
+  return (
+    <div className="flex justify-start">
+      <div className="rounded-2xl rounded-bl-sm bg-[#F0F0F4] px-4 py-3">
+        <span className="inline-block w-2 h-2 bg-[#838389] rounded-full animate-pulse" />
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/use-rendered-messages.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/use-rendered-messages.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import React, { useMemo } from "react";
+import type {
+  Message,
+  AssistantMessage,
+  UserMessage,
+  ReasoningMessage,
+  ActivityMessage,
+  ToolMessage,
+} from "@ag-ui/core";
+import {
+  CopilotChatReasoningMessage,
+  useRenderToolCall,
+  useRenderActivityMessage,
+  useRenderCustomMessages,
+} from "@copilotkit/react-core/v2";
+
+/**
+ * Manual per-message composition for the TRULY headless chat cell.
+ *
+ * This hook mirrors — line-for-line in spirit — the role-dispatch that happens
+ * inside `renderMessageBlock` in the canonical primitive:
+ *
+ *   packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx:542-612
+ *
+ * The point of this cell is to demonstrate that the FULL generative-UI weave
+ * (assistant text + tool-call renders + reasoning + activity + custom before /
+ * after slots) can be re-composed from the low-level hooks directly, without
+ * importing `<CopilotChatMessageView>` or `<CopilotChatAssistantMessage>`.
+ * Only the reasoning-message LEAF component is imported — it's a pure
+ * presentational primitive, not a dispatcher.
+ *
+ * Return shape: the original messages, each augmented with a `renderedContent`
+ * field that the parent list drops directly into a `<UserBubble>` or
+ * `<AssistantBubble>` chrome wrapper.
+ *
+ * Text rendering: we intentionally use plain text (a `<div>` with
+ * `whitespace-pre-wrap`) rather than a markdown pipeline. Rationale: the cell's
+ * goal is to show what "truly headless" looks like — every piece of composition
+ * lives in user code — so pulling in a markdown library here would re-hide
+ * a chunk of formatting decisions behind an opaque black box. Apps that want
+ * markdown can drop Streamdown / react-markdown in at this exact line.
+ */
+// @region[use-rendered-messages-hook]
+export type RenderedMessage = Message & { renderedContent: React.ReactNode };
+
+export function useRenderedMessages(
+  messages: Message[],
+  isRunning: boolean,
+): RenderedMessage[] {
+  const renderToolCall = useRenderToolCall();
+  const { renderActivityMessage } = useRenderActivityMessage();
+  const renderCustomMessage = useRenderCustomMessages();
+
+  return useMemo(() => {
+    return messages.map((message): RenderedMessage => {
+      const renderedContent = renderMessageContent({
+        message,
+        messages,
+        isRunning,
+        renderToolCall,
+        renderActivityMessage,
+        renderCustomMessage,
+      });
+      return { ...message, renderedContent } as RenderedMessage;
+    });
+    // `renderToolCall`, `renderActivityMessage`, and `renderCustomMessage` are
+    // callbacks produced by their respective hooks; their identity turns over
+    // whenever the underlying registries / agent / config change, which is
+    // exactly when we want to recompute.
+  }, [
+    messages,
+    isRunning,
+    renderToolCall,
+    renderActivityMessage,
+    renderCustomMessage,
+  ]);
+}
+// @endregion[use-rendered-messages-hook]
+
+function renderMessageContent(args: {
+  message: Message;
+  messages: Message[];
+  isRunning: boolean;
+  renderToolCall: ReturnType<typeof useRenderToolCall>;
+  renderActivityMessage: ReturnType<
+    typeof useRenderActivityMessage
+  >["renderActivityMessage"];
+  renderCustomMessage: ReturnType<typeof useRenderCustomMessages>;
+}): React.ReactNode {
+  const {
+    message,
+    messages,
+    isRunning,
+    renderToolCall,
+    renderActivityMessage,
+    renderCustomMessage,
+  } = args;
+
+  // Tool-role messages carry a tool-call RESULT whose UI lives inline inside
+  // the PRECEDING assistant message's `toolCalls[i]` render (keyed by
+  // toolCallId). We return null here so the list skips them, mirroring the
+  // fact that CopilotChatMessageView's `renderMessageBlock` has no
+  // `message.role === "tool"` branch.
+  if (message.role === "tool") {
+    return null;
+  }
+
+  const customBefore = renderCustomMessage
+    ? renderCustomMessage({ message, position: "before" })
+    : null;
+  const customAfter = renderCustomMessage
+    ? renderCustomMessage({ message, position: "after" })
+    : null;
+
+  let body: React.ReactNode = null;
+
+  // @region[manual-activity-message-rendering]
+  if (message.role === "assistant") {
+    body = renderAssistantBody({
+      message: message as AssistantMessage,
+      messages,
+      renderToolCall,
+    });
+  } else if (message.role === "user") {
+    body = renderUserBody(message as UserMessage);
+  } else if (message.role === "reasoning") {
+    body = (
+      <CopilotChatReasoningMessage
+        message={message as ReasoningMessage}
+        messages={messages}
+        isRunning={isRunning}
+      />
+    );
+  } else if (message.role === "activity") {
+    body = renderActivityMessage(message as ActivityMessage);
+  }
+  // @endregion[manual-activity-message-rendering]
+
+  if (!customBefore && !customAfter) {
+    return body;
+  }
+  return (
+    <>
+      {customBefore}
+      {body}
+      {customAfter}
+    </>
+  );
+}
+
+// @region[manual-tool-call-rendering]
+function renderAssistantBody(args: {
+  message: AssistantMessage;
+  messages: Message[];
+  renderToolCall: ReturnType<typeof useRenderToolCall>;
+}): React.ReactNode {
+  const { message, messages, renderToolCall } = args;
+  const text = message.content ?? "";
+  const hasText = text.trim().length > 0;
+  const toolCalls = message.toolCalls ?? [];
+
+  return (
+    <>
+      {hasText && <div className="whitespace-pre-wrap break-words">{text}</div>}
+      {toolCalls.map((toolCall) => {
+        // Tool result lives on a sibling `tool`-role message keyed by toolCallId.
+        // Mirrors CopilotChatToolCallsView (react-core/v2/components/chat/CopilotChatToolCallsView.tsx).
+        const toolMessage = messages.find(
+          (m) => m.role === "tool" && m.toolCallId === toolCall.id,
+        ) as ToolMessage | undefined;
+        return (
+          <React.Fragment key={toolCall.id}>
+            {renderToolCall({ toolCall, toolMessage })}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+}
+// @endregion[manual-tool-call-rendering]
+
+function renderUserBody(message: UserMessage): React.ReactNode {
+  // AG-UI user messages may carry a string OR an array of parts (text, image,
+  // audio, video, document, binary). The headless cell renders only the text
+  // parts — swap this for a richer renderer when you need attachments.
+  const { content } = message;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join("");
+  }
+  return "";
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/user-bubble.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/user-bubble.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Right-aligned user bubble — pure chrome.
+ *
+ * Receives a precomputed `renderedContent` node (built by
+ * `useRenderedMessages`). For user messages that's just the text content of
+ * the message (attachments etc. are stripped in the headless composer).
+ */
+// @region[custom-bubbles]
+export function UserBubble({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[75%] rounded-2xl rounded-br-sm bg-[#010507] text-white px-4 py-2 text-sm whitespace-pre-wrap break-words">
+        {children}
+      </div>
+    </div>
+  );
+}
+// @endregion[custom-bubbles]

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/weather-card.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/weather-card.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Compact blue weather card rendered when the backend `get_weather`
+ * tool runs. Wired to the manual `useRenderToolCall` path via the
+ * `useRenderTool({ name: "get_weather", ... })` registration in
+ * `tool-renderers.tsx`.
+ */
+export interface WeatherCardProps {
+  loading: boolean;
+  location: string;
+  temperature?: number;
+  conditions?: string;
+}
+
+export function WeatherCard({
+  loading,
+  location,
+  temperature,
+  conditions,
+}: WeatherCardProps) {
+  return (
+    <div className="mt-2 mb-2 max-w-xs rounded-xl border border-[#DBDBE5] bg-[#EDEDF5] p-3 text-[#010507] shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+            {loading ? "Fetching weather" : "Weather"}
+          </div>
+          <div className="truncate text-sm font-semibold capitalize text-[#010507]">
+            {location || "Unknown"}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-2xl font-semibold leading-none text-[#010507] tracking-tight">
+            {loading ? "..." : temperature != null ? `${temperature}°` : "--"}
+          </div>
+          {!loading && (
+            <div className="mt-0.5 text-[11px] capitalize text-[#57575B]">
+              {conditions ?? ""}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  CopilotKit,
+  useAgent,
+  useComponent,
+  useCopilotKit,
+  useRenderToolCall,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+export default function HeadlessSimpleDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+      <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
+        <div className="w-full max-w-4xl">
+          <HeadlessChat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function ShowCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="my-2 rounded-lg border border-gray-300 bg-white p-4 shadow-sm">
+      <div className="font-semibold text-gray-900">{title}</div>
+      <div className="mt-1 text-sm text-gray-700 whitespace-pre-wrap">
+        {body}
+      </div>
+    </div>
+  );
+}
+
+function HeadlessChat() {
+  // @region[use-agent-simple]
+  // @region[headless-hooks]
+  const { agent } = useAgent({ agentId: "headless-simple" });
+  const { copilotkit } = useCopilotKit();
+  const [input, setInput] = useState("");
+
+  useComponent({
+    name: "show_card",
+    description: "Display a titled card with a short body of text.",
+    parameters: z.object({
+      title: z.string().describe("Short heading for the card."),
+      body: z.string().describe("Body text for the card."),
+    }),
+    render: ShowCard,
+  });
+
+  const renderToolCall = useRenderToolCall();
+  // @endregion[headless-hooks]
+  // @endregion[use-agent-simple]
+
+  const send = () => {
+    const text = input.trim();
+    if (!text || agent.isRunning) return;
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    });
+    // Use copilotkit.runAgent so frontend tools registered via useComponent are
+    // forwarded to the agent. Calling agent.runAgent() directly would bypass
+    // tool registration and the agent would never see `show_card`.
+    void copilotkit.runAgent({ agent }).catch(() => {});
+    setInput("");
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
+      <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
+        {agent.messages.length === 0 && (
+          <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
+        )}
+        {agent.messages.map((m) => {
+          if (m.role === "user") {
+            return (
+              <div
+                key={m.id}
+                className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
+              >
+                {typeof m.content === "string" ? m.content : ""}
+              </div>
+            );
+          }
+          if (m.role === "assistant") {
+            const toolCalls =
+              "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
+            return (
+              <div key={m.id} className="self-start max-w-[90%]">
+                {m.content && (
+                  <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
+                    {m.content}
+                  </div>
+                )}
+                {toolCalls.map((tc) => (
+                  <div key={tc.id}>{renderToolCall({ toolCall: tc })}</div>
+                ))}
+              </div>
+            );
+          }
+          return null;
+        })}
+        {agent.isRunning && (
+          <div className="text-xs text-gray-400">Agent is thinking...</div>
+        )}
+        {/* @endregion[message-list-simple] */}
+      </div>
+      <div className="flex gap-2">
+        <textarea
+          className="flex-1 rounded-lg border border-gray-300 p-2 text-sm"
+          rows={2}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
+          placeholder="Type a message. Ask me to 'show a card about cats'."
+        />
+        <button
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-50"
+          onClick={send}
+          disabled={agent.isRunning || !input.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/approval-dialog.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/approval-dialog.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+// Modal dialog rendered at the APP level via a `fixed inset-0` overlay
+// (instead of createPortal) to avoid pulling in @types/react-dom. The
+// caller supplies `pending` (the message/context the agent wants
+// approval for) and an `onResolve` completion callback. The user's
+// click on Approve / Reject fires the callback, which resolves the
+// pending frontend-tool Promise back in the parent page.
+
+import React, { useState } from "react";
+
+export type PendingApproval = {
+  message: string;
+  context?: string;
+};
+
+type Props = {
+  pending: PendingApproval;
+  onResolve: (result: { approved: boolean; reason?: string }) => void;
+};
+
+export function ApprovalDialog({ pending, onResolve }: Props) {
+  const [reason, setReason] = useState("");
+
+  return (
+    <div
+      data-testid="approval-dialog-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[#010507]/40 backdrop-blur-sm"
+    >
+      <div
+        data-testid="approval-dialog"
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-md rounded-2xl border border-[#DBDBE5] bg-white p-6 shadow-sm"
+      >
+        <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.14em] text-[#57575B]">
+          Action requires your approval
+        </div>
+        <h2 className="mb-3 text-lg font-semibold text-[#010507]">
+          {pending.message}
+        </h2>
+        {pending.context && (
+          <p className="mb-4 rounded-xl border border-[#E9E9EF] bg-[#FAFAFC] p-3 text-sm text-[#57575B]">
+            {pending.context}
+          </p>
+        )}
+        <label className="mb-1 block text-xs font-medium text-[#57575B]">
+          Note (optional)
+        </label>
+        <textarea
+          data-testid="approval-dialog-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Add a short note the assistant will see…"
+          className="mb-4 w-full resize-none rounded-xl border border-[#DBDBE5] px-3 py-2 text-sm text-[#010507] focus:border-[#BEC2FF] focus:outline-none focus:ring-2 focus:ring-[#BEC2FF33]"
+          rows={2}
+        />
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            data-testid="approval-dialog-reject"
+            onClick={() =>
+              onResolve({
+                approved: false,
+                reason: reason.trim() || undefined,
+              })
+            }
+            className="rounded-xl border border-[#DBDBE5] bg-white px-4 py-2 text-sm font-medium text-[#57575B] hover:bg-[#FAFAFC] transition-colors"
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            data-testid="approval-dialog-approve"
+            onClick={() =>
+              onResolve({
+                approved: true,
+                reason: reason.trim() || undefined,
+              })
+            }
+            className="rounded-xl bg-[#010507] px-4 py-2 text-sm font-medium text-white hover:bg-[#2B2B2B] transition-colors"
+          >
+            Approve
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  CopilotChat,
+  useFrontendTool,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { z } from "zod";
+import { ApprovalDialog, type PendingApproval } from "./approval-dialog";
+
+// Mock tickets the "operator" is working through. Hard-coded so the
+// agent has real-looking data to reference when asked to take an action.
+const SUPPORT_TICKETS = [
+  {
+    id: "#12345",
+    customer: "Jordan Rivera",
+    subject: "Refund request — duplicate charge",
+    status: "Open",
+    amount: 50,
+  },
+  {
+    id: "#12346",
+    customer: "Priya Shah",
+    subject: "Downgrade plan to Starter",
+    status: "Open",
+    amount: 0,
+  },
+  {
+    id: "#12347",
+    customer: "Morgan Lee",
+    subject: "Escalate: payment stuck in pending",
+    status: "Escalating",
+    amount: 0,
+  },
+];
+
+export default function HitlInAppDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+      <Layout />
+    </CopilotKit>
+  );
+}
+
+// Internal state shape: the args the agent passed plus the `resolve`
+// fn we captured from the Promise returned by the tool handler.
+type ResolveFn = (value: { approved: boolean; reason?: string }) => void;
+type DialogState =
+  | { open: false }
+  | { open: true; pending: PendingApproval; resolve: ResolveFn };
+
+function Layout() {
+  const [dialog, setDialog] = useState<DialogState>({ open: false });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Approve refund for #12345",
+        message:
+          "Please approve a $50 refund to Jordan Rivera on ticket #12345 for the duplicate charge.",
+      },
+      {
+        title: "Downgrade plan for #12346",
+        message:
+          "Please downgrade Priya Shah (#12346) to the Starter plan effective next billing cycle.",
+      },
+      {
+        title: "Escalate ticket #12347",
+        message:
+          "Please escalate ticket #12347 to the payments team — Morgan Lee's payment is stuck.",
+      },
+    ],
+    available: "always",
+  });
+
+  useFrontendTool({
+    name: "request_user_approval",
+    description:
+      "Ask the operator to approve or reject an action before you take it. " +
+      "The operator will respond via an in-app modal dialog that appears " +
+      "OUTSIDE the chat surface. The tool returns an object of the shape " +
+      "{ approved: boolean, reason?: string }.",
+    parameters: z.object({
+      message: z
+        .string()
+        .describe(
+          "Short summary of the action needing approval (include concrete numbers / IDs).",
+        ),
+      context: z
+        .string()
+        .optional()
+        .describe(
+          "Optional extra context — e.g. the ticket ID or policy rule.",
+        ),
+    }),
+    handler: async ({
+      message,
+      context,
+    }: {
+      message: string;
+      context?: string;
+    }) => {
+      return await new Promise<{ approved: boolean; reason?: string }>(
+        (resolve) => {
+          setDialog({ open: true, pending: { message, context }, resolve });
+        },
+      );
+    },
+  });
+
+  const handleResolve = (result: { approved: boolean; reason?: string }) => {
+    if (dialog.open) {
+      dialog.resolve(result);
+      setDialog({ open: false });
+    }
+  };
+
+  return (
+    <div className="grid h-screen grid-cols-[1fr_420px] bg-gray-50">
+      <TicketsPanel />
+      <div className="border-l border-gray-200 bg-white">
+        <CopilotChat agentId="hitl-in-app" className="h-full" />
+      </div>
+      {dialog.open && (
+        <ApprovalDialog pending={dialog.pending} onResolve={handleResolve} />
+      )}
+    </div>
+  );
+}
+
+function TicketsPanel() {
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <header className="border-b border-gray-200 bg-white px-6 py-4">
+        <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
+          Support Inbox
+        </div>
+        <h1 className="text-xl font-semibold text-gray-900">Open tickets</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Ask the copilot to take an action. Every customer-affecting action
+          will pop up an approval dialog here in the app — outside the chat.
+        </p>
+      </header>
+      <div className="flex-1 overflow-y-auto p-6">
+        <ul className="space-y-3">
+          {SUPPORT_TICKETS.map((t) => (
+            <li
+              key={t.id}
+              data-testid={`ticket-${t.id.replace("#", "")}`}
+              className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-xs text-gray-500">{t.id}</span>
+                <span
+                  className={
+                    t.status === "Escalating"
+                      ? "rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+                      : "rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800"
+                  }
+                >
+                  {t.status}
+                </span>
+              </div>
+              <div className="mt-2 text-sm font-semibold text-gray-900">
+                {t.customer}
+              </div>
+              <div className="text-sm text-gray-700">{t.subject}</div>
+              {t.amount > 0 && (
+                <div className="mt-2 text-xs text-gray-500">
+                  Disputed amount: ${t.amount.toFixed(2)}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/multimodal/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+/**
+ * Multimodal Attachments demo — Claude Agent SDK (Python).
+ *
+ * Wires CopilotChat's `AttachmentsConfig` for image + PDF uploads and
+ * adds two "Try with sample X" buttons that inject bundled files
+ * through the same pipeline the paperclip button uses.
+ *
+ * Architecture:
+ * - Dedicated runtime route at `/api/copilotkit-multimodal` (see
+ *   ../../api/copilotkit-multimodal/route.ts). The vision-capable
+ *   Claude agent is scoped to this cell, so other demos keep their
+ *   cheaper text-only defaults.
+ * - Dedicated Python endpoint at `/multimodal` on the agent server
+ *   (see src/agent_server.py). Images are forwarded to Claude's native
+ *   vision input; PDFs are flattened to text via `pypdf` for
+ *   provider-agnostic behavior.
+ * - Sample files live at `/demo-files/sample.png` and
+ *   `/demo-files/sample.pdf`. The sample-buttons component fetches
+ *   them client-side, wraps the blob in a File, and drives the same
+ *   hidden `<input type="file">` the paperclip path uses (DataTransfer
+ *   + dispatch `change`). This keeps the sample and real-upload paths
+ *   on one code path.
+ *
+ * No legacy-binary shim
+ * ---------------------
+ * The langgraph-python reference installs an `onRunInitialized` hook
+ * that rewrites modern AG-UI `image`/`document` parts into the legacy
+ * `binary` shape — a workaround for the published
+ * `@ag-ui/langgraph@0.0.27` converter which drops modern parts.
+ *
+ * Claude Agent SDK does not need that shim. The Python backend's
+ * `convert_part_for_claude` (src/agents/multimodal_agent.py) consumes
+ * the modern AG-UI shape directly — images become Claude image blocks
+ * (base64 inline) and documents are flattened to text — so the request
+ * passes through from CopilotChat to the backend untouched.
+ */
+
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import type { AttachmentUploadResult } from "@copilotkit/shared";
+
+import { SampleAttachmentButtons } from "./sample-attachment-buttons";
+
+/**
+ * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
+ * always return the `data` variant — the demo inlines base64 instead of
+ * uploading to external storage, matching the langgraph-python reference.
+ */
+type DataUploadResult = Extract<AttachmentUploadResult, { type: "data" }>;
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+const ACCEPT_MIME = "image/*,application/pdf";
+/**
+ * Selector used by <SampleAttachmentButtons /> to locate CopilotChat's
+ * hidden file input. Kept as a constant so the wrapper element and the
+ * sample buttons cannot drift.
+ */
+const CHAT_ROOT_SELECTOR = "[data-multimodal-demo-chat-root]";
+
+/**
+ * Convert a File into the `AttachmentsConfig.onUpload` result shape —
+ * inline base64 with the browser-provided mime type. We do this in the
+ * browser rather than uploading to external storage because this is a
+ * self-contained demo; `maxSize: 10 MB` (set below) caps bloat.
+ *
+ * `FileReader` produces a `data:<mime>;base64,<payload>` URL; we strip
+ * the prefix so the runtime forwards the raw base64 value (what the
+ * backend expects in `source.value`).
+ */
+function fileToDataAttachment(file: File): Promise<DataUploadResult> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () =>
+      reject(reader.error ?? new Error(`FileReader failed for ${file.name}`));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        reject(new Error(`Unexpected FileReader result type for ${file.name}`));
+        return;
+      }
+      // result looks like "data:image/png;base64,iVBORw0K..." — strip the prefix.
+      const commaIdx = result.indexOf(",");
+      const base64 = commaIdx >= 0 ? result.slice(commaIdx + 1) : result;
+      resolve({
+        type: "data",
+        value: base64,
+        mimeType: file.type || "application/octet-stream",
+        metadata: {
+          filename: file.name,
+          size: file.size,
+        },
+      });
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function MultimodalDemoPage() {
+  // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both
+  // the paperclip button and the sample-injection path route files
+  // through this same function.
+  const onUpload = useCallback(fileToDataAttachment, []);
+
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+      <div
+        data-testid="multimodal-demo-root"
+        className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"
+      >
+        <header className="space-y-1">
+          <h1 className="text-lg font-semibold">Multimodal attachments</h1>
+          <p className="text-sm text-black/70 dark:text-white/70">
+            Attach an image or PDF with the paperclip, drag-and-drop onto the
+            chat, paste from the clipboard, or try one of the bundled samples
+            below. Then ask a question about the attachment and press send.
+          </p>
+        </header>
+
+        <SampleAttachmentButtons rootSelector={CHAT_ROOT_SELECTOR} />
+
+        <div
+          data-multimodal-demo-chat-root
+          className="min-h-0 flex-1 overflow-hidden rounded-lg border border-black/10 dark:border-white/10"
+        >
+          <CopilotChat
+            agentId="multimodal-demo"
+            className="h-full"
+            attachments={{
+              enabled: true,
+              accept: ACCEPT_MIME,
+              maxSize: MAX_FILE_SIZE_BYTES,
+              onUpload,
+              onUploadFailed: (err) => {
+                console.warn("[multimodal-demo] attachment rejected", err);
+              },
+            }}
+          />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+/**
+ * Two buttons that inject bundled sample files into the active CopilotChat's
+ * attachment queue. The queue is owned internally by <CopilotChat /> (via its
+ * `useAttachments` hook), so we inject at the DOM level: find the hidden
+ * `<input type="file">` CopilotChat renders, populate its `.files` via
+ * DataTransfer, and dispatch a `change` event. This exercises the *same*
+ * onChange handler the paperclip / drag-and-drop paths use — which means our
+ * sample path runs through the `AttachmentsConfig.onUpload` the page wires
+ * on the chat, the same file-size + accept-filter validation, the same
+ * placeholder-then-ready lifecycle. No duplicated queueing code.
+ *
+ * Container scope: the sample buttons live next to the chat inside a
+ * `data-multimodal-demo-root` wrapper (see page.tsx). We scope our
+ * `querySelector` to that root so multiple CopilotChat instances on the
+ * page (there aren't any today, but the pattern should be safe) don't
+ * collide.
+ */
+
+import { useCallback, useState } from "react";
+
+interface SampleSpec {
+  readonly buttonLabel: string;
+  readonly filename: string;
+  readonly mimeType: string;
+  readonly testId: string;
+  readonly fetchUrl: string;
+}
+
+const SAMPLES: readonly SampleSpec[] = [
+  {
+    buttonLabel: "Try with sample image",
+    filename: "sample.png",
+    mimeType: "image/png",
+    testId: "multimodal-sample-image-button",
+    fetchUrl: "/demo-files/sample.png",
+  },
+  {
+    buttonLabel: "Try with sample PDF",
+    filename: "sample.pdf",
+    mimeType: "application/pdf",
+    testId: "multimodal-sample-pdf-button",
+    fetchUrl: "/demo-files/sample.pdf",
+  },
+];
+
+export interface SampleAttachmentButtonsProps {
+  /**
+   * Selector (scoped to `document`) that resolves to the wrapper element
+   * rendered around `<CopilotChat />`. The component walks this element's
+   * subtree to find the hidden file input CopilotChat renders.
+   */
+  readonly rootSelector: string;
+}
+
+function findChatFileInput(rootSelector: string): HTMLInputElement | null {
+  if (typeof document === "undefined") return null;
+  const root = document.querySelector(rootSelector);
+  if (!root) return null;
+  // CopilotChat renders exactly one hidden `<input type="file">` directly
+  // inside its chatContainerRef div. Match on `type="file"` to avoid
+  // sibling inputs (there are none today but it costs nothing to be
+  // defensive).
+  return root.querySelector<HTMLInputElement>('input[type="file"]');
+}
+
+/**
+ * Magic-byte prefixes used to validate fetched sample files. We check
+ * these because Next.js will happily serve a Git LFS *pointer* file (a
+ * short plain-text stub starting with `version https://git-lfs...`) with
+ * a `Content-Type: image/png` header if LFS wasn't pulled at build time.
+ * Without this guard, the broken pointer bytes get base64-encoded,
+ * fed into CopilotChat as a valid-looking PNG, and rendered as a broken
+ * <img>. Fail loudly with an actionable error instead.
+ */
+const MAGIC_BYTES: Record<string, number[]> = {
+  "image/png": [0x89, 0x50, 0x4e, 0x47], // ‰PNG
+  "application/pdf": [0x25, 0x50, 0x44, 0x46], // %PDF
+};
+
+const LFS_POINTER_PREFIX = "version https://git-lfs";
+
+function bytesStartWith(bytes: Uint8Array, prefix: number[]): boolean {
+  if (bytes.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (bytes[i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
+async function fetchAsFile(spec: SampleSpec): Promise<File> {
+  const res = await fetch(spec.fetchUrl);
+  if (!res.ok) {
+    throw new Error(
+      `Could not fetch sample "${spec.filename}" — HTTP ${res.status}. ` +
+        `Is the file bundled under public${spec.fetchUrl}?`,
+    );
+  }
+  const buffer = await res.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+
+  // Detect Git LFS pointer stub — the file on disk hasn't been materialized.
+  const asciiHead = new TextDecoder("utf-8", { fatal: false }).decode(
+    bytes.slice(0, Math.min(bytes.length, 64)),
+  );
+  if (asciiHead.startsWith(LFS_POINTER_PREFIX)) {
+    throw new Error(
+      `Sample "${spec.filename}" is a Git LFS pointer, not the real asset. ` +
+        "The deploy environment needs to run `git lfs pull` (or set " +
+        "`GIT_LFS_ENABLED=1`) so the binary is checked out before the Next.js " +
+        "app serves it.",
+    );
+  }
+
+  const expectedMagic = MAGIC_BYTES[spec.mimeType];
+  if (expectedMagic && !bytesStartWith(bytes, expectedMagic)) {
+    throw new Error(
+      `Sample "${spec.filename}" does not have a valid ${spec.mimeType} ` +
+        "signature. The file may be corrupted or a wrong asset was committed.",
+    );
+  }
+
+  // Re-wrap the bytes into a blob/File with the explicit MIME type rather than
+  // trusting whatever Content-Type the dev server returned.
+  const blob = new Blob([buffer], { type: spec.mimeType });
+  return new File([blob], spec.filename, { type: spec.mimeType });
+}
+
+export function SampleAttachmentButtons({
+  rootSelector,
+}: SampleAttachmentButtonsProps) {
+  const [loading, setLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const injectSample = useCallback(
+    async (spec: SampleSpec): Promise<void> => {
+      setError(null);
+      setLoading(spec.testId);
+      try {
+        const fileInput = findChatFileInput(rootSelector);
+        if (!fileInput) {
+          throw new Error(
+            `CopilotChat file input not found under "${rootSelector}". ` +
+              "Is <CopilotChat /> mounted with `attachments.enabled: true`?",
+          );
+        }
+        const file = await fetchAsFile(spec);
+
+        // Populate the file input's `.files` list via a fresh DataTransfer.
+        // This is the only way to programmatically set `HTMLInputElement.files`
+        // — assigning a plain array fails in every browser.
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        fileInput.files = dt.files;
+
+        // Dispatch a bubbling `change` event. CopilotChat's internal
+        // `useAttachments.handleFileUpload` listens on `onChange`, which
+        // React wires up as a native `change` listener — so a standard
+        // DOM Event with `bubbles: true` reaches it.
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      } catch (err) {
+        console.error(
+          "[multimodal-demo] sample-attachment injection failed",
+          err,
+        );
+        setError(
+          err instanceof Error ? err.message : "Sample injection failed.",
+        );
+      } finally {
+        setLoading(null);
+      }
+    },
+    [rootSelector],
+  );
+
+  return (
+    <div
+      data-testid="multimodal-sample-row"
+      className="flex flex-wrap items-center gap-2 rounded-md border border-black/10 bg-black/[0.03] px-3 py-2 text-sm dark:border-white/10 dark:bg-white/[0.04]"
+    >
+      <span className="text-xs font-medium text-black/60 dark:text-white/60">
+        Bundled samples:
+      </span>
+      {SAMPLES.map((spec) => {
+        const isLoading = loading === spec.testId;
+        return (
+          <button
+            key={spec.testId}
+            type="button"
+            data-testid={spec.testId}
+            disabled={loading !== null}
+            onClick={() => void injectSample(spec)}
+            className="rounded border border-black/15 bg-white px-3 py-1 text-xs font-medium text-black transition hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-neutral-900 dark:text-white dark:hover:bg-white/5"
+          >
+            {isLoading ? "Loading…" : spec.buttonLabel}
+          </button>
+        );
+      })}
+      {error && (
+        <span
+          data-testid="multimodal-sample-error"
+          className="ml-auto max-w-[24rem] truncate text-xs text-red-600 dark:text-red-400"
+          title={error}
+        >
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * Open-Ended Generative UI (Advanced) — with frontend sandbox-function calling.
+ * ----------------------------------------------------------------------------
+ * The agent streams ONE `generateSandboxedUi` tool call; the runtime's
+ * `OpenGenerativeUIMiddleware` (enabled via `openGenerativeUI: { agents: [...] }`
+ * in `api/copilotkit-ogui/route.ts`) converts that stream into
+ * `open-generative-ui` activity events. Passing `openGenerativeUI` here
+ * activates the built-in `OpenGenerativeUIActivityRenderer`, which mounts
+ * the agent-authored HTML + CSS inside a sandboxed iframe that can invoke
+ * host-registered `sandboxFunctions`.
+ */
+
+import React from "react";
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { openGenUiSandboxFunctions } from "./sandbox-functions";
+import { openGenUiSuggestions } from "./suggestions";
+
+export default function OpenGenUiAdvancedDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-ogui"
+      agent="open-gen-ui-advanced"
+      openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}
+    >
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  useConfigureSuggestions({
+    suggestions: openGenUiSuggestions,
+    available: "always",
+  });
+
+  return (
+    <div className="flex h-full w-full flex-col p-3">
+      <CopilotChat
+        agentId="open-gen-ui-advanced"
+        className="flex-1 rounded-2xl"
+      />
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+/**
+ * Host-side functions that agent-authored, sandboxed UIs can invoke from
+ * inside the iframe via `Websandbox.connection.remote.<name>(args)`.
+ */
+export const openGenUiSandboxFunctions = [
+  {
+    name: "evaluateExpression",
+    description:
+      "Safely evaluate a basic arithmetic expression on the host page and return the numeric result. " +
+      "Supports +, -, *, /, parentheses, and decimal numbers.",
+    parameters: z.object({
+      expression: z
+        .string()
+        .describe("An arithmetic expression, e.g. '12 * (3 + 4.5)'"),
+    }),
+    handler: async ({ expression }: { expression: string }) => {
+      if (!/^[\d+\-*/().\s]+$/.test(expression)) {
+        return { ok: false, error: "Unsupported characters in expression." };
+      }
+      try {
+        // eslint-disable-next-line no-new-func
+        const value = Function(`"use strict"; return (${expression});`)();
+        if (typeof value !== "number" || !Number.isFinite(value)) {
+          return { ok: false, error: "Not a finite number." };
+        }
+        console.log(
+          "[open-gen-ui/advanced] evaluateExpression",
+          expression,
+          "=",
+          value,
+        );
+        return { ok: true, value };
+      } catch (err) {
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  },
+  {
+    name: "notifyHost",
+    description:
+      "Send a short notification message from the sandboxed UI to the host page. " +
+      "The host logs the message and returns a confirmation object.",
+    parameters: z.object({
+      message: z.string().describe("A short status message."),
+    }),
+    handler: async ({ message }: { message: string }) => {
+      console.log("[open-gen-ui/advanced] notifyHost:", message);
+      return { ok: true, receivedAt: new Date().toISOString(), message };
+    },
+  },
+];

--- a/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/suggestions.ts
+++ b/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/suggestions.ts
@@ -1,0 +1,33 @@
+/**
+ * Suggestion prompts surfaced in the chat composer. Each suggestion
+ * explicitly asks the agent to produce an interactive sandboxed UI that
+ * calls one of the host-side sandbox functions.
+ */
+export const openGenUiSuggestions = [
+  {
+    title: "Calculator (calls evaluateExpression)",
+    message:
+      "Build a modern calculator UI. Do NOT use a <form> element or type='submit' buttons " +
+      "(the sandbox blocks form submissions). Use <button type='button'> with click handlers. " +
+      "When the user presses '=', the handler MUST `await " +
+      "Websandbox.connection.remote.evaluateExpression({ expression })` with the current " +
+      "display expression, then read `res.value` (when `res.ok` is true) and update the display.",
+  },
+  {
+    title: "Ping the host (calls notifyHost)",
+    message:
+      "Build a simple card with a single 'Say hi to the host' button (type='button', NO <form>). " +
+      "When clicked, the handler MUST `await " +
+      "Websandbox.connection.remote.notifyHost({ message: 'Hi from the sandbox!' })` and then " +
+      "display the returned confirmation object (including `receivedAt` timestamp) inside the card.",
+  },
+  {
+    title: "Inline expression evaluator",
+    message:
+      "Build a tiny UI with a text input and an 'Evaluate' button. Do NOT wrap them in a " +
+      "<form>, and do NOT use type='submit'. Use <button type='button'> wired with " +
+      "addEventListener('click', ...). When clicked, read the input value, call `const res = await " +
+      "Websandbox.connection.remote.evaluateExpression({ expression })`, and render " +
+      "`res.value` (if `res.ok === true`) or `res.error` (if `res.ok === false`) below the input.",
+  },
+];

--- a/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * Open-Ended Generative UI — minimal setup.
+ * -----------------------------------------
+ * Enabling `openGenerativeUI` in the runtime (see
+ * `src/app/api/copilotkit-ogui/route.ts`) is all that's needed — the
+ * runtime middleware streams agent-authored HTML + CSS to the built-in
+ * `OpenGenerativeUIActivityRenderer`, which mounts it inside a
+ * sandboxed iframe. No custom sandbox functions, no custom tools — just
+ * chat.
+ *
+ * Reference: https://docs.copilotkit.ai/generative-ui/open-generative-ui
+ */
+
+import React from "react";
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+
+const VISUALIZATION_DESIGN_SKILL = `When generating UI with generateSandboxedUi, your goal is to produce a polished, intricate, EDUCATIONAL visualisation that teaches the concept the user asked about. Treat the output like a figure from a well-designed textbook or explorable-explanation — not a bare-bones demo.
+
+Geometry + rendering:
+- Use inline SVG (preferred) or <canvas> for geometric content — NEVER stack dozens of <div>s to draw shapes.
+- Fit content within a ~600x400 content area with ~16-24px of edge padding. Use viewBox + preserveAspectRatio.
+- For 3D-ish scenes, either use SVG with manual perspective math OR CSS 3D transforms.
+
+Animation:
+- Prefer CSS @keyframes + transitions over JS setInterval. 300-900ms per cycle; loop cyclical concepts with animation-iteration-count: infinite.
+- When JS timing IS needed, use requestAnimationFrame, not setInterval.
+- Stagger related elements with animation-delay.
+
+Labels + legend + annotations:
+- EVERY axis gets a label. EVERY colour-coded series gets a legend swatch.
+- Add short text callouts that explain what the viewer is watching.
+- Include a 1-line title + 1-line subtitle at the top.
+
+Palette (use consistently):
+- Accent / primary motion: indigo #6366f1
+- Success / stable: emerald #10b981
+- Warning / active: amber #f59e0b
+- Error / destructive: rose #ef4444
+- Neutral axes / gridlines: slate #64748b
+- Surfaces: white #ffffff; subtle container bg #f8fafc; text #0f172a
+
+Typography:
+- system-ui, -apple-system, "Segoe UI", sans-serif.
+- Title 16-18px / 600, subtitle 12-13px / 500, axis + legend 11-12px.
+
+Containers:
+- Outer card: white background, 1px solid #e2e8f0 border, 10-12px border-radius, 20-24px padding.
+
+Motion principles:
+- Motion must teach. No decorative spinners or jitter for its own sake.
+
+Interactivity:
+- This minimal cell has NO host-side sandbox functions — the visualisation is self-running.
+
+Output contract (in order):
+- Emit initialHeight first (typically 480-560 for these visualisations).
+- placeholderMessages: 2-3 short lines.
+- css: complete and self-contained.
+- html: ONE root container with the title + subtitle + SVG/canvas + legend.
+
+Accessibility:
+- Text contrast >= 4.5:1 against its background.`;
+
+const minimalSuggestions = [
+  {
+    title: "3D axis visualization (model airplane)",
+    message:
+      "Visualize pitch, yaw, and roll using a 3D model airplane. Render a simple airplane silhouette (SVG or CSS-3D) at the origin, with three labelled axes. Animate the airplane cycling through each rotation in turn — rotate about X, pause, rotate about Y, pause, rotate about Z, pause — with a legend showing which axis is active.",
+  },
+  {
+    title: "How a neural network works",
+    message:
+      'Animate how a simple feed-forward neural network processes an input. Show 3 layers (input 4 nodes, hidden 5 nodes, output 2 nodes) with connections whose thickness encodes weight magnitude. Animate activations pulsing forward in a loop. Use indigo for active signal, slate for quiescent.',
+  },
+  {
+    title: "Quicksort visualization",
+    message:
+      'Visualize quicksort on an array of ~10 bars of varying heights. At each step highlight the pivot in amber, elements being compared in indigo, and swapped elements in emerald; fade sorted elements to slate.',
+  },
+];
+
+export default function OpenGenUiDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit-ogui"
+      agent="open-gen-ui"
+      openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}
+    >
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl flex flex-col p-3">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  useConfigureSuggestions({
+    suggestions: minimalSuggestions,
+    available: "always",
+  });
+
+  return <CopilotChat agentId="open-gen-ui" className="flex-1 rounded-2xl" />;
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
@@ -76,12 +76,12 @@ const minimalSuggestions = [
   {
     title: "How a neural network works",
     message:
-      'Animate how a simple feed-forward neural network processes an input. Show 3 layers (input 4 nodes, hidden 5 nodes, output 2 nodes) with connections whose thickness encodes weight magnitude. Animate activations pulsing forward in a loop. Use indigo for active signal, slate for quiescent.',
+      "Animate how a simple feed-forward neural network processes an input. Show 3 layers (input 4 nodes, hidden 5 nodes, output 2 nodes) with connections whose thickness encodes weight magnitude. Animate activations pulsing forward in a loop. Use indigo for active signal, slate for quiescent.",
   },
   {
     title: "Quicksort visualization",
     message:
-      'Visualize quicksort on an array of ~10 bars of varying heights. At each step highlight the pivot in amber, elements being compared in indigo, and swapped elements in emerald; fade sorted elements to slate.',
+      "Visualize quicksort on an array of ~10 bars of varying heights. At each step highlight the pivot in amber, elements being compared in indigo, and swapped elements in emerald; fade sorted elements to slate.",
   },
 ];
 

--- a/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-popup/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotPopup,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// Outer layer — provider + main content + floating popup launcher.
+export default function PrebuiltPopupDemo() {
+  return (
+    // @region[popup-basic-setup]
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+      <MainContent />
+      <CopilotPopup
+        agentId="prebuilt-popup"
+        defaultOpen={true}
+        labels={{
+          chatInputPlaceholder: "Ask the popup anything...",
+        }}
+      />
+      <Suggestions />
+    </CopilotKit>
+    // @endregion[popup-basic-setup]
+  );
+}
+
+function MainContent() {
+  return (
+    <main className="min-h-screen w-full p-12">
+      <h1 className="text-3xl font-semibold mb-4">
+        Popup demo — look for the floating launcher
+      </h1>
+      <p className="text-gray-600 max-w-xl">
+        This page showcases the pre-built <code>&lt;CopilotPopup /&gt;</code>{" "}
+        component. A floating launcher bubble sits in the corner, opening an
+        overlay chat window on top of the page content. It starts open by
+        default to make the popup form factor obvious.
+      </p>
+    </main>
+  );
+}
+
+function Suggestions() {
+  useConfigureSuggestions({
+    suggestions: [{ title: "Say hi", message: "Say hi from the popup!" }],
+    available: "always",
+  });
+  return null;
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-sidebar/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import {
+  CopilotKit,
+  CopilotSidebar,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// Outer layer — provider + main content + sidebar.
+export default function PrebuiltSidebarDemo() {
+  return (
+    // @region[sidebar-basic-setup]
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+      <MainContent />
+      {/* @region[sidebar-configuration] */}
+      <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
+      <Suggestions />
+    </CopilotKit>
+    // @endregion[sidebar-basic-setup]
+  );
+}
+
+function MainContent() {
+  return (
+    <main className="min-h-screen w-full p-12">
+      <h1 className="text-3xl font-semibold mb-4">
+        Sidebar demo — click the launcher
+      </h1>
+      <p className="text-gray-600 max-w-xl">
+        This page showcases the pre-built <code>&lt;CopilotSidebar /&gt;</code>{" "}
+        component. The sidebar is rendered alongside this main content and can
+        be toggled via its launcher button. It opens by default to make the
+        difference from the full-page chat demo obvious.
+      </p>
+    </main>
+  );
+}
+
+function Suggestions() {
+  useConfigureSuggestions({
+    suggestions: [{ title: "Say hi", message: "Say hi!" }],
+    available: "always",
+  });
+  return null;
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  useAgentContext,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+export default function ReadonlyStateAgentContextDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="readonly-state-agent-context"
+    >
+      <DemoContent />
+    </CopilotKit>
+  );
+}
+
+const TIMEZONES = [
+  "America/Los_Angeles",
+  "America/New_York",
+  "Europe/London",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+const ACTIVITIES = [
+  "Viewed the pricing page",
+  "Added 'Pro Plan' to cart",
+  "Watched the product demo video",
+  "Started the 14-day free trial",
+  "Invited a teammate",
+];
+
+function DemoContent() {
+  const [userName, setUserName] = useState("Atai");
+  const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
+  const [recentActivity, setRecentActivity] = useState<string[]>([
+    ACTIVITIES[0],
+    ACTIVITIES[2],
+  ]);
+
+  useAgentContext({
+    description: "The currently logged-in user's display name",
+    value: userName,
+  });
+  useAgentContext({
+    description: "The user's IANA timezone (used when mentioning times)",
+    value: userTimezone,
+  });
+  useAgentContext({
+    description: "The user's recent activity in the app, newest first",
+    value: recentActivity,
+  });
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Who am I?",
+        message: "What do you know about me from my context?",
+      },
+      {
+        title: "Suggest next steps",
+        message: "Based on my recent activity, what should I try next?",
+      },
+      {
+        title: "Plan my morning",
+        message:
+          "What time is it in my timezone and what should I do for the next hour?",
+      },
+    ],
+    available: "always",
+  });
+
+  const toggleActivity = (activity: string) => {
+    setRecentActivity((prev) =>
+      prev.includes(activity)
+        ? prev.filter((a) => a !== activity)
+        : [...prev, activity],
+    );
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row h-screen w-full bg-gray-50">
+      <aside className="p-4 md:w-[360px] md:shrink-0 overflow-y-auto">
+        <div
+          data-testid="context-card"
+          className="w-full max-w-md p-6 bg-white rounded-2xl shadow-lg border border-gray-100 space-y-5"
+        >
+          <div>
+            <h2 className="text-xl font-bold text-gray-800">Agent Context</h2>
+            <p className="text-xs text-gray-500 mt-1">
+              Read-only context provided to the agent via{" "}
+              <code>useAgentContext</code>. The agent cannot modify these.
+            </p>
+          </div>
+
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">Name</span>
+            <input
+              data-testid="ctx-name"
+              type="text"
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+              placeholder="e.g. Atai"
+              className="mt-1 w-full border rounded px-3 py-2 text-sm"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">Timezone</span>
+            <select
+              data-testid="ctx-timezone"
+              value={userTimezone}
+              onChange={(e) => setUserTimezone(e.target.value)}
+              className="mt-1 w-full border rounded px-3 py-2 text-sm"
+            >
+              {TIMEZONES.map((tz) => (
+                <option key={tz} value={tz}>
+                  {tz}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div>
+            <span className="text-sm font-medium text-gray-700">
+              Recent Activity
+            </span>
+            <div className="mt-2 flex flex-col gap-2">
+              {ACTIVITIES.map((activity) => {
+                const selected = recentActivity.includes(activity);
+                return (
+                  <label
+                    key={activity}
+                    className="flex items-center gap-2 text-sm cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selected}
+                      onChange={() => toggleActivity(activity)}
+                    />
+                    <span>{activity}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="pt-3 border-t border-gray-100">
+            <div className="text-[11px] uppercase tracking-wide text-gray-400 mb-1">
+              Published Context
+            </div>
+            <pre
+              data-testid="ctx-state-json"
+              className="bg-gray-50 rounded p-2 text-xs text-gray-700 overflow-x-auto"
+            >
+              {JSON.stringify(
+                { name: userName, timezone: userTimezone, recentActivity },
+                null,
+                2,
+              )}
+            </pre>
+          </div>
+        </div>
+      </aside>
+      <main className="flex-1 flex flex-col min-h-0">
+        <CopilotChat
+          agentId="readonly-state-agent-context"
+          className="flex-1 min-h-0"
+          labels={{ chatInputPlaceholder: "Ask about your context..." }}
+        />
+      </main>
+    </div>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/custom-catchall-renderer.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/custom-catchall-renderer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React from "react";
+
+// Branded catch-all renderer for the tool-rendering-custom-catchall cell.
+
+export type CatchallToolStatus = "inProgress" | "executing" | "complete";
+
+export interface CustomCatchallRendererProps {
+  name: string;
+  status: CatchallToolStatus;
+  parameters: unknown;
+  result: string | undefined;
+}
+
+export function CustomCatchallRenderer({
+  name,
+  status,
+  parameters,
+  result,
+}: CustomCatchallRendererProps) {
+  const parsedResult = parseResult(result);
+  const done = status === "complete";
+
+  return (
+    <div
+      data-testid="custom-catchall-card"
+      data-tool-name={name}
+      data-status={status}
+      className="my-3 overflow-hidden rounded-2xl border border-[#DBDBE5] bg-white shadow-sm"
+    >
+      <div className="flex items-center justify-between border-b border-[#E9E9EF] bg-[#FAFAFC] px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-[#838389]">
+            Tool
+          </span>
+          <span
+            data-testid="custom-catchall-tool-name"
+            className="font-mono text-sm text-[#010507]"
+          >
+            {name}
+          </span>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+
+      <div className="grid gap-3 p-4 text-sm">
+        <Section label="Arguments">
+          <pre
+            data-testid="custom-catchall-args"
+            className="overflow-x-auto rounded-lg border border-[#E9E9EF] bg-[#FAFAFC] p-2.5 font-mono text-xs text-[#010507]"
+          >
+            {safeStringify(parameters)}
+          </pre>
+        </Section>
+
+        <Section label="Result">
+          {done ? (
+            <pre
+              data-testid="custom-catchall-result"
+              className="overflow-x-auto rounded-lg border border-[#85ECCE4D] bg-[#85ECCE]/10 p-2.5 font-mono text-xs text-[#010507]"
+            >
+              {parsedResult !== undefined
+                ? safeStringify(parsedResult)
+                : "(empty)"}
+            </pre>
+          ) : (
+            <p className="text-xs italic text-[#838389]">
+              waiting for tool to finish…
+            </p>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[#838389]">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: CatchallToolStatus }) {
+  const { label, tone } = describeStatus(status);
+  return (
+    <span
+      data-testid="custom-catchall-status"
+      className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] ${tone}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function describeStatus(status: CatchallToolStatus): {
+  label: string;
+  tone: string;
+} {
+  switch (status) {
+    case "inProgress":
+      return {
+        label: "streaming",
+        tone: "border border-[#FFAC4D33] bg-[#FFAC4D]/15 text-[#57575B]",
+      };
+    case "executing":
+      return {
+        label: "running",
+        tone: "border border-[#BEC2FF] bg-[#BEC2FF1A] text-[#010507]",
+      };
+    case "complete":
+      return {
+        label: "done",
+        tone: "border border-[#85ECCE4D] bg-[#85ECCE]/20 text-[#189370]",
+      };
+  }
+}
+
+function parseResult(result: string | undefined): unknown {
+  if (result === undefined || result === null) return undefined;
+  if (typeof result !== "string") return result;
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result;
+  }
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+// Tool Rendering — CUSTOM CATCH-ALL variant.
+//
+// Same backend tools as `tool-rendering-default-catchall`, but this
+// cell opts out of CopilotKit's built-in default tool-call UI by
+// registering a SINGLE custom wildcard renderer via
+// `useDefaultRenderTool`. The same branded card now paints every tool
+// call — no per-tool renderers yet.
+
+import React from "react";
+import {
+  CopilotChat,
+  useDefaultRenderTool,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import {
+  CustomCatchallRenderer,
+  type CatchallToolStatus,
+} from "./custom-catchall-renderer";
+
+export default function ToolRenderingCustomCatchallDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering-custom-catchall"
+    >
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Weather in SF",
+        message: "What's the weather in San Francisco?",
+      },
+      {
+        title: "Find flights",
+        message: "Find flights from SFO to JFK.",
+      },
+      {
+        title: "Check financial data",
+        message: "Show me the latest financial data.",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <CopilotChat
+      agentId="tool-rendering-custom-catchall"
+      className="h-full rounded-2xl"
+    />
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+// Tool Rendering — DEFAULT CATCH-ALL variant (simplest).
+//
+// The backend exposes a handful of mock tools (get_weather, search_flights,
+// etc.) and the frontend ONLY opts into CopilotKit's built-in default
+// tool-call card — no per-tool renderers, no custom wildcard UI.
+//
+// `useDefaultRenderTool()` (called with no config) registers the built-
+// in `DefaultToolCallRenderer` under the `*` wildcard.
+
+import React from "react";
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+  useDefaultRenderTool,
+} from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+
+export default function ToolRenderingDefaultCatchallDemo() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering-default-catchall"
+    >
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  // Opt in to CopilotKit's built-in default tool-call card. Called with
+  // no config so the package-provided `DefaultToolCallRenderer` is used
+  // as the wildcard renderer.
+  useDefaultRenderTool();
+
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Weather in SF",
+        message: "What's the weather in San Francisco?",
+      },
+      {
+        title: "Find flights",
+        message: "Find flights from SFO to JFK.",
+      },
+      {
+        title: "Check financial data",
+        message: "Show me the latest financial data.",
+      },
+    ],
+    available: "always",
+  });
+
+  return (
+    <CopilotChat
+      agentId="tool-rendering-default-catchall"
+      className="h-full rounded-2xl"
+    />
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/voice/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/voice/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { SampleAudioButton } from "./sample-audio-button";
+
+const RUNTIME_URL = "/api/copilotkit-voice";
+const AGENT_ID = "voice-demo";
+const SAMPLE_AUDIO_PATH = "/demo-audio/sample.wav";
+const SAMPLE_LABEL = "What is the weather in Tokyo?";
+
+// Voice demo.
+//
+// Two affordances live on this page:
+//
+// 1. The default mic button rendered by <CopilotChat /> when the runtime at
+//    RUNTIME_URL advertises `audioFileTranscriptionEnabled: true`. Click it,
+//    speak, click again — text is transcribed into the composer.
+//
+// 2. The <SampleAudioButton /> below the chat, which fetches a bundled
+//    sample.wav, POSTs it to the same transcription endpoint, and writes the
+//    result into the chat's textarea (bypassing mic permissions so Playwright
+//    and screenshot flows work too).
+//
+// Injecting text into the composer goes through the DOM: CopilotChat owns its
+// input state internally (no external controlled-input API on v2 today), but
+// the textarea is tagged `data-testid="copilot-chat-textarea"`. Setting its
+// value via the native HTMLTextareaElement value setter and dispatching a
+// synthetic `input` event is the React-compatible way to flip the managed
+// state without reaching into CopilotChat's internals.
+export default function VoiceDemoPage() {
+  const handleTranscribed = useCallback((text: string) => {
+    if (typeof document === "undefined") return;
+    const textarea = document.querySelector<HTMLTextAreaElement>(
+      '[data-testid="copilot-chat-textarea"]',
+    );
+    if (!textarea) {
+      console.warn(
+        "[voice-demo] could not find copilot-chat-textarea to populate",
+      );
+      return;
+    }
+    // React tracks its own "last known value" on controlled inputs. Calling
+    // the native setter is what makes React observe the change on the next
+    // input event.
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (nativeSetter) {
+      nativeSetter.call(textarea, text);
+    } else {
+      textarea.value = text;
+    }
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    textarea.focus();
+  }, []);
+
+  return (
+    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+      <div className="flex h-screen flex-col gap-3 p-6">
+        <header>
+          <h1 className="text-lg font-semibold">Voice input</h1>
+          <p className="text-sm text-black/60 dark:text-white/60">
+            Click the microphone to record, or play the bundled sample audio.
+            Speech is transcribed into the input field — you click send.
+          </p>
+        </header>
+        <SampleAudioButton
+          onTranscribed={handleTranscribed}
+          runtimeUrl={RUNTIME_URL}
+          audioSrc={SAMPLE_AUDIO_PATH}
+          sampleLabel={SAMPLE_LABEL}
+        />
+        <div className="min-h-0 flex-1 overflow-hidden rounded-md border border-black/10 dark:border-white/10">
+          <CopilotChat agentId={AGENT_ID} className="h-full" />
+        </div>
+      </div>
+    </CopilotKit>
+  );
+}

--- a/showcase/packages/claude-sdk-python/src/app/demos/voice/sample-audio-button.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/voice/sample-audio-button.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Sample-audio button for the voice demo.
+ *
+ * Bypasses the microphone entirely: fetches a bundled audio clip from
+ * /public, base64-encodes it, and POSTs the single-route transcription
+ * envelope to the configured runtime URL. On success, invokes
+ * `onTranscribed(text)` so the caller can populate the chat composer.
+ *
+ * Matches the payload shape `transcribeAudio()` in
+ * `@copilotkit/react-core`'s transcription-client.ts uses when the runtime
+ * is in single-route transport mode — the default for
+ * `copilotRuntimeNextJSAppRouterEndpoint`.
+ */
+export interface SampleAudioButtonProps {
+  /** Called with the transcribed text on success. */
+  onTranscribed: (text: string) => void;
+  /** Runtime URL to POST the transcribe envelope to. */
+  runtimeUrl: string;
+  /** Public path of the sample audio clip. */
+  audioSrc: string;
+  /** Caption shown next to the button — what the user should expect. */
+  sampleLabel: string;
+}
+
+export function SampleAudioButton({
+  onTranscribed,
+  runtimeUrl,
+  audioSrc,
+  sampleLabel,
+}: SampleAudioButtonProps) {
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+
+  async function handleClick() {
+    setStatus("loading");
+    try {
+      const audioRes = await fetch(audioSrc);
+      if (!audioRes.ok) {
+        throw new Error(`Failed to fetch sample audio: ${audioRes.status}`);
+      }
+      const blob = await audioRes.blob();
+      const buffer = await blob.arrayBuffer();
+      const base64 = bufferToBase64(buffer);
+      const transcribeRes = await fetch(runtimeUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          method: "transcribe",
+          body: {
+            audio: base64,
+            mimeType: blob.type || "audio/wav",
+            filename: "sample.wav",
+          },
+        }),
+      });
+      if (!transcribeRes.ok) {
+        throw new Error(`Transcribe failed: ${transcribeRes.status}`);
+      }
+      const json = (await transcribeRes.json()) as { text?: string };
+      if (!json.text) {
+        throw new Error("Transcribe returned no text");
+      }
+      onTranscribed(json.text);
+      setStatus("idle");
+    } catch (err) {
+      console.error("[voice-demo] sample transcription failed", err);
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div
+      data-testid="voice-sample-audio"
+      className="flex items-center gap-3 rounded-md border border-black/10 bg-black/[0.02] px-3 py-2 text-sm dark:border-white/10 dark:bg-white/[0.02]"
+    >
+      <button
+        type="button"
+        data-testid="voice-sample-audio-button"
+        onClick={handleClick}
+        disabled={status === "loading"}
+        className="rounded border border-black/10 bg-white px-3 py-1 text-xs font-medium hover:bg-black/5 disabled:opacity-50 dark:border-white/10 dark:bg-black/30 dark:hover:bg-white/10"
+      >
+        {status === "loading" ? "Transcribing…" : "Play sample"}
+      </button>
+      <span className="text-black/60 dark:text-white/60">
+        Sample: &ldquo;{sampleLabel}&rdquo;
+      </span>
+      {status === "error" && (
+        <span
+          data-testid="voice-sample-audio-error"
+          className="ml-auto text-red-600 dark:text-red-400"
+        >
+          Error — see console
+        </span>
+      )}
+    </div>
+  );
+}
+
+function bufferToBase64(buffer: ArrayBuffer): string {
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + chunkSize)),
+    );
+  }
+  return btoa(binary);
+}

--- a/showcase/packages/claude-sdk-python/tests/e2e/agent-config.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/agent-config.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Agent Config Object", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/agent-config");
+  });
+
+  test("config card renders with all three selects", async ({ page }) => {
+    await expect(
+      page.locator('[data-testid="agent-config-card"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="agent-config-tone-select"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="agent-config-expertise-select"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="agent-config-length-select"]'),
+    ).toBeVisible();
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/auth.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/auth.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Authentication", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/auth");
+  });
+
+  test("banner starts authenticated by default", async ({ page }) => {
+    const banner = page.locator('[data-testid="auth-banner"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute("data-authenticated", "true");
+    await expect(
+      page.locator('[data-testid="auth-sign-out-button"]'),
+    ).toBeVisible();
+  });
+
+  test("sign-out transitions the banner to unauthenticated", async ({
+    page,
+  }) => {
+    await page.locator('[data-testid="auth-sign-out-button"]').click();
+    const banner = page.locator('[data-testid="auth-banner"]');
+    await expect(banner).toHaveAttribute("data-authenticated", "false");
+    await expect(
+      page.locator('[data-testid="auth-authenticate-button"]'),
+    ).toBeVisible();
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/byoc-hashbrown.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/byoc-hashbrown.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("BYOC hashbrown", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/byoc-hashbrown");
+  });
+
+  test("header renders", async ({ page }) => {
+    await expect(page.getByText("BYOC: Hashbrown")).toBeVisible();
+  });
+
+  test("chat composer is visible", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/byoc-json-render.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/byoc-json-render.spec.ts
@@ -12,7 +12,9 @@ test.describe("BYOC json-render", () => {
   });
 
   test("suggestion pills are rendered", async ({ page }) => {
-    await expect(page.getByText("Sales dashboard", { exact: false }).first()).toBeVisible({
+    await expect(
+      page.getByText("Sales dashboard", { exact: false }).first(),
+    ).toBeVisible({
       timeout: 10000,
     });
   });

--- a/showcase/packages/claude-sdk-python/tests/e2e/byoc-json-render.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/byoc-json-render.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("BYOC json-render", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/byoc-json-render");
+  });
+
+  test("page loads with chat composer", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("suggestion pills are rendered", async ({ page }) => {
+    await expect(page.getByText("Sales dashboard", { exact: false }).first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/chat-customization-css.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/chat-customization-css.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Chat Customization (CSS)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/chat-customization-css");
+  });
+
+  test("scoped wrapper applies CopilotKit variable override", async ({
+    page,
+  }) => {
+    const scope = page.locator(".chat-css-demo-scope").first();
+    await expect(scope).toBeVisible();
+
+    // The --copilot-kit-primary-color variable should resolve to #ff006e
+    // inside the scoped wrapper.
+    const primary = await scope.evaluate((el) =>
+      getComputedStyle(el)
+        .getPropertyValue("--copilot-kit-primary-color")
+        .trim(),
+    );
+    expect(primary).toBe("#ff006e");
+  });
+
+  test("chat input is present", async ({ page }) => {
+    await expect(page.getByPlaceholder("Type a message")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/chat-slots.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/chat-slots.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Chat Slots", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/chat-slots");
+  });
+
+  test("custom welcome screen slot renders", async ({ page }) => {
+    await expect(
+      page.locator('[data-testid="custom-welcome-screen"]'),
+    ).toBeVisible();
+    await expect(page.getByText("Welcome to the Slots demo")).toBeVisible();
+  });
+
+  test("page shows suggestion pills", async ({ page }) => {
+    await expect(page.getByText("Write a sonnet").first()).toBeVisible();
+    await expect(page.getByText("Tell me a joke").first()).toBeVisible();
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/frontend-tools-async.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/frontend-tools-async.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Frontend Tools (Async)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/frontend-tools-async");
+  });
+
+  test("page loads with chat surface", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/frontend-tools.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/frontend-tools.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Frontend Tools", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/frontend-tools");
+  });
+
+  test("page loads with chat surface", async ({ page }) => {
+    await expect(page.getByTestId("background-container")).toBeVisible();
+  });
+
+  test("chat input is reachable", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/headless-complete.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/headless-complete.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Headless Chat (Complete)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/headless-complete");
+  });
+
+  test("page loads with custom headless chrome", async ({ page }) => {
+    await expect(page.getByText("Headless Chat (Complete)")).toBeVisible();
+    await expect(page.getByTestId("headless-complete-messages")).toBeVisible();
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/headless-simple.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/headless-simple.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Headless Chat (Simple)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/headless-simple");
+  });
+
+  test("page loads with heading and empty message hint", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Headless Chat (Simple)" }),
+    ).toBeVisible();
+    await expect(page.getByText("No messages yet. Say hi!")).toBeVisible();
+  });
+
+  test("send button is disabled when input is empty", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/hitl-in-app.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/hitl-in-app.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("HITL In-App", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/hitl-in-app");
+  });
+
+  test("page loads with ticket list and chat", async ({ page }) => {
+    await expect(page.getByText("Open tickets")).toBeVisible();
+    await expect(page.getByTestId("ticket-12345")).toBeVisible();
+  });
+
+  test("chat input is reachable", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/multimodal.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/multimodal.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Multimodal attachments", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/multimodal");
+  });
+
+  test("demo root is visible", async ({ page }) => {
+    await expect(
+      page.locator('[data-testid="multimodal-demo-root"]'),
+    ).toBeVisible();
+  });
+
+  test("both sample buttons render", async ({ page }) => {
+    await expect(
+      page.locator('[data-testid="multimodal-sample-image-button"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="multimodal-sample-pdf-button"]'),
+    ).toBeVisible();
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/open-gen-ui-advanced.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/open-gen-ui-advanced.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Open-Ended Generative UI (Advanced)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/open-gen-ui-advanced");
+  });
+
+  test("chat input is reachable", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/open-gen-ui.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/open-gen-ui.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Open-Ended Generative UI", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/open-gen-ui");
+  });
+
+  test("chat input is reachable", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/prebuilt-popup.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/prebuilt-popup.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pre-Built Popup", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/prebuilt-popup");
+  });
+
+  test("page loads with popup launcher content", async ({ page }) => {
+    await expect(
+      page.getByText("Popup demo — look for the floating launcher"),
+    ).toBeVisible();
+  });
+
+  test("popup chat input is reachable", async ({ page }) => {
+    // defaultOpen={true} — the popup chat input should be on the page.
+    await expect(
+      page.getByPlaceholder("Ask the popup anything..."),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/prebuilt-sidebar.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/prebuilt-sidebar.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Pre-Built Sidebar", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/prebuilt-sidebar");
+  });
+
+  test("page loads with main content and sidebar", async ({ page }) => {
+    await expect(
+      page.getByText("Sidebar demo — click the launcher"),
+    ).toBeVisible();
+  });
+
+  test("sidebar chat input is present by default", async ({ page }) => {
+    // Sidebar opens by default, so the chat input should be reachable.
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/readonly-state-agent-context.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/readonly-state-agent-context.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Readonly State (Agent Context)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/readonly-state-agent-context");
+  });
+
+  test("page loads with context card", async ({ page }) => {
+    await expect(page.getByTestId("context-card")).toBeVisible();
+  });
+
+  test("context controls are editable", async ({ page }) => {
+    await expect(page.getByTestId("ctx-name")).toBeVisible();
+    await expect(page.getByTestId("ctx-timezone")).toBeVisible();
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/tool-rendering-custom-catchall.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/tool-rendering-custom-catchall.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Tool Rendering (Custom Catch-all)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/tool-rendering-custom-catchall");
+  });
+
+  test("chat input is reachable", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/tool-rendering-default-catchall.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/tool-rendering-default-catchall.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Tool Rendering (Default Catch-all)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/tool-rendering-default-catchall");
+  });
+
+  test("chat input is reachable", async ({ page }) => {
+    await expect(
+      page.locator('textarea, [placeholder*="message"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/showcase/packages/claude-sdk-python/tests/e2e/voice.spec.ts
+++ b/showcase/packages/claude-sdk-python/tests/e2e/voice.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Voice input", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/voice");
+  });
+
+  test("header and sample button render", async ({ page }) => {
+    await expect(page.getByText("Voice input")).toBeVisible();
+    await expect(
+      page.locator('[data-testid="voice-sample-audio-button"]'),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Brings `showcase/packages/claude-sdk-python/` closer to feature parity with `showcase/packages/langgraph-python/` by porting the frontend-only demos that run against the shared default Claude agent. Additional demos that require new agent-side plumbing (extended thinking streams, langgraph interrupt primitive, MCP client, A2UI catalogs, reasoning chains, etc.) are deferred and documented in `PARITY_NOTES.md`.

Lands alongside parallel PRs for `pydantic-ai` and `claude-sdk-typescript`.

## Ported

- `cli-start` — manifest-only entry with the framework-slug init command.
- `prebuilt-sidebar` — default `<CopilotSidebar />` over the shared agent.
- `prebuilt-popup` — default `<CopilotPopup />` over the shared agent.
- `chat-slots` — `welcomeScreen` / `input.disclaimer` / `messageView.assistantMessage` slot overrides.
- `chat-customization-css` — scoped CSS variable + class overrides.
- `headless-simple` — `useAgent` + `useComponent` minimal custom chat surface.

Each port ships:
- `src/app/demos/<id>/` (page + any supporting components)
- `manifest.yaml` entry in both `features:` and `demos:` (with `highlight:` paths matching the langgraph-python shape).
- `qa/<id>.md` — QA checklist pattern-matched to existing claude-sdk-python QA files.
- `tests/e2e/<id>.spec.ts` — minimal Playwright specs that navigate to the route and assert the page renders.

`src/app/api/copilotkit/route.ts` registers the five new agent ids against the shared `HttpAgent`.

## Skipped (documented in `PARITY_NOTES.md`)

- `gen-ui-interrupt`, `interrupt-headless` — require LangGraph's `interrupt()` primitive; Claude Agent SDK has no equivalent graph-interrupt primitive.
- `agentic-chat-reasoning`, `reasoning-default-render`, `tool-rendering-reasoning-chain` — require streaming Claude extended-thinking content blocks as separate AG-UI parts; the existing `agents/agent.py` AG-UI bridge does not translate `thinking` blocks.
- `mcp-apps` — MCP client + dedicated runtime route; agent-side MCP glue out of scope for this pass.
- `declarative-gen-ui`, `a2ui-fixed-schema` — A2UI catalog plus agent-side `render_a2ui` wiring. Deferred to an A2UI follow-up.
- `beautiful-chat` — 28 supporting files (layout, canvas, chart gen UI, hooks, theme CSS). Skeleton to be added in a follow-up.
- `frontend-tools`, `frontend-tools-async`, `hitl-in-app`, `readonly-state-agent-context`, `open-gen-ui`, `open-gen-ui-advanced`, `tool-rendering-default-catchall`, `tool-rendering-custom-catchall`, `headless-complete` — deferred per PARITY_NOTES.md (each needs a dedicated demo agent and/or multi-file frontend surface).

## Test plan

- [ ] `pnpm typecheck` / `next build` passes at `showcase/packages/claude-sdk-python` (local environment produced broken node_modules symlinks on Windows during this pass — see CONCERNS).
- [ ] Manual smoke: each ported demo route loads without runtime error, chat input is visible, and sending a message reaches the agent.
- [ ] Each new Python module (none added this pass) imports cleanly — n/a here.