### PR TITLE
fix(showcase/langgraph-python): repair six demo runtime regressions (byoc-json-render, hashbrown, multimodal, voice, agent-config, auth)

### DIFF
--- a/showcase/packages/langgraph-python/qa/auth.md
+++ b/showcase/packages/langgraph-python/qa/auth.md
@@ -8,46 +8,48 @@
 
 ## Test Steps
 
-### 1. Initial unauthenticated state
+### 1. Initial authenticated state
 
 - [ ] Navigate to /demos/auth
-- [ ] Verify the banner is visible with an amber/warning appearance (data-testid="auth-banner", data-authenticated="false")
-- [ ] Verify auth-status text reads "⚠ Not authenticated — the agent will reject your messages."
-- [ ] Verify the "Authenticate" button is visible and enabled (data-testid="auth-authenticate-button")
-- [ ] Verify the "Sign out" button is NOT present
+- [ ] Verify the banner is visible with a green/success appearance (data-testid="auth-banner", data-authenticated="true")
+- [ ] Verify auth-status text reads "✓ Signed in as demo user"
+- [ ] Verify the "Sign out" button is visible and enabled (data-testid="auth-sign-out-button")
+- [ ] Verify the "Sign in" button is NOT present
 - [ ] Verify <CopilotChat /> is mounted below the banner
-- [ ] Verify no auth-demo-error surface is shown yet (data-testid="auth-demo-error" absent)
+- [ ] Verify no auth-demo-error surface is shown (data-testid="auth-demo-error" absent)
+- [ ] Verify no console errors on page load (the `/info` handshake should succeed)
 
-### 2. Unauthenticated send → 401
+### 2. Authenticated send → assistant response
 
 - [ ] Type "Hello" and click send
-- [ ] Within 15 seconds, the page-level error surface appears:
-  - `data-testid="auth-demo-error"` visible with text containing "401" and/or "Unauthorized"
-- [ ] Verify no assistant response appears in the transcript
+- [ ] Within 30 seconds, an assistant response is rendered in the transcript
+- [ ] No auth-demo-error surface appears
 
-### 3. Authenticate flips the banner and enables sends
-
-- [ ] Click "Authenticate"
-- [ ] Within 1 second, the banner flips to green/success appearance (data-authenticated="true")
-- [ ] Verify auth-status text reads "✓ Authenticated as demo user"
-- [ ] Verify the "Sign out" button is visible (data-testid="auth-sign-out-button")
-- [ ] Verify the "Authenticate" button is no longer present
-- [ ] Verify the auth-demo-error surface is cleared on authenticate
-- [ ] Type "Hello" and click send
-- [ ] Within 15 seconds, an assistant response is rendered in the transcript
-
-### 4. Sign out reverts behavior
+### 3. Sign out flips the banner and surfaces 401 without crashing
 
 - [ ] Click "Sign out"
-- [ ] Banner flips back to amber within 1 second
-- [ ] Previous transcript (assistant replies from authenticated state) remains visible
-- [ ] Type "Hello again" and send
-- [ ] Within 15 seconds, the auth-demo-error surface reappears for the new send
+- [ ] Within 1 second, the banner flips to amber/warning appearance (data-authenticated="false")
+- [ ] Verify auth-status text reads "⚠ Signed out — the agent will reject your messages until you sign in."
+- [ ] Verify the "Sign in" button is visible (data-testid="auth-authenticate-button")
+- [ ] Verify the "Sign out" button is no longer present
+- [ ] Type "Hello again" and click send
+- [ ] Within 15 seconds, the page-level error surface appears:
+  - `data-testid="auth-demo-error"` visible with text containing "401" and/or "Unauthorized"
+- [ ] Verify the banner is STILL visible — the page must not white-screen
+- [ ] Verify no assistant response appears for the unauthenticated send
 
-### 5. Refresh resets state
+### 4. Sign in clears the error and restores sends
+
+- [ ] Click "Sign in"
+- [ ] Within 1 second, the banner flips back to green (data-authenticated="true")
+- [ ] Verify the auth-demo-error surface is cleared
+- [ ] Type "Hello" and click send
+- [ ] Within 30 seconds, an assistant response is rendered
+
+### 5. Refresh resets state to authenticated
 
 - [ ] Hard-reload the page
-- [ ] Banner is amber on first render (state does NOT persist)
+- [ ] Banner is green on first render (default state is authenticated; state does NOT persist)
 - [ ] No error surface on first render
 
 ### 6. Error Handling
@@ -58,8 +60,9 @@
 
 ## Expected Results
 
-- Banner state flips within 1s of Authenticate / Sign out clicks
-- Unauthenticated sends produce a visible 401 error within 15s via auth-demo-error
-- Authenticated sends produce an assistant response within 15s
-- No console errors during successful flows
-- Refresh fully resets auth state
+- Page loads authenticated by default — no 401 crash on initial `/info` fetch
+- Banner state flips within 1s of Sign out / Sign in clicks
+- Post-sign-out sends produce a visible 401 error within 15s via auth-demo-error
+- Page never white-screens after sign out — banner and composer remain mounted
+- Authenticated sends produce an assistant response within 30s
+- Refresh fully resets auth state (back to authenticated)

--- a/showcase/packages/langgraph-python/src/agents/byoc_hashbrown_agent.py
+++ b/showcase/packages/langgraph-python/src/agents/byoc_hashbrown_agent.py
@@ -4,10 +4,31 @@ Emits hashbrown-shaped structured output that the ported HashBrownDashboard
 renderer (`src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx`) progressively
 parses via `@hashbrownai/react`'s `useJsonParser` + `useUiKit`.
 
-The system prompt teaches the model the small component catalog exposed by
-the frontend kit (metric, pieChart, barChart, dealCard, Markdown) and how to
-assemble them into a `<ui>...</ui>` envelope. Mirrors the starter's
-sales-dashboard prompt shape so the same frontend kit can consume the output.
+Wire format
+-----------
+`@hashbrownai/react`'s `useJsonParser(content, kit.schema)` expects the agent
+to stream a JSON object literal matching `kit.schema` — NOT the `<ui>...</ui>`
+XML-style examples shown inside `useUiKit({ examples })`. Those XML examples
+are the hashbrown prompt DSL that hashbrown compiles into a schema description
+when driving the LLM directly (e.g. `useUiChat`/`useUiCompletion`). Because
+this demo drives the LLM via langgraph instead, we must mirror what
+hashbrown's own schema wire format looks like:
+
+    {
+      "ui": [
+        { "metric":   { "props": { "label": "...", "value": "..." } } },
+        { "pieChart": { "props": { "title": "...", "data": "[{...}]" } } },
+        { "barChart": { "props": { "title": "...", "data": "[{...}]" } } },
+        { "dealCard": { "props": { "title": "...", "stage": "prospect", "value": 100000 } } },
+        { "Markdown": { "props": { "children": "## heading\\nbody" } } }
+      ]
+    }
+
+Every node is a single-key object `{tagName: {props: {...}}}`. The tag names
+and prop schemas match `useSalesDashboardKit()` in
+`hashbrown-renderer.tsx`. `pieChart` and `barChart` receive `data` as a
+JSON-encoded string (this was intentional in PR #4252 to keep the schema
+stable under partial streaming).
 """
 
 from langchain.agents import create_agent
@@ -15,52 +36,55 @@ from langchain_openai import ChatOpenAI
 from copilotkit import CopilotKitMiddleware
 
 BYOC_HASHBROWN_SYSTEM_PROMPT = """\
-You are a sales analytics assistant that replies by emitting a structured UI
-markup consumed by a streaming JSON parser on the frontend.
+You are a sales analytics assistant that replies by emitting a single JSON
+object consumed by a streaming JSON parser on the frontend.
 
-ALWAYS respond with a single <ui>...</ui> root containing ONLY the following
-components. Do NOT wrap the response in code fences. Do NOT include any
-preface or explanation outside the <ui> root.
+ALWAYS respond with a single JSON object of the form:
 
-Available components:
+{
+  "ui": [
+    { <componentName>: { "props": { ... } } },
+    ...
+  ]
+}
 
-- <Markdown children="..."/>
+Do NOT wrap the response in code fences. Do NOT include any preface or
+explanation outside the JSON object. The response MUST be valid JSON.
+
+Available components and their prop schemas:
+
+- "metric": { "props": { "label": string, "value": string } }
+    A KPI card. `value` is a pre-formatted string like "$1.2M" or "248".
+
+- "pieChart": { "props": { "title": string, "data": string } }
+    A donut chart. `data` is a JSON-encoded STRING (embedded JSON) of an
+    array of {label, value} objects with at least 3 segments, e.g.
+    "data": "[{\\"label\\":\\"Enterprise\\",\\"value\\":600000}]".
+
+- "barChart": { "props": { "title": string, "data": string } }
+    A vertical bar chart. `data` is a JSON-encoded STRING of an array of
+    {label, value} objects with at least 3 bars, typically time-ordered.
+
+- "dealCard": { "props": { "title": string, "stage": string, "value": number } }
+    A single sales deal. `stage` MUST be one of: "prospect", "qualified",
+    "proposal", "negotiation", "closed-won", "closed-lost". `value` is a
+    raw number (no currency symbol or comma).
+
+- "Markdown": { "props": { "children": string } }
     Short explanatory text. Use for section headings and brief summaries.
-
-- <metric label="..." value="..." trend="..."/>
-    A KPI card. `label` and `value` are required. `trend` is a short
-    string like "+12% vs Q3" or "-4% MoM" — include it when you have a
-    meaningful comparison, omit it otherwise.
-
-- <pieChart title="..." data='[{"label":"...","value":N},...]'/>
-    A donut chart. `data` is a JSON string of {label, value} objects with
-    at least 3 segments. Omit the attribute if you have no values.
-
-- <barChart title="..." data='[{"label":"...","value":N},...]'/>
-    A vertical bar chart. `data` is a JSON string of {label, value} objects
-    with at least 3 bars, typically time-ordered.
-
-- <dealCard title="..." stage="..." value="NUMBER" assignee="..." dueDate="..."/>
-    A single sales deal. `stage` must be one of: prospect, qualified,
-    proposal, negotiation, closed-won, closed-lost. `value` is a dollar
-    amount with no symbol or comma (e.g. value="250000").
+    Standard markdown is supported in `children`.
 
 Rules:
 - Always produce plausible sample data when the user asks for a dashboard or
   chart — do not refuse for lack of data.
 - Prefer 3-6 rows of data in charts; keep labels short.
-- Use <Markdown> children for short headings or linking sentences between
-  visual components. Do not emit long prose.
+- Use "Markdown" for short headings or linking sentences between visual
+  components. Do not emit long prose.
 - Do not emit components that are not listed above.
+- `data` props on charts MUST be a JSON STRING — escape inner quotes.
 
-Example (sales dashboard):
-<ui>
-  <Markdown children="## Q4 Sales Summary" />
-  <metric label="Total Revenue" value="$1.2M" trend="+12% vs Q3" />
-  <metric label="New Customers" value="248" trend="+18% QoQ" />
-  <pieChart title="Revenue by Segment" data='[{"label":"Enterprise","value":600000},{"label":"SMB","value":400000},{"label":"Startup","value":200000}]' />
-  <barChart title="Monthly Revenue" data='[{"label":"Oct","value":350000},{"label":"Nov","value":400000},{"label":"Dec","value":450000}]' />
-</ui>
+Example response (sales dashboard):
+{"ui":[{"Markdown":{"props":{"children":"## Q4 Sales Summary"}}},{"metric":{"props":{"label":"Total Revenue","value":"$1.2M"}}},{"metric":{"props":{"label":"New Customers","value":"248"}}},{"pieChart":{"props":{"title":"Revenue by Segment","data":"[{\\"label\\":\\"Enterprise\\",\\"value\\":600000},{\\"label\\":\\"SMB\\",\\"value\\":400000},{\\"label\\":\\"Startup\\",\\"value\\":200000}]"}}},{"barChart":{"props":{"title":"Monthly Revenue","data":"[{\\"label\\":\\"Oct\\",\\"value\\":350000},{\\"label\\":\\"Nov\\",\\"value\\":400000},{\\"label\\":\\"Dec\\",\\"value\\":450000}]"}}}]}
 """
 
 graph = create_agent(

--- a/showcase/packages/langgraph-python/src/agents/multimodal_agent.py
+++ b/showcase/packages/langgraph-python/src/agents/multimodal_agent.py
@@ -5,25 +5,37 @@ Wave 2b design: a *dedicated* vision-capable graph scoped to the
 text-only) models — this keeps vision cost isolated to the one demo that
 exercises it.
 
-Inputs the runtime may forward:
-- `{"type": "text", "text": "..."}`
-- `{"type": "image", "source": {"type": "data", "value": "<base64>",
-    "mimeType": "image/png"}}`
-- `{"type": "document", "source": {"type": "data", "value": "<base64>",
-    "mimeType": "application/pdf"}}`
+Wire format the agent sees
+==========================
+Attachments arrive here after travelling through:
 
-OpenAI's chat API natively handles `image` content parts via gpt-4o. PDF
-handling is less uniform — LangChain's OpenAI integration does not yet map
-`document` content parts to OpenAI's `input_file` parts consistently
-across versions. To keep behavior deterministic and provider-agnostic, we
-preprocess `document` parts on the server via an `AgentMiddleware`:
-extract text with `pypdf` and replace the document part with a text part
-prefixed by `[Attached document]`. Images are passed through as-is.
+  CopilotChat  →  AG-UI message content parts  →  @ag-ui/langgraph runtime
+                                                   (ag-ui → LangChain converter)
+              →  this agent (LangChain HumanMessage content parts)
+
+The ag-ui-langgraph converter only understands the legacy
+``{ type: "binary", mimeType, data | url }`` AG-UI part shape — the page
+at ``src/app/demos/multimodal/page.tsx`` installs an
+``onRunInitialized`` shim that rewrites the modern
+``{ type: "image" | "document", source: {...} }`` shape CopilotChat emits
+to the legacy shape before it hits the runtime. Once the converter has
+run, every attachment shows up in this agent as a LangChain
+``image_url`` content part::
+
+    {"type": "image_url", "image_url": {"url": "data:<mime>;base64,<payload>"}}
+
+regardless of whether the upstream modality was ``image`` or ``document``.
+
+We therefore route on ``mimeType``, not the part ``type``:
+``image/*`` parts are forwarded to GPT-4o unchanged (vision-native);
+``application/pdf`` parts are flattened to inline text via ``pypdf`` so
+the model can read them without needing file-part support.
 
 References:
 - src/agents/main.py, src/agents/agentic_chat.py (baseline pattern)
-- packages/runtime/src/agent/converters/tanstack.ts (content-part shape
-  forwarded by the runtime)
+- packages/runtime/src/agent/converters/tanstack.ts (the modern content-
+  part shape — useful context when the runtime gets upgraded and this
+  agent can drop the pypdf flatten)
 """
 
 from __future__ import annotations
@@ -47,6 +59,24 @@ SYSTEM_PROMPT = (
 )
 
 
+def _extract_data_url_parts(url: str) -> tuple[str, str]:
+    """Split a ``data:<mime>;base64,<payload>`` URL into (mime, base64-payload).
+
+    Returns ("", url) if the input is not a base64 data URL — callers can
+    fall back to treating the url as a fetchable reference.
+    """
+    if not url.startswith("data:"):
+        return "", url
+    header, _, payload = url.partition(",")
+    # Header looks like "data:application/pdf;base64" — take the piece
+    # between the colon and the first semicolon.
+    if ":" not in header:
+        return "", payload
+    meta = header.split(":", 1)[1]
+    mime = meta.split(";", 1)[0] if ";" in meta else meta
+    return mime, payload
+
+
 def _extract_pdf_text(b64: str) -> str:
     """Decode an inline-base64 PDF and extract its text.
 
@@ -55,9 +85,6 @@ def _extract_pdf_text(b64: str) -> str:
     and swallowed so one malformed attachment does not tank the whole
     user turn.
     """
-    # Strip a potential data URL prefix ("data:application/pdf;base64,...").
-    if b64.startswith("data:"):
-        _, _, b64 = b64.partition(",")
     try:
         raw = base64.b64decode(b64, validate=False)
     except Exception as exc:  # pragma: no cover - defensive
@@ -84,30 +111,82 @@ def _extract_pdf_text(b64: str) -> str:
         return ""
 
 
-def _preprocess_part(part: Any) -> Any:
-    """Replace a `document` (PDF) part with an inline text block.
+def _classify_attachment_part(part: Any) -> tuple[str, str, str] | None:
+    """Inspect a content part and return (kind, mime, base64_payload).
 
-    Non-document parts are returned unchanged. Images pass through so
-    gpt-4o can consume them natively.
+    ``kind`` is one of ``"image"``, ``"pdf"``, ``"other"``. Returns
+    ``None`` if the part is not an attachment we recognise (plain text,
+    unrelated dict, string, etc.).
+
+    Handles the shapes we actually see in practice:
+
+    - ``{"type": "image_url", "image_url": {"url": "data:..."}}``
+      (what the ag-ui-langgraph converter emits for every attachment
+      after the page rewrites to legacy ``binary``).
+    - ``{"type": "image_url", "image_url": "data:..."}``
+      (older LangChain/OpenAI shape where ``image_url`` is a raw string).
+    - ``{"type": "document", "source": {"type": "data",
+      "value": "<base64>", "mimeType": "application/pdf"}}``
+      (modern AG-UI shape — preserved for forward-compat if the runtime
+      ever starts forwarding modern parts directly).
     """
     if not isinstance(part, dict):
+        return None
+    part_type = part.get("type")
+
+    if part_type == "image_url":
+        image_url = part.get("image_url")
+        url: str | None = None
+        if isinstance(image_url, str):
+            url = image_url
+        elif isinstance(image_url, dict):
+            raw_url = image_url.get("url")
+            if isinstance(raw_url, str):
+                url = raw_url
+        if not url:
+            return None
+        mime, payload = _extract_data_url_parts(url)
+        if not payload or not mime:
+            return None
+        if mime.startswith("image/"):
+            return ("image", mime, payload)
+        if "pdf" in mime.lower():
+            return ("pdf", mime, payload)
+        return ("other", mime, payload)
+
+    if part_type == "document":
+        source = part.get("source")
+        if not isinstance(source, dict) or source.get("type") != "data":
+            return None
+        value = source.get("value")
+        mime = source.get("mimeType", "")
+        if not isinstance(value, str) or not isinstance(mime, str):
+            return None
+        if "pdf" in mime.lower():
+            return ("pdf", mime, value)
+        return ("other", mime, value)
+
+    return None
+
+
+def _preprocess_part(part: Any) -> Any:
+    """Flatten PDF attachments to text; pass everything else through.
+
+    Images stay as-is so GPT-4o consumes them natively via its vision
+    adapter. PDFs (which gpt-4o cannot read directly) become a text part
+    prefixed with ``[Attached document]`` and the extracted body. If
+    extraction fails we emit a structured placeholder so the model can
+    tell the user the document was unreadable instead of pretending no
+    attachment was sent.
+    """
+    classified = _classify_attachment_part(part)
+    if classified is None:
         return part
-    if part.get("type") != "document":
+    kind, _mime, payload = classified
+    if kind != "pdf":
         return part
-    source = part.get("source") or {}
-    if source.get("type") != "data":
-        # URL-source documents are rare in this demo (we always inline base64).
-        # Leave them alone; the model may or may not fetch the URL.
-        return part
-    mime_type = source.get("mimeType", "")
-    if "pdf" not in mime_type.lower():
-        # Non-PDF documents are unusual — pass through; nothing else we can do.
-        return part
-    value = source.get("value", "")
-    text = _extract_pdf_text(value) if isinstance(value, str) else ""
+    text = _extract_pdf_text(payload)
     if not text:
-        # Empty or unreadable PDF — give the model a structured note so it
-        # can tell the user we couldn't read the document.
         return {
             "type": "text",
             "text": "[Attached document: PDF could not be read.]",
@@ -116,7 +195,7 @@ def _preprocess_part(part: Any) -> Any:
 
 
 def _rewrite_messages(messages: list[Any]) -> list[Any]:
-    """Rewrite user messages so `document` parts become text parts.
+    """Rewrite user messages so non-image attachments become text parts.
 
     Operates on the messages list stored in agent state. Returns a *new*
     list; the input list is not mutated.
@@ -137,11 +216,11 @@ def _rewrite_messages(messages: list[Any]) -> list[Any]:
 
 
 class _PdfFlattenMiddleware(AgentMiddleware):
-    """Flatten `document` (PDF) content parts to text before the model call.
+    """Flatten PDF content parts to text before the model call.
 
-    We run this in `before_model` so every model invocation — including
+    We run this in ``before_model`` so every model invocation — including
     retries after tool calls — sees the flattened view. The middleware is
-    idempotent: once a part has been rewritten to `{"type": "text", ...}`
+    idempotent: once a part has been rewritten to ``{"type": "text", ...}``
     it is returned unchanged on subsequent passes.
     """
 
@@ -158,7 +237,7 @@ class _PdfFlattenMiddleware(AgentMiddleware):
         return {"messages": rewritten}
 
 
-# Vision-capable model. gpt-4o consumes `image` content parts natively.
+# Vision-capable model. gpt-4o consumes `image_url` content parts natively.
 _MODEL = ChatOpenAI(model="gpt-4o", temperature=0.2)
 
 

--- a/showcase/packages/langgraph-python/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/copilotkit-agent-config/route.ts
@@ -14,7 +14,8 @@
 // - src/agents/agent_config_agent.py — the graph
 // - src/app/demos/agent-config/page.tsx — the provider config
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
   ExperimentalEmptyAdapter,
@@ -22,10 +23,125 @@ import {
 } from "@copilotkit/runtime";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
+// Shape of the AG-UI run input we care about. We avoid a direct import of
+// `RunAgentInput` from `@ag-ui/client` so this route has no additional
+// peer-dep on internal AG-UI packages — the field we touch (`forwardedProps`)
+// is part of the stable AG-UI protocol contract.
+type RunInputWithForwardedProps = {
+  forwardedProps?: Record<string, unknown> | undefined;
+  [k: string]: unknown;
+};
+
 const LANGGRAPH_URL =
   process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
-const agentConfigAgent = new LangGraphAgent({
+// Keys on `forwardedProps` that the ag-ui LangGraphAgent treats as reserved
+// stream-payload fields (e.g. `config`, `command`, `streamMode`). These must
+// NOT be repacked under `configurable.properties` — they are structural fields
+// the LangGraph SDK understands directly. Anything else on `forwardedProps`
+// is user-supplied frontend state that needs to reach the graph node.
+//
+// Keep this list in sync with ag-ui/langgraph/typescript/src/agent.ts
+// `RunAgentExtendedInput["forwardedProps"]`.
+const RESERVED_FORWARDED_PROPS_KEYS = new Set<string>([
+  "config",
+  "command",
+  "streamMode",
+  "streamSubgraphs",
+  "nodeName",
+  "threadMetadata",
+  "checkpointId",
+  "checkpointDuring",
+  "interruptBefore",
+  "interruptAfter",
+  "multitaskStrategy",
+  "ifNotExists",
+  "afterSeconds",
+  "onCompletion",
+  "onDisconnect",
+  "webhook",
+  "feedbackKeys",
+  "metadata",
+]);
+
+/**
+ * Wrapper around `LangGraphAgent` that repacks the CopilotKit provider's
+ * `properties` (which arrive as top-level keys on `forwardedProps`) into
+ * `forwardedProps.config.configurable.properties` so the Python LangGraph
+ * graph can read them from `RunnableConfig["configurable"]["properties"]`.
+ *
+ * Why this bridge exists: the CopilotKit runtime forwards
+ * `CopilotKitCore.properties` as `forwardedProps` (see core's run-handler).
+ * The ag-ui LangGraphAgent spreads unknown forwardedProps keys into the
+ * top-level LangGraph stream payload, where they are ignored by the server.
+ * Only `forwardedProps.config.configurable.*` actually reaches the graph's
+ * `RunnableConfig`. This class closes that gap for this demo.
+ */
+class AgentConfigLangGraphAgent extends LangGraphAgent {
+  // Intercept each run() to repack provider `properties` (which land on
+  // `forwardedProps`) into `forwardedProps.config.configurable.properties`,
+  // the only place the LangGraph SDK will surface them to the Python graph's
+  // `RunnableConfig["configurable"]["properties"]`.
+  run(
+    input: Parameters<LangGraphAgent["run"]>[0],
+  ): ReturnType<LangGraphAgent["run"]> {
+    const repacked = repackForwardedPropsIntoConfigurable(
+      input as RunInputWithForwardedProps,
+    );
+    return super.run(repacked as Parameters<LangGraphAgent["run"]>[0]);
+  }
+}
+
+function repackForwardedPropsIntoConfigurable<
+  T extends RunInputWithForwardedProps,
+>(input: T): T {
+  const fp = (input.forwardedProps ?? {}) as Record<string, unknown>;
+  if (!fp || typeof fp !== "object") return input;
+
+  // Split forwardedProps into (structural) and (user-supplied) halves.
+  const userProps: Record<string, unknown> = {};
+  const structural: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(fp)) {
+    if (RESERVED_FORWARDED_PROPS_KEYS.has(key)) {
+      structural[key] = value;
+    } else {
+      userProps[key] = value;
+    }
+  }
+
+  if (Object.keys(userProps).length === 0) return input;
+
+  const existingConfig = (structural.config ?? {}) as {
+    configurable?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+  const existingConfigurable =
+    (existingConfig.configurable as Record<string, unknown> | undefined) ?? {};
+  const existingProperties =
+    (existingConfigurable.properties as Record<string, unknown> | undefined) ??
+    {};
+
+  const mergedConfig = {
+    ...existingConfig,
+    configurable: {
+      ...existingConfigurable,
+      properties: {
+        ...existingProperties,
+        ...userProps,
+      },
+    },
+  };
+
+  return {
+    ...input,
+    forwardedProps: {
+      ...structural,
+      config: mergedConfig,
+    },
+  } as T;
+}
+
+const agentConfigAgent = new AgentConfigLangGraphAgent({
   deploymentUrl: LANGGRAPH_URL,
   graphId: "agent_config_agent",
   langsmithApiKey: process.env.LANGSMITH_API_KEY || "",

--- a/showcase/packages/langgraph-python/src/app/api/copilotkit-voice/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/copilotkit-voice/route.ts
@@ -11,18 +11,40 @@
 // The underlying graph is the same neutral `sample_agent` other chat demos
 // use: voice is an input-modality concern, not an agent-behavior concern.
 //
+// Two non-obvious things this file does:
+//
+// 1. It bypasses the V1 `CopilotRuntime` wrapper's silent drop of
+//    `transcriptionService` by writing the service onto the V2 runtime
+//    instance directly. See `packages/runtime/src/lib/runtime/copilot-runtime.ts`
+//    — `transcriptionService` is `Omit`ed from the V1 constructor type and the
+//    constructor explicitly does not forward it to the V2 runtime (see the
+//    "TODO: add support for transcriptionService" comment there). Until that
+//    is unblocked upstream, per-demo routes that need transcription must
+//    reach through `.instance`.
+//
+// 2. It always mounts a transcription service (so `/info` advertises the
+//    mic-capable state and the composer renders the mic button) but makes
+//    the service return a deterministic, human-readable error when
+//    OPENAI_API_KEY is not set on the deployment. That keeps the frontend
+//    affordance visible while failing loudly with a 4xx instead of a silent
+//    503 when the deployment is misconfigured.
+//
 // References:
 // - packages/voice/src/transcription/transcription-service-openai.ts
 // - packages/runtime/src/v2/runtime/handlers/handle-transcribe.ts
+// - packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
 // - src/app/api/copilotkit-beautiful-chat/route.ts (per-demo route shape)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
   ExperimentalEmptyAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
 } from "@copilotkit/runtime";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
+import { TranscriptionService } from "@copilotkit/runtime/v2";
+import type { TranscribeFileOptions } from "@copilotkit/runtime/v2";
 import { TranscriptionServiceOpenAI } from "@copilotkit/voice";
 import OpenAI from "openai";
 
@@ -35,18 +57,59 @@ const voiceDemoAgent = new LangGraphAgent({
   langsmithApiKey: process.env.LANGSMITH_API_KEY || "",
 });
 
-// Construct the OpenAI client + runtime lazily on first request so the
-// Next.js build step (which imports and page-data-collects every route
+/**
+ * Transcription service wrapper that reports a clean, typed auth error when
+ * OPENAI_API_KEY is not configured.
+ *
+ * The underlying runtime's `handleTranscribe` categorizes error messages by
+ * substring match — in particular, a message containing "api key" or
+ * "unauthorized" is mapped to `AUTH_FAILED` (HTTP 401). Throwing here with a
+ * deterministic message funnels the missing-key case into that 4xx path
+ * instead of leaking an opaque 500/503 through the provider-error fallback.
+ *
+ * If the key is present we delegate to the real OpenAI-backed service; any
+ * upstream Whisper error keeps its natural categorization.
+ */
+class GuardedOpenAITranscriptionService extends TranscriptionService {
+  private delegate: TranscriptionServiceOpenAI | null;
+
+  constructor() {
+    super();
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (apiKey) {
+      this.delegate = new TranscriptionServiceOpenAI({
+        openai: new OpenAI({ apiKey }),
+      });
+    } else {
+      this.delegate = null;
+    }
+  }
+
+  async transcribeFile(options: TranscribeFileOptions): Promise<string> {
+    if (!this.delegate) {
+      // Message includes "api key" so the runtime's error categorizer maps
+      // this to AUTH_FAILED → HTTP 401 with a readable body. This is the
+      // intended 4xx path for a misconfigured deployment.
+      throw new Error(
+        "OPENAI_API_KEY not configured for this deployment (api key missing). " +
+          "Set OPENAI_API_KEY to enable voice transcription.",
+      );
+    }
+    return this.delegate.transcribeFile(options);
+  }
+}
+
+// Construct the runtime + transcription service lazily on first request so
+// the Next.js build step (which imports and page-data-collects every route
 // module) can complete even when OPENAI_API_KEY is not set in the Docker
-// build context. Whisper calls only fire when the user triggers
-// transcription at runtime on Railway, where the env var is set.
+// build context. Whisper calls only fire when the user triggers transcription
+// at runtime, where the env var is set (or, if it isn't, the guarded service
+// above returns a deterministic 4xx).
 let cachedRuntime: CopilotRuntime | null = null;
 function getRuntime(): CopilotRuntime {
   if (cachedRuntime) return cachedRuntime;
-  const transcriptionService = new TranscriptionServiceOpenAI({
-    openai: new OpenAI({ apiKey: process.env.OPENAI_API_KEY }),
-  });
-  cachedRuntime = new CopilotRuntime({
+
+  const runtime = new CopilotRuntime({
     // @ts-ignore -- see main route.ts: published CopilotRuntime agents type
     // wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain
     // Records; fixed in source, pending release.
@@ -58,8 +121,18 @@ function getRuntime(): CopilotRuntime {
       // default-agent lookups resolve against the same graph.
       default: voiceDemoAgent,
     },
-    transcriptionService,
   });
+
+  // V1 CopilotRuntime's constructor drops `transcriptionService` on the floor
+  // (see file header note #1). Write it onto the V2 runtime instance directly
+  // so `/info` advertises `audioFileTranscriptionEnabled: true` and so
+  // `POST {method: "transcribe"}` has a service to invoke.
+  const v2Instance = runtime.instance as unknown as {
+    transcriptionService?: TranscriptionService;
+  };
+  v2Instance.transcriptionService = new GuardedOpenAITranscriptionService();
+
+  cachedRuntime = runtime;
   return cachedRuntime;
 }
 
@@ -80,4 +153,8 @@ export const POST = async (req: NextRequest) => {
   }
 };
 
+// The v2 runtime client tries `GET {runtimeUrl}/info` first and falls back to
+// single-route POST on failure. Exporting `GET` here keeps the 405 we'd
+// otherwise return from being treated as a server error in logs; the v2
+// auto-detect ignores the 405 and moves on to the working POST path.
 export const GET = POST;

--- a/showcase/packages/langgraph-python/src/app/demos/auth/auth-banner.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/auth/auth-banner.tsx
@@ -20,8 +20,8 @@ export function AuthBanner({
     ? "border-emerald-300 bg-emerald-50 text-emerald-900"
     : "border-amber-300 bg-amber-50 text-amber-900";
   const statusText = authenticated
-    ? "✓ Authenticated as demo user"
-    : "⚠ Not authenticated — the agent will reject your messages.";
+    ? "✓ Signed in as demo user"
+    : "⚠ Signed out — the agent will reject your messages until you sign in.";
 
   return (
     <div
@@ -48,7 +48,7 @@ export function AuthBanner({
           onClick={onAuthenticate}
           className="rounded border border-amber-400 bg-white px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
         >
-          Authenticate
+          Sign in
         </button>
       )}
     </div>

--- a/showcase/packages/langgraph-python/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/auth/page.tsx
@@ -6,16 +6,86 @@
 // `Authorization: Bearer <demo-token>` header on every request. The runtime
 // route (/api/copilotkit-auth) rejects any request without the header.
 //
+// Default UX: the page loads authenticated so the initial `/info` handshake
+// succeeds and the chat is immediately usable. Clicking "Sign out" flips to
+// the unauthenticated state — the next chat submission (and any re-fetch of
+// `/info`) will 401, which we surface via the page-level error banner. This
+// inverts the historical unauth-first flow, which crashed the page on load
+// when `/info` returned 401 before `onError` handlers could attach.
+//
 // Error surfacing: <CopilotChat /> surfaces transport errors inconsistently
 // across states, so this page additionally captures errors via the
 // <CopilotKit onError> prop and renders a persistent error banner below the
-// chat. This guarantees the 401 failure path is always visible to the user
-// and gives the Playwright E2E a stable assertion target.
+// chat. A local ErrorBoundary guards against any uncaught render-time error
+// from chat internals in the unauthenticated state so the page never white-
+// screens — instead, the user sees a clear in-page message.
 
-import { useCallback, useMemo, useState } from "react";
+import { Component, useCallback, useMemo, useState } from "react";
+import type { ErrorInfo, ReactNode } from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import { useDemoAuth } from "./use-demo-auth";
 import { AuthBanner } from "./auth-banner";
+
+interface ChatErrorBoundaryProps {
+  authenticated: boolean;
+  children: ReactNode;
+}
+
+interface ChatErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Guards <CopilotChat /> against uncaught render-time errors. If the chat
+ * internals throw (most commonly while the app is in the unauthenticated
+ * state and a transient response payload is missing), we render a clear
+ * in-page message instead of white-screening the entire route. The boundary
+ * resets whenever `authenticated` flips, so signing back in restores the
+ * live chat without requiring a full page reload.
+ */
+class ChatErrorBoundary extends Component<
+  ChatErrorBoundaryProps,
+  ChatErrorBoundaryState
+> {
+  state: ChatErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ChatErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: ChatErrorBoundaryProps): void {
+    // Reset on auth transition so signing in re-mounts a fresh <CopilotChat />.
+    if (prevProps.authenticated !== this.props.authenticated && this.state.error) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Keep the console trail for devtools but do not rethrow.
+    console.error("[auth-demo] chat error boundary caught:", error, info);
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div
+          data-testid="auth-demo-chat-boundary"
+          className="flex h-full items-center justify-center p-6 text-center text-sm text-neutral-600"
+        >
+          <div>
+            <p className="font-medium text-neutral-800">
+              Chat unavailable while signed out
+            </p>
+            <p className="mt-1 text-xs text-neutral-500">
+              Click Sign in above to restore the conversation.
+            </p>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 export default function AuthDemoPage() {
   const auth = useDemoAuth();
@@ -54,7 +124,7 @@ export default function AuthDemoPage() {
         err?.status ?? err?.statusCode ?? errorEvent?.context?.response?.status;
       if (status === 401 || /401|unauthor/i.test(message)) {
         setLastError(
-          "401 Unauthorized — click Authenticate above to send messages.",
+          "401 Unauthorized — click Sign in above to restore access.",
         );
       } else {
         setLastError(message);
@@ -83,12 +153,14 @@ export default function AuthDemoPage() {
             <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-xs">
               onRequest
             </code>{" "}
-            hook. Try sending a message while unauthenticated, then click
-            Authenticate.
+            hook. You start signed in — click Sign out above to exercise the
+            401 path, then Sign in to restore access.
           </p>
         </header>
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <ChatErrorBoundary authenticated={auth.authenticated}>
+            <CopilotChat agentId="auth-demo" className="h-full" />
+          </ChatErrorBoundary>
         </div>
         {lastError && (
           <div

--- a/showcase/packages/langgraph-python/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/auth/page.tsx
@@ -55,7 +55,10 @@ class ChatErrorBoundary extends Component<
 
   componentDidUpdate(prevProps: ChatErrorBoundaryProps): void {
     // Reset on auth transition so signing in re-mounts a fresh <CopilotChat />.
-    if (prevProps.authenticated !== this.props.authenticated && this.state.error) {
+    if (
+      prevProps.authenticated !== this.props.authenticated &&
+      this.state.error
+    ) {
       this.setState({ error: null });
     }
   }
@@ -153,8 +156,8 @@ export default function AuthDemoPage() {
             <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-xs">
               onRequest
             </code>{" "}
-            hook. You start signed in — click Sign out above to exercise the
-            401 path, then Sign in to restore access.
+            hook. You start signed in — click Sign out above to exercise the 401
+            path, then Sign in to restore access.
           </p>
         </header>
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">

--- a/showcase/packages/langgraph-python/src/app/demos/auth/use-demo-auth.ts
+++ b/showcase/packages/langgraph-python/src/app/demos/auth/use-demo-auth.ts
@@ -15,11 +15,13 @@ export interface DemoAuthHandle {
 
 /**
  * In-memory auth state for the /demos/auth showcase cell. No persistence —
- * refreshing the page resets to unauth, which is intentional for demo
- * resetability.
+ * refreshing the page resets to the default authenticated state, which keeps
+ * the demo immediately usable and avoids the 401 crash on initial `/info`
+ * fetch that happens when starting unauthenticated. Users can click "Sign
+ * out" to exercise the unauthenticated / 401 path on demand.
  */
 export function useDemoAuth(): DemoAuthHandle {
-  const [authenticated, setAuthenticated] = useState(false);
+  const [authenticated, setAuthenticated] = useState(true);
 
   const authenticate = useCallback(() => {
     setAuthenticated(true);

--- a/showcase/packages/langgraph-python/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
@@ -13,6 +13,25 @@
  * hashbrown schema via `@hashbrownai/react`'s `useUiKit`. Renders assistant
  * messages through `useJsonParser` for progressive JSON→UI streaming.
  *
+ * Wire format
+ * -----------
+ * `useJsonParser(content, kit.schema)` parses a streaming JSON object of the
+ * shape produced by `createUiKit(...).schema`:
+ *
+ *   {
+ *     "ui": [
+ *       { "metric":   { "props": { "label": "...", "value": "..." } } },
+ *       { "pieChart": { "props": { "title": "...", "data": "[{...}]" } } },
+ *       { "Markdown": { "props": { "children": "..." } } }
+ *     ]
+ *   }
+ *
+ * The `useUiKit({ examples: ... })` `<ui>` JSX is hashbrown's prompt DSL used
+ * when hashbrown drives the LLM directly (e.g. `useUiChat`). Because this
+ * demo drives the LLM via langgraph, the backend agent
+ * (`src/agents/byoc_hashbrown_agent.py`) is responsible for emitting the JSON
+ * shape shown above.
+ *
  * Consume the renderer like this in a page:
  *
  *   <HashBrownDashboard>

--- a/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/json-render-renderer.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/json-render-renderer.tsx
@@ -30,11 +30,9 @@
  */
 
 import React, { useMemo } from "react";
-import {
-  CopilotChatAssistantMessage,
-  type CopilotChatAssistantMessageProps,
-} from "@copilotkit/react-core/v2";
-import { Renderer } from "@json-render/react";
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+import type { CopilotChatAssistantMessageProps } from "@copilotkit/react-core/v2";
+import { JSONUIProvider, Renderer } from "@json-render/react";
 import { registry } from "./registry";
 import type { JsonRenderSpec } from "./types";
 
@@ -61,17 +59,24 @@ export function JsonRenderAssistantMessage(
     return <CopilotChatAssistantMessage {...props} />;
   }
 
-  // Valid spec — render via json-render. Wrap in the same bubble-level
-  // container the default renderer would use so the message still looks
-  // like an assistant message in the transcript.
+  // Valid spec — render via json-render. `<Renderer />` alone does not
+  // set up the StateProvider / VisibilityProvider / ActionProvider /
+  // ValidationProvider contexts its `ElementRenderer` requires (it would
+  // crash with `useVisibility must be used within a VisibilityProvider`).
+  // `JSONUIProvider` wires all four in one; we don't use actions or
+  // state here, so defaults are fine.
   return (
     <div data-testid="json-render-root" className="w-full">
-      <Renderer
-        spec={
-          parseResult.spec as unknown as Parameters<typeof Renderer>[0]["spec"]
-        }
-        registry={registry}
-      />
+      <JSONUIProvider registry={registry}>
+        <Renderer
+          spec={
+            parseResult.spec as unknown as Parameters<
+              typeof Renderer
+            >[0]["spec"]
+          }
+          registry={registry}
+        />
+      </JSONUIProvider>
     </div>
   );
 }

--- a/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/registry.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/registry.tsx
@@ -20,8 +20,19 @@ import { PieChart } from "./charts/pie-chart";
 
 export const { registry } = defineRegistry(catalog, {
   components: {
-    MetricCard: ({ props }) => (
-      <MetricCard label={props.label} value={props.value} trend={props.trend} />
+    // The agent's system prompt includes a worked example where a MetricCard
+    // is the root of a sales dashboard with a BarChart nested in its
+    // `children` array. Forward `children` through so that multi-component
+    // dashboards render as one wrapped block rather than dropping the chart.
+    MetricCard: ({ props, children }) => (
+      <div className="flex w-full flex-col items-stretch gap-3">
+        <MetricCard
+          label={props.label}
+          value={props.value}
+          trend={props.trend}
+        />
+        {children}
+      </div>
     ),
     BarChart: ({ props }) => (
       <BarChart

--- a/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
@@ -36,11 +36,7 @@
  */
 
 import { useCallback, useEffect, useMemo } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  useAgent,
-} from "@copilotkit/react-core/v2";
+import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
@@ -136,7 +132,12 @@ function rewriteMultimodalPart(part: unknown): unknown {
     };
   };
   const type = candidate.type;
-  if (type !== "image" && type !== "document" && type !== "audio" && type !== "video") {
+  if (
+    type !== "image" &&
+    type !== "document" &&
+    type !== "audio" &&
+    type !== "video"
+  ) {
     return part;
   }
   const source = candidate.source;

--- a/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
@@ -23,13 +23,40 @@
  *   `<input type="file">` the paperclip path uses (DataTransfer + dispatch
  *   `change`). This keeps the sample and real-upload paths on a single
  *   code path — whatever works for one works for both.
+ *
+ * Legacy-shape rewrite:
+ * - The published `@ag-ui/langgraph` converter (0.0.x) only understands
+ *   the legacy `{ type: "binary", mimeType, data | url }` content-part
+ *   shape when forwarding AG-UI messages to LangChain. The modern
+ *   `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
+ *   parts that CopilotChat emits are silently dropped. Until the runtime
+ *   ships an updated converter, we rewrite the outgoing user message in
+ *   `onRunInitialized` so image/document/audio/video parts round-trip
+ *   through the legacy shape the converter preserves.
  */
 
-import { useCallback } from "react";
-import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo } from "react";
+import {
+  CopilotKit,
+  CopilotChat,
+  useAgent,
+} from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
+
+/**
+ * Minimal structural shape of an AG-UI message. `@ag-ui/client`'s
+ * exported `Message` is a tagged union by role, but for the rewrite
+ * we only care about the `user` branch and treat every other role as
+ * pass-through. Keeping the type local avoids pulling `@ag-ui/client`
+ * into this package's direct dependencies.
+ */
+type AgentMessage = {
+  id?: string;
+  role: string;
+  content?: unknown;
+};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -85,6 +112,128 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
+/**
+ * Rewrites a single `InputContent` part from the modern multimodal shape
+ * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
+ * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
+ *
+ * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
+ * in that package) only recognizes legacy `binary` parts — modern parts
+ * are silently filtered out, so the LangGraph agent never sees them.
+ * Returning the legacy shape keeps the attachment visible to the agent
+ * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
+ * untouched. Text parts and already-legacy parts pass through unchanged.
+ */
+function rewriteMultimodalPart(part: unknown): unknown {
+  if (!part || typeof part !== "object") return part;
+  const candidate = part as {
+    type?: string;
+    text?: string;
+    source?: {
+      type?: string;
+      value?: string;
+      mimeType?: string;
+    };
+  };
+  const type = candidate.type;
+  if (type !== "image" && type !== "document" && type !== "audio" && type !== "video") {
+    return part;
+  }
+  const source = candidate.source;
+  if (!source || typeof source.value !== "string") {
+    return part;
+  }
+  const mimeType = source.mimeType ?? "application/octet-stream";
+  if (source.type === "data") {
+    return {
+      type: "binary",
+      mimeType,
+      data: source.value,
+    };
+  }
+  if (source.type === "url") {
+    return {
+      type: "binary",
+      mimeType,
+      url: source.value,
+    };
+  }
+  return part;
+}
+
+/**
+ * Walks a message list and rewrites user-message multimodal content parts
+ * to the legacy `binary` shape. Non-user messages and plain-string user
+ * messages pass through untouched. Idempotent: already-legacy `binary`
+ * parts are a no-op for `rewriteMultimodalPart`.
+ *
+ * Returns the same array reference if nothing changed so the subscriber
+ * in `onRunInitialized` can skip an unnecessary state write.
+ */
+function rewriteMessagesForLegacyConverter(
+  messages: ReadonlyArray<Readonly<AgentMessage>>,
+): AgentMessage[] | null {
+  let mutated = false;
+  const next = messages.map((message) => {
+    if (message.role !== "user") return message as AgentMessage;
+    const content = message.content;
+    if (!Array.isArray(content)) return message as AgentMessage;
+    let partMutated = false;
+    const rewrittenParts = content.map((part) => {
+      const rewritten = rewriteMultimodalPart(part);
+      if (rewritten !== part) partMutated = true;
+      return rewritten;
+    });
+    if (!partMutated) return message as AgentMessage;
+    mutated = true;
+    return {
+      ...(message as object),
+      content: rewrittenParts,
+    } as AgentMessage;
+  });
+  return mutated ? next : null;
+}
+
+/**
+ * Installs the `onRunInitialized` subscriber on the active agent. Scoped
+ * to a small inner component so it can use the `useAgent` hook the
+ * <CopilotChat> parent already relies on — subscribing there means we
+ * rewrite messages on the *same* agent instance CopilotChat dispatches
+ * through, even when threads are cloned or swapped.
+ */
+function LegacyConverterShim() {
+  const { agent } = useAgent({ agentId: "multimodal-demo" });
+
+  const subscriber = useMemo(
+    () => ({
+      onRunInitialized: ({
+        messages,
+      }: {
+        messages: ReadonlyArray<Readonly<AgentMessage>>;
+      }) => {
+        const rewritten = rewriteMessagesForLegacyConverter(messages);
+        if (!rewritten) return;
+        return { messages: rewritten };
+      },
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    if (!agent) return;
+    // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
+    // structural message shape and returns only partial mutations, so
+    // cast at the subscribe boundary. The cast is safe: our
+    // onRunInitialized only ever returns a messages-mutation or void.
+    const handle = agent.subscribe(
+      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
+    );
+    return () => handle.unsubscribe();
+  }, [agent, subscriber]);
+
+  return null;
+}
+
 export default function MultimodalDemoPage() {
   // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
   // paperclip button and the sample-injection path route files through
@@ -95,6 +244,7 @@ export default function MultimodalDemoPage() {
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/packages/langgraph-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/multimodal/sample-attachment-buttons.tsx
@@ -65,6 +65,30 @@ function findChatFileInput(rootSelector: string): HTMLInputElement | null {
   return root.querySelector<HTMLInputElement>('input[type="file"]');
 }
 
+/**
+ * Magic-byte prefixes used to validate fetched sample files. We check
+ * these because Next.js will happily serve a Git LFS *pointer* file (a
+ * short plain-text stub starting with `version https://git-lfs...`) with
+ * a `Content-Type: image/png` header if LFS wasn't pulled at build time.
+ * Without this guard, the broken pointer bytes get base64-encoded,
+ * fed into CopilotChat as a valid-looking PNG, and rendered as a broken
+ * <img>. Fail loudly with an actionable error instead.
+ */
+const MAGIC_BYTES: Record<string, number[]> = {
+  "image/png": [0x89, 0x50, 0x4e, 0x47], // ‰PNG
+  "application/pdf": [0x25, 0x50, 0x44, 0x46], // %PDF
+};
+
+const LFS_POINTER_PREFIX = "version https://git-lfs";
+
+function bytesStartWith(bytes: Uint8Array, prefix: number[]): boolean {
+  if (bytes.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (bytes[i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
 async function fetchAsFile(spec: SampleSpec): Promise<File> {
   const res = await fetch(spec.fetchUrl);
   if (!res.ok) {
@@ -73,7 +97,33 @@ async function fetchAsFile(spec: SampleSpec): Promise<File> {
         `Is the file bundled under public${spec.fetchUrl}?`,
     );
   }
-  const blob = await res.blob();
+  const buffer = await res.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+
+  // Detect Git LFS pointer stub — the file on disk hasn't been materialized.
+  const asciiHead = new TextDecoder("utf-8", { fatal: false }).decode(
+    bytes.slice(0, Math.min(bytes.length, 64)),
+  );
+  if (asciiHead.startsWith(LFS_POINTER_PREFIX)) {
+    throw new Error(
+      `Sample "${spec.filename}" is a Git LFS pointer, not the real asset. ` +
+        "The deploy environment needs to run `git lfs pull` (or set " +
+        "`GIT_LFS_ENABLED=1`) so the binary is checked out before the Next.js " +
+        "app serves it.",
+    );
+  }
+
+  const expectedMagic = MAGIC_BYTES[spec.mimeType];
+  if (expectedMagic && !bytesStartWith(bytes, expectedMagic)) {
+    throw new Error(
+      `Sample "${spec.filename}" does not have a valid ${spec.mimeType} ` +
+        "signature. The file may be corrupted or a wrong asset was committed.",
+    );
+  }
+
+  // Re-wrap the bytes into a blob/File with the explicit MIME type rather than
+  // trusting whatever Content-Type the dev server returned.
+  const blob = new Blob([buffer], { type: spec.mimeType });
   return new File([blob], spec.filename, { type: spec.mimeType });
 }
 

--- a/showcase/packages/langgraph-python/tests/e2e/auth.spec.ts
+++ b/showcase/packages/langgraph-python/tests/e2e/auth.spec.ts
@@ -27,7 +27,9 @@ test.describe("Authentication", () => {
     );
   });
 
-  test("authenticated send produces an assistant response", async ({ page }) => {
+  test("authenticated send produces an assistant response", async ({
+    page,
+  }) => {
     const input = page.getByPlaceholder("Type a message");
     await input.fill("Hello");
     await input.press("Enter");

--- a/showcase/packages/langgraph-python/tests/e2e/auth.spec.ts
+++ b/showcase/packages/langgraph-python/tests/e2e/auth.spec.ts
@@ -5,20 +5,20 @@ test.describe("Authentication", () => {
     await page.goto("/demos/auth");
   });
 
-  test("page loads unauthenticated with amber banner + Authenticate button", async ({
+  test("page loads authenticated with green banner + Sign out button", async ({
     page,
   }) => {
     const banner = page.locator('[data-testid="auth-banner"]');
     await expect(banner).toBeVisible();
-    await expect(banner).toHaveAttribute("data-authenticated", "false");
+    await expect(banner).toHaveAttribute("data-authenticated", "true");
     await expect(page.locator('[data-testid="auth-status"]')).toContainText(
-      "Not authenticated",
+      "Signed in",
     );
     await expect(
-      page.locator('[data-testid="auth-authenticate-button"]'),
+      page.locator('[data-testid="auth-sign-out-button"]'),
     ).toBeEnabled();
     await expect(
-      page.locator('[data-testid="auth-sign-out-button"]'),
+      page.locator('[data-testid="auth-authenticate-button"]'),
     ).toHaveCount(0);
     await expect(page.getByPlaceholder("Type a message")).toBeVisible();
     // No error surface on first load.
@@ -27,75 +27,74 @@ test.describe("Authentication", () => {
     );
   });
 
-  test("unauthenticated send surfaces a 401 error via auth-demo-error", async ({
-    page,
-  }) => {
+  test("authenticated send produces an assistant response", async ({ page }) => {
     const input = page.getByPlaceholder("Type a message");
     await input.fill("Hello");
     await input.press("Enter");
 
-    // Page-level error surface is the stable contract; <CopilotChat />
-    // error rendering varies by state.
-    const errorSurface = page.locator('[data-testid="auth-demo-error"]');
-    await expect(errorSurface).toBeVisible({ timeout: 15000 });
-    await expect(errorSurface).toContainText(/401|unauthor/i);
-
-    // No assistant message should have landed.
-    await expect(page.locator('[data-role="assistant"]')).toHaveCount(0);
-  });
-
-  test("clicking Authenticate flips banner and enables successful sends", async ({
-    page,
-  }) => {
-    const banner = page.locator('[data-testid="auth-banner"]');
-    await page.locator('[data-testid="auth-authenticate-button"]').click();
-
-    await expect(banner).toHaveAttribute("data-authenticated", "true", {
-      timeout: 2000,
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
     });
-    await expect(page.locator('[data-testid="auth-status"]')).toContainText(
-      "Authenticated",
+    // No error surface should appear while authenticated.
+    await expect(page.locator('[data-testid="auth-demo-error"]')).toHaveCount(
+      0,
     );
-    await expect(
-      page.locator('[data-testid="auth-sign-out-button"]'),
-    ).toBeVisible();
-    await expect(
-      page.locator('[data-testid="auth-authenticate-button"]'),
-    ).toHaveCount(0);
-
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-      timeout: 30000,
-    });
   });
 
-  test("signing out reverts to the 401 path on the next send", async ({
+  test("signing out flips banner and surfaces 401 on next send without crashing", async ({
     page,
   }) => {
-    // Authenticate first.
-    await page.locator('[data-testid="auth-authenticate-button"]').click();
-    const input = page.getByPlaceholder("Type a message");
-    await input.fill("Hello");
-    await input.press("Enter");
-    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
-      timeout: 30000,
-    });
-
-    // Sign out.
-    await page.locator('[data-testid="auth-sign-out-button"]').click();
     const banner = page.locator('[data-testid="auth-banner"]');
+    await page.locator('[data-testid="auth-sign-out-button"]').click();
+
     await expect(banner).toHaveAttribute("data-authenticated", "false", {
       timeout: 2000,
     });
+    await expect(page.locator('[data-testid="auth-status"]')).toContainText(
+      "Signed out",
+    );
+    await expect(
+      page.locator('[data-testid="auth-authenticate-button"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="auth-sign-out-button"]'),
+    ).toHaveCount(0);
 
-    // Next send should 401 and show the error surface.
+    // Next send should 401 and show the error surface — no white-screen.
+    const input = page.getByPlaceholder("Type a message");
     await input.fill("Hello again");
     await input.press("Enter");
     const errorSurface = page.locator('[data-testid="auth-demo-error"]');
     await expect(errorSurface).toBeVisible({ timeout: 15000 });
     await expect(errorSurface).toContainText(/401|unauthor/i);
+
+    // Banner must still be rendered — a crash would unmount it.
+    await expect(banner).toBeVisible();
+  });
+
+  test("signing back in clears the error and re-enables successful sends", async ({
+    page,
+  }) => {
+    // Sign out, fire a failing send to populate the error surface.
+    await page.locator('[data-testid="auth-sign-out-button"]').click();
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Hello");
+    await input.press("Enter");
+    const errorSurface = page.locator('[data-testid="auth-demo-error"]');
+    await expect(errorSurface).toBeVisible({ timeout: 15000 });
+
+    // Sign back in — error clears, banner flips, chat works.
+    await page.locator('[data-testid="auth-authenticate-button"]').click();
+    const banner = page.locator('[data-testid="auth-banner"]');
+    await expect(banner).toHaveAttribute("data-authenticated", "true", {
+      timeout: 2000,
+    });
+    await expect(errorSurface).toHaveCount(0);
+
+    await input.fill("Hello again");
+    await input.press("Enter");
+    await expect(page.locator('[data-role="assistant"]').first()).toBeVisible({
+      timeout: 30000,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Six langgraph-python showcase demos had runtime regressions after the Wave 2a–4b consolidation landed. This PR bundles fixes for all six into a single branch to avoid six separate merge/rebase cycles.

Each fix was developed in isolation on its own branch and merged here in order. Every slot touches a disjoint subtree under `showcase/packages/langgraph-python/src/app/demos/<slug>/` (plus the matching per-demo runtime route and, where needed, the demo's Python agent).

### Slot B1 — `byoc-json-render` (crash + missing rendering)
- `<Renderer />` from `@json-render/react` delegates to `ElementRenderer`, which calls `useVisibility()` / `useActions()` / `useStateStore()` / `useFunctions()`. These need four sibling providers; the assistant-message slot was rendering `<Renderer />` bare, so every suggestion that produced valid JSON crashed with `useVisibility must be used within a VisibilityProvider`.
- Wrap the renderer in `<JSONUIProvider>` (composes all four required providers).
- Also forward `children` through the `MetricCard` registry wrapper so the Sales Dashboard example (MetricCard as root with BarChart nested) renders both components.

### Slot B2 — `byoc-hashbrown` (nothing rendered at all)
- The byoc-hashbrown Python agent was prompted to emit `<ui>...</ui>` XML-ish markup, but the frontend renderer uses `useJsonParser(message.content, kit.schema)`, which expects a streaming JSON envelope matching `@hashbrownai/react`'s `createUiKit(...).schema`. With XML content the parser returned `{value: undefined}` and the renderer bailed to `null`.
- Rewrite `BYOC_HASHBROWN_SYSTEM_PROMPT` to emit the JSON envelope (`{"ui":[{"metric":{"props":{...}}}, ...]}`), matching the current kit's prop schema exactly. No frontend code change — just a docstring update flagging the wire format for future readers.

### Slot B3 — `multimodal` (broken image + "no image attached")
- Three issues: (1) sample PNG/PDF shipped as Git LFS pointers — when LFS wasn't pulled the dev server served the 130-byte stub, which got base64-encoded into a "valid" PNG rendering as a broken `<img>`; (2) the published `@ag-ui/langgraph@0.0.27` converter only recognizes the legacy `{ type: "binary" }` AG-UI content-part shape, so the modern `{ type: "image" | "document", source: {...} }` parts CopilotChat sends were silently filtered out before the Python agent ever saw them; (3) manual drag-drop hit the same dropout.
- Client-side LFS-pointer guard (validate magic bytes + actionable error pointing at `git lfs pull`).
- `onRunInitialized` hook on the agent rewrites modern `image | document | audio | video` user parts into the legacy `binary` shape the deployed converter preserves.
- Multimodal Python agent now routes on MIME: `image/*` → GPT-4o image_url natively; `application/pdf` → text via `pypdf`.

### Slot B4 — `voice` (no mic button + 503 on transcribe)
- The V1 `CopilotRuntime` wrapper silently drops `transcriptionService` (see the `// TODO: add support for transcriptionService` in the runtime's constructor), so `/info` never advertised `audioFileTranscriptionEnabled: true` and the composer never showed the mic button.
- Write the transcription service onto the V2 runtime instance directly. Wrap it in a `GuardedOpenAITranscriptionService` that throws a typed auth error ("api key missing") when `OPENAI_API_KEY` is absent, which the runtime's error categorizer maps to `AUTH_FAILED → 401` instead of the opaque 503 users were hitting.

### Slot B5 — `agent-config` (forwardedProps not reaching the agent)
- Frontend `<CopilotKitProvider properties={...}>` forwards `tone`/`expertise`/`responseLength` as top-level keys on AG-UI `forwardedProps`. The TypeScript `LangGraphAgent` only merges `forwardedProps.config` into the LangGraph stream payload's `config`; other keys get spread as top-level payload fields the server ignores. Net result: the Python agent's `config["configurable"]["properties"]` was always empty.
- Per-demo subclass `AgentConfigLangGraphAgent` overrides `run()` and repacks non-structural `forwardedProps` keys into `forwardedProps.config.configurable.properties` before delegating to `super.run()`. Structural LangGraph stream-payload keys (`config`, `command`, `streamMode`, etc.) are preserved via an explicit reserved-keys set.

### Slot B6 — `auth` (page crashed on initial 401)
- Demo started unauthenticated; the very first `/info` GET returned 401 before any error handler attached, tearing down the React tree.
- Flip `useDemoAuth` default to `true` so the demo mounts with a valid `Authorization: Bearer <token>` header. Button labels inverted to "Sign out" (authed) / "Sign in" (unauthed).
- `ChatErrorBoundary` around `<CopilotChat />` backstops any post-sign-out render throw; auto-resets when `authenticated` flips so signing back in remounts cleanly.
- Runtime auth gate (`/api/copilotkit-auth/route.ts`) unchanged — still returns 401 for missing/invalid bearer; just handled gracefully on the frontend.

## Test plan

- [ ] `/demos/byoc-json-render` — click each of Sales Dashboard, Expense Thread, Revenue by Category; each renders components (no `useVisibility` crash).
- [ ] `/demos/byoc-hashbrown` — click any suggestion; metric / chart / deal cards render within a few seconds.
- [ ] `/demos/multimodal` — "try with sample image" shows a real thumbnail; "try with sample pdf" attaches; ask to analyze, agent responds contextually (not "no image attached"). Manual drag-drop of an image works.
- [ ] `/demos/voice` — mic button visible in composer; "Play Sample" either succeeds (when `OPENAI_API_KEY` is set) or returns a human-readable 4xx (never silent 503).
- [ ] `/demos/agent-config` — toggle tone/expertise/response-length, ask the same question; answer changes meaningfully.
- [ ] `/demos/auth` — page loads authenticated; Sign out toggles to 401 state without crashing; Sign in restores chat.
