### PR TITLE
ci(format): drop .mdx from oxfmt candidate glob

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -74,7 +74,7 @@ jobs:
           git diff --name-only --diff-filter=ACMR "origin/$base_ref"...HEAD -- \
             '*.js' '*.jsx' '*.ts' '*.tsx' '*.mjs' '*.cjs' \
             '*.json' '*.jsonc' '*.json5' \
-            '*.md' '*.mdx' \
+            '*.md' \
             '*.css' '*.yml' '*.yaml' '*.html' '*.vue' \
             > .pr-format-files.txt
           : > .pr-format-files.existing.txt


### PR DESCRIPTION
## Summary

- `oxfmt@0.36` supports `.md` but not `.mdx` — it exits with `Expected at least one target file` when every input is `.mdx`.
- Mixed PRs (`.mdx` + `.tsx`/`.json`/etc) currently pass because the non-MDX files keep the target set non-empty. MDX-only PRs (e.g. docs-sync bot PRs, shell-docs-only edits) fail the `format` check with no real formatting issue.
- Removing `'*.mdx'` from the candidate glob at \`.github/workflows/static_quality.yml\` lets MDX-only PRs hit the existing \`count=0\` skip path and pass cleanly. `.mdx` can be re-added once oxfmt ships MDX support.

## Repro

\`\`\`
$ oxfmt --check foo.md    # passes
$ oxfmt --check foo.ts    # passes
$ oxfmt --check foo.mdx   # "Expected at least one target file"
\`\`\`

## Test plan

- [ ] `format` check passes on this PR (non-MDX change, so it should run oxfmt normally on the workflow file itself — \`.yml\` is oxfmt-supported).
- [ ] Verify the next MDX-only PR (e.g. docs-sync bot PR #4276) now passes \`format\` once rebased on this.