### PR TITLE
ci(showcase): exempt stub packages from e2e baseline check

### DIFF
--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -121,6 +121,19 @@ jobs:
             [ -d "$pkg_dir" ] || continue
             found=$((found + 1))
             pkg=$(basename "$pkg_dir")
+            # Skip stub packages — those registered in the integration
+            # registry for docs-side references but without a showcase
+            # implementation yet. `deployed: false` in manifest.yaml is the
+            # semantic marker for that state (validated as a boolean by
+            # showcase/scripts/lib/manifest.ts). These packages legitimately
+            # have no demos / specs / e2e tests to enforce a baseline on;
+            # validate-parity still emits a SHOULD warning for them so the
+            # gap stays visible without gating CI.
+            manifest="${pkg_dir}manifest.yaml"
+            if [ -f "$manifest" ] && grep -qiE '^deployed:[[:space:]]*false[[:space:]]*$' "$manifest"; then
+              echo "skip: $pkg (deployed: false — stub package)"
+              continue
+            fi
             e2e_dir="${pkg_dir}tests/e2e/"
             if [ ! -d "$e2e_dir" ]; then
               echo "::error file=$pkg_dir::Package '$pkg' is missing tests/e2e/ directory (required for baseline e2e coverage)"


### PR DESCRIPTION
## Summary

- The `Showcase: Validate` workflow's \"Enforce e2e spec count\" step iterates every `showcase/packages/*/` directory and requires each to have a `tests/e2e/` directory with N specs. Built-in Agent was registered as a manifest-only stub in #4278 so the docs layer could reference it; the showcase implementation is owned by a different workstream and hasn't landed. The baseline check therefore fails every run on `main`.
- Add a skip in the bash loop for packages marked `deployed: false` in `manifest.yaml`. That flag is the existing semantic marker for \"registered but no showcase implementation\" — validated as a boolean by `showcase/scripts/lib/manifest.ts`, already consumed by shell and shell-docs to gate pickability and filtering. Stub packages legitimately have no demos / specs / qa to enforce a baseline on.
- `validate-parity.ts` still emits a SHOULD warning (\"demo count 0 deviates from baseline 9\") for stub packages so the gap stays visible to the team without gating CI.

## Test plan

- [ ] CI passes on this branch (Showcase: Validate is the only step that was failing on main).
- [ ] Run locally against every manifest:
  ```bash
  for m in showcase/packages/*/manifest.yaml; do
    pkg=$(basename $(dirname \"$m\"))
    if grep -qiE '^deployed:[[:space:]]*false[[:space:]]*$' \"$m\"; then echo \"SKIP  $pkg\"
    elif grep -qiE '^deployed:[[:space:]]*true[[:space:]]*$' \"$m\"; then echo \"CHECK $pkg\"
    else echo \"???   $pkg\"; fi
  done | sort
  ```
  Result: 17 CHECK, `built-in-agent` alone SKIP.