### PR TITLE
fix(showcase): CR round 1 fixes

### DIFF
--- a/showcase/packages/langgraph-fastapi/manifest.yaml
+++ b/showcase/packages/langgraph-fastapi/manifest.yaml
@@ -36,7 +36,7 @@ features:
   - tool-rendering-reasoning-chain
   - agentic-chat-reasoning
   - reasoning-default-render
-  - hitl-in-chat
+  - hitl
   - gen-ui-tool-based
   - gen-ui-agent
   - gen-ui-interrupt
@@ -81,8 +81,8 @@ demos:
       - agent-capabilities
     route: /demos/tool-rendering
     animated_preview_url:
-  - id: hitl-in-chat
-    name: In-Chat Human in the Loop
+  - id: hitl
+    name: In-Chat Human in the Loop (Original)
     description: User approves agent actions before execution
     tags:
       - interactivity

--- a/showcase/packages/langgraph-typescript/manifest.yaml
+++ b/showcase/packages/langgraph-typescript/manifest.yaml
@@ -33,7 +33,7 @@ starter:
   clone_command: npx degit CopilotKit/CopilotKit/showcase/starters/langgraph-typescript my-copilotkit-app
 features:
   - agentic-chat
-  - hitl-in-chat
+  - hitl
   - tool-rendering
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
@@ -77,8 +77,8 @@ demos:
       - chat-ui
     route: /demos/agentic-chat
     animated_preview_url:
-  - id: hitl-in-chat
-    name: In-Chat Human in the Loop
+  - id: hitl
+    name: In-Chat Human in the Loop (Original)
     description: User approves agent actions before execution
     tags:
       - interactivity

--- a/showcase/packages/langroid/tests/python/test_agui_adapter.py
+++ b/showcase/packages/langroid/tests/python/test_agui_adapter.py
@@ -311,7 +311,7 @@ def test_parse_tool_args_dict_passthrough():
 
 
 def test_parse_tool_args_empty_string_is_malformed():
-    """Empty string is treated as DEGRADED, not "ok with {}".
+    """Empty string is treated as malformed, not "ok with {}".
     Consistent with the oai-path rationale: firing a tool with no
     arguments produces a meaningless UI card, so we skip it the same
     way we skip unparseable JSON."""
@@ -342,7 +342,7 @@ def test_parse_tool_args_malformed_returns_malformed_status(caplog):
 
 
 def test_parse_tool_args_non_dict_json_is_malformed(caplog):
-    """Valid JSON but not a dict (e.g. an array) is likewise DEGRADED."""
+    """Valid JSON but not a dict (e.g. an array) is likewise malformed."""
     with caplog.at_level(logging.WARNING, logger=agui_adapter.logger.name):
         parsed = _parse_tool_args("[1, 2, 3]")
     assert parsed.status == "malformed"
@@ -630,11 +630,6 @@ def test_try_parse_tool_non_str_content_warns_and_returns_none(caplog):
 
 
 # ---------------------------------------------------------------------------
-# Logging hygiene: plain-text turns must NOT emit warnings
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
 # CR Round 4: bytes-args handling in _try_parse_tool
 # ---------------------------------------------------------------------------
 
@@ -651,10 +646,6 @@ def test_try_parse_tool_function_call_bytes_arguments():
     # Use a real backend tool from ALL_TOOLS so this exercises the actual
     # dispatch loop rather than a synthetic stub.
     request_name = agent_module.GetWeatherTool.default_value("request")
-    content = json.dumps({
-        "name": request_name,
-        "arguments": b'{"location": "SF"}'.decode("utf-8"),
-    })
     # Patch the function_call payload to carry a bytes ``arguments`` at
     # parse time. We construct the wrapper JSON as normal (str) but the
     # inner ``arguments`` field is a str whose *decoded* value would be

--- a/showcase/packages/ms-agent-dotnet/manifest.yaml
+++ b/showcase/packages/ms-agent-dotnet/manifest.yaml
@@ -43,7 +43,7 @@ features:
   - frontend-tools
   - frontend-tools-async
   - gen-ui-tool-based
-  - hitl-in-chat
+  - hitl
   - hitl-in-app
   - gen-ui-interrupt
   - interrupt-headless
@@ -143,8 +143,8 @@ demos:
       - src/app/demos/frontend-tools-async/page.tsx
       - src/app/demos/frontend-tools-async/notes-card.tsx
       - src/app/api/copilotkit/route.ts
-  - id: hitl-in-chat
-    name: In-Chat Human in the Loop
+  - id: hitl
+    name: In-Chat Human in the Loop (Original)
     description: User approves agent actions before execution
     tags:
       - interactivity

--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -144,13 +144,15 @@
       "id": "hitl-in-chat-booking",
       "name": "In-Chat HITL (Booking)",
       "category": "controlled-generative-ui",
-      "description": "Time-picker card rendered inline via useHumanInTheLoop for a booking flow"
+      "description": "Time-picker card rendered inline via useHumanInTheLoop for a booking flow",
+      "kind": "primary"
     },
     {
       "id": "hitl",
       "name": "In-Chat Human in the Loop (Original)",
       "category": "controlled-generative-ui",
-      "description": "Original HITL demo kept for backwards compatibility"
+      "description": "Original HITL demo kept for backwards compatibility",
+      "kind": "primary"
     },
     {
       "id": "interrupt-headless",


### PR DESCRIPTION
Fixes from CR round 1 on omnibus PR #4280

## Changes

- **hitl demo mislabeling (bucket a)**: 3 manifests (langgraph-fastapi, langgraph-typescript, ms-agent-dotnet) claimed `hitl-in-chat` but actually implement the original `hitl` demo. Fixed feature list, demo ID, and demo name in all 3.
- **Dead variable in test (bucket b)**: Removed unused `content` variable in `test_try_parse_tool_function_call_bytes_arguments`.
- **Docstring/code mismatch (bucket b)**: Two docstrings said "DEGRADED" where the code uses "malformed". Fixed to match.
- **Empty section header (bucket b)**: Removed orphaned section header "Logging hygiene: plain-text turns must NOT emit warnings" (the actual test lives elsewhere in the file).
- **Feature registry kind fields (bucket b)**: Added `"kind": "primary"` to `hitl` and `hitl-in-chat-booking` entries to match convention.

## Verification

- `generate-registry.ts` ran clean (18 integrations, all shells)
- `generate-starters.ts` ran clean (17 starters)
- `validate-pins.ts` fail count (127) and hash match existing baseline -- no ratchet update needed