### PR TITLE
fix(showcase-dashboard): fix e2e key mismatch blocking D3/D4 depth chips

### DIFF
--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -203,7 +203,7 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
           name="E2E"
           badge={cell.e2e}
           dimensionKey={keyFor(
-            "e2e_smoke",
+            "e2e",
             ctx.integration.slug,
             ctx.feature.id,
           )}

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -202,11 +202,7 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
         <LiveBadge
           name="E2E"
           badge={cell.e2e}
-          dimensionKey={keyFor(
-            "e2e",
-            ctx.integration.slug,
-            ctx.feature.id,
-          )}
+          dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
         />
       </div>
     </>

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -3,7 +3,7 @@
  * `computeColumnTally` (§5.4 rollup + §5.3 offline handling).
  *
  * Phase 3: QA removed, smoke removed from per-cell tally. E2E uses
- * e2e_smoke dimension. Tally now counts health (once) + e2e per feature.
+ * e2e dimension. Tally now counts health (once) + e2e per feature.
  */
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
@@ -76,8 +76,8 @@ describe("computeColumnTally", () => {
 
   it("counts health once + e2e per feature", () => {
     const live: LiveStatusMap = new Map();
-    live.set("e2e_smoke:i1/f1", row("e2e_smoke:i1/f1", "e2e_smoke", "red"));
-    live.set("e2e_smoke:i1/f2", row("e2e_smoke:i1/f2", "e2e_smoke", "green"));
+    live.set("e2e:i1/f1", row("e2e:i1/f1", "e2e", "red"));
+    live.set("e2e:i1/f2", row("e2e:i1/f2", "e2e", "green"));
     live.set("health:i1", row("health:i1", "health", "green"));
     const t = computeColumnTally(integration, features, live);
     // health (integration): green → +1g
@@ -96,14 +96,14 @@ describe("computeColumnTally", () => {
 
   it("missing health row contributes zero (does not count as red)", () => {
     const live: LiveStatusMap = new Map();
-    live.set("e2e_smoke:i1/f1", row("e2e_smoke:i1/f1", "e2e_smoke", "green"));
+    live.set("e2e:i1/f1", row("e2e:i1/f1", "e2e", "green"));
     const t = computeColumnTally(integration, features, live);
     expect(t).toEqual({ green: 1, amber: 0, red: 0, unknown: false });
   });
 
   it("returns unknown=true when connection is error", () => {
     const live: LiveStatusMap = new Map();
-    live.set("e2e_smoke:i1/f1", row("e2e_smoke:i1/f1", "e2e_smoke", "green"));
+    live.set("e2e:i1/f1", row("e2e:i1/f1", "e2e", "green"));
     const t = computeColumnTally(integration, features, live, "error");
     expect(t.unknown).toBe(true);
     expect(t.green).toBe(0);

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -36,7 +36,7 @@ export type CellRenderer = (ctx: CellContext) => React.ReactNode;
  * all features.
  *
  * Signal scoping (spec §5.4):
- *   - Feature-level dimensions (`e2e_smoke`) are counted per feature.
+ *   - Feature-level dimensions (`e2e`) are counted per feature.
  *   - Integration-level dimensions (`health`) are counted EXACTLY ONCE
  *     per integration — the health row keyed `health:<slug>` is a single
  *     signal for the whole column, not one signal per feature.
@@ -82,7 +82,7 @@ export function computeColumnTally(
     }
   }
 
-  // Feature-level dimensions: e2e_smoke per feature-with-demo.
+  // Feature-level dimensions: e2e per feature-with-demo.
   for (const feature of features) {
     const demo = integration.demos.find((d) => d.id === feature.id);
     if (!demo) continue;

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -39,9 +39,7 @@ describe("keyFor", () => {
     expect(keyFor("smoke", "agno", "agentic-chat")).toBe(
       "smoke:agno/agentic-chat",
     );
-    expect(keyFor("e2e", "agno", "agentic-chat")).toBe(
-      "e2e:agno/agentic-chat",
-    );
+    expect(keyFor("e2e", "agno", "agentic-chat")).toBe("e2e:agno/agentic-chat");
   });
 });
 

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -39,8 +39,8 @@ describe("keyFor", () => {
     expect(keyFor("smoke", "agno", "agentic-chat")).toBe(
       "smoke:agno/agentic-chat",
     );
-    expect(keyFor("e2e_smoke", "agno", "agentic-chat")).toBe(
-      "e2e_smoke:agno/agentic-chat",
+    expect(keyFor("e2e", "agno", "agentic-chat")).toBe(
+      "e2e:agno/agentic-chat",
     );
   });
 });
@@ -60,14 +60,14 @@ describe("upsertByKey", () => {
   });
 });
 
-describe("resolveCell — post-Phase 3 (rollup uses health + e2e_smoke only)", () => {
+describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
   // Order: red > degraded > green > error > unknown.
-  // Rollup contributors: health, e2e_smoke (Decision #7: smokeRow dropped).
+  // Rollup contributors: health, e2e (Decision #7: smokeRow dropped).
 
   it("rolls up to red when any contributing dimension is red", () => {
     const live = mapOf([
       row("health:agno", "health", "red"),
-      row("e2e_smoke:agno/ac", "e2e_smoke", "green"),
+      row("e2e:agno/ac", "e2e", "green"),
     ]);
     const c = resolveCell(live, "agno", "ac");
     expect(c.rollup).toBe("red");
@@ -76,29 +76,29 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e_smoke only)", (
   it("rolls up to degraded when no red but any degraded", () => {
     const live = mapOf([
       row("health:agno", "health", "green"),
-      row("e2e_smoke:agno/ac", "e2e_smoke", "degraded"),
+      row("e2e:agno/ac", "e2e", "degraded"),
     ]);
     const c = resolveCell(live, "agno", "ac");
     expect(c.rollup).toBe("amber");
   });
 
-  it("rolls up to green when health present+green and e2e_smoke absent", () => {
+  it("rolls up to green when health present+green and e2e absent", () => {
     const live = mapOf([row("health:agno", "health", "green")]);
     const c = resolveCell(live, "agno", "ac");
     expect(c.rollup).toBe("green");
   });
 
-  it("rolls up to green when health+e2e_smoke both green", () => {
+  it("rolls up to green when health+e2e both green", () => {
     const live = mapOf([
       row("health:agno", "health", "green"),
-      row("e2e_smoke:agno/ac", "e2e_smoke", "green"),
+      row("e2e:agno/ac", "e2e", "green"),
     ]);
     const c = resolveCell(live, "agno", "ac");
     expect(c.rollup).toBe("green");
   });
 
   it("rolls up to unknown when health is missing", () => {
-    const live = mapOf([row("e2e_smoke:agno/ac", "e2e_smoke", "green")]);
+    const live = mapOf([row("e2e:agno/ac", "e2e", "green")]);
     const c = resolveCell(live, "agno", "ac");
     expect(c.rollup).toBe("gray");
   });
@@ -135,7 +135,7 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e_smoke only)", (
     for (const c of combos) {
       const rows: StatusRow[] = [];
       if (c.health) rows.push(row("health:a", "health", c.health));
-      if (c.e2e) rows.push(row("e2e_smoke:a/b", "e2e_smoke", c.e2e));
+      if (c.e2e) rows.push(row("e2e:a/b", "e2e", c.e2e));
       const out = resolveCell(mapOf(rows), "a", "b");
       expect(out.rollup, JSON.stringify(c)).toBe(c.expect);
     }
@@ -145,7 +145,7 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e_smoke only)", (
     const live = mapOf([
       row("smoke:a/b", "smoke", "green"),
       row("health:a", "health", "red"),
-      row("e2e_smoke:a/b", "e2e_smoke", "degraded"),
+      row("e2e:a/b", "e2e", "degraded"),
     ]);
     const c = resolveCell(live, "a", "b");
     expect(c.smoke.tone).toBe("green");
@@ -161,7 +161,7 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e_smoke only)", (
     expect(c.health.label).toBe("?");
   });
 
-  it("health green with e2e_smoke=null rolls up to green (C5 F13)", () => {
+  it("health green with e2e=null rolls up to green (C5 F13)", () => {
     const live = mapOf([row("health:a", "health", "green")]);
     const c = resolveCell(live, "a", "b");
     expect(c.rollup).toBe("green");
@@ -170,7 +170,7 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e_smoke only)", (
   it("all-green rows + connection=error: rollup is error, NOT stale-green (R5 F5.1)", () => {
     const live = mapOf([
       row("health:a", "health", "green"),
-      row("e2e_smoke:a/b", "e2e_smoke", "green"),
+      row("e2e:a/b", "e2e", "green"),
     ]);
     const c = resolveCell(live, "a", "b", { connection: "error" });
     expect(c.rollup).toBe("error");
@@ -186,7 +186,7 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e_smoke only)", (
   it("degraded does NOT render a green check glyph (C5 F12)", () => {
     const live = mapOf([
       row("smoke:a/b", "smoke", "degraded"),
-      row("e2e_smoke:a/b", "e2e_smoke", "degraded"),
+      row("e2e:a/b", "e2e", "degraded"),
       row("health:a", "health", "degraded"),
     ]);
     const c = resolveCell(live, "a", "b");

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -5,7 +5,7 @@
  * PB row keys: `<dimension>:<slug>` for integration-level dimensions
  * (e.g. `health`, `agent`, `chat`, `tools`), or
  * `<dimension>:<slug>/<featureId>` for per-feature dimensions
- * (e.g. `smoke`, `e2e_smoke`).
+ * (e.g. `smoke`, `e2e`).
  */
 
 export type State = "green" | "red" | "degraded";
@@ -76,13 +76,12 @@ function rowTone(row: StatusRow | null): BadgeTone {
 
 /** Dimension identifiers for formatLabel / formatTooltip. */
 export type LiveDimension =
-  | "e2e_smoke"
+  | "e2e"
   | "smoke"
   | "health"
   | "agent"
   | "chat"
-  | "tools"
-  | "e2e";
+  | "tools";
 
 function formatLabel(dim: LiveDimension, row: StatusRow | null): string {
   if (!row) return "?";
@@ -137,8 +136,8 @@ export interface ResolveCellOptions {
  * Multi-dimension precedence (spec §5.4):
  *   red > degraded > green > error > unknown
  *
- * Rollup contributors: health + e2e_smoke only. smokeRow was dropped from
- * the rollup in Phase 3 (Decision #7) because the producer writes
+ * Rollup contributors: health + e2e only. smokeRow was dropped from the
+ * rollup in Phase 3 (Decision #7) because the producer writes
  * integration-scoped smoke:<slug>, not feature-scoped smoke:<slug>/<feature>.
  * The L1 signal now lives in the per-integration strip.
  */
@@ -151,10 +150,10 @@ export function resolveCell(
   const connection: ConnectionStatus = opts.connection ?? "live";
 
   const healthRow = live.get(keyFor("health", slug)) ?? null;
-  const e2eRow = live.get(keyFor("e2e_smoke", slug, featureId)) ?? null;
+  const e2eRow = live.get(keyFor("e2e", slug, featureId)) ?? null;
   const smokeRow = live.get(keyFor("smoke", slug, featureId)) ?? null;
 
-  // Rollup contributors: health + e2e_smoke (Decision #7: smokeRow dropped).
+  // Rollup contributors: health + e2e (Decision #7: smokeRow dropped).
   const contributors: Array<StatusRow | null> = [healthRow, e2eRow];
   const toneSet = contributors.map(rowTone);
   const hasAnyRed = toneSet.includes("red");
@@ -189,8 +188,8 @@ export function resolveCell(
   return {
     e2e: {
       tone: rowTone(e2eRow),
-      label: formatLabel("e2e_smoke", e2eRow),
-      tooltip: formatTooltip("e2e_smoke", e2eRow, connection),
+      label: formatLabel("e2e", e2eRow),
+      tooltip: formatTooltip("e2e", e2eRow, connection),
       row: e2eRow,
     },
     smoke: {

--- a/showcase/shell-dashboard/tests/visual/dashboard.spec.ts
+++ b/showcase/shell-dashboard/tests/visual/dashboard.spec.ts
@@ -2,7 +2,7 @@
  * Visual regression for the shell-dashboard feature matrix at 3 viewports
  * under 3 synthetic PB states: all-green, mixed, all-unknown.
  *
- * Phase 3: e2e→e2e_smoke, qa removed, agent/chat/tools added for strip.
+ * Phase 3: e2e→e2e, qa removed, agent/chat/tools added for strip.
  */
 import { test, expect } from "@playwright/test";
 
@@ -36,13 +36,13 @@ function fixtureFor(label: StateLabel): Array<Record<string, unknown>> {
     }
     // Feature-level dimensions
     for (const feat of FEATURES) {
-      for (const dim of ["smoke", "e2e_smoke"]) {
+      for (const dim of ["smoke", "e2e"]) {
         const state =
           label === "all-green"
             ? "green"
             : dim === "smoke" && slug === "crewai-crews"
               ? "degraded"
-              : dim === "e2e_smoke" && feat === "human-in-the-loop"
+              : dim === "e2e" && feat === "human-in-the-loop"
                 ? "red"
                 : "green";
         rows.push({


### PR DESCRIPTION
## Summary

The e2e-demos probe writes PocketBase rows as `e2e:<slug>/<featureId>` but the dashboard looked up `e2e_smoke:<slug>/<featureId>`. Keys never matched, so per-demo depth was always null and cells were stuck at D2.

One-line fix in `resolveCell` (change dimension from `e2e_smoke` to `e2e`), plus corresponding updates to all tests and the cell-pieces/feature-grid components that referenced the old dimension name.

## Test plan
- [x] All 130 unit tests pass (`npm test` in shell-dashboard)
- [ ] After deploy, dashboard cells show D3/D4 for demos the probe has already visited