### PR TITLE
feat(showcase-dashboard): add UWCT legend to Packages tab

### DIFF
--- a/showcase/shell-dashboard/src/components/packages-section.test.tsx
+++ b/showcase/shell-dashboard/src/components/packages-section.test.tsx
@@ -69,4 +69,12 @@ describe("PackagesSection", () => {
     );
     expect(getByText("Depth")).toBeDefined();
   });
+
+  it("renders the UWCT legend in the L1-L4 Status header", () => {
+    const { getByTestId } = render(
+      <PackagesSection liveStatus={emptyLiveStatus} connection="live" />,
+    );
+    const legend = getByTestId("packages-uwct-legend");
+    expect(legend.textContent).toBe("(U=Up, W=Wired, C=Chats, T=Tools)");
+  });
 });

--- a/showcase/shell-dashboard/src/components/packages-section.tsx
+++ b/showcase/shell-dashboard/src/components/packages-section.tsx
@@ -95,6 +95,12 @@ export function PackagesSection({
                 <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
                   L1-L4 Status
                 </span>
+                <span
+                  className="ml-2 text-[10px] font-normal normal-case text-[var(--text-muted)]"
+                  data-testid="packages-uwct-legend"
+                >
+                  (U=Up, W=Wired, C=Chats, T=Tools)
+                </span>
               </th>
               <th className="bg-[var(--bg-muted)] px-4 py-2 text-center border-b border-l border-[var(--border)]">
                 <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary

Surface the U/W/C/T tier mapping inline next to the L1-L4 Status column header on the Packages tab, so operators can read the strip without cross-referencing docs.

| Letter | Label | Probe dimension |
|--------|-------|-----------------|
| U | Up | `health:<slug>` |
| W | Wired | `agent:<slug>` |
| C | Chats | `chat:<slug>` |
| T | Tools | `tools:<slug>` |

## Test plan

- [x] New test asserts the legend renders with exact text `(U=Up, W=Wired, C=Chats, T=Tools)` and `data-testid="packages-uwct-legend"`
- [x] All 6 packages-section tests pass
- [x] `npx tsc --noEmit` clean