### PR TITLE
ci(showcase): add showcase-ops to deploy matrix for GHCR auto-rebuild

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -52,6 +52,7 @@ on:
           - shell-dojo
           - shell-dashboard
           - shell-docs
+          - showcase-ops
 
 concurrency:
   # Key on `event_name + ref` so push events and manual workflow_dispatch
@@ -176,6 +177,11 @@ jobs:
               - 'showcase/shared/**'
               - 'showcase/scripts/**'
               - 'showcase/packages/*/manifest.yaml'
+            showcase_ops:
+              - 'showcase/ops/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/packages/*/manifest.yaml'
 
       - name: Build service matrix
         id: build-matrix
@@ -225,7 +231,8 @@ jobs:
             {"dispatch_name":"starter-strands","filter_key":"starter_strands","context":"showcase/starters/strands","image":"showcase-starter-strands","railway_id":"06db2bb8-e15d-4c6a-97ad-e14777c92d9f","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
             {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"}
+            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
+            {"dispatch_name":"showcase-ops","filter_key":"showcase_ops","context":".","image":"showcase-ops","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/ops/Dockerfile","health_path":"/health"}
           ]'
 
           DISPATCH="${{ github.event.inputs.service }}"


### PR DESCRIPTION
## Summary

- Adds `showcase-ops` as a first-class entry in `.github/workflows/showcase_deploy.yml` so commits touching `showcase/ops/**` produce a fresh GHCR image and trigger a Railway redeploy.
- New matrix slot: `dispatch_name=showcase-ops`, `dockerfile=showcase/ops/Dockerfile`, `context=.`, `image=showcase-ops`, `railway_id=3a14bfed-...`, `health_path=/health`, `timeout=20`, `lfs=false`.
- New paths-filter `showcase_ops` keys on `showcase/ops/**`, `showcase/shared/**`, `showcase/scripts/**`, and `showcase/packages/*/manifest.yaml` — every tree the Dockerfile copies into the runtime image.

## Why

PR #4293 (Status tab + `/api/probes` route) merged to `main` on 2026-04-26 but the `Showcase: Build & Deploy` workflow had no `showcase-ops` matrix entry, so it never produced a new image. The deployed Railway service is still running the pre-#4293 image and `/api/probes` returns 404 in production. This is a CI gap, not a code bug — fixing it here so future `showcase/ops/**` commits rebuild automatically the same way every other showcase service does.

Build context is `.` (repo root) because `showcase/ops/Dockerfile` needs `pnpm-workspace.yaml`, `packages/` manifests, and `showcase/{ops,shared,packages,scripts}` to install workspace deps and run `generate-registry.ts` at build time.

## Test plan

- [ ] After merge, manual `workflow_dispatch` with `service=showcase-ops` to confirm the new leg builds, pushes to `ghcr.io/copilotkit/showcase-ops:latest`, redeploys on Railway, and the verify step gets `/health` -> 200 twice.
- [ ] Confirm `https://<railway-domain>/api/probes` returns 200 after redeploy (currently 404 on the stale image).
- [ ] Subsequent `showcase/ops/**` push triggers the matrix leg automatically (verified by paths-filter).