### PR TITLE
fix(showcase/crewai-crews): replace BaseHTTPMiddleware body-replay with raw ASGI splice

### DIFF
--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -73,10 +73,17 @@ class HealthMiddleware(BaseHTTPMiddleware):
 # Scope: only mutate when `forwardedProps.tone` / `expertise` / `responseLength`
 # is present, so non-agent-config demos keep their exact request bytes.
 #
-# This is Starlette middleware (not FastAPI `Depends`) because we need to
-# rewrite the ASGI `receive` callable before the FastAPI body parser reads
-# it — `Depends` runs after the body has already been bound to the Pydantic
-# `RunAgentInput` model.
+# IMPLEMENTATION NOTE — why this is a *raw* ASGI middleware, not a
+# `BaseHTTPMiddleware` subclass: an earlier version of this splice was a
+# `BaseHTTPMiddleware` that called `await request.body()` and reinstalled
+# `request._receive` with a one-shot replay. That layered on top of
+# `HealthMiddleware` (also `BaseHTTPMiddleware`) and race-conditioned with
+# Starlette's inner anyio TaskGroup `wrapped_receive`
+# (starlette/middleware/base.py:54), throwing
+# `RuntimeError: Unexpected message received: http.request` mid-stream and
+# aborting AG-UI SSE streams (`RUN_STARTED` then `RUN_ERROR:
+# INCOMPLETE_STREAM`, no `RUN_FINISHED`). Raw ASGI sidesteps that machinery
+# entirely — we own the receive stream from the outset, no replay surgery.
 _AGENT_CONFIG_KEYS = ("tone", "expertise", "responseLength")
 
 _TONE_RULES = {
@@ -139,98 +146,178 @@ def _has_agent_config_props(props: Any) -> bool:
     return any(k in props for k in _AGENT_CONFIG_KEYS)
 
 
-class ForwardedPropsMiddleware(BaseHTTPMiddleware):
-    """Merges AG-UI `forwardedProps` into `state.inputs` for agent-config demos.
+def _splice_forwarded_props(body: Any) -> Any:
+    """Splice agent-config `forwardedProps` into `body.state.inputs`.
 
-    See block comment above for the full rationale. Keeps all other POSTs
-    byte-identical by only rewriting bodies that carry agent-config props.
+    Pure dict-in / dict-out helper — no ASGI surgery. Returns the body
+    unchanged when no agent-config props are present, so non-config demos
+    keep their exact request bytes.
+    """
+    if not isinstance(body, dict):
+        return body
+    forwarded = body.get("forwardedProps")
+    if not _has_agent_config_props(forwarded):
+        return body
+
+    existing_state = body.get("state")
+    state = existing_state if isinstance(existing_state, dict) else {}
+
+    inputs = state.get("inputs") if isinstance(state.get("inputs"), dict) else {}
+    inputs = dict(inputs)  # copy
+    # Build a prose guidance string the LLM can actually follow. The upstream
+    # flow appends `Current inputs: {json}` verbatim to the system prompt —
+    # raw enum values ("casual", "intermediate", "concise") are ambiguous,
+    # so we expand them into explicit behavior rules here and stash them
+    # under a well-named key. The original enums are also retained so the
+    # demo can verify the forwarded props reached the backend.
+    tone = forwarded.get("tone")
+    expertise = forwarded.get("expertise")
+    response_length = forwarded.get("responseLength")
+    if tone is not None:
+        inputs["tone"] = tone
+    if expertise is not None:
+        inputs["expertise"] = expertise
+    if response_length is not None:
+        inputs["response_length"] = response_length
+    inputs["agent_config_guidance"] = _build_agent_config_guidance(
+        tone=tone,
+        expertise=expertise,
+        response_length=response_length,
+    )
+    state["inputs"] = inputs
+    body["state"] = state
+    return body
+
+
+class ForwardedPropsASGIMiddleware:
+    """Raw ASGI middleware that splices `forwardedProps` into `state.inputs`.
+
+    Why raw ASGI (and not `BaseHTTPMiddleware`):
+    `BaseHTTPMiddleware` wraps the request in an inner anyio TaskGroup that
+    owns the `receive` callable. Reading `await request.body()` and then
+    reinstalling `request._receive` with a one-shot replay (the previous
+    approach) races with that TaskGroup's `wrapped_receive` — Starlette
+    fires `RuntimeError: Unexpected message received: http.request` mid
+    streaming response. AG-UI clients saw `RUN_STARTED` and then the SSE
+    stream aborted (`RUN_ERROR: INCOMPLETE_STREAM`), no `RUN_FINISHED` ever
+    emitted. See the agent_config block-comment above.
+
+    A raw ASGI middleware (this class) buffers the request body BEFORE
+    handing the inner ASGI app a fresh `receive` that re-emits the
+    (possibly rewritten) bytes — it does this once, at the boundary, with
+    no `BaseHTTPMiddleware` machinery in the way.
+
+    Scope guard: only POST `/` with `application/json` and an
+    `forwardedProps` carrying `tone` / `expertise` / `responseLength` is
+    rewritten; everything else is a straight pass-through.
     """
 
-    async def dispatch(self, request, call_next):
-        if request.method != "POST" or request.url.path not in ("/", ""):
-            return await call_next(request)
+    def __init__(self, app):
+        self.app = app
 
-        content_type = request.headers.get("content-type", "")
-        if "application/json" not in content_type:
-            return await call_next(request)
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
 
-        try:
-            raw = await request.body()
-        except Exception:
-            return await call_next(request)
+        method = scope.get("method", "")
+        path = scope.get("path", "")
+        if method != "POST" or path not in ("/", ""):
+            await self.app(scope, receive, send)
+            return
 
-        if not raw:
-            return await call_next(request)
+        # `headers` is a list of (bytes, bytes) — find content-type.
+        headers = scope.get("headers") or []
+        content_type = b""
+        for k, v in headers:
+            if k == b"content-type":
+                content_type = v
+                break
+        if b"application/json" not in content_type:
+            await self.app(scope, receive, send)
+            return
 
-        try:
-            body = json.loads(raw)
-        except (ValueError, TypeError):
-            return await call_next(request)
+        # Buffer the body. ASGI delivers it as N `http.request` messages
+        # with `more_body=True` until the last one (`more_body=False`).
+        chunks: list[bytes] = []
+        more_body = True
+        while more_body:
+            message = await receive()
+            if message["type"] != "http.request":
+                # Unexpected (e.g. http.disconnect before body fully sent):
+                # replay what we already have and propagate the early
+                # disconnect so the inner app can handle it.
+                async def _replay_disconnect(msg=message):
+                    return msg
 
-        forwarded = body.get("forwardedProps") if isinstance(body, dict) else None
-        if not _has_agent_config_props(forwarded):
-            # Restore body unchanged (our .body() read consumed the receive
-            # queue, so we must put it back for downstream handlers).
-            return await _call_with_body(request, call_next, raw)
+                await self.app(scope, _replay_disconnect, send)
+                return
+            chunks.append(message.get("body") or b"")
+            more_body = message.get("more_body", False)
 
-        existing_state = body.get("state") if isinstance(body, dict) else None
-        state = existing_state if isinstance(existing_state, dict) else {}
+        raw = b"".join(chunks)
 
-        inputs = state.get("inputs") if isinstance(state.get("inputs"), dict) else {}
-        inputs = dict(inputs)  # copy
-        # Build a prose guidance string the LLM can actually follow. The upstream
-        # flow appends `Current inputs: {json}` verbatim to the system prompt —
-        # raw enum values ("casual", "intermediate", "concise") are ambiguous,
-        # so we expand them into explicit behavior rules here and stash them
-        # under a well-named key. The original enums are also retained so the
-        # demo can verify the forwarded props reached the backend.
-        tone = forwarded.get("tone")
-        expertise = forwarded.get("expertise")
-        response_length = forwarded.get("responseLength")
-        if tone is not None:
-            inputs["tone"] = tone
-        if expertise is not None:
-            inputs["expertise"] = expertise
-        if response_length is not None:
-            inputs["response_length"] = response_length
-        inputs["agent_config_guidance"] = _build_agent_config_guidance(
-            tone=tone,
-            expertise=expertise,
-            response_length=response_length,
-        )
-        state["inputs"] = inputs
-        body["state"] = state
+        # Try to splice. On any parse failure, replay original bytes verbatim.
+        # `_splice_forwarded_props` returns the same dict if no agent-config
+        # props are present, OR a mutated dict if it spliced — we detect
+        # "no-op" by checking `_has_agent_config_props` on `forwardedProps`
+        # directly (the splice only fires when that returns True).
+        new_raw = raw
+        if raw:
+            try:
+                body = json.loads(raw)
+            except (ValueError, TypeError):
+                body = None
+            if isinstance(body, dict) and _has_agent_config_props(
+                body.get("forwardedProps")
+            ):
+                spliced = _splice_forwarded_props(body)
+                new_raw = json.dumps(spliced).encode("utf-8")
 
-        new_raw = json.dumps(body).encode("utf-8")
-        return await _call_with_body(request, call_next, new_raw)
+        # If we rewrote the body, content-length in headers is stale.
+        # Strip it from the scope copy — the inner ASGI app reads bytes
+        # from `receive`, not from content-length, so this is safe and
+        # avoids tripping any downstream length-validating layer.
+        if new_raw is not raw:
+            new_headers = [
+                (k, v) for k, v in headers if k.lower() != b"content-length"
+            ]
+            new_headers.append((b"content-length", str(len(new_raw)).encode()))
+            scope = dict(scope)
+            scope["headers"] = new_headers
 
+        # Replay the (possibly rewritten) body as a single message.
+        sent_body = False
+        sent_disconnect = False
 
-async def _call_with_body(request, call_next, body_bytes: bytes):
-    """Replay ``body_bytes`` as the ASGI ``receive`` stream, then delegate.
+        async def replay_receive():
+            nonlocal sent_body, sent_disconnect
+            if not sent_body:
+                sent_body = True
+                return {
+                    "type": "http.request",
+                    "body": new_raw,
+                    "more_body": False,
+                }
+            # After the body is consumed, forward any further events from
+            # the original receive (e.g. http.disconnect). This is what
+            # streaming responses need to detect client disconnects.
+            if sent_disconnect:
+                return {"type": "http.disconnect"}
+            try:
+                msg = await receive()
+            except Exception:
+                sent_disconnect = True
+                return {"type": "http.disconnect"}
+            if msg.get("type") == "http.disconnect":
+                sent_disconnect = True
+            return msg
 
-    Starlette consumes the ASGI ``receive`` callable when ``request.body()``
-    runs, so downstream handlers would otherwise see an empty body. We rebuild
-    a one-shot ``receive`` that emits our (possibly rewritten) bytes.
-    """
-    sent = False
-
-    async def receive():
-        nonlocal sent
-        if sent:
-            return {"type": "http.disconnect"}
-        sent = True
-        return {
-            "type": "http.request",
-            "body": body_bytes,
-            "more_body": False,
-        }
-
-    request._receive = receive  # type: ignore[attr-defined]
-    return await call_next(request)
+        await self.app(scope, replay_receive, send)
 
 
 app.add_middleware(HealthMiddleware)
-app.add_middleware(ForwardedPropsMiddleware)
+app.add_middleware(ForwardedPropsASGIMiddleware)
 
 # CORS: `allow_origins=["*"]` is intentional for this LOCAL DEMO / SHOWCASE
 # STARTER package. The agent server binds to localhost:8000 during `pnpm dev`

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -33,6 +33,7 @@ configure_aimock()
 
 import asyncio
 import json
+import sys
 from typing import Any
 
 from ag_ui_crewai.endpoint import add_crewai_crew_fastapi_endpoint
@@ -308,6 +309,7 @@ class ForwardedPropsASGIMiddleware:
                 print(
                     f"[ForwardedPropsASGIMiddleware] JSON parse failed for "
                     f"{method} {path}: {exc!r}",
+                    file=sys.stderr,
                     flush=True,
                 )
                 body = None
@@ -363,6 +365,7 @@ class ForwardedPropsASGIMiddleware:
                 print(
                     f"[ForwardedPropsASGIMiddleware] receive() raised "
                     f"{type(exc).__name__}: {exc!r} — treating as disconnect",
+                    file=sys.stderr,
                     flush=True,
                 )
                 sent_disconnect = True

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -158,12 +158,14 @@ def _splice_forwarded_props(body: Any) -> Any:
     forwarded = body.get("forwardedProps")
     if not _has_agent_config_props(forwarded):
         return body
+    # _has_agent_config_props guarantees forwarded is a dict — narrow for type checker.
+    assert isinstance(forwarded, dict)
 
     existing_state = body.get("state")
-    state = existing_state if isinstance(existing_state, dict) else {}
+    state: dict[str, Any] = existing_state if isinstance(existing_state, dict) else {}
 
-    inputs = state.get("inputs") if isinstance(state.get("inputs"), dict) else {}
-    inputs = dict(inputs)  # copy
+    raw_inputs = state.get("inputs")
+    inputs: dict[str, Any] = dict(raw_inputs) if isinstance(raw_inputs, dict) else {}
     # Build a prose guidance string the LLM can actually follow. The upstream
     # flow appends `Current inputs: {json}` verbatim to the system prompt —
     # raw enum values ("casual", "intermediate", "concise") are ambiguous,

--- a/showcase/packages/crewai-crews/src/agent_server.py
+++ b/showcase/packages/crewai-crews/src/agent_server.py
@@ -31,6 +31,7 @@ configure_aimock()
 # is what the shim was reaching for. With the requirements.txt pin bumped to
 # `>=0.2.0,<0.3.0`, the shim is dead code and has been removed.
 
+import asyncio
 import json
 from typing import Any
 
@@ -149,7 +150,8 @@ def _has_agent_config_props(props: Any) -> bool:
 def _splice_forwarded_props(body: Any) -> Any:
     """Splice agent-config `forwardedProps` into `body.state.inputs`.
 
-    Pure dict-in / dict-out helper — no ASGI surgery. Returns the body
+    In-place mutation: the input `body` dict is modified and also returned
+    for fluent use. No ASGI surgery happens here. Returns the body
     unchanged when no agent-config props are present, so non-config demos
     keep their exact request bytes.
     """
@@ -158,8 +160,12 @@ def _splice_forwarded_props(body: Any) -> Any:
     forwarded = body.get("forwardedProps")
     if not _has_agent_config_props(forwarded):
         return body
-    # _has_agent_config_props guarantees forwarded is a dict — narrow for type checker.
-    assert isinstance(forwarded, dict)
+    # `_has_agent_config_props` guarantees `forwarded` is a dict, but
+    # narrow it explicitly for the type checker — using `assert` here
+    # would be stripped under `python -O`, leaving the type checker
+    # without a guarantee.
+    if not isinstance(forwarded, dict):
+        return body
 
     existing_state = body.get("state")
     state: dict[str, Any] = existing_state if isinstance(existing_state, dict) else {}
@@ -224,15 +230,20 @@ class ForwardedPropsASGIMiddleware:
 
         method = scope.get("method", "")
         path = scope.get("path", "")
-        if method != "POST" or path not in ("/", ""):
+        # Per ASGI spec, `path` is always at least "/" — no need to also
+        # check for the empty string.
+        if method != "POST" or path != "/":
             await self.app(scope, receive, send)
             return
 
         # `headers` is a list of (bytes, bytes) — find content-type.
+        # ASGI normalizes header names to lowercase, but match
+        # case-insensitively for parity with the content-length filter
+        # below and to be defensive against non-spec ASGI servers.
         headers = scope.get("headers") or []
         content_type = b""
         for k, v in headers:
-            if k == b"content-type":
+            if k.lower() == b"content-type":
                 content_type = v
                 break
         if b"application/json" not in content_type:
@@ -246,13 +257,32 @@ class ForwardedPropsASGIMiddleware:
         while more_body:
             message = await receive()
             if message["type"] != "http.request":
-                # Unexpected (e.g. http.disconnect before body fully sent):
-                # replay what we already have and propagate the early
-                # disconnect so the inner app can handle it.
-                async def _replay_disconnect(msg=message):
-                    return msg
+                # Unexpected (e.g. http.disconnect before body fully sent).
+                # Replay the buffered chunks we already received as a single
+                # http.request BEFORE forwarding the disconnect — otherwise
+                # the inner ASGI app sees disconnect with no body even when
+                # partial chunks arrived. The inner app can then choose
+                # whether to surface a 4xx from the partial body or honor
+                # the disconnect.
+                pending: list[dict] = [
+                    {
+                        "type": "http.request",
+                        "body": b"".join(chunks),
+                        "more_body": False,
+                    },
+                    message,
+                ]
+                idx = 0
 
-                await self.app(scope, _replay_disconnect, send)
+                async def _replay_partial():
+                    nonlocal idx
+                    if idx < len(pending):
+                        m = pending[idx]
+                        idx += 1
+                        return m
+                    return {"type": "http.disconnect"}
+
+                await self.app(scope, _replay_partial, send)
                 return
             chunks.append(message.get("body") or b"")
             more_body = message.get("more_body", False)
@@ -268,7 +298,18 @@ class ForwardedPropsASGIMiddleware:
         if raw:
             try:
                 body = json.loads(raw)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError) as exc:
+                # Don't change behavior — still pass through the original
+                # bytes verbatim — but make the failure observable so a
+                # malformed frontend body doesn't disappear silently. This
+                # package has no structured logger, so we use stderr
+                # directly with method/path context (same convention as
+                # the rest of the showcase Python entrypoints).
+                print(
+                    f"[ForwardedPropsASGIMiddleware] JSON parse failed for "
+                    f"{method} {path}: {exc!r}",
+                    flush=True,
+                )
                 body = None
             if isinstance(body, dict) and _has_agent_config_props(
                 body.get("forwardedProps")
@@ -308,7 +349,22 @@ class ForwardedPropsASGIMiddleware:
                 return {"type": "http.disconnect"}
             try:
                 msg = await receive()
-            except Exception:
+            except asyncio.CancelledError:
+                # Cancellation MUST propagate — the outer ASGI server is
+                # cancelling this task, and swallowing it leaks the task
+                # and corrupts task-cancellation semantics. Do NOT mark
+                # disconnect; let the cancellation unwind cleanly.
+                raise
+            except Exception as exc:  # noqa: BLE001  pragma: no cover
+                # Narrow this further once we know which transport errors
+                # actually surface here. For now, log the failure so it's
+                # observable rather than silently converted into a clean
+                # disconnect (which masked real bugs).
+                print(
+                    f"[ForwardedPropsASGIMiddleware] receive() raised "
+                    f"{type(exc).__name__}: {exc!r} — treating as disconnect",
+                    flush=True,
+                )
                 sent_disconnect = True
                 return {"type": "http.disconnect"}
             if msg.get("type") == "http.disconnect":

--- a/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
+++ b/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
@@ -1,0 +1,486 @@
+"""
+Red-green tests for the forwardedProps -> state.inputs splice.
+
+Background — the regression this test pins down:
+The previous implementation (`ForwardedPropsMiddleware`, a `BaseHTTPMiddleware`
+subclass that called `await request.body()` and reinstalled `request._receive`)
+race-conditioned with Starlette's inner anyio TaskGroup wrapped_receive (see
+`starlette/middleware/base.py`). Stacking it under `HealthMiddleware` (also
+`BaseHTTPMiddleware`) caused a `RuntimeError: Unexpected message received:
+http.request` mid-stream — AG-UI clients saw RUN_STARTED and then the SSE
+stream aborted (`RUN_ERROR: INCOMPLETE_STREAM`), no TEXT_MESSAGE_* /
+RUN_FINISHED ever emitted.
+
+The fix moves the splice OUT of ASGI middleware and into the FastAPI route
+handler (where Pydantic has already parsed the body — no receive surgery
+needed). These tests pin the new contract:
+
+1. POSTs to "/" stream cleanly with HealthMiddleware in the chain — no
+   `Unexpected message received: http.request` RuntimeError, full body
+   delivered to the route handler.
+2. `forwardedProps.tone` / `expertise` / `responseLength` still flow through
+   to `state.inputs` (the agent-config demo's contract).
+3. Bodies WITHOUT agent-config props are left untouched (non-config demos
+   keep their exact request bytes).
+4. /health short-circuits without touching the body splice path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, StreamingResponse
+
+
+# Force-disable aimock import-time side-effects so we can import agent_server
+# in a unit-test process without dotenv loading a developer-local OPENAI key.
+os.environ.setdefault("AIMOCK_URL", "")
+
+
+# We import the module under test lazily inside fixtures so individual tests
+# can reach in for the helpers (`_build_agent_config_guidance`,
+# `_has_agent_config_props`, the splice helper) without paying the full
+# crewai import cost when the test only needs the helpers. The full app
+# (with crewai-backed routes mounted) is exercised via a stub app that
+# wires up the same middleware + a streaming route — the regression is
+# purely an ASGI layering bug, not a crewai bug.
+
+
+# --------------------------------------------------------------------------- #
+# Helper: build a minimal app that replicates the production middleware stack #
+# (HealthMiddleware on the outside, the forwardedProps splice on the inside)  #
+# plus a streaming route at "/" — the surface where the bug manifested.       #
+# --------------------------------------------------------------------------- #
+
+
+class _HealthMiddleware(BaseHTTPMiddleware):
+    """Mirror of agent_server.HealthMiddleware — same shape, same dispatch."""
+
+    async def dispatch(self, request, call_next):
+        if request.url.path == "/health" and request.method == "GET":
+            return JSONResponse({"status": "ok"})
+        return await call_next(request)
+
+
+def _make_streaming_app(splice_fn) -> FastAPI:
+    """Build a FastAPI app whose '/' route streams a small SSE-ish payload.
+
+    `splice_fn` takes the parsed body dict and returns a (possibly mutated)
+    body dict. This is what the post-fix code path looks like: body is parsed
+    by Pydantic / FastAPI first, splice happens IN the handler, then the
+    streaming generator runs over the spliced state.
+
+    The mock crew echoes back state.inputs in the streamed payload so we
+    can assert the splice landed.
+    """
+    app = FastAPI()
+
+    @app.post("/")
+    async def root(request: Request):
+        body = await request.json()
+        spliced = splice_fn(body) if splice_fn else body
+
+        async def gen():
+            # Three small frames — buffer-size below the threshold that
+            # would mask a body-replay race. The race fires the moment the
+            # streaming response BEGINS pulling from `receive`, so even a
+            # one-frame stream surfaces it.
+            yield b"event: RUN_STARTED\ndata: {}\n\n"
+            yield (
+                b"event: STATE\n"
+                b"data: " + json.dumps(spliced.get("state", {})).encode() + b"\n\n"
+            )
+            yield b"event: RUN_FINISHED\ndata: {}\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    app.add_middleware(_HealthMiddleware)
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def _import_agent_server_helpers():
+    """Import only the helpers (no crewai required)."""
+    # The src/ directory is on sys.path via pytest.ini's `pythonpath = src`.
+    # We import the helpers directly to avoid pulling in agents/* (which
+    # imports crewai). This mirrors how the helpers are unit-tested
+    # elsewhere in the repo.
+    import importlib.util
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.normpath(os.path.join(here, "..", "..", "src"))
+    path = os.path.join(src, "agent_server.py")
+
+    # We can't `import agent_server` directly because it pulls in
+    # ag_ui_crewai + crewai (heavy). Instead, parse + exec the helper
+    # block by reading the source and executing only the symbols we need.
+    # Simpler: use the post-fix module shape, which exposes the helpers
+    # at module scope and DOES NOT import crewai at import time… that
+    # is not the case today, so we use a tiny shim: copy the helper
+    # functions into this test file. The fix PR will keep these
+    # helpers in agent_server.py (re-importable cleanly).
+    raise NotImplementedError  # not used — see inline copies below
+
+
+# Inline copy of the splice helpers — matches what's in agent_server.py.
+# Keeping a local copy lets the test run without importing crewai.
+# (The post-fix agent_server.py keeps them at module scope; an integration
+# smoke test elsewhere asserts they're still in sync.)
+_AGENT_CONFIG_KEYS = ("tone", "expertise", "responseLength")
+
+_TONE_RULES = {
+    "professional": "Use neutral, precise language. No emoji. Short sentences.",
+    "casual": "Use friendly, conversational language. Contractions OK. Light humor welcome.",
+    "enthusiastic": "Use upbeat, energetic language. Exclamation points OK. Emoji OK.",
+}
+_EXPERTISE_RULES = {
+    "beginner": "Assume no prior knowledge. Define jargon. Use analogies.",
+    "intermediate": "Assume common terms are understood; explain specialized terms.",
+    "expert": "Assume technical fluency. Use precise terminology. Skip basics.",
+}
+_LENGTH_RULES = {
+    "concise": "Respond in 1-3 sentences.",
+    "detailed": "Respond in multiple paragraphs with examples where relevant.",
+}
+
+
+def _build_agent_config_guidance(tone, expertise, response_length):
+    tone_rule = _TONE_RULES.get(str(tone), _TONE_RULES["professional"])
+    expertise_rule = _EXPERTISE_RULES.get(str(expertise), _EXPERTISE_RULES["intermediate"])
+    length_rule = _LENGTH_RULES.get(str(response_length), _LENGTH_RULES["concise"])
+    return (
+        "Follow these style rules for your response to the user. "
+        f"TONE: {tone_rule} "
+        f"EXPERTISE: {expertise_rule} "
+        f"LENGTH: {length_rule}"
+    )
+
+
+def _has_agent_config_props(props):
+    if not isinstance(props, dict):
+        return False
+    return any(k in props for k in _AGENT_CONFIG_KEYS)
+
+
+def _splice_forwarded_props(body):
+    """Reference splice — what the route handler should call post-fix."""
+    if not isinstance(body, dict):
+        return body
+    forwarded = body.get("forwardedProps")
+    if not _has_agent_config_props(forwarded):
+        return body
+    existing_state = body.get("state")
+    state = existing_state if isinstance(existing_state, dict) else {}
+    inputs = state.get("inputs") if isinstance(state.get("inputs"), dict) else {}
+    inputs = dict(inputs)
+    tone = forwarded.get("tone")
+    expertise = forwarded.get("expertise")
+    response_length = forwarded.get("responseLength")
+    if tone is not None:
+        inputs["tone"] = tone
+    if expertise is not None:
+        inputs["expertise"] = expertise
+    if response_length is not None:
+        inputs["response_length"] = response_length
+    inputs["agent_config_guidance"] = _build_agent_config_guidance(
+        tone=tone, expertise=expertise, response_length=response_length
+    )
+    state["inputs"] = inputs
+    body["state"] = state
+    return body
+
+
+# --- Production-shape regression test -------------------------------------- #
+# This test imports the REAL `agent_server` module's middleware stack and
+# wires it up with a stub streaming route. Pre-fix, the body-replay race
+# in `ForwardedPropsMiddleware` causes a `RuntimeError` mid-stream. The
+# test fails (RED) on master and passes (GREEN) post-fix.
+
+
+def _build_app_with_real_middleware():
+    """Replicate the production middleware stack against a stub streaming route.
+
+    We DO NOT import `agent_server` directly because it pulls in crewai +
+    ag_ui_crewai (heavy + requires LLM env vars). Instead we replicate the
+    shape: HealthMiddleware (outer) + ForwardedPropsMiddleware (inner) on
+    a FastAPI app whose '/' route streams a few SSE frames. The bug is
+    purely an ASGI layering issue — same shape reproduces it.
+
+    Post-fix this helper is updated to NOT install ForwardedPropsMiddleware
+    at all (it should be deleted from the source). The test's GREEN
+    assertion is enforced by `test_no_forwarded_props_middleware_class`
+    below.
+    """
+    # Lazy import the middleware class so this test can run on a tree
+    # where it has been deleted (post-fix). The post-fix tree exposes
+    # only the helpers; the middleware class is gone.
+    try:
+        # We want to test the OLD middleware behavior to prove the test
+        # catches the regression. Inline a copy of it here, matching
+        # exactly what was in agent_server.py pre-fix.
+        from starlette.middleware.base import BaseHTTPMiddleware as _BH
+
+        class _OldForwardedPropsMiddleware(_BH):
+            async def dispatch(self, request, call_next):
+                if request.method != "POST" or request.url.path not in ("/", ""):
+                    return await call_next(request)
+                content_type = request.headers.get("content-type", "")
+                if "application/json" not in content_type:
+                    return await call_next(request)
+                try:
+                    raw = await request.body()
+                except Exception:
+                    return await call_next(request)
+                if not raw:
+                    return await call_next(request)
+                try:
+                    body = json.loads(raw)
+                except (ValueError, TypeError):
+                    return await call_next(request)
+                forwarded = body.get("forwardedProps") if isinstance(body, dict) else None
+                if not _has_agent_config_props(forwarded):
+                    return await _call_with_body(request, call_next, raw)
+                spliced = _splice_forwarded_props(body)
+                new_raw = json.dumps(spliced).encode("utf-8")
+                return await _call_with_body(request, call_next, new_raw)
+
+        async def _call_with_body(request, call_next, body_bytes):
+            sent = False
+
+            async def receive():
+                nonlocal sent
+                if sent:
+                    return {"type": "http.disconnect"}
+                sent = True
+                return {
+                    "type": "http.request",
+                    "body": body_bytes,
+                    "more_body": False,
+                }
+
+            request._receive = receive
+            return await call_next(request)
+
+        return _OldForwardedPropsMiddleware
+    except Exception:
+        return None
+
+
+def test_streaming_post_with_forwarded_props_completes_without_runtimeerror():
+    """RED on master: HealthMiddleware -> ForwardedPropsMiddleware -> streaming
+    route triggers `RuntimeError: Unexpected message received: http.request`.
+    GREEN post-fix: middleware deleted, splice moved into route handler."""
+    app = FastAPI()
+
+    @app.post("/")
+    async def root(request: Request):
+        body = await request.json()
+        spliced = _splice_forwarded_props(body)
+
+        async def gen():
+            yield b"event: RUN_STARTED\ndata: {}\n\n"
+            yield (
+                b"event: STATE\ndata: "
+                + json.dumps(spliced.get("state", {})).encode()
+                + b"\n\n"
+            )
+            yield b"event: RUN_FINISHED\ndata: {}\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    # Wire the middleware stack EXACTLY as production does.
+    app.add_middleware(_HealthMiddleware)
+    OldMW = _build_app_with_real_middleware()
+    if OldMW is not None:
+        # If we're running against the PRE-FIX tree, this re-introduces the
+        # racy middleware, and the test should fail. POST-FIX this is also
+        # exercised but we ALSO assert (below) that the real source no
+        # longer contains the class — that's the irreversible RED→GREEN.
+        # Important: the post-fix code path no longer installs the
+        # middleware in production. This block reproduces the pre-fix
+        # bug for the regression assertion.
+        pass
+
+    payload = {
+        "threadId": "t1",
+        "runId": "r1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "state": {"inputs": {}},
+        "forwardedProps": {"tone": "casual", "expertise": "beginner"},
+    }
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/",
+            json=payload,
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 200
+        text = response.text
+        assert "RUN_STARTED" in text
+        assert "RUN_FINISHED" in text
+        # Splice landed:
+        assert "casual" in text
+        assert "agent_config_guidance" in text
+
+
+def test_forwarded_props_middleware_class_removed_from_agent_server():
+    """GREEN-only assertion: the racy `ForwardedPropsMiddleware` class must
+    NOT exist in agent_server.py anymore. Pre-fix this fails. Post-fix the
+    class is deleted (splice moved into the route handler).
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.normpath(os.path.join(here, "..", "..", "src", "agent_server.py"))
+    with open(src) as f:
+        source = f.read()
+    assert "class ForwardedPropsMiddleware(BaseHTTPMiddleware" not in source, (
+        "ForwardedPropsMiddleware (BaseHTTPMiddleware subclass) must be "
+        "removed — it caused a body-replay race against Starlette's inner "
+        "TaskGroup, aborting AG-UI streams with "
+        "`RuntimeError: Unexpected message received: http.request`. "
+        "Use a raw ASGI middleware instead."
+    )
+    # Also assert the helpers stay (so the route handler can call them):
+    assert "_build_agent_config_guidance" in source
+    assert "_has_agent_config_props" in source
+
+
+def test_real_agent_server_streams_post_root_without_runtimeerror():
+    """End-to-end: import the REAL `agent_server` module and POST to '/' to
+    confirm the middleware stack no longer raises the body-replay
+    RuntimeError. Stubs out the heavy crewai-backed route with a streaming
+    one so the test stays unit-scoped (no LLM, no crewai install needed).
+    """
+    # Stub heavy modules BEFORE importing agent_server.
+    import types
+
+    # ag_ui_crewai.endpoint — provide a no-op `add_crewai_crew_fastapi_endpoint`.
+    ag_ui_crewai = types.ModuleType("ag_ui_crewai")
+    ag_ui_crewai_endpoint = types.ModuleType("ag_ui_crewai.endpoint")
+
+    def _add_crewai_crew_fastapi_endpoint(app, crew, path):
+        # Mount a streaming stub at `path`. The crewai-crews root mount is "/",
+        # which is where the regression manifests. We use `app.post(path)` to
+        # register; FastAPI's signature introspection sees `request: Request`
+        # and binds it to the actual Request object (not a query parameter).
+        # Each call defines a fresh local function so closures don't collide
+        # across the multiple `add_crewai_crew_fastapi_endpoint` calls in
+        # agent_server.py.
+        def _make_stub():
+            async def _stub(request: Request):
+                body = (
+                    await request.json() if request.method == "POST" else {}
+                )
+
+                async def gen():
+                    yield b"event: RUN_STARTED\ndata: {}\n\n"
+                    yield (
+                        b"event: STATE\ndata: "
+                        + json.dumps(body.get("state", {})).encode()
+                        + b"\n\n"
+                    )
+                    yield b"event: RUN_FINISHED\ndata: {}\n\n"
+
+                return StreamingResponse(gen(), media_type="text/event-stream")
+
+            return _stub
+
+        app.post(path)(_make_stub())
+
+    ag_ui_crewai_endpoint.add_crewai_crew_fastapi_endpoint = _add_crewai_crew_fastapi_endpoint
+    sys.modules["ag_ui_crewai"] = ag_ui_crewai
+    sys.modules["ag_ui_crewai.endpoint"] = ag_ui_crewai_endpoint
+
+    # Stub agents.* — agent_server imports several crew classes; replace them
+    # with no-arg sentinels so import succeeds without crewai being installed.
+    agents_pkg = types.ModuleType("agents")
+    agents_pkg.__path__ = []  # mark as package
+    sys.modules["agents"] = agents_pkg
+    for name in ("crew", "a2ui_fixed", "beautiful_chat", "byoc_hashbrown_agent",
+                 "byoc_json_render_agent", "declarative_gen_ui"):
+        m = types.ModuleType(f"agents.{name}")
+        sys.modules[f"agents.{name}"] = m
+    sys.modules["agents.crew"].LatestAiDevelopment = lambda: object()
+    sys.modules["agents.a2ui_fixed"].A2UIFixedSchema = lambda: object()
+    sys.modules["agents.beautiful_chat"].BeautifulChat = lambda: object()
+    sys.modules["agents.byoc_hashbrown_agent"].ByocHashbrown = lambda: object()
+    sys.modules["agents.byoc_json_render_agent"].ByocJsonRender = lambda: object()
+    sys.modules["agents.declarative_gen_ui"].DeclarativeGenUI = lambda: object()
+
+    # Now import the real module. This will fail loudly pre-fix because the
+    # middleware class is referenced; the test's intent is to exercise the
+    # post-fix module shape.
+    if "agent_server" in sys.modules:
+        del sys.modules["agent_server"]
+    import agent_server  # noqa: F401
+
+    payload = {
+        "threadId": "t1",
+        "runId": "r1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "state": {"inputs": {}},
+        "forwardedProps": {"tone": "casual", "expertise": "beginner"},
+    }
+
+    with TestClient(agent_server.app) as client:
+        response = client.post(
+            "/",
+            json=payload,
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 200, response.text
+        text = response.text
+        assert "RUN_STARTED" in text
+        assert "RUN_FINISHED" in text
+        # Splice landed in state.inputs (this is the agent-config contract):
+        assert "casual" in text
+        assert "agent_config_guidance" in text
+
+
+def test_health_endpoint_short_circuits():
+    """/health must continue to short-circuit at the middleware layer."""
+    # Same setup as the real-module test above.
+    if "agent_server" in sys.modules:
+        # Re-use the stubs from the previous test if they're already in place.
+        pass
+    import agent_server  # noqa: F401
+
+    with TestClient(agent_server.app) as client:
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
+
+
+def test_post_without_forwarded_props_passes_through_unchanged():
+    """Bodies without agent-config props must reach the handler with state
+    unmodified — non-config demos keep their exact request bytes."""
+    import agent_server  # noqa: F401
+
+    payload = {
+        "threadId": "t1",
+        "runId": "r1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "state": {"inputs": {"some_demo_key": "preserved"}},
+    }
+
+    with TestClient(agent_server.app) as client:
+        response = client.post(
+            "/",
+            json=payload,
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 200, response.text
+        # Original state.inputs preserved, no agent_config_guidance injected:
+        assert "preserved" in response.text
+        assert "agent_config_guidance" not in response.text

--- a/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
+++ b/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
@@ -180,10 +180,12 @@ def _splice_forwarded_props(body):
     forwarded = body.get("forwardedProps")
     if not _has_agent_config_props(forwarded):
         return body
+    # _has_agent_config_props guarantees forwarded is a dict — narrow for type checker.
+    assert isinstance(forwarded, dict)
     existing_state = body.get("state")
-    state = existing_state if isinstance(existing_state, dict) else {}
-    inputs = state.get("inputs") if isinstance(state.get("inputs"), dict) else {}
-    inputs = dict(inputs)
+    state: dict[str, Any] = existing_state if isinstance(existing_state, dict) else {}
+    raw_inputs = state.get("inputs")
+    inputs: dict[str, Any] = dict(raw_inputs) if isinstance(raw_inputs, dict) else {}
     tone = forwarded.get("tone")
     expertise = forwarded.get("expertise")
     response_length = forwarded.get("responseLength")
@@ -398,7 +400,11 @@ def test_real_agent_server_streams_post_root_without_runtimeerror():
 
         app.post(path)(_make_stub())
 
-    ag_ui_crewai_endpoint.add_crewai_crew_fastapi_endpoint = _add_crewai_crew_fastapi_endpoint
+    setattr(
+        ag_ui_crewai_endpoint,
+        "add_crewai_crew_fastapi_endpoint",
+        _add_crewai_crew_fastapi_endpoint,
+    )
     sys.modules["ag_ui_crewai"] = ag_ui_crewai
     sys.modules["ag_ui_crewai.endpoint"] = ag_ui_crewai_endpoint
 
@@ -411,12 +417,18 @@ def test_real_agent_server_streams_post_root_without_runtimeerror():
                  "byoc_json_render_agent", "declarative_gen_ui"):
         m = types.ModuleType(f"agents.{name}")
         sys.modules[f"agents.{name}"] = m
-    sys.modules["agents.crew"].LatestAiDevelopment = lambda: object()
-    sys.modules["agents.a2ui_fixed"].A2UIFixedSchema = lambda: object()
-    sys.modules["agents.beautiful_chat"].BeautifulChat = lambda: object()
-    sys.modules["agents.byoc_hashbrown_agent"].ByocHashbrown = lambda: object()
-    sys.modules["agents.byoc_json_render_agent"].ByocJsonRender = lambda: object()
-    sys.modules["agents.declarative_gen_ui"].DeclarativeGenUI = lambda: object()
+    setattr(sys.modules["agents.crew"], "LatestAiDevelopment", lambda: object())
+    setattr(sys.modules["agents.a2ui_fixed"], "A2UIFixedSchema", lambda: object())
+    setattr(sys.modules["agents.beautiful_chat"], "BeautifulChat", lambda: object())
+    setattr(
+        sys.modules["agents.byoc_hashbrown_agent"], "ByocHashbrown", lambda: object()
+    )
+    setattr(
+        sys.modules["agents.byoc_json_render_agent"], "ByocJsonRender", lambda: object()
+    )
+    setattr(
+        sys.modules["agents.declarative_gen_ui"], "DeclarativeGenUI", lambda: object()
+    )
 
     # Now import the real module. This will fail loudly pre-fix because the
     # middleware class is referenced; the test's intent is to exercise the

--- a/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
+++ b/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
@@ -1,7 +1,7 @@
 """
 Red-green tests for the forwardedProps -> state.inputs splice.
 
-Background — the regression this test pins down:
+Background — the regression these tests pin down:
 The previous implementation (`ForwardedPropsMiddleware`, a `BaseHTTPMiddleware`
 subclass that called `await request.body()` and reinstalled `request._receive`)
 race-conditioned with Starlette's inner anyio TaskGroup wrapped_receive (see
@@ -11,9 +11,11 @@ http.request` mid-stream — AG-UI clients saw RUN_STARTED and then the SSE
 stream aborted (`RUN_ERROR: INCOMPLETE_STREAM`), no TEXT_MESSAGE_* /
 RUN_FINISHED ever emitted.
 
-The fix moves the splice OUT of ASGI middleware and into the FastAPI route
-handler (where Pydantic has already parsed the body — no receive surgery
-needed). These tests pin the new contract:
+The fix replaces the racy `BaseHTTPMiddleware` subclass with a *raw* ASGI
+middleware (`ForwardedPropsASGIMiddleware`) that buffers the body once at the
+ASGI boundary and replays it via a fresh `receive` callable — no
+`request._receive` surgery, no inner-TaskGroup race. These tests pin the new
+contract:
 
 1. POSTs to "/" stream cleanly with HealthMiddleware in the chain — no
    `Unexpected message received: http.request` RuntimeError, full body
@@ -23,6 +25,8 @@ needed). These tests pin the new contract:
 3. Bodies WITHOUT agent-config props are left untouched (non-config demos
    keep their exact request bytes).
 4. /health short-circuits without touching the body splice path.
+5. The racy `BaseHTTPMiddleware` shape never reappears in agent_server.py
+   (irreversible structural pin against the regression).
 """
 
 from __future__ import annotations
@@ -30,6 +34,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import types
 from typing import Any
 
 import pytest
@@ -42,15 +47,6 @@ from starlette.responses import JSONResponse, StreamingResponse
 # Force-disable aimock import-time side-effects so we can import agent_server
 # in a unit-test process without dotenv loading a developer-local OPENAI key.
 os.environ.setdefault("AIMOCK_URL", "")
-
-
-# We import the module under test lazily inside fixtures so individual tests
-# can reach in for the helpers (`_build_agent_config_guidance`,
-# `_has_agent_config_props`, the splice helper) without paying the full
-# crewai import cost when the test only needs the helpers. The full app
-# (with crewai-backed routes mounted) is exercised via a stub app that
-# wires up the same middleware + a streaming route — the regression is
-# purely an ASGI layering bug, not a crewai bug.
 
 
 # --------------------------------------------------------------------------- #
@@ -69,74 +65,15 @@ class _HealthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-def _make_streaming_app(splice_fn) -> FastAPI:
-    """Build a FastAPI app whose '/' route streams a small SSE-ish payload.
-
-    `splice_fn` takes the parsed body dict and returns a (possibly mutated)
-    body dict. This is what the post-fix code path looks like: body is parsed
-    by Pydantic / FastAPI first, splice happens IN the handler, then the
-    streaming generator runs over the spliced state.
-
-    The mock crew echoes back state.inputs in the streamed payload so we
-    can assert the splice landed.
-    """
-    app = FastAPI()
-
-    @app.post("/")
-    async def root(request: Request):
-        body = await request.json()
-        spliced = splice_fn(body) if splice_fn else body
-
-        async def gen():
-            # Three small frames — buffer-size below the threshold that
-            # would mask a body-replay race. The race fires the moment the
-            # streaming response BEGINS pulling from `receive`, so even a
-            # one-frame stream surfaces it.
-            yield b"event: RUN_STARTED\ndata: {}\n\n"
-            yield (
-                b"event: STATE\n"
-                b"data: " + json.dumps(spliced.get("state", {})).encode() + b"\n\n"
-            )
-            yield b"event: RUN_FINISHED\ndata: {}\n\n"
-
-        return StreamingResponse(gen(), media_type="text/event-stream")
-
-    app.add_middleware(_HealthMiddleware)
-    return app
-
-
 # --------------------------------------------------------------------------- #
-# Tests                                                                        #
+# Inline copy of the splice helpers — matches what's in agent_server.py.      #
+# Keeping a local copy lets the streaming-shape test run without importing    #
+# crewai. The structural-pin test (`test_forwarded_props_middleware_class_..  #
+# _removed_from_agent_server`) reads the source file directly, and the       #
+# real-module test (`test_real_agent_server_*`) imports agent_server with     #
+# heavy deps stubbed — both keep the production helpers as the source of     #
+# truth. If the helpers below drift, the real-module tests will catch it.    #
 # --------------------------------------------------------------------------- #
-
-
-def _import_agent_server_helpers():
-    """Import only the helpers (no crewai required)."""
-    # The src/ directory is on sys.path via pytest.ini's `pythonpath = src`.
-    # We import the helpers directly to avoid pulling in agents/* (which
-    # imports crewai). This mirrors how the helpers are unit-tested
-    # elsewhere in the repo.
-    import importlib.util
-
-    here = os.path.dirname(os.path.abspath(__file__))
-    src = os.path.normpath(os.path.join(here, "..", "..", "src"))
-    path = os.path.join(src, "agent_server.py")
-
-    # We can't `import agent_server` directly because it pulls in
-    # ag_ui_crewai + crewai (heavy). Instead, parse + exec the helper
-    # block by reading the source and executing only the symbols we need.
-    # Simpler: use the post-fix module shape, which exposes the helpers
-    # at module scope and DOES NOT import crewai at import time… that
-    # is not the case today, so we use a tiny shim: copy the helper
-    # functions into this test file. The fix PR will keep these
-    # helpers in agent_server.py (re-importable cleanly).
-    raise NotImplementedError  # not used — see inline copies below
-
-
-# Inline copy of the splice helpers — matches what's in agent_server.py.
-# Keeping a local copy lets the test run without importing crewai.
-# (The post-fix agent_server.py keeps them at module scope; an integration
-# smoke test elsewhere asserts they're still in sync.)
 _AGENT_CONFIG_KEYS = ("tone", "expertise", "responseLength")
 
 _TONE_RULES = {
@@ -203,187 +140,34 @@ def _splice_forwarded_props(body):
     return body
 
 
-# --- Production-shape regression test -------------------------------------- #
-# This test imports the REAL `agent_server` module's middleware stack and
-# wires it up with a stub streaming route. Pre-fix, the body-replay race
-# in `ForwardedPropsMiddleware` causes a `RuntimeError` mid-stream. The
-# test fails (RED) on master and passes (GREEN) post-fix.
+# --------------------------------------------------------------------------- #
+# Fixture: stub heavy modules + (re)import agent_server for every test that  #
+# needs the real module. Module-scoped + autouse so any of the real-module   #
+# tests can run standalone or in any order (e.g. -k filters, pytest-xdist,   #
+# pytest-randomly). The stub install is idempotent and the stale            #
+# `agent_server` entry is purged so re-imports pick up our stubs.            #
+# --------------------------------------------------------------------------- #
 
 
-def _build_app_with_real_middleware():
-    """Replicate the production middleware stack against a stub streaming route.
-
-    We DO NOT import `agent_server` directly because it pulls in crewai +
-    ag_ui_crewai (heavy + requires LLM env vars). Instead we replicate the
-    shape: HealthMiddleware (outer) + ForwardedPropsMiddleware (inner) on
-    a FastAPI app whose '/' route streams a few SSE frames. The bug is
-    purely an ASGI layering issue — same shape reproduces it.
-
-    Post-fix this helper is updated to NOT install ForwardedPropsMiddleware
-    at all (it should be deleted from the source). The test's GREEN
-    assertion is enforced by `test_no_forwarded_props_middleware_class`
-    below.
+@pytest.fixture(autouse=True)
+def _stub_agent_server_deps():
+    """Install stubs for ag_ui_crewai + agents.* so `import agent_server`
+    succeeds without crewai installed, and reset the cached module so each
+    test gets a fresh import bound to OUR stubs (not whatever sibling test
+    happened to import first).
     """
-    # Lazy import the middleware class so this test can run on a tree
-    # where it has been deleted (post-fix). The post-fix tree exposes
-    # only the helpers; the middleware class is gone.
-    try:
-        # We want to test the OLD middleware behavior to prove the test
-        # catches the regression. Inline a copy of it here, matching
-        # exactly what was in agent_server.py pre-fix.
-        from starlette.middleware.base import BaseHTTPMiddleware as _BH
-
-        class _OldForwardedPropsMiddleware(_BH):
-            async def dispatch(self, request, call_next):
-                if request.method != "POST" or request.url.path not in ("/", ""):
-                    return await call_next(request)
-                content_type = request.headers.get("content-type", "")
-                if "application/json" not in content_type:
-                    return await call_next(request)
-                try:
-                    raw = await request.body()
-                except Exception:
-                    return await call_next(request)
-                if not raw:
-                    return await call_next(request)
-                try:
-                    body = json.loads(raw)
-                except (ValueError, TypeError):
-                    return await call_next(request)
-                forwarded = body.get("forwardedProps") if isinstance(body, dict) else None
-                if not _has_agent_config_props(forwarded):
-                    return await _call_with_body(request, call_next, raw)
-                spliced = _splice_forwarded_props(body)
-                new_raw = json.dumps(spliced).encode("utf-8")
-                return await _call_with_body(request, call_next, new_raw)
-
-        async def _call_with_body(request, call_next, body_bytes):
-            sent = False
-
-            async def receive():
-                nonlocal sent
-                if sent:
-                    return {"type": "http.disconnect"}
-                sent = True
-                return {
-                    "type": "http.request",
-                    "body": body_bytes,
-                    "more_body": False,
-                }
-
-            request._receive = receive
-            return await call_next(request)
-
-        return _OldForwardedPropsMiddleware
-    except Exception:
-        return None
-
-
-def test_streaming_post_with_forwarded_props_completes_without_runtimeerror():
-    """RED on master: HealthMiddleware -> ForwardedPropsMiddleware -> streaming
-    route triggers `RuntimeError: Unexpected message received: http.request`.
-    GREEN post-fix: middleware deleted, splice moved into route handler."""
-    app = FastAPI()
-
-    @app.post("/")
-    async def root(request: Request):
-        body = await request.json()
-        spliced = _splice_forwarded_props(body)
-
-        async def gen():
-            yield b"event: RUN_STARTED\ndata: {}\n\n"
-            yield (
-                b"event: STATE\ndata: "
-                + json.dumps(spliced.get("state", {})).encode()
-                + b"\n\n"
-            )
-            yield b"event: RUN_FINISHED\ndata: {}\n\n"
-
-        return StreamingResponse(gen(), media_type="text/event-stream")
-
-    # Wire the middleware stack EXACTLY as production does.
-    app.add_middleware(_HealthMiddleware)
-    OldMW = _build_app_with_real_middleware()
-    if OldMW is not None:
-        # If we're running against the PRE-FIX tree, this re-introduces the
-        # racy middleware, and the test should fail. POST-FIX this is also
-        # exercised but we ALSO assert (below) that the real source no
-        # longer contains the class — that's the irreversible RED→GREEN.
-        # Important: the post-fix code path no longer installs the
-        # middleware in production. This block reproduces the pre-fix
-        # bug for the regression assertion.
-        pass
-
-    payload = {
-        "threadId": "t1",
-        "runId": "r1",
-        "messages": [{"role": "user", "content": "hi"}],
-        "state": {"inputs": {}},
-        "forwardedProps": {"tone": "casual", "expertise": "beginner"},
-    }
-
-    with TestClient(app) as client:
-        response = client.post(
-            "/",
-            json=payload,
-            headers={"content-type": "application/json"},
-        )
-        assert response.status_code == 200
-        text = response.text
-        assert "RUN_STARTED" in text
-        assert "RUN_FINISHED" in text
-        # Splice landed:
-        assert "casual" in text
-        assert "agent_config_guidance" in text
-
-
-def test_forwarded_props_middleware_class_removed_from_agent_server():
-    """GREEN-only assertion: the racy `ForwardedPropsMiddleware` class must
-    NOT exist in agent_server.py anymore. Pre-fix this fails. Post-fix the
-    class is deleted (splice moved into the route handler).
-    """
-    here = os.path.dirname(os.path.abspath(__file__))
-    src = os.path.normpath(os.path.join(here, "..", "..", "src", "agent_server.py"))
-    with open(src) as f:
-        source = f.read()
-    assert "class ForwardedPropsMiddleware(BaseHTTPMiddleware" not in source, (
-        "ForwardedPropsMiddleware (BaseHTTPMiddleware subclass) must be "
-        "removed — it caused a body-replay race against Starlette's inner "
-        "TaskGroup, aborting AG-UI streams with "
-        "`RuntimeError: Unexpected message received: http.request`. "
-        "Use a raw ASGI middleware instead."
-    )
-    # Also assert the helpers stay (so the route handler can call them):
-    assert "_build_agent_config_guidance" in source
-    assert "_has_agent_config_props" in source
-
-
-def test_real_agent_server_streams_post_root_without_runtimeerror():
-    """End-to-end: import the REAL `agent_server` module and POST to '/' to
-    confirm the middleware stack no longer raises the body-replay
-    RuntimeError. Stubs out the heavy crewai-backed route with a streaming
-    one so the test stays unit-scoped (no LLM, no crewai install needed).
-    """
-    # Stub heavy modules BEFORE importing agent_server.
-    import types
-
-    # ag_ui_crewai.endpoint — provide a no-op `add_crewai_crew_fastapi_endpoint`.
+    # ag_ui_crewai.endpoint — provide a no-op `add_crewai_crew_fastapi_endpoint`
+    # that mounts a streaming stub at the requested path.
     ag_ui_crewai = types.ModuleType("ag_ui_crewai")
     ag_ui_crewai_endpoint = types.ModuleType("ag_ui_crewai.endpoint")
 
     def _add_crewai_crew_fastapi_endpoint(app, crew, path):
-        # Mount a streaming stub at `path`. The crewai-crews root mount is "/",
-        # which is where the regression manifests. We use `app.post(path)` to
-        # register; FastAPI's signature introspection sees `request: Request`
-        # and binds it to the actual Request object (not a query parameter).
         # Each call defines a fresh local function so closures don't collide
         # across the multiple `add_crewai_crew_fastapi_endpoint` calls in
         # agent_server.py.
         def _make_stub():
             async def _stub(request: Request):
-                body = (
-                    await request.json() if request.method == "POST" else {}
-                )
+                body = await request.json() if request.method == "POST" else {}
 
                 async def gen():
                     yield b"event: RUN_STARTED\ndata: {}\n\n"
@@ -413,28 +197,133 @@ def test_real_agent_server_streams_post_root_without_runtimeerror():
     agents_pkg = types.ModuleType("agents")
     agents_pkg.__path__ = []  # mark as package
     sys.modules["agents"] = agents_pkg
-    for name in ("crew", "a2ui_fixed", "beautiful_chat", "byoc_hashbrown_agent",
-                 "byoc_json_render_agent", "declarative_gen_ui"):
-        m = types.ModuleType(f"agents.{name}")
-        sys.modules[f"agents.{name}"] = m
+    for name in (
+        "crew",
+        "a2ui_fixed",
+        "beautiful_chat",
+        "byoc_hashbrown_agent",
+        "byoc_json_render_agent",
+        "declarative_gen_ui",
+    ):
+        sys.modules[f"agents.{name}"] = types.ModuleType(f"agents.{name}")
     setattr(sys.modules["agents.crew"], "LatestAiDevelopment", lambda: object())
     setattr(sys.modules["agents.a2ui_fixed"], "A2UIFixedSchema", lambda: object())
     setattr(sys.modules["agents.beautiful_chat"], "BeautifulChat", lambda: object())
-    setattr(
-        sys.modules["agents.byoc_hashbrown_agent"], "ByocHashbrown", lambda: object()
-    )
-    setattr(
-        sys.modules["agents.byoc_json_render_agent"], "ByocJsonRender", lambda: object()
-    )
-    setattr(
-        sys.modules["agents.declarative_gen_ui"], "DeclarativeGenUI", lambda: object()
-    )
+    setattr(sys.modules["agents.byoc_hashbrown_agent"], "ByocHashbrown", lambda: object())
+    setattr(sys.modules["agents.byoc_json_render_agent"], "ByocJsonRender", lambda: object())
+    setattr(sys.modules["agents.declarative_gen_ui"], "DeclarativeGenUI", lambda: object())
 
-    # Now import the real module. This will fail loudly pre-fix because the
-    # middleware class is referenced; the test's intent is to exercise the
-    # post-fix module shape.
-    if "agent_server" in sys.modules:
-        del sys.modules["agent_server"]
+    # Drop any stale agent_server import — we want the next `import agent_server`
+    # to re-run module-init against OUR stubs.
+    sys.modules.pop("agent_server", None)
+
+    yield
+
+    # Teardown: leave the stubs in place across tests (cheap), but drop
+    # agent_server so a follow-up test re-binds against fresh stubs.
+    sys.modules.pop("agent_server", None)
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_streaming_post_with_forwarded_props_completes_without_runtimeerror():
+    """Stand-in regression shape: HealthMiddleware (BaseHTTPMiddleware) wraps
+    a streaming route that consumes a JSON body and emits SSE frames. The
+    pre-fix `ForwardedPropsMiddleware` (also BaseHTTPMiddleware) would have
+    raced with Starlette's inner TaskGroup here and aborted the stream with
+    `RuntimeError: Unexpected message received: http.request`.
+
+    Post-fix the splice is a *raw* ASGI middleware
+    (`ForwardedPropsASGIMiddleware` in agent_server.py) that buffers the body
+    at the ASGI boundary and replays it via a fresh `receive` callable — no
+    `BaseHTTPMiddleware` machinery in the body path, no race. The structural
+    pin in `test_forwarded_props_middleware_class_removed_from_agent_server`
+    enforces that the racy shape can never re-enter the source.
+
+    This test exercises the *post-fix* contract: splice happens via the
+    `_splice_forwarded_props` helper inside the route handler, the streaming
+    response runs to completion under HealthMiddleware, and the spliced
+    state.inputs reaches the handler intact.
+    """
+    app = FastAPI()
+
+    @app.post("/")
+    async def root(request: Request):
+        body = await request.json()
+        spliced = _splice_forwarded_props(body)
+
+        async def gen():
+            yield b"event: RUN_STARTED\ndata: {}\n\n"
+            yield (
+                b"event: STATE\ndata: "
+                + json.dumps(spliced.get("state", {})).encode()
+                + b"\n\n"
+            )
+            yield b"event: RUN_FINISHED\ndata: {}\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    app.add_middleware(_HealthMiddleware)
+
+    payload = {
+        "threadId": "t1",
+        "runId": "r1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "state": {"inputs": {}},
+        "forwardedProps": {"tone": "casual", "expertise": "beginner"},
+    }
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/",
+            json=payload,
+            headers={"content-type": "application/json"},
+        )
+        assert response.status_code == 200
+        text = response.text
+        assert "RUN_STARTED" in text
+        assert "RUN_FINISHED" in text
+        # Splice landed:
+        assert "casual" in text
+        assert "agent_config_guidance" in text
+
+
+def test_forwarded_props_middleware_class_removed_from_agent_server():
+    """Structural regression pin: the racy `ForwardedPropsMiddleware`
+    (BaseHTTPMiddleware subclass) MUST NOT exist in agent_server.py. The
+    raw-ASGI replacement (`ForwardedPropsASGIMiddleware`) is fine.
+
+    Pre-fix this fails. Post-fix the BaseHTTPMiddleware-subclass shape is
+    gone. This test is the irreversible RED→GREEN pin — re-introducing the
+    bad pattern (a BaseHTTPMiddleware that does body-replay surgery) trips
+    it immediately.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.normpath(os.path.join(here, "..", "..", "src", "agent_server.py"))
+    with open(src) as f:
+        source = f.read()
+    assert "class ForwardedPropsMiddleware(BaseHTTPMiddleware" not in source, (
+        "ForwardedPropsMiddleware (BaseHTTPMiddleware subclass) must be "
+        "removed — it caused a body-replay race against Starlette's inner "
+        "TaskGroup, aborting AG-UI streams with "
+        "`RuntimeError: Unexpected message received: http.request`. "
+        "Use a raw ASGI middleware instead."
+    )
+    # Also assert the helpers stay (so the route handler can call them):
+    assert "_build_agent_config_guidance" in source
+    assert "_has_agent_config_props" in source
+
+
+def test_real_agent_server_streams_post_root_without_runtimeerror():
+    """End-to-end: import the REAL `agent_server` module and POST to '/' to
+    confirm the middleware stack no longer raises the body-replay
+    RuntimeError. Stubs out the heavy crewai-backed route with a streaming
+    one (via the autouse fixture) so the test stays unit-scoped (no LLM,
+    no crewai install needed).
+    """
     import agent_server  # noqa: F401
 
     payload = {
@@ -462,10 +351,6 @@ def test_real_agent_server_streams_post_root_without_runtimeerror():
 
 def test_health_endpoint_short_circuits():
     """/health must continue to short-circuit at the middleware layer."""
-    # Same setup as the real-module test above.
-    if "agent_server" in sys.modules:
-        # Re-use the stubs from the previous test if they're already in place.
-        pass
     import agent_server  # noqa: F401
 
     with TestClient(agent_server.app) as client:

--- a/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
+++ b/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
@@ -117,8 +117,11 @@ def _splice_forwarded_props(body):
     forwarded = body.get("forwardedProps")
     if not _has_agent_config_props(forwarded):
         return body
-    # _has_agent_config_props guarantees forwarded is a dict — narrow for type checker.
-    assert isinstance(forwarded, dict)
+    # _has_agent_config_props guarantees forwarded is a dict, but narrow for the
+    # type checker without using `assert` (which is stripped under `python -O`).
+    # Mirrors the production-side pattern in agent_server.py.
+    if not isinstance(forwarded, dict):
+        return body
     existing_state = body.get("state")
     state: dict[str, Any] = existing_state if isinstance(existing_state, dict) else {}
     raw_inputs = state.get("inputs")
@@ -142,10 +145,14 @@ def _splice_forwarded_props(body):
 
 # --------------------------------------------------------------------------- #
 # Fixture: stub heavy modules + (re)import agent_server for every test that  #
-# needs the real module. Module-scoped + autouse so any of the real-module   #
+# needs the real module. Function-scoped + autouse so any of the real-module #
 # tests can run standalone or in any order (e.g. -k filters, pytest-xdist,   #
-# pytest-randomly). The stub install is idempotent and the stale            #
-# `agent_server` entry is purged so re-imports pick up our stubs.            #
+# pytest-randomly). Function scope is REQUIRED — the teardown purges        #
+# `agent_server` from sys.modules so the next test re-binds against fresh   #
+# stubs; module/session scope would only run teardown once per module and   #
+# break ordering independence (sibling tests would share stale module state). #
+# The stub install is idempotent and the stale `agent_server` entry is      #
+# purged so re-imports pick up our stubs.                                   #
 # --------------------------------------------------------------------------- #
 
 
@@ -344,9 +351,20 @@ def test_real_agent_server_streams_post_root_without_runtimeerror():
         text = response.text
         assert "RUN_STARTED" in text
         assert "RUN_FINISHED" in text
-        # Splice landed in state.inputs (this is the agent-config contract):
-        assert "casual" in text
-        assert "agent_config_guidance" in text
+        # Splice landed in state.inputs (this is the agent-config contract).
+        # Parse the STATE event JSON rather than relying on bare substring
+        # checks — substring checks pass even if the props land in the wrong
+        # place (e.g. echoed in headers, or under a sibling key).
+        state_payload = None
+        for line in text.splitlines():
+            if line.startswith("data: ") and "inputs" in line:
+                state_payload = json.loads(line[len("data: ") :])
+                break
+        assert state_payload is not None, f"No STATE event with inputs found in: {text!r}"
+        assert state_payload["inputs"]["tone"] == "casual"
+        # `agent_config_guidance` expands enums to prose rules — assert the
+        # well-known prefix shape rather than the raw enum value.
+        assert "TONE:" in state_payload["inputs"]["agent_config_guidance"]
 
 
 def test_health_endpoint_short_circuits():

--- a/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
+++ b/showcase/packages/crewai-crews/tests/python/test_forwarded_props.py
@@ -381,3 +381,189 @@ def test_post_without_forwarded_props_passes_through_unchanged():
         # Original state.inputs preserved, no agent_config_guidance injected:
         assert "preserved" in response.text
         assert "agent_config_guidance" not in response.text
+
+
+# --------------------------------------------------------------------------- #
+# Bucket (a) regression tests: ASGI middleware error-handling semantics.       #
+# --------------------------------------------------------------------------- #
+#
+# These tests drive `ForwardedPropsASGIMiddleware` directly (bypassing
+# TestClient) because they need to inject specific receive() event sequences
+# and exception types that the test client's transport does not emit.
+
+
+def _get_middleware_class():
+    """Import the real `ForwardedPropsASGIMiddleware` from agent_server.
+
+    Stubs for `ag_ui_crewai` and `agents.*` are installed by the module-scoped
+    `_stub_agent_server_deps` autouse fixture before each test runs, so a
+    fresh `import agent_server` here binds against those stubs.
+    """
+    if "agent_server" not in sys.modules:
+        import agent_server  # noqa: F401
+    return sys.modules["agent_server"].ForwardedPropsASGIMiddleware
+
+
+def _build_http_scope(body_bytes: bytes) -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body_bytes)).encode()),
+        ],
+    }
+
+
+@pytest.mark.anyio
+async def test_replay_receive_propagates_cancellederror():
+    """`replay_receive` MUST propagate `asyncio.CancelledError` so the outer
+    task can be cancelled cleanly. The bare `except Exception` was a
+    correctness hazard: even if Python 3.8+ correctly inherits CancelledError
+    from BaseException, the broad except still swallows programming errors
+    (KeyError, AttributeError) that should surface, not silently convert
+    into a clean http.disconnect.
+
+    Post-fix: CancelledError is caught explicitly and re-raised; any other
+    unexpected exception is logged (observable) rather than silently
+    swallowed.
+    """
+    import asyncio
+
+    MW = _get_middleware_class()
+
+    body = json.dumps({"threadId": "t1"}).encode()
+
+    async def inner_app(scope, receive, send):
+        msg1 = await receive()
+        assert msg1["type"] == "http.request"
+        # Poll again — this is where CancelledError should propagate up.
+        await receive()
+
+    mw = MW(inner_app)
+
+    state = {"calls": 0}
+
+    async def receive():
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return {"type": "http.request", "body": body, "more_body": False}
+        raise asyncio.CancelledError()
+
+    async def send(_msg):
+        pass
+
+    scope = _build_http_scope(body)
+
+    with pytest.raises(asyncio.CancelledError):
+        await mw(scope, receive, send)
+
+
+def test_replay_receive_explicitly_handles_cancellederror():
+    """Source-level RED-GREEN: assert `replay_receive` catches
+    `asyncio.CancelledError` explicitly (and re-raises) BEFORE the broader
+    except. The bare `except Exception` left CancelledError propagation
+    contingent on Python version and the BaseException hierarchy, which is
+    fragile; the fix makes it explicit and version-independent."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    src_path = os.path.normpath(
+        os.path.join(here, "..", "..", "src", "agent_server.py")
+    )
+    with open(src_path) as f:
+        source = f.read()
+
+    # Locate the replay_receive function body.
+    marker = "async def replay_receive"
+    idx = source.find(marker)
+    assert idx != -1, "replay_receive function not found in agent_server.py"
+    # Take a window large enough to include its body.
+    window = source[idx : idx + 1500]
+
+    assert "except asyncio.CancelledError" in window, (
+        "replay_receive must catch asyncio.CancelledError explicitly and "
+        "re-raise it. A bare `except Exception` is too broad — it can "
+        "swallow programming errors that should surface, and is fragile "
+        "across Python versions where CancelledError's class hierarchy "
+        "changes."
+    )
+
+
+@pytest.mark.anyio
+async def test_replay_disconnect_delivers_buffered_chunks_before_disconnect():
+    """RED pre-fix: when http.disconnect arrives mid-buffer, the middleware
+    only forwards the disconnect — buffered body chunks are silently dropped.
+
+    GREEN post-fix: the inner ASGI app must observe the buffered chunks (as
+    a single http.request message) BEFORE the http.disconnect, so it sees
+    the partial body that actually arrived.
+    """
+    MW = _get_middleware_class()
+
+    chunk1 = b'{"threadId":"t1",'
+    chunk2 = b'"runId":"r1",'
+    # No final chunk — disconnect arrives mid-stream.
+
+    received: list[dict] = []
+
+    async def inner_app(scope, receive, send):
+        # Drain receive until we see a disconnect.
+        while True:
+            msg = await receive()
+            received.append(msg)
+            if msg["type"] == "http.disconnect":
+                return
+
+    mw = MW(inner_app)
+
+    state = {"step": 0}
+
+    async def receive():
+        state["step"] += 1
+        if state["step"] == 1:
+            return {"type": "http.request", "body": chunk1, "more_body": True}
+        if state["step"] == 2:
+            return {"type": "http.request", "body": chunk2, "more_body": True}
+        if state["step"] == 3:
+            return {"type": "http.disconnect"}
+        # No further events.
+        return {"type": "http.disconnect"}
+
+    async def send(_msg):
+        pass
+
+    # Body bytes hint for content-length is approximate; middleware doesn't
+    # validate it against actual chunks, so any value works.
+    scope = _build_http_scope(chunk1 + chunk2)
+    await mw(scope, receive, send)
+
+    # The inner app must have seen at least one http.request with the
+    # buffered chunks BEFORE the http.disconnect.
+    request_msgs = [m for m in received if m["type"] == "http.request"]
+    disconnect_msgs = [m for m in received if m["type"] == "http.disconnect"]
+    assert request_msgs, (
+        "Inner ASGI app did not receive buffered body chunks before disconnect — "
+        "they were silently dropped."
+    )
+    assert disconnect_msgs, "Inner ASGI app never observed http.disconnect."
+
+    # Buffered chunks must combine to chunk1+chunk2.
+    combined = b"".join(m.get("body", b"") for m in request_msgs)
+    assert combined == chunk1 + chunk2, (
+        f"Buffered body mismatch: expected {chunk1 + chunk2!r}, got {combined!r}"
+    )
+
+    # Order: at least one request message must precede the first disconnect.
+    first_disconnect_idx = next(
+        i for i, m in enumerate(received) if m["type"] == "http.disconnect"
+    )
+    first_request_idx = next(
+        (i for i, m in enumerate(received) if m["type"] == "http.request"), None
+    )
+    assert first_request_idx is not None
+    assert first_request_idx < first_disconnect_idx
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
## Summary

- Replaces the racy `ForwardedPropsMiddleware` (a `BaseHTTPMiddleware`
  subclass that called `await request.body()` and reinstalled
  `request._receive`) with a raw ASGI middleware that owns the receive
  stream from the outset.
- Extracts the `forwardedProps` -> `state.inputs` splice into a pure
  `_splice_forwarded_props` helper so the agent-config demo's tone /
  expertise / responseLength contract is preserved verbatim.
- Adds `tests/python/test_forwarded_props.py` — TDD red-green coverage
  that reproduces the production failure at the ASGI layer (no LLM, no
  crewai required) and pins five contracts.

## Why

Production logs from the crewai-crews Railway service showed the chat
regression as AG-UI clients receiving `RUN_STARTED` and then the SSE
stream aborting with `RUN_ERROR: INCOMPLETE_STREAM` — no
`TEXT_MESSAGE_*` / `RUN_FINISHED` ever emitted. Server-side root cause:

```
RuntimeError: Unexpected message received: http.request
  at starlette/middleware/base.py:55
```

The previous implementation used `BaseHTTPMiddleware`, called
`await request.body()` to inspect / mutate the JSON body, then
reinstalled `request._receive` with a one-shot replay. Stacked under
`HealthMiddleware` (also `BaseHTTPMiddleware`), that body-replay raced
with Starlette's inner anyio TaskGroup `wrapped_receive`. The
middleware's `forwardedProps` bailout check ran **after**
`request.body()` had already consumed the receive queue, so the bug
fired on every POST regardless of whether `forwardedProps` was present.

Switching to a raw ASGI middleware sidesteps the `BaseHTTPMiddleware`
machinery entirely. We buffer the request body once, optionally
rewrite it in dict form, and replay the (possibly mutated) bytes via a
single fresh `receive` to the inner ASGI app. No `_receive`
reinstallation, no inner TaskGroup to race against.

## Test plan

- [x] RED test reproduces the exact production `RuntimeError` via
      Starlette `TestClient` — no LLM / crewai needed.
- [x] GREEN: `tests/python/test_forwarded_props.py` — all 5 cases pass:
      streaming POST completes without `RuntimeError`, the racy
      `BaseHTTPMiddleware` subclass is gone from the source, the real
      `agent_server` module imports + streams cleanly, `/health` still
      short-circuits, and non-agent-config POSTs pass through with the
      original body bytes.
- [x] Existing test suite (`tests/python/test_aimock_toggle.py`) still
      green: 99 / 99 pass overall.
- [x] Ruff lint count unchanged from `main` (13 pre-existing E402s from
      the order-critical `load_dotenv()` shim — unrelated to this PR).
- [ ] CI to confirm.
- [ ] Smoke test the chat probe against the crewai-crews showcase
      service after merge.