### PR TITLE
hotfix(showcase-ops): register e2e_deep + e2e_parity drivers in orchestrator (post-merge fix for #4292)

### DIFF
--- a/showcase/ops/src/orchestrator.test.ts
+++ b/showcase/ops/src/orchestrator.test.ts
@@ -10,7 +10,9 @@ import {
   diffCronSchedules,
   envForCfg,
   createRailwayAdapter,
+  registerAllProbeDrivers,
 } from "./orchestrator.js";
+import { createProbeRegistry } from "./probes/drivers/index.js";
 import { createScheduler } from "./scheduler/scheduler.js";
 import { createEventBus } from "./events/event-bus.js";
 import { logger } from "./logger.js";
@@ -1764,6 +1766,59 @@ describe("orchestrator boot serve() async bind error cleanup (R4-A.3)", () => {
     // of cleanup. Pre-fix, the async bind error was unobserved by the
     // R2-B.2 try/catch and boot() resolved with the scheduler running.
     expect(stopSpy).toHaveBeenCalled();
+  });
+});
+
+/**
+ * Post-#4292 hotfix regression guard.
+ *
+ * Production symptom: probe-loader emitted `probe-loader.file-failed`
+ *   `no driver registered for kind 'e2e_deep'`
+ *   `no driver registered for kind 'e2e_parity'`
+ * on every showcase-ops boot after #4292 merged. The D5 (`e2e_deep`)
+ * and D6 (`e2e_parity`) drivers shipped as exports but the
+ * orchestrator never registered them — so the probe-loader rejected
+ * their YAML at boot, the drivers never ran, and no D5/D6 PB rows
+ * were ever written. This test locks every required probe-kind into
+ * the orchestrator's canonical registration set so a future driver
+ * landing without a registration call fails CI instead of prod.
+ */
+describe("orchestrator.registerAllProbeDrivers (post-#4292 hotfix guard)", () => {
+  it("registers every probe-kind referenced by config/probes/*.yml", () => {
+    const registry = createProbeRegistry();
+    registerAllProbeDrivers(registry);
+    const kinds = registry.list();
+    // Every kind below is referenced by a YAML in showcase/ops/config/probes
+    // — drift between this set and the YAMLs is exactly the
+    // probe-loader.file-failed bug we're guarding against.
+    expect(kinds).toEqual(
+      [
+        "aimock_wiring",
+        "e2e_deep",
+        "e2e_demos",
+        "e2e_parity",
+        "e2e_smoke",
+        "image_drift",
+        "pin_drift",
+        "qa",
+        "redirect_decommission",
+        "smoke",
+        "version_drift",
+      ].sort(),
+    );
+  });
+
+  it("includes e2e_deep and e2e_parity (the #4292 regressors)", () => {
+    // Tighter assertion narrowed to the two kinds that triggered the
+    // production probe-loader.file-failed alert. If a future refactor
+    // accidentally drops just these two registrations, the broader
+    // equality check above still catches it — but this test names the
+    // exact regression for whoever finds it red in CI.
+    const registry = createProbeRegistry();
+    registerAllProbeDrivers(registry);
+    const kinds = registry.list();
+    expect(kinds).toContain("e2e_deep");
+    expect(kinds).toContain("e2e_parity");
   });
 });
 

--- a/showcase/ops/src/orchestrator.ts
+++ b/showcase/ops/src/orchestrator.ts
@@ -28,6 +28,7 @@ import { createDiscoveryRegistry } from "./probes/discovery/index.js";
 import { createProbeLoader } from "./probes/loader/probe-loader.js";
 import { buildProbeInvoker } from "./probes/loader/probe-invoker.js";
 import type { ProbeConfig } from "./probes/loader/schema.js";
+import type { ProbeRegistry } from "./probes/types.js";
 import { createProbeRunWriter } from "./probes/run-history.js";
 import { aimockWiringDriver } from "./probes/drivers/aimock-wiring.js";
 import { pinDriftDriver } from "./probes/drivers/pin-drift.js";
@@ -37,6 +38,8 @@ import { versionDriftDriver } from "./probes/drivers/version-drift.js";
 import { redirectDecommissionDriver } from "./probes/drivers/redirect-decommission.js";
 import { e2eSmokeDriver } from "./probes/drivers/e2e-smoke.js";
 import { e2eDemosDriver } from "./probes/drivers/e2e-demos.js";
+import { e2eDeepDriver } from "./probes/drivers/e2e-deep.js";
+import { e2eParityDriver } from "./probes/drivers/e2e-parity.js";
 import { qaDriver } from "./probes/drivers/qa.js";
 import { railwayServicesSource } from "./probes/discovery/railway-services.js";
 import { pnpmPackagesDiscoverySource } from "./probes/discovery/pnpm-packages.js";
@@ -249,15 +252,7 @@ export async function boot(opts: BootOptions = {}): Promise<{
 
   const probeRegistry = createProbeRegistry();
   const discoveryRegistry = createDiscoveryRegistry();
-  probeRegistry.register(aimockWiringDriver);
-  probeRegistry.register(pinDriftDriver);
-  probeRegistry.register(smokeDriver);
-  probeRegistry.register(imageDriftDriver);
-  probeRegistry.register(versionDriftDriver);
-  probeRegistry.register(redirectDecommissionDriver);
-  probeRegistry.register(e2eSmokeDriver);
-  probeRegistry.register(e2eDemosDriver);
-  probeRegistry.register(qaDriver);
+  registerAllProbeDrivers(probeRegistry);
   discoveryRegistry.register(railwayServicesSource);
   discoveryRegistry.register(pnpmPackagesDiscoverySource);
   const probeConfigDir =
@@ -825,6 +820,33 @@ export async function boot(opts: BootOptions = {}): Promise<{
       });
     },
   };
+}
+
+/**
+ * Register every probe driver this orchestrator knows about onto the
+ * given registry. Single source of truth for the registered probe-kind
+ * set so YAML probe configs (`config/probes/*.yml`) and orchestrator
+ * boot can never drift: if a driver file ships without a registration
+ * call here, the probe-loader rejects its YAML at boot with
+ * `no driver registered for kind 'X'` — which is exactly the
+ * production failure that motivated extracting this helper. Exported
+ * so unit tests can lock the registered set without spinning up the
+ * full boot path (PB, scheduler, http server, ...).
+ */
+export function registerAllProbeDrivers(
+  probeRegistry: Pick<ProbeRegistry, "register">,
+): void {
+  probeRegistry.register(aimockWiringDriver);
+  probeRegistry.register(pinDriftDriver);
+  probeRegistry.register(smokeDriver);
+  probeRegistry.register(imageDriftDriver);
+  probeRegistry.register(versionDriftDriver);
+  probeRegistry.register(redirectDecommissionDriver);
+  probeRegistry.register(e2eSmokeDriver);
+  probeRegistry.register(e2eDemosDriver);
+  probeRegistry.register(e2eDeepDriver);
+  probeRegistry.register(e2eParityDriver);
+  probeRegistry.register(qaDriver);
 }
 
 /**


### PR DESCRIPTION
## Summary

Post-#4292 production hotfix. The D5 (`e2e_deep`) and D6 (`e2e_parity`) drivers shipped as exports but were never wired into the orchestrator's driver-registry block, so probe-loader rejected their YAMLs at every boot.

## Production symptom

After PR #4292 merged, every showcase-ops boot logged:

```
err="probe-loader: e2e-deep.yml: no driver registered for kind 'e2e_deep'
     (registered: aimock_wiring, e2e_demos, e2e_smoke, image_drift,
      pin_drift, qa, redirect_decommission, smoke, version_drift)"
err="probe-loader: e2e-parity.yml: no driver registered for kind 'e2e_parity'
     (registered: ...same...)"
```

Net effect: D5 and D6 never ran; no `probe_runs` / `status` rows for either dimension were ever written.

## Root cause

`showcase/ops/src/probes/drivers/e2e-deep.ts` exports `e2eDeepDriver` and `showcase/ops/src/probes/drivers/e2e-parity.ts` exports `e2eParityDriver`. The orchestrator's registration block in `orchestrator.ts` listed every other driver but never registered these two — so the `createProbeRegistry()` instance built at boot lacked the `e2e_deep` and `e2e_parity` kinds the YAMLs reference.

## Fix

Two new `probeRegistry.register(...)` calls — added alongside the import lines for the two drivers:

```ts
probeRegistry.register(e2eDeepDriver);
probeRegistry.register(e2eParityDriver);
```

While in the file, extracted the registration block into an exported `registerAllProbeDrivers(registry)` helper. This gives a unit test (`src/orchestrator.test.ts`) a clean target for asserting the canonical probe-kind set without spinning up the full boot path — same shape of regression won't slip past CI on the next driver landing.

## Origin

PR #4292.

## Test plan

- [x] Red-green: stashed registrations, confirmed both new tests fail with `expected to include 'e2e_deep'`
- [x] Restored registrations, both tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1286 tests passing across 65 files
- [x] `oxfmt --check` clean
- [x] `oxlint` clean
- [x] `pnpm build` clean