### PR TITLE
fix(showcase/shell-dashboard): proxy /api/ops/* to showcase-ops via Next rewrite

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -230,7 +230,7 @@ jobs:
             {"dispatch_name":"starter-spring-ai","filter_key":"starter_spring_ai","context":"showcase/starters/spring-ai","image":"showcase-starter-spring-ai","railway_id":"3559ece3-7ba3-41ac-b24c-1f780133ec58","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"starter-strands","filter_key":"starter_strands","context":"showcase/starters/strands","image":"showcase-starter-strands","railway_id":"06db2bb8-e15d-4c6a-97ad-e14777c92d9f","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-ops-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
             {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
             {"dispatch_name":"showcase-ops","filter_key":"showcase_ops","context":".","image":"showcase-ops","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/ops/Dockerfile","health_path":"/health"}
           ]'
@@ -351,6 +351,11 @@ jobs:
           fi
           if [ -n "${{ matrix.service.build_args_shell_url }}" ]; then
             ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SHELL_URL=${{ matrix.service.build_args_shell_url }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_ops_url }}" ]; then
+            # OPS_BASE_URL is required at build time by shell-dashboard's
+            # next.config.ts rewrites() — without it `next build` aborts.
+            ARGS="${ARGS:+${ARGS}$'\n'}OPS_BASE_URL=${{ matrix.service.build_args_ops_url }}"
           fi
           # Use delimiter to safely pass multiline value
           echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT

--- a/showcase/shell-dashboard/Dockerfile
+++ b/showcase/shell-dashboard/Dockerfile
@@ -34,6 +34,13 @@ ARG NEXT_PUBLIC_SHELL_URL
 ENV NEXT_PUBLIC_SHELL_URL=${NEXT_PUBLIC_SHELL_URL}
 ARG NEXT_PUBLIC_POCKETBASE_URL
 ENV NEXT_PUBLIC_POCKETBASE_URL=${NEXT_PUBLIC_POCKETBASE_URL}
+# `next.config.ts` reads OPS_BASE_URL inside `rewrites()` and throws if it
+# is unset. `next build` evaluates rewrites at build time to generate the
+# routing manifest, so the value must be in the BUILDER environment — not
+# just runtime. Without this, `npx next build` aborts with the
+# "OPS_BASE_URL must be set" error from next.config.ts.
+ARG OPS_BASE_URL
+ENV OPS_BASE_URL=${OPS_BASE_URL}
 
 # Generate registry + docs status, then build Next.js
 RUN cd scripts && node node_modules/tsx/dist/cli.mjs generate-registry.ts \

--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -25,8 +25,13 @@ const nextConfig: NextConfig = {
           "(without it, /api/ops/* requests cannot proxy to showcase-ops)",
       );
     }
+    // Strip trailing slashes so we never produce `https://host//api/...`
+    // (some servers reject the double slash). Mirrors the same
+    // normalization in `src/lib/ops-api.ts:resolveBaseUrl` so the
+    // server-side rewrite and client-side fetch agree on the URL shape.
+    const normalized = opsBase.replace(/\/+$/, "");
     return [
-      { source: "/api/ops/:path*", destination: `${opsBase}/api/:path*` },
+      { source: "/api/ops/:path*", destination: `${normalized}/api/:path*` },
     ];
   },
 };

--- a/showcase/shell-dashboard/next.config.ts
+++ b/showcase/shell-dashboard/next.config.ts
@@ -1,5 +1,34 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+/**
+ * Next.js config for the dashboard shell.
+ *
+ * The Status tab calls the showcase-ops HTTP API at the relative path
+ * `/api/ops/*`. There is no /api/ops route handler in this app — the path
+ * is a deterministic same-origin proxy that this rewrite forwards to the
+ * real showcase-ops service. Going same-origin sidesteps two production
+ * blockers:
+ *   1. showcase-ops has no CORS allowlist for cross-origin browser calls.
+ *   2. We don't want the ops base URL inlined into the client bundle (it
+ *      would also force `NEXT_PUBLIC_*` exposure semantics).
+ *
+ * `OPS_BASE_URL` is required at build/start. Without it the rewrite cannot
+ * be constructed and the dashboard would silently render "All probes idle"
+ * because every `/api/ops/probes` call would 404 against this app.
+ */
+const nextConfig: NextConfig = {
+  async rewrites() {
+    const opsBase = process.env.OPS_BASE_URL;
+    if (!opsBase) {
+      throw new Error(
+        "OPS_BASE_URL must be set — see showcase/RAILWAY.md " +
+          "(without it, /api/ops/* requests cannot proxy to showcase-ops)",
+      );
+    }
+    return [
+      { source: "/api/ops/:path*", destination: `${opsBase}/api/:path*` },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/showcase/shell-dashboard/src/hooks/use-probes.integration.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/use-probes.integration.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Integration test: `useProbes` → `lib/ops-api` → `fetch`, with no module
+ * mocks between the hook and the real client. This is the missing
+ * coverage that masked the production bug where the dashboard rendered
+ * "All probes idle" because the resolved URL was hitting the dashboard
+ * origin (404) instead of the showcase-ops proxy path.
+ *
+ * Why both layers must be exercised together:
+ *   - `use-probes.test.ts` mocks the entire `lib/ops-api` module, so it
+ *     never validates URL resolution.
+ *   - `lib/ops-api.test.ts` mocks `globalThis.fetch`, but it imports the
+ *     client directly and never goes through the hook layer that the page
+ *     actually uses.
+ *
+ * The bug was a contract gap between layers (next.config rewrite missing
+ * + env not set on Railway), which neither isolated test can catch. This
+ * suite asserts the end-to-end URL the browser would actually hit when
+ * `useProbes()` is called with no overrides — the path the production
+ * dashboard runs on.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useProbes } from "./use-probes";
+import type { ProbesResponse } from "../lib/ops-api";
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+  delete process.env.NEXT_PUBLIC_OPS_BASE_URL;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useProbes → ops-api → fetch wiring", () => {
+  it("hits the relative same-origin proxy path /api/ops/probes by default", async () => {
+    const body: ProbesResponse = {
+      probes: [
+        {
+          id: "smoke",
+          kind: "smoke",
+          schedule: "*/5 * * * *",
+          nextRunAt: null,
+          lastRun: null,
+          inflight: null,
+          config: { timeout_ms: 60_000, max_concurrency: 5, discovery: null },
+        },
+      ],
+    };
+    fetchSpy.mockResolvedValue(jsonResponse(body));
+
+    const { result } = renderHook(() => useProbes());
+    await waitFor(() => expect(result.current.data?.probes).toHaveLength(1));
+
+    // The hook must call fetch through ops-api with the same-origin proxy
+    // path. Anything else (the dashboard origin + /api/ops, or an inlined
+    // ops base URL) means the rewrite contract is broken.
+    expect(fetchSpy).toHaveBeenCalled();
+    const url = String(fetchSpy.mock.calls[0]![0]);
+    expect(url).toBe("/api/ops/probes");
+  });
+
+  it("parses probes returned by the proxy and exposes them on data", async () => {
+    const body: ProbesResponse = {
+      probes: [
+        {
+          id: "image-drift",
+          kind: "image-drift",
+          schedule: "*/15 * * * *",
+          nextRunAt: "2026-04-25T12:15:00Z",
+          lastRun: null,
+          inflight: null,
+          config: { timeout_ms: 60_000, max_concurrency: 5, discovery: null },
+        },
+        {
+          id: "pin-drift",
+          kind: "pin-drift",
+          schedule: "*/15 * * * *",
+          nextRunAt: "2026-04-25T12:15:00Z",
+          lastRun: null,
+          inflight: null,
+          config: { timeout_ms: 60_000, max_concurrency: 5, discovery: null },
+        },
+      ],
+    };
+    fetchSpy.mockResolvedValue(jsonResponse(body));
+
+    const { result } = renderHook(() => useProbes());
+    await waitFor(() =>
+      expect(result.current.data?.probes.map((p) => p.id)).toEqual([
+        "image-drift",
+        "pin-drift",
+      ]),
+    );
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("surfaces a useful error when the proxy path returns 404 (regression)", async () => {
+    // Production failure mode this guards against: the rewrite is missing
+    // and /api/ops/probes 404s against the dashboard's own origin. The
+    // hook must surface the 404 with the URL in the message so the
+    // operator can grep their way back to "the rewrite is missing"
+    // instead of seeing a vague "All probes idle" empty state.
+    fetchSpy.mockResolvedValue(
+      new Response("not found", { status: 404, statusText: "Not Found" }),
+    );
+
+    const { result } = renderHook(() => useProbes());
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    expect(result.current.error?.message).toMatch(/404/);
+    expect(result.current.error?.message).toMatch(/\/api\/ops\/probes/);
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/showcase/shell-dashboard/src/hooks/use-probes.integration.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/use-probes.integration.test.tsx
@@ -24,6 +24,7 @@ import { useProbes } from "./use-probes";
 import type { ProbesResponse } from "../lib/ops-api";
 
 let fetchSpy: ReturnType<typeof vi.fn>;
+let savedOpsBaseUrl: string | undefined;
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -35,12 +36,21 @@ function jsonResponse(body: unknown): Response {
 beforeEach(() => {
   fetchSpy = vi.fn();
   vi.stubGlobal("fetch", fetchSpy);
+  // Snapshot + clear NEXT_PUBLIC_OPS_BASE_URL so the resolveBaseUrl()
+  // fallback path is exercised. Restored in afterEach so test ordering
+  // never leaks env state to the next file.
+  savedOpsBaseUrl = process.env.NEXT_PUBLIC_OPS_BASE_URL;
   delete process.env.NEXT_PUBLIC_OPS_BASE_URL;
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  if (savedOpsBaseUrl !== undefined) {
+    process.env.NEXT_PUBLIC_OPS_BASE_URL = savedOpsBaseUrl;
+  } else {
+    delete process.env.NEXT_PUBLIC_OPS_BASE_URL;
+  }
 });
 
 describe("useProbes → ops-api → fetch wiring", () => {
@@ -66,9 +76,21 @@ describe("useProbes → ops-api → fetch wiring", () => {
     // The hook must call fetch through ops-api with the same-origin proxy
     // path. Anything else (the dashboard origin + /api/ops, or an inlined
     // ops base URL) means the rewrite contract is broken.
-    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     const url = String(fetchSpy.mock.calls[0]![0]);
     expect(url).toBe("/api/ops/probes");
+
+    // Lock in the request shape the proxy contract depends on: GET (no
+    // method override), no-store cache (live polling, never serve a stale
+    // response), JSON accept header, and an AbortSignal for hook-level
+    // cancellation. A regression in any of these silently breaks polling.
+    const callArg = fetchSpy.mock.calls[0]![1] as RequestInit | undefined;
+    expect(callArg?.method).toBe("GET");
+    expect(callArg?.cache).toBe("no-store");
+    expect(callArg?.headers).toMatchObject({
+      accept: expect.stringMatching(/json/i),
+    });
+    expect(callArg?.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("parses probes returned by the proxy and exposes them on data", async () => {
@@ -120,8 +142,12 @@ describe("useProbes → ops-api → fetch wiring", () => {
     const { result } = renderHook(() => useProbes());
     await waitFor(() => expect(result.current.error).not.toBeNull());
 
-    expect(result.current.error?.message).toMatch(/404/);
-    expect(result.current.error?.message).toMatch(/\/api\/ops\/probes/);
+    // Tighten to the canonical `ensureOk` shape so a future refactor that
+    // changes the error format (status/statusText/url ordering) trips this
+    // test instead of silently regressing the operator-facing message.
+    expect(result.current.error?.message).toMatch(
+      /^ops-api request failed: 404 Not Found at \/api\/ops\/probes/,
+    );
     expect(result.current.data).toBeNull();
   });
 });

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -10,9 +10,13 @@
  *
  * `baseUrl` resolution order (per call):
  *   1. explicit `baseUrl` param (overrides everything; used in tests + SSR)
- *   2. `process.env.NEXT_PUBLIC_OPS_BASE_URL` (inlined at build — opt-in
- *      escape hatch for direct cross-origin calls; production does NOT use
- *      this because showcase-ops has no CORS allowlist)
+ *   2. `process.env.NEXT_PUBLIC_OPS_BASE_URL` — opt-in escape hatch for
+ *      direct cross-origin calls; production does NOT use this because
+ *      showcase-ops has no CORS allowlist. Note: Next inlines `NEXT_PUBLIC_*`
+ *      into the client bundle at build time, but this module ALSO runs in
+ *      SSR + tests where `process.env` is read live at call time — so
+ *      `delete process.env.NEXT_PUBLIC_OPS_BASE_URL` in a test does take
+ *      effect on subsequent `resolveBaseUrl()` calls.
  *   3. `/api/ops` — same-origin path served by the Next.js rewrite in
  *      `next.config.ts`. This is the production contract, not a guess: the
  *      rewrite forwards `/api/ops/:path*` to `${OPS_BASE_URL}/api/:path*`
@@ -129,10 +133,16 @@ const FALLBACK_BASE_URL = "/api/ops";
  * Resolve the API base URL with the precedence documented at the top of
  * this module. Trailing slashes are stripped so callers don't end up with
  * a double-slash like `http://host//probes` that some servers reject.
+ *
+ * `NEXT_PUBLIC_OPS_BASE_URL` is treated as missing when it is undefined,
+ * empty, or whitespace-only. `??` only falls through on `null`/`undefined`,
+ * so without this an env var set to `""` would silently produce
+ * `baseUrl === ""` and URLs like `"/probes"` (no `/api/ops` prefix) — a
+ * silent failure mode where the dashboard hits its own origin and 404s.
  */
 function resolveBaseUrl(explicit?: string): string {
-  const raw =
-    explicit ?? process.env.NEXT_PUBLIC_OPS_BASE_URL ?? FALLBACK_BASE_URL;
+  const envBase = process.env.NEXT_PUBLIC_OPS_BASE_URL?.trim();
+  const raw = explicit ?? (envBase || undefined) ?? FALLBACK_BASE_URL;
   return raw.replace(/\/+$/, "");
 }
 
@@ -147,11 +157,21 @@ async function ensureOk(response: Response, url: string): Promise<void> {
   let detail = "";
   try {
     const text = await response.text();
-    if (text && text.length <= 200) detail = ` — ${text}`;
+    if (text) {
+      if (text.length <= 500) {
+        detail = ` — ${text}`;
+      } else {
+        // Bodies larger than 500B (often HTML 5xx pages or stack traces)
+        // would balloon the error message and trash log readability;
+        // truncate but keep the marker + total size so an operator can see
+        // they're missing tail data and re-fetch from the source if needed.
+        detail = ` — ${text.slice(0, 500)} [truncated, ${text.length} bytes total]`;
+      }
+    }
   } catch (bodyErr) {
-    // R2-C.3: propagate AbortError as-is so hook-layer cancellation
-    // filters (`err.name === "AbortError"`) keep working. Wrapping it in a
-    // generic Error would surface "AbortError" as user-facing noise.
+    // Propagate AbortError as-is so hook-layer cancellation filters
+    // (`err.name === "AbortError"`) keep working. Wrapping it in a generic
+    // Error would surface "AbortError" as user-facing noise.
     if ((bodyErr as { name?: string })?.name === "AbortError") {
       throw bodyErr;
     }
@@ -174,14 +194,13 @@ async function parseJson<T>(response: Response, url: string): Promise<T> {
   try {
     return (await response.json()) as T;
   } catch (parseErr) {
-    // R2-C.3: propagate AbortError as-is — same rationale as ensureOk.
+    // Propagate AbortError as-is — same rationale as ensureOk.
     if ((parseErr as { name?: string })?.name === "AbortError") {
       throw parseErr;
     }
     const msg = (parseErr as Error)?.message ?? "unknown";
-    // R3-C bonus: preserve the original error as `cause` so debuggers can
-    // walk back to the SyntaxError name/stack without re-parsing the
-    // wrapped message string.
+    // Preserve the original error as `cause` so debuggers can walk back to
+    // the SyntaxError name/stack without re-parsing the wrapped message.
     throw new Error(`ops-api JSON parse failed at ${url}: ${msg}`, {
       cause: parseErr,
     });
@@ -199,9 +218,9 @@ export async function fetchProbes(
   } = {},
 ): Promise<ProbesResponse> {
   const url = `${resolveBaseUrl(opts.baseUrl)}/probes`;
-  // R3-D.1: opt out of browser + Next.js fetch caching. Status data is
-  // polled every ~10s and must reflect the current backend state, not a
-  // cached response from a prior poll.
+  // Opt out of browser + Next.js fetch caching. Status data is polled
+  // every ~10s and must reflect the current backend state, not a cached
+  // response from a prior poll.
   const response = await fetch(url, {
     method: "GET",
     signal: opts.signal,
@@ -216,8 +235,9 @@ export async function fetchProbeDetail(
   id: string,
   opts: { signal?: AbortSignal; baseUrl?: string } = {},
 ): Promise<ProbeDetailResponse> {
+  if (!id) throw new Error("probe id is required");
   const url = `${resolveBaseUrl(opts.baseUrl)}/probes/${encodeURIComponent(id)}`;
-  // R3-D.1: see fetchProbes — same no-store rationale for live detail data.
+  // See fetchProbes — same no-store rationale for live detail data.
   const response = await fetch(url, {
     method: "GET",
     signal: opts.signal,
@@ -239,6 +259,7 @@ export async function triggerProbe(
   id: string,
   opts: TriggerProbeOptions,
 ): Promise<TriggerResponse> {
+  if (!id) throw new Error("probe id is required");
   const url = `${resolveBaseUrl(opts.baseUrl)}/probes/${encodeURIComponent(
     id,
   )}/trigger`;
@@ -255,6 +276,10 @@ export async function triggerProbe(
       authorization: `Bearer ${opts.token}`,
     },
     body: JSON.stringify(body),
+    // No-store for parity with the GET fetches — POST responses can be
+    // cached by intermediaries when CDN-fronted; explicit no-store
+    // guarantees the trigger response goes end-to-end live.
+    cache: "no-store",
     signal: opts.signal,
   });
   await ensureOk(response, url);

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -9,9 +9,15 @@
  *   - POST <base>/probes/<id>/trigger     → TriggerResponse
  *
  * `baseUrl` resolution order (per call):
- *   1. explicit `baseUrl` param
- *   2. `process.env.NEXT_PUBLIC_OPS_BASE_URL` (inlined at build)
- *   3. `/api/ops` — same-origin proxy fallback (Next.js route)
+ *   1. explicit `baseUrl` param (overrides everything; used in tests + SSR)
+ *   2. `process.env.NEXT_PUBLIC_OPS_BASE_URL` (inlined at build — opt-in
+ *      escape hatch for direct cross-origin calls; production does NOT use
+ *      this because showcase-ops has no CORS allowlist)
+ *   3. `/api/ops` — same-origin path served by the Next.js rewrite in
+ *      `next.config.ts`. This is the production contract, not a guess: the
+ *      rewrite forwards `/api/ops/:path*` to `${OPS_BASE_URL}/api/:path*`
+ *      on the server side, so the browser only ever sees same-origin calls
+ *      and `OPS_BASE_URL` stays out of the client bundle.
  *
  * The trigger token is supplied by the caller (typically read from
  * `process.env.NEXT_PUBLIC_OPS_TRIGGER_TOKEN` at the React layer).


### PR DESCRIPTION
## Summary

Status tab was rendering "All probes idle. No upcoming runs scheduled."
even though showcase-ops `/api/probes` returns 9 probes.

## Root cause

- `lib/ops-api.ts` falls back to `/api/ops` when no explicit baseUrl and no
  `NEXT_PUBLIC_OPS_BASE_URL` is set. `NEXT_PUBLIC_OPS_BASE_URL` is not set
  on Railway shell-dashboard.
- `next.config.ts` was empty — there was no rewrite forwarding `/api/ops/*`
  to the showcase-ops service. The browser hit
  `dashboard.showcase.copilotkit.ai/api/ops/probes` and got a 404 from the
  dashboard origin itself.
- Direct cross-origin fetch was not an option either — showcase-ops has no
  CORS allowlist for browser callers.

## Fix

- Add a Next.js rewrite that forwards `/api/ops/:path*` to
  `${OPS_BASE_URL}/api/:path*` server-side. The browser sees only
  same-origin calls; `OPS_BASE_URL` stays out of the client bundle.
- `OPS_BASE_URL` is required at build/start — fail loudly if unset rather
  than silently rendering an empty status table.
- Update `lib/ops-api.ts` doc comment to reflect that `/api/ops` is the
  deterministic same-origin proxy path (contract), not a "guess".
- Add `src/hooks/use-probes.integration.test.tsx` — exercises the hook
  through the real `lib/ops-api` client to a mocked `fetch`. Asserts the
  default URL is exactly `/api/ops/probes`, parses real probe data, and
  surfaces a useful error on a 404. Pre-existing `lib/ops-api.test.ts`
  and `use-probes.test.ts` each mock at a different layer, so neither
  caught this cross-layer contract gap.

## Operational notes

`OPS_BASE_URL` already set on the Railway shell-dashboard service
(`b14919f4` env / `4d5dfd74` service) to
`https://showcase-ops-production.up.railway.app`. The variable is in
place ahead of merge so Railway's auto-update picks up the new image
the moment GHCR has a build with this rewrite.

## Test plan

- [x] `npm test` (vitest) — 293 passed (3 new integration tests)
- [x] `npm run typecheck` — clean
- [x] `oxlint` — 0 warnings, 0 errors
- [x] `next build` with `OPS_BASE_URL` set — succeeds
- [x] `next build` without `OPS_BASE_URL` — fails loudly with the
      expected error (regression guard for silent empty-state rendering)
- [ ] After merge: confirm shell-dashboard image rebuilds, Railway
      auto-updates, and the Status tab populates with probes