### PR TITLE
fix(showcase-ops): restore e2e-deep + e2e-parity probe YAMLs

### DIFF
--- a/showcase/ops/config/probes/e2e-deep.yml
+++ b/showcase/ops/config/probes/e2e-deep.yml
@@ -1,0 +1,88 @@
+# Probe: e2e-deep (D5 — multi-turn complex-interact parity vs reference)
+#
+# Drives a Playwright multi-turn conversation through every D5 feature
+# type wired on each showcase Railway service. Where `e2e-demos` does a
+# cheap goto + chat-input-ready check (1 page-load per cell) and
+# `e2e-smoke` does a single chat round-trip on two canonical demos,
+# `e2e-deep` runs the full conversation script — multiple turns,
+# tool-call routing, hitl, gen-ui — captured as fixtures under
+# `showcase/ops/fixtures/d5/`.
+#
+# Rows emitted per driver invocation (see `src/probes/drivers/e2e-deep.ts`):
+#   - Primary `e2e-deep:<slug>`     ProbeResult carrying the aggregate
+#                                   { total, passed, failed[], skipped[],
+#                                     shape, backendUrl } signal.
+#                                   Green iff every runnable feature
+#                                   completed without a failure_turn.
+#                                   Red if ANY runnable feature flipped.
+#   - Side    `d5:<slug>/<featureType>`   One per declared feature type.
+#                                   Green when the conversation completed
+#                                   cleanly; red with `errorClass` ∈
+#                                   { goto-error, conversation-error,
+#                                     abort, driver-error } and a Slack-
+#                                   safe `errorDesc`. Green-with-note
+#                                   `"no script registered"` when Wave 2b
+#                                   hasn't landed the script for that
+#                                   featureType yet — coverage gap, not
+#                                   regression.
+#
+# ── Cadence: */60 (every 60 minutes) ────────────────────────────────────
+#
+# D5 is the slowest probe in the fleet — multi-turn conversations against
+# real Playwright + real (mocked) LLM. A single conversation can span 1-3
+# turns × ~5-10s/turn × ~10 feature types × 17 services. Even with
+# `max_concurrency: 2` capping parallel chromium and the per-feature
+# timeout budget, one tick is several minutes of wall time. Hourly
+# strikes the right balance: catches regressions within a half-deploy
+# window without flooding the scheduler. Speed up only after observing
+# headroom in production for a full cycle.
+#
+# Cron string: `*/60 * * * *` (every 60 minutes, on the hour). Matches
+# the spec D5 cadence directive.
+#
+# ── timeout_ms: 300_000 (5 min) ─────────────────────────────────────────
+#
+# Outer driver-invocation cap. Per-feature run subdivides further: the
+# conversation-runner's per-turn `responseTimeoutMs` defaults to 30s,
+# the driver's per-page goto timeout is 30s. With ~10 features per
+# service × 1-3 turns × 30s/turn worst case = ~5-7min worst case before
+# the cap fires. 5 min cap catches pathological stalls without starving
+# siblings.
+#
+# ── max_concurrency: 2 ──────────────────────────────────────────────────
+#
+# 2 simultaneous chromium contexts × 2 long-running multi-turn
+# conversations. Each context resident-set is ~300MB; 2 parallel = ~600MB
+# peak which fits the orchestrator's Railway footprint. Higher
+# concurrency trades faster tick completion for OOM risk. Keep at 2
+# until production memory headroom is measured against the multi-turn
+# load.
+#
+# ── Scope: all showcase packages ────────────────────────────────────────
+#
+# Discovery matches all `showcase-*` Railway services via `namePrefix`.
+# Infra services are excluded — same list as smoke / e2e-smoke / e2e-
+# demos so a new infra service added there lands here too during review.
+# Starters short-circuit green inside the driver (no /demos routing).
+kind: e2e_deep
+id: e2e-deep
+schedule: "*/60 * * * *"
+timeout_ms: 300000
+max_concurrency: 2
+discovery:
+  source: railway-services
+  filter:
+    namePrefix: "showcase-"
+    nameExcludes:
+      - showcase-aimock
+      - showcase-ops
+      - showcase-pocketbase
+      - showcase-shell
+      - showcase-shell-dashboard
+      - showcase-shell-docs
+      - showcase-shell-dojo
+  # Primary row key uses the Railway service name (not the stripped
+  # slug) to stay consistent with sibling driver families. The driver
+  # strips `showcase-` from the name internally for the per-feature
+  # side-row keys (`d5:<slug>/<featureType>`).
+  key_template: "e2e-deep:${name}"

--- a/showcase/ops/config/probes/e2e-parity.yml
+++ b/showcase/ops/config/probes/e2e-parity.yml
@@ -1,0 +1,109 @@
+# Probe: e2e-parity (D6 — multi-turn parity vs reference)
+#
+# Drives a Playwright multi-turn conversation through every D5 feature
+# type for ONE integration per tick, captures a `ParitySnapshot`, and
+# compares it against the on-disk reference snapshot under
+# `showcase/ops/fixtures/d6-reference/`. The reference baseline is
+# captured against the LangGraph-Python (LGP) showcase — every other
+# integration is graded against LGP's behaviour as the canonical
+# implementation.
+#
+# Rows emitted per driver invocation (see `src/probes/drivers/e2e-parity.ts`):
+#   - Primary `e2e-parity:<name>`     ProbeResult carrying the aggregate
+#                                     { mode, selectedThisTick, total,
+#                                       passed, amber, red, skipped,
+#                                       axisFailures, scopingReason }.
+#                                     Aggregate state:
+#                                       red iff any feature is red
+#                                       degraded iff any feature is amber
+#                                       green otherwise.
+#   - Side    `d6:<slug>/<featureType>`  One per declared feature type for
+#                                     the integration the rotation picked.
+#                                     Severity from per-feature axis-
+#                                     failure count: 0 → green, 1-2 →
+#                                     amber (mapped to ProbeState
+#                                     "degraded"), 3-4 → red. Skip
+#                                     semantics: no script registered →
+#                                     green note "no script registered";
+#                                     no reference snapshot on disk →
+#                                     green note "no reference snapshot";
+#                                     reference present-but-malformed →
+#                                     red so operators fix the fixture.
+#
+# ── Cadence: Mondays 04:00 UTC (`0 4 * * 1`) ────────────────────────────
+#
+# Per spec resolution (Notion 34c3aa38, Q3) D6 runs on a weekly rotation:
+# `weekIndex % integrationCount` selects ONE integration per Monday tick,
+# all feature types for that integration are compared, the rest of the
+# fleet sits out. With ~17 integrations the rotation covers the full
+# fleet over ~17 weeks — the same cadence at which the reference baseline
+# is refreshed against LGP. Aligning the comparison cadence with the
+# reference-refresh cadence keeps both sides on the same drift clock.
+#
+# The ACTUAL cron string lives on Railway (the showcase-ops scheduler
+# reads cadence from there, not from this YAML); the value below documents
+# the intended schedule and is what the loader will surface to operators
+# inspecting the config. Mondays 04:00 UTC = early morning before the
+# US business day so a fresh red is on the dashboard when on-call
+# arrives.
+#
+# ── On-demand mode (out-of-band, NOT cron) ──────────────────────────────
+#
+# Operators can re-run a single integration by setting
+# `D6_MODE=on-demand` and `D6_TARGET_INTEGRATION=<slug>` on the
+# showcase-ops service env, then triggering a manual tick. This bypasses
+# the rotation entirely and is intended for ad-hoc triage:
+#   - post-deploy verification of one integration,
+#   - post-fixture-update sanity check,
+#   - post-tolerance-recalibration re-baseline confirmation.
+# On-demand runs do NOT happen on the cron — they're explicit, manual,
+# operator-driven. The driver throws if `D6_MODE=on-demand` is set
+# without `D6_TARGET_INTEGRATION` so silent misconfigurations turn into
+# loud red ticks.
+#
+# ── timeout_ms: 600_000 (10 min) ────────────────────────────────────────
+#
+# Outer driver-invocation cap. Per-feature run subdivides further: the
+# conversation-runner's per-turn `responseTimeoutMs` defaults to 30s,
+# the driver's per-page goto timeout is 30s. With ~10 features × 1-3
+# turns × 30s/turn worst case = ~5-7 min for one integration; 10 min
+# cap is double that to absorb transient cold-paths without false reds.
+#
+# ── max_concurrency: 2 ──────────────────────────────────────────────────
+#
+# 2 simultaneous chromium contexts × 2 parallel feature comparisons
+# within the chosen integration. Same memory budget as e2e-deep — keep
+# at 2 until production memory headroom is observed.
+#
+# ── Scope: all showcase packages ────────────────────────────────────────
+#
+# Discovery matches all `showcase-*` Railway services via `namePrefix`,
+# excluding the same infra services as e2e-deep so a new infra service
+# added there lands here too. The driver short-circuits inside `run()`
+# for any service not selected by the rotation this tick — the
+# discovery returns the full list, the driver does the rotation pick.
+kind: e2e_parity
+id: e2e-parity
+# Hard-gated by `D6_ENABLED` env var (default false). Driver short-circuits
+# with "D6 disabled" note when unset; cron schedule is irrelevant until the
+# gate is flipped.
+schedule: "0 4 * * 1"
+timeout_ms: 600000
+max_concurrency: 2
+discovery:
+  source: railway-services
+  filter:
+    namePrefix: "showcase-"
+    nameExcludes:
+      - showcase-aimock
+      - showcase-ops
+      - showcase-pocketbase
+      - showcase-shell
+      - showcase-shell-dashboard
+      - showcase-shell-docs
+      - showcase-shell-dojo
+  # Primary row key uses the Railway service name (not the stripped
+  # slug) to stay consistent with sibling driver families. The driver
+  # strips `showcase-` from the name internally for the per-feature
+  # side-row keys (`d6:<slug>/<featureType>`).
+  key_template: "e2e-parity:${name}"


### PR DESCRIPTION
## Summary

Restores the two probe YAMLs for the D5 (`e2e_deep`) and D6 (`e2e_parity`) drivers. Without these, showcase-ops boots cleanly but D5 and D6 never tick.

## Why

PR #4292 originally shipped these YAMLs alongside the D5/D6 drivers. The drivers themselves merged but were never wired into `orchestrator.ts`'s registration block, so the probe-loader emitted `probe-loader.file-failed` on every boot.

To stop the noise, commit `8e7417354` (PR #4300) deleted the orphan YAMLs with the note "re-adding the YAMLs in a future PR is one-line."

PR #4301 has now landed the missing registry calls. This PR completes the chain by restoring the YAMLs so the drivers can actually be scheduled.

## Changes

- Restored `showcase/ops/config/probes/e2e-deep.yml` verbatim from `origin/blitz/d5-driver`
- Restored `showcase/ops/config/probes/e2e-parity.yml` verbatim from `origin/blitz/d6-driver`, plus a one-line comment near the schedule documenting that D6 is hard-gated by the `D6_ENABLED` env var (default false; driver short-circuits with "D6 disabled" note when unset; cron schedule is irrelevant until the gate is flipped)

No source changes — pure YAML restore. The existing `orchestrator.test.ts` registry-list assertion (added by #4301) covers the wiring; this PR adds the YAMLs that wiring depends on.

## Test plan

- [x] `pnpm typecheck` clean (no source changes)
- [x] `pnpm test` — all 1286 tests pass
- [x] Formatter check clean
- [ ] CI green