### PR TITLE
fix(showcase-ops): wire demos→features mapping in e2e-deep driver

### DIFF
--- a/showcase/ops/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.test.ts
@@ -537,6 +537,144 @@ describe("e2e-deep driver", () => {
     expect(sig.errorDesc).toBe("launcher-error");
     expect(sig.failureSummary).toMatch(/chromium launch failed/);
   });
+
+  it("derives features from demos[] when explicit features are absent", async () => {
+    // Production discovery (`railway-services`) populates `demos`
+    // with registry feature IDs; the driver maps them to D5 feature
+    // types via `demosToFeatureTypes`. Use the registry → D5 mapping
+    // to drive a service whose declared `demos[]` carry IDs that
+    // DON'T match a D5 type verbatim:
+    //   - `tool-rendering-default-catchall` → `tool-rendering`
+    //   - `shared-state-read-write` → BOTH `shared-state-read` AND
+    //     `shared-state-write` (one-to-many)
+    //   - `voice` is unmapped and silently dropped.
+    // Only the shared-state script is registered, so
+    // `tool-rendering` lands in `skipped[]` — the test exercises
+    // both the mapping AND the closed-set filter without paying
+    // the per-feature ~1.5s settle window for every demo.
+    registerD5Script(
+      makeScript({
+        featureTypes: ["shared-state-read", "shared-state-write"],
+        fixtureFile: "shared-state.json",
+      }),
+    );
+
+    const { browser } = makeBrowser([{}, {}]);
+    const driver = createE2eDeepDriver({
+      launcher: async () => browser,
+      scriptLoader: async () => {
+        /* registry already populated above */
+      },
+    });
+    const { writer, writes } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-langgraph-python",
+      publicUrl: "https://showcase-langgraph-python.example.com",
+      name: "showcase-langgraph-python",
+      // No `features` field — production discovery shape.
+      demos: [
+        "tool-rendering-default-catchall", // → tool-rendering (skipped, no script)
+        "shared-state-read-write", // → shared-state-read + shared-state-write (run)
+        "voice", // unmapped → dropped
+      ],
+      shape: "package",
+    });
+
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    // 3 mapped D5 types: tool-rendering (skipped) + shared-state-read
+    // + shared-state-write (both run). `voice` was dropped before
+    // counting.
+    expect(sig.total).toBe(3);
+    expect(sig.passed).toBe(2);
+    expect(sig.failed).toEqual([]);
+    expect(sig.skipped).toEqual(["tool-rendering"]);
+
+    const sideKeys = writes.map((w) => w.key).sort();
+    expect(sideKeys).toEqual([
+      "d5:langgraph-python/shared-state-read",
+      "d5:langgraph-python/shared-state-write",
+      "d5:langgraph-python/tool-rendering",
+    ]);
+  });
+
+  it("explicit features wins over demos when both are present", async () => {
+    // Tests pass `features` directly. Verify the demos fallback is
+    // NOT consulted when `features` carries entries — otherwise the
+    // existing test suite's `features: [...]` calls would silently
+    // pull in extra D5 types from a populated `demos` field.
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+      }),
+    );
+
+    const { browser } = makeBrowser([{}]);
+    const driver = createE2eDeepDriver({
+      launcher: async () => browser,
+      scriptLoader: async () => {
+        /* registry already populated above */
+      },
+    });
+    const { writer, writes } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-langgraph-python",
+      publicUrl: "https://showcase-langgraph-python.example.com",
+      name: "showcase-langgraph-python",
+      features: ["agentic-chat"],
+      // demos would normally add tool-rendering + more — overridden
+      // by explicit features, so the driver runs only agentic-chat.
+      demos: ["tool-rendering", "hitl-in-app", "shared-state-read-write"],
+      shape: "package",
+    });
+
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.total).toBe(1);
+    expect(sig.passed).toBe(1);
+    expect(writes.map((w) => w.key)).toEqual([
+      "d5:langgraph-python/agentic-chat",
+    ]);
+  });
+
+  it("short-circuits 'no D5 features declared' when both demos and features are empty", async () => {
+    // Both empty: discovery emitted a record with neither field
+    // populated (e.g. unmapped service whose slug isn't in
+    // registry.json). The driver must still take the no-op green
+    // path WITHOUT launching chromium — otherwise we pay the launch
+    // cost on every unmapped service.
+    let launched = false;
+    const driver = createE2eDeepDriver({
+      launcher: async () => {
+        launched = true;
+        const { browser } = makeBrowser([{}]);
+        return browser;
+      },
+      scriptLoader: async () => {
+        /* registry stays empty */
+      },
+    });
+    const { writer, writes } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-mystery",
+      publicUrl: "https://showcase-mystery.example.com",
+      name: "showcase-mystery",
+      features: [],
+      demos: [],
+      shape: "package",
+    });
+
+    expect(launched).toBe(false);
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.total).toBe(0);
+    expect(sig.note).toMatch(/no D5 features declared/);
+    expect(writes).toEqual([]);
+  });
 });
 
 describe("D5_SCRIPT_FILE_MATCHER", () => {

--- a/showcase/ops/src/probes/drivers/e2e-deep.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.ts
@@ -10,6 +10,7 @@ import {
   type D5FeatureType,
   type D5Script,
 } from "../helpers/d5-registry.js";
+import { demosToFeatureTypes } from "../helpers/d5-feature-mapping.js";
 import {
   runConversation,
   type ConversationResult,
@@ -61,8 +62,24 @@ const inputSchema = z
      * The list of D5 feature types the integration declares. Driver
      * fans out over this list. Empty / absent → aggregate-green
      * short-circuit, no chromium launched.
+     *
+     * Tests pass `features` directly. Production discovery
+     * (`railway-services`) populates `demos: string[]` (registry
+     * feature IDs) instead — the driver maps `demos` → `features`
+     * via `demosToFeatureTypes` BEFORE the `requestedFeatures`
+     * filter when `features` is empty/absent. Explicit `features`
+     * always wins so test fixtures never interact with the demos
+     * mapping.
      */
     features: z.array(z.string()).optional(),
+    /**
+     * Registry-feature-id list, populated by the `railway-services`
+     * discovery source from `feature-registry.json` joined by
+     * integration slug. Used as a fallback source for `features`
+     * via `demosToFeatureTypes` when `features` is empty/absent —
+     * see the import site for the mapping table.
+     */
+    demos: z.array(z.string()).optional(),
     shape: showcaseShapeSchema.optional(),
   })
   .passthrough()
@@ -360,13 +377,25 @@ export function createE2eDeepDriver(
         };
       }
 
-      // Filter the integration's declared features to known D5 feature
-      // types. Anything else (e.g. legacy `e2e-features` ids that map
-      // to demo routes but not to a D5 conversation) is silently
-      // dropped — D5 covers a closed set.
-      const requestedFeatures = (input.features ?? []).filter(
-        isKnownFeatureType,
-      );
+      // Resolve the feature list. Explicit `features` (from tests or a
+      // hand-authored YAML target) wins; otherwise translate the
+      // discovery-supplied `demos[]` (registry feature IDs) into D5
+      // feature types via `demosToFeatureTypes`. Without this fallback
+      // production discovery records — which carry `demos` but never
+      // `features` — would always short-circuit "no D5 features
+      // declared" green even on services with full demo coverage.
+      const featuresFromInput = input.features ?? [];
+      const featureSource: readonly string[] =
+        featuresFromInput.length > 0
+          ? featuresFromInput
+          : demosToFeatureTypes(input.demos ?? []);
+
+      // Filter to the known D5 feature-type set. The mapping output is
+      // already typed `D5FeatureType[]`, but explicit `features` may
+      // carry legacy / typo strings that aren't in the closed enum —
+      // run the same filter for both code paths so behaviour stays
+      // uniform.
+      const requestedFeatures = featureSource.filter(isKnownFeatureType);
 
       if (requestedFeatures.length === 0) {
         return {

--- a/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
@@ -1,0 +1,122 @@
+/**
+ * D5 — registry-feature-id → D5-feature-type mapping.
+ *
+ * The Railway `railway-services` discovery source populates each
+ * service's record with a `demos: string[]` field — the demo IDs from
+ * `showcase/shared/feature-registry.json` joined by integration slug.
+ * The D5 (`e2e-deep`) and D6 (`e2e-parity`) drivers, however, fan out
+ * over the closed `D5FeatureType` enum from `helpers/d5-registry.ts`.
+ *
+ * Most demo IDs do not match the D5 feature type names verbatim —
+ * `tool-rendering-default-catchall`, `hitl-in-chat`, `hitl-in-app`,
+ * `gen-ui-tool-based`, `headless-simple`, etc. all describe demo
+ * routes whose D5 conversation script is registered against a
+ * different `D5FeatureType` literal. Without an explicit mapping
+ * every service's `demos[]` would silently fail the
+ * `isKnownFeatureType` filter in the driver and the driver would
+ * short-circuit "no D5 features declared" green.
+ *
+ * Source of truth for which D5 feature types each demo maps to:
+ *
+ *   - The D5 script files under `src/probes/scripts/d5-*.ts` declare
+ *     their `featureTypes` literal — that's the closed set of D5
+ *     types the registry can hold.
+ *   - The registry's demo IDs that share semantics with one of those
+ *     types are declared here. Many registry IDs map to the same D5
+ *     type (many-to-one); a few map to multiple D5 types (one-to-many,
+ *     e.g. `shared-state-read-write` covers both read and write).
+ *
+ * Demo IDs not in this map are silently dropped — D5 covers a closed
+ * set and registry features outside it (e.g. `auth`, `voice`,
+ * `multimodal`, `byoc-*`) have no D5 conversation script.
+ */
+
+import type { D5FeatureType } from "./d5-registry.js";
+
+/**
+ * Map registry feature ID (from `feature-registry.json` `features[].id`)
+ * to one or more `D5FeatureType` literals.
+ *
+ * Entries are grouped by D5 destination to make the many-to-one shape
+ * obvious at a glance:
+ *   - `agentic-chat`           : 1 demo
+ *   - `tool-rendering`         : 4 demos (all the tool-rendering variants)
+ *   - `gen-ui-headless`        : 2 demos (headless chat surfaces)
+ *   - `gen-ui-custom`          : 1 demo
+ *   - `hitl-text-input`        : 4 demos (in-chat HITL variants)
+ *   - `hitl-approve-deny`      : 1 demo (modal/in-app approval)
+ *   - `shared-state-read|write`: 1 demo, 2 D5 types (one-to-many)
+ *   - `mcp-apps`               : 1 demo
+ *   - `subagents`              : 1 demo
+ */
+const REGISTRY_TO_D5: Readonly<Record<string, readonly D5FeatureType[]>> = {
+  // agentic-chat (1:1)
+  "agentic-chat": ["agentic-chat"],
+
+  // tool-rendering — every variant exercises the per-tool render pipeline
+  "tool-rendering": ["tool-rendering"],
+  "tool-rendering-default-catchall": ["tool-rendering"],
+  "tool-rendering-custom-catchall": ["tool-rendering"],
+  "tool-rendering-reasoning-chain": ["tool-rendering"],
+
+  // gen-ui (headless tier) — D5 script `d5-gen-ui-headless.ts` drives
+  // /demos/headless-simple, but the registry also exposes a fuller
+  // /demos/headless-complete demo on the same surface.
+  "headless-simple": ["gen-ui-headless"],
+  "headless-complete": ["gen-ui-headless"],
+
+  // gen-ui (custom tier)
+  "gen-ui-tool-based": ["gen-ui-custom"],
+
+  // hitl (text-input / in-chat tier) — every in-chat HITL variant maps
+  // to the `hitl-text-input` D5 script (which navigates to
+  // /demos/hitl-in-chat via preNavigateRoute).
+  "hitl-in-chat": ["hitl-text-input"],
+  "hitl-in-chat-booking": ["hitl-text-input"],
+  "gen-ui-interrupt": ["hitl-text-input"],
+  hitl: ["hitl-text-input"],
+
+  // hitl (approve/deny tier) — out-of-chat modal approval flow.
+  "hitl-in-app": ["hitl-approve-deny"],
+
+  // shared-state — one demo covers both read+write (the D5 script
+  // claims both feature types and runs once per type via
+  // preNavigateRoute split).
+  "shared-state-read-write": ["shared-state-read", "shared-state-write"],
+
+  // mcp-apps + subagents (registry has both feature IDs; D5 script
+  // covers both featureTypes via one /demos/subagents conversation).
+  "mcp-apps": ["mcp-apps"],
+  subagents: ["subagents"],
+};
+
+/**
+ * Translate a list of registry feature IDs (from a service's `demos[]`)
+ * into the closed set of `D5FeatureType` literals the D5/D6 drivers
+ * understand. Returns a deduplicated, stable-ordered array.
+ *
+ *   - Unknown / unmapped registry IDs are silently skipped (D5 covers a
+ *     closed set; non-D5 demos have no script and would just be marked
+ *     `skipped` downstream — better to drop them upfront).
+ *   - The output preserves first-occurrence order across the input list,
+ *     so two callers passing the same demo set get the same feature
+ *     order in their output. Determinism matters for snapshot-style
+ *     tests and dashboard tile ordering.
+ */
+export function demosToFeatureTypes(
+  demos: readonly string[],
+): D5FeatureType[] {
+  const out: D5FeatureType[] = [];
+  const seen = new Set<D5FeatureType>();
+  for (const id of demos) {
+    const mapped = REGISTRY_TO_D5[id];
+    if (!mapped) continue;
+    for (const ft of mapped) {
+      if (!seen.has(ft)) {
+        seen.add(ft);
+        out.push(ft);
+      }
+    }
+  }
+  return out;
+}

--- a/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
@@ -103,9 +103,7 @@ const REGISTRY_TO_D5: Readonly<Record<string, readonly D5FeatureType[]>> = {
  *     order in their output. Determinism matters for snapshot-style
  *     tests and dashboard tile ordering.
  */
-export function demosToFeatureTypes(
-  demos: readonly string[],
-): D5FeatureType[] {
+export function demosToFeatureTypes(demos: readonly string[]): D5FeatureType[] {
   const out: D5FeatureType[] = [];
   const seen = new Set<D5FeatureType>();
   for (const id of demos) {


### PR DESCRIPTION
## Summary

- The e2e-deep (D5) driver expected `features[]` in its input but railway-services discovery only populates `demos[]` (from registry.json). Every service short-circuited with "no D5 features declared" green — D5 probes were structurally complete but functionally inert.
- Adds `d5-feature-mapping.ts` — a many-to-one mapping from registry feature IDs to D5 feature types, derived from what each `d5-*.ts` script actually registers.
- Driver now falls back to `demosToFeatureTypes(input.demos)` when `input.features` is empty. Explicit `features` (used by tests) still wins.

## Test plan

- [x] New tests: demos-only path, explicit features override, both-empty short-circuit
- [x] `nx run @copilotkit/showcase-ops:build` — green
- [x] `nx run @copilotkit/showcase-ops:test` — 1287/1287 passing
- [ ] After merge + deploy: trigger `e2e-deep` probe, verify per-feature `d5:<slug>/<featureType>` side rows appear in PocketBase (currently zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)