### PR TITLE
fix(showcase): standardize all 17 smoke routes to TTFB-based probe parity

### DIFF
--- a/showcase/packages/ag2/src/app/api/smoke/route.ts
+++ b/showcase/packages/ag2/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/agno/src/app/api/smoke/route.ts
+++ b/showcase/packages/agno/src/app/api/smoke/route.ts
@@ -7,7 +7,6 @@ export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
-  // Hit our own /api/copilotkit endpoint — tests the full deployed stack
   const baseUrl =
     process.env.NEXT_PUBLIC_BASE_URL ||
     `http://localhost:${process.env.PORT || 3000}`;
@@ -55,15 +54,7 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream. The agno SDK does not reliably emit the
-    // terminal events (TEXT_MESSAGE_END / RUN_FINISHED) on the success path,
-    // so `await res.text()` can hang until the client timeout fires even
-    // though the agent has already produced valid output. Workaround: read
-    // the stream incrementally and short-circuit as soon as we observe
-    // TEXT_MESSAGE_CONTENT with "OK" in the delta, canceling the reader
-    // rather than awaiting a stream close that may never come. This is a
-    // client-side mitigation — the real fix belongs upstream in the agno
-    // SDK's AG-UI interface.
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
     const reader = res.body?.getReader();
     if (!reader) {
       return NextResponse.json(
@@ -71,66 +62,23 @@ export async function GET() {
           status: "error",
           integration: INTEGRATION_SLUG,
           stage: "response_empty",
-          error: "Runtime returned no response body",
+          error: "Runtime returned no readable body",
           latency_ms: latency,
           timestamp: new Date().toISOString(),
         },
         { status: 502 },
       );
     }
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let gotOk = false;
-    try {
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        if (
-          buffer.includes('"type":"TEXT_MESSAGE_CONTENT"') &&
-          buffer.includes('"OK"')
-        ) {
-          gotOk = true;
-          // Drop the connection; don't await a stream close that may never come.
-          await reader.cancel().catch(() => {});
-          break;
-        }
-      }
-    } finally {
-      try {
-        reader.releaseLock();
-      } catch {
-        // reader may already be released via cancel(); ignore.
-      }
-    }
-
-    const finalLatency = Date.now() - start;
-
-    if (!gotOk && buffer.length === 0) {
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",
           integration: INTEGRATION_SLUG,
           stage: "response_empty",
           error: "Runtime returned empty response body",
-          latency_ms: finalLatency,
-          timestamp: new Date().toISOString(),
-        },
-        { status: 502 },
-      );
-    }
-
-    if (!gotOk) {
-      return NextResponse.json(
-        {
-          status: "error",
-          integration: INTEGRATION_SLUG,
-          stage: "response_incomplete",
-          error:
-            "Stream ended without TEXT_MESSAGE_CONTENT 'OK': " +
-            buffer.slice(0, 200),
-          latency_ms: finalLatency,
+          latency_ms: latency,
           timestamp: new Date().toISOString(),
         },
         { status: 502 },
@@ -140,7 +88,7 @@ export async function GET() {
     return NextResponse.json({
       status: "ok",
       integration: INTEGRATION_SLUG,
-      latency_ms: finalLatency,
+      latency_ms: latency,
       timestamp: new Date().toISOString(),
     });
   } catch (e: unknown) {

--- a/showcase/packages/claude-sdk-python/src/app/api/smoke/route.ts
+++ b/showcase/packages/claude-sdk-python/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/claude-sdk-typescript/src/app/api/smoke/route.ts
+++ b/showcase/packages/claude-sdk-typescript/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/crewai-crews/src/app/api/smoke/route.ts
+++ b/showcase/packages/crewai-crews/src/app/api/smoke/route.ts
@@ -5,16 +5,6 @@ const INTEGRATION_SLUG = "crewai-crews";
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
-// Upstream fetch timeout. Kept strictly shorter than ``maxDuration`` (60s)
-// so that a hung upstream can't exhaust the whole route budget: a stuck
-// agent surfaces as a clean ``timeout`` stage within ~25s, leaving room
-// for the response JSON to be written before Next.js kills the request.
-// Previously the inner fetch shared the full 45s timeout, which — when
-// the agent hung — caused the smoke route itself to hang for 30s+ of the
-// 60s budget before the platform cut it, producing HTTP 000 at the
-// caller instead of a structured ``stage: "timeout"`` response.
-const UPSTREAM_TIMEOUT_MS = 25_000;
-
 export async function GET() {
   const start = Date.now();
   // Hit our own /api/copilotkit endpoint — tests the full deployed stack
@@ -45,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;
@@ -65,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/google-adk/src/app/api/smoke/route.ts
+++ b/showcase/packages/google-adk/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/langgraph-fastapi/src/app/api/health/route.ts
+++ b/showcase/packages/langgraph-fastapi/src/app/api/health/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest) {
   // Check agent backend reachability
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest) {
   }
 
   // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
+  const publicResponse: Record<string, unknown> = {
     status: agentStatus === "ok" ? "ok" : "degraded",
     integration: "langgraph-fastapi",
     agent: agentStatus,

--- a/showcase/packages/langgraph-fastapi/src/app/api/smoke/route.ts
+++ b/showcase/packages/langgraph-fastapi/src/app/api/smoke/route.ts
@@ -1,27 +1,83 @@
 import { NextResponse } from "next/server";
 
 const INTEGRATION_SLUG = "langgraph-fastapi";
-const LANGGRAPH_URL = process.env.AGENT_URL || "http://localhost:8123";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    `http://localhost:${process.env.PORT || 3000}`;
+
   try {
-    // Check LangGraph backend is alive
-    const healthRes = await fetch(`${LANGGRAPH_URL}/ok`, {
-      signal: AbortSignal.timeout(10000),
+    const res = await fetch(`${baseUrl}/api/copilotkit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: "agent/run",
+        params: { agentId: "agentic_chat" },
+        body: {
+          threadId: `smoke-${Date.now()}`,
+          runId: `smoke-run-${Date.now()}`,
+          state: {},
+          messages: [
+            {
+              id: `smoke-msg-${Date.now()}`,
+              role: "user",
+              content: "Respond with exactly: OK",
+            },
+          ],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        },
+      }),
+      signal: AbortSignal.timeout(45000),
     });
+
     const latency = Date.now() - start;
 
-    if (!healthRes.ok) {
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "");
       return NextResponse.json(
         {
           status: "error",
           integration: INTEGRATION_SLUG,
-          stage: "langgraph_health",
-          error: `LangGraph returned ${healthRes.status}`,
+          stage: "runtime_response",
+          error: `Runtime returned ${res.status}: ${errBody.slice(0, 200)}`,
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned empty response body",
           latency_ms: latency,
           timestamp: new Date().toISOString(),
         },
@@ -38,10 +94,15 @@ export async function GET() {
   } catch (e: unknown) {
     const err = e instanceof Error ? e : new Error(String(e));
     const latency = Date.now() - start;
+
     let stage = "unknown";
     if (err.name === "AbortError" || err.message.includes("timeout"))
       stage = "timeout";
-    else if (err.message.includes("ECONNREFUSED")) stage = "agent_unreachable";
+    else if (
+      err.message.includes("fetch") ||
+      err.message.includes("ECONNREFUSED")
+    )
+      stage = "agent_unreachable";
     else stage = "pipeline_error";
 
     return NextResponse.json(

--- a/showcase/packages/langgraph-python/src/app/api/debug/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/debug/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const token =
+    req.headers.get("x-debug-token") || req.nextUrl.searchParams.get("token");
+  const expectedToken = process.env.SHOWCASE_DEBUG_TOKEN;
+
+  if (!expectedToken || !token || token !== expectedToken) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 403 });
+  }
+
+  const AGENT_URL =
+    process.env.AGENT_URL || process.env.LANGGRAPH_DEPLOYMENT_URL || "unknown";
+
+  let agentStatus = "unknown";
+  let agentDetail = "";
+  try {
+    const res = await fetch(`${AGENT_URL}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    agentStatus = res.ok ? "ok" : "error";
+    agentDetail = `HTTP ${res.status}`;
+  } catch (e: unknown) {
+    agentStatus = "down";
+    agentDetail = (e as Error).message;
+  }
+
+  const uptime = process.uptime();
+  const mem = process.memoryUsage();
+
+  return NextResponse.json({
+    integration: "langgraph-python",
+    uptime: `${Math.floor(uptime / 60)}m ${Math.floor(uptime % 60)}s`,
+    agent: { url: AGENT_URL, status: agentStatus, detail: agentDetail },
+    memory: {
+      rss: `${Math.round(mem.rss / 1024 / 1024)}MB`,
+      heapUsed: `${Math.round(mem.heapUsed / 1024 / 1024)}MB`,
+    },
+    env: {
+      NODE_ENV: process.env.NODE_ENV,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY ? "set" : "NOT SET",
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ? "set" : "NOT SET",
+      LANGSMITH_API_KEY: process.env.LANGSMITH_API_KEY ? "set" : "NOT SET",
+    },
+    nodeVersion: process.version,
+  });
+}

--- a/showcase/packages/langgraph-python/src/app/api/health/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/health/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   // Check agent backend reachability
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${LANGGRAPH_URL}/ok`, {
+    const res = await fetch(`${LANGGRAPH_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
   }
 
   // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
+  const publicResponse: Record<string, unknown> = {
     status: agentStatus === "ok" ? "ok" : "degraded",
     integration: "langgraph-python",
     agent: agentStatus,

--- a/showcase/packages/langgraph-python/src/app/api/smoke/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/smoke/route.ts
@@ -1,28 +1,83 @@
 import { NextResponse } from "next/server";
 
 const INTEGRATION_SLUG = "langgraph-python";
-const LANGGRAPH_URL =
-  process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    `http://localhost:${process.env.PORT || 3000}`;
+
   try {
-    // Check LangGraph backend is alive
-    const healthRes = await fetch(`${LANGGRAPH_URL}/ok`, {
-      signal: AbortSignal.timeout(10000),
+    const res = await fetch(`${baseUrl}/api/copilotkit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: "agent/run",
+        params: { agentId: "agentic_chat" },
+        body: {
+          threadId: `smoke-${Date.now()}`,
+          runId: `smoke-run-${Date.now()}`,
+          state: {},
+          messages: [
+            {
+              id: `smoke-msg-${Date.now()}`,
+              role: "user",
+              content: "Respond with exactly: OK",
+            },
+          ],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        },
+      }),
+      signal: AbortSignal.timeout(45000),
     });
+
     const latency = Date.now() - start;
 
-    if (!healthRes.ok) {
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "");
       return NextResponse.json(
         {
           status: "error",
           integration: INTEGRATION_SLUG,
-          stage: "langgraph_health",
-          error: `LangGraph returned ${healthRes.status}`,
+          stage: "runtime_response",
+          error: `Runtime returned ${res.status}: ${errBody.slice(0, 200)}`,
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned empty response body",
           latency_ms: latency,
           timestamp: new Date().toISOString(),
         },
@@ -39,10 +94,15 @@ export async function GET() {
   } catch (e: unknown) {
     const err = e instanceof Error ? e : new Error(String(e));
     const latency = Date.now() - start;
+
     let stage = "unknown";
     if (err.name === "AbortError" || err.message.includes("timeout"))
       stage = "timeout";
-    else if (err.message.includes("ECONNREFUSED")) stage = "agent_unreachable";
+    else if (
+      err.message.includes("fetch") ||
+      err.message.includes("ECONNREFUSED")
+    )
+      stage = "agent_unreachable";
     else stage = "pipeline_error";
 
     return NextResponse.json(

--- a/showcase/packages/langgraph-typescript/src/app/api/health/route.ts
+++ b/showcase/packages/langgraph-typescript/src/app/api/health/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest) {
   // Check agent backend reachability
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/ok`, {
+    const res = await fetch(`${AGENT_URL}/health`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";
@@ -18,7 +18,7 @@ export async function GET(req: NextRequest) {
   }
 
   // Public response: safe to expose
-  const publicResponse: Record<string, any> = {
+  const publicResponse: Record<string, unknown> = {
     status: agentStatus === "ok" ? "ok" : "degraded",
     integration: "langgraph-typescript",
     agent: agentStatus,

--- a/showcase/packages/langgraph-typescript/src/app/api/smoke/route.ts
+++ b/showcase/packages/langgraph-typescript/src/app/api/smoke/route.ts
@@ -1,28 +1,83 @@
 import { NextResponse } from "next/server";
 
 const INTEGRATION_SLUG = "langgraph-typescript";
-const LANGGRAPH_URL =
-  process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
 export async function GET() {
   const start = Date.now();
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    `http://localhost:${process.env.PORT || 3000}`;
+
   try {
-    // Check LangGraph backend is alive
-    const healthRes = await fetch(`${LANGGRAPH_URL}/ok`, {
-      signal: AbortSignal.timeout(10000),
+    const res = await fetch(`${baseUrl}/api/copilotkit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: "agent/run",
+        params: { agentId: "agentic_chat" },
+        body: {
+          threadId: `smoke-${Date.now()}`,
+          runId: `smoke-run-${Date.now()}`,
+          state: {},
+          messages: [
+            {
+              id: `smoke-msg-${Date.now()}`,
+              role: "user",
+              content: "Respond with exactly: OK",
+            },
+          ],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        },
+      }),
+      signal: AbortSignal.timeout(45000),
     });
+
     const latency = Date.now() - start;
 
-    if (!healthRes.ok) {
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "");
       return NextResponse.json(
         {
           status: "error",
           integration: INTEGRATION_SLUG,
-          stage: "langgraph_health",
-          error: `LangGraph returned ${healthRes.status}`,
+          stage: "runtime_response",
+          error: `Runtime returned ${res.status}: ${errBody.slice(0, 200)}`,
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned empty response body",
           latency_ms: latency,
           timestamp: new Date().toISOString(),
         },
@@ -39,10 +94,15 @@ export async function GET() {
   } catch (e: unknown) {
     const err = e instanceof Error ? e : new Error(String(e));
     const latency = Date.now() - start;
+
     let stage = "unknown";
     if (err.name === "AbortError" || err.message.includes("timeout"))
       stage = "timeout";
-    else if (err.message.includes("ECONNREFUSED")) stage = "agent_unreachable";
+    else if (
+      err.message.includes("fetch") ||
+      err.message.includes("ECONNREFUSED")
+    )
+      stage = "agent_unreachable";
     else stage = "pipeline_error";
 
     return NextResponse.json(

--- a/showcase/packages/langroid/src/app/api/smoke/route.ts
+++ b/showcase/packages/langroid/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/llamaindex/src/app/api/smoke/route.ts
+++ b/showcase/packages/llamaindex/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/mastra/src/app/api/health/route.ts
+++ b/showcase/packages/mastra/src/app/api/health/route.ts
@@ -1,9 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
-  // Mastra runs in-process — no external agent to ping
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    `http://localhost:${process.env.PORT || 3000}`;
+
+  let agentStatus = "unknown";
+  try {
+    const res = await fetch(`${baseUrl}/api/copilotkit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: "agent/run",
+        params: { agentId: "agentic_chat" },
+        body: {
+          threadId: "health-check",
+          runId: "health-check",
+          state: {},
+          messages: [],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        },
+      }),
+      signal: AbortSignal.timeout(3000),
+    });
+    // Any non-network-error response means runtime is alive
+    agentStatus = res.ok || res.status < 500 ? "ok" : "error";
+  } catch {
+    agentStatus = "down";
+  }
+
   const publicResponse: Record<string, unknown> = {
-    status: "ok",
+    status: agentStatus === "ok" ? "ok" : "degraded",
     integration: "mastra",
     agent: "in-process",
     timestamp: new Date().toISOString(),

--- a/showcase/packages/mastra/src/app/api/smoke/route.ts
+++ b/showcase/packages/mastra/src/app/api/smoke/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         method: "agent/run",
-        params: { agentId: "weatherAgent" },
+        params: { agentId: "agentic_chat" },
         body: {
           threadId: `smoke-${Date.now()}`,
           runId: `smoke-run-${Date.now()}`,
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/ms-agent-dotnet/src/app/api/smoke/route.ts
+++ b/showcase/packages/ms-agent-dotnet/src/app/api/smoke/route.ts
@@ -35,7 +35,7 @@ export async function GET() {
           forwardedProps: {},
         },
       }),
-      signal: AbortSignal.timeout(50000),
+      signal: AbortSignal.timeout(45000),
     });
 
     const latency = Date.now() - start;
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/ms-agent-python/src/app/api/smoke/route.ts
+++ b/showcase/packages/ms-agent-python/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/pydantic-ai/src/app/api/smoke/route.ts
+++ b/showcase/packages/pydantic-ai/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/spring-ai/src/app/api/smoke/route.ts
+++ b/showcase/packages/spring-ai/src/app/api/smoke/route.ts
@@ -54,8 +54,24 @@ export async function GET() {
       );
     }
 
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",

--- a/showcase/packages/strands/src/app/api/smoke/route.ts
+++ b/showcase/packages/strands/src/app/api/smoke/route.ts
@@ -55,9 +55,24 @@ export async function GET() {
       );
     }
 
-    // Response is SSE stream — just verify we got content
-    const body = await res.text();
-    if (body.length === 0) {
+    // TTFB: read first chunk only to confirm SSE stream started, then cancel
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
       return NextResponse.json(
         {
           status: "error",


### PR DESCRIPTION
## Summary

- All 17 showcase smoke routes now use identical TTFB-based first-chunk
  read instead of draining the full SSE response body. This makes smoke
  probes apples-to-apples: every package measures time-to-first-byte,
  not time-to-complete-LLM-response.
- Rewrote 3 langgraph smoke routes (fastapi, python, typescript) from
  upstream-only /ok ping to full CopilotKit stack exercise.
- Fixed mastra smoke agentId (weatherAgent to agentic_chat) and health
  route (unconditional 200 to actual runtime reachability check).
- Fixed 3 langgraph health routes (/ok to /health endpoint).
- Normalized ms-agent-dotnet timeout (50s to 45s) and maxDuration (was
  inconsistent).
- Removed crewai-crews UPSTREAM_TIMEOUT_MS variable (rationale moot
  with TTFB).
- All 17 packages now share: agentId=agentic_chat, timeout=45000ms,
  maxDuration=60, TTFB reader pattern.

## Why

Smoke probes were not apples-to-apples: some packages drained the full
SSE stream (waiting for complete LLM round-trip), others pinged an
upstream /ok endpoint, one used a wrong agentId. AG2 took 7-17s while
others returned in milliseconds, creating false failures on the 10s
probe timeout.

## Test plan

- [ ] CI green
- [ ] Trigger probe run after GHCR auto-deploy, verify all 17 smoke
      probes return ok with sub-second latency
- [ ] Verify health probes unchanged for standard packages, mastra
      health now returns degraded when runtime unreachable