### PR TITLE
fix(showcase-ops): target textarea not wrapper div in chat input selector cascade

### DIFF
--- a/showcase/ops/src/probes/drivers/e2e-demos.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-demos.test.ts
@@ -628,11 +628,12 @@ describe("e2e-demos driver", () => {
     expect(sig.passed).toBe(1);
     expect(sig.failed).toEqual([]);
 
-    // The chain was walked in order: testid → placeholder → textarea
-    // (match). Stronger fallbacks past the match are not attempted.
+    // The chain was walked in order: V2 textarea testid → scoped
+    // textarea descendant → bare `textarea` (match). Stronger fallbacks
+    // past the match are not attempted.
     expect(selectorsTried).toEqual([
-      '[data-testid="copilot-chat-input"]',
-      'input[placeholder="Type a message"]',
+      '[data-testid="copilot-chat-textarea"]',
+      '[data-testid="copilot-chat-input"] textarea',
       "textarea",
     ]);
 
@@ -640,7 +641,7 @@ describe("e2e-demos driver", () => {
     expect(writes[0]?.state).toBe("green");
   });
 
-  it("fails red only when all 5 fallback selectors miss", async () => {
+  it("fails red only when all 6 fallback selectors miss", async () => {
     // Harden the expanded selector chain: if every selector misses the
     // row must still red out as a selector-error (not swallowed as green
     // by the additional fallbacks).
@@ -686,9 +687,10 @@ describe("e2e-demos driver", () => {
 
     expect(result.state).toBe("red");
     expect(selectorsTried).toEqual([
-      '[data-testid="copilot-chat-input"]',
-      'input[placeholder="Type a message"]',
+      '[data-testid="copilot-chat-textarea"]',
+      '[data-testid="copilot-chat-input"] textarea',
       "textarea",
+      'input[placeholder="Type a message"]',
       'input[type="text"]',
       '[role="textbox"]',
     ]);
@@ -1101,11 +1103,11 @@ describe("e2e-demos driver", () => {
 
   // --- C7: selector-loop is abort-responsive ---------------------------
 
-  it("aborts mid-selector-loop without walking all 5 selectors", async () => {
+  it("aborts mid-selector-loop without walking all 6 selectors", async () => {
     // Slow waitForSelector + cap fires mid-loop. Without the abort
-    // check between iterations, the worst case is 5*pageTimeoutMs per
+    // check between iterations, the worst case is 6*pageTimeoutMs per
     // demo. Assert the loop bails after a small constant number of
-    // selectors (< 5) once the cap fires.
+    // selectors (< 6) once the cap fires.
     const selectorsTried: string[] = [];
     let resolveFirstSel!: () => void;
     const firstSelGate = new Promise<void>((r) => {
@@ -1173,7 +1175,7 @@ describe("e2e-demos driver", () => {
     // mid-loop abort check must bail before the second iteration runs.
     expect(selectorsTried.length).toBeLessThan(5);
     // Side row must reflect either abort or selector-error/timeout, NOT
-    // a wall-clock-bloated five-selector walk.
+    // a wall-clock-bloated six-selector walk.
     const sideRow = writes.find((w) => w.key === "e2e:abort-mid-loop/d1");
     const sig = sideRow?.signal as { errorClass?: string };
     expect(["abort", "selector-error", "selector-timeout"]).toContain(

--- a/showcase/ops/src/probes/drivers/e2e-demos.ts
+++ b/showcase/ops/src/probes/drivers/e2e-demos.ts
@@ -216,21 +216,31 @@ const TIMEOUT_ENV_VAR = "E2E_DEMOS_TIMEOUT_MS";
  * exact ordering — a refactor that re-orders the list surfaces as a test
  * diff.
  *
- * Ordering rationale:
- *   1. CopilotKit canonical testid — deterministic, the strictest signal.
- *   2. Default placeholder — covers CopilotKit UIs that haven't yet added
- *      the testid.
- *   3-5. Generic chat-affordance fallbacks. Custom-composer demos (e.g.
+ * Ordering rationale (kept in lockstep with `conversation-runner.ts`'s
+ * CHAT_INPUT_SELECTORS — this driver only checks visibility so the
+ * div-wrapper testid wouldn't actually break it, but matching ordering
+ * keeps a single mental model for both probes):
+ *   1. CopilotKit V2 canonical textarea testid — the actual `<textarea>`
+ *      inside the V2 chat input. Strictest, fillable signal.
+ *   2. Scoped descendant — any `<textarea>` nested under the V2 wrapper
+ *      `[data-testid="copilot-chat-input"]`, for V2 UIs whose textarea
+ *      doesn't carry its own testid.
+ *   3. Bare `textarea` — covers V1 CopilotKit and generic chat UIs whose
+ *      composer is a plain `<textarea>` without a testid.
+ *   4. Default placeholder — input-element composers whose UI uses
+ *      `<input placeholder="Type a message">` instead of a textarea.
+ *   5-6. Generic chat-affordance fallbacks. Custom-composer demos (e.g.
  *      `headless-simple`, `headless-complete`) build their own UI on top
  *      of `useAgent`, so they lack both the testid and the default
- *      placeholder but still render a `textarea` / text input / ARIA
- *      textbox. A match on any of these is enough structural evidence
- *      that the demo route booted.
+ *      placeholder but still render a text input / ARIA textbox. A match
+ *      on any of these is enough structural evidence that the demo
+ *      route booted.
  */
 const READY_SELECTORS = [
-  '[data-testid="copilot-chat-input"]',
-  'input[placeholder="Type a message"]',
+  '[data-testid="copilot-chat-textarea"]',
+  '[data-testid="copilot-chat-input"] textarea',
   "textarea",
+  'input[placeholder="Type a message"]',
   'input[type="text"]',
   '[role="textbox"]',
 ] as const;
@@ -800,7 +810,7 @@ async function runDemo(opts: {
     //
     // Abort responsiveness (C7): check the signal at the top of every
     // iteration so a cap that fires mid-loop bails promptly rather
-    // than walking all 5 selectors at `pageTimeoutMs` each.
+    // than walking all 6 selectors at `pageTimeoutMs` each.
     //
     // Deadline responsiveness (C11): break out as `selector-timeout`
     // when the per-demo budget is exhausted instead of starting another

--- a/showcase/ops/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/ops/src/probes/helpers/conversation-runner.test.ts
@@ -222,7 +222,7 @@ describe("runConversation", () => {
     expect(result.turn_durations_ms).toEqual([]);
   });
 
-  it("falls through the 5 chat-input selectors and uses the first that resolves", async () => {
+  it("falls through the chat-input selectors and uses the first that resolves", async () => {
     // Track which selectors were tried. The first that doesn't throw wins.
     const triedSelectors: string[] = [];
     let evalCalls = 0;
@@ -231,7 +231,7 @@ describe("runConversation", () => {
         triedSelectors.push(selector);
         // Force the first two to throw so the third one wins. The runner
         // must keep trying — anything else means it would false-fail on
-        // showcases that don't have the canonical testid.
+        // showcases that don't have the canonical V2 textarea testid.
         if (triedSelectors.length < 3) {
           throw new Error(`no match: ${selector}`);
         }
@@ -252,9 +252,69 @@ describe("runConversation", () => {
 
     expect(result.turns_completed).toBe(1);
     expect(triedSelectors.length).toBeGreaterThanOrEqual(3);
-    // First selector should be the canonical testid (matching the
-    // e2e-demos cascade ordering).
-    expect(triedSelectors[0]).toBe('[data-testid="copilot-chat-input"]');
+    // First selector must be the canonical V2 textarea testid — fillable.
+    // The previous wrapper-div testid (`[data-testid="copilot-chat-input"]`)
+    // matched a `<div>` and `page.fill()` would always throw on it.
+    expect(triedSelectors[0]).toBe('[data-testid="copilot-chat-textarea"]');
+    // Second selector scopes a textarea descendant under the wrapper for
+    // V2 UIs whose textarea doesn't have its own testid.
+    expect(triedSelectors[1]).toBe(
+      '[data-testid="copilot-chat-input"] textarea',
+    );
+    // Third selector is the bare `textarea` fallback (V1 / generic UIs).
+    expect(triedSelectors[2]).toBe("textarea");
+    // The bare wrapper-div selector MUST NOT appear before `textarea` —
+    // it's a non-fillable `<div>` and Playwright's `fill()` would throw.
+    const wrapperIdx = triedSelectors.indexOf(
+      '[data-testid="copilot-chat-input"]',
+    );
+    const textareaIdx = triedSelectors.indexOf("textarea");
+    if (wrapperIdx !== -1) {
+      expect(wrapperIdx).toBeGreaterThan(textareaIdx);
+    }
+  });
+
+  it("calls fill() on the resolved fillable selector, not the wrapper div", async () => {
+    // Simulate the V2 DOM where the wrapper-div testid would match (if
+    // it were in the cascade) but only the textarea descendant is
+    // actually fillable. The cascade must resolve to the textarea
+    // selector and `fill()` must be invoked with THAT selector — never
+    // the bare wrapper div.
+    const filledSelectors: string[] = [];
+    const triedSelectors: string[] = [];
+    let evalCalls = 0;
+    const page: Page = {
+      async waitForSelector(selector) {
+        triedSelectors.push(selector);
+        // Pretend the V2 textarea testid resolves successfully (it's the
+        // first selector in the cascade and the strictest, fillable one).
+      },
+      async fill(selector, _value) {
+        filledSelectors.push(selector);
+        // The bare wrapper-div selector must never reach fill() — that's
+        // the bug this test pins. Throw loudly if it ever does.
+        if (selector === '[data-testid="copilot-chat-input"]') {
+          throw new Error(
+            "fill() invoked on wrapper div — would throw in real Playwright",
+          );
+        }
+      },
+      async press() {},
+      async evaluate() {
+        evalCalls++;
+        return (evalCalls === 1 ? 0 : 1) as never;
+      },
+    };
+
+    const result = await runConversation(page, [{ input: "hello" }], {
+      assistantSettleMs: 30,
+    });
+
+    expect(result.turns_completed).toBe(1);
+    // Resolved selector is the V2 textarea testid (cascade slot #1).
+    expect(filledSelectors).toEqual(['[data-testid="copilot-chat-textarea"]']);
+    // And explicitly NOT the wrapper-div selector that `page.fill()` chokes on.
+    expect(filledSelectors).not.toContain('[data-testid="copilot-chat-input"]');
   });
 
   it("honours opts.chatInputSelector when provided (skips cascade)", async () => {

--- a/showcase/ops/src/probes/helpers/conversation-runner.ts
+++ b/showcase/ops/src/probes/helpers/conversation-runner.ts
@@ -4,7 +4,7 @@
  * Drives a sequence of turns through a CopilotKit chat surface in a
  * Playwright Page. Each turn:
  *
- *   1. Locate the chat input via a 5-selector cascade (mirrors
+ *   1. Locate the chat input via a 6-selector cascade (mirrors
  *      `e2e-demos.ts` so showcases that don't yet expose
  *      `[data-testid="copilot-chat-input"]` still get probed).
  *   2. Fill the input, press Enter.
@@ -29,20 +29,39 @@
 
 /** Chat-input selector cascade — matches `e2e-demos.ts` READY_SELECTORS.
  *
- * Ordering (load-bearing):
- *   1. CopilotKit canonical testid — strictest signal.
- *   2. Default placeholder — covers UIs without the testid.
- *   3-5. Generic chat-affordance fallbacks for custom-composer demos
+ * Ordering (load-bearing — Playwright `fill()` only works on
+ * input/textarea/select/contenteditable elements; matching the wrapper
+ * `<div data-testid="copilot-chat-input">` resolves visibly but throws
+ * on `fill()`. So the cascade MUST resolve to a real fillable element):
+ *
+ *   1. CopilotKit V2 canonical textarea testid — the actual `<textarea>`
+ *      element inside the V2 chat input. Strictest, fillable signal.
+ *   2. Scoped descendant — any `<textarea>` nested under the V2 wrapper
+ *      `[data-testid="copilot-chat-input"]`, for V2 UIs whose textarea
+ *      doesn't carry its own testid.
+ *   3. Bare `textarea` — covers V1 CopilotKit and generic chat UIs whose
+ *      composer is a plain `<textarea>` without a testid.
+ *   4. Default placeholder — V1/V2 input-element composers whose UI uses
+ *      `<input placeholder="Type a message">` instead of a textarea.
+ *   5-6. Generic chat-affordance fallbacks for custom-composer demos
  *        (e.g. `headless-simple`) that build their own UI on top of
  *        `useAgent` and lack both the testid and placeholder.
+ *
+ * Note: the V2 wrapper selector `[data-testid="copilot-chat-input"]` is
+ * intentionally OMITTED here — it matches a `<div>` wrapper, and
+ * `page.fill()` would always throw on it ("Element is not an
+ * <input>, <textarea>, <select> or [contenteditable]"). The visibility-
+ * only `e2e-demos.ts` cascade keeps the same ordering for parity but the
+ * wrapper selector can land further down without affecting that driver.
  *
  * Kept as a const tuple so it's literally the same shape as the
  * e2e-demos cascade. Any divergence is a refactor signal, not a feature.
  */
 const CHAT_INPUT_SELECTORS = [
-  '[data-testid="copilot-chat-input"]',
-  'input[placeholder="Type a message"]',
+  '[data-testid="copilot-chat-textarea"]',
+  '[data-testid="copilot-chat-input"] textarea',
   "textarea",
+  'input[placeholder="Type a message"]',
   'input[type="text"]',
   '[role="textbox"]',
 ] as const;
@@ -145,7 +164,7 @@ export interface ConversationResult {
 
 export interface ConversationRunnerOptions {
   /**
-   * Override the chat-input selector. When set, the 5-selector cascade
+   * Override the chat-input selector. When set, the 6-selector cascade
    * is skipped and only this selector is tried. Useful for showcases
    * with non-standard chat UIs where the cascade would mis-match.
    */
@@ -261,7 +280,7 @@ export async function runConversation(
 }
 
 /**
- * Probe the 5-selector cascade and return the first one that resolves.
+ * Probe the 6-selector cascade and return the first one that resolves.
  * When `override` is provided, only that selector is tried. Each probe
  * uses a short timeout (`SELECTOR_PROBE_TIMEOUT_MS`) so the cascade
  * doesn't multiply the page-level timeout by 5x on showcases where


### PR DESCRIPTION
## Summary

- Reorder `CHAT_INPUT_SELECTORS` (conversation-runner) and `READY_SELECTORS` (e2e-demos) to target `[data-testid="copilot-chat-textarea"]` first instead of the wrapper `[data-testid="copilot-chat-input"]` div
- The wrapper div resolves visibly but `page.fill()` throws because it's a `<div>`, not an `<input>`/`<textarea>` — this caused all D5 conversation probes to fail with `conversation-error` across all 17 packages
- Add new regression test pinning that the wrapper-div selector never reaches `fill()`

## Why

After PR #4305 wired `demos[]→features[]` mapping, D5 probes started running real Playwright conversations but every single one failed. Root cause: the first selector in the cascade matched the CopilotKit V2 wrapper `<div>`, not the actual `<textarea>` inside it. Verified via live Playwright testing against production showcases before writing the fix.

## Test plan

- [x] `nx run @copilotkit/showcase-ops:test` — 1290 passed
- [x] `nx run @copilotkit/showcase-ops:build` — green
- [x] Live Playwright verification: `fill('[data-testid="copilot-chat-textarea"]')` succeeds on production showcases where old selector fails
- [ ] CI green
- [ ] After merge + deploy: trigger D5 probe and verify conversation-error rate drops