### PR TITLE
fix(showcase-ops): dodge Cloudflare rate-limit on Railway GraphQL calls

### DIFF
--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -753,6 +753,30 @@ interface GqlResult<T> {
 
 export const RAILWAY_GRAPHQL_ENDPOINT = ENDPOINT;
 
+/**
+ * Extract the GraphQL operation name from a query string.
+ *
+ * Railway's Cloudflare WAF applies a much stricter rate limit when the
+ * `/graphql/v2` endpoint is called without a query string (error 1015 /
+ * HTTP 429). The community-confirmed workaround — also used by the
+ * official Terraform provider — is to append `?query=<operationName>`
+ * to every request. The value is purely cosmetic from a GraphQL
+ * standpoint (the real query lives in the POST body); Cloudflare just
+ * needs *some* query string to route the request to the relaxed
+ * bucket.
+ *
+ * Returns "anonymous" when the query has no named operation (rare in
+ * this file, but possible if a caller passes a bare selection set).
+ *
+ * Refs:
+ *  - https://station.railway.com/questions/railway-api-cloudflare-rate-limiting-369be022
+ *  - https://station.railway.com/questions/frequent-graph-ql-api-rate-limiting-erro-d4316760
+ */
+export function extractOperationName(query: string): string {
+  const match = query.match(/(?:query|mutation)\s+(\w+)/);
+  return match?.[1] ?? "anonymous";
+}
+
 export function makeGql(opts: {
   fetchImpl: typeof fetch;
   token: string;
@@ -770,7 +794,11 @@ export function makeGql(opts: {
   ): Promise<GqlResult<T>> {
     let res: Response;
     try {
-      res = await fetchImpl(ENDPOINT, {
+      // Append `?query=<operationName>` to dodge Cloudflare's strict
+      // rate-limit bucket for query-string-less GraphQL calls. See
+      // `extractOperationName` for the full rationale.
+      const url = `${ENDPOINT}?query=${extractOperationName(query)}`;
+      res = await fetchImpl(url, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,

--- a/showcase/ops/src/probes/drivers/aimock-wiring.ts
+++ b/showcase/ops/src/probes/drivers/aimock-wiring.ts
@@ -3,6 +3,7 @@ import {
   aimockWiringProbe,
   type AimockWiringSignal,
 } from "../aimock-wiring.js";
+import { extractOperationName } from "../discovery/railway-services.js";
 import type { ProbeDriver } from "../types.js";
 import type { Logger } from "../../types/index.js";
 
@@ -168,7 +169,11 @@ function createRailwayAdapter(
     query: string,
     variables: Record<string, unknown>,
   ): Promise<T> {
-    const res = await fetchImpl(endpoint, {
+    // Append `?query=<operationName>` to dodge Cloudflare's strict
+    // rate-limit bucket for query-string-less GraphQL calls. See
+    // `extractOperationName` for the full rationale.
+    const url = `${endpoint}?query=${extractOperationName(query)}`;
+    const res = await fetchImpl(url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${opts.token}`,


### PR DESCRIPTION
## Summary

- Append `?query=<operationName>` to all Railway GraphQL API calls in showcase-ops
- Fixes Cloudflare error 1015 / HTTP 429 that was blocking all probe discovery runs

## Why

Railway's Cloudflare WAF applies a much stricter rate limit when `/graphql/v2` is called without a query string. showcase-ops makes 34+ per-service variable queries per tick, easily triggering the strict limit. The workaround (confirmed by Railway community and used by the official Terraform provider) is to include any query parameter in the URL.

Refs:
- https://station.railway.com/questions/railway-api-cloudflare-rate-limiting-369be022
- https://station.railway.com/questions/frequent-graph-ql-api-rate-limiting-erro-d4316760

## Test plan

- [x] `tsc -p tsconfig.build.json` passes
- [x] railway-services.test.ts (64 tests) pass
- [x] aimock-wiring tests (41 tests) pass
- [ ] Deploy to Railway and verify discovery stops returning 429s