### PR TITLE
fix(showcase-ops): fix D5 script crashes on package showcases

### DIFF
--- a/showcase/ops/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.test.ts
@@ -82,6 +82,9 @@ function makePage(script: PageScript = {}): E2eDeepPage {
       void fn;
       return messageCount as unknown as R;
     },
+    async click() {
+      /* no-op */
+    },
     async close() {
       /* no-op */
     },

--- a/showcase/ops/src/probes/drivers/e2e-deep.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.ts
@@ -169,6 +169,7 @@ export interface E2eDeepPage extends Page {
     },
   ): Promise<unknown>;
   close(): Promise<void>;
+  click(selector: string, opts?: { timeout?: number }): Promise<void>;
   /**
    * Returns browser-side diagnostic data captured since page creation.
    * Optional because tests inject scripted fakes that don't track
@@ -291,11 +292,9 @@ const defaultLauncher: E2eDeepBrowserLauncher =
               press: (s, k, o) => page.press(s, k, o),
               evaluate: <R>(fn: () => R) => page.evaluate(fn),
               goto: (url, opts) =>
-                page.goto(
-                  url,
-                  opts as Parameters<typeof page.goto>[1],
-                ),
+                page.goto(url, opts as Parameters<typeof page.goto>[1]),
               close: () => page.close(),
+              click: (s, o) => page.click(s, o),
               getDiagnostics: () => ({
                 consoleLogs: consoleLogs.slice(-20),
                 requestFailures: requestFailures.slice(-10),

--- a/showcase/ops/src/probes/scripts/_gen-ui-shared.ts
+++ b/showcase/ops/src/probes/scripts/_gen-ui-shared.ts
@@ -59,7 +59,7 @@ export const GEN_UI_COMPONENT_SELECTORS = [
   '[role="article"]',
 ] as const;
 
-const DEFAULT_RENDER_TIMEOUT_MS = 30_000;
+const DEFAULT_RENDER_TIMEOUT_MS = 45_000;
 const POLL_INTERVAL_MS = 200;
 
 /**
@@ -86,10 +86,34 @@ export async function waitForGenUiComponent(
     await sleep(POLL_INTERVAL_MS);
   }
 
+  const domSnapshot = await page.evaluate(() => {
+    const win = globalThis as unknown as {
+      document: {
+        querySelectorAll(sel: string): ArrayLike<{
+          tagName: string;
+          childElementCount: number;
+          className: string;
+          textContent: string | null;
+        }>;
+      };
+    };
+    const articles = win.document.querySelectorAll('[role="article"]');
+    const summary: string[] = [];
+    for (let i = 0; i < Math.min(articles.length, 5); i++) {
+      const el = articles[i]!;
+      summary.push(
+        `<${el.tagName.toLowerCase()} class="${el.className}" children=${el.childElementCount}>` +
+          `${(el.textContent ?? "").slice(0, 80)}`,
+      );
+    }
+    return summary.length > 0
+      ? summary.join(" | ")
+      : "no [role=article] elements found";
+  });
   throw new Error(
     `gen-ui component did not render within ${timeoutMs}ms (${
       lastError ?? "no candidate selector matched"
-    })`,
+    }; DOM: ${domSnapshot})`,
   );
 }
 

--- a/showcase/ops/src/probes/scripts/d5-agentic-chat.ts
+++ b/showcase/ops/src/probes/scripts/d5-agentic-chat.ts
@@ -104,7 +104,7 @@ function expectAssistantContains(opts: {
   label: string;
 }): (page: Page) => Promise<void> {
   return async (page: Page) => {
-    const transcript = await readAssistantTranscript(page);
+    const transcript = (await readAssistantTranscript(page)) ?? "";
     if (transcript.trim().length === 0) {
       throw new Error(`${opts.label}: assistant response was empty`);
     }
@@ -129,7 +129,7 @@ function expectAssistantContains(opts: {
  */
 function expectAssistantNonEmpty(label: string): (page: Page) => Promise<void> {
   return async (page: Page) => {
-    const transcript = await readAssistantTranscript(page);
+    const transcript = (await readAssistantTranscript(page)) ?? "";
     if (transcript.trim().length === 0) {
       throw new Error(`${label}: assistant response was empty`);
     }

--- a/showcase/ops/src/probes/scripts/d5-shared-state.ts
+++ b/showcase/ops/src/probes/scripts/d5-shared-state.ts
@@ -136,7 +136,7 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
     {
       input: TURN_1_INPUT,
       assertions: async (page: Page) => {
-        const text = await readLatestAssistantText(page);
+        const text = (await readLatestAssistantText(page)) ?? "";
         if (text.length === 0) {
           throw new Error(
             "turn 1: no assistant message text found after settle",
@@ -156,7 +156,7 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
     {
       input: TURN_2_INPUT,
       assertions: async (page: Page) => {
-        const text = await readLatestAssistantText(page);
+        const text = (await readLatestAssistantText(page)) ?? "";
         if (text.length === 0) {
           throw new Error(
             "turn 2: no assistant message text found after settle",


### PR DESCRIPTION
## Summary

- Add `click()` to `E2eDeepPage` interface and `defaultLauncher` wrapped page — unblocks both HITL scripts (hitl-approve-deny, hitl-text-input) that need to drive approval dialogs and time-pickers
- Coerce `page.evaluate()` results with `?? ""` in d5-agentic-chat and d5-shared-state to prevent `undefined.trim()`/`undefined.length` crashes when DOM queries return no assistant messages
- Bump gen-ui render timeout from 30s to 45s and add DOM snapshot diagnostics on failure for actionable debugging

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 17 e2e-deep driver tests pass
- [x] oxfmt check clean
- [ ] Deploy to showcase-ops, trigger D5 run, verify improved green rate on package showcases