### PR TITLE
fix(showcase): restore /ok health probe for langgraph packages

### DIFF
--- a/showcase/packages/langgraph-fastapi/src/app/api/health/route.ts
+++ b/showcase/packages/langgraph-fastapi/src/app/api/health/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest) {
   // Check agent backend reachability
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/health`, {
+    const res = await fetch(`${AGENT_URL}/ok`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/packages/langgraph-python/src/app/api/health/route.ts
+++ b/showcase/packages/langgraph-python/src/app/api/health/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   // Check agent backend reachability
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${LANGGRAPH_URL}/health`, {
+    const res = await fetch(`${LANGGRAPH_URL}/ok`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";

--- a/showcase/packages/langgraph-typescript/src/app/api/health/route.ts
+++ b/showcase/packages/langgraph-typescript/src/app/api/health/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest) {
   // Check agent backend reachability
   let agentStatus = "unknown";
   try {
-    const res = await fetch(`${AGENT_URL}/health`, {
+    const res = await fetch(`${AGENT_URL}/ok`, {
       signal: AbortSignal.timeout(3000),
     });
     agentStatus = res.ok ? "ok" : "error";


### PR DESCRIPTION
## Summary

- Restores the agent health probe URL from `/health` back to `/ok` for the 3 langgraph showcase packages (langgraph-python, langgraph-typescript, langgraph-fastapi)
- PR #4306 changed this URL but the langgraph-cli dev server only exposes `/ok`, not `/health` — causing `/api/health` to return HTTP 503 and Railway healthchecks to fail
- All 3 services have had every deploy fail since #4306 merged (04-27); old 04-25 deployments still serving via Railway overlap

## Test plan

- [ ] CI green
- [ ] After merge + GHCR push, trigger Railway redeploy for all 3 services
- [ ] Verify `/api/health` returns `{"status":"ok"}` (HTTP 200) on each