### PR TITLE
fix(showcase/claude-sdk-typescript): copy full dist tree so agent imports resolve

### DIFF
--- a/showcase/packages/claude-sdk-typescript/Dockerfile
+++ b/showcase/packages/claude-sdk-typescript/Dockerfile
@@ -36,9 +36,10 @@ COPY --chown=app:app --from=builder /app/node_modules ./node_modules
 COPY --chown=app:app --from=builder /app/package.json ./
 COPY --chown=app:app --from=builder /app/public ./public
 
-# Precompiled agent entry (from builder stage). entrypoint.sh invokes
-# `node /app/agent_server.js` instead of `npx tsx src/agent_server.ts`.
-COPY --chown=app:app --from=builder /app/dist/agent_server.js ./agent_server.js
+# Precompiled agent tree (from builder stage) — tsc emits agent_server.js
+# plus agent/*.js prompt modules; copy the whole dist/ tree so require()
+# resolves the sibling imports at runtime.
+COPY --chown=app:app --from=builder /app/dist/ ./
 
 # Entrypoint
 COPY --chown=app:app entrypoint.sh ./


### PR DESCRIPTION
## Summary

- Dockerfile Stage 2 was copying only `dist/agent_server.js`, but tsc emits sibling modules under `dist/agent/` (prompt files imported by agent_server.ts)
- At runtime, `require('./agent/byoc-json-render-prompt')` failed with MODULE_NOT_FOUND
- Fix: copy the entire `dist/` tree instead of a single file

## Test plan

- [ ] CI green
- [ ] After merge + GHCR push, Railway deploy succeeds
- [ ] `/api/health` returns `{"status":"ok"}` with agent healthy