### PR TITLE
fix(showcase-ops): fix ASI bug in D5 probe evaluate patterns

### DIFF
--- a/showcase/ops/src/probes/aimock-fixture-coverage.test.ts
+++ b/showcase/ops/src/probes/aimock-fixture-coverage.test.ts
@@ -252,6 +252,7 @@ function isCovered(prompt: string, fixtures: Fixture[]): boolean {
   }
   const lower = prompt.toLowerCase();
   for (const f of fixtures) {
+    if (!f.match.userMessage) continue;
     const matchLower = f.match.userMessage.toLowerCase();
     if (lower.includes(matchLower)) return true;
   }

--- a/showcase/ops/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.test.ts
@@ -707,19 +707,20 @@ describe("D5_SCRIPT_FILE_MATCHER", () => {
 
 // Regression test for the ASI bug in the page-evaluated transcript reader.
 //
-// readAssistantTranscript ships a `code` string to `page.evaluate(...)`,
-// which Playwright wraps in `new Function("return " + code)()`. When the
-// script source begins with a newline, JavaScript's Automatic Semicolon
-// Insertion (ASI) terminates the `return` statement BEFORE the IIFE runs,
-// so the function returns `undefined` and the assistant message count
-// stays at 0 — the conversation-runner then times out on every turn.
+// D5 probe helpers (readAssistantTranscript, readLatestAssistantText, etc.)
+// build a code string from a template literal, wrap it via
+// `new Function("return " + code)`, and pass the result to `page.evaluate`.
+// When the code string begins with a newline, JavaScript's Automatic
+// Semicolon Insertion (ASI) terminates the `return` statement BEFORE the
+// IIFE runs, so the function returns `undefined` and the assistant message
+// count stays at 0 — the conversation-runner then times out on every turn.
 //
 // The fix is to `.trim()` the code before concatenation so the IIFE
 // follows `return ` on the same line.
 describe("ASI / new Function evaluate", () => {
-  // The exact code shape Playwright's evaluate uses internally:
-  //   new Function("return " + userCode)()
-  // When userCode opens with "\n  (() => ...)()" ASI bites.
+  // The code shape our probe helpers use:
+  //   new Function("return " + code)()
+  // When code opens with "\n  (() => ...)()" ASI bites.
   const codeWithLeadingNewline = '\n  (() => { return "hello"; })()\n';
 
   it("demonstrates the ASI bug: leading-newline code returns undefined", () => {

--- a/showcase/ops/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.test.ts
@@ -735,9 +735,7 @@ describe("ASI / new Function evaluate", () => {
     // The fix: strip leading whitespace/newlines before concatenation
     // so `return` and the IIFE share a line. A trailing semicolon is
     // also added defensively.
-    const fixed = new Function(
-      "return " + codeWithLeadingNewline.trim() + ";",
-    );
+    const fixed = new Function("return " + codeWithLeadingNewline.trim() + ";");
     expect(fixed()).toBe("hello");
   });
 

--- a/showcase/ops/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.test.ts
@@ -704,3 +704,58 @@ describe("D5_SCRIPT_FILE_MATCHER", () => {
     expect(D5_SCRIPT_FILE_MATCHER.test("README.md")).toBe(false);
   });
 });
+
+// Regression test for the ASI bug in the page-evaluated transcript reader.
+//
+// readAssistantTranscript ships a `code` string to `page.evaluate(...)`,
+// which Playwright wraps in `new Function("return " + code)()`. When the
+// script source begins with a newline, JavaScript's Automatic Semicolon
+// Insertion (ASI) terminates the `return` statement BEFORE the IIFE runs,
+// so the function returns `undefined` and the assistant message count
+// stays at 0 — the conversation-runner then times out on every turn.
+//
+// The fix is to `.trim()` the code before concatenation so the IIFE
+// follows `return ` on the same line.
+describe("ASI / new Function evaluate", () => {
+  // The exact code shape Playwright's evaluate uses internally:
+  //   new Function("return " + userCode)()
+  // When userCode opens with "\n  (() => ...)()" ASI bites.
+  const codeWithLeadingNewline = '\n  (() => { return "hello"; })()\n';
+
+  it("demonstrates the ASI bug: leading-newline code returns undefined", () => {
+    // This mirrors the BROKEN call shape:
+    //   new Function("return " + "\n  (() => {...})()\n")()
+    // ASI inserts a semicolon after `return`, the IIFE becomes dead
+    // code, and the function returns undefined.
+    const broken = new Function("return " + codeWithLeadingNewline);
+    expect(broken()).toBeUndefined();
+  });
+
+  it("trim() fix: leading newline removed → IIFE is reached and value returned", () => {
+    // The fix: strip leading whitespace/newlines before concatenation
+    // so `return` and the IIFE share a line. A trailing semicolon is
+    // also added defensively.
+    const fixed = new Function(
+      "return " + codeWithLeadingNewline.trim() + ";",
+    );
+    expect(fixed()).toBe("hello");
+  });
+
+  it("ASI bug also bites realistic transcript-reader code shape", () => {
+    // Approximates the readAssistantTranscript pattern: a page-side
+    // IIFE that walks the DOM and returns a count. Without trim() the
+    // function returns undefined; with trim() it returns the count.
+    const transcriptLikeCode = `
+      (() => {
+        const fakeMessages = [1, 2, 3];
+        return fakeMessages.length;
+      })()
+    `;
+
+    const broken = new Function("return " + transcriptLikeCode);
+    expect(broken()).toBeUndefined();
+
+    const fixed = new Function("return " + transcriptLikeCode.trim() + ";");
+    expect(fixed()).toBe(3);
+  });
+});

--- a/showcase/ops/src/probes/helpers/reference-capture.ts
+++ b/showcase/ops/src/probes/helpers/reference-capture.ts
@@ -432,7 +432,7 @@ export async function serializeRelevantDom(
   // conversation-runner's type-erased indirection, only this one
   // captures local constants via string interpolation rather than via
   // closure (closures don't survive the evaluate boundary).
-  const fn = new Function(`return ${code};`) as () => {
+  const fn = new Function(`return ${code.trim()};`) as () => {
     fallback: boolean;
     elements: Array<{ tag: string; classes: string[]; testId?: string }>;
   };

--- a/showcase/ops/src/probes/scripts/_gen-ui-shared.ts
+++ b/showcase/ops/src/probes/scripts/_gen-ui-shared.ts
@@ -270,7 +270,7 @@ export async function readLastAssistantText(page: Page): Promise<string> {
       return (last && last.textContent ? last.textContent : "").trim();
     })()
   `;
-  const fn = new Function(`return ${code};`) as () => string;
+  const fn = new Function(`return ${code.trim()};`) as () => string;
   return await page.evaluate(fn);
 }
 

--- a/showcase/ops/src/probes/scripts/_hitl-shared.ts
+++ b/showcase/ops/src/probes/scripts/_hitl-shared.ts
@@ -282,7 +282,7 @@ export async function readAssistantCount(page: Page): Promise<number> {
         return fallback.length;
       })()
     `;
-    const fn = new Function(`return ${code};`) as () => number;
+    const fn = new Function(`return ${code.trim()};`) as () => number;
     return await page.evaluate(fn);
   } catch {
     return 0;
@@ -313,7 +313,7 @@ async function readLatestAssistantText(page: Page): Promise<string> {
         return (last && last.textContent ? last.textContent : "").trim();
       })()
     `;
-    const fn = new Function(`return ${code};`) as () => string;
+    const fn = new Function(`return ${code.trim()};`) as () => string;
     return await page.evaluate(fn);
   } catch {
     return "";

--- a/showcase/ops/src/probes/scripts/d5-agentic-chat.ts
+++ b/showcase/ops/src/probes/scripts/d5-agentic-chat.ts
@@ -81,7 +81,7 @@ async function readAssistantTranscript(page: Page): Promise<string> {
       return out.toLowerCase();
     })()
   `;
-  const fn = new Function(`return ${code};`) as () => string;
+  const fn = new Function(`return ${code.trim()};`) as () => string;
   return page.evaluate(fn);
 }
 

--- a/showcase/ops/src/probes/scripts/d5-shared-state.ts
+++ b/showcase/ops/src/probes/scripts/d5-shared-state.ts
@@ -110,7 +110,7 @@ async function readLatestAssistantText(page: Page): Promise<string> {
       return text.toLowerCase();
     })()
   `;
-  const fn = new Function(`return ${code};`) as () => string;
+  const fn = new Function(`return ${code.trim()};`) as () => string;
   return page.evaluate(fn);
 }
 


### PR DESCRIPTION
## Summary
- Fix JavaScript ASI (Automatic Semicolon Insertion) bug in `new Function('return \n...')` patterns that caused all D5 probe evaluate calls to return `undefined` instead of actual DOM query results
- Add `.trim()` to 6 occurrences across 5 files so `return` and the IIFE expression share a line
- Add regression test proving the ASI bug and verifying the fix
- Fix pre-existing test failure in `aimock-fixture-coverage.test.ts` where `toolCallId`-only fixtures crashed the `isCovered` function

## Why
17 of 34 D5 showcase probes were failing because `readAssistantTranscript`, `readLatestAssistantText`, `readAssistantCount`, and `readLastAssistantText` all returned `undefined` from their `page.evaluate()` calls. Root cause: `new Function('return ${code}')` where `code` starts with a newline — ASI inserts a semicolon after `return`, making the IIFE dead code.

## Test plan
- [x] Regression test proves ASI bug returns `undefined` without `.trim()` and `"hello"` with it
- [x] All 1293 showcase-ops tests pass (including the previously-broken fixture coverage test)
- [x] TypeScript compiles clean
- [x] oxfmt clean
- [ ] CI green
- [ ] Deploy to Railway, trigger D5 probes, verify improvement