### PR TITLE
fix(showcase-ops): wait for React hydration before D5 probe interaction

### DIFF
--- a/showcase/ops/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.test.ts
@@ -85,6 +85,9 @@ function makePage(script: PageScript = {}): E2eDeepPage {
     async click() {
       /* no-op */
     },
+    async waitForFunction() {
+      /* hydration guard — fake passes immediately */
+    },
     async close() {
       /* no-op */
     },

--- a/showcase/ops/src/probes/drivers/e2e-deep.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.ts
@@ -164,12 +164,24 @@ export interface E2eDeepPage extends Page {
   goto(
     url: string,
     opts?: {
-      waitUntil?: "networkidle" | "domcontentloaded";
+      waitUntil?: "networkidle" | "domcontentloaded" | "load";
       timeout?: number;
     },
   ): Promise<unknown>;
   close(): Promise<void>;
   click(selector: string, opts?: { timeout?: number }): Promise<void>;
+  /**
+   * Poll a browser-side predicate until it returns truthy. Used by the
+   * driver to wait for React hydration to attach `__react*` properties
+   * to the SSR'd chat textarea before the conversation runner tries to
+   * fill + Enter. Without this guard the keypress fires before React
+   * has bound `onKeyDown`, the request never goes out, and the probe
+   * times out with a "no assistant response" error.
+   */
+  waitForFunction(
+    fn: () => boolean,
+    opts?: { timeout?: number },
+  ): Promise<unknown>;
   /**
    * Returns browser-side diagnostic data captured since page creation.
    * Optional because tests inject scripted fakes that don't track
@@ -295,6 +307,12 @@ const defaultLauncher: E2eDeepBrowserLauncher =
                 page.goto(url, opts as Parameters<typeof page.goto>[1]),
               close: () => page.close(),
               click: (s, o) => page.click(s, o),
+              waitForFunction: (fn, opts) =>
+                page.waitForFunction(
+                  fn as Parameters<typeof page.waitForFunction>[0],
+                  undefined,
+                  opts,
+                ),
               getDiagnostics: () => ({
                 consoleLogs: consoleLogs.slice(-20),
                 requestFailures: requestFailures.slice(-10),
@@ -764,7 +782,7 @@ async function runFeature(opts: {
     // sufficient.
     try {
       await page.goto(url, {
-        waitUntil: "domcontentloaded",
+        waitUntil: "load",
         timeout: pageTimeoutMs,
       });
     } catch (err) {
@@ -774,6 +792,37 @@ async function runFeature(opts: {
         errorClass: "goto-error",
         errorDesc: truncateUtf8(msg, 1200),
       };
+    }
+
+    // Wait for React hydration — React attaches __reactFiber$* and
+    // __reactProps$* properties to DOM elements during hydration.
+    // Without this, the SSR'd textarea is visible but Enter has no
+    // handler, so the first turn's keypress is a no-op and the probe
+    // times out waiting for an assistant response that never comes.
+    try {
+      await page.waitForFunction(
+        () => {
+          // DOM types reached via type-erased indirection — the
+          // package's tsconfig excludes the `dom` lib. Same pattern
+          // used in `captureDiagnostics()` below.
+          const win = globalThis as unknown as {
+            document: {
+              querySelector(sel: string): object | null;
+            };
+          };
+          const el = win.document.querySelector(
+            '[data-testid="copilot-chat-textarea"], [data-testid="copilot-chat"] textarea, textarea',
+          );
+          if (!el) return false;
+          return Object.getOwnPropertyNames(el).some((k) =>
+            k.startsWith("__react"),
+          );
+        },
+        { timeout: 15_000 },
+      );
+    } catch {
+      // Non-fatal — proceed anyway; worst case is a downstream timeout
+      // error that's more diagnosable than "assistant did not respond".
     }
 
     const turns = script.buildTurns(buildCtx);


### PR DESCRIPTION
## Summary

- Fixes the dominant D5 e2e-deep probe failure mode (62/114 red cells across all 17 package services)
- Root cause: the probe navigated with `waitUntil:"domcontentloaded"`, found the SSR-rendered textarea instantly, and pressed Enter before React hydrated — the onKeyDown handler wasn't bound yet, so the keypress was a no-op
- Switch to `waitUntil:"load"` and add an explicit `waitForFunction` guard that polls for React's `__reactFiber$*` property on the textarea (definitive hydration signal, 15s non-fatal timeout)

## Why

All 17 package services were failing 100% of D5 features. Manual Playwright testing confirmed the same pages work correctly when interaction is delayed by human typing speed. The ASI fix from #4313 eliminated its specific error class but didn't address this timing race.

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 1293 showcase-ops tests pass
- [x] oxfmt formatting clean
- [ ] CI green
- [ ] Deploy to Railway, trigger D5 probe run, verify improved pass rate