### PR TITLE
fix(showcase-ops): fix D5 probe selectors, routes, and headless attributes

### DIFF
--- a/showcase/ops/src/probes/drivers/e2e-deep.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.ts
@@ -229,7 +229,7 @@ const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_PAGE_TIMEOUT_MS = 30 * 1000;
 
 /** Default route shape for a feature when the script doesn't override. */
-function defaultRoute(featureType: D5FeatureType): string {
+function defaultRoute(featureType: D5FeatureType, _ctx?: unknown): string {
   return `/demos/${featureType}`;
 }
 
@@ -617,7 +617,9 @@ export function createE2eDeepDriver(
         for (const ft of runnable) {
           const sideKey = `d5:${slug}/${ft}`;
           const script = D5_REGISTRY.get(ft)!;
-          const route = (script.preNavigateRoute ?? defaultRoute)(ft);
+          const route = (script.preNavigateRoute ?? defaultRoute)(ft, {
+            demos: input.demos,
+          });
           const url = `${backendUrl}${route}`;
 
           if (abort.signal.aborted) {

--- a/showcase/ops/src/probes/drivers/e2e-parity.ts
+++ b/showcase/ops/src/probes/drivers/e2e-parity.ts
@@ -101,6 +101,15 @@ const inputSchema = z
      * skipped with a green note row.
      */
     features: z.array(z.string()).optional(),
+    /**
+     * Registry-feature-id list (`feature-registry.json` `features[].id`)
+     * for this integration. Optional — when present, the driver hands
+     * the list to `D5Script.preNavigateRoute` so scripts can vary the
+     * navigation path based on which legacy / modern demo IDs the
+     * integration declares (e.g. legacy `hitl` route vs. modern
+     * `hitl-in-chat` route).
+     */
+    demos: z.array(z.string()).optional(),
     shape: showcaseShapeSchema.optional(),
   })
   .passthrough()
@@ -276,7 +285,7 @@ const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 600s — covers conversation + DOM
 const DEFAULT_PAGE_TIMEOUT_MS = 30 * 1000;
 
 /** Default route shape for a feature when the script doesn't override. */
-function defaultRoute(featureType: D5FeatureType): string {
+function defaultRoute(featureType: D5FeatureType, _ctx?: unknown): string {
   return `/demos/${featureType}`;
 }
 
@@ -678,7 +687,9 @@ export function createE2eParityDriver(
         const sideObservedAt = ctx.now().toISOString();
         for (const ft of requestedKnown) {
           const script = D5_REGISTRY.get(ft);
-          const route = (script?.preNavigateRoute ?? defaultRoute)(ft);
+          const route = (script?.preNavigateRoute ?? defaultRoute)(ft, {
+            demos: input.demos,
+          });
           const url = `${backendUrl}${route}`;
           await sideEmit(ctx, {
             key: `d6:${slug}/${ft}`,
@@ -909,7 +920,9 @@ export function createE2eParityDriver(
           for (const ft of runnable) {
             const script = D5_REGISTRY.get(ft);
             const sideKey = `d6:${slug}/${ft}`;
-            const route = (script?.preNavigateRoute ?? defaultRoute)(ft);
+            const route = (script?.preNavigateRoute ?? defaultRoute)(ft, {
+              demos: input.demos,
+            });
             const url = `${backendUrl}${route}`;
             await sideEmit(ctx, {
               key: sideKey,
@@ -955,7 +968,9 @@ export function createE2eParityDriver(
           const script = D5_REGISTRY.get(ft)!;
           const reference = referenceSnapshots.get(ft)!;
           const refPath = referencePaths.get(ft);
-          const route = (script.preNavigateRoute ?? defaultRoute)(ft);
+          const route = (script.preNavigateRoute ?? defaultRoute)(ft, {
+            demos: input.demos,
+          });
           const url = `${backendUrl}${route}`;
 
           if (abort.signal.aborted) {

--- a/showcase/ops/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/ops/src/probes/helpers/conversation-runner.test.ts
@@ -430,14 +430,21 @@ describe("runConversation", () => {
         if (sel === '[data-testid="copilot-assistant-message"]') {
           return { length: 0 };
         }
-        // Tagged-assistant articles: 0 (forces last-resort path).
+        // Tagged-assistant articles: 0 (forces narrowed-article path).
         if (sel === '[role="article"][data-message-role="assistant"]') {
           return { length: 0 };
         }
-        // Last-resort selector excludes user-tagged articles.
+        // Narrowed-article selector excludes user-tagged articles.
         // First call (baseline) → 0; subsequent calls → 2 (settled).
         if (sel === '[role="article"]:not([data-message-role="user"])') {
           return { length: evalCount === 0 ? 0 : 2 };
+        }
+        // Headless tier: present in cascade for custom-composer demos
+        // (e.g. headless-simple) that don't use [role="article"].
+        // Returns 0 here so the narrowed-article tier is the one that
+        // actually drives the settle loop.
+        if (sel === '[data-message-role="assistant"]') {
+          return { length: 0 };
         }
         // ANY other [role="article"] selector means we leaked the
         // unscoped fallback that this fix was supposed to remove.

--- a/showcase/ops/src/probes/helpers/conversation-runner.ts
+++ b/showcase/ops/src/probes/helpers/conversation-runner.ts
@@ -77,18 +77,26 @@ const CHAT_INPUT_SELECTORS = [
  * bubbles toward the assistant total). Pinning the selector here is
  * the single-source-of-truth fix.
  *
- * The cascade has two preferences:
+ * The cascade has three preferences:
  *   1. `[data-testid="copilot-assistant-message"]` — canonical CopilotKit testid.
  *   2. `[role="article"]:not([data-message-role="user"])` — generic
- *      ARIA + explicit user-bubble exclusion. This last clause is
+ *      ARIA + explicit user-bubble exclusion. This clause is
  *      load-bearing: some composers tag their bubbles
  *      `[role="article"][data-message-role="user"]` and a bare
  *      `[role="article"]` would over-count.
+ *   3. `[data-message-role="assistant"]` — last-resort fallback for
+ *      headless / custom-composer demos that don't wrap bubbles in
+ *      `[role="article"]` at all. The headless-simple template tags
+ *      its assistant `<div>` with `data-message-role="assistant"` so
+ *      the runner can still detect "response settled" without the
+ *      canonical CopilotKit testids being present.
  */
 export const ASSISTANT_MESSAGE_PRIMARY_SELECTOR =
   '[data-testid="copilot-assistant-message"]';
 export const ASSISTANT_MESSAGE_FALLBACK_SELECTOR =
   '[role="article"]:not([data-message-role="user"])';
+export const ASSISTANT_MESSAGE_HEADLESS_SELECTOR =
+  '[data-message-role="assistant"]';
 
 const DEFAULT_RESPONSE_TIMEOUT_MS = 30_000;
 const DEFAULT_SETTLE_MS = 1500;
@@ -341,14 +349,23 @@ async function readMessageCount(page: Page): Promise<number> {
         '[role="article"][data-message-role="assistant"]',
       );
       if (tagged.length > 0) return tagged.length;
-      // Last resort: any [role="article"] that is NOT explicitly
-      // tagged as a user message. This still matches untagged
-      // articles (the historical behaviour) but excludes user
-      // bubbles that some composers tag with `data-message-role="user"`.
+      // Next: any [role="article"] that is NOT explicitly tagged as a
+      // user message. This still matches untagged articles (the
+      // historical behaviour) but excludes user bubbles that some
+      // composers tag with `data-message-role="user"`.
       const fallback = win.document.querySelectorAll(
         '[role="article"]:not([data-message-role="user"])',
       );
-      return fallback.length;
+      if (fallback.length > 0) return fallback.length;
+      // Last resort: headless / custom-composer demos that don't use
+      // [role="article"] at all but tag their assistant bubble with
+      // `data-message-role="assistant"`. Without this tier the runner
+      // would never detect "response settled" on the headless-simple
+      // template since none of the prior selectors match its DOM.
+      const headless = win.document.querySelectorAll(
+        '[data-message-role="assistant"]',
+      );
+      return headless.length;
     });
   } catch {
     return 0;

--- a/showcase/ops/src/probes/helpers/d5-registry.ts
+++ b/showcase/ops/src/probes/helpers/d5-registry.ts
@@ -93,6 +93,25 @@ export interface D5BuildContext {
 }
 
 /**
+ * Optional context handed to `D5Script.preNavigateRoute`. Scripts that
+ * need to vary the navigation route based on which registry demo IDs
+ * triggered this featureType (e.g. legacy `hitl` vs. modern
+ * `hitl-in-chat`) can read `demos` and branch. Existing scripts that
+ * take no arguments continue to work unchanged — the parameter is
+ * optional and ignored by zero-arg implementations.
+ *
+ * `demos` mirrors the `demos[]` populated by `railway-services`
+ * discovery from `feature-registry.json` for this integration. When
+ * the driver doesn't have demo information available (e.g. tests
+ * passing `features` directly, or e2e-parity's snapshot path) the
+ * field is omitted; scripts must therefore tolerate a missing /
+ * empty `demos` and return a sensible default route.
+ */
+export interface D5RouteContext {
+  demos?: readonly string[];
+}
+
+/**
  * D5 script contract. One file under `src/probes/scripts/d5-<name>.ts`
  * exports a top-level `registerD5Script(...)` call with this shape.
  *
@@ -116,7 +135,10 @@ export interface D5Script {
   featureTypes: D5FeatureType[];
   fixtureFile: string;
   buildTurns: (ctx: D5BuildContext) => ConversationTurn[];
-  preNavigateRoute?: (featureType: D5FeatureType) => string;
+  preNavigateRoute?: (
+    featureType: D5FeatureType,
+    ctx?: D5RouteContext,
+  ) => string;
 }
 
 /**

--- a/showcase/ops/src/probes/scripts/_gen-ui-shared.ts
+++ b/showcase/ops/src/probes/scripts/_gen-ui-shared.ts
@@ -28,6 +28,7 @@
 
 import {
   ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
+  ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
   ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
   type Page,
 } from "../helpers/conversation-runner.js";
@@ -43,9 +44,15 @@ import {
  *        showcases attach to the wrapper around `useComponent` output.
  *   4.   `.copilotkit-render-component` — class hook some custom-composer
  *        renderers attach when calling `useRenderToolCall`.
- *   5-6. Generic structural fallbacks — `[role="article"]` is what the
- *        chat-message renderer wraps each assistant message in; an SVG
- *        anywhere on the page indicates a chart-style component
+ *   5-7. Canonical V2 assistant-message scoped fallbacks. The V2 chat
+ *        wraps each assistant bubble in
+ *        `[data-testid="copilot-assistant-message"]`, and gen-UI
+ *        components materialise INSIDE that bubble (e.g. an SVG chart,
+ *        or a testid-tagged custom component). Try SVG first (chart
+ *        shape), then any nested testid, then the bubble itself.
+ *   8-9. Generic structural fallbacks — `[role="article"]` is what
+ *        older chat-message renderers wrap each assistant message in;
+ *        an SVG anywhere on the page indicates a chart-style component
  *        materialised. Both are last-resort and intentionally broad.
  *
  * Kept as a const tuple so the order is preserved across iteration.
@@ -55,6 +62,9 @@ export const GEN_UI_COMPONENT_SELECTORS = [
   '[data-testid="gen-ui-component"]',
   "[data-tool-name]",
   ".copilotkit-render-component",
+  '[data-testid="copilot-assistant-message"] svg',
+  '[data-testid="copilot-assistant-message"] [data-testid]',
+  '[data-testid="copilot-assistant-message"]',
   '[role="article"] svg',
   '[role="article"]',
 ] as const;
@@ -145,6 +155,9 @@ async function findFirstNonTrivial(
       '[data-testid="gen-ui-component"]',
       "[data-tool-name]",
       ".copilotkit-render-component",
+      '[data-testid="copilot-assistant-message"] svg',
+      '[data-testid="copilot-assistant-message"] [data-testid]',
+      '[data-testid="copilot-assistant-message"]',
       '[role="article"] svg',
       '[role="article"]',
     ];
@@ -260,11 +273,16 @@ export async function readLastAssistantText(page: Page): Promise<string> {
       const canonical = doc.querySelectorAll(${JSON.stringify(
         ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
       )});
-      const list = canonical.length > 0
+      let list = canonical.length > 0
         ? canonical
         : doc.querySelectorAll(${JSON.stringify(
           ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
         )});
+      if (list.length === 0) {
+        list = doc.querySelectorAll(${JSON.stringify(
+          ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
+        )});
+      }
       if (list.length === 0) return "";
       const last = list[list.length - 1];
       return (last && last.textContent ? last.textContent : "").trim();

--- a/showcase/ops/src/probes/scripts/d5-hitl-text-input.test.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-text-input.test.ts
@@ -107,6 +107,57 @@ describe("d5-hitl-text-input script", () => {
   });
 });
 
+describe("d5-hitl-text-input preNavigateRoute branching", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("returns /demos/hitl-in-chat when no demos context is supplied (default)", async () => {
+    const mod = await import("./d5-hitl-text-input.js");
+    expect(mod.preNavigateRoute("hitl-text-input")).toBe("/demos/hitl-in-chat");
+  });
+
+  it("returns /demos/hitl-in-chat when modern in-chat ids are declared", async () => {
+    const mod = await import("./d5-hitl-text-input.js");
+    expect(
+      mod.preNavigateRoute("hitl-text-input", { demos: ["hitl-in-chat"] }),
+    ).toBe("/demos/hitl-in-chat");
+    expect(
+      mod.preNavigateRoute("hitl-text-input", {
+        demos: ["hitl-in-chat-booking"],
+      }),
+    ).toBe("/demos/hitl-in-chat");
+    expect(
+      mod.preNavigateRoute("hitl-text-input", { demos: ["gen-ui-interrupt"] }),
+    ).toBe("/demos/hitl-in-chat");
+  });
+
+  it("returns /demos/hitl when only the legacy hitl id is declared", async () => {
+    const mod = await import("./d5-hitl-text-input.js");
+    expect(mod.preNavigateRoute("hitl-text-input", { demos: ["hitl"] })).toBe(
+      "/demos/hitl",
+    );
+  });
+
+  it("prefers the modern route when both legacy and modern ids are declared", async () => {
+    const mod = await import("./d5-hitl-text-input.js");
+    expect(
+      mod.preNavigateRoute("hitl-text-input", {
+        demos: ["hitl", "hitl-in-chat"],
+      }),
+    ).toBe("/demos/hitl-in-chat");
+  });
+
+  it("falls back to /demos/hitl-in-chat when demos are present but unmatched", async () => {
+    const mod = await import("./d5-hitl-text-input.js");
+    expect(
+      mod.preNavigateRoute("hitl-text-input", {
+        demos: ["agentic-chat", "tool-rendering"],
+      }),
+    ).toBe("/demos/hitl-in-chat");
+  });
+});
+
 describe("d5-hitl-text-input registry side-effect", () => {
   it("populates the registry with the feature type after import", async () => {
     __clearD5RegistryForTesting();

--- a/showcase/ops/src/probes/scripts/d5-hitl-text-input.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-text-input.ts
@@ -25,7 +25,19 @@
  *
  * Route override: feature type `hitl-text-input` would default to
  * `/demos/hitl-text-input`, which doesn't exist. The reference showcase
- * exposes the demo at `/demos/hitl-in-chat`.
+ * (langgraph-python) exposes the demo at `/demos/hitl-in-chat`, but
+ * several legacy integrations (langgraph-fastapi, langgraph-typescript,
+ * ms-agent-python, pydantic-ai, langroid, claude-sdk-typescript) only
+ * expose `/demos/hitl/` — they declare the legacy `hitl` registry id
+ * rather than the modern `hitl-in-chat` id. We branch on which demo
+ * id triggered this featureType (via `D5RouteContext.demos`): if the
+ * integration declares any of the modern in-chat ids
+ * (`hitl-in-chat`, `hitl-in-chat-booking`, `gen-ui-interrupt`) we use
+ * `/demos/hitl-in-chat`; if it ONLY declares the legacy `hitl` id we
+ * use `/demos/hitl`. When the driver passes no demos context (tests,
+ * e2e-parity without registry context) we keep the modern default —
+ * that's the canonical reference path and matches every integration
+ * that has been updated to the modern id set.
  *
  * Assertion: the follow-up assistant message references the booking.
  * "Alice" is the load-bearing token from the fixture — the
@@ -36,7 +48,7 @@
  */
 
 import { registerD5Script } from "../helpers/d5-registry.js";
-import type { D5Script } from "../helpers/d5-registry.js";
+import type { D5RouteContext, D5Script } from "../helpers/d5-registry.js";
 import {
   pickTimeSlot,
   readAssistantCount,
@@ -54,10 +66,56 @@ import type { Page as ConversationPage } from "../helpers/conversation-runner.js
  */
 const REFERENCE_TOKENS = ["Alice"] as const;
 
+/**
+ * Modern in-chat HITL registry ids — every integration that exposes
+ * `/demos/hitl-in-chat` declares at least one of these in its
+ * `feature-registry.json` entry. Source-of-truth mirror of the keys in
+ * `helpers/d5-feature-mapping.ts` that map to the `hitl-text-input`
+ * D5 type. Kept as a tuple (not imported from the mapping) so this
+ * script stays decoupled — the mapping table is allowed to grow new
+ * legacy ids without forcing this script to relink.
+ */
+const MODERN_IN_CHAT_DEMO_IDS = [
+  "hitl-in-chat",
+  "hitl-in-chat-booking",
+  "gen-ui-interrupt",
+] as const;
+
+/**
+ * Resolve the navigation route based on which registry demo ids the
+ * integration declares. Exported for unit tests so the branching logic
+ * can be exercised without booting the full driver pipeline.
+ */
+export function preNavigateRoute(
+  _featureType: unknown,
+  ctx?: D5RouteContext,
+): string {
+  const demos = ctx?.demos ?? [];
+  if (demos.length === 0) {
+    // No demos context (tests, e2e-parity without registry join, or a
+    // service whose discovery record carried an empty `demos[]`).
+    // Default to the modern reference path — every integration in the
+    // current fleet either declares modern in-chat ids OR the legacy
+    // `hitl` id, and the legacy branch only fires when we have proof
+    // (an explicit `hitl` entry) that the legacy route is the right
+    // one.
+    return "/demos/hitl-in-chat";
+  }
+  const hasModern = demos.some((id) =>
+    (MODERN_IN_CHAT_DEMO_IDS as readonly string[]).includes(id),
+  );
+  if (hasModern) return "/demos/hitl-in-chat";
+  if (demos.includes("hitl")) return "/demos/hitl";
+  // Demos present but none of the known hitl ids matched — fall back
+  // to the modern reference path so a future registry id we haven't
+  // taught this script about doesn't silently 404.
+  return "/demos/hitl-in-chat";
+}
+
 const script: D5Script = {
   featureTypes: ["hitl-text-input"],
   fixtureFile: "hitl-text-input.json",
-  preNavigateRoute: () => "/demos/hitl-in-chat",
+  preNavigateRoute,
   buildTurns: () => [
     {
       input: "Book a 30-minute onboarding call for Alice",

--- a/showcase/packages/ag2/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/headless-simple/page.tsx
@@ -79,6 +79,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -89,7 +90,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content as React.ReactNode}

--- a/showcase/packages/agno/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/agno/src/app/demos/headless-simple/page.tsx
@@ -74,6 +74,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -84,7 +85,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {typeof m.content === "string" ? m.content : ""}

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/crewai-crews/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/headless-simple/page.tsx
@@ -74,6 +74,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -84,7 +85,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/langgraph-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/langgraph-typescript/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
@@ -74,6 +74,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -84,7 +85,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/llamaindex/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/headless-simple/page.tsx
@@ -74,6 +74,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -84,7 +85,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content as React.ReactNode}

--- a/showcase/packages/mastra/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/ms-agent-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/pydantic-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/headless-simple/page.tsx
@@ -74,6 +74,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -84,7 +85,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/spring-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/headless-simple/page.tsx
@@ -74,6 +74,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -84,7 +85,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content as React.ReactNode}

--- a/showcase/packages/strands/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/strands/src/app/demos/headless-simple/page.tsx
@@ -82,6 +82,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -92,7 +93,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}


### PR DESCRIPTION
## Summary

Fixes three categories of D5 e2e-deep probe failures discovered after the hydration-race fix (PR #4315):

- **hitl-text-input route 404**: Probe hardcoded `/demos/hitl-in-chat` but legacy services serve at `/demos/hitl`. Added context-aware routing via D5RouteContext that inspects the service's demo list.
- **gen-ui selector cascade mismatch**: Probe looked for `[role="article"]` and `[data-testid="gen-ui-card"]` which don't exist in V2 CopilotKit DOM. Added V2-canonical selectors (`[data-testid="copilot-assistant-message"]` variants).
- **Headless-simple missing message-role attributes**: 16 headless-simple demos render bare `<div>` elements with no testids or roles. Added `data-message-role="assistant"` and `data-message-role="user"` attributes, plus a new fallback tier in conversation-runner.

Together with the hydration fix, these changes move D5 probe pass rate from 0% to an estimated 60-70%.

## Test plan

- [ ] `nx run @copilotkit/showcase-ops:test` passes (hitl route, gen-ui selector, conversation-runner tests)
- [ ] D5 e2e-deep probe run after deploy shows improvement on hitl-text-input, gen-ui-custom, gen-ui-headless features
- [ ] Headless-simple demos render with `data-message-role` attributes in browser