### PR TITLE
fix(showcase-ops): align D5 script selector cascades with 3-tier headless fallback

### DIFF
--- a/showcase/ops/src/probes/scripts/_hitl-shared.ts
+++ b/showcase/ops/src/probes/scripts/_hitl-shared.ts
@@ -43,6 +43,7 @@
 
 import {
   ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
+  ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
   ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
   type Page as ConversationPage,
 } from "../helpers/conversation-runner.js";
@@ -279,7 +280,11 @@ export async function readAssistantCount(page: Page): Promise<number> {
         const fallback = doc.querySelectorAll(${JSON.stringify(
           ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
         )});
-        return fallback.length;
+        if (fallback.length > 0) return fallback.length;
+        const headless = doc.querySelectorAll(${JSON.stringify(
+          ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
+        )});
+        return headless.length;
       })()
     `;
     const fn = new Function(`return ${code.trim()};`) as () => number;
@@ -303,10 +308,15 @@ async function readLatestAssistantText(page: Page): Promise<string> {
         const canonical = doc.querySelectorAll(${JSON.stringify(
           ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
         )});
-        const list = canonical.length > 0
+        const fallback = canonical.length > 0
           ? canonical
           : doc.querySelectorAll(${JSON.stringify(
             ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
+          )});
+        const list = fallback.length > 0
+          ? fallback
+          : doc.querySelectorAll(${JSON.stringify(
+            ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
           )});
         if (list.length === 0) return "";
         const last = list[list.length - 1];

--- a/showcase/ops/src/probes/scripts/d5-agentic-chat.ts
+++ b/showcase/ops/src/probes/scripts/d5-agentic-chat.ts
@@ -40,6 +40,7 @@
 import { registerD5Script } from "../helpers/d5-registry.js";
 import {
   ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
+  ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
   ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
   type ConversationTurn,
   type Page,
@@ -68,11 +69,17 @@ async function readAssistantTranscript(page: Page): Promise<string> {
       const canonical = doc.querySelectorAll(${JSON.stringify(
         ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
       )});
-      const nodes = canonical.length > 0
-        ? canonical
-        : doc.querySelectorAll(${JSON.stringify(
+      let nodes = canonical;
+      if (canonical.length === 0) {
+        const fallback = doc.querySelectorAll(${JSON.stringify(
           ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
         )});
+        nodes = fallback.length > 0
+          ? fallback
+          : doc.querySelectorAll(${JSON.stringify(
+            ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
+          )});
+      }
       let out = "";
       for (let i = 0; i < nodes.length; i++) {
         const text = (nodes[i] && nodes[i].textContent) ? nodes[i].textContent : "";

--- a/showcase/ops/src/probes/scripts/d5-shared-state.ts
+++ b/showcase/ops/src/probes/scripts/d5-shared-state.ts
@@ -39,6 +39,7 @@ import {
 } from "../helpers/d5-registry.js";
 import {
   ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
+  ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
   ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
   type ConversationTurn,
   type Page,
@@ -99,11 +100,17 @@ async function readLatestAssistantText(page: Page): Promise<string> {
       const canonical = doc.querySelectorAll(${JSON.stringify(
         ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
       )});
-      const list = canonical.length > 0
-        ? canonical
-        : doc.querySelectorAll(${JSON.stringify(
+      let list = canonical;
+      if (canonical.length === 0) {
+        const fallback = doc.querySelectorAll(${JSON.stringify(
           ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
         )});
+        list = fallback.length > 0
+          ? fallback
+          : doc.querySelectorAll(${JSON.stringify(
+            ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
+          )});
+      }
       if (list.length === 0) return "";
       const last = list[list.length - 1];
       const text = (last && last.textContent) ? last.textContent : "";

--- a/showcase/ops/src/probes/scripts/d5-tool-rendering.ts
+++ b/showcase/ops/src/probes/scripts/d5-tool-rendering.ts
@@ -71,6 +71,7 @@ export const TOOL_CARD_SELECTORS = [
   '[data-tool-name="get_weather"]',
   ".copilotkit-tool-render",
   '[data-testid="copilot-tool-render"]',
+  '[data-testid="copilot-assistant-message"]',
 ] as const;
 
 /** Per-selector probe timeout (ms). The runner has already waited for
@@ -129,6 +130,7 @@ export async function probeToolCard(page: Page): Promise<ToolCardProbeResult> {
       '[data-tool-name="get_weather"]',
       ".copilotkit-tool-render",
       '[data-testid="copilot-tool-render"]',
+      '[data-testid="copilot-assistant-message"]',
     ];
     for (const sel of selectors) {
       const el = win.document.querySelector(sel);


### PR DESCRIPTION
## Summary

Aligns all D5 probe scripts with the 3-tier assistant-message selector cascade that `conversation-runner.ts` already uses:

1. `[data-testid="copilot-assistant-message"]` (V2 canonical)
2. `[role="article"]:not([data-message-role="user"])` (article fallback)
3. `[data-message-role="assistant"]` (headless fallback)

Without this, the conversation runner could detect "response settled" on headless-simple demos but per-script assertions couldn't read the text, causing false failures.

**Scripts fixed:**
- `_hitl-shared.ts` — `readAssistantCount` + `readLatestAssistantText`
- `d5-shared-state.ts` — `readLatestAssistantText`
- `d5-agentic-chat.ts` — `readAssistantTranscript`
- `d5-tool-rendering.ts` — added `copilot-assistant-message` V2 fallback to card probe cascade

## Test plan

- [x] `nx run @copilotkit/showcase-ops:test` — 1298 tests pass
- [ ] D5 probe run shows improvement on headless demos