### PR TITLE
feat(react-core): deprecate useSingleEndpoint, add useLegacyRuntime

### DIFF
--- a/docs/content/docs/reference/v2/index.mdx
+++ b/docs/content/docs/reference/v2/index.mdx
@@ -73,7 +73,7 @@ import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 </PropertyReference>
 
 <PropertyReference name="useSingleEndpoint" type="boolean" deprecated>
-  **Deprecated since v1.57.0.** Use `useLegacyRuntime` instead. When enabled, all runtime calls use a single endpoint.
+  **Deprecated.** Use `useLegacyRuntime` instead. When enabled, all runtime calls use a single endpoint.
 </PropertyReference>
 
 <PropertyReference name="agents__unsafe_dev_only" type="Record<string, AbstractAgent>">

--- a/docs/content/docs/reference/v2/index.mdx
+++ b/docs/content/docs/reference/v2/index.mdx
@@ -68,8 +68,12 @@ import { CopilotKitProvider } from "@copilotkit/react-core/v2";
   Runtime metadata payload.
 </PropertyReference>
 
-<PropertyReference name="useSingleEndpoint" type="boolean">
-  When enabled, all runtime calls use a single endpoint.
+<PropertyReference name="useLegacyRuntime" type="boolean" default="false">
+  When `true`, uses the legacy single-endpoint transport (all runtime calls go through a single POST endpoint with a JSON envelope). When `false` or omitted, the modern multi-endpoint REST transport is used.
+</PropertyReference>
+
+<PropertyReference name="useSingleEndpoint" type="boolean" deprecated>
+  **Deprecated since v1.57.0.** Use `useLegacyRuntime` instead. When enabled, all runtime calls use a single endpoint.
 </PropertyReference>
 
 <PropertyReference name="agents__unsafe_dev_only" type="Record<string, AbstractAgent>">

--- a/examples/canvas/gemini/app/wrapper.tsx
+++ b/examples/canvas/gemini/app/wrapper.tsx
@@ -5,7 +5,7 @@ import { useLayout } from "./contexts/LayoutContext";
 export default function Wrapper({ children }: { children: React.ReactNode }) {
   const { layoutState } = useLayout();
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={layoutState.agent}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={layoutState.agent}>
       {children}
     </CopilotKit>
   );

--- a/examples/canvas/gemini/app/wrapper.tsx
+++ b/examples/canvas/gemini/app/wrapper.tsx
@@ -5,7 +5,11 @@ import { useLayout } from "./contexts/LayoutContext";
 export default function Wrapper({ children }: { children: React.ReactNode }) {
   const { layoutState } = useLayout();
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={layoutState.agent}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent={layoutState.agent}
+    >
       {children}
     </CopilotKit>
   );

--- a/examples/canvas/langgraph-python/src/app/layout.tsx
+++ b/examples/canvas/langgraph-python/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
       <body className="subpixel-antialiased">
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"
           showDevConsole={false}

--- a/examples/canvas/llamaindex-composio/src/app/layout.tsx
+++ b/examples/canvas/llamaindex-composio/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
       <body className="subpixel-antialiased">
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"
           publicApiKey={process.env.COPILOT_CLOUD_PUBLIC_API_KEY} // optional (for CopilotKit Cloud features)

--- a/examples/canvas/llamaindex/src/app/layout.tsx
+++ b/examples/canvas/llamaindex/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
       <body className="subpixel-antialiased">
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"
           showDevConsole={false}

--- a/examples/canvas/mastra-pm/src/app/layout.tsx
+++ b/examples/canvas/mastra-pm/src/app/layout.tsx
@@ -30,6 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="weatherAgent"
           showDevConsole={false}

--- a/examples/canvas/mastra/src/app/layout.tsx
+++ b/examples/canvas/mastra/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
       <body className="subpixel-antialiased">
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"
           showDevConsole={false}

--- a/examples/canvas/pydantic-ai/src/app/layout.tsx
+++ b/examples/canvas/pydantic-ai/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
       <body className="subpixel-antialiased">
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"
           showDevConsole={false}

--- a/examples/integrations/a2a-middleware/components/chat.tsx
+++ b/examples/integrations/a2a-middleware/components/chat.tsx
@@ -127,7 +127,7 @@ export default function Chat({
   onAnalysisUpdate,
 }: ChatProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="a2a_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="a2a_chat">
       <ChatInner
         onResearchUpdate={onResearchUpdate}
         onAnalysisUpdate={onAnalysisUpdate}

--- a/examples/integrations/adk/src/app/layout.tsx
+++ b/examples/integrations/adk/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="my_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/adk/src/app/layout.tsx
+++ b/examples/integrations/adk/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/agno/src/app/layout.tsx
+++ b/examples/integrations/agno/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agno_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="agno_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/agno/src/app/layout.tsx
+++ b/examples/integrations/agno/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="agno_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agno_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/crewai-crews/src/app/layout.tsx
+++ b/examples/integrations/crewai-crews/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="starterAgent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/crewai-crews/src/app/layout.tsx
+++ b/examples/integrations/crewai-crews/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="starterAgent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/crewai-flows/src/app/layout.tsx
+++ b/examples/integrations/crewai-flows/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="sample_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/crewai-flows/src/app/layout.tsx
+++ b/examples/integrations/crewai-flows/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/langgraph-fastapi/src/app/layout.tsx
+++ b/examples/integrations/langgraph-fastapi/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="sample_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/langgraph-fastapi/src/app/layout.tsx
+++ b/examples/integrations/langgraph-fastapi/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/langgraph-js/app/layout.tsx
+++ b/examples/integrations/langgraph-js/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="starterAgent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/langgraph-js/app/layout.tsx
+++ b/examples/integrations/langgraph-js/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="starterAgent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/langgraph-python-threads/apps/app/src/App.tsx
+++ b/examples/integrations/langgraph-python-threads/apps/app/src/App.tsx
@@ -59,7 +59,6 @@ export default function App() {
         runtimeUrl={runtimeUrl}
         a2ui={{ catalog: demonstrationCatalog }}
         openGenerativeUI={{}}
-        useSingleEndpoint={false}
       >
         <HomePage />
       </CopilotKitProvider>

--- a/examples/integrations/langgraph-python/src/app/layout.tsx
+++ b/examples/integrations/langgraph-python/src/app/layout.tsx
@@ -28,7 +28,6 @@ export default function RootLayout({
             inspectorDefaultAnchor={{ horizontal: "right", vertical: "top" }}
             a2ui={{ catalog: demonstrationCatalog }}
             openGenerativeUI={{}}
-            useSingleEndpoint={false}
           >
             {children}
           </CopilotKit>

--- a/examples/integrations/langgraph-python/src/app/layout.tsx
+++ b/examples/integrations/langgraph-python/src/app/layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout({
       <body className={`antialiased`}>
         <ThemeProvider>
           <CopilotKit
+            useLegacyRuntime
             runtimeUrl="/api/copilotkit"
             inspectorDefaultAnchor={{ horizontal: "right", vertical: "top" }}
             a2ui={{ catalog: demonstrationCatalog }}

--- a/examples/integrations/llamaindex/src/app/layout.tsx
+++ b/examples/integrations/llamaindex/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="sample_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/llamaindex/src/app/layout.tsx
+++ b/examples/integrations/llamaindex/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/mastra/src/app/layout.tsx
+++ b/examples/integrations/mastra/src/app/layout.tsx
@@ -29,7 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="weatherAgent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="weatherAgent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/mastra/src/app/layout.tsx
+++ b/examples/integrations/mastra/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="weatherAgent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="weatherAgent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/mcp-apps/app/layout.tsx
+++ b/examples/integrations/mcp-apps/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          showDevConsole={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/mcp-apps/app/layout.tsx
+++ b/examples/integrations/mcp-apps/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="my_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="my_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/pydantic-ai/src/app/layout.tsx
+++ b/examples/integrations/pydantic-ai/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="my_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/pydantic-ai/src/app/layout.tsx
+++ b/examples/integrations/pydantic-ai/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/strands-python/src/app/layout.tsx
+++ b/examples/integrations/strands-python/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="strands_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="strands_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/strands-python/src/app/layout.tsx
+++ b/examples/integrations/strands-python/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="strands_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="strands_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/a2a-travel/components/travel-chat.tsx
+++ b/examples/showcases/a2a-travel/components/travel-chat.tsx
@@ -300,6 +300,7 @@ export default function TravelChat({
 }: TravelChatProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       showDevConsole={false}
       agent="a2a_chat"

--- a/examples/showcases/adk-dashboard/src/app/layout.tsx
+++ b/examples/showcases/adk-dashboard/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
       <body className={"subpixel-antialiased"}>
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="my_agent"
           showDevConsole={false}

--- a/examples/showcases/banking/src/app/wrapper.tsx
+++ b/examples/showcases/banking/src/app/wrapper.tsx
@@ -12,6 +12,7 @@ export function CopilotKitWrapper({ children }: { children: React.ReactNode }) {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       showDevConsole={false}
       properties={{

--- a/examples/showcases/chatkit-studio/apps/playground/src/app/preview/layout.tsx
+++ b/examples/showcases/chatkit-studio/apps/playground/src/app/preview/layout.tsx
@@ -14,7 +14,7 @@ export default function PreviewLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <CopilotKit runtimeUrl="/api/copilotkit-preview" agent="sample_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-preview" agent="sample_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/chatkit-studio/apps/playground/src/app/preview/layout.tsx
+++ b/examples/showcases/chatkit-studio/apps/playground/src/app/preview/layout.tsx
@@ -14,7 +14,11 @@ export default function PreviewLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-preview" agent="sample_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit-preview"
+          agent="sample_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/chatkit-studio/apps/world/src/app/layout.tsx
+++ b/examples/showcases/chatkit-studio/apps/world/src/app/layout.tsx
@@ -23,6 +23,7 @@ export default function RootLayout({
       <body>
         <ApiKeyInput />
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="world_agent"
           headers={{

--- a/examples/showcases/deep-agents-job-search/src/app/layout.tsx
+++ b/examples/showcases/deep-agents-job-search/src/app/layout.tsx
@@ -18,6 +18,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={"antialiased"}>
         <CopilotKit
+          useLegacyRuntime
           runtimeUrl="/api/copilotkit"
           agent="job_application_assistant"
         >

--- a/examples/showcases/deep-agents/src/app/layout.tsx
+++ b/examples/showcases/deep-agents/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="research_assistant">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="research_assistant">
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/deep-agents/src/app/layout.tsx
+++ b/examples/showcases/deep-agents/src/app/layout.tsx
@@ -29,7 +29,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="research_assistant">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="research_assistant"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/enterprise-brex/src/app/wrapper.tsx
+++ b/examples/showcases/enterprise-brex/src/app/wrapper.tsx
@@ -12,6 +12,7 @@ export function CopilotKitWrapper({ children }: { children: React.ReactNode }) {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       showDevConsole={false}
       properties={{

--- a/examples/showcases/langgraph-js-support-agents/apps/web/src/app/layout.tsx
+++ b/examples/showcases/langgraph-js-support-agents/apps/web/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="starterAgent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/langgraph-js-support-agents/apps/web/src/app/layout.tsx
+++ b/examples/showcases/langgraph-js-support-agents/apps/web/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="starterAgent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="starterAgent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/microsoft-kanban/src/app/layout.tsx
+++ b/examples/showcases/microsoft-kanban/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
         />
       </head>
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/microsoft-kanban/src/app/layout.tsx
+++ b/examples/showcases/microsoft-kanban/src/app/layout.tsx
@@ -29,7 +29,11 @@ export default function RootLayout({
         />
       </head>
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="my_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/open-mcp-client/apps/web/app/components/CopilotKitProvider.tsx
+++ b/examples/showcases/open-mcp-client/apps/web/app/components/CopilotKitProvider.tsx
@@ -80,6 +80,7 @@ export function DynamicCopilotKitProvider({
   return (
     <McpServersContext.Provider value={{ servers, setServers }}>
       <CopilotKit
+        useLegacyRuntime
         runtimeUrl="/api/mastra-agent"
         headers={headers}
         showDevConsole={false}

--- a/examples/showcases/orca/frontend/app/layout.tsx
+++ b/examples/showcases/orca/frontend/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <CopilotKit runtimeUrl="/api/copilotkit">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit">
           <ThemeProvider
             attribute="class"
             defaultTheme="light"

--- a/examples/showcases/presentation/src/app/page.tsx
+++ b/examples/showcases/presentation/src/app/page.tsx
@@ -11,6 +11,7 @@ export default function AIPresentation() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       publicApiKey={process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY}
       // Alternatively, you can use runtimeUrl to host your own CopilotKit Runtime
       runtimeUrl="/api/copilotkit"

--- a/examples/showcases/pydantic-ai-todos/src/app/layout.tsx
+++ b/examples/showcases/pydantic-ai-todos/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="my_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/pydantic-ai-todos/src/app/layout.tsx
+++ b/examples/showcases/pydantic-ai-todos/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/research-canvas/final/frontend/src/app/layout.tsx
+++ b/examples/showcases/research-canvas/final/frontend/src/app/layout.tsx
@@ -33,6 +33,7 @@ export default function RootLayout({
     <html lang="en" className="h-full">
       <body className={`${lato.variable} ${noto.className} antialiased h-full`}>
         <CopilotKit
+          useLegacyRuntime
           publicApiKey={process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY} // if using copilot cloud
           runtimeUrl={
             process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY

--- a/examples/showcases/research-canvas/frontend/src/app/layout.tsx
+++ b/examples/showcases/research-canvas/frontend/src/app/layout.tsx
@@ -33,6 +33,7 @@ export default function RootLayout({
     <html lang="en" className="h-full">
       <body className={`${lato.variable} ${noto.className} antialiased h-full`}>
         <CopilotKit
+          useLegacyRuntime
           publicApiKey={process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY} // if using copilot cloud
           runtimeUrl={
             process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY

--- a/examples/showcases/scene-creator/src/app/layout.tsx
+++ b/examples/showcases/scene-creator/src/app/layout.tsx
@@ -25,7 +25,11 @@ export default function RootLayout({
       <body
         className={`${spaceMono.className} antialiased bg-[var(--bg-primary)] text-[var(--fg-primary)]`}
       >
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="sample_agent"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/scene-creator/src/app/layout.tsx
+++ b/examples/showcases/scene-creator/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
       <body
         className={`${spaceMono.className} antialiased bg-[var(--bg-primary)] text-[var(--fg-primary)]`}
       >
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="sample_agent">
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/spreadsheet/src/app/page.tsx
+++ b/examples/showcases/spreadsheet/src/app/page.tsx
@@ -22,6 +22,7 @@ import { sampleData, sampleData2 } from "./utils/sampleData";
 const HomePage = () => {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="api/copilotkit"
       transcribeAudioUrl="/api/transcribe"
       textToSpeechUrl="/api/tts"

--- a/examples/showcases/strands-file-analyzer/src/app/layout.tsx
+++ b/examples/showcases/strands-file-analyzer/src/app/layout.tsx
@@ -17,7 +17,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="file_investigator">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="file_investigator"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/strands-file-analyzer/src/app/layout.tsx
+++ b/examples/showcases/strands-file-analyzer/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="file_investigator">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="file_investigator">
           {children}
         </CopilotKit>
       </body>

--- a/examples/showcases/todo/src/app/page.tsx
+++ b/examples/showcases/todo/src/app/page.tsx
@@ -32,6 +32,7 @@ export default function Home() {
        **/}
 
       <CopilotKit
+        useLegacyRuntime
         publicApiKey={process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY}
         // Alternatively, you can use runtimeUrl to host your own CopilotKit Runtime
         // runtimeUrl="/api/copilotkit"

--- a/examples/v1/_legacy/copilot-anthropic-pinecone/src/app/layout.tsx
+++ b/examples/v1/_legacy/copilot-anthropic-pinecone/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <CopilotKit runtimeUrl="/api/copilotkit">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit">
           <MantineProvider>{children}</MantineProvider>
         </CopilotKit>
       </body>

--- a/examples/v1/_legacy/copilot-fully-custom/app/layout.tsx
+++ b/examples/v1/_legacy/copilot-fully-custom/app/layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <CopilotKit
+          useLegacyRuntime
           publicApiKey={process.env.COPILOT_CLOUD_PUBLIC_API_KEY}
           runtimeUrl={
             process.env.COPILOT_CLOUD_PUBLIC_API_KEY

--- a/examples/v1/_legacy/copilot-openai-mongodb-atlas-vector-search/src/app/layout.tsx
+++ b/examples/v1/_legacy/copilot-openai-mongodb-atlas-vector-search/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <CopilotKit runtimeUrl="/api/copilotkit">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit">
           <MantineProvider>{children}</MantineProvider>
         </CopilotKit>
       </body>

--- a/examples/v1/_legacy/saas-dynamic-dashboards/frontend/app/layout.tsx
+++ b/examples/v1/_legacy/saas-dynamic-dashboards/frontend/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <CopilotKit runtimeUrl="/api/copilotkit">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit">
           <ThemeProvider
             attribute="class"
             defaultTheme="light"

--- a/examples/v1/chat-with-your-data/app/layout.tsx
+++ b/examples/v1/chat-with-your-data/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/v1/chat-with-your-data/app/layout.tsx
+++ b/examples/v1/chat-with-your-data/app/layout.tsx
@@ -30,7 +30,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          showDevConsole={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/v1/form-filling/app/layout.tsx
+++ b/examples/v1/form-filling/app/layout.tsx
@@ -29,7 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          showDevConsole={false}
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/v1/form-filling/app/layout.tsx
+++ b/examples/v1/form-filling/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/v1/next-openai/src/app/headless/page.tsx
+++ b/examples/v1/next-openai/src/app/headless/page.tsx
@@ -83,7 +83,7 @@ export default function PanelPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      <CopilotKit {...copilotKitProps}>
+      <CopilotKit useLegacyRuntime {...copilotKitProps}>
         <ChatApp />
       </CopilotKit>
     </div>

--- a/examples/v1/next-openai/src/app/multi/page.tsx
+++ b/examples/v1/next-openai/src/app/multi/page.tsx
@@ -50,7 +50,7 @@ export default function PanelPage() {
   };
 
   return (
-    <CopilotKit {...copilotKitProps}>
+    <CopilotKit useLegacyRuntime {...copilotKitProps}>
       <TravelPlanner />
     </CopilotKit>
   );

--- a/examples/v1/next-openai/src/app/page.tsx
+++ b/examples/v1/next-openai/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function WaterBnb() {
   };
 
   return (
-    <CopilotKit {...copilotKitProps}>
+    <CopilotKit useLegacyRuntime {...copilotKitProps}>
       <CopilotSidebar
         onThumbsUp={(message) => {
           console.log("thumbs up", message);

--- a/examples/v1/next-openai/src/app/presentation/page.tsx
+++ b/examples/v1/next-openai/src/app/presentation/page.tsx
@@ -25,7 +25,7 @@ export default function AIPresentation() {
   };
 
   return (
-    <CopilotKit {...copilotKitProps}>
+    <CopilotKit useLegacyRuntime {...copilotKitProps}>
       <div
         style={
           {

--- a/examples/v1/next-openai/src/app/textarea/page.tsx
+++ b/examples/v1/next-openai/src/app/textarea/page.tsx
@@ -28,7 +28,7 @@ export default function CopilotTextareaDemo() {
   };
 
   return (
-    <CopilotKit {...copilotKitProps}>
+    <CopilotKit useLegacyRuntime {...copilotKitProps}>
       <TextAreas />
     </CopilotKit>
   );

--- a/examples/v1/next-openai/src/app/travel/page.tsx
+++ b/examples/v1/next-openai/src/app/travel/page.tsx
@@ -26,7 +26,7 @@ export default function PanelPage() {
   };
 
   return (
-    <CopilotKit {...copilotKitProps}>
+    <CopilotKit useLegacyRuntime {...copilotKitProps}>
       <TravelPlanner />
     </CopilotKit>
   );

--- a/examples/v1/next-pages-router/pages/index.tsx
+++ b/examples/v1/next-pages-router/pages/index.tsx
@@ -10,6 +10,7 @@ const inter = Inter({ subsets: ["latin"] });
 export default function Home() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       transcribeAudioUrl="/api/transcribe"
       textToSpeechUrl="/api/tts"

--- a/examples/v1/research-canvas/src/app/page.tsx
+++ b/examples/v1/research-canvas/src/app/page.tsx
@@ -29,7 +29,7 @@ function Home() {
       }`;
 
   return (
-    <CopilotKit runtimeUrl={runtimeUrl} showDevConsole={false} agent={agent}>
+    <CopilotKit useLegacyRuntime runtimeUrl={runtimeUrl} showDevConsole={false} agent={agent}>
       <Main />
     </CopilotKit>
   );

--- a/examples/v1/research-canvas/src/app/page.tsx
+++ b/examples/v1/research-canvas/src/app/page.tsx
@@ -29,7 +29,12 @@ function Home() {
       }`;
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl={runtimeUrl} showDevConsole={false} agent={agent}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl={runtimeUrl}
+      showDevConsole={false}
+      agent={agent}
+    >
       <Main />
     </CopilotKit>
   );

--- a/examples/v1/state-machine/src/app/layout.tsx
+++ b/examples/v1/state-machine/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
           <GlobalStateProvider>
             <div className="h-screen w-screen grid grid-cols-[40fr,60fr] p-10 gap-5">
               <div className="overflow-y-auto rounded-xl border">

--- a/examples/v1/state-machine/src/app/layout.tsx
+++ b/examples/v1/state-machine/src/app/layout.tsx
@@ -13,7 +13,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" showDevConsole={false}>
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          showDevConsole={false}
+        >
           <GlobalStateProvider>
             <div className="h-screen w-screen grid grid-cols-[40fr,60fr] p-10 gap-5">
               <div className="overflow-y-auto rounded-xl border">

--- a/examples/v1/travel/app/page.tsx
+++ b/examples/v1/travel/app/page.tsx
@@ -55,6 +55,7 @@ export default function Home() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       agent="travel"
       runtimeUrl={
         process.env.NEXT_PUBLIC_CPK_PUBLIC_API_KEY == undefined

--- a/examples/v2/docs/reference/copilot-runtime.mdx
+++ b/examples/v2/docs/reference/copilot-runtime.mdx
@@ -203,7 +203,7 @@ Allowed `method` values are:
 - `info`
 - `transcribe`
 
-Pair this server endpoint with the React provider flag `<CopilotKitProvider useSingleEndpoint />`.
+Pair this server endpoint with the React provider flag `<CopilotKitProvider useLegacyRuntime />`.
 
 ### Next.js (App Router) with Hono
 
@@ -221,7 +221,7 @@ export const GET = handle(app);
 export const POST = handle(app);
 ```
 
-Swap `createCopilotEndpoint` for `createCopilotEndpointSingleRoute` if you configure the client with `useSingleEndpoint`.
+Swap `createCopilotEndpoint` for `createCopilotEndpointSingleRoute` if you configure the client with `useLegacyRuntime`.
 
 ### Express (REST-style)
 
@@ -251,7 +251,7 @@ app.use(
 );
 ```
 
-Single-route Express works identically to the Hono version: send the JSON envelope described earlier, and set `useSingleEndpoint` on the client.
+Single-route Express works identically to the Hono version: send the JSON envelope described earlier, and set `useLegacyRuntime` on the client.
 
 ### NestJS (Express backend)
 
@@ -297,7 +297,7 @@ Available routes (no global prefix):
 - `GET  /api/copilotkit/info`
 - `POST /api/copilotkit/transcribe`
 
-If you prefer the single-route transport, mount the single-route helper instead and set `useSingleEndpoint` on the client:
+If you prefer the single-route transport, mount the single-route helper instead and set `useLegacyRuntime` on the client:
 
 ```ts
 import { createCopilotEndpointSingleRouteExpress } from "@copilotkit/runtime/express";
@@ -336,6 +336,6 @@ Use this to verify deployments and surface diagnostics in your UI.
 
 ## Next Steps
 
-- Configure the React client with `runtimeUrl` (and `useSingleEndpoint` if you chose the single endpoint helper).
+- Configure the React client with `runtimeUrl` (and `useLegacyRuntime` if you chose the single endpoint helper).
 - Register frontend tools with `CopilotKitProvider` so agents can trigger UI actions.
 - Extend the runtime runner or middleware hooks to integrate logging, rate limiting, or background queues.

--- a/examples/v2/docs/reference/copilotkit-provider.mdx
+++ b/examples/v2/docs/reference/copilotkit-provider.mdx
@@ -134,9 +134,9 @@ On the server, mount one of the single-route runtimes (`createCopilotEndpointSin
 
 `boolean` **(optional)**
 
-> **Deprecated since v1.57.0.** Use `useLegacyRuntime` instead.
+> **Deprecated.** Use `useLegacyRuntime` instead.
 
-Legacy alias for `useLegacyRuntime`. If both are set, `useLegacyRuntime` takes precedence.
+Predecessor to `useLegacyRuntime` with equivalent behavior when explicitly set. If both are provided, `useLegacyRuntime` takes precedence.
 
 ### renderToolCalls
 

--- a/examples/v2/docs/reference/copilotkit-provider.mdx
+++ b/examples/v2/docs/reference/copilotkit-provider.mdx
@@ -114,7 +114,7 @@ const devAgent = new HttpAgent({
 </CopilotKitProvider>;
 ```
 
-### useSingleEndpoint
+### useLegacyRuntime
 
 `boolean` **(optional, default: `false`)**
 
@@ -123,12 +123,20 @@ When set to `true`, the provider connects to runtimes that expose the **single-r
 Pair this flag with the matching server endpoint helper:
 
 ```tsx
-<CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
+<CopilotKitProvider runtimeUrl="/api/copilotkit" useLegacyRuntime>
   {children}
 </CopilotKitProvider>
 ```
 
 On the server, mount one of the single-route runtimes (`createCopilotEndpointSingleRoute` for Hono or `createCopilotEndpointSingleRouteExpress` for Express).
+
+### useSingleEndpoint *(deprecated)*
+
+`boolean` **(optional)**
+
+> **Deprecated since v1.57.0.** Use `useLegacyRuntime` instead.
+
+Legacy alias for `useLegacyRuntime`. If both are set, `useLegacyRuntime` takes precedence.
 
 ### renderToolCalls
 

--- a/examples/v2/interrupts-langgraph/apps/web/src/app/layout.tsx
+++ b/examples/v2/interrupts-langgraph/apps/web/src/app/layout.tsx
@@ -18,7 +18,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="default">
+        <CopilotKit
+          useLegacyRuntime
+          runtimeUrl="/api/copilotkit"
+          agent="default"
+        >
           {children}
         </CopilotKit>
       </body>

--- a/examples/v2/interrupts-langgraph/apps/web/src/app/layout.tsx
+++ b/examples/v2/interrupts-langgraph/apps/web/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={"antialiased"}>
-        <CopilotKit runtimeUrl="/api/copilotkit" agent="default">
+        <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="default">
           {children}
         </CopilotKit>
       </body>

--- a/examples/v2/next-pages-router/README.md
+++ b/examples/v2/next-pages-router/README.md
@@ -37,4 +37,4 @@ pnpm -C ../../ --filter next-pages-router example-build
 ## Notes
 
 - This example uses the Next.js App Router (`app/` directory).
-- The client sets `useSingleEndpoint` to match the Express runtime.
+- The client sets `useLegacyRuntime` to match the Express single-route runtime.

--- a/examples/v2/next-pages-router/app/page.tsx
+++ b/examples/v2/next-pages-router/app/page.tsx
@@ -8,7 +8,7 @@ const runtimeUrl =
 
 export default function Home() {
   return (
-    <CopilotKitProvider runtimeUrl={runtimeUrl} useSingleEndpoint>
+    <CopilotKitProvider runtimeUrl={runtimeUrl} useLegacyRuntime>
       <div className="page">
         <main className="content">
           <h1>CopilotKit v2 + Express (Single Route)</h1>

--- a/examples/v2/react/demo/src/app/single/page.tsx
+++ b/examples/v2/react/demo/src/app/single/page.tsx
@@ -38,7 +38,7 @@ export default function SingleEndpointDemo() {
   return (
     <CopilotKitProvider
       runtimeUrl="/api/copilotkit-single"
-      useSingleEndpoint
+      useLegacyRuntime
       renderToolCalls={[wildcardRenderer]}
       showDevConsole="auto"
     >

--- a/packages/angular/src/lib/agent.spec.ts
+++ b/packages/angular/src/lib/agent.spec.ts
@@ -16,6 +16,7 @@ import {
   CopilotKitCore,
   ProxiedCopilotRuntimeAgent,
   CopilotKitCoreRuntimeConnectionStatus,
+  type CopilotRuntimeTransport,
 } from "@copilotkit/core";
 
 /** Shape of the `core` property on the stub — derived from CopilotKitCore
@@ -131,7 +132,7 @@ class CopilotKitStub {
       CopilotKitCoreRuntimeConnectionStatus.Disconnected,
     );
   readonly #runtimeUrl = signal<string | undefined>(undefined);
-  readonly #runtimeTransport = signal<"rest" | "single" | "auto">("auto");
+  readonly #runtimeTransport = signal<CopilotRuntimeTransport>("rest");
   readonly #headers = signal<Record<string, string>>({});
   getAgent = vi.fn((id: string) => this.#agents()[id]);
   agents = this.#agents.asReadonly();
@@ -142,7 +143,7 @@ class CopilotKitStub {
   #coreInstance = new CopilotKitCore({});
   core: StubCore = {
     runtimeUrl: undefined,
-    runtimeTransport: "auto",
+    runtimeTransport: "rest",
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Disconnected,
     headers: {},
     subscribeToAgentWithOptions:
@@ -169,7 +170,7 @@ class CopilotKitStub {
     this.core = { ...this.core, headers: value };
   }
 
-  setRuntimeTransport(value: "rest" | "single" | "auto") {
+  setRuntimeTransport(value: CopilotRuntimeTransport) {
     this.#runtimeTransport.set(value);
     this.core = { ...this.core, runtimeTransport: value };
   }

--- a/packages/angular/src/lib/copilotkit.spec.ts
+++ b/packages/angular/src/lib/copilotkit.spec.ts
@@ -41,7 +41,7 @@ vi.mock("@copilotkit/core", () => {
     readonly getAgent = mockGetAgent;
     agents: Record<string, any> = {};
     runtimeUrl = undefined;
-    runtimeTransport = "auto";
+    runtimeTransport = "rest";
     headers: Record<string, string> = {};
     runtimeConnectionStatus =
       CopilotKitCoreRuntimeConnectionStatus.Disconnected;

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -39,7 +39,7 @@ export class CopilotKit {
   readonly runtimeConnectionStatus = this.#runtimeConnectionStatus.asReadonly();
   readonly #runtimeUrl = signal<string | undefined>(undefined);
   readonly runtimeUrl = this.#runtimeUrl.asReadonly();
-  readonly #runtimeTransport = signal<CopilotRuntimeTransport>("auto");
+  readonly #runtimeTransport = signal<CopilotRuntimeTransport>("rest");
   readonly runtimeTransport = this.#runtimeTransport.asReadonly();
   readonly #headers = signal<Record<string, string>>({});
   readonly headers = this.#headers.asReadonly();

--- a/packages/core/src/__tests__/proxied-runtime-transport.test.ts
+++ b/packages/core/src/__tests__/proxied-runtime-transport.test.ts
@@ -365,7 +365,7 @@ function createSseResponse(): Response {
   });
 }
 
-describe("Auto-detect transport from runtime info response", () => {
+describe("Explicit transport from runtime info response", () => {
   const originalFetch = global.fetch;
   const originalWindow = (globalThis as { window?: unknown }).window;
 
@@ -392,8 +392,8 @@ describe("Auto-detect transport from runtime info response", () => {
     }
   });
 
-  it("auto-detects REST transport when GET /info succeeds", async () => {
-    const runtimeUrl = "https://runtime.example/rest-auto";
+  it("defaults to REST transport when no runtimeTransport is specified", async () => {
+    const runtimeUrl = "https://runtime.example/rest-default";
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(infoResponse), {
         status: 200,
@@ -403,7 +403,6 @@ describe("Auto-detect transport from runtime info response", () => {
     // @ts-expect-error - override in test environment
     global.fetch = fetchMock;
 
-    // No runtimeTransport specified — defaults to "auto"
     const core = new CopilotKitCore({
       runtimeUrl,
       headers: { Authorization: "Bearer token" },
@@ -413,7 +412,7 @@ describe("Auto-detect transport from runtime info response", () => {
       expect(fetchMock).toHaveBeenCalled();
     });
 
-    // Should have tried REST first (GET /info)
+    // Should use REST (GET /info)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(`${runtimeUrl}/info`);
     expect(init.method ?? "GET").toBe("GET");
@@ -423,68 +422,11 @@ describe("Auto-detect transport from runtime info response", () => {
     expect(remoteAgent).toBeDefined();
     expect(remoteAgent?.agentId).toBe("remote");
 
-    // Transport should have been resolved to "rest"
+    // Transport should be "rest"
     expect(core.runtimeTransport).toBe("rest");
   });
 
-  it("auto-detects single-endpoint transport when GET /info fails", async () => {
-    const runtimeUrl = "https://runtime.example/single-auto";
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string, init?: RequestInit) => {
-        // REST attempt: GET /info → 404
-        if (
-          typeof url === "string" &&
-          url.endsWith("/info") &&
-          (!init?.method || init.method === "GET")
-        ) {
-          return Promise.resolve(new Response("Not Found", { status: 404 }));
-        }
-        // Single-endpoint attempt: POST with { method: "info" }
-        if (init?.method === "POST") {
-          return Promise.resolve(
-            new Response(JSON.stringify(infoResponse), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }
-        return Promise.reject(new Error("Unexpected fetch call"));
-      });
-    // @ts-expect-error - override in test environment
-    global.fetch = fetchMock;
-
-    // No runtimeTransport specified — defaults to "auto"
-    const core = new CopilotKitCore({
-      runtimeUrl,
-      headers: { Authorization: "Bearer token" },
-    });
-
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    // First call should be REST attempt (GET /info)
-    const [url1] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url1).toBe(`${runtimeUrl}/info`);
-
-    // Second call should be single-endpoint attempt (POST with { method: "info" })
-    const [url2, init2] = fetchMock.mock.calls[1] as [string, RequestInit];
-    expect(url2).toBe(runtimeUrl);
-    expect(init2.method).toBe("POST");
-    const body = JSON.parse(init2.body as string);
-    expect(body).toEqual({ method: "info" });
-
-    // Remote agent should be registered
-    const remoteAgent = core.getAgent("remote");
-    expect(remoteAgent).toBeDefined();
-    expect(remoteAgent?.agentId).toBe("remote");
-
-    // Transport should have been resolved to "single"
-    expect(core.runtimeTransport).toBe("single");
-  });
-
-  it("explicit transport='single' flag still works without auto-detection", async () => {
+  it("explicit transport='single' uses single-endpoint", async () => {
     const runtimeUrl = "https://runtime.example/explicit-single";
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(infoResponse), {
@@ -505,8 +447,6 @@ describe("Auto-detect transport from runtime info response", () => {
       expect(fetchMock).toHaveBeenCalled();
     });
 
-    // Should have gone directly to single-endpoint (POST with { method: "info" })
-    // without trying REST first
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(runtimeUrl);
@@ -514,16 +454,13 @@ describe("Auto-detect transport from runtime info response", () => {
     const body = JSON.parse(init.body as string);
     expect(body).toEqual({ method: "info" });
 
-    // Remote agent should be registered
     const remoteAgent = core.getAgent("remote");
     expect(remoteAgent).toBeDefined();
     expect(remoteAgent?.agentId).toBe("remote");
-
-    // Transport stays "single"
     expect(core.runtimeTransport).toBe("single");
   });
 
-  it("explicit transport='rest' flag still works without auto-detection", async () => {
+  it("explicit transport='rest' uses REST endpoints", async () => {
     const runtimeUrl = "https://runtime.example/explicit-rest";
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify(infoResponse), {
@@ -544,257 +481,23 @@ describe("Auto-detect transport from runtime info response", () => {
       expect(fetchMock).toHaveBeenCalled();
     });
 
-    // Should have gone directly to REST (GET /info) without trying single
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(`${runtimeUrl}/info`);
     expect(init.method ?? "GET").toBe("GET");
 
-    // Remote agent should be registered
     const remoteAgent = core.getAgent("remote");
     expect(remoteAgent).toBeDefined();
-
-    // Transport stays "rest"
     expect(core.runtimeTransport).toBe("rest");
   });
 });
 
-describe("Auto-detect transport edge cases (AgentRegistry)", () => {
-  const originalFetch = global.fetch;
-  const originalWindow = (globalThis as { window?: unknown }).window;
-
-  const infoResponse = {
-    version: "1.0.0",
-    agents: {
-      remote: {
-        description: "Remote agent",
-      },
-    },
-  };
-
-  beforeEach(() => {
-    (globalThis as { window?: unknown }).window = {};
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-    global.fetch = originalFetch;
-    if (originalWindow === undefined) {
-      delete (globalThis as { window?: unknown }).window;
-    } else {
-      (globalThis as { window?: unknown }).window = originalWindow;
-    }
-  });
-
-  it("falls back to single-endpoint when REST probe returns 500 with JSON body", async () => {
-    const runtimeUrl = "https://runtime.example/auto-500";
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string, init?: RequestInit) => {
-        // REST attempt: GET /info → 500 with a JSON error body.
-        // The bug: without the fix, the code treats any non-404/405 as REST
-        // and parses this JSON as RuntimeInfo, corrupting the agent list.
-        if (
-          typeof url === "string" &&
-          url.endsWith("/info") &&
-          (!init?.method || init.method === "GET")
-        ) {
-          return Promise.resolve(
-            new Response(JSON.stringify({ error: "Internal Server Error" }), {
-              status: 500,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }
-        // Single-endpoint attempt: POST with { method: "info" }
-        if (init?.method === "POST") {
-          return Promise.resolve(
-            new Response(JSON.stringify(infoResponse), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }
-        return Promise.reject(new Error("Unexpected fetch call"));
-      });
-    // @ts-expect-error - override in test environment
-    global.fetch = fetchMock;
-
-    const core = new CopilotKitCore({ runtimeUrl });
-
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    // First call: REST (GET /info → 500)
-    const [url1] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url1).toBe(`${runtimeUrl}/info`);
-
-    // Second call: single-endpoint (POST)
-    const [url2, init2] = fetchMock.mock.calls[1] as [string, RequestInit];
-    expect(url2).toBe(runtimeUrl);
-    expect(init2.method).toBe("POST");
-
-    // Agent registered, transport resolved to "single"
-    expect(core.getAgent("remote")).toBeDefined();
-    expect(core.runtimeTransport).toBe("single");
-  });
-
-  it("falls back to single-endpoint when REST probe returns 403", async () => {
-    const runtimeUrl = "https://runtime.example/auto-403";
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string, init?: RequestInit) => {
-        if (
-          typeof url === "string" &&
-          url.endsWith("/info") &&
-          (!init?.method || init.method === "GET")
-        ) {
-          return Promise.resolve(new Response("Forbidden", { status: 403 }));
-        }
-        if (init?.method === "POST") {
-          return Promise.resolve(
-            new Response(JSON.stringify(infoResponse), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }
-        return Promise.reject(new Error("Unexpected fetch call"));
-      });
-    // @ts-expect-error - override in test environment
-    global.fetch = fetchMock;
-
-    const core = new CopilotKitCore({ runtimeUrl });
-
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    expect(core.getAgent("remote")).toBeDefined();
-    expect(core.runtimeTransport).toBe("single");
-  });
-
-  it("falls back to single-endpoint when REST probe throws a network error", async () => {
-    const runtimeUrl = "https://runtime.example/auto-net-err";
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string, init?: RequestInit) => {
-        if (
-          typeof url === "string" &&
-          url.endsWith("/info") &&
-          (!init?.method || init.method === "GET")
-        ) {
-          return Promise.reject(new TypeError("Failed to fetch"));
-        }
-        if (init?.method === "POST") {
-          return Promise.resolve(
-            new Response(JSON.stringify(infoResponse), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }
-        return Promise.reject(new Error("Unexpected fetch call"));
-      });
-    // @ts-expect-error - override in test environment
-    global.fetch = fetchMock;
-
-    const core = new CopilotKitCore({ runtimeUrl });
-
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    expect(core.getAgent("remote")).toBeDefined();
-    expect(core.runtimeTransport).toBe("single");
-  });
-
-  it("reports error when both REST and single-endpoint probes fail", async () => {
-    const runtimeUrl = "https://runtime.example/auto-both-fail";
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string, init?: RequestInit) => {
-        if (
-          typeof url === "string" &&
-          url.endsWith("/info") &&
-          (!init?.method || init.method === "GET")
-        ) {
-          return Promise.resolve(new Response("Not Found", { status: 404 }));
-        }
-        if (init?.method === "POST") {
-          return Promise.resolve(
-            new Response("Internal Server Error", { status: 500 }),
-          );
-        }
-        return Promise.reject(new Error("Unexpected fetch call"));
-      });
-    // @ts-expect-error - override in test environment
-    global.fetch = fetchMock;
-
-    const errorSpy = vi.fn();
-    const core = new CopilotKitCore({ runtimeUrl });
-    core.subscribe({
-      onError: errorSpy,
-    });
-
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    // Should have emitted an error since single-endpoint also returned 500
-    // The connection status should be Error
-    await vi.waitFor(() => {
-      expect(core.runtimeConnectionStatus).toBe("error");
-    });
-  });
-
-  it("falls back to single-endpoint when REST probe returns 405", async () => {
-    const runtimeUrl = "https://runtime.example/auto-405";
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string, init?: RequestInit) => {
-        if (
-          typeof url === "string" &&
-          url.endsWith("/info") &&
-          (!init?.method || init.method === "GET")
-        ) {
-          return Promise.resolve(
-            new Response("Method Not Allowed", { status: 405 }),
-          );
-        }
-        if (init?.method === "POST") {
-          return Promise.resolve(
-            new Response(JSON.stringify(infoResponse), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            }),
-          );
-        }
-        return Promise.reject(new Error("Unexpected fetch call"));
-      });
-    // @ts-expect-error - override in test environment
-    global.fetch = fetchMock;
-
-    const core = new CopilotKitCore({ runtimeUrl });
-
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    expect(core.getAgent("remote")).toBeDefined();
-    expect(core.runtimeTransport).toBe("single");
-  });
-});
-
 describe("ProxiedCopilotRuntimeAgent construction and defaults", () => {
-  it("defaults transport to 'auto' when not specified", () => {
+  it("defaults transport to 'rest' when not specified", () => {
     const agent = new ProxiedCopilotRuntimeAgent({
       runtimeUrl: "https://runtime.example/default",
       agentId: "test-agent",
     });
-    // The agent should have been created without throwing.
-    // When transport is "auto", the URL is set as REST-style initially.
     expect(agent).toBeDefined();
     expect(agent.agentId).toBe("test-agent");
   });

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -100,7 +100,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     const normalizedRuntimeUrl = config.runtimeUrl
       ? config.runtimeUrl.replace(/\/$/, "")
       : undefined;
-    const transport = config.transport ?? "auto";
+    const transport = config.transport ?? "rest";
     const runUrl =
       transport === "single"
         ? (normalizedRuntimeUrl ?? config.runtimeUrl ?? "")
@@ -427,10 +427,6 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       ...this.headers,
     };
 
-    if (this.transport === "auto") {
-      return this.fetchRuntimeInfoAutoDetect(headers);
-    }
-
     let init: RequestInit;
     let url: string;
 
@@ -458,47 +454,6 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
         `Runtime info request failed with status ${response.status}`,
       );
     }
-    return (await response.json()) as RuntimeInfo;
-  }
-
-  private async fetchRuntimeInfoAutoDetect(
-    headers: Record<string, string>,
-  ): Promise<RuntimeInfo> {
-    // Try REST first (GET /info)
-    try {
-      const response = await fetch(`${this.runtimeUrl}/info`, {
-        headers: { ...headers },
-        ...(this.credentials ? { credentials: this.credentials } : {}),
-      });
-      // Only treat a successful (2xx) response as a valid REST runtime.
-      // 404/405 means the endpoint doesn't exist; other non-2xx errors
-      // (500, 403, etc.) should also fall through to single-endpoint.
-      if (response.status >= 200 && response.status < 300) {
-        this.transport = "rest";
-        return (await response.json()) as RuntimeInfo;
-      }
-    } catch {
-      // REST failed — fall through to single-endpoint attempt
-    }
-
-    // Try single-endpoint (POST with { method: "info" })
-    const singleHeaders = { ...headers };
-    if (!singleHeaders["Content-Type"]) {
-      singleHeaders["Content-Type"] = "application/json";
-    }
-    const response = await fetch(this.runtimeUrl!, {
-      method: "POST",
-      headers: singleHeaders,
-      body: JSON.stringify({ method: "info" }),
-      ...(this.credentials ? { credentials: this.credentials } : {}),
-    });
-    if (!response.ok) {
-      throw new Error(
-        `Runtime info request failed with status ${response.status}`,
-      );
-    }
-    this.transport = "single";
-    this.singleEndpointUrl = this.runtimeUrl;
     return (await response.json()) as RuntimeInfo;
   }
 

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -407,7 +407,6 @@ export class AgentRegistry {
     return (await response.json()) as RuntimeInfo;
   }
 
-
   /**
    * Assign agent IDs to a record of agents
    */

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -37,7 +37,7 @@ export class AgentRegistry {
   private _runtimeVersion?: string;
   private _runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus =
     CopilotKitCoreRuntimeConnectionStatus.Disconnected;
-  private _runtimeTransport: CopilotRuntimeTransport = "auto";
+  private _runtimeTransport: CopilotRuntimeTransport = "rest";
   private _audioFileTranscriptionEnabled: boolean = false;
   private _runtimeMode: RuntimeMode = RUNTIME_MODE_SSE;
   private _intelligence?: IntelligenceRuntimeInfo;

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -337,8 +337,12 @@ export class AgentRegistry {
 
       const message =
         error instanceof Error ? error.message : JSON.stringify(error);
+      const transportHint =
+        this._runtimeTransport === "rest"
+          ? ` If your server uses a single-endpoint runtime, set useLegacyRuntime={true} on your CopilotKitProvider.`
+          : "";
       logger.warn(
-        `Failed to load runtime info (${this.runtimeUrl}/info): ${message}`,
+        `Failed to load runtime info (${this._runtimeTransport} transport, ${this.runtimeUrl}): ${message}.${transportHint}`,
       );
       const runtimeError =
         error instanceof Error ? error : new Error(String(error));
@@ -367,10 +371,6 @@ export class AgentRegistry {
 
     if (this._runtimeTransport === "single") {
       return this.fetchRuntimeInfoSingle(headers, credentials);
-    }
-
-    if (this._runtimeTransport === "auto") {
-      return this.fetchRuntimeInfoAutoDetect(headers, credentials);
     }
 
     // REST transport
@@ -407,39 +407,6 @@ export class AgentRegistry {
     return (await response.json()) as RuntimeInfo;
   }
 
-  /**
-   * Auto-detect transport by trying REST first, then falling back to single-endpoint.
-   * Updates `_runtimeTransport` to the detected value so subsequent requests use it directly.
-   */
-  private async fetchRuntimeInfoAutoDetect(
-    headers: Record<string, string>,
-    credentials: RequestCredentials | undefined,
-  ): Promise<RuntimeInfo> {
-    // Try REST first (GET /info)
-    try {
-      const response = await fetch(`${this.runtimeUrl}/info`, {
-        headers: { ...headers },
-        ...(credentials ? { credentials } : {}),
-      });
-      // Only treat a successful (2xx) response as a valid REST runtime.
-      // 404/405 means the endpoint doesn't exist; other non-2xx errors
-      // (500, 403, etc.) should also fall through to single-endpoint.
-      if (response.status >= 200 && response.status < 300) {
-        this._runtimeTransport = "rest";
-        return (await response.json()) as RuntimeInfo;
-      }
-      // Non-2xx — try single-endpoint below
-    } catch {
-      // REST failed (network error, etc.) — fall through to single-endpoint attempt
-    }
-
-    const result = await this.fetchRuntimeInfoSingle(
-      { ...headers },
-      credentials,
-    );
-    this._runtimeTransport = "single";
-    return result;
-  }
 
   /**
    * Assign agent IDs to a record of agents

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -325,7 +325,7 @@ export class CopilotKitCore {
 
   constructor({
     runtimeUrl,
-    runtimeTransport = "auto",
+    runtimeTransport = "rest",
     headers = {},
     credentials,
     properties = {},

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,7 +15,7 @@ export enum ToolCallStatus {
   Complete = "complete",
 }
 
-export type CopilotRuntimeTransport = "rest" | "single" | "auto";
+export type CopilotRuntimeTransport = "rest" | "single";
 export type { RuntimeMode, IntelligenceRuntimeInfo, RuntimeLicenseStatus };
 
 /**

--- a/packages/react-core/src/components/copilot-provider/__tests__/v1-transport-default.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/v1-transport-default.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CopilotKit } from "../copilotkit";
+import { useCopilotKit } from "../../../v2/providers/CopilotKitProvider";
+import type { CopilotKitProps } from "../copilotkit-props";
+
+type V1Props = CopilotKitProps & {
+  agents__unsafe_dev_only?: Record<string, unknown>;
+};
+const CopilotKitAny = CopilotKit as unknown as React.FC<V1Props>;
+
+/**
+ * Verifies that the v1 <CopilotKit> wrapper correctly maps transport props
+ * through to the underlying v2 CopilotKitProvider. After the deprecation of
+ * useSingleEndpoint, the v1 wrapper no longer defaults to single-endpoint
+ * transport — it defaults to REST like v2.
+ */
+describe("v1 <CopilotKit> wrapper → transport default", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("defaults to 'rest' transport when no transport prop is set", () => {
+    const { result } = renderHook(() => useCopilotKit(), {
+      wrapper: ({ children }) => (
+        <CopilotKitAny publicApiKey="test-key">{children}</CopilotKitAny>
+      ),
+    });
+
+    expect(result.current.copilotkit.runtimeTransport).toBe("rest");
+  });
+
+  it("maps useLegacyRuntime=true to 'single' transport", () => {
+    const { result } = renderHook(() => useCopilotKit(), {
+      wrapper: ({ children }) => (
+        <CopilotKitAny publicApiKey="test-key" useLegacyRuntime={true}>
+          {children}
+        </CopilotKitAny>
+      ),
+    });
+
+    expect(result.current.copilotkit.runtimeTransport).toBe("single");
+  });
+
+  it("maps deprecated useSingleEndpoint=true to 'single' transport", () => {
+    const { result } = renderHook(() => useCopilotKit(), {
+      wrapper: ({ children }) => (
+        <CopilotKitAny publicApiKey="test-key" useSingleEndpoint={true}>
+          {children}
+        </CopilotKitAny>
+      ),
+    });
+
+    expect(result.current.copilotkit.runtimeTransport).toBe("single");
+  });
+});

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -94,7 +94,8 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
             {...props}
             showDevConsole={showInspector}
             renderCustomMessages={renderArr}
-            useSingleEndpoint={props.useSingleEndpoint ?? true}
+            useSingleEndpoint={props.useSingleEndpoint}
+            useLegacyRuntime={props.useLegacyRuntime}
           >
             <CopilotKitInternal {...props}>{children}</CopilotKitInternal>
           </CopilotKitV2Provider>

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -133,10 +133,10 @@ export interface CopilotKitProviderProps {
   licenseToken?: string;
   properties?: Record<string, unknown>;
   /**
-   * @deprecated Since v1.57.0. Use `useLegacyRuntime` instead.
+   * @deprecated Use `useLegacyRuntime` instead.
    * When `true`, all runtime calls use a single POST endpoint with a JSON envelope
-   * (the legacy GQL-era transport). When `false` or omitted, the modern multi-endpoint
-   * REST transport is used.
+   * (the legacy single-endpoint transport). When `false` or omitted, the modern
+   * multi-endpoint REST transport is used.
    */
   useSingleEndpoint?: boolean;
   /**
@@ -556,13 +556,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   ]);
 
   // Resolve transport: useLegacyRuntime takes precedence over deprecated useSingleEndpoint.
-  const resolvedTransport = (() => {
-    if (useLegacyRuntime !== undefined && useSingleEndpoint !== undefined) {
-      console.warn(
-        "[CopilotKit] Both `useLegacyRuntime` and `useSingleEndpoint` are set. " +
-        "`useLegacyRuntime` takes precedence. Remove `useSingleEndpoint` to silence this warning.",
-      );
-    }
+  const resolvedTransport = useMemo(() => {
     if (useLegacyRuntime !== undefined) {
       return useLegacyRuntime ? "single" : "rest";
     }
@@ -570,7 +564,22 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
       return useSingleEndpoint ? "single" : "rest";
     }
     return "rest";
-  })();
+  }, [useLegacyRuntime, useSingleEndpoint]);
+
+  const hasWarnedConflictRef = useRef(false);
+  useEffect(() => {
+    if (
+      !hasWarnedConflictRef.current &&
+      useLegacyRuntime !== undefined &&
+      useSingleEndpoint !== undefined
+    ) {
+      hasWarnedConflictRef.current = true;
+      console.warn(
+        "[CopilotKit] Both `useLegacyRuntime` and `useSingleEndpoint` are set. " +
+          "`useLegacyRuntime` takes precedence. Remove `useSingleEndpoint` to silence this warning.",
+      );
+    }
+  }, [useLegacyRuntime, useSingleEndpoint]);
 
   // Stable instance: created once for the provider lifetime.
   // Updates are applied via setter effects below rather than recreating the instance.

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -132,7 +132,21 @@ export interface CopilotKitProviderProps {
    */
   licenseToken?: string;
   properties?: Record<string, unknown>;
+  /**
+   * @deprecated Since v1.57.0. Use `useLegacyRuntime` instead.
+   * When `true`, all runtime calls use a single POST endpoint with a JSON envelope
+   * (the legacy GQL-era transport). When `false` or omitted, the modern multi-endpoint
+   * REST transport is used.
+   */
   useSingleEndpoint?: boolean;
+  /**
+   * When `true`, uses the legacy single-endpoint transport (all runtime calls go
+   * through a single POST endpoint with a JSON envelope). When `false` or omitted,
+   * the modern multi-endpoint REST transport is used (default).
+   *
+   * This replaces the deprecated `useSingleEndpoint` prop.
+   */
+  useLegacyRuntime?: boolean;
   agents__unsafe_dev_only?: Record<string, AbstractAgent>;
   selfManagedAgents?: Record<string, AbstractAgent>;
   renderToolCalls?: ReactToolCallRenderer<any>[];
@@ -284,6 +298,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   openGenerativeUI,
   showDevConsole = false,
   useSingleEndpoint,
+  useLegacyRuntime,
   onError,
   a2ui,
   defaultThrottleMs,
@@ -540,18 +555,30 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     processedHumanInTheLoopTools,
   ]);
 
+  // Resolve transport: useLegacyRuntime takes precedence over deprecated useSingleEndpoint.
+  const resolvedTransport = (() => {
+    if (useLegacyRuntime !== undefined && useSingleEndpoint !== undefined) {
+      console.warn(
+        "[CopilotKit] Both `useLegacyRuntime` and `useSingleEndpoint` are set. " +
+        "`useLegacyRuntime` takes precedence. Remove `useSingleEndpoint` to silence this warning.",
+      );
+    }
+    if (useLegacyRuntime !== undefined) {
+      return useLegacyRuntime ? "single" : "rest";
+    }
+    if (useSingleEndpoint !== undefined) {
+      return useSingleEndpoint ? "single" : "rest";
+    }
+    return "rest";
+  })();
+
   // Stable instance: created once for the provider lifetime.
   // Updates are applied via setter effects below rather than recreating the instance.
   const copilotkitRef = useRef<CopilotKitCoreReact | null>(null);
   if (copilotkitRef.current === null) {
     copilotkitRef.current = new CopilotKitCoreReact({
       runtimeUrl: chatApiEndpoint,
-      runtimeTransport:
-        useSingleEndpoint === true
-          ? "single"
-          : useSingleEndpoint === false
-            ? "rest"
-            : "auto",
+      runtimeTransport: resolvedTransport,
       headers: mergedHeaders,
       credentials,
       properties,
@@ -661,13 +688,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
 
   useEffect(() => {
     copilotkit.setRuntimeUrl(chatApiEndpoint);
-    copilotkit.setRuntimeTransport(
-      useSingleEndpoint === true
-        ? "single"
-        : useSingleEndpoint === false
-          ? "rest"
-          : "auto",
-    );
+    copilotkit.setRuntimeTransport(resolvedTransport);
     copilotkit.setHeaders(mergedHeaders);
     copilotkit.setCredentials(credentials);
     copilotkit.setProperties(properties);
@@ -680,7 +701,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     credentials,
     properties,
     mergedAgents,
-    useSingleEndpoint,
+    resolvedTransport,
     debug,
   ]);
 

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -632,9 +632,7 @@ describe("CopilotKitProvider", () => {
       expect(result.current.copilotkit.runtimeTransport).toBe("rest");
     });
 
-    it("useLegacyRuntime takes precedence over useSingleEndpoint", () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
+    it("useLegacyRuntime=true takes precedence over useSingleEndpoint=false", () => {
       const { result } = renderHook(() => useCopilotKit(), {
         wrapper: ({ children }) => (
           <CopilotKitProvider useLegacyRuntime={true} useSingleEndpoint={false}>
@@ -644,11 +642,24 @@ describe("CopilotKitProvider", () => {
       });
 
       expect(result.current.copilotkit.runtimeTransport).toBe("single");
-      expect(warnSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining("Both `useLegacyRuntime` and `useSingleEndpoint` are set"),
       );
+    });
 
-      warnSpy.mockRestore();
+    it("useLegacyRuntime=false takes precedence over useSingleEndpoint=true", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider useLegacyRuntime={false} useSingleEndpoint={true}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.copilotkit.runtimeTransport).toBe("rest");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Both `useLegacyRuntime` and `useSingleEndpoint` are set"),
+      );
     });
 
     it("updates transport when useLegacyRuntime prop changes", () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -643,7 +643,9 @@ describe("CopilotKitProvider", () => {
 
       expect(result.current.copilotkit.runtimeTransport).toBe("single");
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Both `useLegacyRuntime` and `useSingleEndpoint` are set"),
+        expect.stringContaining(
+          "Both `useLegacyRuntime` and `useSingleEndpoint` are set",
+        ),
       );
     });
 
@@ -658,7 +660,9 @@ describe("CopilotKitProvider", () => {
 
       expect(result.current.copilotkit.runtimeTransport).toBe("rest");
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Both `useLegacyRuntime` and `useSingleEndpoint` are set"),
+        expect.stringContaining(
+          "Both `useLegacyRuntime` and `useSingleEndpoint` are set",
+        ),
       );
     });
 

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -573,8 +573,42 @@ describe("CopilotKitProvider", () => {
     });
   });
 
-  describe("useSingleEndpoint → runtimeTransport mapping", () => {
-    it("maps useSingleEndpoint=true to 'single' transport", () => {
+  describe("runtimeTransport mapping", () => {
+    it("defaults to 'rest' transport when no props are set", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider>{children}</CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.copilotkit.runtimeTransport).toBe("rest");
+    });
+
+    it("maps useLegacyRuntime=true to 'single' transport", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider useLegacyRuntime={true}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.copilotkit.runtimeTransport).toBe("single");
+    });
+
+    it("maps useLegacyRuntime=false to 'rest' transport", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider useLegacyRuntime={false}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.copilotkit.runtimeTransport).toBe("rest");
+    });
+
+    it("maps deprecated useSingleEndpoint=true to 'single' transport", () => {
       const { result } = renderHook(() => useCopilotKit(), {
         wrapper: ({ children }) => (
           <CopilotKitProvider useSingleEndpoint={true}>
@@ -586,7 +620,7 @@ describe("CopilotKitProvider", () => {
       expect(result.current.copilotkit.runtimeTransport).toBe("single");
     });
 
-    it("maps useSingleEndpoint=false to 'rest' transport", () => {
+    it("maps deprecated useSingleEndpoint=false to 'rest' transport", () => {
       const { result } = renderHook(() => useCopilotKit(), {
         wrapper: ({ children }) => (
           <CopilotKitProvider useSingleEndpoint={false}>
@@ -598,17 +632,26 @@ describe("CopilotKitProvider", () => {
       expect(result.current.copilotkit.runtimeTransport).toBe("rest");
     });
 
-    it("maps omitted useSingleEndpoint to 'auto' transport", () => {
+    it("useLegacyRuntime takes precedence over useSingleEndpoint", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
       const { result } = renderHook(() => useCopilotKit(), {
         wrapper: ({ children }) => (
-          <CopilotKitProvider>{children}</CopilotKitProvider>
+          <CopilotKitProvider useLegacyRuntime={true} useSingleEndpoint={false}>
+            {children}
+          </CopilotKitProvider>
         ),
       });
 
-      expect(result.current.copilotkit.runtimeTransport).toBe("auto");
+      expect(result.current.copilotkit.runtimeTransport).toBe("single");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Both `useLegacyRuntime` and `useSingleEndpoint` are set"),
+      );
+
+      warnSpy.mockRestore();
     });
 
-    it("updates transport when useSingleEndpoint prop changes", () => {
+    it("updates transport when useLegacyRuntime prop changes", () => {
       let capturedCopilotkit: ReturnType<typeof useCopilotKit>["copilotkit"];
 
       function Collector({ children }: { children?: React.ReactNode }) {
@@ -618,7 +661,7 @@ describe("CopilotKitProvider", () => {
       }
 
       const { rerender } = render(
-        <CopilotKitProvider useSingleEndpoint={false}>
+        <CopilotKitProvider useLegacyRuntime={false}>
           <Collector />
         </CopilotKitProvider>,
       );
@@ -626,7 +669,7 @@ describe("CopilotKitProvider", () => {
       expect(capturedCopilotkit!.runtimeTransport).toBe("rest");
 
       rerender(
-        <CopilotKitProvider useSingleEndpoint={true}>
+        <CopilotKitProvider useLegacyRuntime={true}>
           <Collector />
         </CopilotKitProvider>,
       );
@@ -639,7 +682,7 @@ describe("CopilotKitProvider", () => {
         </CopilotKitProvider>,
       );
 
-      expect(capturedCopilotkit!.runtimeTransport).toBe("auto");
+      expect(capturedCopilotkit!.runtimeTransport).toBe("rest");
     });
   });
 

--- a/showcase/packages/ag2/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/chat-customization-css/page.tsx
@@ -12,7 +12,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/ag2/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/chat-customization-css/page.tsx
@@ -12,7 +12,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/ag2/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ag2/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ag2/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ag2/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ag2/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/ag2/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/ag2/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/ag2/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/ag2/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ag2/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ag2/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/ag2/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/ag2/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/ag2/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/ag2/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/ag2/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/ag2/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/ag2/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/ag2/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/ag2/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/ag2/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -27,6 +27,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/ag2/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ag2/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/agno/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -32,7 +32,11 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/agno/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -32,7 +32,7 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/agno/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/agno/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/auth/page.tsx
+++ b/showcase/packages/agno/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/agno/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/agno/src/app/demos/chat-customization-css/page.tsx
@@ -11,7 +11,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/agno/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/agno/src/app/demos/chat-customization-css/page.tsx
@@ -11,7 +11,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/agno/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/agno/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/agno/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/agno/src/app/demos/frontend-tools-async/page.tsx
@@ -75,7 +75,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/agno/src/app/demos/frontend-tools-async/page.tsx
@@ -75,7 +75,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/agno/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/agno/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/agno/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/agno/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/agno/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/agno/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/agno/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/agno/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/agno/src/app/demos/headless-complete/page.tsx
@@ -45,7 +45,7 @@ const AGENT_ID = "headless-complete";
 // Outer wrapper — provides the CopilotKit runtime + page layout.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/agno/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/agno/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/agno/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/agno/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/agno/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/agno/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/agno/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/agno/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/agno/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/agno/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/agno/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/agno/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/agno/src/app/demos/prebuilt-popup/page.tsx
@@ -10,7 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/agno/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/agno/src/app/demos/prebuilt-popup/page.tsx
@@ -10,7 +10,11 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/agno/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/agno/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,11 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/agno/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/agno/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,7 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/agno/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/agno/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/agno/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/agno/src/app/demos/reasoning-default-render/page.tsx
@@ -15,7 +15,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/agno/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/agno/src/app/demos/reasoning-default-render/page.tsx
@@ -15,7 +15,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/agno/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/agno/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/agno/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/agno/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/agno/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/agno/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -18,6 +18,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/agno/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/agno/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -15,6 +15,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/agno/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/agno/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -56,6 +56,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/agno/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/agno/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/agno/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/agno/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/auth/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-hashbrown/page.tsx
@@ -36,6 +36,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/page.tsx
@@ -77,7 +77,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools-async/page.tsx
@@ -77,7 +77,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-complete/page.tsx
@@ -32,7 +32,7 @@ const AGENT_ID = "headless-complete";
 
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/page.tsx
@@ -38,7 +38,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/hitl-in-app/page.tsx
@@ -38,7 +38,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/multimodal/page.tsx
@@ -104,7 +104,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/packages/claude-sdk-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/multimodal/page.tsx
@@ -104,7 +104,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -24,6 +24,7 @@ import { openGenUiSuggestions } from "./suggestions";
 export default function OpenGenUiAdvancedDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
@@ -88,6 +88,7 @@ const minimalSuggestions = [
 export default function OpenGenUiDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -20,6 +20,7 @@ import { CopilotKit } from "@copilotkit/react-core";
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-python/src/app/demos/voice/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/auth/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/byoc-hashbrown/page.tsx
@@ -26,6 +26,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/declarative-gen-ui/page.tsx
@@ -36,6 +36,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/multimodal/page.tsx
@@ -162,7 +162,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/multimodal/page.tsx
@@ -162,7 +162,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -29,6 +29,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/open-gen-ui/page.tsx
@@ -116,6 +116,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/voice/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/crewai-crews/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -28,6 +28,7 @@ import { fixedCatalog } from "./a2ui/catalog";
 export default function A2UIFixedSchemaDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/crewai-crews/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/agent-config/page.tsx
@@ -20,6 +20,7 @@ export default function AgentConfigDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -13,7 +13,7 @@ import { ReasoningBlock } from "./reasoning-block";
 
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -13,7 +13,11 @@ import { ReasoningBlock } from "./reasoning-block";
 
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/auth/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/auth/page.tsx
@@ -142,6 +142,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/crewai-crews/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/beautiful-chat/page.tsx
@@ -29,6 +29,7 @@ export default function BeautifulChatPage() {
   return (
     <ThemeProvider>
       <CopilotKit
+        useLegacyRuntime
         runtimeUrl="/api/copilotkit-beautiful-chat"
         agent="beautiful-chat"
         a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/packages/crewai-crews/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/byoc-hashbrown/page.tsx
@@ -30,6 +30,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/crewai-crews/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div
         data-testid="byoc-json-render-root"
         className="flex justify-center items-center h-screen w-full"

--- a/showcase/packages/crewai-crews/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div
         data-testid="byoc-json-render-root"
         className="flex justify-center items-center h-screen w-full"

--- a/showcase/packages/crewai-crews/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/chat-customization-css/page.tsx
@@ -9,7 +9,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/crewai-crews/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/chat-customization-css/page.tsx
@@ -9,7 +9,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/crewai-crews/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/declarative-gen-ui/page.tsx
@@ -30,6 +30,7 @@ import { myCatalog } from "./a2ui/catalog";
 export default function DeclarativeGenUIDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/crewai-crews/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/frontend-tools-async/page.tsx
@@ -75,7 +75,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/frontend-tools-async/page.tsx
@@ -75,7 +75,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/crewai-crews/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/crewai-crews/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/headless-complete/page.tsx
@@ -24,7 +24,7 @@ const AGENT_ID = "headless-complete";
 
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/crewai-crews/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/crewai-crews/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/crewai-crews/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/crewai-crews/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/multimodal/page.tsx
@@ -219,7 +219,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/crewai-crews/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/multimodal/page.tsx
@@ -219,7 +219,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/crewai-crews/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -18,6 +18,7 @@ import { openGenUiSuggestions } from "./suggestions";
 export default function OpenGenUiAdvancedDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/crewai-crews/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/open-gen-ui/page.tsx
@@ -41,6 +41,7 @@ const minimalSuggestions = [
 export default function OpenGenUiDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
@@ -10,7 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
@@ -10,7 +10,11 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,11 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,7 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/crewai-crews/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
@@ -9,7 +9,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
@@ -9,7 +9,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -19,6 +19,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/crewai-crews/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -15,6 +15,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/crewai-crews/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -48,6 +48,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/crewai-crews/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/crewai-crews/src/app/demos/voice/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/voice/page.tsx
@@ -60,7 +60,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/google-adk/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/google-adk/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/google-adk/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/google-adk/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/google-adk/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -30,6 +30,7 @@ export default function A2UIFixedSchemaDemo() {
   return (
     // `a2ui.catalog` wires the fixed catalog into the A2UI activity renderer.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,7 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,11 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/beautiful-chat/page.tsx
@@ -36,15 +36,7 @@ export default function BeautifulChatPage() {
         agent="beautiful-chat"
         a2ui={{ catalog: demonstrationCatalog }}
         openGenerativeUI={{}}
-        /*
-         * `useSingleEndpoint` defaults to true (the single-POST-endpoint
-         * protocol). The canonical reference sets it to false to use the
-         * v2 multi-endpoint protocol (GET /info + POST /agent/{name}/connect),
-         * which requires a Hono-based endpoint via `createCopilotEndpoint`.
-         * The 4085 showcase uses `copilotRuntimeNextJSAppRouterEndpoint`
-         * (single-endpoint), which matches the other 4085 cells — so we
-         * use its default behavior here. Functionally equivalent for this demo.
-         */
+        useLegacyRuntime
       >
         <HomePage />
       </CopilotKit>

--- a/showcase/packages/langgraph-fastapi/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/byoc-hashbrown/page.tsx
@@ -36,6 +36,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/langgraph-fastapi/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langgraph-fastapi/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langgraph-fastapi/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/declarative-gen-ui/page.tsx
@@ -36,6 +36,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-interrupt/page.tsx
@@ -18,7 +18,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-interrupt"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-interrupt/page.tsx
@@ -18,7 +18,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/langgraph-fastapi/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/headless-complete/page.tsx
@@ -43,7 +43,7 @@ const AGENT_ID = "headless-complete";
 // `use-rendered-messages.tsx` picks up the emitted activity events.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/langgraph-fastapi/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/headless-complete/page.tsx
@@ -43,7 +43,11 @@ const AGENT_ID = "headless-complete";
 // `use-rendered-messages.tsx` picks up the emitted activity events.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/langgraph-fastapi/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/interrupt-headless/page.tsx
@@ -41,7 +41,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="interrupt-headless"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/interrupt-headless/page.tsx
@@ -41,7 +41,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/langgraph-fastapi/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/langgraph-fastapi/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -29,6 +29,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/open-gen-ui/page.tsx
@@ -116,6 +116,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/langgraph-fastapi/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/langgraph-fastapi/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -27,6 +27,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -56,6 +56,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-fastapi/src/app/demos/voice/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/langgraph-python/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -30,6 +30,7 @@ export default function A2UIFixedSchemaDemo() {
   return (
     // `a2ui.catalog` wires the fixed catalog into the A2UI activity renderer.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/langgraph-python/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/langgraph-python/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,7 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,11 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/agentic-chat/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function AgenticChatDemo() {
   return (
     // @region[provider-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/agentic-chat/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function AgenticChatDemo() {
   return (
     // @region[provider-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/langgraph-python/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/beautiful-chat/page.tsx
@@ -36,15 +36,7 @@ export default function BeautifulChatPage() {
         agent="beautiful-chat"
         a2ui={{ catalog: demonstrationCatalog }}
         openGenerativeUI={{}}
-        /*
-         * `useSingleEndpoint` defaults to true (the single-POST-endpoint
-         * protocol). The canonical reference sets it to false to use the
-         * v2 multi-endpoint protocol (GET /info + POST /agent/{name}/connect),
-         * which requires a Hono-based endpoint via `createCopilotEndpoint`.
-         * The 4085 showcase uses `copilotRuntimeNextJSAppRouterEndpoint`
-         * (single-endpoint), which matches the other 4085 cells — so we
-         * use its default behavior here. Functionally equivalent for this demo.
-         */
+        useLegacyRuntime
       >
         <HomePage />
       </CopilotKit>

--- a/showcase/packages/langgraph-python/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/byoc-hashbrown/page.tsx
@@ -36,6 +36,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langgraph-python/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langgraph-python/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/declarative-gen-ui/page.tsx
@@ -36,6 +36,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/langgraph-python/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/gen-ui-agent/page.tsx
@@ -25,7 +25,7 @@ import { InlineAgentStateCard, type Step } from "./InlineAgentStateCard";
  */
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/gen-ui-agent/page.tsx
@@ -25,7 +25,11 @@ import { InlineAgentStateCard, type Step } from "./InlineAgentStateCard";
  */
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/gen-ui-interrupt/page.tsx
@@ -18,7 +18,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-interrupt"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/gen-ui-interrupt/page.tsx
@@ -18,7 +18,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/gen-ui-tool-based/page.tsx
@@ -12,7 +12,11 @@ import { PieChart, pieChartPropsSchema } from "./pie-chart";
 
 export default function ControlledGenUiDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/gen-ui-tool-based/page.tsx
@@ -12,7 +12,7 @@ import { PieChart, pieChartPropsSchema } from "./pie-chart";
 
 export default function ControlledGenUiDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/headless-complete/page.tsx
@@ -43,7 +43,7 @@ const AGENT_ID = "headless-complete";
 // `use-rendered-messages.tsx` picks up the emitted activity events.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/langgraph-python/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/headless-complete/page.tsx
@@ -43,7 +43,11 @@ const AGENT_ID = "headless-complete";
 // `use-rendered-messages.tsx` picks up the emitted activity events.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/langgraph-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langgraph-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langgraph-python/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/interrupt-headless/page.tsx
@@ -41,7 +41,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="interrupt-headless"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/interrupt-headless/page.tsx
@@ -41,7 +41,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/langgraph-python/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -29,6 +29,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/langgraph-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/open-gen-ui/page.tsx
@@ -116,6 +116,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/langgraph-python/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langgraph-python/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langgraph-python/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/langgraph-python/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/langgraph-python/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/langgraph-python/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/langgraph-python/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/langgraph-python/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/shared-state-read-write/page.tsx
@@ -30,7 +30,7 @@ interface RWAgentState {
 
 export default function SharedStateReadWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/shared-state-read-write/page.tsx
@@ -30,7 +30,11 @@ interface RWAgentState {
 
 export default function SharedStateReadWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langgraph-python/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langgraph-python/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/shared-state-streaming/page.tsx
@@ -17,7 +17,7 @@ interface StreamingAgentState {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/shared-state-streaming/page.tsx
@@ -17,7 +17,11 @@ interface StreamingAgentState {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/subagents/page.tsx
@@ -17,7 +17,7 @@ interface SubagentsAgentState {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/langgraph-python/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -27,6 +27,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/langgraph-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -56,6 +56,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/langgraph-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/tool-rendering/page.tsx
@@ -53,7 +53,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/tool-rendering/page.tsx
@@ -53,7 +53,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-python/src/app/demos/voice/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/langgraph-typescript/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -30,6 +30,7 @@ export default function A2UIFixedSchemaDemo() {
   return (
     // `a2ui.catalog` wires the fixed catalog into the A2UI activity renderer.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/langgraph-typescript/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,7 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,11 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/langgraph-typescript/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/beautiful-chat/page.tsx
@@ -36,15 +36,7 @@ export default function BeautifulChatPage() {
         agent="beautiful-chat"
         a2ui={{ catalog: demonstrationCatalog }}
         openGenerativeUI={{}}
-        /*
-         * `useSingleEndpoint` defaults to true (the single-POST-endpoint
-         * protocol). The canonical reference sets it to false to use the
-         * v2 multi-endpoint protocol (GET /info + POST /agent/{name}/connect),
-         * which requires a Hono-based endpoint via `createCopilotEndpoint`.
-         * The 4085 showcase uses `copilotRuntimeNextJSAppRouterEndpoint`
-         * (single-endpoint), which matches the other 4085 cells — so we
-         * use its default behavior here. Functionally equivalent for this demo.
-         */
+        useLegacyRuntime
       >
         <HomePage />
       </CopilotKit>

--- a/showcase/packages/langgraph-typescript/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/byoc-hashbrown/page.tsx
@@ -36,6 +36,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/langgraph-typescript/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langgraph-typescript/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langgraph-typescript/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/declarative-gen-ui/page.tsx
@@ -36,6 +36,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-interrupt/page.tsx
@@ -18,7 +18,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-interrupt"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-interrupt/page.tsx
@@ -18,7 +18,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/langgraph-typescript/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/headless-complete/page.tsx
@@ -43,7 +43,7 @@ const AGENT_ID = "headless-complete";
 // `use-rendered-messages.tsx` picks up the emitted activity events.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/langgraph-typescript/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/headless-complete/page.tsx
@@ -43,7 +43,11 @@ const AGENT_ID = "headless-complete";
 // `use-rendered-messages.tsx` picks up the emitted activity events.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/langgraph-typescript/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/interrupt-headless/page.tsx
@@ -41,7 +41,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="interrupt-headless"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/interrupt-headless/page.tsx
@@ -41,7 +41,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langgraph-typescript/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/langgraph-typescript/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/langgraph-typescript/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -29,6 +29,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/langgraph-typescript/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/open-gen-ui/page.tsx
@@ -116,6 +116,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/langgraph-typescript/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/langgraph-typescript/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/langgraph-typescript/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -27,6 +27,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -56,6 +56,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langgraph-typescript/src/app/demos/voice/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/langroid/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -17,7 +17,7 @@ import { ReasoningBlock } from "./reasoning-block";
 
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -17,7 +17,11 @@ import { ReasoningBlock } from "./reasoning-block";
 
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langroid/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/auth/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/langroid/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-customization-css/page.tsx
@@ -12,7 +12,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langroid/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-customization-css/page.tsx
@@ -12,7 +12,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langroid/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langroid/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langroid/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/declarative-gen-ui/page.tsx
@@ -36,6 +36,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/langroid/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/frontend-tools-async/page.tsx
@@ -74,7 +74,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langroid/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/frontend-tools-async/page.tsx
@@ -74,7 +74,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/langroid/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/langroid/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/langroid/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-complete/page.tsx
@@ -43,7 +43,7 @@ const AGENT_ID = "headless-complete";
 // still works; MCP activity events are simply not emitted by this backend.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/langroid/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langroid/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/langroid/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/langroid/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/langroid/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/langroid/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/reasoning-default-render/page.tsx
@@ -13,7 +13,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langroid/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/reasoning-default-render/page.tsx
@@ -13,7 +13,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/langroid/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langroid/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/langroid/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -21,6 +21,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/langroid/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -18,6 +18,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/langroid/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/langroid/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -26,6 +26,7 @@ import { fixedCatalog } from "./a2ui/catalog";
 export default function A2UIFixedSchemaDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/llamaindex/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/llamaindex/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,7 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,11 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/auth/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/llamaindex/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/byoc-hashbrown/page.tsx
@@ -36,6 +36,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/llamaindex/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/chat-customization-css/page.tsx
@@ -6,7 +6,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat_customization_css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat_customization_css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/llamaindex/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/chat-customization-css/page.tsx
@@ -6,7 +6,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat_customization_css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat_customization_css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/llamaindex/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/chat-slots/page.tsx
@@ -10,7 +10,11 @@ import { CustomWelcomeScreen } from "./custom-welcome-screen";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat_slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat_slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/chat-slots/page.tsx
@@ -10,7 +10,7 @@ import { CustomWelcomeScreen } from "./custom-welcome-screen";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat_slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat_slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/declarative-gen-ui/page.tsx
@@ -28,6 +28,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/llamaindex/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/frontend-tools-async/page.tsx
@@ -62,7 +62,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools_async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools_async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/frontend-tools-async/page.tsx
@@ -62,7 +62,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools_async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools_async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/llamaindex/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/llamaindex/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/headless-complete/page.tsx
@@ -23,7 +23,7 @@ const AGENT_ID = "headless_complete";
 
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/llamaindex/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless_simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless_simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/llamaindex/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless_simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless_simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/llamaindex/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl_in_app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl_in_app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl_in_app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl_in_app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/llamaindex/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/multimodal/page.tsx
@@ -94,7 +94,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/packages/llamaindex/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/multimodal/page.tsx
@@ -94,7 +94,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/packages/llamaindex/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -29,6 +29,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/llamaindex/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/open-gen-ui/page.tsx
@@ -116,6 +116,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/llamaindex/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt_popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt_popup"

--- a/showcase/packages/llamaindex/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt_popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt_popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt_popup"

--- a/showcase/packages/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt_sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt_sidebar"
+    >
       <MainContent />
       <CopilotSidebar agentId="prebuilt_sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt_sidebar">
       <MainContent />
       <CopilotSidebar agentId="prebuilt_sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/llamaindex/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly_state_agent_context"
     >

--- a/showcase/packages/llamaindex/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/reasoning-default-render/page.tsx
@@ -13,7 +13,7 @@ import { CopilotKit } from "@copilotkit/react-core";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/llamaindex/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/reasoning-default-render/page.tsx
@@ -13,7 +13,11 @@ import { CopilotKit } from "@copilotkit/react-core";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/llamaindex/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -18,6 +18,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/llamaindex/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -53,6 +53,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/llamaindex/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/llamaindex/src/app/demos/voice/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/mastra/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -26,6 +26,7 @@ import { fixedCatalog } from "./a2ui/catalog";
 export default function A2UIFixedSchemaDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/mastra/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agent-config/page.tsx
@@ -18,7 +18,11 @@ import { useAgentConfig } from "./use-agent-config";
 
 export default function AgentConfigDemoPage() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agent-config">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agent-config"
+    >
       <Inner />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agent-config/page.tsx
@@ -18,7 +18,7 @@ import { useAgentConfig } from "./use-agent-config";
 
 export default function AgentConfigDemoPage() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agent-config">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agent-config">
       <Inner />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -16,7 +16,7 @@ import { ReasoningBlock } from "./reasoning-block";
 
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -16,7 +16,11 @@ import { ReasoningBlock } from "./reasoning-block";
 
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/auth/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/mastra/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/chat-customization-css/page.tsx
@@ -13,7 +13,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/mastra/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/chat-customization-css/page.tsx
@@ -13,7 +13,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/mastra/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/declarative-gen-ui/page.tsx
@@ -32,6 +32,7 @@ import { myCatalog } from "./a2ui/catalog";
 export default function DeclarativeGenUIDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/mastra/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/mastra/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/mastra/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-complete/page.tsx
@@ -42,7 +42,7 @@ const AGENT_ID = "headless-complete";
 // to the shared runtime and drop the sketch suggestion).
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/mastra/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/mastra/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/mastra/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/mastra/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/mastra/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/mastra/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,11 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/mastra/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,7 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/mastra/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/mastra/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/mastra/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/mastra/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/mastra/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/mastra/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/mastra/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -27,6 +27,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -30,6 +30,7 @@ export default function A2UIFixedSchemaDemo() {
   return (
     // `a2ui.catalog` wires the fixed catalog into the A2UI activity renderer.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/agent-config/page.tsx
@@ -11,7 +11,11 @@ const AGENT_ID = "agent-config-demo";
 
 export default function AgentConfigDemoPage() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-agent-config" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-agent-config"
+      agent={AGENT_ID}
+    >
       <AgentConfigInner />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/agent-config/page.tsx
@@ -11,7 +11,7 @@ const AGENT_ID = "agent-config-demo";
 
 export default function AgentConfigDemoPage() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-agent-config" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-agent-config" agent={AGENT_ID}>
       <AgentConfigInner />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,6 +28,7 @@ import { ReasoningBlock } from "./reasoning-block";
 export default function AgenticChatReasoningDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-reasoning"
       agent="agentic-chat-reasoning"
     >

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/auth/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/auth/page.tsx
@@ -137,6 +137,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/beautiful-chat/page.tsx
@@ -24,6 +24,7 @@ export default function BeautifulChatPage() {
   return (
     <ThemeProvider>
       <CopilotKit
+        useLegacyRuntime
         runtimeUrl="/api/copilotkit-beautiful-chat"
         agent="beautiful-chat"
         a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/byoc-hashbrown/page.tsx
@@ -27,6 +27,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/byoc-json-render/page.tsx
@@ -22,7 +22,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/byoc-json-render/page.tsx
@@ -22,7 +22,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/declarative-gen-ui/page.tsx
@@ -34,6 +34,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-interrupt/page.tsx
@@ -37,7 +37,7 @@ type MeetingDecision =
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-interrupt/page.tsx
@@ -37,7 +37,11 @@ type MeetingDecision =
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-interrupt"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/headless-complete/page.tsx
@@ -50,7 +50,7 @@ const AGENT_ID = "headless-complete";
 // through `/api/copilotkit` which proxies to the .NET SalesAgent.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/hitl-in-app/page.tsx
@@ -53,7 +53,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/hitl-in-app/page.tsx
@@ -53,7 +53,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/interrupt-headless/page.tsx
@@ -47,7 +47,7 @@ type MeetingDecision =
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/interrupt-headless/page.tsx
@@ -47,7 +47,11 @@ type MeetingDecision =
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="interrupt-headless"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function McpAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function McpAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/multimodal/page.tsx
@@ -191,7 +191,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/multimodal/page.tsx
@@ -191,7 +191,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -33,6 +33,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/open-gen-ui/page.tsx
@@ -116,6 +116,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/reasoning-default-render/page.tsx
@@ -17,6 +17,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 export default function ReasoningDefaultRenderDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-reasoning"
       agent="reasoning-default-render"
     >

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -22,6 +22,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -26,6 +26,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -74,6 +74,7 @@ function extractFlights(parsed: FlightSearchResult): Flight[] {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/voice/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/voice/page.tsx
@@ -58,7 +58,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/ms-agent-python/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -30,6 +30,7 @@ export default function A2UIFixedSchemaDemo() {
   return (
     // `a2ui.catalog` wires the fixed catalog into the A2UI activity renderer.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/ms-agent-python/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/agent-config/page.tsx
@@ -24,6 +24,7 @@ export default function AgentConfigDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/ms-agent-python/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -25,6 +25,7 @@ import { ReasoningBlock } from "./reasoning-block";
 export default function AgenticChatReasoningDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-reasoning"
       agent="agentic-chat-reasoning"
     >

--- a/showcase/packages/ms-agent-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/auth/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/auth/page.tsx
@@ -136,6 +136,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/ms-agent-python/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/beautiful-chat/page.tsx
@@ -36,15 +36,7 @@ export default function BeautifulChatPage() {
         agent="beautiful-chat"
         a2ui={{ catalog: demonstrationCatalog }}
         openGenerativeUI={{}}
-        /*
-         * `useSingleEndpoint` defaults to true (the single-POST-endpoint
-         * protocol). The canonical reference sets it to false to use the
-         * v2 multi-endpoint protocol (GET /info + POST /agent/{name}/connect),
-         * which requires a Hono-based endpoint via `createCopilotEndpoint`.
-         * The 4085 showcase uses `copilotRuntimeNextJSAppRouterEndpoint`
-         * (single-endpoint), which matches the other 4085 cells — so we
-         * use its default behavior here. Functionally equivalent for this demo.
-         */
+        useLegacyRuntime
       >
         <HomePage />
       </CopilotKit>

--- a/showcase/packages/ms-agent-python/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/byoc-hashbrown/page.tsx
@@ -36,6 +36,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/ms-agent-python/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/chat-customization-css/page.tsx
@@ -15,7 +15,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/ms-agent-python/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/chat-customization-css/page.tsx
@@ -15,7 +15,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/ms-agent-python/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/chat-slots/page.tsx
@@ -11,7 +11,11 @@ import { CustomWelcomeScreen } from "./custom-welcome-screen";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/chat-slots/page.tsx
@@ -11,7 +11,7 @@ import { CustomWelcomeScreen } from "./custom-welcome-screen";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/declarative-gen-ui/page.tsx
@@ -34,6 +34,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/ms-agent-python/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/gen-ui-interrupt/page.tsx
@@ -35,7 +35,11 @@ type PickerResult =
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-interrupt"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/gen-ui-interrupt/page.tsx
@@ -35,7 +35,7 @@ type PickerResult =
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/ms-agent-python/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/ms-agent-python/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/headless-complete/page.tsx
@@ -49,7 +49,7 @@ const AGENT_ID = "headless-complete";
 // Outer wrapper — provides the CopilotKit runtime + page layout.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/ms-agent-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/ms-agent-python/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/ms-agent-python/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/hitl-in-app/page.tsx
@@ -53,7 +53,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/hitl-in-app/page.tsx
@@ -53,7 +53,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/interrupt-headless/page.tsx
@@ -47,7 +47,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="interrupt-headless"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/interrupt-headless/page.tsx
@@ -47,7 +47,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="interrupt-headless">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/ms-agent-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/multimodal/page.tsx
@@ -205,7 +205,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/ms-agent-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/multimodal/page.tsx
@@ -205,7 +205,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/ms-agent-python/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -36,6 +36,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/ms-agent-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/open-gen-ui/page.tsx
@@ -113,6 +113,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/ms-agent-python/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit } from "@copilotkit/react-core";
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/ms-agent-python/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit } from "@copilotkit/react-core";
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/ms-agent-python/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit } from "@copilotkit/react-core";
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/ms-agent-python/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit } from "@copilotkit/react-core";
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/ms-agent-python/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/ms-agent-python/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/reasoning-default-render/page.tsx
@@ -23,6 +23,7 @@ import { z } from "zod";
 export default function ReasoningDefaultRenderDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-reasoning"
       agent="reasoning-default-render"
     >

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/ms-agent-python/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -27,6 +27,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/ms-agent-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -56,6 +56,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/ms-agent-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/ms-agent-python/src/app/demos/voice/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/pydantic-ai/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -30,6 +30,7 @@ export default function A2UIFixedSchemaDemo() {
   return (
     // `a2ui.catalog` wires the fixed catalog into the A2UI activity renderer.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/pydantic-ai/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/pydantic-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/auth/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/pydantic-ai/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/beautiful-chat/page.tsx
@@ -36,15 +36,7 @@ export default function BeautifulChatPage() {
         agent="beautiful-chat"
         a2ui={{ catalog: demonstrationCatalog }}
         openGenerativeUI={{}}
-        /*
-         * `useSingleEndpoint` defaults to true (the single-POST-endpoint
-         * protocol). The canonical reference sets it to false to use the
-         * v2 multi-endpoint protocol (GET /info + POST /agent/{name}/connect),
-         * which requires a Hono-based endpoint via `createCopilotEndpoint`.
-         * The 4085 showcase uses `copilotRuntimeNextJSAppRouterEndpoint`
-         * (single-endpoint), which matches the other 4085 cells — so we
-         * use its default behavior here. Functionally equivalent for this demo.
-         */
+        useLegacyRuntime
       >
         <HomePage />
       </CopilotKit>

--- a/showcase/packages/pydantic-ai/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/byoc-hashbrown/page.tsx
@@ -36,6 +36,7 @@ import { BYOC_HASHBROWN_SUGGESTIONS } from "./suggestions";
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/pydantic-ai/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,7 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/pydantic-ai/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/byoc-json-render/page.tsx
@@ -27,7 +27,11 @@ const AGENT_ID = "byoc_json_render";
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
@@ -9,7 +9,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
@@ -9,7 +9,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/pydantic-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/pydantic-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/pydantic-ai/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/declarative-gen-ui/page.tsx
@@ -34,6 +34,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/pydantic-ai/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/frontend-tools-async/page.tsx
@@ -74,7 +74,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/pydantic-ai/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/frontend-tools-async/page.tsx
@@ -74,7 +74,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/pydantic-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/pydantic-ai/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/pydantic-ai/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/headless-complete/page.tsx
@@ -44,7 +44,7 @@ const AGENT_ID = "headless-complete";
 // stays in place for future MCP-apps parity; today it simply never fires.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/pydantic-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/pydantic-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/pydantic-ai/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/hitl-in-app/page.tsx
@@ -36,7 +36,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/pydantic-ai/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/multimodal/page.tsx
@@ -244,7 +244,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/pydantic-ai/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -29,6 +29,7 @@ export default function OpenGenUiAdvancedDemo() {
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/pydantic-ai/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/open-gen-ui/page.tsx
@@ -116,6 +116,7 @@ export default function OpenGenUiDemo() {
   // guidance in place of the default shadcn design skill.
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -10,7 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -10,7 +10,11 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,11 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,7 +10,7 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/pydantic-ai/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -17,6 +17,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/pydantic-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -15,6 +15,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/pydantic-ai/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/pydantic-ai/src/app/demos/voice/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/spring-ai/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -28,6 +28,7 @@ import { fixedCatalog } from "./a2ui/catalog";
 export default function A2UIFixedSchemaDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/spring-ai/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/agent-config/page.tsx
@@ -30,6 +30,7 @@ export default function AgentConfigDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/spring-ai/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,7 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,11 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/auth/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth"
       headers={headers}

--- a/showcase/packages/spring-ai/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/beautiful-chat/page.tsx
@@ -46,7 +46,7 @@ const BRAND_SUGGESTIONS = [
 
 export default function BeautifulChatPage() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div
         className="relative flex h-screen w-full flex-col items-center justify-center overflow-hidden"
         style={{

--- a/showcase/packages/spring-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/chat-customization-css/page.tsx
@@ -13,7 +13,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/spring-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/chat-customization-css/page.tsx
@@ -13,7 +13,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/spring-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/chat-slots/page.tsx
@@ -13,7 +13,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/declarative-gen-ui/page.tsx
@@ -36,6 +36,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/spring-ai/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/frontend-tools-async/page.tsx
@@ -62,7 +62,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/frontend-tools-async/page.tsx
@@ -62,7 +62,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/spring-ai/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/spring-ai/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/headless-complete/page.tsx
@@ -45,7 +45,7 @@ const AGENT_ID = "headless-complete";
 // useRenderActivityMessage for A2UI — still composes correctly.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/spring-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/spring-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/spring-ai/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/hitl-in-app/page.tsx
@@ -37,7 +37,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/hitl-in-app/page.tsx
@@ -37,7 +37,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/hitl-in-chat/page.tsx
@@ -19,7 +19,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,7 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/mcp-apps/page.tsx
@@ -31,7 +31,11 @@ export default function MCPAppsDemo() {
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-mcp-apps" agent="mcp-apps">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-mcp-apps"
+      agent="mcp-apps"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/spring-ai/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/multimodal/page.tsx
@@ -94,7 +94,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/packages/spring-ai/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/multimodal/page.tsx
@@ -94,7 +94,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/packages/spring-ai/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -26,6 +26,7 @@ export default function OpenGenUiAdvancedDemo() {
   return (
     // @region[sandbox-function-registration]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/spring-ai/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/open-gen-ui/page.tsx
@@ -85,6 +85,7 @@ const minimalSuggestions = [
 export default function OpenGenUiDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/spring-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/spring-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
       <Suggestions />

--- a/showcase/packages/spring-ai/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/spring-ai/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/reasoning-default-render/page.tsx
@@ -19,7 +19,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/spring-ai/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/reasoning-default-render/page.tsx
@@ -19,7 +19,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -19,6 +19,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/spring-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -18,6 +18,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/spring-ai/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -56,6 +56,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/spring-ai/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/spring-ai/src/app/demos/voice/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/voice/page.tsx
@@ -45,7 +45,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/packages/strands/src/app/demos/a2ui-fixed-schema/page.tsx
+++ b/showcase/packages/strands/src/app/demos/a2ui-fixed-schema/page.tsx
@@ -30,6 +30,7 @@ export default function A2UIFixedSchemaDemo() {
   return (
     // `a2ui.catalog` wires the fixed catalog into the A2UI activity renderer.
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-a2ui-fixed-schema"
       agent="a2ui-fixed-schema"
       a2ui={{ catalog: fixedCatalog }}

--- a/showcase/packages/strands/src/app/demos/agent-config/page.tsx
+++ b/showcase/packages/strands/src/app/demos/agent-config/page.tsx
@@ -25,6 +25,7 @@ export default function AgentConfigDemoPage() {
   return (
     // @region[provider-setup]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-agent-config"
       agent="agent-config-demo"
       properties={providerProperties}

--- a/showcase/packages/strands/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/strands/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,7 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/strands/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,7 +28,11 @@ import { ReasoningBlock } from "./reasoning-block";
 // Outer layer — provider + layout chrome.
 export default function AgenticChatReasoningDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic-chat-reasoning"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/strands/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="agentic_chat"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/strands/src/app/demos/agentic-chat/page.tsx
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/auth/page.tsx
+++ b/showcase/packages/strands/src/app/demos/auth/page.tsx
@@ -138,6 +138,7 @@ export default function AuthDemoPage() {
 
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-auth"
       agent="auth-demo"
       headers={headers}

--- a/showcase/packages/strands/src/app/demos/byoc-hashbrown/page.tsx
+++ b/showcase/packages/strands/src/app/demos/byoc-hashbrown/page.tsx
@@ -84,6 +84,7 @@ Rules:
 export default function ByocHashbrownDemoPage() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-byoc-hashbrown"
       agent="byoc-hashbrown-demo"
     >

--- a/showcase/packages/strands/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/strands/src/app/demos/byoc-json-render/page.tsx
@@ -82,7 +82,7 @@ Rules:
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/byoc-json-render/page.tsx
+++ b/showcase/packages/strands/src/app/demos/byoc-json-render/page.tsx
@@ -82,7 +82,11 @@ Rules:
 
 export default function ByocJsonRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-byoc-json-render" agent={AGENT_ID}>
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-byoc-json-render"
+      agent={AGENT_ID}
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/strands/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,11 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-customization-css"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/strands/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/strands/src/app/demos/chat-customization-css/page.tsx
@@ -14,7 +14,7 @@ import "./theme.css";
 
 export default function ChatCustomizationCssDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-customization-css">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-customization-css">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="chat-css-demo-scope h-full w-full max-w-4xl">
           <CopilotChat

--- a/showcase/packages/strands/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/strands/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,11 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="chat-slots"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/strands/src/app/demos/chat-slots/page.tsx
@@ -14,7 +14,7 @@ import { CustomDisclaimer } from "./custom-disclaimer";
 // Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="chat-slots">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="chat-slots">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/strands/src/app/demos/declarative-gen-ui/page.tsx
@@ -36,6 +36,7 @@ export default function DeclarativeGenUIDemo() {
   return (
     // @region[provider-a2ui-prop]
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
       a2ui={{ catalog: myCatalog }}

--- a/showcase/packages/strands/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/strands/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,7 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/frontend-tools-async/page.tsx
+++ b/showcase/packages/strands/src/app/demos/frontend-tools-async/page.tsx
@@ -78,7 +78,11 @@ function parseJsonResult<T>(result: unknown): T {
 
 export default function FrontendToolsAsyncDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend-tools-async">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend-tools-async"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/strands/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/strands/src/app/demos/frontend-tools/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function FrontendToolsDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="frontend_tools">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="frontend_tools"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/strands/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,11 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-agent"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/packages/strands/src/app/demos/gen-ui-agent/page.tsx
@@ -18,7 +18,7 @@ interface AgentState {
 
 export default function GenUiAgentDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-agent">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/strands/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,7 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/strands/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/strands/src/app/demos/gen-ui-tool-based/page.tsx
@@ -18,7 +18,11 @@ interface Haiku {
 
 export default function GenUiToolBasedDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="gen-ui-tool-based"
+    >
       <SidebarWithSuggestions />
       <HaikuDisplay />
     </CopilotKit>

--- a/showcase/packages/strands/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/strands/src/app/demos/headless-complete/page.tsx
@@ -44,7 +44,7 @@ const AGENT_ID = "headless-complete";
 // messages) all work fine against the shared Strands agent.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">

--- a/showcase/packages/strands/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/strands/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,11 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="headless-simple"
+    >
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/strands/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/strands/src/app/demos/headless-simple/page.tsx
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 export default function HeadlessSimpleDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="headless-simple">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="headless-simple">
       <div className="flex justify-center items-start min-h-screen w-full p-6 bg-gray-50">
         <div className="w-full max-w-4xl">
           <HeadlessChat />

--- a/showcase/packages/strands/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/strands/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,7 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/strands/src/app/demos/hitl-in-app/page.tsx
@@ -40,7 +40,11 @@ const SUPPORT_TICKETS = [
 
 export default function HitlInAppDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-app">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-app"
+    >
       <Layout />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/strands/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,11 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="hitl-in-chat"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/strands/src/app/demos/hitl-in-chat/page.tsx
@@ -21,7 +21,7 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function HitlInChatDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="hitl-in-chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />

--- a/showcase/packages/strands/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/strands/src/app/demos/hitl/page.tsx
@@ -16,7 +16,11 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="human_in_the_loop"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/strands/src/app/demos/hitl/page.tsx
@@ -16,7 +16,7 @@ interface Step {
 
 export default function HitlDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/strands/src/app/demos/multimodal/page.tsx
@@ -201,7 +201,7 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/strands/src/app/demos/multimodal/page.tsx
+++ b/showcase/packages/strands/src/app/demos/multimodal/page.tsx
@@ -201,7 +201,11 @@ export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit-multimodal"
+      agent="multimodal-demo"
+    >
       <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"

--- a/showcase/packages/strands/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/packages/strands/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -19,6 +19,7 @@ import { openGenUiSuggestions } from "./suggestions";
 export default function OpenGenUiAdvancedDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
       openGenerativeUI={{ sandboxFunctions: openGenUiSandboxFunctions }}

--- a/showcase/packages/strands/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/packages/strands/src/app/demos/open-gen-ui/page.tsx
@@ -87,6 +87,7 @@ const minimalSuggestions = [
 export default function OpenGenUiDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}

--- a/showcase/packages/strands/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/strands/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-popup"
+    >
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/strands/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/strands/src/app/demos/prebuilt-popup/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltPopupDemo() {
   return (
     // @region[popup-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
         agentId="prebuilt-popup"

--- a/showcase/packages/strands/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/strands/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,7 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/strands/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/strands/src/app/demos/prebuilt-sidebar/page.tsx
@@ -11,7 +11,11 @@ import {
 export default function PrebuiltSidebarDemo() {
   return (
     // @region[sidebar-basic-setup]
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="prebuilt-sidebar"
+    >
       <MainContent />
       {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />

--- a/showcase/packages/strands/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/packages/strands/src/app/demos/readonly-state-agent-context/page.tsx
@@ -11,6 +11,7 @@ import {
 export default function ReadonlyStateAgentContextDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="readonly-state-agent-context"
     >

--- a/showcase/packages/strands/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/strands/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,11 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="reasoning-default-render"
+    >
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/strands/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/packages/strands/src/app/demos/reasoning-default-render/page.tsx
@@ -11,7 +11,7 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function ReasoningDefaultRenderDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           {/* @region[default-reasoning-zero-config] */}

--- a/showcase/packages/strands/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-read-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,11 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-read"
+    >
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/strands/src/app/demos/shared-state-read/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-read/page.tsx
@@ -77,7 +77,7 @@ const INITIAL_STATE: RecipeAgentState = {
 
 export default function SharedStateReadDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-read">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-read">
       <div className="min-h-screen w-full flex items-center justify-center">
         <Recipe />
         <CopilotSidebar

--- a/showcase/packages/strands/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateStreamingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-streaming">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-streaming"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,11 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="shared-state-write"
+    >
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/shared-state-write/page.tsx
+++ b/showcase/packages/strands/src/app/demos/shared-state-write/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateWriteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="shared-state-write">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="shared-state-write">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/subagents/page.tsx
+++ b/showcase/packages/strands/src/app/demos/subagents/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SubagentsDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="subagents">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="subagents">
       <DemoContent />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/packages/strands/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -23,6 +23,7 @@ import {
 export default function ToolRenderingCustomCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-custom-catchall"
     >

--- a/showcase/packages/strands/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/packages/strands/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -27,6 +27,7 @@ import {
 export default function ToolRenderingDefaultCatchallDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-default-catchall"
     >

--- a/showcase/packages/strands/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/packages/strands/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -56,6 +56,7 @@ function parseJsonResult<T>(result: unknown): T {
 export default function ToolRenderingReasoningChainDemo() {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent="tool-rendering-reasoning-chain"
     >

--- a/showcase/packages/strands/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/strands/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,11 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit
+      useLegacyRuntime
+      runtimeUrl="/api/copilotkit"
+      agent="tool-rendering"
+    >
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/strands/src/app/demos/tool-rendering/page.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 export default function ToolRenderingDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent="tool-rendering">
       <Chat />
     </CopilotKit>
   );

--- a/showcase/packages/strands/src/app/demos/voice/page.tsx
+++ b/showcase/packages/strands/src/app/demos/voice/page.tsx
@@ -57,7 +57,7 @@ export default function VoiceDemoPage() {
   }, []);
 
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Voice input</h1>

--- a/showcase/shell-docs/src/content/reference/index.mdx
+++ b/showcase/shell-docs/src/content/reference/index.mdx
@@ -68,8 +68,12 @@ If you need direct control over the v2 provider (e.g. for custom integrations), 
   Runtime metadata payload.
 </PropertyReference>
 
-<PropertyReference name="useSingleEndpoint" type="boolean">
-  When enabled, all runtime calls use a single endpoint.
+<PropertyReference name="useLegacyRuntime" type="boolean" default="false">
+  When `true`, uses the legacy single-endpoint transport. When `false` or omitted, the modern multi-endpoint REST transport is used.
+</PropertyReference>
+
+<PropertyReference name="useSingleEndpoint" type="boolean" deprecated>
+  **Deprecated since v1.57.0.** Use `useLegacyRuntime` instead.
 </PropertyReference>
 
 <PropertyReference

--- a/showcase/shell-docs/src/content/reference/index.mdx
+++ b/showcase/shell-docs/src/content/reference/index.mdx
@@ -73,7 +73,7 @@ If you need direct control over the v2 provider (e.g. for custom integrations), 
 </PropertyReference>
 
 <PropertyReference name="useSingleEndpoint" type="boolean" deprecated>
-  **Deprecated since v1.57.0.** Use `useLegacyRuntime` instead.
+  **Deprecated.** Use `useLegacyRuntime` instead.
 </PropertyReference>
 
 <PropertyReference

--- a/showcase/starters/ag2/src/app/page.tsx
+++ b/showcase/starters/ag2/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/ag2/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/ag2/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/ag2/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/ag2/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/agno/src/app/page.tsx
+++ b/showcase/starters/agno/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/agno/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/agno/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/agno/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/agno/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/claude-sdk-python/src/app/page.tsx
+++ b/showcase/starters/claude-sdk-python/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/claude-sdk-python/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/claude-sdk-python/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/claude-sdk-python/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/claude-sdk-python/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/claude-sdk-typescript/src/app/page.tsx
+++ b/showcase/starters/claude-sdk-typescript/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/claude-sdk-typescript/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/claude-sdk-typescript/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/claude-sdk-typescript/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/claude-sdk-typescript/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/crewai-crews/src/app/page.tsx
+++ b/showcase/starters/crewai-crews/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/crewai-crews/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/crewai-crews/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/crewai-crews/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/crewai-crews/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/google-adk/src/app/page.tsx
+++ b/showcase/starters/google-adk/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/google-adk/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/google-adk/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/google-adk/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/google-adk/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/langgraph-fastapi/src/app/page.tsx
+++ b/showcase/starters/langgraph-fastapi/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/langgraph-fastapi/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/langgraph-fastapi/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/langgraph-fastapi/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/langgraph-fastapi/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/langgraph-python/src/app/page.tsx
+++ b/showcase/starters/langgraph-python/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/langgraph-python/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/langgraph-python/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/langgraph-python/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/langgraph-python/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/langgraph-typescript/src/app/page.tsx
+++ b/showcase/starters/langgraph-typescript/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/langgraph-typescript/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/langgraph-typescript/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/langgraph-typescript/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/langgraph-typescript/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/langroid/src/app/page.tsx
+++ b/showcase/starters/langroid/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/langroid/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/langroid/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/langroid/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/langroid/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/llamaindex/src/app/page.tsx
+++ b/showcase/starters/llamaindex/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/llamaindex/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/llamaindex/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/llamaindex/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/llamaindex/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/mastra/src/app/page.tsx
+++ b/showcase/starters/mastra/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/mastra/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/mastra/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/mastra/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/mastra/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/ms-agent-dotnet/src/app/page.tsx
+++ b/showcase/starters/ms-agent-dotnet/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/ms-agent-dotnet/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/ms-agent-dotnet/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/ms-agent-dotnet/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/ms-agent-dotnet/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/ms-agent-python/src/app/page.tsx
+++ b/showcase/starters/ms-agent-python/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/ms-agent-python/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/ms-agent-python/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/ms-agent-python/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/ms-agent-python/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/pydantic-ai/src/app/page.tsx
+++ b/showcase/starters/pydantic-ai/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/pydantic-ai/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/pydantic-ai/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/pydantic-ai/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/pydantic-ai/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/spring-ai/src/app/page.tsx
+++ b/showcase/starters/spring-ai/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/spring-ai/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/spring-ai/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/spring-ai/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/spring-ai/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/strands/src/app/page.tsx
+++ b/showcase/starters/strands/src/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/strands/src/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/strands/src/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/strands/src/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/strands/src/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );

--- a/showcase/starters/template/frontend/app/page.tsx
+++ b/showcase/starters/template/frontend/app/page.tsx
@@ -43,7 +43,7 @@ function HashBrownInner() {
   useShowcaseSuggestions();
 
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
       <div className="min-h-screen w-full flex items-center justify-center">
         <SalesDashboard agentId={AGENT_ID} />
         <CopilotSidebar

--- a/showcase/starters/template/frontend/components/renderers/a2ui/index.tsx
+++ b/showcase/starters/template/frontend/components/renderers/a2ui/index.tsx
@@ -32,6 +32,7 @@ function DashboardContent({ agentId }: A2UIDashboardProps) {
 export function A2UIDashboard({ agentId }: A2UIDashboardProps) {
   return (
     <CopilotKit
+      useLegacyRuntime
       runtimeUrl="/api/copilotkit"
       agent={agentId}
       a2ui={{ catalog: demonstrationCatalog }}

--- a/showcase/starters/template/frontend/components/renderers/tool-based/index.tsx
+++ b/showcase/starters/template/frontend/components/renderers/tool-based/index.tsx
@@ -30,7 +30,7 @@ function DashboardContent({ agentId }: ToolBasedDashboardProps) {
 
 export function ToolBasedDashboard({ agentId }: ToolBasedDashboardProps) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={agentId}>
+    <CopilotKit useLegacyRuntime runtimeUrl="/api/copilotkit" agent={agentId}>
       <DashboardContent agentId={agentId} />
     </CopilotKit>
   );


### PR DESCRIPTION
## Summary

- Adds `useLegacyRuntime` prop to `CopilotKitProvider` and `CopilotKit` — when `true`, uses the legacy single-endpoint transport; defaults to `false` (modern REST)
- Deprecates `useSingleEndpoint` with `@deprecated` JSDoc; if both props are set, `useLegacyRuntime` wins with a console warning
- Removes auto-discovery transport probing (`"auto"` mode) that caused bugs and added unnecessary magic — transport is now explicit (`"rest"` or `"single"`)
- Changes the v1 `<CopilotKit>` wrapper default from single-endpoint to REST, aligning it with the v2 provider

## Breaking behavior change

Users of the v1 `<CopilotKit>` wrapper who relied on the implicit `useSingleEndpoint=true` default will now get REST transport. If their server uses `copilotRuntimeNextJSAppRouterEndpoint` (single-endpoint), they need to add `useLegacyRuntime` to their provider.

## Test plan

- [x] `@copilotkit/core` — 387 tests passing
- [x] `@copilotkit/react-core` — 1,156 tests passing
- [x] New tests for `useLegacyRuntime` prop mapping, deprecated `useSingleEndpoint` backward compat, conflict warning, and default transport
- [ ] Verify showcase apps work with `useLegacyRuntime` prop
- [ ] Verify examples with removed `useSingleEndpoint={false}` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)