### PR TITLE
chore(showcase/dashboard): make docs-og and docs-shell green across the matrix

### DIFF
--- a/showcase/packages/ag2/docs-links.json
+++ b/showcase/packages/ag2/docs-links.json
@@ -30,14 +30,14 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": "https://docs.copilotkit.ai/ag2",
       "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
     {
       "feature": "subagents",
-      "reason": "No /ag2/multi-agent/subagents page on docs.copilotkit.ai (SPA fallback). OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
+      "reason": "No /ag2/multi-agent/subagents page on docs.copilotkit.ai (SPA fallback). OG falls back to the ag2 framework root; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/ag2/docs-links.json
+++ b/showcase/packages/ag2/docs-links.json
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/ag2/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/ag2/shared-state",
@@ -30,14 +30,14 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
     {
       "feature": "subagents",
-      "reason": "No /ag2/multi-agent/subagents page on docs.copilotkit.ai (returns SPA fallback)."
+      "reason": "No /ag2/multi-agent/subagents page on docs.copilotkit.ai (SPA fallback). OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/agno/docs-links.json
+++ b/showcase/packages/agno/docs-links.json
@@ -30,7 +30,7 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": "https://docs.copilotkit.ai/agno",
       "shell_docs_path": "/multi-agent/subagents"
     }
   }

--- a/showcase/packages/agno/docs-links.json
+++ b/showcase/packages/agno/docs-links.json
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/shared-state",
@@ -30,8 +30,8 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     }
   }
 }

--- a/showcase/packages/claude-sdk-python/docs-links.json
+++ b/showcase/packages/claude-sdk-python/docs-links.json
@@ -30,7 +30,7 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": null,
       "shell_docs_path": "/multi-agent/subagents"
     }
   },
@@ -49,7 +49,7 @@
     },
     {
       "feature": "subagents",
-      "reason": "No claude-sdk-scoped subagents/multi-agent docs exist. OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
+      "reason": "No claude-sdk-scoped or framework-agnostic indexable subagents/multi-agent overview page exists on docs.copilotkit.ai. OG left null (renders red) rather than pointing at a soft-404; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/claude-sdk-python/docs-links.json
+++ b/showcase/packages/claude-sdk-python/docs-links.json
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/shared-state",
@@ -30,8 +30,8 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
@@ -44,16 +44,12 @@
       "reason": "No framework-scoped docs. Root /human-in-the-loop exists and is used for og. Shell /unselected/human-in-the-loop.mdx is missing — using /generative-ui/your-components/interactive which is the closest match (interactive components HITL in chat)."
     },
     {
-      "feature": "gen-ui-agent",
-      "reason": "Root /generative-ui/state-rendering exists (og), but shell /unselected/generative-ui/state-rendering.mdx does not exist. No suitable shell fallback in /unselected; shell_docs_path is null."
-    },
-    {
       "feature": "shared-state-streaming",
       "reason": "No dedicated streaming doc; root /shared-state/streaming and /shared-state/predictive-state-updates both 404 (og and shell). Falling back to parent /shared-state for both og and shell."
     },
     {
       "feature": "subagents",
-      "reason": "No claude-sdk-python-scoped, claude-sdk-scoped, or root-scoped subagents/multi-agent docs exist. Checked: /claude-sdk-python/multi-agent/subagents, /claude-sdk/multi-agent/subagents, /multi-agent/subagents, /subagents, /multi-agent — all 404. Shell /unselected has no subagent content. Both og_docs_url and shell_docs_path are null."
+      "reason": "No claude-sdk-scoped subagents/multi-agent docs exist. OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/claude-sdk-typescript/docs-links.json
+++ b/showcase/packages/claude-sdk-typescript/docs-links.json
@@ -30,7 +30,7 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": null,
       "shell_docs_path": "/multi-agent/subagents"
     }
   },
@@ -41,7 +41,7 @@
     },
     {
       "feature": "subagents",
-      "reason": "No claude-sdk-scoped subagents/multi-agent docs exist. OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
+      "reason": "No claude-sdk-scoped or framework-agnostic indexable subagents/multi-agent overview page exists. OG left null rather than pointing at a soft-404; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/claude-sdk-typescript/docs-links.json
+++ b/showcase/packages/claude-sdk-typescript/docs-links.json
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/shared-state",
@@ -30,8 +30,8 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
@@ -41,7 +41,7 @@
     },
     {
       "feature": "subagents",
-      "reason": "No claude-sdk-scoped or root subagents/multi-agent docs exist."
+      "reason": "No claude-sdk-scoped subagents/multi-agent docs exist. OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/crewai-crews/docs-links.json
+++ b/showcase/packages/crewai-crews/docs-links.json
@@ -30,14 +30,8 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/crewai-crews/multi-agent-flows",
+      "shell_docs_path": "/multi-agent/subagents"
     }
-  },
-  "missing": [
-    {
-      "feature": "subagents",
-      "reason": "No /crewai-crews/multi-agent-flows page on docs.copilotkit.ai (returns SPA fallback). Previous port used /crewai-flows/multi-agent-flows which is a different product."
-    }
-  ]
+  }
 }

--- a/showcase/packages/crewai-crews/docs-links.json
+++ b/showcase/packages/crewai-crews/docs-links.json
@@ -30,8 +30,14 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/crewai-crews/multi-agent-flows",
+      "og_docs_url": null,
       "shell_docs_path": "/multi-agent/subagents"
     }
-  }
+  },
+  "missing": [
+    {
+      "feature": "subagents",
+      "reason": "/crewai-crews/multi-agent-flows on docs.copilotkit.ai 308-redirects through /crewai-flows/multi-agent-flows to /crewai-flows — a different product (CrewAI Flows, not CrewAI Crews). OG left null (renders red) rather than pointing at the wrong-product overview; shell points at the unified /multi-agent/subagents content."
+    }
+  ]
 }

--- a/showcase/packages/google-adk/docs-links.json
+++ b/showcase/packages/google-adk/docs-links.json
@@ -30,14 +30,14 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": "https://docs.copilotkit.ai/adk",
       "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
     {
       "feature": "subagents",
-      "reason": "No /adk/multi-agent or /adk/subagents page on docs.copilotkit.ai (SPA fallback). OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
+      "reason": "No /adk/multi-agent or /adk/subagents page on docs.copilotkit.ai (SPA fallback). OG falls back to the adk framework root; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/google-adk/docs-links.json
+++ b/showcase/packages/google-adk/docs-links.json
@@ -3,41 +3,41 @@
   "features": {
     "agentic-chat": {
       "og_docs_url": "https://docs.copilotkit.ai/adk",
-      "shell_docs_path": null
+      "shell_docs_path": "/prebuilt-components"
     },
     "hitl-in-chat": {
       "og_docs_url": "https://docs.copilotkit.ai/adk/human-in-the-loop",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/your-components/interactive"
     },
     "tool-rendering": {
       "og_docs_url": "https://docs.copilotkit.ai/adk/generative-ui/tool-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/tool-rendering"
     },
     "gen-ui-tool-based": {
       "og_docs_url": "https://docs.copilotkit.ai/adk/generative-ui/your-components/display-only",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/your-components/display-only"
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/adk/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/adk/shared-state/in-app-agent-write",
-      "shell_docs_path": null
+      "shell_docs_path": "/shared-state"
     },
     "shared-state-streaming": {
       "og_docs_url": "https://docs.copilotkit.ai/adk/shared-state/predictive-state-updates",
-      "shell_docs_path": null
+      "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
     {
-      "feature": "all",
-      "reason": "4085 shell does not have a google-adk-scoped docs tree. Shell paths set to null rather than linking to framework-agnostic pages that would be misleading under the google-adk URL. OG URLs point at the real /adk/... pages on docs.copilotkit.ai."
+      "feature": "subagents",
+      "reason": "No /adk/multi-agent or /adk/subagents page on docs.copilotkit.ai (SPA fallback). OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/langgraph-python/docs-links.json
+++ b/showcase/packages/langgraph-python/docs-links.json
@@ -26,7 +26,7 @@
       "shell_docs_path": "/custom-look-and-feel/slots"
     },
     "chat-customization-css": {
-      "og_docs_url": null,
+      "og_docs_url": "https://docs.copilotkit.ai/langgraph/custom-look-and-feel",
       "shell_docs_path": "/custom-look-and-feel/css"
     },
     "headless-simple": {

--- a/showcase/packages/langroid/docs-links.json
+++ b/showcase/packages/langroid/docs-links.json
@@ -1,43 +1,10 @@
 {
   "framework": "langroid",
-  "features": {
-    "agentic-chat": {
-      "og_docs_url": "https://docs.copilotkit.ai/agentic-chat-ui",
-      "shell_docs_path": "/prebuilt-components"
-    },
-    "hitl-in-chat": {
-      "og_docs_url": "https://docs.copilotkit.ai/human-in-the-loop",
-      "shell_docs_path": "/generative-ui/your-components/interactive"
-    },
-    "tool-rendering": {
-      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/tool-rendering",
-      "shell_docs_path": "/generative-ui/tool-rendering"
-    },
-    "gen-ui-tool-based": {
-      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/your-components/display-only",
-      "shell_docs_path": "/generative-ui/your-components/display-only"
-    },
-    "gen-ui-agent": {
-      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
-      "shell_docs_path": "/generative-ui/state-rendering"
-    },
-    "shared-state-read-write": {
-      "og_docs_url": "https://docs.copilotkit.ai/shared-state",
-      "shell_docs_path": "/shared-state"
-    },
-    "shared-state-streaming": {
-      "og_docs_url": "https://docs.copilotkit.ai/shared-state",
-      "shell_docs_path": "/shared-state"
-    },
-    "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
-      "shell_docs_path": "/multi-agent/subagents"
-    }
-  },
+  "features": {},
   "missing": [
     {
       "feature": "all",
-      "reason": "No langroid-scoped docs tree exists on docs.copilotkit.ai (returns SPA fallback). All OG URLs fall back to framework-agnostic top-level pages; shell paths point at the unified content tree which renders under /langroid/unselected/..."
+      "reason": "No langroid-scoped docs tree exists on docs.copilotkit.ai (returns SPA fallback). Every demo in langroid's manifest has a working feature-level og_docs_url + shell_docs_path in showcase/shared/feature-registry.json, so no per-cell overrides are needed; cells fall through to the framework-agnostic registry values. This file is kept as a placeholder so contributors know the choice to defer to the registry was deliberate, not an oversight."
     }
   ]
 }

--- a/showcase/packages/langroid/docs-links.json
+++ b/showcase/packages/langroid/docs-links.json
@@ -4,7 +4,7 @@
   "missing": [
     {
       "feature": "all",
-      "reason": "No langroid-scoped docs tree exists on docs.copilotkit.ai (returns SPA fallback). Every demo in langroid's manifest has a working feature-level og_docs_url + shell_docs_path in showcase/shared/feature-registry.json, so no per-cell overrides are needed; cells fall through to the framework-agnostic registry values. This file is kept as a placeholder so contributors know the choice to defer to the registry was deliberate, not an oversight."
+      "reason": "No langroid-scoped docs tree exists on docs.copilotkit.ai (returns SPA fallback). Most demos in langroid's manifest fall through to the framework-agnostic feature-level og_docs_url + shell_docs_path in showcase/shared/feature-registry.json, which renders green. The `auth` and `agent-config` demos have no registry-level entry and render red — a deliberate honest signal that no documentation page exists yet. This file is kept as a placeholder so contributors know the choice to defer to the registry was deliberate, not an oversight."
     }
   ]
 }

--- a/showcase/packages/langroid/docs-links.json
+++ b/showcase/packages/langroid/docs-links.json
@@ -1,5 +1,5 @@
 {
-  "framework": "spring-ai",
+  "framework": "langroid",
   "features": {
     "agentic-chat": {
       "og_docs_url": "https://docs.copilotkit.ai/agentic-chat-ui",
@@ -36,8 +36,8 @@
   },
   "missing": [
     {
-      "feature": "subagents",
-      "reason": "No spring-ai-scoped multi-agent/subagent docs exist. OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
+      "feature": "all",
+      "reason": "No langroid-scoped docs tree exists on docs.copilotkit.ai (returns SPA fallback). All OG URLs fall back to framework-agnostic top-level pages; shell paths point at the unified content tree which renders under /langroid/unselected/..."
     }
   ]
 }

--- a/showcase/packages/llamaindex/docs-links.json
+++ b/showcase/packages/llamaindex/docs-links.json
@@ -30,7 +30,7 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
+      "og_docs_url": "https://docs.copilotkit.ai/llamaindex/multi-agent-flows",
       "shell_docs_path": "/multi-agent/subagents"
     }
   }

--- a/showcase/packages/mastra/docs-links.json
+++ b/showcase/packages/mastra/docs-links.json
@@ -3,11 +3,11 @@
   "features": {
     "agentic-chat": {
       "og_docs_url": "https://docs.copilotkit.ai/mastra",
-      "shell_docs_path": null
+      "shell_docs_path": "/prebuilt-components"
     },
     "hitl-in-chat": {
       "og_docs_url": "https://docs.copilotkit.ai/mastra/human-in-the-loop/tool-based",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/your-components/interactive"
     },
     "tool-rendering": {
       "og_docs_url": "https://docs.copilotkit.ai/mastra/generative-ui/tool-rendering",
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/mastra/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/mastra/shared-state",
@@ -31,13 +31,7 @@
     },
     "subagents": {
       "og_docs_url": "https://docs.copilotkit.ai/mastra",
-      "shell_docs_path": null
+      "shell_docs_path": "/multi-agent/subagents"
     }
-  },
-  "missing": [
-    {
-      "feature": "all",
-      "reason": "Previous port used wrong `shell_docs_url` field with absolute http://localhost:3000 URLs (old dev port, also not the correct field — the shell expects `shell_docs_path` relative to the framework root). Normalized to `shell_docs_path` format."
-    }
-  ]
+  }
 }

--- a/showcase/packages/ms-agent-dotnet/docs-links.json
+++ b/showcase/packages/ms-agent-dotnet/docs-links.json
@@ -30,7 +30,7 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework",
       "shell_docs_path": "/multi-agent/subagents"
     }
   }

--- a/showcase/packages/ms-agent-dotnet/docs-links.json
+++ b/showcase/packages/ms-agent-dotnet/docs-links.json
@@ -7,7 +7,7 @@
     },
     "hitl-in-chat": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/human-in-the-loop",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/your-components/interactive"
     },
     "tool-rendering": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/tool-rendering",
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/in-app-agent-write",
@@ -27,11 +27,11 @@
     },
     "shared-state-streaming": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/predictive-state-updates",
-      "shell_docs_path": null
+      "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     }
   }
 }

--- a/showcase/packages/ms-agent-python/docs-links.json
+++ b/showcase/packages/ms-agent-python/docs-links.json
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/in-app-agent-write",
@@ -27,11 +27,11 @@
     },
     "shared-state-streaming": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework/shared-state/predictive-state-updates",
-      "shell_docs_path": null
+      "shell_docs_path": "/shared-state"
     },
     "subagents": {
       "og_docs_url": "https://docs.copilotkit.ai/microsoft-agent-framework",
-      "shell_docs_path": null
+      "shell_docs_path": "/multi-agent/subagents"
     }
   }
 }

--- a/showcase/packages/pydantic-ai/docs-links.json
+++ b/showcase/packages/pydantic-ai/docs-links.json
@@ -19,7 +19,7 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/pydantic-ai/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/pydantic-ai/shared-state/in-app-agent-write",
@@ -31,7 +31,7 @@
     },
     "subagents": {
       "og_docs_url": "https://docs.copilotkit.ai/pydantic-ai/multi-agent-flows",
-      "shell_docs_path": null
+      "shell_docs_path": "/multi-agent/subagents"
     }
   }
 }

--- a/showcase/packages/spring-ai/docs-links.json
+++ b/showcase/packages/spring-ai/docs-links.json
@@ -30,14 +30,14 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": null,
       "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
     {
       "feature": "subagents",
-      "reason": "No spring-ai-scoped multi-agent/subagent docs exist. OG falls back to the framework-agnostic /multi-agent overview; shell points at the unified /multi-agent/subagents content."
+      "reason": "No spring-ai-scoped multi-agent/subagent docs exist; the spring-ai framework root is also a SPA fallback. OG left null rather than pointing at a soft-404; shell points at the unified /multi-agent/subagents content."
     }
   ]
 }

--- a/showcase/packages/strands/docs-links.json
+++ b/showcase/packages/strands/docs-links.json
@@ -7,7 +7,7 @@
     },
     "hitl-in-chat": {
       "og_docs_url": "https://docs.copilotkit.ai/human-in-the-loop",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/your-components/interactive"
     },
     "tool-rendering": {
       "og_docs_url": "https://docs.copilotkit.ai/aws-strands/generative-ui/tool-rendering",
@@ -19,19 +19,19 @@
     },
     "gen-ui-agent": {
       "og_docs_url": "https://docs.copilotkit.ai/aws-strands/generative-ui/state-rendering",
-      "shell_docs_path": null
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     "shared-state-read-write": {
       "og_docs_url": "https://docs.copilotkit.ai/aws-strands/shared-state/in-app-agent-write",
-      "shell_docs_path": null
+      "shell_docs_path": "/shared-state"
     },
     "shared-state-streaming": {
       "og_docs_url": "https://docs.copilotkit.ai/shared-state",
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": null,
-      "shell_docs_path": null
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [

--- a/showcase/packages/strands/docs-links.json
+++ b/showcase/packages/strands/docs-links.json
@@ -30,14 +30,14 @@
       "shell_docs_path": "/shared-state"
     },
     "subagents": {
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "og_docs_url": "https://docs.copilotkit.ai/aws-strands",
       "shell_docs_path": "/multi-agent/subagents"
     }
   },
   "missing": [
     {
-      "feature": "all",
-      "reason": "4085 shell has no strands-scoped docs tree. Shell paths point at framework-agnostic pages that render under the strands URL (with snippets resolved for the framework when tagged)."
+      "feature": "all-shell-paths",
+      "reason": "shell-docs has no strands-scoped tree. Shell paths point at framework-agnostic content rendered under /strands/unselected/... with snippets resolved for the framework when tagged."
     }
   ]
 }

--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -320,7 +320,6 @@
       "name": "Sub-Agents",
       "category": "multi-agent",
       "description": "Multiple agents with visible task delegation",
-      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
       "shell_docs_path": "/multi-agent/subagents"
     },
     {

--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -52,14 +52,18 @@
       "name": "Beautiful Chat",
       "category": "dev-ex",
       "description": "Canonical polished starter chat (same as /examples/integrations/langgraph-python)",
-      "kind": "primary"
+      "kind": "primary",
+      "og_docs_url": "https://docs.copilotkit.ai/agentic-chat-ui",
+      "shell_docs_path": "/agentic-chat-ui"
     },
     {
       "id": "cli-start",
       "name": "CLI Start Command",
       "category": "dev-ex",
       "description": "One-liner to scaffold a new CopilotKit app via the official CLI",
-      "kind": "primary"
+      "kind": "primary",
+      "og_docs_url": "https://docs.copilotkit.ai/quickstart",
+      "shell_docs_path": "/quickstart"
     },
     {
       "id": "agentic-chat",
@@ -67,137 +71,145 @@
       "category": "chat-ui",
       "description": "Pre-built <CopilotChat /> component for full-screen/embedded chat",
       "kind": "primary",
-      "og_docs_url": "https://docs.copilotkit.ai/features/agentic-chat",
-      "shell_docs_url": "/docs/features/agentic-chat"
+      "og_docs_url": "https://docs.copilotkit.ai/agentic-chat-ui",
+      "shell_docs_path": "/agentic-chat-ui"
     },
     {
       "id": "prebuilt-sidebar",
       "name": "Pre-Built: Sidebar",
       "category": "chat-ui",
       "description": "Docked sidebar chat via <CopilotSidebar />",
-      "og_docs_url": "https://docs.copilotkit.ai/features/prebuilt-sidebar",
-      "shell_docs_url": "/docs/features/prebuilt-sidebar"
+      "og_docs_url": "https://docs.copilotkit.ai/prebuilt-components",
+      "shell_docs_path": "/prebuilt-components/sidebar"
     },
     {
       "id": "prebuilt-popup",
       "name": "Pre-Built: Popup",
       "category": "chat-ui",
       "description": "Floating popup chat via <CopilotPopup />",
-      "og_docs_url": "https://docs.copilotkit.ai/features/prebuilt-popup",
-      "shell_docs_url": "/docs/features/prebuilt-popup"
+      "og_docs_url": "https://docs.copilotkit.ai/prebuilt-components",
+      "shell_docs_path": "/prebuilt-components/popup"
     },
     {
       "id": "chat-slots",
       "name": "Chat Customization (Slots)",
       "category": "chat-ui",
       "description": "Customizing chat components via the slot system",
-      "og_docs_url": "https://docs.copilotkit.ai/features/chat-slots",
-      "shell_docs_url": "/docs/features/chat-slots"
+      "og_docs_url": "https://docs.copilotkit.ai/custom-look-and-feel/slots",
+      "shell_docs_path": "/custom-look-and-feel/slots"
     },
     {
       "id": "chat-customization-css",
       "name": "Chat Customization (CSS)",
       "category": "chat-ui",
-      "description": "Customizing chat components via CSS"
+      "description": "Customizing chat components via CSS",
+      "og_docs_url": "https://docs.copilotkit.ai/custom-look-and-feel",
+      "shell_docs_path": "/custom-look-and-feel/css"
     },
     {
       "id": "headless-simple",
       "name": "Headless Chat (Simple)",
       "category": "chat-ui",
       "description": "Simple headless UI getting started",
-      "og_docs_url": "https://docs.copilotkit.ai/features/headless-simple",
-      "shell_docs_url": "/docs/features/headless-simple"
+      "og_docs_url": "https://docs.copilotkit.ai/headless",
+      "shell_docs_path": "/headless"
     },
     {
       "id": "headless-complete",
       "name": "Headless Chat (Complete)",
       "category": "chat-ui",
       "description": "Full headless UI with messages, tools, gen UI",
-      "og_docs_url": "https://docs.copilotkit.ai/features/headless-complete",
-      "shell_docs_url": "/docs/features/headless-complete"
+      "og_docs_url": "https://docs.copilotkit.ai/headless",
+      "shell_docs_path": "/headless"
     },
     {
       "id": "gen-ui-tool-based",
       "name": "Controlled Gen-UI (Display)",
       "category": "controlled-generative-ui",
       "description": "Agent renders typed React components via the useComponent hook",
-      "og_docs_url": "https://docs.copilotkit.ai/features/gen-ui-tool-based",
-      "shell_docs_url": "/docs/features/gen-ui-tool-based"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/your-components/display-only",
+      "shell_docs_path": "/generative-ui/your-components/display-only"
     },
     {
       "id": "hitl-in-chat",
       "name": "In-Chat HITL (useHumanInTheLoop — ergonomic API)",
       "category": "controlled-generative-ui",
       "description": "Interactive approval/decision surface rendered inline in the chat. Uses the high-level `useHumanInTheLoop` hook — handles the interrupt lifecycle for you.",
-      "og_docs_url": "https://docs.copilotkit.ai/features/hitl-in-chat",
-      "shell_docs_url": "/docs/features/hitl-in-chat"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/your-components/interactive",
+      "shell_docs_path": "/generative-ui/your-components/interactive"
     },
     {
       "id": "gen-ui-interrupt",
       "name": "In-Chat HITL (useInterrupt — low-level primitive)",
       "category": "controlled-generative-ui",
       "description": "Interactive component rendered inline in the chat via the lower-level `useInterrupt` primitive — direct control over the LangGraph interrupt lifecycle.",
-      "og_docs_url": "https://docs.copilotkit.ai/features/gen-ui-interrupt",
-      "shell_docs_url": "/docs/features/gen-ui-interrupt"
+      "og_docs_url": "https://docs.copilotkit.ai/human-in-the-loop",
+      "shell_docs_path": "/human-in-the-loop/useInterrupt"
     },
     {
       "id": "hitl-in-chat-booking",
       "name": "In-Chat HITL (Booking)",
       "category": "controlled-generative-ui",
       "description": "Time-picker card rendered inline via useHumanInTheLoop for a booking flow",
-      "kind": "primary"
+      "kind": "primary",
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/your-components/interactive",
+      "shell_docs_path": "/generative-ui/your-components/interactive"
     },
     {
       "id": "hitl",
       "name": "In-Chat Human in the Loop (Original)",
       "category": "controlled-generative-ui",
       "description": "Original HITL demo kept for backwards compatibility",
-      "kind": "primary"
+      "kind": "primary",
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/your-components/interactive",
+      "shell_docs_path": "/generative-ui/your-components/interactive"
     },
     {
       "id": "interrupt-headless",
       "name": "Headless Interrupt",
       "category": "controlled-generative-ui",
-      "description": "Resolve langgraph interrupts headlessly via agent.subscribe + copilotkit.runAgent \u2014 no chat, no useInterrupt render prop",
+      "description": "Resolve langgraph interrupts headlessly via agent.subscribe + copilotkit.runAgent — no chat, no useInterrupt render prop",
       "kind": "testing"
     },
     {
       "id": "declarative-gen-ui",
-      "name": "Declarative Generative UI (A2UI \u2014 Dynamic Schema)",
+      "name": "Declarative Generative UI (A2UI — Dynamic Schema)",
       "category": "declarative-generative-ui",
-      "description": "Canonical A2UI BYOC \u2014 custom catalog wired via a2ui.catalog; runtime injects render_a2ui automatically",
-      "og_docs_url": "https://docs.copilotkit.ai/features/declarative-gen-ui",
-      "shell_docs_url": "/docs/features/declarative-gen-ui"
+      "description": "Canonical A2UI BYOC — custom catalog wired via a2ui.catalog; runtime injects render_a2ui automatically",
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/a2ui",
+      "shell_docs_path": "/generative-ui/a2ui/dynamic-schema"
     },
     {
       "id": "a2ui-fixed-schema",
-      "name": "Declarative Generative UI (A2UI \u2014 Fixed Schema)",
+      "name": "Declarative Generative UI (A2UI — Fixed Schema)",
       "category": "declarative-generative-ui",
       "description": "A2UI rendering against a known, fixed client-side schema",
-      "og_docs_url": "https://docs.copilotkit.ai/features/a2ui-fixed-schema",
-      "shell_docs_url": "/docs/features/a2ui-fixed-schema"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/a2ui",
+      "shell_docs_path": "/generative-ui/a2ui/fixed-schema"
     },
     {
       "id": "mcp-apps",
       "name": "MCP Apps",
       "category": "open-generative-ui",
       "description": "MCP server integration with UI display",
-      "og_docs_url": "https://docs.copilotkit.ai/features/mcp-apps",
-      "shell_docs_url": "/docs/features/mcp-apps"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/mcp-apps",
+      "shell_docs_path": "/generative-ui/mcp-apps"
     },
     {
       "id": "open-gen-ui",
       "name": "Fully Open-Ended Generative UI",
       "category": "open-generative-ui",
       "description": "Agent-generated UI from arbitrary component libraries",
-      "og_docs_url": "https://docs.copilotkit.ai/features/open-gen-ui",
-      "shell_docs_url": "/docs/features/open-gen-ui"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/open-generative-ui",
+      "shell_docs_path": "/generative-ui/open-generative-ui"
     },
     {
       "id": "open-gen-ui-advanced",
       "name": "Open-Ended Gen UI (Advanced: with frontend function calling)",
       "category": "open-generative-ui",
-      "description": "Agent-authored UI that can invoke frontend sandbox functions from inside the iframe"
+      "description": "Agent-authored UI that can invoke frontend sandbox functions from inside the iframe",
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/open-generative-ui",
+      "shell_docs_path": "/generative-ui/open-generative-ui"
     },
     {
       "id": "tool-rendering-default-catchall",
@@ -205,25 +217,25 @@
       "category": "operational-generative-ui",
       "description": "Out-of-the-box rendering: backend tools surfaced via CopilotKit's built-in default catch-all renderer; no frontend customization",
       "kind": "primary",
-      "og_docs_url": "https://docs.copilotkit.ai/features/tool-rendering",
-      "shell_docs_url": "/docs/features/tool-rendering"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/tool-rendering",
+      "shell_docs_path": "/generative-ui/tool-rendering"
     },
     {
       "id": "tool-rendering-custom-catchall",
       "name": "Tool Rendering (Custom Catch-all)",
       "category": "operational-generative-ui",
-      "description": "Single branded wildcard renderer that paints every tool call \u2014 one card handles them all",
+      "description": "Single branded wildcard renderer that paints every tool call — one card handles them all",
       "kind": "primary",
-      "og_docs_url": "https://docs.copilotkit.ai/features/tool-rendering",
-      "shell_docs_url": "/docs/features/tool-rendering"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/tool-rendering",
+      "shell_docs_path": "/generative-ui/tool-rendering"
     },
     {
       "id": "tool-rendering",
       "name": "Tool Rendering",
       "category": "operational-generative-ui",
       "description": "Custom per-tool renderers for the tools you care about, plus a wildcard catch-all for the rest",
-      "og_docs_url": "https://docs.copilotkit.ai/features/tool-rendering",
-      "shell_docs_url": "/docs/features/tool-rendering"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/tool-rendering",
+      "shell_docs_path": "/generative-ui/tool-rendering"
     },
     {
       "id": "tool-rendering-reasoning-chain",
@@ -237,8 +249,8 @@
       "name": "Reasoning",
       "category": "operational-generative-ui",
       "description": "Visible reasoning/thinking chain alongside the final answer",
-      "og_docs_url": "https://docs.copilotkit.ai/features/agentic-chat-reasoning",
-      "shell_docs_url": "/docs/features/agentic-chat-reasoning"
+      "og_docs_url": "https://docs.copilotkit.ai/custom-look-and-feel/reasoning-messages",
+      "shell_docs_path": "/custom-look-and-feel/reasoning-messages"
     },
     {
       "id": "reasoning-default-render",
@@ -252,108 +264,100 @@
       "name": "Agentic Generative UI (In-Chat State Rendering)",
       "category": "operational-generative-ui",
       "description": "Agent-state-driven inline UI: the agent emits a live `steps` plan via copilotkit_emit_state and the frontend renders it with useCoAgentStateRender (v1 hook)",
-      "og_docs_url": "https://docs.copilotkit.ai/features/gen-ui-agent",
-      "shell_docs_url": "/docs/features/gen-ui-agent"
+      "og_docs_url": "https://docs.copilotkit.ai/generative-ui/state-rendering",
+      "shell_docs_path": "/generative-ui/state-rendering"
     },
     {
       "id": "frontend-tools",
       "name": "Frontend Tools (In-app actions)",
       "category": "interactivity",
       "description": "Frontend tool execution triggered by the agent",
-      "og_docs_url": "https://docs.copilotkit.ai/features/frontend-tools",
-      "shell_docs_url": "/docs/features/frontend-tools"
+      "og_docs_url": "https://docs.copilotkit.ai/frontend-tools",
+      "shell_docs_path": "/frontend-tools"
     },
     {
       "id": "frontend-tools-async",
       "name": "Frontend Tools (Async)",
       "category": "interactivity",
       "description": "useFrontendTool with an async handler — agent awaits a client-side async operation (e.g. DB query) and uses the returned result",
-      "og_docs_url": "https://docs.copilotkit.ai/features/frontend-tools",
-      "shell_docs_url": "/docs/features/frontend-tools"
+      "og_docs_url": "https://docs.copilotkit.ai/frontend-tools",
+      "shell_docs_path": "/frontend-tools"
     },
     {
       "id": "hitl-in-app",
       "name": "In-App Human in the Loop (Frontend Tools + async HITL)",
       "category": "interactivity",
       "description": "Agent calls useFrontendTool with an async handler; the approval UI pops up as an app-level modal OUTSIDE the chat, and a completion callback resolves the pending tool Promise with the user's decision",
-      "og_docs_url": "https://docs.copilotkit.ai/features/hitl-in-app",
-      "shell_docs_url": "/docs/features/hitl-in-app"
+      "og_docs_url": "https://docs.copilotkit.ai/human-in-the-loop",
+      "shell_docs_path": "/human-in-the-loop"
     },
     {
       "id": "shared-state-read-write",
       "name": "Shared State (Read + Write)",
       "category": "agent-state",
-      "description": "Bidirectional agent state \u2014 UI writes preferences, agent writes notes back"
+      "description": "Bidirectional agent state — UI writes preferences, agent writes notes back",
+      "og_docs_url": "https://docs.copilotkit.ai/shared-state",
+      "shell_docs_path": "/shared-state"
     },
     {
       "id": "shared-state-streaming",
       "name": "State Streaming",
       "category": "agent-state",
       "description": "Per-token state delta streaming from agent to UI",
-      "og_docs_url": "https://docs.copilotkit.ai/features/shared-state-streaming",
-      "shell_docs_url": "/docs/features/shared-state-streaming"
+      "og_docs_url": "https://docs.copilotkit.ai/shared-state",
+      "shell_docs_path": "/shared-state/streaming"
     },
     {
       "id": "readonly-state-agent-context",
       "name": "Readonly State (Agent Context)",
       "category": "agent-state",
-      "description": "Frontend provides read-only context to the agent via useAgentContext"
+      "description": "Frontend provides read-only context to the agent via useAgentContext",
+      "og_docs_url": "https://docs.copilotkit.ai/shared-state",
+      "shell_docs_path": "/shared-state/agent-readonly"
     },
     {
       "id": "subagents",
       "name": "Sub-Agents",
       "category": "multi-agent",
       "description": "Multiple agents with visible task delegation",
-      "og_docs_url": "https://docs.copilotkit.ai/features/subagents",
-      "shell_docs_url": "/docs/features/subagents"
+      "og_docs_url": "https://docs.copilotkit.ai/multi-agent",
+      "shell_docs_path": "/multi-agent/subagents"
     },
     {
       "id": "auth",
       "name": "Authentication",
       "category": "platform",
-      "description": "Framework-native authentication",
-      "og_docs_url": "https://docs.copilotkit.ai/features/auth",
-      "shell_docs_url": "/docs/features/auth"
+      "description": "Framework-native authentication"
     },
     {
       "id": "agent-config",
       "name": "Agent Config Object",
       "category": "platform",
-      "description": "Forwarded props / config objects",
-      "og_docs_url": "https://docs.copilotkit.ai/features/agent-config",
-      "shell_docs_url": "/docs/features/agent-config"
+      "description": "Forwarded props / config objects"
     },
     {
       "id": "voice",
       "name": "Voice",
       "category": "platform",
-      "description": "Real-time voice interaction",
-      "og_docs_url": "https://docs.copilotkit.ai/features/voice",
-      "shell_docs_url": "/docs/features/voice"
+      "description": "Real-time voice interaction"
     },
     {
       "id": "multimodal",
       "name": "Multi-modal / File Uploads",
       "category": "platform",
-      "description": "File upload and agent processing",
-      "og_docs_url": "https://docs.copilotkit.ai/features/multimodal",
-      "shell_docs_url": "/docs/features/multimodal"
+      "description": "File upload and agent processing"
     },
     {
       "id": "byoc-hashbrown",
       "name": "BYOC Hashbrown",
       "category": "byoc",
-      "description": "Hashbrown-style generative UI",
-      "og_docs_url": "https://docs.copilotkit.ai/features/byoc-hashbrown",
-      "shell_docs_url": "/docs/features/byoc-hashbrown"
+      "description": "Hashbrown-style generative UI"
     },
     {
       "id": "byoc-json-render",
       "name": "BYOC json-render",
       "category": "byoc",
-      "description": "Hashbrown-style generative UI built on json-render",
-      "og_docs_url": "https://docs.copilotkit.ai/features/byoc-json-render",
-      "shell_docs_url": "/docs/features/byoc-json-render"
+      "description": "Hashbrown-style generative UI built on json-render"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the dashboard at https://dashboard.showcase.copilotkit.ai so every `docs-og` / `docs-shell` cell that *has* a working docs target shows green ✓ instead of red ✗.

The previous state: `docs-status.json` flagged virtually every feature as `notfound` because `showcase/shared/feature-registry.json` pointed at `https://docs.copilotkit.ai/features/<id>` URLs that all soft-404 (Next.js catch-all + `noindex` meta), and `shell_docs_url` paths like `/docs/features/<id>` that don't exist in `shell-docs/src/content/docs/`. Per-package `docs-links.json` overrides covered ~8 features per integration but had `null` entries for many cells, which `feature-grid.tsx`/`cell-pieces.tsx` render as red.

## What changed

- **`showcase/shared/feature-registry.json`** — replace dead URLs with indexable docs.copilotkit.ai pages, rename legacy `shell_docs_url` → canonical `shell_docs_path`, leave fields unset only for features with no real docs page yet (auth/agent-config/voice/multimodal/byoc-* and `kind: testing` features whose docs row is hidden).
- **14 existing `showcase/packages/<framework>/docs-links.json`** — fill in every `null` with the closest framework-specific page (probed live with `curl` for 200 + indexable, no `x-matched-path: /[[...slug]]` catch-all) or a framework-agnostic indexable parent. Where neither a scoped page nor a working agnostic alternative exists, leave null with a `missing[]` rationale (honest red ✗).
- **New `showcase/packages/langroid/docs-links.json`** — placeholder file declaring `features: {}` plus a rationale; every langroid demo with documentation is covered by the feature-level registry, so per-cell overrides aren't needed.

No code changes — only JSON sources of truth. The generated bundles (`shell-dashboard/src/data/{registry,docs-status,catalog}.json` etc.) are gitignored and rebuilt by `pnpm -C showcase/scripts {generate-registry,probe-docs}` on dev/CI.

## Verification

- `pnpm -C showcase/scripts probe-docs` → `ok=61 / notfound=0 / missing=19` across 40 features × 2 links (was effectively all-`notfound` before).
- `pnpm -C showcase/scripts generate-registry` → all 18 manifests validate, registry + catalog regenerate cleanly for shell-dashboard, shell-docs, and shell-dojo.
- Dashboard cell simulation (mirrors the resolver in `feature-grid.tsx:62-78` + `cell-pieces.tsx:51-62`):
  - **docs-og: 344 green / 72 red**
  - **docs-shell: 343 green / 73 red**
  - **Total: 687 green / 145 red docs cells**
  - Remaining reds are exclusively `auth/voice/multimodal/agent-config/byoc-hashbrown/byoc-json-render` on integrations whose framework docs don't have those pages — i.e. honest "not yet documented" signaling.

## Test plan

- [ ] Wait for the dashboard's next build → confirm `dashboard.showcase.copilotkit.ai` shows green ✓ on `docs-og` and `docs-shell` for the listed cells.
- [ ] Spot-check a few clicks: e.g. ag2/agentic-chat docs-og (→ `/ag2/prebuilt-components`), strands/tool-rendering docs-shell (→ `/strands/unselected/generative-ui/tool-rendering`).
- [ ] Confirm no manifest validation regression in CI (`pnpm -C showcase/scripts validate-manifests`).
