### PR TITLE
fix: D5 all-green — load fixtures into aimock + add hitl-steps probe

### DIFF
--- a/showcase/aimock/RAILWAY.md
+++ b/showcase/aimock/RAILWAY.md
@@ -100,18 +100,27 @@ query {
 
 ## 4. Fixture sources
 
-Two fixtures are served, fetched remotely at container boot:
+Three fixtures are served, fetched remotely at container boot:
 
+- D5 fixture bundle: <https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/d5-all.json>
+  — 23 fixtures covering the 9 D5 (e2e-deep) probe feature types. Bundled
+  from `showcase/ops/fixtures/d5/*.json`. Must load BEFORE feature-parity
+  to win match precedence (D5 uses specific prompts that overlap with
+  feature-parity's broader substring matches).
 - Smoke fixture: <https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/smoke.json>
   — minimal "OK" ping for health verification.
 - Feature-parity fixture: <https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/feature-parity.json>
   — realistic tool-call / reasoning / streaming responses used by the
   showcase demos.
 
-Both files sit in this same directory (`showcase/aimock/`). Edits land in the
+All files sit in this directory (`showcase/aimock/`). Edits land in the
 container on the next Railway restart — aimock fetches fixtures at boot and
 caches to disk. Note the `raw.githubusercontent.com` edge cache is ~5 minutes,
 so propagation after a merge is usually ~5 min + restart latency.
+
+When updating D5 fixtures, edit the individual files in `showcase/ops/fixtures/d5/`,
+then re-bundle into `d5-all.json` by running the merge script or manually
+combining the `fixtures` arrays. The bundle must stay in sync.
 
 ## 5. Start command
 
@@ -128,6 +137,7 @@ node /app/dist/cli.js \
   --provider-openai https://api.openai.com \
   --provider-anthropic https://api.anthropic.com \
   --provider-gemini https://generativelanguage.googleapis.com \
+  --fixtures https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/d5-all.json \
   --fixtures https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/smoke.json \
   --fixtures https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/feature-parity.json \
   --validate-on-load \
@@ -144,7 +154,7 @@ Flag-by-flag:
 | `--provider-openai`     | `https://api.openai.com`                    | Upstream URL for OpenAI passthrough.                                                      |
 | `--provider-anthropic`  | `https://api.anthropic.com`                 | Upstream URL for Anthropic passthrough.                                                   |
 | `--provider-gemini`     | `https://generativelanguage.googleapis.com` | Upstream URL for Gemini passthrough.                                                      |
-| `--fixtures` (×2 URLs)  | Remote URLs above                           | Repeatable flag; each loads one JSON fixture at boot, with cache-fallback on failure.     |
+| `--fixtures` (×3 URLs)  | Remote URLs above                           | Repeatable flag; each loads one JSON fixture at boot, with cache-fallback on failure. D5 must appear first for match precedence. |
 | `--validate-on-load`    | —                                           | Fail-loud on schema errors; allows cache-fallback only when network fetch fails.          |
 | `--host`                | `0.0.0.0`                                   | Bind all interfaces so Railway can route to the container.                                |
 | `--port`                | `4010`                                      | Hardcoded listen port — matches the legacy wrapper container convention and the fixed     |

--- a/showcase/aimock/RAILWAY.md
+++ b/showcase/aimock/RAILWAY.md
@@ -103,7 +103,7 @@ query {
 Three fixtures are served, fetched remotely at container boot:
 
 - D5 fixture bundle: <https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/d5-all.json>
-  — 23 fixtures covering the 9 D5 (e2e-deep) probe feature types. Bundled
+  — 22 fixtures across 9 fixture files covering all 11 D5 feature types. Bundled
   from `showcase/ops/fixtures/d5/*.json`. Must load BEFORE feature-parity
   to win match precedence (D5 uses specific prompts that overlap with
   feature-parity's broader substring matches).

--- a/showcase/aimock/RAILWAY.md
+++ b/showcase/aimock/RAILWAY.md
@@ -147,18 +147,18 @@ node /app/dist/cli.js \
 
 Flag-by-flag:
 
-| Flag                    | Value                                       | Purpose                                                                                   |
-| ----------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `node /app/dist/cli.js` | —                                           | Explicit bin invocation — required because Railway's `startCommand` overrides ENTRYPOINT. |
-| `--proxy-only`          | —                                           | Forward unmatched requests to upstream providers instead of failing.                      |
-| `--provider-openai`     | `https://api.openai.com`                    | Upstream URL for OpenAI passthrough.                                                      |
-| `--provider-anthropic`  | `https://api.anthropic.com`                 | Upstream URL for Anthropic passthrough.                                                   |
-| `--provider-gemini`     | `https://generativelanguage.googleapis.com` | Upstream URL for Gemini passthrough.                                                      |
+| Flag                    | Value                                       | Purpose                                                                                                                          |
+| ----------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `node /app/dist/cli.js` | —                                           | Explicit bin invocation — required because Railway's `startCommand` overrides ENTRYPOINT.                                        |
+| `--proxy-only`          | —                                           | Forward unmatched requests to upstream providers instead of failing.                                                             |
+| `--provider-openai`     | `https://api.openai.com`                    | Upstream URL for OpenAI passthrough.                                                                                             |
+| `--provider-anthropic`  | `https://api.anthropic.com`                 | Upstream URL for Anthropic passthrough.                                                                                          |
+| `--provider-gemini`     | `https://generativelanguage.googleapis.com` | Upstream URL for Gemini passthrough.                                                                                             |
 | `--fixtures` (×3 URLs)  | Remote URLs above                           | Repeatable flag; each loads one JSON fixture at boot, with cache-fallback on failure. D5 must appear first for match precedence. |
-| `--validate-on-load`    | —                                           | Fail-loud on schema errors; allows cache-fallback only when network fetch fails.          |
-| `--host`                | `0.0.0.0`                                   | Bind all interfaces so Railway can route to the container.                                |
-| `--port`                | `4010`                                      | Hardcoded listen port — matches the legacy wrapper container convention and the fixed     |
-|                         |                                             | Railway domain routing. Railway injects `$PORT` but the image defaults align with 4010.   |
+| `--validate-on-load`    | —                                           | Fail-loud on schema errors; allows cache-fallback only when network fetch fails.                                                 |
+| `--host`                | `0.0.0.0`                                   | Bind all interfaces so Railway can route to the container.                                                                       |
+| `--port`                | `4010`                                      | Hardcoded listen port — matches the legacy wrapper container convention and the fixed                                            |
+|                         |                                             | Railway domain routing. Railway injects `$PORT` but the image defaults align with 4010.                                          |
 
 If adopting `$PORT` interpolation in the future, both startCommand and any
 upstream `OPENAI_BASE_URL` env vars pointing at this service stay unchanged —

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -1,0 +1,303 @@
+{
+  "_comment": "Bundled D5 (e2e-deep) fixtures. Source files: showcase/ops/fixtures/d5/*.json. Loaded by aimock before feature-parity.json for match precedence.",
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "good name for a goldfish"
+      },
+      "response": {
+        "content": "How about Bubbles? It is friendly, classic, and easy to call out at the tank. If you want alternatives: Goldie, Finley, or Mango."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "name for its tank"
+      },
+      "response": {
+        "content": "Following the Bubbles theme, you could call the tank The Bubble Bowl. It pairs naturally with the goldfish's name and keeps the playful tone."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "what we named the goldfish"
+      },
+      "response": {
+        "content": "We named the goldfish Bubbles, and the tank The Bubble Bowl."
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_render_pie_chart_001"
+      },
+      "response": {
+        "content": "Pie chart rendered above \u2014 Electronics is the largest slice, followed by Clothing, Food, and Books."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a pie chart of revenue by category"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_render_pie_chart_001",
+            "name": "render_pie_chart",
+            "arguments": {
+              "title": "Revenue by Category",
+              "description": "Revenue breakdown by product category (Q4)",
+              "data": [
+                {
+                  "label": "Electronics",
+                  "value": 42000
+                },
+                {
+                  "label": "Clothing",
+                  "value": 28000
+                },
+                {
+                  "label": "Food",
+                  "value": 18000
+                },
+                {
+                  "label": "Books",
+                  "value": 12000
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_show_card_001"
+      },
+      "response": {
+        "content": "Here is a quick card for Ada Lovelace \u2014 the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a profile card for Ada Lovelace"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_show_card_001",
+            "name": "show_card",
+            "arguments": {
+              "title": "Ada Lovelace",
+              "body": "English mathematician (1815\u20131852), credited as the first computer programmer for her notes on Charles Babbage's Analytical Engine \u2014 including what is now recognized as the first algorithm intended to be carried out by a machine."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_request_approval_001"
+      },
+      "response": {
+        "content": "Approved \u2014 processing the $50 refund to customer #12345 now."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Issue a $50 refund to customer #12345"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_request_approval_001",
+            "name": "request_user_approval",
+            "arguments": {
+              "message": "Issue a $50 refund to customer #12345.",
+              "context": "Per the standard goodwill-credit policy for shipping delays."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_generate_steps_001"
+      },
+      "response": {
+        "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "trip to mars"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_generate_steps_001",
+            "type": "function",
+            "function": {
+              "name": "generate_task_steps",
+              "arguments": "{\"steps\":[{\"description\":\"Research Mars mission requirements and timeline\",\"status\":\"enabled\"},{\"description\":\"Design spacecraft and life support systems\",\"status\":\"enabled\"},{\"description\":\"Recruit and train the crew\",\"status\":\"enabled\"},{\"description\":\"Launch and navigate to Mars\",\"status\":\"enabled\"},{\"description\":\"Land and establish base camp\",\"status\":\"enabled\"}]}"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_book_call_001"
+      },
+      "response": {
+        "content": "Booked Alice's onboarding call for the time you selected \u2014 calendar invite is on its way."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Book a 30-minute onboarding call for Alice"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_book_call_001",
+            "name": "book_call",
+            "arguments": {
+              "topic": "Onboarding call",
+              "name": "Alice"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_critique_agent_001"
+      },
+      "response": {
+        "content": "Here is the summary, after research \u2192 drafting \u2192 critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_writing_agent_001"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_critique_agent_001",
+            "name": "critique_agent",
+            "arguments": {
+              "draft": "Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_research_agent_001"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_writing_agent_001",
+            "name": "writing_agent",
+            "arguments": {
+              "brief": "One-paragraph summary on the benefits of remote work, grounded in the research facts.",
+              "facts": "- Eliminates commute, returning ~10 hours per week\n- Higher reported job satisfaction in repeated surveys\n- Wider talent pool for employers, no geographic limit\n- Reduced office overhead\n- Trade-offs: collaboration, mentorship, cultural cohesion"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_research_agent_001",
+            "name": "research_agent",
+            "arguments": {
+              "topic": "Benefits of remote work"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_set_notes_001"
+      },
+      "response": {
+        "content": "Got it \u2014 I have noted that your favorite color is blue."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "remember that my favorite color is blue"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_set_notes_001",
+            "name": "set_notes",
+            "arguments": {
+              "notes": [
+                "Favorite color: blue"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "favorite color"
+      },
+      "response": {
+        "content": "Your favorite color is blue \u2014 I noted it earlier."
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_search_flights_001"
+      },
+      "response": {
+        "content": "Tokyo is currently 22\u00b0C and partly cloudy \u2014 pleasant and walk-friendly. I also pulled SFO\u2192NRT options in case you want to head over: most carriers have non-stops at around $720\u2013$890 round-trip in the next two weeks. Want me to narrow by date or airline?"
+      }
+    },
+    {
+      "match": {
+        "toolCallId": "call_d5_get_weather_001"
+      },
+      "response": {
+        "content": "Tokyo is 22\u00b0C and partly cloudy."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "weather in Tokyo"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_get_weather_001",
+            "name": "get_weather",
+            "arguments": {
+              "location": "Tokyo"
+            }
+          },
+          {
+            "id": "call_d5_search_flights_001",
+            "name": "search_flights",
+            "arguments": {
+              "origin": "SFO",
+              "destination": "Tokyo"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -243,9 +243,7 @@
             "id": "call_d5_set_notes_001",
             "name": "set_notes",
             "arguments": {
-              "notes": [
-                "Favorite color: blue"
-              ]
+              "notes": ["Favorite color: blue"]
             }
           }
         ]

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -30,7 +30,7 @@
         "toolCallId": "call_d5_render_pie_chart_001"
       },
       "response": {
-        "content": "Pie chart rendered above \u2014 Electronics is the largest slice, followed by Clothing, Food, and Books."
+        "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
       }
     },
     {
@@ -42,28 +42,7 @@
           {
             "id": "call_d5_render_pie_chart_001",
             "name": "render_pie_chart",
-            "arguments": {
-              "title": "Revenue by Category",
-              "description": "Revenue breakdown by product category (Q4)",
-              "data": [
-                {
-                  "label": "Electronics",
-                  "value": 42000
-                },
-                {
-                  "label": "Clothing",
-                  "value": 28000
-                },
-                {
-                  "label": "Food",
-                  "value": 18000
-                },
-                {
-                  "label": "Books",
-                  "value": 12000
-                }
-              ]
-            }
+            "arguments": "{\"title\":\"Revenue by Category\",\"description\":\"Revenue breakdown by product category (Q4)\",\"data\":[{\"label\":\"Electronics\",\"value\":42000},{\"label\":\"Clothing\",\"value\":28000},{\"label\":\"Food\",\"value\":18000},{\"label\":\"Books\",\"value\":12000}]}"
           }
         ]
       }
@@ -73,7 +52,7 @@
         "toolCallId": "call_d5_show_card_001"
       },
       "response": {
-        "content": "Here is a quick card for Ada Lovelace \u2014 the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
+        "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
       }
     },
     {
@@ -85,10 +64,7 @@
           {
             "id": "call_d5_show_card_001",
             "name": "show_card",
-            "arguments": {
-              "title": "Ada Lovelace",
-              "body": "English mathematician (1815\u20131852), credited as the first computer programmer for her notes on Charles Babbage's Analytical Engine \u2014 including what is now recognized as the first algorithm intended to be carried out by a machine."
-            }
+            "arguments": "{\"title\":\"Ada Lovelace\",\"body\":\"English mathematician (1815\\u20131852), credited as the first computer programmer for her notes on Charles Babbage's Analytical Engine \\u2014 including what is now recognized as the first algorithm intended to be carried out by a machine.\"}"
           }
         ]
       }
@@ -98,7 +74,7 @@
         "toolCallId": "call_d5_request_approval_001"
       },
       "response": {
-        "content": "Approved \u2014 processing the $50 refund to customer #12345 now."
+        "content": "Approved — processing the $50 refund to customer #12345 now."
       }
     },
     {
@@ -110,10 +86,7 @@
           {
             "id": "call_d5_request_approval_001",
             "name": "request_user_approval",
-            "arguments": {
-              "message": "Issue a $50 refund to customer #12345.",
-              "context": "Per the standard goodwill-credit policy for shipping delays."
-            }
+            "arguments": "{\"message\":\"Issue a $50 refund to customer #12345.\",\"context\":\"Per the standard goodwill-credit policy for shipping delays.\"}"
           }
         ]
       }
@@ -135,15 +108,7 @@
           {
             "id": "call_d5_generate_steps_001",
             "name": "generate_task_steps",
-            "arguments": {
-              "steps": [
-                { "description": "Research Mars mission requirements and timeline", "status": "enabled" },
-                { "description": "Design spacecraft and life support systems", "status": "enabled" },
-                { "description": "Recruit and train the crew", "status": "enabled" },
-                { "description": "Launch and navigate to Mars", "status": "enabled" },
-                { "description": "Land and establish base camp", "status": "enabled" }
-              ]
-            }
+            "arguments": "{\"steps\":[{\"description\":\"Research Mars mission requirements and timeline\",\"status\":\"enabled\"},{\"description\":\"Design spacecraft and life support systems\",\"status\":\"enabled\"},{\"description\":\"Recruit and train the crew\",\"status\":\"enabled\"},{\"description\":\"Launch and navigate to Mars\",\"status\":\"enabled\"},{\"description\":\"Land and establish base camp\",\"status\":\"enabled\"}]}"
           }
         ]
       }
@@ -153,7 +118,7 @@
         "toolCallId": "call_d5_book_call_001"
       },
       "response": {
-        "content": "Booked Alice's onboarding call for the time you selected \u2014 calendar invite is on its way."
+        "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
       }
     },
     {
@@ -165,10 +130,7 @@
           {
             "id": "call_d5_book_call_001",
             "name": "book_call",
-            "arguments": {
-              "topic": "Onboarding call",
-              "name": "Alice"
-            }
+            "arguments": "{\"topic\":\"Onboarding call\",\"name\":\"Alice\"}"
           }
         ]
       }
@@ -178,7 +140,7 @@
         "toolCallId": "call_d5_critique_agent_001"
       },
       "response": {
-        "content": "Here is the summary, after research \u2192 drafting \u2192 critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
+        "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
       }
     },
     {
@@ -190,9 +152,7 @@
           {
             "id": "call_d5_critique_agent_001",
             "name": "critique_agent",
-            "arguments": {
-              "draft": "Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
-            }
+            "arguments": "{\"draft\":\"Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly.\"}"
           }
         ]
       }
@@ -206,10 +166,7 @@
           {
             "id": "call_d5_writing_agent_001",
             "name": "writing_agent",
-            "arguments": {
-              "brief": "One-paragraph summary on the benefits of remote work, grounded in the research facts.",
-              "facts": "- Eliminates commute, returning ~10 hours per week\n- Higher reported job satisfaction in repeated surveys\n- Wider talent pool for employers, no geographic limit\n- Reduced office overhead\n- Trade-offs: collaboration, mentorship, cultural cohesion"
-            }
+            "arguments": "{\"brief\":\"One-paragraph summary on the benefits of remote work, grounded in the research facts.\",\"facts\":\"- Eliminates commute, returning ~10 hours per week\\n- Higher reported job satisfaction in repeated surveys\\n- Wider talent pool for employers, no geographic limit\\n- Reduced office overhead\\n- Trade-offs: collaboration, mentorship, cultural cohesion\"}"
           }
         ]
       }
@@ -223,9 +180,7 @@
           {
             "id": "call_d5_research_agent_001",
             "name": "research_agent",
-            "arguments": {
-              "topic": "Benefits of remote work"
-            }
+            "arguments": "{\"topic\":\"Benefits of remote work\"}"
           }
         ]
       }
@@ -235,7 +190,7 @@
         "toolCallId": "call_d5_set_notes_001"
       },
       "response": {
-        "content": "Got it \u2014 I have noted that your favorite color is blue."
+        "content": "Got it — I have noted that your favorite color is blue."
       }
     },
     {
@@ -247,9 +202,7 @@
           {
             "id": "call_d5_set_notes_001",
             "name": "set_notes",
-            "arguments": {
-              "notes": ["Favorite color: blue"]
-            }
+            "arguments": "{\"notes\":[\"Favorite color: blue\"]}"
           }
         ]
       }
@@ -259,7 +212,7 @@
         "userMessage": "favorite color"
       },
       "response": {
-        "content": "Your favorite color is blue \u2014 I noted it earlier."
+        "content": "Your favorite color is blue — I noted it earlier."
       }
     },
     {
@@ -267,7 +220,7 @@
         "toolCallId": "call_d5_get_weather_001"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22°C and partly cloudy."
       }
     },
     {
@@ -279,9 +232,7 @@
           {
             "id": "call_d5_get_weather_001",
             "name": "get_weather",
-            "arguments": {
-              "location": "Tokyo"
-            }
+            "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
       }

--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -134,10 +134,15 @@
         "toolCalls": [
           {
             "id": "call_d5_generate_steps_001",
-            "type": "function",
-            "function": {
-              "name": "generate_task_steps",
-              "arguments": "{\"steps\":[{\"description\":\"Research Mars mission requirements and timeline\",\"status\":\"enabled\"},{\"description\":\"Design spacecraft and life support systems\",\"status\":\"enabled\"},{\"description\":\"Recruit and train the crew\",\"status\":\"enabled\"},{\"description\":\"Launch and navigate to Mars\",\"status\":\"enabled\"},{\"description\":\"Land and establish base camp\",\"status\":\"enabled\"}]}"
+            "name": "generate_task_steps",
+            "arguments": {
+              "steps": [
+                { "description": "Research Mars mission requirements and timeline", "status": "enabled" },
+                { "description": "Design spacecraft and life support systems", "status": "enabled" },
+                { "description": "Recruit and train the crew", "status": "enabled" },
+                { "description": "Launch and navigate to Mars", "status": "enabled" },
+                { "description": "Land and establish base camp", "status": "enabled" }
+              ]
             }
           }
         ]
@@ -259,14 +264,6 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_search_flights_001"
-      },
-      "response": {
-        "content": "Tokyo is currently 22\u00b0C and partly cloudy \u2014 pleasant and walk-friendly. I also pulled SFO\u2192NRT options in case you want to head over: most carriers have non-stops at around $720\u2013$890 round-trip in the next two weeks. Want me to narrow by date or airline?"
-      }
-    },
-    {
-      "match": {
         "toolCallId": "call_d5_get_weather_001"
       },
       "response": {
@@ -284,14 +281,6 @@
             "name": "get_weather",
             "arguments": {
               "location": "Tokyo"
-            }
-          },
-          {
-            "id": "call_d5_search_flights_001",
-            "name": "search_flights",
-            "arguments": {
-              "origin": "SFO",
-              "destination": "Tokyo"
             }
           }
         ]

--- a/showcase/ops/fixtures/d5/README.md
+++ b/showcase/ops/fixtures/d5/README.md
@@ -1,6 +1,6 @@
 # D5 Multi-Turn aimock Fixtures
 
-Eight feature-type fixtures used by the D5 (complex interact) probes in
+Nine feature-type fixtures used by the D5 (complex interact) probes in
 `showcase/ops/src/probes/drivers/e2e-deep.ts` (forthcoming) against the LangGraph
 Python (LGP) showcase as the reference implementation.
 
@@ -36,8 +36,8 @@ color"` rather than `"What is my favorite color"`).
   will never fire.
 
 `tool-rendering`, `shared-state`, `hitl-approve-deny`, `hitl-text-input`,
-`gen-ui-headless`, `gen-ui-custom`, and `mcp-subagents` all rely on this
-toolCallId-routed pattern. `agentic-chat` is purely text — no tools — so it uses
+`hitl-steps`, `gen-ui-headless`, `gen-ui-custom`, and `mcp-subagents` all rely
+on this toolCallId-routed pattern. `agentic-chat` is purely text — no tools — so it uses
 three plain `userMessage` substring matches.
 
 ## Per-feature-type-against-LGP-only
@@ -51,7 +51,7 @@ specific integration; we will then either (a) update the integration to bring
 it in line or (b) add a per-integration override fixture.
 
 This trade — replay a single canonical fixture rather than re-record per
-integration — keeps the fleet of fixtures small (8 files, not 8×17 = 136), and
+integration — keeps the fleet of fixtures small (9 files, not 9×17 = 153), and
 keeps drift contained: when LGP changes, we re-record once, not 17 times.
 
 ## How each fixture was constructed
@@ -69,10 +69,11 @@ For each feature type, the authoring inputs were:
 | Feature           | LGP source files                                                                                                                                                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | agentic-chat      | `showcase/packages/langgraph-python/src/agents/agentic_chat.py`                                                                                                    |
-| tool-rendering    | `src/agents/tool_rendering_agent.py` (chains `get_weather` → `search_flights`) + `src/app/demos/tool-rendering/{weather-card,flight-list-card}.tsx`                |
+| tool-rendering    | `src/agents/tool_rendering_agent.py` (`get_weather`) + `src/app/demos/tool-rendering/weather-card.tsx`                                                             |
 | shared-state      | `src/agents/shared_state_read_write.py` (`set_notes` tool, `Preferences` shared state) + `src/app/demos/shared-state-read-write/{notes-card,preferences-card}.tsx` |
 | hitl-approve-deny | `src/agents/hitl_in_app.py` + `src/app/demos/hitl-in-app/{page,approval-dialog}.tsx` (`request_user_approval` frontend tool)                                       |
 | hitl-text-input   | `src/agents/hitl_in_chat_agent.py` + `src/app/demos/hitl-in-chat/{page,time-picker-card}.tsx` (`book_call` HITL tool)                                              |
+| hitl-steps        | `src/agents/hitl_agent.py` + `src/app/demos/hitl/page.tsx` (`generate_task_steps` frontend tool)                                                                   |
 | gen-ui-headless   | `src/app/demos/headless-simple/page.tsx` (`show_card` `useComponent`) — backend agent is `src/agents/main.py`                                                      |
 | gen-ui-custom     | `src/agents/gen_ui_tool_based.py` + `src/app/demos/gen-ui-tool-based/page.tsx` (`render_bar_chart` / `render_pie_chart`)                                           |
 | mcp-subagents     | `src/agents/subagents.py` + `src/app/demos/subagents/{page,delegation-log}.tsx` (`research_agent` / `writing_agent` / `critique_agent`)                            |
@@ -116,8 +117,8 @@ re-author the affected fixture by hand following the existing pattern:
    then issue chat-completions requests for each turn (turn 1 user message,
    turn 1 follow-up after tool result, turn 2 user message, ...) and assert
    the response shape matches what the fixture promises (text content or
-   `tool_calls`). The set of 8 fixtures was bootstrapped this way at
-   authoring time — 20 legs across 8 files, all replay-passing.
+   `tool_calls`). The set of 9 fixtures was bootstrapped this way at
+   authoring time — 22 legs across 9 files, all replay-passing.
 6. Once the D5 driver exists, run it against the LGP showcase locally with
    aimock pointed at the per-fixture file and confirm the full conversation
    short-circuits the live LLM (no requests should escape to the real
@@ -132,7 +133,7 @@ providers and diffs against checked-in fixtures — same idea sketched in
 
 **Pros:**
 
-- 8 fixture files, not 136. Fewer files to keep in sync.
+- 9 fixture files, not 153. Fewer files to keep in sync.
 - LGP is the reference implementation by design — fixtures that match LGP's
   contract surface other integrations' divergences as legitimate parity
   failures rather than masking them with bespoke fixtures.
@@ -157,13 +158,14 @@ fixture pool (first-match-wins).
 | Fixture                  | Status                                              |
 | ------------------------ | --------------------------------------------------- |
 | `agentic-chat.json`      | real (3 turns, no tools)                            |
-| `tool-rendering.json`    | real (1 turn, 2 chained tool calls)                 |
+| `tool-rendering.json`    | real (1 turn, 1 tool call)                          |
 | `shared-state.json`      | real (2 user turns + 1 tool-routed leg)             |
 | `hitl-approve-deny.json` | real (1 turn, frontend HITL tool, approve path)     |
 | `hitl-text-input.json`   | real (1 turn, frontend HITL tool, text/time picker) |
+| `hitl-steps.json`        | real (2 legs: toolCallId match + userMessage match) |
 | `gen-ui-headless.json`   | real (1 turn, `show_card` `useComponent`)           |
 | `gen-ui-custom.json`     | real (1 turn, custom chart component)               |
 | `mcp-subagents.json`     | real (1 turn, 3 chained sub-agent delegations)      |
 
-None are marked `pending` — all eight are exercisable on LGP today against the
+None are marked `pending` — all nine are exercisable on LGP today against the
 agent source as it stands.

--- a/showcase/ops/fixtures/d5/gen-ui-custom.json
+++ b/showcase/ops/fixtures/d5/gen-ui-custom.json
@@ -2,7 +2,9 @@
   "_comment": "D5 fixture for /demos/gen-ui-tool-based against LangGraph Python (LGP). Tool-based gen-UI with custom components — the frontend registers `render_bar_chart` and `render_pie_chart` via useComponent (see src/app/demos/gen-ui-tool-based/page.tsx); the backend agent (src/agents/gen_ui_tool_based.py) emits the tool call with title/description/data and a custom React chart component renders. After the tool result is appended, the agent re-invokes the LLM — second-leg matches by toolCallId. The system prompt in gen_ui_tool_based.py says 'Keep chat responses brief — let the chart do the talking', so the follow-up text is intentionally minimal. ORDER: toolCallId fixture above userMessage fixture to avoid infinite-loop re-matching.",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_render_pie_chart_001" },
+      "match": {
+        "toolCallId": "call_d5_render_pie_chart_001"
+      },
       "response": {
         "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
       }
@@ -16,16 +18,7 @@
           {
             "id": "call_d5_render_pie_chart_001",
             "name": "render_pie_chart",
-            "arguments": {
-              "title": "Revenue by Category",
-              "description": "Revenue breakdown by product category (Q4)",
-              "data": [
-                { "label": "Electronics", "value": 42000 },
-                { "label": "Clothing", "value": 28000 },
-                { "label": "Food", "value": 18000 },
-                { "label": "Books", "value": 12000 }
-              ]
-            }
+            "arguments": "{\"title\":\"Revenue by Category\",\"description\":\"Revenue breakdown by product category (Q4)\",\"data\":[{\"label\":\"Electronics\",\"value\":42000},{\"label\":\"Clothing\",\"value\":28000},{\"label\":\"Food\",\"value\":18000},{\"label\":\"Books\",\"value\":12000}]}"
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/gen-ui-headless.json
+++ b/showcase/ops/fixtures/d5/gen-ui-headless.json
@@ -2,7 +2,9 @@
   "_comment": "D5 fixture for /demos/headless-simple against LangGraph Python (LGP). Headless gen-UI via the frontend-defined `show_card` tool (useComponent — see src/app/demos/headless-simple/page.tsx). The backend agent (src/agents/main.py) has no backend tools; the frontend injects show_card at runtime. The agent calls show_card with title+body; the frontend's headless chat surface renders the ShowCard component. After the tool result is appended (the headless surface synthesizes a tool result), the agent re-invokes the LLM — second-leg fixture matches by toolCallId. ORDER: toolCallId fixture above userMessage fixture to avoid infinite-loop re-matching.",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_show_card_001" },
+      "match": {
+        "toolCallId": "call_d5_show_card_001"
+      },
       "response": {
         "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
       }
@@ -16,10 +18,7 @@
           {
             "id": "call_d5_show_card_001",
             "name": "show_card",
-            "arguments": {
-              "title": "Ada Lovelace",
-              "body": "English mathematician (1815–1852), credited as the first computer programmer for her notes on Charles Babbage's Analytical Engine — including what is now recognized as the first algorithm intended to be carried out by a machine."
-            }
+            "arguments": "{\"title\":\"Ada Lovelace\",\"body\":\"English mathematician (1815\\u20131852), credited as the first computer programmer for her notes on Charles Babbage's Analytical Engine \\u2014 including what is now recognized as the first algorithm intended to be carried out by a machine.\"}"
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/hitl-approve-deny.json
+++ b/showcase/ops/fixtures/d5/hitl-approve-deny.json
@@ -2,7 +2,9 @@
   "_comment": "D5 fixture for /demos/hitl-in-app against LangGraph Python (LGP). Approve/deny HITL via the frontend-defined `request_user_approval` tool (see src/app/demos/hitl-in-app/page.tsx and src/agents/hitl_in_app.py). The agent calls request_user_approval; the frontend opens an out-of-chat modal; on approval the async handler resolves with {approved: true, reason: ...} and the tool result is appended back to the conversation. The agent then re-invokes the LLM — second-leg fixture matches on toolCallId. Per the system prompt the agent then issues a one-sentence acknowledgement, no further tool calls. ORDER: toolCallId fixture above userMessage fixture to avoid infinite-loop re-matching (the user message has not changed across the agent loop).",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_request_approval_001" },
+      "match": {
+        "toolCallId": "call_d5_request_approval_001"
+      },
       "response": {
         "content": "Approved — processing the $50 refund to customer #12345 now."
       }
@@ -16,10 +18,7 @@
           {
             "id": "call_d5_request_approval_001",
             "name": "request_user_approval",
-            "arguments": {
-              "message": "Issue a $50 refund to customer #12345.",
-              "context": "Per the standard goodwill-credit policy for shipping delays."
-            }
+            "arguments": "{\"message\":\"Issue a $50 refund to customer #12345.\",\"context\":\"Per the standard goodwill-credit policy for shipping delays.\"}"
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/hitl-steps.json
+++ b/showcase/ops/fixtures/d5/hitl-steps.json
@@ -2,27 +2,23 @@
   "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool.",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_generate_steps_001" },
+      "match": {
+        "toolCallId": "call_d5_generate_steps_001"
+      },
       "response": {
         "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
       }
     },
     {
-      "match": { "userMessage": "trip to mars" },
+      "match": {
+        "userMessage": "trip to mars"
+      },
       "response": {
         "toolCalls": [
           {
             "id": "call_d5_generate_steps_001",
             "name": "generate_task_steps",
-            "arguments": {
-              "steps": [
-                { "description": "Research Mars mission requirements and timeline", "status": "enabled" },
-                { "description": "Design spacecraft and life support systems", "status": "enabled" },
-                { "description": "Recruit and train the crew", "status": "enabled" },
-                { "description": "Launch and navigate to Mars", "status": "enabled" },
-                { "description": "Land and establish base camp", "status": "enabled" }
-              ]
-            }
+            "arguments": "{\"steps\":[{\"description\":\"Research Mars mission requirements and timeline\",\"status\":\"enabled\"},{\"description\":\"Design spacecraft and life support systems\",\"status\":\"enabled\"},{\"description\":\"Recruit and train the crew\",\"status\":\"enabled\"},{\"description\":\"Launch and navigate to Mars\",\"status\":\"enabled\"},{\"description\":\"Land and establish base camp\",\"status\":\"enabled\"}]}"
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/hitl-steps.json
+++ b/showcase/ops/fixtures/d5/hitl-steps.json
@@ -1,0 +1,26 @@
+{
+  "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool.",
+  "fixtures": [
+    {
+      "match": { "toolCallId": "call_d5_generate_steps_001" },
+      "response": {
+        "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
+      }
+    },
+    {
+      "match": { "userMessage": "trip to mars" },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_generate_steps_001",
+            "type": "function",
+            "function": {
+              "name": "generate_task_steps",
+              "arguments": "{\"steps\":[{\"description\":\"Research Mars mission requirements and timeline\",\"status\":\"enabled\"},{\"description\":\"Design spacecraft and life support systems\",\"status\":\"enabled\"},{\"description\":\"Recruit and train the crew\",\"status\":\"enabled\"},{\"description\":\"Launch and navigate to Mars\",\"status\":\"enabled\"},{\"description\":\"Land and establish base camp\",\"status\":\"enabled\"}]}"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/showcase/ops/fixtures/d5/hitl-steps.json
+++ b/showcase/ops/fixtures/d5/hitl-steps.json
@@ -13,10 +13,15 @@
         "toolCalls": [
           {
             "id": "call_d5_generate_steps_001",
-            "type": "function",
-            "function": {
-              "name": "generate_task_steps",
-              "arguments": "{\"steps\":[{\"description\":\"Research Mars mission requirements and timeline\",\"status\":\"enabled\"},{\"description\":\"Design spacecraft and life support systems\",\"status\":\"enabled\"},{\"description\":\"Recruit and train the crew\",\"status\":\"enabled\"},{\"description\":\"Launch and navigate to Mars\",\"status\":\"enabled\"},{\"description\":\"Land and establish base camp\",\"status\":\"enabled\"}]}"
+            "name": "generate_task_steps",
+            "arguments": {
+              "steps": [
+                { "description": "Research Mars mission requirements and timeline", "status": "enabled" },
+                { "description": "Design spacecraft and life support systems", "status": "enabled" },
+                { "description": "Recruit and train the crew", "status": "enabled" },
+                { "description": "Launch and navigate to Mars", "status": "enabled" },
+                { "description": "Land and establish base camp", "status": "enabled" }
+              ]
             }
           }
         ]

--- a/showcase/ops/fixtures/d5/hitl-text-input.json
+++ b/showcase/ops/fixtures/d5/hitl-text-input.json
@@ -2,7 +2,9 @@
   "_comment": "D5 fixture for /demos/hitl-in-chat against LangGraph Python (LGP). Text-input HITL via the frontend-defined `book_call` tool (see src/app/demos/hitl-in-chat/page.tsx and src/agents/hitl_in_chat_agent.py). The agent calls book_call with topic and name; the frontend renders an inline time-picker card via useHumanInTheLoop; the user picks a slot and the value is sent back as the tool result; the agent re-invokes with that result and emits a short acknowledgement. We match the second leg by toolCallId because the user's original message has not changed. ORDER: toolCallId fixture above userMessage fixture to avoid infinite-loop re-matching.",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_book_call_001" },
+      "match": {
+        "toolCallId": "call_d5_book_call_001"
+      },
       "response": {
         "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
       }
@@ -16,10 +18,7 @@
           {
             "id": "call_d5_book_call_001",
             "name": "book_call",
-            "arguments": {
-              "topic": "Onboarding call",
-              "name": "Alice"
-            }
+            "arguments": "{\"topic\":\"Onboarding call\",\"name\":\"Alice\"}"
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/mcp-subagents.json
+++ b/showcase/ops/fixtures/d5/mcp-subagents.json
@@ -2,36 +2,37 @@
   "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). The supervisor agent in src/agents/subagents.py exposes three sub-agents as tools — research_agent, writing_agent, critique_agent — with a delegations log in shared state. A typical chained run: supervisor calls research_agent → gets facts → calls writing_agent → gets a draft → calls critique_agent → gets a review → composes a final reply. Each delegation appends a Delegation entry to shared state which the UI renders live in DelegationLog. We model the chain as three sequential tool calls (one per turn through the agent loop). The user message does not change between turns, so the supervisor's second/third tool-call decisions are routed by toolCallId on the LAST tool message — which always carries the id of the most recently completed sub-agent. A final text reply fires after the critique tool result is appended. ORDER MATTERS: toolCallId fixtures must precede the userMessage fixture so they win on every loop iteration; the chain is also ordered critique → writing → research so that 'last tool result is critique' resolves to the final text rather than re-firing writing_agent. NOTE on naming: the spec calls this 'mcp-subagents' but LGP's canonical multi-agent demo is /demos/subagents (subagents-as-tools); the LGP /demos/mcp-apps demo points at a public Excalidraw MCP server which would require that external server to be reachable to record realistically. Subagents is the closer real-on-LGP fit.",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_critique_agent_001" },
+      "match": {
+        "toolCallId": "call_d5_critique_agent_001"
+      },
       "response": {
         "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
       }
     },
     {
-      "match": { "toolCallId": "call_d5_writing_agent_001" },
+      "match": {
+        "toolCallId": "call_d5_writing_agent_001"
+      },
       "response": {
         "toolCalls": [
           {
             "id": "call_d5_critique_agent_001",
             "name": "critique_agent",
-            "arguments": {
-              "draft": "Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
-            }
+            "arguments": "{\"draft\":\"Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly.\"}"
           }
         ]
       }
     },
     {
-      "match": { "toolCallId": "call_d5_research_agent_001" },
+      "match": {
+        "toolCallId": "call_d5_research_agent_001"
+      },
       "response": {
         "toolCalls": [
           {
             "id": "call_d5_writing_agent_001",
             "name": "writing_agent",
-            "arguments": {
-              "brief": "One-paragraph summary on the benefits of remote work, grounded in the research facts.",
-              "facts": "- Eliminates commute, returning ~10 hours per week\n- Higher reported job satisfaction in repeated surveys\n- Wider talent pool for employers, no geographic limit\n- Reduced office overhead\n- Trade-offs: collaboration, mentorship, cultural cohesion"
-            }
+            "arguments": "{\"brief\":\"One-paragraph summary on the benefits of remote work, grounded in the research facts.\",\"facts\":\"- Eliminates commute, returning ~10 hours per week\\n- Higher reported job satisfaction in repeated surveys\\n- Wider talent pool for employers, no geographic limit\\n- Reduced office overhead\\n- Trade-offs: collaboration, mentorship, cultural cohesion\"}"
           }
         ]
       }
@@ -45,9 +46,7 @@
           {
             "id": "call_d5_research_agent_001",
             "name": "research_agent",
-            "arguments": {
-              "topic": "Benefits of remote work"
-            }
+            "arguments": "{\"topic\":\"Benefits of remote work\"}"
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/shared-state.json
+++ b/showcase/ops/fixtures/d5/shared-state.json
@@ -2,25 +2,31 @@
   "_comment": "D5 multi-turn fixture for /demos/shared-state-read-write against LangGraph Python (LGP). Demonstrates the agent-write half of bidirectional shared state: turn 1 the user asks the agent to remember something, the agent calls the backend `set_notes` tool (defined in src/agents/shared_state_read_write.py) which mutates shared state via Command(update={'notes': ...}). The frontend NotesCard re-renders. After the tool result is appended, the agent re-invokes the LLM — we match that second leg via toolCallId. Turn 2 the user asks the agent to recall what it remembered; the agent reads its own notes from state and replies. The UI-write half (preferences via agent.setState) does not flow through the LLM, so it is not part of this fixture. ORDER MATTERS: toolCallId fixture MUST appear above the userMessage fixtures or first-match-wins will re-match the original 'remember' fixture after the tool result is appended (the user message has not changed) and create an infinite loop.",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_set_notes_001" },
+      "match": {
+        "toolCallId": "call_d5_set_notes_001"
+      },
       "response": {
         "content": "Got it — I have noted that your favorite color is blue."
       }
     },
     {
-      "match": { "userMessage": "remember that my favorite color is blue" },
+      "match": {
+        "userMessage": "remember that my favorite color is blue"
+      },
       "response": {
         "toolCalls": [
           {
             "id": "call_d5_set_notes_001",
             "name": "set_notes",
-            "arguments": { "notes": ["Favorite color: blue"] }
+            "arguments": "{\"notes\":[\"Favorite color: blue\"]}"
           }
         ]
       }
     },
     {
-      "match": { "userMessage": "favorite color" },
+      "match": {
+        "userMessage": "favorite color"
+      },
       "response": {
         "content": "Your favorite color is blue — I noted it earlier."
       }

--- a/showcase/ops/fixtures/d5/tool-rendering.json
+++ b/showcase/ops/fixtures/d5/tool-rendering.json
@@ -1,12 +1,6 @@
 {
-  "_comment": "D5 multi-turn fixture for /demos/tool-rendering against LangGraph Python (LGP). The LGP backend defines two tools (get_weather, search_flights) and the frontend renders WeatherCard for the weather tool call. The agent's system prompt biases toward CHAINING tools — see src/agents/tool_rendering_agent.py — so a single 'weather in Tokyo' question realistically yields two tool calls (weather, then flights). This fixture mirrors that. After the tool calls return, the agent re-invokes the LLM with the same user message + appended tool results; we match that second leg via toolCallId on the LAST tool message (the search_flights id). ORDER MATTERS: toolCallId-routed fixtures MUST appear ABOVE the userMessage-routed first leg, or first-match-wins will re-match the original tool-call fixture and create an infinite loop (the user message has not changed between the request that emitted the tool calls and the request that carries the tool results back). See showcase/ops/fixtures/d5/README.md § How each fixture was constructed.",
+  "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). The frontend only registers get_weather, so the fixture returns a single tool call. ORDER MATTERS: toolCallId-routed fixtures MUST appear ABOVE the userMessage-routed first leg, or first-match-wins will re-match the original tool-call fixture and create an infinite loop.",
   "fixtures": [
-    {
-      "match": { "toolCallId": "call_d5_search_flights_001" },
-      "response": {
-        "content": "Tokyo is currently 22°C and partly cloudy — pleasant and walk-friendly. I also pulled SFO→NRT options in case you want to head over: most carriers have non-stops at around $720–$890 round-trip in the next two weeks. Want me to narrow by date or airline?"
-      }
-    },
     {
       "match": { "toolCallId": "call_d5_get_weather_001" },
       "response": {
@@ -21,11 +15,6 @@
             "id": "call_d5_get_weather_001",
             "name": "get_weather",
             "arguments": { "location": "Tokyo" }
-          },
-          {
-            "id": "call_d5_search_flights_001",
-            "name": "search_flights",
-            "arguments": { "origin": "SFO", "destination": "Tokyo" }
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/tool-rendering.json
+++ b/showcase/ops/fixtures/d5/tool-rendering.json
@@ -2,19 +2,23 @@
   "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). The frontend only registers get_weather, so the fixture returns a single tool call. ORDER MATTERS: toolCallId-routed fixtures MUST appear ABOVE the userMessage-routed first leg, or first-match-wins will re-match the original tool-call fixture and create an infinite loop.",
   "fixtures": [
     {
-      "match": { "toolCallId": "call_d5_get_weather_001" },
+      "match": {
+        "toolCallId": "call_d5_get_weather_001"
+      },
       "response": {
         "content": "Tokyo is 22°C and partly cloudy."
       }
     },
     {
-      "match": { "userMessage": "weather in Tokyo" },
+      "match": {
+        "userMessage": "weather in Tokyo"
+      },
       "response": {
         "toolCalls": [
           {
             "id": "call_d5_get_weather_001",
             "name": "get_weather",
-            "arguments": { "location": "Tokyo" }
+            "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
       }

--- a/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
@@ -43,7 +43,8 @@ import type { D5FeatureType } from "./d5-registry.js";
  *   - `tool-rendering`         : 4 demos (all the tool-rendering variants)
  *   - `gen-ui-headless`        : 2 demos (headless chat surfaces)
  *   - `gen-ui-custom`          : 1 demo
- *   - `hitl-text-input`        : 4 demos (in-chat HITL variants)
+ *   - `hitl-text-input`        : 3 demos (in-chat HITL variants)
+ *   - `hitl-steps`             : 1 demo (step-selection confirmation)
  *   - `hitl-approve-deny`      : 1 demo (modal/in-app approval)
  *   - `shared-state-read|write`: 1 demo, 2 D5 types (one-to-many)
  *   - `mcp-apps`               : 1 demo
@@ -78,7 +79,7 @@ const REGISTRY_TO_D5: Readonly<Record<string, readonly D5FeatureType[]>> = {
   "hitl-in-chat": ["hitl-text-input"],
   "hitl-in-chat-booking": ["hitl-text-input"],
   "gen-ui-interrupt": ["hitl-text-input"],
-  hitl: ["hitl-text-input"],
+  hitl: ["hitl-steps"],
 
   // hitl (approve/deny tier) — out-of-chat modal approval flow.
   "hitl-in-app": ["hitl-approve-deny"],

--- a/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
@@ -40,7 +40,7 @@ import type { D5FeatureType } from "./d5-registry.js";
  * Entries are grouped by D5 destination to make the many-to-one shape
  * obvious at a glance:
  *   - `agentic-chat`           : 1 demo
- *   - `tool-rendering`         : 4 demos (all the tool-rendering variants)
+ *   - `tool-rendering`         : 3 demos (all the tool-rendering variants)
  *   - `gen-ui-headless`        : 2 demos (headless chat surfaces)
  *   - `gen-ui-custom`          : 1 demo
  *   - `hitl-text-input`        : 3 demos (in-chat HITL variants)

--- a/showcase/ops/src/probes/helpers/d5-registry.ts
+++ b/showcase/ops/src/probes/helpers/d5-registry.ts
@@ -46,9 +46,8 @@ export type D5FeatureType =
 
 /**
  * Closed-set runtime mirror of `D5FeatureType`. Kept in lock-step with
- * the type union so a TypeScript error fires if the two drift apart
- * (the `satisfies` constraint forces this list to remain a superset
- * of the union).
+ * the type union manually. The `satisfies` constraint ensures no invalid
+ * entries but does not enforce completeness.
  */
 const D5_FEATURE_TYPES: readonly D5FeatureType[] = [
   "agentic-chat",

--- a/showcase/ops/src/probes/helpers/d5-registry.ts
+++ b/showcase/ops/src/probes/helpers/d5-registry.ts
@@ -37,6 +37,7 @@ export type D5FeatureType =
   | "shared-state-read"
   | "shared-state-write"
   | "hitl-approve-deny"
+  | "hitl-steps"
   | "hitl-text-input"
   | "gen-ui-headless"
   | "gen-ui-custom"
@@ -55,6 +56,7 @@ const D5_FEATURE_TYPES: readonly D5FeatureType[] = [
   "shared-state-read",
   "shared-state-write",
   "hitl-approve-deny",
+  "hitl-steps",
   "hitl-text-input",
   "gen-ui-headless",
   "gen-ui-custom",

--- a/showcase/ops/src/probes/scripts/d5-hitl-steps.test.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-steps.test.ts
@@ -120,15 +120,13 @@ describe("d5-hitl-steps feature mapping", () => {
 });
 
 describe("d5-hitl-steps registry side-effect", () => {
-  it("populates the registry with the feature type after import", async () => {
+  it("registerD5Script populates the registry for hitl-steps", async () => {
     __clearD5RegistryForTesting();
     const mod = await import("./d5-hitl-steps.js");
-    if (!D5_REGISTRY.has("hitl-steps")) {
-      const { registerD5Script } = await import("../helpers/d5-registry.js");
-      registerD5Script(mod.__d5HitlStepsScript);
-    }
+    const { registerD5Script } = await import("../helpers/d5-registry.js");
+    registerD5Script(mod.__d5HitlStepsScript);
     expect(D5_REGISTRY.has("hitl-steps")).toBe(true);
     const entry = D5_REGISTRY.get("hitl-steps");
-    expect(entry?.fixtureFile).toBe("hitl-steps.json");
+    expect(entry).toBe(mod.__d5HitlStepsScript);
   });
 });

--- a/showcase/ops/src/probes/scripts/d5-hitl-steps.test.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-steps.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `d5-hitl-steps.ts`.
+ *
+ * Mirrors `d5-hitl-text-input.test.ts` — see that file for the
+ * rationale on registry side-effect handling and Page mocking.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  __clearD5RegistryForTesting,
+  D5_REGISTRY,
+} from "../helpers/d5-registry.js";
+import { demosToFeatureTypes } from "../helpers/d5-feature-mapping.js";
+
+describe("d5-hitl-steps script", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("registers under the hitl-steps feature type with the right fixture file", async () => {
+    const mod = await import("./d5-hitl-steps.js");
+    const script = mod.__d5HitlStepsScript;
+
+    expect(script.featureTypes).toEqual(["hitl-steps"]);
+    expect(script.fixtureFile).toBe("hitl-steps.json");
+    expect(script.preNavigateRoute?.("hitl-steps")).toBe("/demos/hitl");
+  });
+
+  it("buildTurns produces a single turn whose input matches the fixture user message", async () => {
+    const mod = await import("./d5-hitl-steps.js");
+    const script = mod.__d5HitlStepsScript;
+    const turns = script.buildTurns({
+      integrationSlug: "langgraph-python",
+      featureType: "hitl-steps",
+      baseUrl: "https://example.test",
+    });
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]!.input).toBe("Please plan a trip to mars in 5 steps");
+    expect(turns[0]!.assertions).toBeTypeOf("function");
+  });
+
+  it("assertion finds steps card, clicks confirm, and passes when follow-up contains 'Mars'", async () => {
+    const mod = await import("./d5-hitl-steps.js");
+    const script = mod.__d5HitlStepsScript;
+    const turns = script.buildTurns({
+      integrationSlug: "langgraph-python",
+      featureType: "hitl-steps",
+      baseUrl: "https://example.test",
+    });
+
+    const calls: { method: string; selector: string }[] = [];
+    let evaluateCount = 0;
+    const page = {
+      async waitForSelector(selector: string) {
+        calls.push({ method: "waitForSelector", selector });
+      },
+      async fill() {},
+      async press() {},
+      async click(selector: string) {
+        calls.push({ method: "click", selector });
+      },
+      async evaluate<R>(_fn: () => R): Promise<R> {
+        evaluateCount += 1;
+        if (evaluateCount === 1) return 1 as unknown as R;
+        if (evaluateCount === 2) return 2 as unknown as R;
+        return "Great choices! I will proceed with executing the selected steps for your trip to Mars." as unknown as R;
+      },
+    };
+
+    await turns[0]!.assertions!(page);
+    expect(
+      calls.some(
+        (c) =>
+          c.method === "waitForSelector" &&
+          c.selector.includes("select-steps"),
+      ),
+    ).toBe(true);
+    expect(calls.some((c) => c.method === "click")).toBe(true);
+  });
+
+  it("assertion throws when the follow-up message is missing 'Mars'", async () => {
+    const mod = await import("./d5-hitl-steps.js");
+    const script = mod.__d5HitlStepsScript;
+    const turns = script.buildTurns({
+      integrationSlug: "langgraph-python",
+      featureType: "hitl-steps",
+      baseUrl: "https://example.test",
+    });
+
+    let evaluateCount = 0;
+    const page = {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {},
+      async click() {},
+      async evaluate<R>(_fn: () => R): Promise<R> {
+        evaluateCount += 1;
+        if (evaluateCount === 1) return 1 as unknown as R;
+        if (evaluateCount === 2) return 2 as unknown as R;
+        return "Done." as unknown as R;
+      },
+    };
+
+    await expect(turns[0]!.assertions!(page)).rejects.toThrow(/missing token/);
+  });
+});
+
+describe("d5-hitl-steps feature mapping", () => {
+  it("demosToFeatureTypes(['hitl']) includes hitl-steps, not hitl-text-input", () => {
+    const result = demosToFeatureTypes(["hitl"]);
+    expect(result).toContain("hitl-steps");
+    expect(result).not.toContain("hitl-text-input");
+  });
+
+  it("demosToFeatureTypes(['hitl-in-chat']) still maps to hitl-text-input", () => {
+    const result = demosToFeatureTypes(["hitl-in-chat"]);
+    expect(result).toContain("hitl-text-input");
+    expect(result).not.toContain("hitl-steps");
+  });
+});
+
+describe("d5-hitl-steps registry side-effect", () => {
+  it("populates the registry with the feature type after import", async () => {
+    __clearD5RegistryForTesting();
+    const mod = await import("./d5-hitl-steps.js");
+    if (!D5_REGISTRY.has("hitl-steps")) {
+      const { registerD5Script } = await import("../helpers/d5-registry.js");
+      registerD5Script(mod.__d5HitlStepsScript);
+    }
+    expect(D5_REGISTRY.has("hitl-steps")).toBe(true);
+    const entry = D5_REGISTRY.get("hitl-steps");
+    expect(entry?.fixtureFile).toBe("hitl-steps.json");
+  });
+});

--- a/showcase/ops/src/probes/scripts/d5-hitl-steps.test.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-steps.test.ts
@@ -72,8 +72,7 @@ describe("d5-hitl-steps script", () => {
     expect(
       calls.some(
         (c) =>
-          c.method === "waitForSelector" &&
-          c.selector.includes("select-steps"),
+          c.method === "waitForSelector" && c.selector.includes("select-steps"),
       ),
     ).toBe(true);
     expect(calls.some((c) => c.method === "click")).toBe(true);

--- a/showcase/ops/src/probes/scripts/d5-hitl-steps.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-steps.ts
@@ -1,0 +1,89 @@
+/**
+ * D5 — `hitl-steps` script.
+ *
+ * Drives the step-selection HITL flow at `/demos/hitl` against the
+ * langgraph-python reference (and any integration that registers
+ * the same feature). Mirrors `showcase/ops/fixtures/d5/hitl-steps.json`:
+ *
+ *   - User: "Please plan a trip to mars in 5 steps"
+ *   - Agent (first leg): tool-calls `generate_task_steps` with 5 steps.
+ *     The frontend renders a `StepsFeedback` card inline in the chat via
+ *     `useHumanInTheLoop`.
+ *   - Probe: clicks the "Confirm" button. Tool result resolves with
+ *     `{ accepted: true, steps: [...] }`.
+ *   - Agent (second leg): emits a follow-up that references Mars.
+ *
+ * Route override: feature type `hitl-steps` would default to
+ * `/demos/hitl-steps`, which doesn't exist. The reference showcase
+ * exposes the demo at `/demos/hitl`.
+ *
+ * Assertion: the follow-up assistant message references "Mars"
+ * (case-insensitive). That's the load-bearing token from the fixture —
+ * any drift that drops it signals a regression in agent continuation.
+ */
+
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5Script } from "../helpers/d5-registry.js";
+import {
+  selectorCascade,
+  readAssistantCount,
+  waitForNextAssistantMessage,
+} from "./_hitl-shared.js";
+import type { Page as HitlPage } from "./_hitl-shared.js";
+import type { Page as ConversationPage } from "../helpers/conversation-runner.js";
+
+const REFERENCE_TOKENS = ["Mars"] as const;
+
+const STEPS_CARD_SELECTORS = [
+  '[data-testid="select-steps"]',
+  '[role="form"]:has([data-testid="step-item"])',
+] as const;
+
+const CONFIRM_BUTTON_SELECTORS = [
+  'button:has-text("Confirm")',
+  'button:has-text("Perform Steps")',
+  '[data-testid="select-steps"] button:not(:has-text("Reject"))',
+] as const;
+
+const script: D5Script = {
+  featureTypes: ["hitl-steps"],
+  fixtureFile: "hitl-steps.json",
+  preNavigateRoute: () => "/demos/hitl",
+  buildTurns: () => [
+    {
+      input: "Please plan a trip to mars in 5 steps",
+      responseTimeoutMs: 60_000,
+      assertions: async (page: ConversationPage) => {
+        const hitlPage = page as unknown as HitlPage;
+        if (typeof (hitlPage as { click?: unknown }).click !== "function") {
+          throw new Error(
+            "d5-hitl-steps: page is missing click() — cannot drive HITL step-selection",
+          );
+        }
+        const baselineCount = await readAssistantCount(hitlPage);
+        await selectorCascade(hitlPage, STEPS_CARD_SELECTORS, "steps card");
+        const confirmSelector = await selectorCascade(
+          hitlPage,
+          CONFIRM_BUTTON_SELECTORS,
+          "confirm button",
+        );
+        await hitlPage.click(confirmSelector);
+        const followup = await waitForNextAssistantMessage(
+          hitlPage,
+          baselineCount,
+        );
+        for (const token of REFERENCE_TOKENS) {
+          if (!followup.toLowerCase().includes(token.toLowerCase())) {
+            throw new Error(
+              `assistant follow-up missing token "${token}" — got: ${followup.slice(0, 200)}`,
+            );
+          }
+        }
+      },
+    },
+  ],
+};
+
+registerD5Script(script);
+
+export const __d5HitlStepsScript = script;

--- a/showcase/ops/src/probes/scripts/d5-tool-rendering.ts
+++ b/showcase/ops/src/probes/scripts/d5-tool-rendering.ts
@@ -11,10 +11,10 @@
  *
  * Why a single turn: the recorded fixture
  * (`showcase/ops/fixtures/d5/tool-rendering.json`) contains one
- * userMessage match — `"weather in Tokyo"` — which fans out into TWO
- * tool calls (`get_weather` + `search_flights`) on the LGP backend per
- * its system prompt. The `toolCallId`-routed fixtures handle the second
- * leg of each tool's request/response. From the conversation runner's
+ * userMessage match — `"weather in Tokyo"` — which emits a single tool
+ * call (`get_weather`) on the LGP backend per its system prompt. The
+ * `toolCallId`-routed fixture handles the second leg of the tool's
+ * request/response. From the conversation runner's
  * perspective this is still ONE user turn — the runner sends one
  * message, waits for the assistant to settle, and runs the assertion
  * once on the resulting DOM.


### PR DESCRIPTION
## Summary

- Bundle all 9 D5 (e2e-deep) fixture files into `showcase/aimock/d5-all.json` so aimock loads them at boot via GitHub raw URL. **Root cause of 93/158 D5 red cells**: the D5 fixtures in `showcase/ops/fixtures/d5/` were never loaded into aimock — probes hit real LLMs producing non-deterministic responses that fail strict assertions.
- Add new `hitl-steps` D5 feature type + probe script for the `/demos/hitl` route, which renders a step-selection UI (`StepsFeedback`), not a time-picker. The previous mapping (`hitl → hitl-text-input`) drove the wrong interaction against the wrong page.
- Update `RAILWAY.md` with the new fixture URL and updated `startCommand` (d5-all.json loads before feature-parity.json for match precedence).

## Post-merge deploy step

After merge, the Railway `startCommand` for `showcase-aimock` must be updated to include the new `--fixtures` URL:

```sh
node /app/dist/cli.js \
  --proxy-only \
  --provider-openai https://api.openai.com \
  --provider-anthropic https://api.anthropic.com \
  --provider-gemini https://generativelanguage.googleapis.com \
  --fixtures https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/d5-all.json \
  --fixtures https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/smoke.json \
  --fixtures https://raw.githubusercontent.com/CopilotKit/CopilotKit/main/showcase/aimock/feature-parity.json \
  --validate-on-load \
  --host 0.0.0.0 \
  --port 4010
```

Then restart the aimock service to pick up the new fixtures.

## Test plan

- [x] 100/100 D5 tests pass (11 test files)
- [x] New hitl-steps tests: 7/7 pass
- [x] Existing hitl-text-input tests: no regression (10/10)
- [x] d5-all.json validated: 23 fixtures, correct structure
- [ ] After deploy: trigger D5 probe cycle and verify red count drops from 93 to near-zero