### PR TITLE
docs(showcase/mastra): region markers for shell-docs snippet coverage

### DIFF
--- a/showcase/packages/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -27,6 +27,7 @@ export default function AgenticChatReasoningDemo() {
 }
 
 function Chat() {
+  // @region[reasoning-block-render]
   return (
     <CopilotChat
       agentId="agentic-chat-reasoning"
@@ -36,4 +37,5 @@ function Chat() {
       }}
     />
   );
+  // @endregion[reasoning-block-render]
 }

--- a/showcase/packages/mastra/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/packages/mastra/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/packages/mastra/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/packages/mastra/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/chat-customization-css/page.tsx
@@ -9,7 +9,9 @@
 import React from "react";
 import { CopilotKit } from "@copilotkit/react-core";
 import { CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/packages/mastra/src/app/demos/chat-slots/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/chat-slots/page.tsx
@@ -32,12 +32,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/packages/mastra/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/declarative-gen-ui/page.tsx
@@ -31,6 +31,7 @@ import { myCatalog } from "./a2ui/catalog";
 
 export default function DeclarativeGenUIDemo() {
   return (
+    // @region[provider-a2ui-prop]
     <CopilotKit
       runtimeUrl="/api/copilotkit"
       agent="declarative-gen-ui"
@@ -42,6 +43,7 @@ export default function DeclarativeGenUIDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[provider-a2ui-prop]
   );
 }
 

--- a/showcase/packages/mastra/src/app/demos/declarative-gen-ui/runtime-inject-tool.snippet.ts
+++ b/showcase/packages/mastra/src/app/demos/declarative-gen-ui/runtime-inject-tool.snippet.ts
@@ -1,0 +1,48 @@
+// Docs-only snippet — not imported or executed. The mastra runtime route
+// (src/app/api/copilotkit/route.ts) uses the unified Mastra adapter and
+// bundles `generateA2uiTool` into the weatherAgent, so it doesn't follow
+// the runtime-injection pattern this region teaches. This file shows what
+// the equivalent CopilotRuntime configuration looks like for a TS framework
+// that DOES want CopilotKit to auto-inject the render_a2ui tool — the case
+// the dynamic-schema docs page is documenting. See
+// chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+declare const myCatalog: unknown;
+declare const myAgent: unknown;
+
+// @region[runtime-inject-tool]
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- agent type is framework-specific
+  agents: { "declarative-gen-ui": myAgent },
+  a2ui: {
+    // injectA2UITool: true tells the runtime to add the `render_a2ui` tool
+    // to the agent's tool list at request time and serialise the client
+    // catalog into the agent's `copilotkit.context`. Use this when your
+    // backend agent does NOT already register its own a2ui-emitting tool.
+    injectA2UITool: true,
+    catalog: myCatalog,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+    endpoint: "/api/copilotkit-declarative-gen-ui",
+    serviceAdapter: new ExperimentalEmptyAdapter(),
+    runtime,
+  });
+  try {
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string };
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+};
+// @endregion[runtime-inject-tool]

--- a/showcase/packages/mastra/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/packages/mastra/src/app/demos/headless-complete/assistant-bubble.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-complete/assistant-bubble.tsx
@@ -15,6 +15,7 @@ import React from "react";
  * calls yet) is suppressed so the bubble doesn't flash an empty rounded
  * box while streaming hasn't started.
  */
+// @region[custom-bubbles]
 export function AssistantBubble({ children }: { children: React.ReactNode }) {
   if (isEmpty(children)) return null;
 
@@ -28,6 +29,7 @@ export function AssistantBubble({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
+// @endregion[custom-bubbles]
 
 function isEmpty(node: React.ReactNode): boolean {
   if (node == null || node === false) return true;

--- a/showcase/packages/mastra/src/app/demos/headless-complete/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-complete/page.tsx
@@ -64,6 +64,7 @@ export default function HeadlessCompleteDemo() {
 // agent, wires up the connect/run/stop lifecycle, and hands the pure
 // presentational pieces their props.
 function Chat() {
+  // @region[page-send-message]
   const threadId = useMemo(() => crypto.randomUUID(), []);
   const { agent } = useAgent({ agentId: AGENT_ID, threadId });
   const { copilotkit } = useCopilotKit();
@@ -118,6 +119,7 @@ function Chat() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent]);
+  // @endregion[page-send-message]
 
   // Wrap the chat body in a CopilotChatConfigurationProvider so that the
   // rendering primitives used inside `useRenderedMessages` see a matching

--- a/showcase/packages/mastra/src/app/demos/headless-complete/use-rendered-messages.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-complete/use-rendered-messages.tsx
@@ -40,6 +40,7 @@ import {
  * formatting decisions behind an opaque black box. Apps that want markdown
  * can drop Streamdown / react-markdown in at this exact line.
  */
+// @region[use-rendered-messages-hook]
 export type RenderedMessage = Message & { renderedContent: React.ReactNode };
 
 export function useRenderedMessages(
@@ -74,6 +75,7 @@ export function useRenderedMessages(
     renderCustomMessage,
   ]);
 }
+// @endregion[use-rendered-messages-hook]
 
 function renderMessageContent(args: {
   message: Message;
@@ -112,6 +114,7 @@ function renderMessageContent(args: {
 
   let body: React.ReactNode = null;
 
+  // @region[manual-activity-message-rendering]
   if (message.role === "assistant") {
     body = renderAssistantBody({
       message: message as AssistantMessage,
@@ -131,6 +134,7 @@ function renderMessageContent(args: {
   } else if (message.role === "activity") {
     body = renderActivityMessage(message as ActivityMessage);
   }
+  // @endregion[manual-activity-message-rendering]
 
   if (!customBefore && !customAfter) {
     return body;
@@ -144,6 +148,7 @@ function renderMessageContent(args: {
   );
 }
 
+// @region[manual-tool-call-rendering]
 function renderAssistantBody(args: {
   message: AssistantMessage;
   messages: Message[];
@@ -171,6 +176,7 @@ function renderAssistantBody(args: {
     </>
   );
 }
+// @endregion[manual-tool-call-rendering]
 
 function renderUserBody(message: UserMessage): React.ReactNode {
   // AG-UI user messages may carry a string OR an array of parts (text, image,

--- a/showcase/packages/mastra/src/app/demos/headless-complete/user-bubble.tsx
+++ b/showcase/packages/mastra/src/app/demos/headless-complete/user-bubble.tsx
@@ -9,6 +9,7 @@ import React from "react";
  * `useRenderedMessages`). For user messages that's just the text content of
  * the message (attachments etc. are stripped in the headless composer).
  */
+// @region[custom-bubbles]
 export function UserBubble({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex justify-end">
@@ -18,3 +19,4 @@ export function UserBubble({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
+// @endregion[custom-bubbles]

--- a/showcase/packages/mastra/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/prebuilt-popup/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -20,6 +21,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/packages/mastra/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,11 +10,15 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
@@ -18,6 +18,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -51,6 +52,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/packages/mastra/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,90 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import {
+  useRenderTool,
+  useDefaultRenderTool,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/packages/mastra/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -7,10 +7,7 @@
 //
 // See chat-component.snippet.tsx in agentic-chat for the same pattern.
 
-import {
-  useRenderTool,
-  useDefaultRenderTool,
-} from "@copilotkit/react-core/v2";
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
 type CatchallToolStatus = "in_progress" | "complete" | "error";

--- a/showcase/packages/mastra/src/mastra/tools/index.ts
+++ b/showcase/packages/mastra/src/mastra/tools/index.ts
@@ -13,6 +13,7 @@ import {
   buildA2uiOperationsFromToolCall,
 } from "@copilotkit/showcase-shared-tools";
 
+// @region[weather-tool-backend]
 export const weatherTool = createTool({
   id: "get-weather",
   description: "Get current weather for a location",
@@ -22,6 +23,7 @@ export const weatherTool = createTool({
   execute: async ({ context }) =>
     JSON.stringify(getWeatherImpl(context.location)),
 });
+// @endregion[weather-tool-backend]
 
 // Mock stock-price tool used by the headless-complete demo to exercise the
 // manual `useRenderTool` path alongside `get_weather`. Returns a fixed

--- a/showcase/starters/mastra/src/mastra/tools/index.ts
+++ b/showcase/starters/mastra/src/mastra/tools/index.ts
@@ -13,6 +13,7 @@ import {
   buildA2uiOperationsFromToolCall,
 } from "../shared-tools";
 
+// @region[weather-tool-backend]
 export const weatherTool = createTool({
   id: "get-weather",
   description: "Get current weather for a location",
@@ -22,6 +23,7 @@ export const weatherTool = createTool({
   execute: async ({ context }) =>
     JSON.stringify(getWeatherImpl(context.location)),
 });
+// @endregion[weather-tool-backend]
 
 // Mock stock-price tool used by the headless-complete demo to exercise the
 // manual `useRenderTool` path alongside `get_weather`. Returns a fixed


### PR DESCRIPTION
## Summary

- Adds `@region[name]` markers to mastra demo source so shell-docs `<Snippet>` calls resolve to mastra-flavored code instead of yellow "Missing snippet" warnings.
- 14 files modified (+42 comment-only lines, no runtime change), 2 new sibling teaching files.
- 10 cells advanced from B (missing regions) to A (ready) in the snippet-coverage audit, plus a partial mirror on `declarative-gen-ui`.

## Two patterns established

**1. In-place region markers** — wrap existing demo source where it already reads as a clean teaching example. Markers are comment-only and stripped from rendered output, so the runtime demo is byte-for-byte unchanged. Used for 12 of the 14 file edits.

**2. Sibling `<region>.snippet.tsx` files** — for cases where the production demo carries QA hooks (frontend tools, render tools, agent context) that aren't relevant to the docs page being taught. The sibling file lives in the demo folder so the bundler picks it up automatically; it's never imported or rendered, so the demo route is unaffected. Used twice this round:

  - `agentic-chat/chat-component.snippet.tsx` — minimal `Chat` for the prebuilt-chat docs page (mastra's production `Chat` carries `useFrontendTool`, `useRenderTool`, `useAgentContext`)
  - `tool-rendering/render-flight-tool.snippet.tsx` — flight + catchall renderer patterns (mastra's tool-rendering demo only registers a weather renderer)

## Cells advanced to ready

`prebuilt-popup`, `prebuilt-sidebar`, `frontend-tools`, `chat-customization-css`, `agentic-chat-reasoning`, `chat-slots`, `agentic-chat`, `tool-rendering`, `headless-complete`, plus `provider-a2ui-prop` on `declarative-gen-ui`.

## Out of scope (not regressions)

- `a2ui-fixed-schema` and `runtime-inject-tool` on `declarative-gen-ui` — the reference framework (langgraph-python) also lacks these regions, so they need a cross-cutting authoring round before per-framework mirroring is possible.
- `shared-state-read-write`, `shared-state-streaming`, `subagents`, `gen-ui-interrupt`, `gen-ui-tool-based`, `mcp-apps`, `open-gen-ui`, `open-gen-ui-advanced`, `interrupt-headless` — stub frontends or no demo folder on mastra. Engineering work, not a docs PR.

## Test plan

- [ ] `/mastra/prebuilt-components/chat` — three snippets resolve, including `chat-component` from the sibling file
- [ ] `/mastra/generative-ui/tool-rendering` — four snippets, exercising in-place + highlight-file + sibling-file patterns
- [ ] `/mastra/custom-look-and-feel/css` — multi-file regions across `page.tsx` + `theme.css`
- [ ] `/mastra/custom-look-and-feel/headless-ui` — five regions across four files
- [ ] `/mastra/generative-ui/a2ui/dynamic-schema` — `provider-a2ui-prop` resolves; `runtime-inject-tool` still yellow (cross-cutting, expected)
- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds