### PR TITLE
fix(showcase): align Feature type shell_docs_url → shell_docs_path

### DIFF
--- a/showcase/shell-dashboard/src/lib/registry.ts
+++ b/showcase/shell-dashboard/src/lib/registry.ts
@@ -10,7 +10,7 @@ export interface Feature {
   description: string;
   kind?: FeatureKind;
   og_docs_url?: string;
-  shell_docs_url?: string;
+  shell_docs_path?: string;
 }
 
 export interface FeatureCategory {


### PR DESCRIPTION
## Summary

- Rename `shell_docs_url` → `shell_docs_path` in the `Feature` interface (`shell-dashboard/src/lib/registry.ts:13`) to match the JSON data field name after #4323.

## Why

PR #4323 renamed all JSON data from `shell_docs_url` to `shell_docs_path` but missed the TypeScript interface. Currently dormant (no code reads Feature-level shell path), but the next person extending this code would hit `undefined` from a field that looks defined in the type.

## Test plan

- [ ] CI green — one-word type rename, no runtime behavior change