### PR TITLE
fix(showcase): move built-in-agent column to last in dashboard matrix

### DIFF
--- a/showcase/shell-dashboard/src/lib/sort-order.ts
+++ b/showcase/shell-dashboard/src/lib/sort-order.ts
@@ -18,4 +18,6 @@ export const sortOrder: Record<string, number> = {
   llamaindex: 67,
   langroid: 68,
   "spring-ai": 69,
+
+  "built-in-agent": 900,
 };


### PR DESCRIPTION
## Summary

- Pin `built-in-agent` to sort position 900 in the dashboard sort map so the REF column (langgraph-python at 10) stays first.

## Why

`built-in-agent/manifest.yaml` has `sort_order: 0`, which made it render as the first column. It should be last — it's a minimal single-feature integration, not the reference.

## Test plan

- [ ] CI green
- [ ] Dashboard at `dashboard.showcase.copilotkit.ai` shows langgraph-python as first column, built-in-agent as last