### PR TITLE
fix(showcase-ops): use bare probe_id for run-history lookup

### DIFF
--- a/showcase/ops/src/http/probes.ts
+++ b/showcase/ops/src/http/probes.ts
@@ -262,7 +262,7 @@ export function registerProbesRoutes(app: Hono, deps: ProbesRouteDeps): void {
     let runs: Awaited<ReturnType<typeof writer.recent>> = [];
     let runsError: string | undefined;
     try {
-      runs = await writer.recent(id, 10);
+      runs = await writer.recent(cfg?.id ?? id, 10);
     } catch (err) {
       runsError = "history_unavailable";
       // Best-effort logging — without a route-level logger, fall back to


### PR DESCRIPTION
## Summary

- Fix probe run history always returning empty — the invoker writes PB rows with bare `cfg.id` (e.g. `e2e-deep`) but the HTTP handler queried with the scheduler entry ID including the `probe:` prefix (e.g. `probe:e2e-deep`), so they never matched

## Test plan

- [x] 1320 tests pass
- [x] Typecheck clean
- [ ] CI green
- [ ] After deploy, click probe:e2e-deep row on dashboard and confirm "Recent Runs" populates