### PR TITLE
Add source-available license to showcase

### DIFF
--- a/showcase/LICENSE
+++ b/showcase/LICENSE
@@ -1,0 +1,96 @@
+Copyright 2024-2026 CopilotKit. All rights reserved.
+
+Licensor:             CopilotKit
+Licensed Work:        CopilotKit Showcase
+Contact:              licensing@copilotkit.ai
+
+
+CopilotKit Source Available License 1.0
+
+
+## Acceptance
+
+By accessing, viewing, or using the software, you agree to all of the terms and
+conditions below.
+
+
+## Permitted Use
+
+The licensor grants you a non-exclusive, non-transferable, non-sublicensable,
+revocable right to view and study the software for personal, non-commercial
+purposes only, such as learning and evaluation.
+
+
+## Restrictions
+
+You may not use the software, or any part of it, for any commercial purpose
+without a separate written license from the licensor.
+
+You may not use the software to build, design, train, or inform the development
+of any product, service, or system that provides functionality similar to or
+competitive with the software or any product or service offered by the licensor.
+This restriction applies whether or not the resulting work copies any code from
+the software, and whether the development is direct, assisted by automated
+tools, or performed as a clean-room implementation informed by knowledge gained
+from the software.
+
+You may not copy, modify, merge, distribute, sublicense, or create derivative
+works of the software, except as expressly permitted above.
+
+You may not remove or alter any licensing, copyright, or other notices in the
+software. Any use of the licensor's trademarks is subject to applicable law.
+
+
+## Commercial Licensing
+
+Use of the software for any purpose not expressly permitted above requires a
+commercial license from the licensor. Contact the licensor at the address above.
+
+
+## No Patents
+
+No patent rights are granted under these terms.
+
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+
+## No Other Rights
+
+These terms do not grant any rights other than those expressly stated above. All
+rights not expressly granted are reserved by the licensor.
+
+
+## Termination
+
+If you violate any of these terms, your rights under this license terminate
+immediately and permanently. The licensor may also terminate your rights at any
+time for any reason by providing written notice.
+
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+
+**commercial purpose** means any use intended for or directed toward commercial
+advantage or monetary compensation, including use within or on behalf of a
+for-profit organization.


### PR DESCRIPTION
## Summary

- Adds **CopilotKit Source Available License 1.0** to `showcase/LICENSE`
- Restricts showcase to personal, non-commercial viewing/study only
- Prohibits using the code as reference for building similar or competitive systems (including clean-room and AI-assisted reimplementation)
- Commercial use, derivative works, and distribution all require a separate written license
- No patent rights granted; license is revocable by licensor

## Why

Showcase is the integration factory for CopilotKit — 17 frameworks, test infrastructure, operational tooling. It lives in the public repo but needs stronger protection than MIT. ELv2 was considered but is too permissive (allows derivative works, grants patent rights, no anti-reference clause).

## Test plan

- [x] LICENSE file renders correctly on GitHub
- [x] Does not affect any build, test, or CI pipeline