### PR TITLE
fix(react-core): use two-arg z.record for Zod 4 compatibility

### DIFF
--- a/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
+++ b/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
@@ -181,7 +181,7 @@ export const MCPAppsActivityContentSchema = z.object({
   // Optional stable server ID from config (takes precedence over serverHash)
   serverId: z.string().optional(),
   // Original tool input arguments
-  toolInput: z.record(z.unknown()).optional(),
+  toolInput: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type MCPAppsActivityContent = z.infer<

--- a/packages/react-core/src/v2/types/__tests__/defineToolCallRenderer.test.tsx
+++ b/packages/react-core/src/v2/types/__tests__/defineToolCallRenderer.test.tsx
@@ -245,7 +245,7 @@ describe("defineToolCallRenderer", () => {
             email: z.string().email(),
           }),
           options: z.array(z.string()),
-          metadata: z.record(z.unknown()).optional(),
+          metadata: z.record(z.string(), z.unknown()).optional(),
         }),
         render: ({ args, status }) => {
           if (status === ToolCallStatus.Executing) {


### PR DESCRIPTION
Fixes #4295

## Problem

`MCPAppsActivityContentSchema` in `@copilotkit/react-core` defines `toolInput` using the single-argument form of `z.record()`:

```ts
toolInput: z.record(z.unknown()).optional()
```

Zod 4 [explicitly removed the single-argument form](https://zod.dev/v4/changelog#drops-single-argument-usage). When a non-empty `toolInput` reaches this schema, Zod 4 throws:

```
Cannot read properties of undefined (reading '_zod')
```

The empty-record case silently passes, making the bug non-obvious until a tool with real input arguments is invoked.

## Solution

Use the two-argument form as required by Zod 4 (and already supported by Zod 3):

```ts
toolInput: z.record(z.string(), z.unknown()).optional()
```

Also updated the corresponding schema in the `defineToolCallRenderer` test file which had the same single-argument pattern.

## Testing

The fix is directly validated by the reproduction case in the issue:

```ts
import { z } from "zod";
const schema = z.object({
  toolInput: z.record(z.string(), z.unknown()).optional(),
});
schema.safeParse({ toolInput: { code: "x" } }); // now succeeds
```