### PR TITLE
fix: driver consistency — abort classification, sideEmit dedup, resolveShape

### DIFF
--- a/showcase/ops/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.test.ts
@@ -428,9 +428,9 @@ describe("e2e-deep driver", () => {
     });
 
     const result = await driver.run(mkCtx(), {
-      key: "e2e-deep:showcase-mastra-starter",
-      publicUrl: "https://showcase-mastra-starter.example.com",
-      name: "showcase-mastra-starter",
+      key: "e2e-deep:showcase-starter-mastra",
+      publicUrl: "https://showcase-starter-mastra.example.com",
+      name: "showcase-starter-mastra",
       features: ["agentic-chat"],
       shape: "starter",
     });

--- a/showcase/ops/src/probes/drivers/e2e-deep.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.ts
@@ -975,10 +975,11 @@ async function runFeature(opts: {
     return { ok: true, conversation };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    const isAbort = err instanceof Error && err.name === "AbortError";
     const diagnostics = page ? await captureDiagnostics(page) : undefined;
     return {
       ok: false,
-      errorClass: abortSignal.aborted ? "abort" : "driver-error",
+      errorClass: isAbort ? "abort" : "driver-error",
       errorDesc: truncateUtf8(msg, 1200),
       diagnostics,
     };

--- a/showcase/ops/src/probes/drivers/e2e-deep.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.ts
@@ -482,6 +482,8 @@ export function createE2eDeepDriver(
         };
       }
 
+      const sideEmit = makeSideEmit(ctx);
+
       // Resolve the feature list. Explicit `features` (from tests or a
       // hand-authored YAML target) wins; otherwise translate the
       // discovery-supplied `demos[]` (registry feature IDs) into D5
@@ -580,7 +582,7 @@ export function createE2eDeepDriver(
       // shows a definite "no-script-yet" badge instead of going gray.
       if (runnable.length === 0) {
         for (const ft of skipped) {
-          await sideEmit(ctx, {
+          await sideEmit({
             key: `d5:${slug}/${ft}`,
             state: "green",
             signal: {
@@ -663,7 +665,7 @@ export function createE2eDeepDriver(
         // dashboards never see a missing badge between runnable
         // features executing.
         for (const ft of skipped) {
-          await sideEmit(ctx, {
+          await sideEmit({
             key: `d5:${slug}/${ft}`,
             state: "green",
             signal: {
@@ -699,7 +701,7 @@ export function createE2eDeepDriver(
           await sem.acquire();
           try {
             if (abort.signal.aborted) {
-              await sideEmit(ctx, {
+              await sideEmit({
                 key: sideKey,
                 state: "red",
                 signal: {
@@ -732,7 +734,7 @@ export function createE2eDeepDriver(
             });
 
             if (featureResult.ok) {
-              await sideEmit(ctx, {
+              await sideEmit({
                 key: sideKey,
                 state: "green",
                 signal: {
@@ -750,7 +752,7 @@ export function createE2eDeepDriver(
               });
               return { ft, ok: true as const };
             } else {
-              await sideEmit(ctx, {
+              await sideEmit({
                 key: sideKey,
                 state: "red",
                 signal: {
@@ -805,7 +807,7 @@ export function createE2eDeepDriver(
             });
             failed.push(ft);
             try {
-              await sideEmit(ctx, {
+              await sideEmit({
                 key: `d5:${slug}/${ft}`,
                 state: "red",
                 signal: {
@@ -1107,22 +1109,29 @@ async function captureDiagnostics(
   return diagnostics;
 }
 
-async function sideEmit(
+function makeSideEmit(
   ctx: ProbeContext,
-  result: ProbeResult<E2eDeepFeatureSignal>,
-): Promise<void> {
-  if (!ctx.writer) {
-    ctx.logger.warn("probe.e2e-deep.writer-missing", { key: result.key });
-    return;
-  }
-  try {
-    await ctx.writer.write(result);
-  } catch (err) {
-    ctx.logger.error("probe.e2e-deep.side-emit-writer-failed", {
-      key: result.key,
-      err: err instanceof Error ? err.message : String(err),
-    });
-  }
+): (result: ProbeResult<E2eDeepFeatureSignal>) => Promise<void> {
+  let warnedNoWriter = false;
+  return async (result) => {
+    if (!ctx.writer) {
+      if (!warnedNoWriter) {
+        warnedNoWriter = true;
+        ctx.logger.warn("probe.e2e-deep.writer-missing", {
+          key: result.key,
+        });
+      }
+      return;
+    }
+    try {
+      await ctx.writer.write(result);
+    } catch (err) {
+      ctx.logger.error("probe.e2e-deep.side-emit-writer-failed", {
+        key: result.key,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
 }
 
 /**

--- a/showcase/ops/src/probes/drivers/e2e-deep.ts
+++ b/showcase/ops/src/probes/drivers/e2e-deep.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
-import { showcaseShapeSchema } from "../discovery/railway-services.js";
+import {
+  resolveShape,
+  showcaseShapeSchema,
+} from "../discovery/railway-services.js";
 import {
   D5_REGISTRY,
   type D5BuildContext,
@@ -464,7 +467,11 @@ export function createE2eDeepDriver(
 
       // Starter short-circuit. Starters have no /demos routing → fan-
       // out would 404 every feature. Mirrors e2e-demos / e2e-smoke.
-      if (input.shape === "starter") {
+      const shape = resolveShape(
+        { name: input.name, shape: input.shape },
+        { logger: ctx.logger },
+      );
+      if (shape === "starter") {
         return {
           key: input.key,
           state: "green",

--- a/showcase/ops/src/probes/drivers/e2e-demos.ts
+++ b/showcase/ops/src/probes/drivers/e2e-demos.ts
@@ -1,7 +1,10 @@
 import { promises as fs } from "node:fs";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
-import { showcaseShapeSchema } from "../discovery/railway-services.js";
+import {
+  resolveShape,
+  showcaseShapeSchema,
+} from "../discovery/railway-services.js";
 import type { ProbeDriver } from "../types.js";
 import type { Logger, ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -434,7 +437,11 @@ export function createE2eDemosDriver(
       // would 404 and flap red. The ordering lock (shape check before
       // resolver) mirrors e2e-smoke so a broken registry / missing
       // chromium image never contributes a false-red row on a starter.
-      if (input.shape === "starter") {
+      const shape = resolveShape(
+        { name: input.name, shape: input.shape },
+        { logger: ctx.logger },
+      );
+      if (shape === "starter") {
         return {
           key: input.key,
           state: "green",

--- a/showcase/ops/src/probes/drivers/e2e-parity.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-parity.test.ts
@@ -963,9 +963,9 @@ describe("e2e-parity driver", () => {
     });
 
     const result = await driver.run(mkCtx(), {
-      key: "e2e-parity:showcase-langgraph-python-starter",
+      key: "e2e-parity:showcase-starter-langgraph-python",
       publicUrl: "https://x.example.com",
-      name: "showcase-langgraph-python-starter",
+      name: "showcase-starter-langgraph-python",
       features: ["agentic-chat"],
       shape: "starter",
     });

--- a/showcase/ops/src/probes/drivers/e2e-parity.ts
+++ b/showcase/ops/src/probes/drivers/e2e-parity.ts
@@ -1266,9 +1266,10 @@ async function runFeatureCapture(
     return { ok: true, captured };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    const isAbort = err instanceof Error && err.name === "AbortError";
     return {
       ok: false,
-      errorClass: abortSignal.aborted ? "abort" : "driver-error",
+      errorClass: isAbort ? "abort" : "driver-error",
       errorDesc: truncateUtf8(msg, 1200),
     };
   } finally {

--- a/showcase/ops/src/probes/drivers/e2e-parity.ts
+++ b/showcase/ops/src/probes/drivers/e2e-parity.ts
@@ -653,6 +653,8 @@ export function createE2eParityDriver(
         };
       }
 
+      const sideEmit = makeSideEmit(ctx);
+
       // Not picked by the scoping logic — sit out this tick. Aggregate
       // green so the dashboard doesn't flap red on every non-target
       // slug; the `scopingReason` carries why so operators tailing
@@ -683,7 +685,7 @@ export function createE2eParityDriver(
             demos: input.demos,
           });
           const url = `${backendUrl}${route}`;
-          await sideEmit(ctx, {
+          await sideEmit({
             key: `d6:${slug}/${ft}`,
             state: "green",
             signal: {
@@ -790,7 +792,7 @@ export function createE2eParityDriver(
       // launch outcomes — the dashboard sees a definite per-cell
       // verdict whether or not the runnable features even start.
       for (const ft of skippedScript) {
-        await sideEmit(ctx, {
+        await sideEmit({
           key: `d6:${slug}/${ft}`,
           state: "green",
           signal: {
@@ -803,7 +805,7 @@ export function createE2eParityDriver(
         });
       }
       for (const { ft, refPath } of skippedRef) {
-        await sideEmit(ctx, {
+        await sideEmit({
           key: `d6:${slug}/${ft}`,
           state: "green",
           signal: {
@@ -817,7 +819,7 @@ export function createE2eParityDriver(
         });
       }
       for (const { ft, refPath, reason } of invalidRef) {
-        await sideEmit(ctx, {
+        await sideEmit({
           key: `d6:${slug}/${ft}`,
           state: "red",
           signal: {
@@ -916,7 +918,7 @@ export function createE2eParityDriver(
               demos: input.demos,
             });
             const url = `${backendUrl}${route}`;
-            await sideEmit(ctx, {
+            await sideEmit({
               key: sideKey,
               state: "red",
               signal: {
@@ -967,7 +969,7 @@ export function createE2eParityDriver(
 
           if (abort.signal.aborted) {
             red += 1;
-            await sideEmit(ctx, {
+            await sideEmit({
               key: sideKey,
               state: "red",
               signal: {
@@ -1005,7 +1007,7 @@ export function createE2eParityDriver(
 
           if (!featureResult.ok) {
             red += 1;
-            await sideEmit(ctx, {
+            await sideEmit({
               key: sideKey,
               state: "red",
               signal: {
@@ -1042,7 +1044,7 @@ export function createE2eParityDriver(
             red += 1;
           }
 
-          await sideEmit(ctx, {
+          await sideEmit({
             key: sideKey,
             state,
             signal: {
@@ -1308,22 +1310,29 @@ function severityFromFailureCount(n: number): "green" | "amber" | "red" {
   return "red";
 }
 
-async function sideEmit(
+function makeSideEmit(
   ctx: ProbeContext,
-  result: ProbeResult<E2eParityFeatureSignal>,
-): Promise<void> {
-  if (!ctx.writer) {
-    ctx.logger.warn("probe.e2e-parity.writer-missing", { key: result.key });
-    return;
-  }
-  try {
-    await ctx.writer.write(result);
-  } catch (err) {
-    ctx.logger.error("probe.e2e-parity.side-emit-writer-failed", {
-      key: result.key,
-      err: err instanceof Error ? err.message : String(err),
-    });
-  }
+): (result: ProbeResult<E2eParityFeatureSignal>) => Promise<void> {
+  let warnedNoWriter = false;
+  return async (result) => {
+    if (!ctx.writer) {
+      if (!warnedNoWriter) {
+        warnedNoWriter = true;
+        ctx.logger.warn("probe.e2e-parity.writer-missing", {
+          key: result.key,
+        });
+      }
+      return;
+    }
+    try {
+      await ctx.writer.write(result);
+    } catch (err) {
+      ctx.logger.error("probe.e2e-parity.side-emit-writer-failed", {
+        key: result.key,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
 }
 
 function deriveSlug(key: string, name?: string): string {

--- a/showcase/ops/src/probes/drivers/e2e-parity.ts
+++ b/showcase/ops/src/probes/drivers/e2e-parity.ts
@@ -1,7 +1,10 @@
 import { promises as fs } from "node:fs";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
-import { showcaseShapeSchema } from "../discovery/railway-services.js";
+import {
+  resolveShape,
+  showcaseShapeSchema,
+} from "../discovery/railway-services.js";
 import {
   D5_REGISTRY,
   type D5BuildContext,
@@ -630,7 +633,11 @@ export function createE2eParityDriver(
       // Starter short-circuit. Same rule as e2e-deep — no /demos
       // routing, so D6 has nothing to compare against. Aggregate
       // green, no chromium launched.
-      if (input.shape === "starter") {
+      const shape = resolveShape(
+        { name: input.name, shape: input.shape },
+        { logger: ctx.logger },
+      );
+      if (shape === "starter") {
         return {
           key: input.key,
           state: "green",

--- a/showcase/ops/src/probes/drivers/e2e-smoke.ts
+++ b/showcase/ops/src/probes/drivers/e2e-smoke.ts
@@ -822,7 +822,10 @@ async function runLevel(opts: {
           backendUrl,
           level,
           failureSummary: truncateUtf8(msg, 1200),
-          errorDesc: abortSignal.aborted ? "abort" : "level-error",
+          errorDesc:
+            err instanceof Error && err.name === "AbortError"
+              ? "abort"
+              : "level-error",
         },
         observedAt: now().toISOString(),
       },

--- a/showcase/ops/src/probes/drivers/qa.ts
+++ b/showcase/ops/src/probes/drivers/qa.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import fs from "node:fs";
 import path from "node:path";
 import yaml from "js-yaml";
-import { showcaseShapeSchema } from "../discovery/railway-services.js";
+import {
+  resolveShape,
+  showcaseShapeSchema,
+} from "../discovery/railway-services.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -107,7 +110,11 @@ export function createQaDriver(
 
       // Starter short-circuit: no /demos/* routing means no per-feature
       // QA coverage to check. Green aggregate, no side rows.
-      if (input.shape === "starter") {
+      const shape = resolveShape(
+        { name: input.name, shape: input.shape },
+        { logger: ctx.logger },
+      );
+      if (shape === "starter") {
         return {
           key: input.key,
           state: "green",


### PR DESCRIPTION
## Summary

Three driver consistency fixes identified during browser-pool CR (#4343):

- **C5 abort classification**: e2e-deep, e2e-parity, and e2e-smoke classified errors using `abortSignal.aborted` at catch time, which races with genuine errors when the abort signal flips between throw and catch. Now uses `err.name === "AbortError"` matching the pattern established in e2e-demos.

- **C10 sideEmit dedup**: e2e-deep and e2e-parity logged "writer-missing" on every `sideEmit` call when `ctx.writer` was absent. Now uses `makeSideEmit(ctx)` factory with `warnedNoWriter` flag, limiting to once per `run()` invocation — matching the pattern in e2e-demos.

- **Shape resolution**: e2e-demos, e2e-deep, e2e-parity, and qa used raw `input.shape === "starter"` which misses services discovered without an explicit `shape` field. Now uses `resolveShape()` which also classifies by service name — matching the pattern in e2e-smoke.

## Test plan

- [ ] 1320/1320 tests pass locally (66 test files)
- [ ] Typecheck clean (`tsc --noEmit`)
- [ ] oxfmt clean
- [ ] CI green