### PR TITLE
fix: D5 all-green — fixtures, tool-rendering, manifest cleanup

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -27,7 +27,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_render_pie_chart_001"
+        "userMessage": "Show me a pie chart of revenue by category",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
@@ -35,7 +36,8 @@
     },
     {
       "match": {
-        "userMessage": "Show me a pie chart of revenue by category"
+        "userMessage": "Show me a pie chart of revenue by category",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -49,7 +51,32 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_show_card_001"
+        "userMessage": "Write me a haiku about nature",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Write me a haiku about nature",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_generate_haiku_001",
+            "name": "generate_haiku",
+            "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a profile card for Ada Lovelace",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
@@ -57,7 +84,8 @@
     },
     {
       "match": {
-        "userMessage": "Show me a profile card for Ada Lovelace"
+        "userMessage": "Show me a profile card for Ada Lovelace",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -71,7 +99,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_request_approval_001"
+        "userMessage": "Issue a $50 refund to customer #12345",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Approved — processing the $50 refund to customer #12345 now."
@@ -79,7 +108,8 @@
     },
     {
       "match": {
-        "userMessage": "Issue a $50 refund to customer #12345"
+        "userMessage": "Issue a $50 refund to customer #12345",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -93,7 +123,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_generate_steps_001"
+        "userMessage": "trip to mars",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
@@ -101,7 +132,8 @@
     },
     {
       "match": {
-        "userMessage": "trip to mars"
+        "userMessage": "trip to mars",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -115,7 +147,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_book_call_001"
+        "userMessage": "Book a 30-minute onboarding call for Alice",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
@@ -123,21 +156,23 @@
     },
     {
       "match": {
-        "userMessage": "Book a 30-minute onboarding call for Alice"
+        "userMessage": "Book a 30-minute onboarding call for Alice",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
           {
             "id": "call_d5_book_call_001",
             "name": "book_call",
-            "arguments": "{\"topic\":\"Onboarding call\",\"name\":\"Alice\"}"
+            "arguments": "{\"topic\":\"Onboarding call\",\"attendee\":\"Alice\"}"
           }
         ]
       }
     },
     {
       "match": {
-        "toolCallId": "call_d5_critique_agent_001"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 3
       },
       "response": {
         "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
@@ -145,7 +180,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_writing_agent_001"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 2
       },
       "response": {
         "toolCalls": [
@@ -159,7 +195,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_research_agent_001"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 1
       },
       "response": {
         "toolCalls": [
@@ -173,7 +210,8 @@
     },
     {
       "match": {
-        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -187,15 +225,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_set_notes_001"
-      },
-      "response": {
-        "content": "Got it — I have noted that your favorite color is blue."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "remember that my favorite color is blue"
+        "userMessage": "remember that my favorite color is blue",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -209,6 +240,15 @@
     },
     {
       "match": {
+        "userMessage": "remember that my favorite color is blue",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": "Got it — I have noted that your favorite color is blue."
+      }
+    },
+    {
+      "match": {
         "userMessage": "favorite color"
       },
       "response": {
@@ -217,7 +257,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_get_weather_001"
+        "userMessage": "weather in Tokyo",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Tokyo is 22°C and partly cloudy."
@@ -225,7 +266,8 @@
     },
     {
       "match": {
-        "userMessage": "weather in Tokyo"
+        "userMessage": "weather in Tokyo",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [

--- a/showcase/ops/fixtures/d5/gen-ui-custom.json
+++ b/showcase/ops/fixtures/d5/gen-ui-custom.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). The fixture carries BOTH tool patterns keyed by different user messages so the probe script can branch on integrationSlug. ORDER: toolCallId fixtures above userMessage fixtures to avoid infinite-loop re-matching.",
+  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). The fixture carries BOTH tool patterns keyed by different user messages so the probe script can branch on integrationSlug. Uses sequenceIndex matching instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixtures above sequenceIndex:0 fixtures to avoid infinite-loop re-matching.",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_render_pie_chart_001"
+        "userMessage": "Show me a pie chart of revenue by category",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
@@ -11,7 +12,8 @@
     },
     {
       "match": {
-        "userMessage": "Show me a pie chart of revenue by category"
+        "userMessage": "Show me a pie chart of revenue by category",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -25,7 +27,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_generate_haiku_001"
+        "userMessage": "Write me a haiku about nature",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
@@ -33,7 +36,8 @@
     },
     {
       "match": {
-        "userMessage": "Write me a haiku about nature"
+        "userMessage": "Write me a haiku about nature",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [

--- a/showcase/ops/fixtures/d5/gen-ui-headless.json
+++ b/showcase/ops/fixtures/d5/gen-ui-headless.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/headless-simple against LangGraph Python (LGP). Headless gen-UI via the frontend-defined `show_card` tool (useComponent — see src/app/demos/headless-simple/page.tsx). The backend agent (src/agents/main.py) has no backend tools; the frontend injects show_card at runtime. The agent calls show_card with title+body; the frontend's headless chat surface renders the ShowCard component. After the tool result is appended (the headless surface synthesizes a tool result), the agent re-invokes the LLM — second-leg fixture matches by toolCallId. ORDER: toolCallId fixture above userMessage fixture to avoid infinite-loop re-matching.",
+  "_comment": "D5 fixture for /demos/headless-simple against LangGraph Python (LGP). Headless gen-UI via the frontend-defined `show_card` tool (useComponent — see src/app/demos/headless-simple/page.tsx). The backend agent (src/agents/main.py) has no backend tools; the frontend injects show_card at runtime. The agent calls show_card with title+body; the frontend's headless chat surface renders the ShowCard component. After the tool result is appended (the headless surface synthesizes a tool result), the agent re-invokes the LLM — second-leg fixture matches by sequenceIndex. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching.",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_show_card_001"
+        "userMessage": "Show me a profile card for Ada Lovelace",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
@@ -11,7 +12,8 @@
     },
     {
       "match": {
-        "userMessage": "Show me a profile card for Ada Lovelace"
+        "userMessage": "Show me a profile card for Ada Lovelace",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [

--- a/showcase/ops/fixtures/d5/hitl-approve-deny.json
+++ b/showcase/ops/fixtures/d5/hitl-approve-deny.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl-in-app against LangGraph Python (LGP). Approve/deny HITL via the frontend-defined `request_user_approval` tool (see src/app/demos/hitl-in-app/page.tsx and src/agents/hitl_in_app.py). The agent calls request_user_approval; the frontend opens an out-of-chat modal; on approval the async handler resolves with {approved: true, reason: ...} and the tool result is appended back to the conversation. The agent then re-invokes the LLM — second-leg fixture matches on toolCallId. Per the system prompt the agent then issues a one-sentence acknowledgement, no further tool calls. ORDER: toolCallId fixture above userMessage fixture to avoid infinite-loop re-matching (the user message has not changed across the agent loop).",
+  "_comment": "D5 fixture for /demos/hitl-in-app against LangGraph Python (LGP). Approve/deny HITL via the frontend-defined `request_user_approval` tool (see src/app/demos/hitl-in-app/page.tsx and src/agents/hitl_in_app.py). The agent calls request_user_approval; the frontend opens an out-of-chat modal; on approval the async handler resolves with {approved: true, reason: ...} and the tool result is appended back to the conversation. The agent then re-invokes the LLM — second-leg fixture matches on sequenceIndex. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. Per the system prompt the agent then issues a one-sentence acknowledgement, no further tool calls. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching (the user message has not changed across the agent loop).",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_request_approval_001"
+        "userMessage": "Issue a $50 refund to customer #12345",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Approved — processing the $50 refund to customer #12345 now."
@@ -11,7 +12,8 @@
     },
     {
       "match": {
-        "userMessage": "Issue a $50 refund to customer #12345"
+        "userMessage": "Issue a $50 refund to customer #12345",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [

--- a/showcase/ops/fixtures/d5/hitl-steps.json
+++ b/showcase/ops/fixtures/d5/hitl-steps.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool.",
+  "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool. Uses sequenceIndex matching instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs.",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_generate_steps_001"
+        "userMessage": "trip to mars",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
@@ -11,7 +12,8 @@
     },
     {
       "match": {
-        "userMessage": "trip to mars"
+        "userMessage": "trip to mars",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [

--- a/showcase/ops/fixtures/d5/hitl-text-input.json
+++ b/showcase/ops/fixtures/d5/hitl-text-input.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl-in-chat against LangGraph Python (LGP). Text-input HITL via the frontend-defined `book_call` tool (see src/app/demos/hitl-in-chat/page.tsx and src/agents/hitl_in_chat_agent.py). The agent calls book_call with topic and name; the frontend renders an inline time-picker card via useHumanInTheLoop; the user picks a slot and the value is sent back as the tool result; the agent re-invokes with that result and emits a short acknowledgement. We match the second leg by toolCallId because the user's original message has not changed. ORDER: toolCallId fixture above userMessage fixture to avoid infinite-loop re-matching.",
+  "_comment": "D5 fixture for /demos/hitl-in-chat against LangGraph Python (LGP). Text-input HITL via the frontend-defined `book_call` tool (see src/app/demos/hitl-in-chat/page.tsx and src/agents/hitl_in_chat_agent.py). The agent calls book_call with topic and name; the frontend renders an inline time-picker card via useHumanInTheLoop; the user picks a slot and the value is sent back as the tool result; the agent re-invokes with that result and emits a short acknowledgement. We match the second leg by sequenceIndex because the user's original message has not changed. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching.",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_book_call_001"
+        "userMessage": "Book a 30-minute onboarding call for Alice",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
@@ -11,14 +12,15 @@
     },
     {
       "match": {
-        "userMessage": "Book a 30-minute onboarding call for Alice"
+        "userMessage": "Book a 30-minute onboarding call for Alice",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
           {
             "id": "call_d5_book_call_001",
             "name": "book_call",
-            "arguments": "{\"topic\":\"Onboarding call\",\"name\":\"Alice\"}"
+            "arguments": "{\"topic\":\"Onboarding call\",\"attendee\":\"Alice\"}"
           }
         ]
       }

--- a/showcase/ops/fixtures/d5/mcp-subagents.json
+++ b/showcase/ops/fixtures/d5/mcp-subagents.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). The supervisor agent in src/agents/subagents.py exposes three sub-agents as tools — research_agent, writing_agent, critique_agent — with a delegations log in shared state. A typical chained run: supervisor calls research_agent → gets facts → calls writing_agent → gets a draft → calls critique_agent → gets a review → composes a final reply. Each delegation appends a Delegation entry to shared state which the UI renders live in DelegationLog. We model the chain as three sequential tool calls (one per turn through the agent loop). The user message does not change between turns, so the supervisor's second/third tool-call decisions are routed by toolCallId on the LAST tool message — which always carries the id of the most recently completed sub-agent. A final text reply fires after the critique tool result is appended. ORDER MATTERS: toolCallId fixtures must precede the userMessage fixture so they win on every loop iteration; the chain is also ordered critique → writing → research so that 'last tool result is critique' resolves to the final text rather than re-firing writing_agent. NOTE on naming: the spec calls this 'mcp-subagents' but LGP's canonical multi-agent demo is /demos/subagents (subagents-as-tools); the LGP /demos/mcp-apps demo points at a public Excalidraw MCP server which would require that external server to be reachable to record realistically. Subagents is the closer real-on-LGP fit.",
+  "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). The supervisor agent in src/agents/subagents.py exposes three sub-agents as tools — research_agent, writing_agent, critique_agent — with a delegations log in shared state. A typical chained run: supervisor calls research_agent → gets facts → calls writing_agent → gets a draft → calls critique_agent → gets a review → composes a final reply. Each delegation appends a Delegation entry to shared state which the UI renders live in DelegationLog. We model the chain as four sequential fixtures (one per turn through the agent loop) disambiguated by sequenceIndex. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:3 → 2 → 1 → 0 so higher-index fixtures win on later loop iterations.",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_critique_agent_001"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 3
       },
       "response": {
         "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
@@ -11,7 +12,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_writing_agent_001"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 2
       },
       "response": {
         "toolCalls": [
@@ -25,7 +27,8 @@
     },
     {
       "match": {
-        "toolCallId": "call_d5_research_agent_001"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 1
       },
       "response": {
         "toolCalls": [
@@ -39,7 +42,8 @@
     },
     {
       "match": {
-        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary"
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [

--- a/showcase/ops/fixtures/d5/shared-state.json
+++ b/showcase/ops/fixtures/d5/shared-state.json
@@ -1,17 +1,10 @@
 {
-  "_comment": "D5 multi-turn fixture for /demos/shared-state-read-write against LangGraph Python (LGP). Demonstrates the agent-write half of bidirectional shared state: turn 1 the user asks the agent to remember something, the agent calls the backend `set_notes` tool (defined in src/agents/shared_state_read_write.py) which mutates shared state via Command(update={'notes': ...}). The frontend NotesCard re-renders. After the tool result is appended, the agent re-invokes the LLM — we match that second leg via toolCallId. Turn 2 the user asks the agent to recall what it remembered; the agent reads its own notes from state and replies. The UI-write half (preferences via agent.setState) does not flow through the LLM, so it is not part of this fixture. ORDER MATTERS: toolCallId fixture MUST appear above the userMessage fixtures or first-match-wins will re-match the original 'remember' fixture after the tool result is appended (the user message has not changed) and create an infinite loop.",
+  "_comment": "D5 multi-turn fixture for /demos/shared-state-read-write. Demonstrates the agent-write half of bidirectional shared state: turn 1 the user asks the agent to remember something, the agent calls the backend `set_notes` tool which mutates shared state. After the tool result is appended, the agent re-invokes the LLM — we match that second leg via sequenceIndex (not toolCallId, because Gemini's function_response format doesn't preserve tool call IDs and aimock synthesizes provider-specific IDs that would not match a fixed string). Turn 2 the user asks the agent to recall what it remembered. The UI-write half (preferences via agent.setState) does not flow through the LLM, so it is not part of this fixture. ORDER: the two sequenced fixtures share the same userMessage; sequenceIndex=0 fires on the first match (tool call), sequenceIndex=1 fires on the second match (text response after tool result).",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_set_notes_001"
-      },
-      "response": {
-        "content": "Got it — I have noted that your favorite color is blue."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "remember that my favorite color is blue"
+        "userMessage": "remember that my favorite color is blue",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -21,6 +14,15 @@
             "arguments": "{\"notes\":[\"Favorite color: blue\"]}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "remember that my favorite color is blue",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": "Got it — I have noted that your favorite color is blue."
       }
     },
     {

--- a/showcase/ops/fixtures/d5/tool-rendering.json
+++ b/showcase/ops/fixtures/d5/tool-rendering.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). The frontend only registers get_weather, so the fixture returns a single tool call. ORDER MATTERS: toolCallId-routed fixtures MUST appear ABOVE the userMessage-routed first leg, or first-match-wins will re-match the original tool-call fixture and create an infinite loop.",
+  "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). The frontend only registers get_weather, so the fixture returns a single tool call. Uses sequenceIndex matching instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching.",
   "fixtures": [
     {
       "match": {
-        "toolCallId": "call_d5_get_weather_001"
+        "userMessage": "weather in Tokyo",
+        "sequenceIndex": 1
       },
       "response": {
         "content": "Tokyo is 22°C and partly cloudy."
@@ -11,7 +12,8 @@
     },
     {
       "match": {
-        "userMessage": "weather in Tokyo"
+        "userMessage": "weather in Tokyo",
+        "sequenceIndex": 0
       },
       "response": {
         "toolCalls": [

--- a/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
+++ b/showcase/ops/src/probes/helpers/d5-feature-mapping.ts
@@ -43,7 +43,7 @@ import type { D5FeatureType } from "./d5-registry.js";
  *   - `tool-rendering`         : 3 demos (all the tool-rendering variants)
  *   - `gen-ui-headless`        : 2 demos (headless chat surfaces)
  *   - `gen-ui-custom`          : 1 demo
- *   - `hitl-text-input`        : 3 demos (in-chat HITL variants)
+ *   - `hitl-text-input`        : 2 demos (in-chat HITL variants using useHumanInTheLoop)
  *   - `hitl-steps`             : 1 demo (step-selection confirmation)
  *   - `hitl-approve-deny`      : 1 demo (modal/in-app approval)
  *   - `shared-state-read|write`: 1 demo, 2 D5 types (one-to-many)
@@ -73,12 +73,20 @@ const REGISTRY_TO_D5: Readonly<Record<string, readonly D5FeatureType[]>> = {
   // gen-ui (custom tier)
   "gen-ui-tool-based": ["gen-ui-custom"],
 
-  // hitl (text-input / in-chat tier) — every in-chat HITL variant maps
-  // to the `hitl-text-input` D5 script (which navigates to
-  // /demos/hitl-in-chat via preNavigateRoute).
+  // hitl (text-input / in-chat tier) — in-chat HITL variants that use
+  // `useHumanInTheLoop` with a `book_call` tool call. The D5 script
+  // navigates to /demos/hitl-in-chat via preNavigateRoute.
+  //
+  // NOTE: `gen-ui-interrupt` is intentionally NOT mapped here. That demo
+  // uses `useInterrupt` (LangGraph interrupt events), not
+  // `useHumanInTheLoop` (frontend tool calls). The hitl-text-input
+  // fixture sends a `book_call` tool call which `useInterrupt` pages
+  // never handle — the TimePickerCard never renders and the probe times
+  // out. gen-ui-interrupt needs its own D5 script + fixture that drives
+  // the interrupt flow; until that exists it is unmapped (silently
+  // skipped by `demosToFeatureTypes`).
   "hitl-in-chat": ["hitl-text-input"],
   "hitl-in-chat-booking": ["hitl-text-input"],
-  "gen-ui-interrupt": ["hitl-text-input"],
   hitl: ["hitl-steps"],
 
   // hitl (approve/deny tier) — out-of-chat modal approval flow.

--- a/showcase/ops/src/probes/scripts/_hitl-shared.ts
+++ b/showcase/ops/src/probes/scripts/_hitl-shared.ts
@@ -65,14 +65,11 @@ export interface Page extends ConversationPage {
 
 const SELECTOR_PROBE_TIMEOUT_MS = 3_000;
 /**
- * Extended timeout for the approval-dialog cascade. The dialog only
- * appears after the full aimock→CopilotKit→frontend-tool→React-render
- * chain completes: the agent response must be received, the tool call
- * dispatched to the frontend handler, the handler must set React state,
- * and the portal must mount (useEffect + createPortal). On Railway this
- * chain regularly exceeds the default 3 s probe timeout.
+ * Extended timeout for HITL card/dialog cascades. These only appear
+ * after the full aimock→CopilotKit→frontend-tool→React-render chain
+ * completes. On Railway this chain regularly exceeds the default 3s.
  */
-const APPROVAL_DIALOG_TIMEOUT_MS = 15_000;
+const HITL_CARD_TIMEOUT_MS = 15_000;
 const ASSISTANT_FOLLOWUP_TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 100;
 /**
@@ -172,7 +169,7 @@ export async function approveOrDeny(
     page,
     APPROVAL_DIALOG_SELECTORS,
     "approval dialog",
-    APPROVAL_DIALOG_TIMEOUT_MS,
+    HITL_CARD_TIMEOUT_MS,
   );
   const buttonSelectors =
     action === "approve" ? APPROVE_BUTTON_SELECTORS : REJECT_BUTTON_SELECTORS;
@@ -203,6 +200,7 @@ export async function pickTimeSlot(page: Page): Promise<void> {
     page,
     TIME_PICKER_CARD_SELECTORS,
     "time-picker card",
+    HITL_CARD_TIMEOUT_MS,
   );
   // Anchor every slot selector under the resolved card selector so
   // a stray `[data-testid="time-picker-slot"]` (or a generic

--- a/showcase/ops/src/probes/scripts/_hitl-shared.ts
+++ b/showcase/ops/src/probes/scripts/_hitl-shared.ts
@@ -69,7 +69,7 @@ const SELECTOR_PROBE_TIMEOUT_MS = 3_000;
  * after the full aimock→CopilotKit→frontend-tool→React-render chain
  * completes. On Railway this chain regularly exceeds the default 3s.
  */
-const HITL_CARD_TIMEOUT_MS = 15_000;
+export const HITL_CARD_TIMEOUT_MS = 15_000;
 const ASSISTANT_FOLLOWUP_TIMEOUT_MS = 30_000;
 const POLL_INTERVAL_MS = 100;
 /**

--- a/showcase/ops/src/probes/scripts/d5-hitl-steps.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-steps.ts
@@ -28,6 +28,7 @@ import {
   selectorCascade,
   readAssistantCount,
   waitForNextAssistantMessage,
+  HITL_CARD_TIMEOUT_MS,
 } from "./_hitl-shared.js";
 import type { Page as HitlPage } from "./_hitl-shared.js";
 import type { Page as ConversationPage } from "../helpers/conversation-runner.js";
@@ -76,11 +77,12 @@ const script: D5Script = {
           );
         }
         const baselineCount = await readAssistantCount(hitlPage);
-        await selectorCascade(hitlPage, STEPS_CARD_SELECTORS, "steps card");
+        await selectorCascade(hitlPage, STEPS_CARD_SELECTORS, "steps card", HITL_CARD_TIMEOUT_MS);
         const confirmSelector = await selectorCascade(
           hitlPage,
           CONFIRM_BUTTON_SELECTORS,
           "confirm button",
+          HITL_CARD_TIMEOUT_MS,
         );
         await hitlPage.click(confirmSelector);
         const followup = await waitForNextAssistantMessage(

--- a/showcase/ops/src/probes/scripts/d5-hitl-steps.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-steps.ts
@@ -77,7 +77,12 @@ const script: D5Script = {
           );
         }
         const baselineCount = await readAssistantCount(hitlPage);
-        await selectorCascade(hitlPage, STEPS_CARD_SELECTORS, "steps card", HITL_CARD_TIMEOUT_MS);
+        await selectorCascade(
+          hitlPage,
+          STEPS_CARD_SELECTORS,
+          "steps card",
+          HITL_CARD_TIMEOUT_MS,
+        );
         const confirmSelector = await selectorCascade(
           hitlPage,
           CONFIRM_BUTTON_SELECTORS,

--- a/showcase/ops/src/probes/scripts/d5-hitl-text-input.test.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-text-input.test.ts
@@ -127,9 +127,16 @@ describe("d5-hitl-text-input preNavigateRoute branching", () => {
         demos: ["hitl-in-chat-booking"],
       }),
     ).toBe("/demos/hitl-in-chat");
+  });
+
+  it("falls back to /demos/hitl-in-chat for gen-ui-interrupt (not routable by this script)", async () => {
+    // gen-ui-interrupt uses `useInterrupt` (LangGraph interrupt events),
+    // not `useHumanInTheLoop` (frontend tool calls). It is no longer in
+    // ROUTE_PRECEDENCE so it falls through to the default route.
+    const mod = await import("./d5-hitl-text-input.js");
     expect(
       mod.preNavigateRoute("hitl-text-input", { demos: ["gen-ui-interrupt"] }),
-    ).toBe("/demos/gen-ui-interrupt");
+    ).toBe("/demos/hitl-in-chat");
   });
 
   it("returns /demos/hitl when only the legacy hitl id is declared", async () => {

--- a/showcase/ops/src/probes/scripts/d5-hitl-text-input.ts
+++ b/showcase/ops/src/probes/scripts/d5-hitl-text-input.ts
@@ -32,7 +32,7 @@
  * rather than the modern `hitl-in-chat` id. We branch on which demo
  * id triggered this featureType (via `D5RouteContext.demos`): if the
  * integration declares any of the modern in-chat ids
- * (`hitl-in-chat`, `hitl-in-chat-booking`, `gen-ui-interrupt`) we use
+ * (`hitl-in-chat`, `hitl-in-chat-booking`) we use
  * `/demos/hitl-in-chat`; if it ONLY declares the legacy `hitl` id we
  * use `/demos/hitl`. When the driver passes no demos context (tests,
  * e2e-parity without registry context) we keep the modern default —
@@ -83,13 +83,15 @@ const ROUTE_PRECEDENCE: ReadonlyArray<readonly [string, string]> = [
   // registry id used by integrations whose example app frames the demo
   // around a booking flow.
   ["hitl-in-chat-booking", "/demos/hitl-in-chat"],
-  // Interrupt-only packages: integrations that expose a generative-UI
-  // interrupt demo at /demos/gen-ui-interrupt without a separate
-  // hitl-in-chat surface.
-  ["gen-ui-interrupt", "/demos/gen-ui-interrupt"],
   // Legacy hitl id — integrations that pre-date the modern split still
   // expose the demo at /demos/hitl.
   ["hitl", "/demos/hitl"],
+  // NOTE: gen-ui-interrupt is NOT listed here. That demo uses
+  // `useInterrupt` (LangGraph interrupt events), not
+  // `useHumanInTheLoop` (frontend tool calls). The hitl-text-input
+  // fixture sends a `book_call` tool call that `useInterrupt` pages
+  // never handle. gen-ui-interrupt was removed from the
+  // d5-feature-mapping so it never reaches this script.
 ];
 
 /**

--- a/showcase/packages/ag2/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ag2/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/agno/manifest.yaml
+++ b/showcase/packages/agno/manifest.yaml
@@ -29,7 +29,6 @@ starter:
   clone_command: npx degit CopilotKit/CopilotKit/showcase/starters/agno my-copilotkit-app
 features:
   - agentic-chat
-  - hitl-in-chat
   - tool-rendering
   - gen-ui-agent
   - shared-state-streaming
@@ -43,7 +42,6 @@ features:
   - readonly-state-agent-context
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
-  - hitl-in-chat-booking
   - agentic-chat-reasoning
   - reasoning-default-render
   - tool-rendering-reasoning-chain
@@ -60,17 +58,6 @@ demos:
     highlight:
       - src/agents/main.py
       - src/app/demos/agentic-chat/page.tsx
-      - src/app/api/copilotkit/route.ts
-  - id: hitl-in-chat
-    name: In-Chat Human in the Loop
-    description: User approves agent actions before execution
-    tags:
-      - interactivity
-    route: /demos/hitl
-    animated_preview_url:
-    highlight:
-      - src/agents/main.py
-      - src/app/demos/hitl/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering
     name: Tool Rendering
@@ -185,18 +172,6 @@ demos:
     highlight:
       - src/agents/main.py
       - src/app/demos/readonly-state-agent-context/page.tsx
-      - src/app/api/copilotkit/route.ts
-  - id: hitl-in-chat-booking
-    name: In-Chat HITL (Booking)
-    description: Time-picker card rendered inline via useHumanInTheLoop
-    tags:
-      - interactivity
-    route: /demos/hitl-in-chat
-    animated_preview_url:
-    highlight:
-      - src/agents/main.py
-      - src/app/demos/hitl-in-chat/page.tsx
-      - src/app/demos/hitl-in-chat/time-picker-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering-default-catchall
     name: Tool Rendering (Default Catch-all)

--- a/showcase/packages/agno/src/agents/main.py
+++ b/showcase/packages/agno/src/agents/main.py
@@ -94,14 +94,14 @@ def change_background(background: str):
 
 
 @tool(external_execution=True)
-def book_call(topic: str, attendee: str):
+def book_call(topic: str, name: str):
     """
     Ask the user to pick a time slot for a call. The picker UI presents
     fixed candidate slots; the user's choice is returned to the agent.
 
     Args:
         topic (str): What the call is about (e.g. "Intro with sales").
-        attendee (str): Who the call is with (e.g. "Alice from Sales").
+        name (str): Name of the attendee (e.g. "Alice").
     """
 
 
@@ -273,8 +273,8 @@ agent = Agent(
 
         BOOK CALL (HITL):
         When the user asks to book a call / schedule an intro / 1:1, call
-        book_call with the topic and attendee. The frontend renders a time
-        picker; the user's choice is returned as the tool result.
+        book_call with the topic and the person's name. The frontend renders a
+        time picker; the user's choice is returned as the tool result.
 
         TASK STEPS (HITL):
         When asked to plan something, use the generate_task_steps tool with a list of steps.

--- a/showcase/packages/agno/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/agno/src/app/demos/hitl-in-chat/page.tsx
@@ -53,15 +53,13 @@ function Chat() {
     parameters: z.object({
       topic: z
         .string()
-        .describe("What the call is about (e.g. 'Intro with sales')"),
-      attendee: z
-        .string()
-        .describe("Who the call is with (e.g. 'Alice from Sales')"),
+        .describe("What the call is about (e.g. 'Onboarding call')"),
+      name: z.string().describe("Name of the attendee"),
     }),
     render: ({ args, status, respond }: any) => (
       <TimePickerCard
         topic={args?.topic ?? "a call"}
-        attendee={args?.attendee}
+        attendee={args?.name}
         slots={DEFAULT_SLOTS}
         status={status}
         onSubmit={(result) => respond?.(result)}

--- a/showcase/packages/agno/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/agno/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/claude-sdk-python/manifest.yaml
+++ b/showcase/packages/claude-sdk-python/manifest.yaml
@@ -24,7 +24,6 @@ interaction_modalities:
 features:
   - cli-start
   - agentic-chat
-  - hitl
   - tool-rendering
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
@@ -60,13 +59,6 @@ demos:
     tags:
       - chat-ui
     route: /demos/agentic-chat
-    animated_preview_url:
-  - id: hitl
-    name: In-Chat Human in the Loop
-    description: User approves agent actions before execution
-    tags:
-      - interactivity
-    route: /demos/hitl
     animated_preview_url:
   - id: tool-rendering
     name: Tool Rendering

--- a/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/claude-sdk-typescript/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/claude-sdk-typescript/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/crewai-crews/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/crewai-crews/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/google-adk/manifest.yaml
+++ b/showcase/packages/google-adk/manifest.yaml
@@ -47,7 +47,6 @@ features:
   - frontend-tools
   - frontend-tools-async
   - gen-ui-tool-based
-  - hitl
   - hitl-in-app
   - declarative-gen-ui
   - a2ui-fixed-schema
@@ -145,17 +144,6 @@ demos:
       - src/agents/shared_chat.py
       - src/app/demos/frontend-tools-async/page.tsx
       - src/app/demos/frontend-tools-async/notes-card.tsx
-      - src/app/api/copilotkit/route.ts
-  - id: hitl
-    name: Human in the Loop (Step Selection)
-    description: Agent proposes steps and the user selects which to execute, rendered inline in the chat
-    tags:
-      - interactivity
-    route: /demos/hitl
-    animated_preview_url:
-    highlight:
-      - src/agents/hitl_in_chat_agent.py
-      - src/app/demos/hitl/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: hitl-in-app
     name: In-App Human in the Loop (Frontend Tools + async HITL)

--- a/showcase/packages/google-adk/src/agents/a2ui_fixed_agent.py
+++ b/showcase/packages/google-adk/src/agents/a2ui_fixed_agent.py
@@ -15,6 +15,8 @@ from typing import Any
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from agents.shared_chat import get_model
+
 CATALOG_ID = "copilotkit://flight-fixed-catalog"
 SURFACE_ID = "flight-fixed-schema"
 
@@ -90,7 +92,7 @@ _INSTRUCTION = (
 
 a2ui_fixed_agent = LlmAgent(
     name="A2uiFixedAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[display_flight],
 )

--- a/showcase/packages/google-adk/src/agents/agent_config_agent.py
+++ b/showcase/packages/google-adk/src/agents/agent_config_agent.py
@@ -18,6 +18,8 @@ from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
 
+from agents.shared_chat import get_model
+
 logger = logging.getLogger(__name__)
 
 CONFIG_PREFIX_SIGNATURE = "[agent-config] config:"
@@ -140,7 +142,7 @@ _INSTRUCTION = (
 
 agent_config_agent = LlmAgent(
     name="AgentConfigAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
     before_model_callback=_inject_config,

--- a/showcase/packages/google-adk/src/agents/beautiful_chat_agent.py
+++ b/showcase/packages/google-adk/src/agents/beautiful_chat_agent.py
@@ -14,6 +14,8 @@ import sys
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from agents.shared_chat import get_model
+
 sys.path.insert(
     0,
     os.path.join(
@@ -53,7 +55,7 @@ _INSTRUCTION = (
 
 beautiful_chat_agent = LlmAgent(
     name="BeautifulChatAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[query_data, search_flights, schedule_meeting],
 )

--- a/showcase/packages/google-adk/src/agents/byoc_agents.py
+++ b/showcase/packages/google-adk/src/agents/byoc_agents.py
@@ -14,6 +14,8 @@ import sys
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from agents.shared_chat import get_model
+
 sys.path.insert(
     0,
     os.path.join(
@@ -37,7 +39,7 @@ _INSTRUCTION = (
 
 byoc_agent = LlmAgent(
     name="ByocAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[query_data],
 )

--- a/showcase/packages/google-adk/src/agents/declarative_gen_ui_agent.py
+++ b/showcase/packages/google-adk/src/agents/declarative_gen_ui_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
 # `agents.main` defines `generate_a2ui` — reuse it here instead of cloning.
 from agents.main import generate_a2ui
 
@@ -24,7 +25,7 @@ _INSTRUCTION = (
 
 declarative_gen_ui_agent = LlmAgent(
     name="DeclarativeGenUiAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[generate_a2ui],
 )

--- a/showcase/packages/google-adk/src/agents/gen_ui_agent.py
+++ b/showcase/packages/google-adk/src/agents/gen_ui_agent.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from agents.shared_chat import get_model
+
 
 def set_steps(tool_context: ToolContext, steps: list[dict]) -> dict:
     """Publish the current plan + step statuses.
@@ -38,7 +40,7 @@ _INSTRUCTION = (
 
 gen_ui_agent = LlmAgent(
     name="GenUiAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[set_steps],
 )

--- a/showcase/packages/google-adk/src/agents/gen_ui_tool_based_agent.py
+++ b/showcase/packages/google-adk/src/agents/gen_ui_tool_based_agent.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
+
 _INSTRUCTION = (
     "You are a helpful assistant that generates richly-formatted UI via "
     "frontend tools. When the user asks for a haiku, call the generate_haiku "
@@ -20,7 +22,7 @@ _INSTRUCTION = (
 
 gen_ui_tool_based_agent = LlmAgent(
     name="GenUiToolBasedAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
 )

--- a/showcase/packages/google-adk/src/agents/hitl_in_app_agent.py
+++ b/showcase/packages/google-adk/src/agents/hitl_in_app_agent.py
@@ -16,7 +16,7 @@ from agents.shared_chat import get_model
 _INSTRUCTION = (
     "You are an approval-flow assistant. Whenever you propose an action "
     "that needs human sign-off (booking a meeting, charging an account, "
-    "deleting a record, etc.), call the `request_approval` frontend tool "
+    "deleting a record, etc.), call the `request_user_approval` frontend tool "
     "with a clear summary of what you propose and why. Wait for the tool "
     "to return — its result is the user's decision (accepted / rejected, "
     "with optional reason). Only proceed if accepted. Keep your messages "

--- a/showcase/packages/google-adk/src/agents/hitl_in_app_agent.py
+++ b/showcase/packages/google-adk/src/agents/hitl_in_app_agent.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
+
 _INSTRUCTION = (
     "You are an approval-flow assistant. Whenever you propose an action "
     "that needs human sign-off (booking a meeting, charging an account, "
@@ -23,7 +25,7 @@ _INSTRUCTION = (
 
 hitl_in_app_agent = LlmAgent(
     name="HitlInAppAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
 )

--- a/showcase/packages/google-adk/src/agents/hitl_in_chat_agent.py
+++ b/showcase/packages/google-adk/src/agents/hitl_in_chat_agent.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from agents.shared_chat import get_model
+
 
 def generate_task_steps(tool_context: ToolContext, steps: list[dict]) -> dict:
     """Generate a list of steps for the user to review.
@@ -41,7 +43,7 @@ _INSTRUCTION = (
 
 hitl_in_chat_agent = LlmAgent(
     name="HitlInChatAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[generate_task_steps],
 )

--- a/showcase/packages/google-adk/src/agents/main.py
+++ b/showcase/packages/google-adk/src/agents/main.py
@@ -25,6 +25,7 @@ sys.path.insert(
     0,
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "shared", "python"),
 )
+from agents.shared_chat import get_model
 from tools import (
     get_weather_impl,
     query_data_impl,
@@ -68,7 +69,16 @@ def _get_genai_client():
     Cache bookkeeping is thread-safe via `functools.lru_cache`; see the
     module-level comment above for the cold-cache race caveat. Call
     `.cache_clear()` in tests that need to reset the memoized instance.
+
+    When `GOOGLE_GEMINI_BASE_URL` is set (Railway aimock proxy), the client
+    is configured to send requests to that endpoint instead of the default
+    Gemini API.
     """
+    base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
+    if base_url:
+        return genai.Client(
+            http_options={"api_endpoint": base_url},
+        )
     return genai.Client()
 
 
@@ -602,7 +612,7 @@ def simple_after_model_modifier(
 
 sales_pipeline_agent = LlmAgent(
     name="SalesPipelineAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction="""
         You are a helpful assistant.
 

--- a/showcase/packages/google-adk/src/agents/multimodal_agent.py
+++ b/showcase/packages/google-adk/src/agents/multimodal_agent.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
+
 _INSTRUCTION = (
     "You are a multimodal assistant. The user can upload images and PDFs "
     "via the chat composer. When attachments are present, describe what "
@@ -20,7 +22,7 @@ _INSTRUCTION = (
 
 multimodal_agent = LlmAgent(
     name="MultimodalAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
 )

--- a/showcase/packages/google-adk/src/agents/open_gen_ui_agents.py
+++ b/showcase/packages/google-adk/src/agents/open_gen_ui_agents.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
+
 _OPEN_GEN_UI_INSTRUCTION = (
     "You are a UI-generation assistant. When the user describes something "
     "they want to see (a card, a form, a small dashboard), respond with a "
@@ -31,14 +33,14 @@ _OPEN_GEN_UI_ADVANCED_INSTRUCTION = (
 
 open_gen_ui_agent = LlmAgent(
     name="OpenGenUiAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_OPEN_GEN_UI_INSTRUCTION,
     tools=[],
 )
 
 open_gen_ui_advanced_agent = LlmAgent(
     name="OpenGenUiAdvancedAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_OPEN_GEN_UI_ADVANCED_INSTRUCTION,
     tools=[],
 )

--- a/showcase/packages/google-adk/src/agents/readonly_state_agent_context_agent.py
+++ b/showcase/packages/google-adk/src/agents/readonly_state_agent_context_agent.py
@@ -18,6 +18,8 @@ from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
 
+from agents.shared_chat import get_model
+
 logger = logging.getLogger(__name__)
 
 CONTEXT_PREFIX_SIGNATURE = "[agent-context] frontend-supplied context:"
@@ -138,7 +140,7 @@ _INSTRUCTION = (
 
 readonly_state_agent_context_agent = LlmAgent(
     name="ReadonlyStateAgentContextAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
     before_model_callback=_inject_context,

--- a/showcase/packages/google-adk/src/agents/shared_chat.py
+++ b/showcase/packages/google-adk/src/agents/shared_chat.py
@@ -8,14 +8,37 @@ headless-simple, headless-complete, voice, frontend-tools, agentic-chat).
 `build_thinking_chat_agent` uses Gemini 2.5 Flash with the thinking_config
 exposed so reasoning is streamed back as `thought` parts; the v2 React core
 renders these via CopilotChatReasoningMessage.
+
+`get_model` returns a `Gemini` instance configured with the aimock proxy
+endpoint when `GOOGLE_GEMINI_BASE_URL` is set, or the default model string
+otherwise. All agent modules should call `get_model()` instead of
+hard-coding `"gemini-2.5-flash"` so Railway deployments route through
+aimock.
 """
 
 from __future__ import annotations
 
+import os
+from typing import Union
+
 from google.adk.agents import LlmAgent
+from google.adk.models.google_llm import Gemini
 from google.genai import types
 
 DEFAULT_MODEL = "gemini-2.5-flash"
+
+
+def get_model(model: str = DEFAULT_MODEL) -> Union[str, Gemini]:
+    """Return a model suitable for LlmAgent's `model=` parameter.
+
+    When `GOOGLE_GEMINI_BASE_URL` is set (Railway aimock proxy), returns a
+    `Gemini` instance with its `base_url` pointed at the proxy. Otherwise
+    returns the plain model string so the ADK resolves the default endpoint.
+    """
+    base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
+    if base_url:
+        return Gemini(model=model, base_url=base_url)
+    return model
 
 
 def build_simple_chat_agent(
@@ -24,7 +47,7 @@ def build_simple_chat_agent(
     instruction: str,
     model: str = DEFAULT_MODEL,
 ) -> LlmAgent:
-    return LlmAgent(name=name, model=model, instruction=instruction, tools=[])
+    return LlmAgent(name=name, model=get_model(model), instruction=instruction, tools=[])
 
 
 def build_thinking_chat_agent(
@@ -42,7 +65,7 @@ def build_thinking_chat_agent(
     """
     return LlmAgent(
         name=name,
-        model=model,
+        model=get_model(model),
         instruction=instruction,
         tools=[],
         generate_content_config=types.GenerateContentConfig(

--- a/showcase/packages/google-adk/src/agents/shared_state_read_agent.py
+++ b/showcase/packages/google-adk/src/agents/shared_state_read_agent.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from agents.shared_chat import get_model
+
 
 def set_recipe(tool_context: ToolContext, recipe: dict) -> dict:
     """Replace the entire recipe in shared state.
@@ -33,7 +35,7 @@ _INSTRUCTION = (
 
 shared_state_read_agent = LlmAgent(
     name="SharedStateReadAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[set_recipe],
 )

--- a/showcase/packages/google-adk/src/agents/shared_state_read_write_agent.py
+++ b/showcase/packages/google-adk/src/agents/shared_state_read_write_agent.py
@@ -18,6 +18,8 @@ from typing import Optional
 
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
+
+from agents.shared_chat import get_model
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.tools import ToolContext
@@ -145,7 +147,7 @@ _INSTRUCTION = (
 
 shared_state_read_write_agent = LlmAgent(
     name="SharedStateReadWriteAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[set_notes],
     before_model_callback=_inject_preferences,

--- a/showcase/packages/google-adk/src/agents/shared_state_streaming_agent.py
+++ b/showcase/packages/google-adk/src/agents/shared_state_streaming_agent.py
@@ -32,6 +32,8 @@ from ag_ui_adk.config import PredictStateMapping
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from agents.shared_chat import get_model
+
 
 def write_document(tool_context: ToolContext, content: str) -> dict:
     """Write a document into shared state.
@@ -54,7 +56,7 @@ _INSTRUCTION = (
 
 shared_state_streaming_agent = LlmAgent(
     name="SharedStateStreamingAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[write_document],
 )

--- a/showcase/packages/google-adk/src/agents/subagents_agent.py
+++ b/showcase/packages/google-adk/src/agents/subagents_agent.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 
 import functools
 import logging
+import os
 import uuid
 
 from google import genai
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 from google.genai import types
+
+from agents.shared_chat import get_model
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,9 @@ _CRITIQUE_SYSTEM = (
 
 @functools.lru_cache(maxsize=1)
 def _client() -> genai.Client:
+    base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
+    if base_url:
+        return genai.Client(http_options={"api_endpoint": base_url})
     return genai.Client()
 
 
@@ -268,7 +274,7 @@ _SUPERVISOR_INSTRUCTION = (
 
 subagents_root_agent = LlmAgent(
     name="SubagentsSupervisor",
-    model=_SUB_MODEL,
+    model=get_model(_SUB_MODEL),
     instruction=_SUPERVISOR_INSTRUCTION,
     tools=[research_agent, writing_agent, critique_agent],
 )

--- a/showcase/packages/google-adk/src/agents/tool_rendering_agent.py
+++ b/showcase/packages/google-adk/src/agents/tool_rendering_agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
 from agents.tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -18,7 +19,7 @@ from agents.tool_rendering_common import (
 
 tool_rendering_agent = LlmAgent(
     name="ToolRenderingAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
 )

--- a/showcase/packages/google-adk/src/agents/tool_rendering_custom_catchall_agent.py
+++ b/showcase/packages/google-adk/src/agents/tool_rendering_custom_catchall_agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
 from agents.tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -18,7 +19,7 @@ from agents.tool_rendering_common import (
 
 tool_rendering_custom_catchall_agent = LlmAgent(
     name="ToolRenderingCustomCatchallAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
 )

--- a/showcase/packages/google-adk/src/agents/tool_rendering_default_catchall_agent.py
+++ b/showcase/packages/google-adk/src/agents/tool_rendering_default_catchall_agent.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from agents.shared_chat import get_model
 from agents.tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -19,7 +20,7 @@ from agents.tool_rendering_common import (
 
 tool_rendering_default_catchall_agent = LlmAgent(
     name="ToolRenderingDefaultCatchallAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
 )

--- a/showcase/packages/google-adk/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/packages/google-adk/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.genai import types
 
+from agents.shared_chat import get_model
 from agents.tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -20,7 +21,7 @@ from agents.tool_rendering_common import (
 
 tool_rendering_reasoning_chain_agent = LlmAgent(
     name="ToolRenderingReasoningChainAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
     generate_content_config=types.GenerateContentConfig(

--- a/showcase/packages/google-adk/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/gen-ui-tool-based/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { CopilotKit } from "@copilotkit/react-core";
 import {
-  CopilotSidebar,
+  CopilotChat,
   useFrontendTool,
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
@@ -14,35 +14,6 @@ interface Haiku {
   english: string[];
   image_name: string | null;
   gradient: string;
-}
-
-export default function GenUiToolBasedDemo() {
-  return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
-      <SidebarWithSuggestions />
-      <HaikuDisplay />
-    </CopilotKit>
-  );
-}
-
-function SidebarWithSuggestions() {
-  useConfigureSuggestions({
-    suggestions: [
-      { title: "Nature Haiku", message: "Write me a haiku about nature." },
-      { title: "Ocean Haiku", message: "Create a haiku about the ocean." },
-      { title: "Spring Haiku", message: "Generate a haiku about spring." },
-    ],
-    available: "always",
-  });
-
-  return (
-    <CopilotSidebar
-      defaultOpen={true}
-      labels={{
-        modalHeaderTitle: "Haiku Generator",
-      }}
-    />
-  );
 }
 
 const VALID_IMAGE_NAMES = [
@@ -58,19 +29,25 @@ const VALID_IMAGE_NAMES = [
   "Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg",
 ];
 
-function HaikuDisplay() {
-  const [haikus, setHaikus] = useState<Haiku[]>([
-    {
-      japanese: ["仮の句よ", "まっさらながら", "花を呼ぶ"],
-      english: [
-        "A placeholder verse--",
-        "even in a blank canvas,",
-        "it beckons flowers.",
-      ],
-      image_name: null,
-      gradient: "",
-    },
-  ]);
+export default function GenUiToolBasedDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-tool-based">
+      <Chat />
+    </CopilotKit>
+  );
+}
+
+function Chat() {
+  const [haikus, setHaikus] = useState<Haiku[]>([]);
+
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Nature Haiku", message: "Write me a haiku about nature." },
+      { title: "Ocean Haiku", message: "Create a haiku about the ocean." },
+      { title: "Spring Haiku", message: "Generate a haiku about spring." },
+    ],
+    available: "always",
+  });
 
   useFrontendTool(
     {
@@ -105,10 +82,7 @@ function HaikuDisplay() {
           image_name: image_name || null,
           gradient: gradient || "",
         };
-        setHaikus((prev) => [
-          newHaiku,
-          ...prev.filter((h) => h.english[0] !== "A placeholder verse--"),
-        ]);
+        setHaikus((prev) => [newHaiku, ...prev]);
         return "Haiku generated!";
       },
       render: ({ args }: { args: Partial<Haiku> }) => {
@@ -120,13 +94,12 @@ function HaikuDisplay() {
   );
 
   return (
-    <div className="relative flex items-center justify-center h-full w-full">
-      <div className="px-20 py-12 w-full max-w-4xl">
-        <div className="space-y-6">
-          {haikus.map((haiku, index) => (
-            <HaikuCard key={index} haiku={haiku} />
-          ))}
-        </div>
+    <div className="flex justify-center items-center h-screen w-full">
+      <div className="h-full w-full max-w-4xl">
+        <CopilotChat
+          agentId="gen-ui-tool-based"
+          className="h-full rounded-2xl"
+        />
       </div>
     </div>
   );

--- a/showcase/packages/google-adk/src/app/demos/headless-simple/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/headless-simple/page.tsx
@@ -74,6 +74,7 @@ function HeadlessChat() {
             return (
               <div
                 key={m.id}
+                data-message-role="user"
                 className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
               >
                 {typeof m.content === "string" ? m.content : ""}
@@ -84,7 +85,11 @@ function HeadlessChat() {
             const toolCalls =
               "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
             return (
-              <div key={m.id} className="self-start max-w-[90%]">
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
                 {m.content && (
                   <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
                     {m.content}

--- a/showcase/packages/google-adk/src/app/demos/hitl-in-app/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/hitl-in-app/page.tsx
@@ -54,19 +54,31 @@ function DemoContent() {
   }, []);
 
   useFrontendTool({
-    name: "request_approval",
+    name: "request_user_approval",
     description:
-      "Request user approval before performing a sensitive action. Pass a short summary of the action and a reason. Returns { accepted, reason? }.",
+      "Ask the operator to approve or reject an action before you take it. " +
+      "The operator will respond via an in-app modal dialog that appears " +
+      "OUTSIDE the chat surface. The tool returns an object of the shape " +
+      "{ approved: boolean, reason?: string }.",
     parameters: z.object({
-      summary: z.string().describe("Short summary of the proposed action."),
-      reason: z.string().describe("Why the action is being proposed."),
+      message: z
+        .string()
+        .describe(
+          "Short summary of the action needing approval (include concrete numbers / IDs).",
+        ),
+      context: z
+        .string()
+        .optional()
+        .describe(
+          "Optional extra context — e.g. the ticket ID or policy rule.",
+        ),
     }),
     handler: async ({
-      summary,
-      reason,
+      message,
+      context,
     }: {
-      summary: string;
-      reason: string;
+      message: string;
+      context?: string;
     }) => {
       const requestId = crypto.randomUUID();
       const decision = await new Promise<{
@@ -77,8 +89,8 @@ function DemoContent() {
           ...prev,
           {
             id: requestId,
-            summary,
-            reason,
+            summary: message,
+            reason: context ?? "",
             resolve: (d) => {
               // Drop our own entry from the queue, then resolve. Filter
               // by id so concurrent resolves don't accidentally drop

--- a/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/google-adk/src/app/demos/tool-rendering/page.tsx
@@ -23,7 +23,7 @@ function Chat() {
     parameters: z.object({
       location: z.string(),
     }),
-    render: ({ args, result, status }: any) => {
+    render: ({ parameters, result, status }: any) => {
       if (status !== "complete") {
         return (
           <div className="bg-[#667eea] text-white p-4 rounded-lg max-w-md">
@@ -44,7 +44,7 @@ function Chat() {
 
       return (
         <WeatherCard
-          location={args.location}
+          location={parameters?.location}
           themeColor={themeColor}
           result={weatherResult}
         />

--- a/showcase/packages/langgraph-fastapi/src/agents/src/agent.py
+++ b/showcase/packages/langgraph-fastapi/src/agents/src/agent.py
@@ -1,7 +1,10 @@
 """
 LangGraph agent for the CopilotKit Showcase (FastAPI variant).
 
-Uses langgraph.prebuilt.create_react_agent with langgraph>=1.1.0.
+Uses copilotkit's create_agent (wrapping langgraph) with CopilotKitMiddleware
+so frontend-registered tools (useHumanInTheLoop, useFrontendTool) are properly
+injected into the LLM's tool list and executed on the frontend rather than
+locally.
 """
 
 import sys
@@ -28,14 +31,14 @@ import json
 import time
 from typing import Any
 
-from langgraph.prebuilt import create_react_agent
 from langchain_openai import ChatOpenAI
 from langchain_core.tools import tool as lc_tool
 from langchain_core.messages import SystemMessage
-from langchain.agents import AgentState as BaseAgentState
+from langchain.agents import AgentState as BaseAgentState, create_agent
 from langchain.tools import ToolRuntime, tool
 from langchain.messages import ToolMessage
 from langgraph.types import Command
+from copilotkit import CopilotKitMiddleware
 
 
 class AgentState(BaseAgentState):
@@ -163,7 +166,7 @@ You can:
 - Generate step-by-step plans for user review (human-in-the-loop)
 """
 
-graph = create_react_agent(
+graph = create_agent(
     model=model,
     tools=[
         get_weather,
@@ -174,5 +177,7 @@ graph = create_react_agent(
         manage_sales_todos,
         get_sales_todos,
     ],
-    prompt=SYSTEM_PROMPT,
+    middleware=[CopilotKitMiddleware()],
+    state_schema=AgentState,
+    system_prompt=SYSTEM_PROMPT,
 )

--- a/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/langgraph-python/manifest.yaml
+++ b/showcase/packages/langgraph-python/manifest.yaml
@@ -148,16 +148,14 @@ demos:
       - src/app/demos/frontend-tools-async/notes-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: hitl
-    name: In-Chat Human in the Loop (Original)
-    description: Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook (original HITL demo)
+    name: Human in the Loop (Step Selection)
+    description: Interactive step-selection surface rendered inline in the chat via `useHumanInTheLoop` and `useLangGraphInterrupt` hooks
     tags:
       - interactivity
-    route: /demos/hitl-in-chat
+    route: /demos/hitl
     animated_preview_url:
     highlight:
-      - src/agents/hitl_in_chat_agent.py
-      - src/app/demos/hitl-in-chat/page.tsx
-      - src/app/demos/hitl-in-chat/time-picker-card.tsx
+      - src/app/demos/hitl/page.tsx
       - src/app/api/copilotkit/route.ts
   - id: hitl-in-chat
     name: In-Chat HITL (useHumanInTheLoop — ergonomic API)

--- a/showcase/packages/langgraph-python/src/app/demos/hitl/page.tsx
+++ b/showcase/packages/langgraph-python/src/app/demos/hitl/page.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import React, { useState } from "react";
+import { CopilotKit, useLangGraphInterrupt } from "@copilotkit/react-core";
+import {
+  CopilotChat,
+  useHumanInTheLoop,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+interface Step {
+  description: string;
+  status: "disabled" | "enabled" | "executing";
+}
+
+export default function HitlDemo() {
+  return (
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="human_in_the_loop">
+      <DemoContent />
+    </CopilotKit>
+  );
+}
+
+function DemoContent() {
+  useConfigureSuggestions({
+    suggestions: [
+      {
+        title: "Simple plan",
+        message: "Please plan a trip to mars in 5 steps.",
+      },
+      {
+        title: "Complex plan",
+        message: "Please plan a pasta dish in 10 steps.",
+      },
+    ],
+    available: "always",
+  });
+
+  useLangGraphInterrupt({
+    render: ({ event, resolve }) => (
+      <StepSelector
+        steps={event.value?.steps || []}
+        onConfirm={(selectedSteps) => {
+          resolve(
+            "The user selected the following steps: " +
+              selectedSteps.map((s) => s.description).join(", "),
+          );
+        }}
+      />
+    ),
+  });
+
+  useHumanInTheLoop({
+    agentId: "human_in_the_loop",
+    name: "generate_task_steps",
+    description: "Generates a list of steps for the user to perform",
+    parameters: z.object({
+      steps: z.array(
+        z.object({
+          description: z.string(),
+          status: z.enum(["enabled", "disabled", "executing"]),
+        }),
+      ),
+    }),
+    render: ({ args, respond, status }: any) => (
+      <StepsFeedback args={args} respond={respond} status={status} />
+    ),
+  });
+
+  return (
+    <div className="flex justify-center items-center h-screen w-full">
+      <div className="h-full w-full max-w-4xl">
+        <CopilotChat
+          agentId="human_in_the_loop"
+          className="h-full rounded-2xl"
+        />
+      </div>
+    </div>
+  );
+}
+
+function StepSelector({
+  steps,
+  onConfirm,
+}: {
+  steps: Array<{ description?: string; status?: string } | string>;
+  onConfirm: (steps: Step[]) => void;
+}) {
+  const [localSteps, setLocalSteps] = useState<Step[]>(() =>
+    steps.map((s) => ({
+      description: typeof s === "string" ? s : s.description || "",
+      status: (typeof s === "object" && s.status === "disabled"
+        ? "disabled"
+        : "enabled") as Step["status"],
+    })),
+  );
+
+  const enabledCount = localSteps.filter((s) => s.status === "enabled").length;
+
+  return (
+    <div
+      className="rounded-xl border border-gray-200 bg-white p-6 shadow-lg w-[500px]"
+      data-testid="select-steps"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-bold text-gray-800">Select Steps</h3>
+        <span className="text-sm text-gray-500">
+          {enabledCount}/{localSteps.length} selected
+        </span>
+      </div>
+      <div className="space-y-2 mb-4">
+        {localSteps.map((step, i) => (
+          <label
+            key={i}
+            className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer"
+            data-testid="step-item"
+          >
+            <input
+              type="checkbox"
+              checked={step.status === "enabled"}
+              onChange={() =>
+                setLocalSteps((prev) =>
+                  prev.map((s, j) =>
+                    j === i
+                      ? {
+                          ...s,
+                          status:
+                            s.status === "enabled" ? "disabled" : "enabled",
+                        }
+                      : s,
+                  ),
+                )
+              }
+              className="w-4 h-4 rounded"
+            />
+            <span
+              className={
+                step.status !== "enabled"
+                  ? "line-through text-gray-400"
+                  : "text-gray-800"
+              }
+              data-testid="step-text"
+            >
+              {step.description}
+            </span>
+          </label>
+        ))}
+      </div>
+      <button
+        onClick={() =>
+          onConfirm(localSteps.filter((s) => s.status === "enabled"))
+        }
+        className="w-full rounded-lg bg-purple-600 px-4 py-2 text-white font-medium hover:bg-purple-700"
+      >
+        Perform Steps ({enabledCount})
+      </button>
+    </div>
+  );
+}
+
+function StepsFeedback({
+  args,
+  respond,
+  status,
+}: {
+  args: any;
+  respond: any;
+  status: any;
+}) {
+  const [localSteps, setLocalSteps] = useState<Step[]>([]);
+  const [decided, setDecided] = useState<boolean | null>(null);
+
+  React.useEffect(() => {
+    if (
+      status === "executing" &&
+      localSteps.length === 0 &&
+      args?.steps?.length > 0
+    ) {
+      setLocalSteps(args.steps);
+    }
+  }, [status, args?.steps, localSteps.length]);
+
+  if (!args?.steps?.length) return null;
+
+  const steps = localSteps.length > 0 ? localSteps : args.steps;
+  const enabledCount = steps.filter((s: any) => s.status === "enabled").length;
+
+  return (
+    <div
+      className="rounded-xl border border-gray-200 bg-white p-6 shadow-lg w-[500px]"
+      data-testid="select-steps"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-bold text-gray-800">Review Steps</h3>
+        <span className="text-sm text-gray-500">
+          {enabledCount}/{steps.length} selected
+        </span>
+      </div>
+      <div className="space-y-2 mb-4">
+        {steps.map((step: any, i: number) => (
+          <label
+            key={i}
+            className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer"
+            data-testid="step-item"
+          >
+            <input
+              type="checkbox"
+              checked={step.status === "enabled"}
+              disabled={status !== "executing"}
+              onChange={() =>
+                setLocalSteps((prev) =>
+                  prev.map((s, j) =>
+                    j === i
+                      ? {
+                          ...s,
+                          status:
+                            s.status === "enabled" ? "disabled" : "enabled",
+                        }
+                      : s,
+                  ),
+                )
+              }
+              className="w-4 h-4 rounded"
+            />
+            <span
+              className={
+                step.status !== "enabled"
+                  ? "line-through text-gray-400"
+                  : "text-gray-800"
+              }
+              data-testid="step-text"
+            >
+              {step.description}
+            </span>
+          </label>
+        ))}
+      </div>
+      {decided === null && (
+        <div className="flex gap-3">
+          <button
+            disabled={status !== "executing"}
+            onClick={() => {
+              setDecided(false);
+              respond?.({ accepted: false });
+            }}
+            className="flex-1 rounded-lg border border-gray-300 px-4 py-2 font-medium hover:bg-gray-50 disabled:opacity-50"
+          >
+            Reject
+          </button>
+          <button
+            disabled={status !== "executing"}
+            onClick={() => {
+              setDecided(true);
+              respond?.({
+                accepted: true,
+                steps: localSteps.filter((s) => s.status === "enabled"),
+              });
+            }}
+            className="flex-1 rounded-lg bg-green-600 px-4 py-2 text-white font-medium hover:bg-green-700 disabled:opacity-50"
+          >
+            Confirm ({enabledCount})
+          </button>
+        </div>
+      )}
+      {decided !== null && (
+        <div
+          className={`text-center py-2 rounded-lg font-medium ${decided ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"}`}
+        >
+          {decided ? "Accepted" : "Rejected"}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/langroid/src/agents/agui_adapter.py
+++ b/showcase/packages/langroid/src/agents/agui_adapter.py
@@ -1,14 +1,20 @@
 """
 AG-UI SSE Adapter for Langroid
 
-Implements the AG-UI protocol over SSE, translating between
-Langroid's ChatAgent and the AG-UI event stream that CopilotKit expects.
+Implements the AG-UI protocol over SSE, calling the OpenAI chat completions
+API directly (via ``openai.AsyncOpenAI``) and translating the response into
+the AG-UI event stream that CopilotKit expects. Tool schemas are derived
+from Langroid ToolMessage subclasses defined in ``agents.agent``.
+
+The adapter preserves structured multi-turn messages (including ``role:
+"tool"`` with ``tool_call_id``) so that aimock fixture matchers can match
+follow-up requests by toolCallId — enabling the frontend tool execution
+loop (e.g. gen-ui-headless: show_card → follow-up narration).
 
 AG-UI event types used:
   - RUN_STARTED / RUN_FINISHED
   - TEXT_MESSAGE_START / TEXT_MESSAGE_CONTENT / TEXT_MESSAGE_END
   - TOOL_CALL_START / TOOL_CALL_ARGS / TOOL_CALL_END
-  - STATE_SNAPSHOT
 """
 
 from __future__ import annotations
@@ -16,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import uuid
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -34,7 +41,6 @@ from ag_ui.core import (
     ToolCallStartEvent,
     ToolCallArgsEvent,
     ToolCallEndEvent,
-    StateSnapshotEvent,
     RunAgentInput,
 )
 from fastapi import Request
@@ -42,14 +48,12 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from agents.agent import (
     build_agent_config_system_prompt,
-    create_agent,
     extract_agent_config_properties,
     ALL_TOOLS,
-    BACKEND_TOOLS,
     FRONTEND_TOOL_NAMES,
+    SYSTEM_PROMPT,
 )
 
-import langroid as lr
 from langroid.agent.tool_message import ToolMessage
 
 
@@ -252,6 +256,214 @@ async def _run_backend_tool(
     )
 
 
+def _agui_messages_to_openai(
+    messages: list,
+    system_prompt: str,
+) -> list[dict[str, Any]]:
+    """Convert AG-UI messages to OpenAI chat completion format.
+
+    AG-UI messages arrive as typed Pydantic models (UserMessage,
+    AssistantMessage, ToolMessage, etc.) with fields like ``tool_calls``
+    and ``tool_call_id``. The previous flattening logic (``"role: content"``)
+    lost these structured fields, preventing aimock's ``toolCallId`` fixture
+    matcher from finding follow-up tool results.
+
+    This function preserves the full message structure so the OpenAI API
+    (or aimock standing in for it) receives proper multi-turn conversations
+    including ``role: "tool"`` messages with ``tool_call_id``.
+    """
+    oai_msgs: list[dict[str, Any]] = [
+        {"role": "system", "content": system_prompt},
+    ]
+
+    for msg in messages:
+        role = getattr(msg, "role", None)
+        if not isinstance(role, str):
+            if isinstance(msg, dict):
+                role = msg.get("role")
+            if not isinstance(role, str):
+                continue
+
+        if role == "tool":
+            # AG-UI ToolMessage → OpenAI tool result message.
+            tool_call_id = getattr(msg, "tool_call_id", None)
+            if isinstance(msg, dict):
+                tool_call_id = tool_call_id or msg.get("tool_call_id")
+            content = getattr(msg, "content", "") or ""
+            if isinstance(msg, dict):
+                content = content or msg.get("content", "")
+            if tool_call_id:
+                oai_msgs.append({
+                    "role": "tool",
+                    "tool_call_id": str(tool_call_id),
+                    "content": str(content),
+                })
+            continue
+
+        if role == "assistant":
+            # AG-UI AssistantMessage may carry tool_calls.
+            content = getattr(msg, "content", None)
+            if isinstance(msg, dict):
+                content = content or msg.get("content")
+            tool_calls_raw = getattr(msg, "tool_calls", None)
+            if isinstance(msg, dict):
+                tool_calls_raw = tool_calls_raw or msg.get("tool_calls")
+
+            oai_msg: dict[str, Any] = {"role": "assistant"}
+            if content:
+                oai_msg["content"] = str(content)
+            if tool_calls_raw:
+                oai_tcs = []
+                for tc in tool_calls_raw:
+                    tc_id = getattr(tc, "id", None)
+                    fn = getattr(tc, "function", None)
+                    if fn is None and isinstance(tc, dict):
+                        fn_name = tc.get("function", {}).get("name", "")
+                        fn_args = tc.get("function", {}).get("arguments", "")
+                        tc_id = tc_id or tc.get("id", "")
+                    else:
+                        fn_name = getattr(fn, "name", "") if fn else ""
+                        fn_args = getattr(fn, "arguments", "") if fn else ""
+                    if tc_id and fn_name:
+                        oai_tcs.append({
+                            "id": str(tc_id),
+                            "type": "function",
+                            "function": {
+                                "name": str(fn_name),
+                                "arguments": str(fn_args),
+                            },
+                        })
+                if oai_tcs:
+                    oai_msg["tool_calls"] = oai_tcs
+                    # OpenAI requires content to be null (not missing)
+                    # when tool_calls are present and there's no text.
+                    if "content" not in oai_msg:
+                        oai_msg["content"] = None
+            else:
+                # Plain assistant text — ensure content is present.
+                if "content" not in oai_msg:
+                    oai_msg["content"] = ""
+            oai_msgs.append(oai_msg)
+            continue
+
+        if role in ("user", "system", "developer"):
+            content = getattr(msg, "content", None)
+            if isinstance(msg, dict):
+                content = content or msg.get("content")
+            if content is not None:
+                oai_msgs.append({
+                    "role": role,
+                    "content": str(content),
+                })
+            continue
+
+        # Unknown role — skip with a debug log.
+        logger.debug(
+            "Skipping message with unrecognized role %r in "
+            "_agui_messages_to_openai",
+            role,
+        )
+
+    return oai_msgs
+
+
+def _build_openai_tools() -> list[dict[str, Any]]:
+    """Build OpenAI-format tool definitions from ALL_TOOLS.
+
+    Each Langroid ToolMessage subclass declares ``request`` (tool name),
+    ``purpose`` (description), and typed fields (parameters). We convert
+    these into the ``{"type": "function", "function": {...}}`` shape that
+    the OpenAI chat completions API expects.
+    """
+    tools: list[dict[str, Any]] = []
+    for tool_cls in ALL_TOOLS:
+        name = tool_cls.default_value("request")
+        purpose = tool_cls.default_value("purpose") if hasattr(tool_cls, "purpose") else ""
+
+        # Build parameters from model fields, excluding metadata.
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for field_name, field_info in tool_cls.model_fields.items():
+            if field_name in ("request", "purpose", "result"):
+                continue
+            # Simple type mapping — sufficient for aimock fixture matching.
+            annotation = field_info.annotation
+            if annotation is str or (hasattr(annotation, "__origin__") is False and annotation is str):
+                prop = {"type": "string"}
+            elif annotation is int:
+                prop = {"type": "integer"}
+            elif annotation is float:
+                prop = {"type": "number"}
+            elif annotation is bool:
+                prop = {"type": "boolean"}
+            elif annotation is list or (hasattr(annotation, "__origin__") and getattr(annotation, "__origin__", None) is list):
+                prop = {"type": "array"}
+            else:
+                prop = {"type": "string"}
+
+            desc = ""
+            if hasattr(field_info, "description") and field_info.description:
+                desc = field_info.description
+            elif hasattr(field_info, "metadata"):
+                for m in field_info.metadata:
+                    if isinstance(m, str):
+                        desc = m
+                        break
+            if desc:
+                prop["description"] = desc
+
+            properties[field_name] = prop
+            if field_info.default is pydantic.fields.PydanticUndefined:
+                required.append(field_name)
+
+        func_def: dict[str, Any] = {
+            "name": name,
+            "description": purpose or f"Tool: {name}",
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+            },
+        }
+        if required:
+            func_def["parameters"]["required"] = required
+
+        tools.append({"type": "function", "function": func_def})
+
+    return tools
+
+
+# Cache tool definitions — they don't change at runtime.
+_OPENAI_TOOLS: list[dict[str, Any]] | None = None
+
+
+def _get_openai_tools() -> list[dict[str, Any]]:
+    """Return cached OpenAI tool definitions."""
+    global _OPENAI_TOOLS
+    if _OPENAI_TOOLS is None:
+        _OPENAI_TOOLS = _build_openai_tools()
+    return _OPENAI_TOOLS
+
+
+async def _call_openai(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    model: str,
+) -> Any:
+    """Call the OpenAI chat completions API directly.
+
+    Uses ``openai.AsyncOpenAI()`` which reads ``OPENAI_API_KEY`` and
+    ``OPENAI_BASE_URL`` from the environment (aimock sets the base URL
+    in the showcase). Returns the first choice's message object.
+    """
+    client = openai.AsyncOpenAI()
+    response = await client.chat.completions.create(
+        model=model,
+        messages=messages,
+        tools=tools if tools else openai.NOT_GIVEN,
+    )
+    return response.choices[0].message
+
+
 async def handle_run(request: Request) -> StreamingResponse:
     """Handle an AG-UI /run endpoint — parse input, run agent, stream events."""
     # Parse request body defensively. A malformed body (bad JSON, missing
@@ -298,49 +510,25 @@ async def handle_run(request: Request) -> StreamingResponse:
     agent_config_props = extract_agent_config_properties(
         run_input.forwarded_props
     )
-    system_override: str | None = None
+    system_prompt = SYSTEM_PROMPT
     if agent_config_props is not None:
-        system_override = build_agent_config_system_prompt(
+        system_prompt = build_agent_config_system_prompt(
             tone=agent_config_props.get("tone"),
             expertise=agent_config_props.get("expertise"),
             response_length=agent_config_props.get("responseLength"),
         )
-    agent = create_agent(system_message=system_override)
 
-    # Build conversation history from all messages so multi-turn works.
-    # Each ``msg.role`` / ``msg.content`` must be a string — silently
-    # f-stringifying ``None`` or a complex object produces garbage like
-    # "None: {'foo': 'bar'}" that the LLM then tries to interpret as
-    # conversation. Drop non-string entries and log a warning so the
-    # shape drift is at least visible in ops logs.
-    conversation_parts: list[str] = []
-    if run_input.messages:
-        for msg in run_input.messages:
-            if hasattr(msg, "role") and hasattr(msg, "content"):
-                role = getattr(msg, "role", None)
-                content = getattr(msg, "content", None)
-                if not isinstance(role, str) or not isinstance(content, str):
-                    logger.warning(
-                        "Skipping message with non-string role/content "
-                        "(role=%s, content=%s)",
-                        type(role).__name__,
-                        type(content).__name__,
-                    )
-                    continue
-                conversation_parts.append(f"{role}: {content}")
-            elif isinstance(msg, dict):
-                role = msg.get("role", "user")
-                content = msg.get("content", "")
-                if not isinstance(role, str) or not isinstance(content, str):
-                    logger.warning(
-                        "Skipping dict message with non-string role/content "
-                        "(role=%s, content=%s)",
-                        type(role).__name__,
-                        type(content).__name__,
-                    )
-                    continue
-                conversation_parts.append(f"{role}: {content}")
-    user_message = "\n".join(conversation_parts) if conversation_parts else ""
+    # Build proper OpenAI-format messages from the AG-UI message history.
+    # The previous approach flattened all messages into a single "role:
+    # content" string, which lost structured fields like tool_call_id and
+    # tool_calls. This prevented aimock's toolCallId fixture matcher from
+    # finding follow-up tool results, breaking the gen-ui-headless flow
+    # (frontend tool → follow-up narration never arrived).
+    oai_messages = _agui_messages_to_openai(
+        run_input.messages or [], system_prompt
+    )
+    model = os.getenv("LANGROID_MODEL", "gpt-4.1")
+    oai_tools = _get_openai_tools()
 
     # Compute the effective thread_id ONCE so every event emitted for this
     # run (RUN_STARTED, RUN_FINISHED, ...) references the same thread.
@@ -384,37 +572,25 @@ async def handle_run(request: Request) -> StreamingResponse:
             run_id=run_id,
         ))
 
-        # Run the Langroid agent. Any failure here happens *after*
-        # RUN_STARTED was emitted, so the frontend is already waiting
-        # for a RUN_FINISHED. If we let the exception escape here, the
-        # generator dies mid-stream and the UI hangs forever. Emit a
-        # sanitized TEXT_MESSAGE triple (so the user sees *something*)
-        # and then RUN_FINISHED to close out the run cleanly. The
-        # full traceback is preserved server-side via
-        # ``logger.exception``.
+        # Call the LLM directly via the OpenAI client. This replaced
+        # langroid's ``agent.llm_response_async(flattened_string)`` to
+        # preserve structured multi-turn messages (tool_calls,
+        # tool_call_id) that aimock's fixture matchers depend on for
+        # follow-up requests (e.g. gen-ui-headless second-leg narration).
         #
-        # Exception scope: narrowed to the set of runtime failures we
-        # actually expect from ``agent.llm_response_async`` — upstream
-        # LLM API errors (``openai.APIError``), transport failures
-        # (``httpx.HTTPError``), timeouts, and schema drift
-        # (``pydantic.ValidationError``). Programmer bugs
-        # (``AttributeError``, ``NameError``, ``TypeError``) are NOT
-        # sanitized here — they propagate up and surface as real
-        # tracebacks. Any uncaught mid-stream exception is still
-        # handled one level up by the route boundary's try/except, but
-        # with a less operator-friendly "unknown error" message —
-        # that's the right trade: a narrower list keeps legitimate
-        # bugs visible instead of masking them as "Agent run failed:
-        # AttributeError".
+        # Any failure here happens *after* RUN_STARTED was emitted, so
+        # the frontend is already waiting for a RUN_FINISHED. Emit a
+        # sanitized TEXT_MESSAGE triple and then RUN_FINISHED to close
+        # out the run cleanly. The full traceback is preserved
+        # server-side via ``logger.exception``.
         try:
-            response = await agent.llm_response_async(user_message)
+            response = await _call_openai(oai_messages, oai_tools, model)
         except (
             openai.APIError,
             httpx.HTTPError,
             asyncio.TimeoutError,
-            pydantic.ValidationError,
         ) as exc:
-            logger.exception("agent.llm_response_async failed mid-stream")
+            logger.exception("_call_openai failed mid-stream")
             err_payload = json.dumps({
                 "error": f"Agent run failed: {exc.__class__.__name__}"
             })
@@ -436,20 +612,12 @@ async def handle_run(request: Request) -> StreamingResponse:
             ))
             return
 
-        # `response` is a Langroid ChatDocument. `.content` is the canonical
-        # source of text; `str(response)` includes debug formatting and is
-        # not a useful fallback, so default to "" when content is absent.
+        # ``response`` is an OpenAI ChatCompletionMessage. ``.content``
+        # is the text; ``.tool_calls`` carries structured tool calls.
         content = getattr(response, "content", None) or ""
+        oai_tool_calls = getattr(response, "tool_calls", None) or []
 
-        # Langroid's OpenAI-backed LLM emits tool calls on
-        # `response.oai_tool_calls` (OpenAI tools API) or `response.function_call`
-        # (legacy function-calling API) with empty `content`. We must synthesize
-        # AG-UI TOOL_CALL_* events from those so CopilotKit's frontend can
-        # render the tool card (weather, haiku, etc.).
-        oai_tool_calls = getattr(response, "oai_tool_calls", None) or []
-        function_call = getattr(response, "function_call", None)
-
-        if oai_tool_calls or function_call:
+        if oai_tool_calls:
             # Emit synthesized tool-call events for each OAI tool call.
             # ``_parse_tool_args`` returns a ``ParsedArgs`` with
             # ``status`` in ``{"ok", "empty", "malformed"}``. We only
@@ -459,31 +627,14 @@ async def handle_run(request: Request) -> StreamingResponse:
             # UI card). The warning already fired inside
             # ``_parse_tool_args`` on the malformed path.
             calls_to_emit = []
-            if oai_tool_calls:
-                for tc in oai_tool_calls:
-                    fn = getattr(tc, "function", None)
-                    name = getattr(fn, "name", None) if fn is not None else None
-                    raw_args = getattr(fn, "arguments", {}) if fn is not None else {}
-                    parsed = _parse_tool_args(raw_args)
-                    call_id = getattr(tc, "id", None) or str(uuid.uuid4())
-                    if name and parsed.usable:
-                        calls_to_emit.append((call_id, name, parsed.args))
-                    elif name:
-                        logger.warning(
-                            "Skipping tool call %s: arguments could not be parsed (status=%s)",
-                            name,
-                            parsed.status,
-                        )
-            elif function_call is not None:
-                # Legacy function_call shape: single call. Empty-string
-                # ``arguments`` is normalized to ``"malformed"`` by
-                # ``_parse_tool_args`` so this path behaves identically
-                # to a malformed-JSON oai call (skip + warn).
-                name = getattr(function_call, "name", None)
-                raw_args = getattr(function_call, "arguments", "") or ""
+            for tc in oai_tool_calls:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", None) if fn is not None else None
+                raw_args = getattr(fn, "arguments", {}) if fn is not None else {}
                 parsed = _parse_tool_args(raw_args)
+                call_id = getattr(tc, "id", None) or str(uuid.uuid4())
                 if name and parsed.usable:
-                    calls_to_emit.append((str(uuid.uuid4()), name, parsed.args))
+                    calls_to_emit.append((call_id, name, parsed.args))
                 elif name:
                     logger.warning(
                         "Skipping tool call %s: arguments could not be parsed (status=%s)",
@@ -491,40 +642,62 @@ async def handle_run(request: Request) -> StreamingResponse:
                         parsed.status,
                     )
 
-            for call_id, tool_name, tool_args in calls_to_emit:
-                yield _sse_line(ToolCallStartEvent(
-                    type=EventType.TOOL_CALL_START,
-                    tool_call_id=call_id,
-                    tool_call_name=tool_name,
+            if calls_to_emit:
+                # Emit a TEXT_MESSAGE_START to create a parent assistant
+                # message that the tool calls attach to.  Without this,
+                # the AG-UI client still synthesizes a message per tool
+                # call, but the Runtime's middleware SSE parser (used by
+                # open-gen-ui and other middleware) cannot associate tool
+                # calls with a parent message — they are silently dropped.
+                # Emitting the triple (START → tool calls → END) mirrors
+                # what LangGraph and google-adk adapters produce.
+                tc_parent_id = str(uuid.uuid4())
+                yield _sse_line(TextMessageStartEvent(
+                    type=EventType.TEXT_MESSAGE_START,
+                    message_id=tc_parent_id,
                 ))
 
-                yield _sse_line(ToolCallArgsEvent(
-                    type=EventType.TOOL_CALL_ARGS,
-                    tool_call_id=call_id,
-                    delta=json.dumps(tool_args),
+                for call_id, tool_name, tool_args in calls_to_emit:
+                    yield _sse_line(ToolCallStartEvent(
+                        type=EventType.TOOL_CALL_START,
+                        tool_call_id=call_id,
+                        tool_call_name=tool_name,
+                        parent_message_id=tc_parent_id,
+                    ))
+
+                    yield _sse_line(ToolCallArgsEvent(
+                        type=EventType.TOOL_CALL_ARGS,
+                        tool_call_id=call_id,
+                        delta=json.dumps(tool_args),
+                    ))
+
+                    yield _sse_line(ToolCallEndEvent(
+                        type=EventType.TOOL_CALL_END,
+                        tool_call_id=call_id,
+                    ))
+
+                    # For backend tools, execute and stream the result as text.
+                    # Both the oai-path and the content-JSON path below fan
+                    # out through ``_run_backend_tool`` so sanitization and
+                    # off-thread execution behave identically.
+                    if tool_name not in FRONTEND_TOOL_NAMES:
+                        tool_cls = _TOOL_BY_NAME.get(tool_name)
+                        result: str | None = None
+                        if tool_cls is not None:
+                            result = await _run_backend_tool(
+                                tool_cls, tool_name, tool_args
+                            )
+
+                        if result:
+                            msg_id = str(uuid.uuid4())
+                            for line in emit_text_block(msg_id, result):
+                                yield line
+
+                # Close the parent message that wraps the tool calls.
+                yield _sse_line(TextMessageEndEvent(
+                    type=EventType.TEXT_MESSAGE_END,
+                    message_id=tc_parent_id,
                 ))
-
-                yield _sse_line(ToolCallEndEvent(
-                    type=EventType.TOOL_CALL_END,
-                    tool_call_id=call_id,
-                ))
-
-                # For backend tools, execute and stream the result as text.
-                # Both the oai-path and the content-JSON path below fan
-                # out through ``_run_backend_tool`` so sanitization and
-                # off-thread execution behave identically.
-                if tool_name not in FRONTEND_TOOL_NAMES:
-                    tool_cls = _TOOL_BY_NAME.get(tool_name)
-                    result: str | None = None
-                    if tool_cls is not None:
-                        result = await _run_backend_tool(
-                            tool_cls, tool_name, tool_args
-                        )
-
-                    if result:
-                        msg_id = str(uuid.uuid4())
-                        for line in emit_text_block(msg_id, result):
-                            yield line
 
             yield _sse_line(RunFinishedEvent(
                 type=EventType.RUN_FINISHED,
@@ -534,7 +707,7 @@ async def handle_run(request: Request) -> StreamingResponse:
             return
 
         # Check if the response contains a tool call parsed from content
-        tool_msg = _try_parse_tool(content, agent)
+        tool_msg = _try_parse_tool(content)
 
         if tool_msg is not None:
             tool_name = tool_msg.default_value("request") if hasattr(tool_msg, "default_value") else getattr(tool_msg, "request", "unknown")
@@ -553,10 +726,21 @@ async def handle_run(request: Request) -> StreamingResponse:
                     continue
                 tool_args[field_name] = value
 
+            # Emit a parent TEXT_MESSAGE that wraps the tool call, same
+            # as the oai_tool_calls path above. Without this, the
+            # Runtime middleware-sse-parser cannot attach the tool call
+            # to a parent message and silently drops it.
+            ct_parent_id = str(uuid.uuid4())
+            yield _sse_line(TextMessageStartEvent(
+                type=EventType.TEXT_MESSAGE_START,
+                message_id=ct_parent_id,
+            ))
+
             yield _sse_line(ToolCallStartEvent(
                 type=EventType.TOOL_CALL_START,
                 tool_call_id=tool_call_id,
                 tool_call_name=tool_name,
+                parent_message_id=ct_parent_id,
             ))
 
             yield _sse_line(ToolCallArgsEvent(
@@ -604,6 +788,10 @@ async def handle_run(request: Request) -> StreamingResponse:
                         str(uuid.uuid4()), err_payload
                     ):
                         yield line
+                    yield _sse_line(TextMessageEndEvent(
+                        type=EventType.TEXT_MESSAGE_END,
+                        message_id=ct_parent_id,
+                    ))
                     yield _sse_line(RunFinishedEvent(
                         type=EventType.RUN_FINISHED,
                         thread_id=thread_id,
@@ -613,6 +801,12 @@ async def handle_run(request: Request) -> StreamingResponse:
                 if result:
                     for line in emit_text_block(message_id, result):
                         yield line
+
+            # Close the parent message that wraps the tool call.
+            yield _sse_line(TextMessageEndEvent(
+                type=EventType.TEXT_MESSAGE_END,
+                message_id=ct_parent_id,
+            ))
         else:
             # Plain text response — stream it. emit_text_block handles the
             # empty-delta guard (AG-UI requires non-empty deltas, e.g. a
@@ -637,14 +831,14 @@ async def handle_run(request: Request) -> StreamingResponse:
     )
 
 
-def _try_parse_tool(content: str, agent: lr.ChatAgent) -> ToolMessage | None:
+def _try_parse_tool(content: str) -> ToolMessage | None:
     """Try to parse a Langroid ToolMessage from the LLM response content.
 
-    Langroid's `agent.llm_response_async(...)` returns a `ChatDocument`,
-    not a `ToolMessage`, so the previous isinstance-based path was
-    effectively dead code. We rely on the JSON fallback, which matches
-    both the Langroid tool envelope (`{"request": ..., ...}`) and the
-    OpenAI function-call shape (`{"name": ..., "arguments": ...}`).
+    The OpenAI response's ``content`` field sometimes contains a JSON
+    tool envelope (Langroid convention: ``{"request": ..., ...}``) or
+    an OpenAI function-call shape (``{"name": ..., "arguments": ...}``).
+    This fallback path catches those cases when the response didn't use
+    the structured ``tool_calls`` field.
 
     Logging philosophy (matters — this is on the hot path for every
     turn, including plain chat replies like "hello"):

--- a/showcase/packages/langroid/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/langroid/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/langroid/tests/python/test_agui_adapter.py
+++ b/showcase/packages/langroid/tests/python/test_agui_adapter.py
@@ -1,11 +1,9 @@
 """Unit tests for the Langroid AG-UI SSE adapter.
 
 These tests exercise the event-emission logic of ``handle_run`` by driving
-it with fabricated ``Request``/``ChatAgent`` doubles. They deliberately
-avoid spinning up a real ``langroid.ChatAgent`` (network + OpenAI key
-required) — instead we replace ``agents.agui_adapter.create_agent`` with
-a stub that returns a fake agent whose ``llm_response_async`` yields the
-scenario under test.
+it with fabricated ``Request`` doubles. They mock ``_call_openai`` to return
+controlled OpenAI ChatCompletionMessage-shaped responses, avoiding the need
+for a real LLM or aimock.
 
 Run: ``pytest tests/python/ -v`` from the langroid package root.
 """
@@ -35,19 +33,6 @@ from agents.agent import ALL_TOOLS, FRONTEND_TOOL_NAMES
 # ---------------------------------------------------------------------------
 
 
-class _FakeAgent:
-    """Minimal stand-in for ``lr.ChatAgent`` — records the prompt and
-    returns a preconfigured response object."""
-
-    def __init__(self, response: Any):
-        self._response = response
-        self.calls: list[str] = []
-
-    async def llm_response_async(self, user_message: str) -> Any:
-        self.calls.append(user_message)
-        return self._response
-
-
 class _FakeRequest:
     """Stand-in for ``fastapi.Request`` — only ``.json()`` is used."""
 
@@ -58,10 +43,11 @@ class _FakeRequest:
         return self._body
 
 
-def _install_fake_agent(monkeypatch: pytest.MonkeyPatch, response: Any) -> _FakeAgent:
-    agent = _FakeAgent(response)
-    monkeypatch.setattr(agui_adapter, "create_agent", lambda **kwargs: agent)
-    return agent
+def _install_fake_openai(monkeypatch: pytest.MonkeyPatch, response: Any) -> None:
+    """Replace ``_call_openai`` with a coroutine that returns *response*."""
+    async def _fake_call_openai(messages, tools, model):
+        return response
+    monkeypatch.setattr(agui_adapter, "_call_openai", _fake_call_openai)
 
 
 def _minimal_run_input(thread_id: str = "") -> dict:
@@ -106,14 +92,16 @@ def _parse_events(lines: list[str]) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Happy path: oai_tool_calls with valid JSON args
+# Happy path: tool_calls with valid JSON args
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_oai_tool_calls_emit_start_args_end_in_order(monkeypatch):
-    """A single ``oai_tool_calls`` entry with valid JSON args should emit
-    TOOL_CALL_START -> TOOL_CALL_ARGS -> TOOL_CALL_END in that exact order."""
+    """A single ``tool_calls`` entry with valid JSON args should emit
+    TEXT_MESSAGE_START -> TOOL_CALL_START -> TOOL_CALL_ARGS ->
+    TOOL_CALL_END -> TEXT_MESSAGE_END in that exact order (tool calls
+    are wrapped in a parent TextMessage)."""
     tool_call = SimpleNamespace(
         id="call-1",
         function=SimpleNamespace(
@@ -121,8 +109,8 @@ async def test_oai_tool_calls_emit_start_args_end_in_order(monkeypatch):
             arguments='{"background": "linear-gradient(red, blue)"}',
         ),
     )
-    response = SimpleNamespace(content="", oai_tool_calls=[tool_call], function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="", tool_calls=[tool_call])
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-1"))
     resp = await handle_run(req)
@@ -131,15 +119,17 @@ async def test_oai_tool_calls_emit_start_args_end_in_order(monkeypatch):
     types = [e["type"] for e in events]
     assert types == [
         "RUN_STARTED",
+        "TEXT_MESSAGE_START",
         "TOOL_CALL_START",
         "TOOL_CALL_ARGS",
         "TOOL_CALL_END",
+        "TEXT_MESSAGE_END",
         "RUN_FINISHED",
     ]
 
-    start = events[1]
-    args = events[2]
-    end = events[3]
+    start = next(e for e in events if e["type"] == "TOOL_CALL_START")
+    args = next(e for e in events if e["type"] == "TOOL_CALL_ARGS")
+    end = next(e for e in events if e["type"] == "TOOL_CALL_END")
     assert start["toolCallId"] == "call-1"
     assert start["toolCallName"] == "change_background"
     assert args["toolCallId"] == "call-1"
@@ -148,7 +138,37 @@ async def test_oai_tool_calls_emit_start_args_end_in_order(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Malformed args → warning + {} args
+# parentMessageId is set on TOOL_CALL_START
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_call_has_parent_message_id(monkeypatch):
+    """TOOL_CALL_START must carry parentMessageId matching the wrapping
+    TEXT_MESSAGE_START's messageId — the Runtime middleware-sse-parser
+    uses this to attach tool calls to their parent message."""
+    tool_call = SimpleNamespace(
+        id="call-pm",
+        function=SimpleNamespace(
+            name="change_background",
+            arguments='{"background": "teal"}',
+        ),
+    )
+    response = SimpleNamespace(content="", tool_calls=[tool_call])
+    _install_fake_openai(monkeypatch, response)
+
+    req = _FakeRequest(_minimal_run_input(thread_id="t-pm"))
+    resp = await handle_run(req)
+    events = _parse_events(await _collect(resp))
+
+    txt_start = next(e for e in events if e["type"] == "TEXT_MESSAGE_START")
+    tc_start = next(e for e in events if e["type"] == "TOOL_CALL_START")
+    assert "parentMessageId" in tc_start
+    assert tc_start["parentMessageId"] == txt_start["messageId"]
+
+
+# ---------------------------------------------------------------------------
+# Malformed args → warning + skip
 # ---------------------------------------------------------------------------
 
 
@@ -162,8 +182,8 @@ async def test_malformed_args_skip_tool_call_and_logs_warning(monkeypatch, caplo
         id="call-2",
         function=SimpleNamespace(name="change_background", arguments="not json {"),
     )
-    response = SimpleNamespace(content="", oai_tool_calls=[tool_call], function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="", tool_calls=[tool_call])
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-2"))
     with caplog.at_level(logging.WARNING, logger=agui_adapter.logger.name):
@@ -182,37 +202,6 @@ async def test_malformed_args_skip_tool_call_and_logs_warning(monkeypatch, caplo
 
 
 # ---------------------------------------------------------------------------
-# Legacy function_call path
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_legacy_function_call_path_emits_tool_events(monkeypatch):
-    """When the LLM returns ``function_call`` (legacy shape) rather than
-    ``oai_tool_calls``, the adapter should still synthesize tool events."""
-    function_call = SimpleNamespace(
-        name="change_background",
-        arguments='{"background": "teal"}',
-    )
-    response = SimpleNamespace(content="", oai_tool_calls=None, function_call=function_call)
-    _install_fake_agent(monkeypatch, response)
-
-    req = _FakeRequest(_minimal_run_input(thread_id="t-3"))
-    resp = await handle_run(req)
-    events = _parse_events(await _collect(resp))
-
-    types = [e["type"] for e in events]
-    assert "TOOL_CALL_START" in types
-    assert "TOOL_CALL_ARGS" in types
-    assert "TOOL_CALL_END" in types
-
-    start = next(e for e in events if e["type"] == "TOOL_CALL_START")
-    args = next(e for e in events if e["type"] == "TOOL_CALL_ARGS")
-    assert start["toolCallName"] == "change_background"
-    assert json.loads(args["delta"]) == {"background": "teal"}
-
-
-# ---------------------------------------------------------------------------
 # Empty-string content → no TEXT_MESSAGE_* events
 # ---------------------------------------------------------------------------
 
@@ -221,8 +210,8 @@ async def test_legacy_function_call_path_emits_tool_events(monkeypatch):
 async def test_empty_content_skips_text_message_events(monkeypatch):
     """A response with empty content and no tool calls must not emit
     any TEXT_MESSAGE_* events (AG-UI rejects empty deltas)."""
-    response = SimpleNamespace(content="", oai_tool_calls=None, function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="", tool_calls=None)
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-4"))
     resp = await handle_run(req)
@@ -243,8 +232,8 @@ async def test_thread_id_stable_when_caller_omits(monkeypatch):
     """Invariant: RUN_STARTED and RUN_FINISHED MUST share the same
     ``thread_id``. When the caller omits it, the adapter synthesizes one
     UUID and reuses it across every event emitted for the run."""
-    response = SimpleNamespace(content="hello", oai_tool_calls=None, function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="hello", tool_calls=None)
+    _install_fake_openai(monkeypatch, response)
 
     # Empty string triggers the ``run_input.thread_id or str(uuid.uuid4())``
     # fallback — exactly the same code path as a missing thread_id.
@@ -266,8 +255,8 @@ async def test_thread_id_from_caller_preserved(monkeypatch):
     """Invariant: when the caller supplies a thread_id, the adapter MUST
     preserve it verbatim — no new UUID is synthesized, and RUN_STARTED
     and RUN_FINISHED both carry the caller's value."""
-    response = SimpleNamespace(content="hello", oai_tool_calls=None, function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="hello", tool_calls=None)
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="abc"))
     resp = await handle_run(req)
@@ -419,23 +408,26 @@ async def test_backend_tool_execution_happy_path(monkeypatch):
             arguments='{"location": "SF"}',
         ),
     )
-    response = SimpleNamespace(content="", oai_tool_calls=[tool_call], function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="", tool_calls=[tool_call])
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-wx"))
     resp = await handle_run(req)
     events = _parse_events(await _collect(resp))
 
     types = [e["type"] for e in events]
-    # Backend tools emit TEXT_MESSAGE_* triple after TOOL_CALL_END.
+    # Backend tools emit TEXT_MESSAGE_* triple after TOOL_CALL_END,
+    # all wrapped in a parent TEXT_MESSAGE_START/END.
     assert types == [
         "RUN_STARTED",
+        "TEXT_MESSAGE_START",      # parent message wrapper
         "TOOL_CALL_START",
         "TOOL_CALL_ARGS",
         "TOOL_CALL_END",
-        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_START",      # backend tool result
         "TEXT_MESSAGE_CONTENT",
         "TEXT_MESSAGE_END",
+        "TEXT_MESSAGE_END",        # parent message close
         "RUN_FINISHED",
     ], f"unexpected event sequence: {types}"
 
@@ -481,8 +473,8 @@ async def test_backend_tool_exception_returns_sanitized_error(monkeypatch, caplo
             arguments='{"location": "SF"}',
         ),
     )
-    response = SimpleNamespace(content="", oai_tool_calls=[tool_call], function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="", tool_calls=[tool_call])
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-err"))
     with caplog.at_level(logging.ERROR, logger=agui_adapter.logger.name):
@@ -533,8 +525,8 @@ async def test_str_exc_never_appears_in_sse_stream(monkeypatch, caplog):
             arguments='{"location": "SF"}',
         ),
     )
-    response = SimpleNamespace(content="", oai_tool_calls=[tool_call], function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="", tool_calls=[tool_call])
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-sse-sanit"))
     with caplog.at_level(logging.ERROR, logger=agui_adapter.logger.name):
@@ -620,7 +612,7 @@ def test_try_parse_tool_non_str_content_warns_and_returns_none(caplog):
     from agents.agui_adapter import _try_parse_tool
 
     with caplog.at_level(logging.WARNING, logger=agui_adapter.logger.name):
-        result = _try_parse_tool(12345, agent=None)  # type: ignore[arg-type]
+        result = _try_parse_tool(12345)  # type: ignore[arg-type]
 
     assert result is None
     assert any(
@@ -646,19 +638,7 @@ def test_try_parse_tool_function_call_bytes_arguments():
     # Use a real backend tool from ALL_TOOLS so this exercises the actual
     # dispatch loop rather than a synthetic stub.
     request_name = agent_module.GetWeatherTool.default_value("request")
-    # Patch the function_call payload to carry a bytes ``arguments`` at
-    # parse time. We construct the wrapper JSON as normal (str) but the
-    # inner ``arguments`` field is a str whose *decoded* value would be
-    # bytes in a real payload — so we exercise the guard by passing a
-    # dict directly into the adapter's internals.
-    #
-    # To exercise the bytes branch, call with a dict that mirrors the
-    # post-``json.loads`` shape:
     data = {"name": request_name, "arguments": b'{"location": "SF"}'}
-    # Feed via the content path: we serialize once so ``_try_parse_tool``
-    # re-parses. But ``json.dumps`` on bytes raises. Instead, mimic by
-    # directly invoking the inner logic: patch ``json.loads`` to return
-    # the dict with bytes ``arguments`` so we test the branch.
     import agents.agui_adapter as adapter_mod
 
     real_loads = adapter_mod.json.loads
@@ -675,7 +655,7 @@ def test_try_parse_tool_function_call_bytes_arguments():
     import unittest.mock as mock
 
     with mock.patch.object(adapter_mod.json, "loads", side_effect=_fake_loads):
-        result = _try_parse_tool("ignored-outer", agent=None)  # type: ignore[arg-type]
+        result = _try_parse_tool("ignored-outer")
 
     assert result is not None, (
         "bytes arguments should round-trip through the (str, bytes, bytearray) guard"
@@ -685,35 +665,30 @@ def test_try_parse_tool_function_call_bytes_arguments():
 
 
 # ---------------------------------------------------------------------------
-# mid-stream llm_response_async failure must not hang the UI
+# mid-stream _call_openai failure must not hang the UI
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_llm_response_async_failure_emits_run_finished(monkeypatch, caplog):
-    """When ``agent.llm_response_async`` raises a narrowed runtime error
-    (``openai.APIError`` / ``httpx.HTTPError`` / ``asyncio.TimeoutError``
-    / ``pydantic.ValidationError``) *after* RUN_STARTED has been
-    emitted, the generator must emit a sanitized TEXT_MESSAGE triple +
-    RUN_FINISHED (never leave the frontend hanging).
+async def test_call_openai_failure_emits_run_finished(monkeypatch, caplog):
+    """When ``_call_openai`` raises a narrowed runtime error
+    (``openai.APIError`` / ``httpx.HTTPError`` / ``asyncio.TimeoutError``)
+    *after* RUN_STARTED has been emitted, the generator must emit a
+    sanitized TEXT_MESSAGE triple + RUN_FINISHED (never leave the
+    frontend hanging).
 
     Uses ``asyncio.TimeoutError`` as the representative covered
     exception — it's the simplest of the four to construct and
-    exercises the same code path as the others. The test message is
-    surfaced as ``str(exc)``-free (sanitized) regardless.
+    exercises the same code path as the others.
     """
     import asyncio as _asyncio
 
-    class _ExplodingAgent:
-        async def llm_response_async(self, user_message: str) -> Any:
-            # TimeoutError doesn't carry the sensitive message the way
-            # a ValueError would, but the sanitization contract is the
-            # same: only the class name leaks, never ``str(exc)``.
-            raise _asyncio.TimeoutError(
-                "secret: postgres://user:pass@host/db /opt/app/internal.py line 99"
-            )
+    async def _exploding_call_openai(messages, tools, model):
+        raise _asyncio.TimeoutError(
+            "secret: postgres://user:pass@host/db /opt/app/internal.py line 99"
+        )
 
-    monkeypatch.setattr(agui_adapter, "create_agent", lambda **kwargs: _ExplodingAgent())
+    monkeypatch.setattr(agui_adapter, "_call_openai", _exploding_call_openai)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-boom"))
     with caplog.at_level(logging.ERROR, logger=agui_adapter.logger.name):
@@ -742,35 +717,26 @@ async def test_llm_response_async_failure_emits_run_finished(monkeypatch, caplog
 
     # Full traceback preserved server-side.
     assert any(r.exc_info for r in caplog.records), (
-        "expected logger.exception to capture the llm_response_async failure"
+        "expected logger.exception to capture the _call_openai failure"
     )
 
 
 @pytest.mark.asyncio
-async def test_llm_response_async_programmer_bug_propagates(monkeypatch):
+async def test_call_openai_programmer_bug_propagates(monkeypatch):
     """Programmer bugs (``AttributeError``, ``NameError``, ``TypeError``)
-    from ``agent.llm_response_async`` must NOT be sanitized — they
-    indicate real bugs and must propagate so the outer framework can
-    log/flag them with a real traceback.
-
-    Regression guard for the over-broad ``except Exception`` that
-    previously swallowed every failure as "LLM error", making these
-    kinds of bugs invisible in production logs.
+    from ``_call_openai`` must NOT be sanitized — they indicate real
+    bugs and must propagate so the outer framework can log/flag them
+    with a real traceback.
     """
 
-    class _TypoAgent:
-        async def llm_response_async(self, user_message: str) -> Any:
-            # Simulate a programmer bug — e.g. a typo that references
-            # an attribute that doesn't exist on the response object.
-            raise AttributeError("typo")
+    async def _typo_call_openai(messages, tools, model):
+        raise AttributeError("typo")
 
-    monkeypatch.setattr(agui_adapter, "create_agent", lambda **kwargs: _TypoAgent())
+    monkeypatch.setattr(agui_adapter, "_call_openai", _typo_call_openai)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-bug"))
     resp = await handle_run(req)
     with pytest.raises(AttributeError, match="typo"):
-        # The exception propagates out of the event_stream generator
-        # when it's drained; the generator itself is lazy.
         await _collect(resp)
 
 
@@ -812,59 +778,6 @@ async def test_invalid_run_agent_input_returns_422():
 
 
 # ---------------------------------------------------------------------------
-# non-string role/content is skipped with a warning
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_non_string_role_or_content_skipped(monkeypatch, caplog):
-    """Messages whose ``role`` or ``content`` are not strings must be
-    skipped with a warning rather than silently f-stringified into
-    garbage like ``"None: {'foo': ...}"``.
-
-    Pydantic's ``RunAgentInput`` normally rejects these upstream, but
-    if a future schema change or a non-validating code path ever lands
-    a non-string field in ``run_input.messages``, the guard in
-    ``handle_run`` is the last line of defense against garbage prompts.
-    We bypass pydantic by substituting a stub ``RunAgentInput`` that
-    returns a hand-built object with mixed message types.
-    """
-    agent = _install_fake_agent(
-        monkeypatch,
-        SimpleNamespace(content="ok", oai_tool_calls=None, function_call=None),
-    )
-
-    class _StubRunInput:
-        def __init__(self, **_kwargs: Any) -> None:
-            self.thread_id = "t-msg"
-            self.run_id = "run-x"
-            self.forwarded_props = {}
-            self.messages = [
-                SimpleNamespace(role="user", content="hello"),
-                # non-string content
-                SimpleNamespace(role="user", content={"obj": 1}),
-                # non-string role
-                SimpleNamespace(role=None, content="huh"),
-            ]
-
-    monkeypatch.setattr(agui_adapter, "RunAgentInput", _StubRunInput)
-
-    req = _FakeRequest({"stub": True})  # content irrelevant — stub ignores
-    with caplog.at_level(logging.WARNING, logger=agui_adapter.logger.name):
-        resp = await handle_run(req)
-        await _collect(resp)
-
-    # Only the first message should have reached the agent.
-    assert agent.calls == ["user: hello"], (
-        f"non-string messages must be dropped; got prompt: {agent.calls!r}"
-    )
-    assert any(
-        "non-string role/content" in rec.getMessage()
-        for rec in caplog.records
-    ), "expected a warning log for dropped messages"
-
-
-# ---------------------------------------------------------------------------
 # tool-collision RuntimeError names the colliding classes
 # ---------------------------------------------------------------------------
 
@@ -873,10 +786,6 @@ def test_duplicate_tool_error_includes_class_identity():
     """When two tool classes collide on ``request`` name, the startup
     RuntimeError must include fully-qualified class identities so the
     developer can find the duplicate definitions without grepping."""
-    # Simulate the import-time guard on a synthetic ALL_TOOLS with a
-    # collision. Rebuild the same check directly — we can't re-import
-    # the module to re-trigger it, but the guard's logic is simple
-    # enough to exercise via a tiny fixture.
     from langroid.agent.tool_message import ToolMessage
 
     class ToolA(ToolMessage):
@@ -908,8 +817,8 @@ async def test_plain_text_turn_does_not_warn(monkeypatch, caplog):
     """A normal chat reply like "hello" is NOT JSON. The adapter's
     tool-parse fallback must fail silently — warning on every chat turn
     floods logs and drowns real signal."""
-    response = SimpleNamespace(content="hello", oai_tool_calls=None, function_call=None)
-    _install_fake_agent(monkeypatch, response)
+    response = SimpleNamespace(content="hello", tool_calls=None)
+    _install_fake_openai(monkeypatch, response)
 
     req = _FakeRequest(_minimal_run_input(thread_id="t-plain"))
     with caplog.at_level(logging.WARNING, logger=agui_adapter.logger.name):
@@ -929,3 +838,83 @@ async def test_plain_text_turn_does_not_warn(monkeypatch, caplog):
         "plain-text turn unexpectedly logged warnings: "
         f"{[r.getMessage() for r in adapter_warnings]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _agui_messages_to_openai: message conversion tests
+# ---------------------------------------------------------------------------
+
+
+def test_agui_messages_to_openai_user_message():
+    """Simple user message is preserved."""
+    from agents.agui_adapter import _agui_messages_to_openai
+
+    msgs = [SimpleNamespace(role="user", content="hello")]
+    result = _agui_messages_to_openai(msgs, "sys prompt")
+    assert result[0] == {"role": "system", "content": "sys prompt"}
+    assert result[1] == {"role": "user", "content": "hello"}
+
+
+def test_agui_messages_to_openai_tool_message():
+    """Tool result messages preserve tool_call_id."""
+    from agents.agui_adapter import _agui_messages_to_openai
+
+    msgs = [
+        SimpleNamespace(role="tool", content="result text", tool_call_id="tc-123"),
+    ]
+    result = _agui_messages_to_openai(msgs, "sys")
+    assert result[1] == {
+        "role": "tool",
+        "tool_call_id": "tc-123",
+        "content": "result text",
+    }
+
+
+def test_agui_messages_to_openai_assistant_with_tool_calls():
+    """Assistant messages with tool_calls preserve the full structure."""
+    from agents.agui_adapter import _agui_messages_to_openai
+
+    tc = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(name="show_card", arguments='{"title":"Ada"}'),
+    )
+    msgs = [
+        SimpleNamespace(role="assistant", content=None, tool_calls=[tc]),
+    ]
+    result = _agui_messages_to_openai(msgs, "sys")
+    assistant_msg = result[1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] is None  # null, not missing
+    assert len(assistant_msg["tool_calls"]) == 1
+    assert assistant_msg["tool_calls"][0]["id"] == "call-1"
+    assert assistant_msg["tool_calls"][0]["function"]["name"] == "show_card"
+
+
+def test_agui_messages_to_openai_full_tool_roundtrip():
+    """Full multi-turn: user -> assistant+tool_call -> tool_result.
+    This is the exact sequence that gen-ui-headless needs for the
+    follow-up aimock match to work."""
+    from agents.agui_adapter import _agui_messages_to_openai
+
+    tc = SimpleNamespace(
+        id="call_d5_show_card_001",
+        function=SimpleNamespace(
+            name="show_card",
+            arguments='{"title":"Ada Lovelace","body":"mathematician"}',
+        ),
+    )
+    msgs = [
+        SimpleNamespace(role="user", content="Show me a profile card for Ada Lovelace"),
+        SimpleNamespace(role="assistant", content=None, tool_calls=[tc]),
+        SimpleNamespace(role="tool", content="", tool_call_id="call_d5_show_card_001"),
+    ]
+    result = _agui_messages_to_openai(msgs, "sys")
+
+    # System + user + assistant + tool = 4 messages
+    assert len(result) == 4
+    assert result[0]["role"] == "system"
+    assert result[1]["role"] == "user"
+    assert result[2]["role"] == "assistant"
+    assert result[2]["tool_calls"][0]["id"] == "call_d5_show_card_001"
+    assert result[3]["role"] == "tool"
+    assert result[3]["tool_call_id"] == "call_d5_show_card_001"

--- a/showcase/packages/llamaindex/manifest.yaml
+++ b/showcase/packages/llamaindex/manifest.yaml
@@ -32,7 +32,6 @@ features:
   - tool-rendering-reasoning-chain
   - frontend-tools
   - frontend-tools-async
-  - hitl-in-chat
   - tool-rendering
   - tool-rendering-default-catchall
   - tool-rendering-custom-catchall
@@ -89,18 +88,6 @@ demos:
       - src/app/demos/frontend-tools-async/agent.py
       - src/app/demos/frontend-tools-async/page.tsx
       - src/app/demos/frontend-tools-async/notes-card.tsx
-      - src/app/api/copilotkit/route.ts
-  - id: hitl-in-chat
-    name: In-Chat HITL (useHumanInTheLoop — ergonomic API)
-    description: Interactive approval/decision surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook
-    tags:
-      - interactivity
-    route: /demos/hitl-in-chat
-    animated_preview_url:
-    highlight:
-      - src/app/demos/hitl-in-chat/agent.py
-      - src/app/demos/hitl-in-chat/page.tsx
-      - src/app/demos/hitl-in-chat/time-picker-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: tool-rendering
     name: Tool Rendering

--- a/showcase/packages/llamaindex/src/agents/agent.py
+++ b/showcase/packages/llamaindex/src/agents/agent.py
@@ -58,6 +58,14 @@ def generate_task_steps(
     return f"Generated {len(steps)} steps for review"
 
 
+def book_call(
+    topic: Annotated[str, "What the call is about (e.g. 'Onboarding call')"],
+    name: Annotated[str, "Name of the attendee"],
+) -> str:
+    """Ask the user to pick a time slot for a call. The picker UI presents fixed candidate slots; the user's choice is returned to the agent."""
+    return f"Booking call about {topic} with {name}"
+
+
 # --- Backend tools (executed server-side, using shared implementations) ---
 
 async def get_weather(
@@ -160,7 +168,7 @@ if os.environ.get("OPENAI_BASE_URL"):
 
 agent_router = get_ag_ui_workflow_router(
     llm=OpenAI(model="gpt-4.1", **_openai_kwargs),
-    frontend_tools=[change_background, generate_haiku, generate_task_steps],
+    frontend_tools=[change_background, generate_haiku, generate_task_steps, book_call],
     backend_tools=[get_weather, query_data, manage_sales_todos, get_sales_todos_tool, schedule_meeting, search_flights, generate_a2ui],
     system_prompt=(
         "You are a polished, professional demo assistant for CopilotKit. "
@@ -175,8 +183,10 @@ agent_router = get_ag_ui_workflow_router(
         "- Search flights and display rich A2UI cards (via search_flights tool)\n"
         "- Generate dynamic A2UI dashboards from conversation context (via generate_a2ui tool)\n"
         "- Generate step-by-step plans for user review (human-in-the-loop)\n"
+        "- Book calls with people (via book_call frontend tool)\n"
         "When asked about weather, always use the get_weather tool. "
-        "When asked about financial data or charts, use query_data first."
+        "When asked about financial data or charts, use query_data first. "
+        "When asked to book a call, use the book_call tool with topic and name."
     ),
     initial_state={
         "todos": [],

--- a/showcase/packages/llamaindex/src/agents/agent.py
+++ b/showcase/packages/llamaindex/src/agents/agent.py
@@ -154,8 +154,12 @@ async def generate_a2ui(
     return json.dumps(result)
 
 
+_openai_kwargs = {}
+if os.environ.get("OPENAI_BASE_URL"):
+    _openai_kwargs["api_base"] = os.environ["OPENAI_BASE_URL"]
+
 agent_router = get_ag_ui_workflow_router(
-    llm=OpenAI(model="gpt-4.1"),
+    llm=OpenAI(model="gpt-4.1", **_openai_kwargs),
     frontend_tools=[change_background, generate_haiku, generate_task_steps],
     backend_tools=[get_weather, query_data, manage_sales_todos, get_sales_todos_tool, schedule_meeting, search_flights, generate_a2ui],
     system_prompt=(

--- a/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
@@ -47,17 +47,18 @@ function Chat() {
 
   useHumanInTheLoop({
     agentId: "human_in_the_loop",
-    name: "schedule_meeting",
+    name: "book_call",
     description:
       "Ask the user to pick a time slot for a meeting. The picker UI presents fixed candidate slots; the user's choice is returned to the agent.",
     parameters: z.object({
-      reason: z
+      topic: z
         .string()
-        .describe("What the call is about (e.g. 'Intro with sales')"),
+        .describe("What the call is about (e.g. 'Onboarding call')"),
+      name: z.string().describe("Name of the attendee"),
     }),
     render: ({ args, status, respond }: any) => (
       <TimePickerCard
-        topic={args?.reason ?? "a call"}
+        topic={args?.topic ?? "a call"}
         slots={DEFAULT_SLOTS}
         status={status}
         onSubmit={(result) => respond?.(result)}

--- a/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/hitl-in-chat/page.tsx
@@ -59,6 +59,7 @@ function Chat() {
     render: ({ args, status, respond }: any) => (
       <TimePickerCard
         topic={args?.topic ?? "a call"}
+        attendee={args?.name}
         slots={DEFAULT_SLOTS}
         status={status}
         onSubmit={(result) => respond?.(result)}

--- a/showcase/packages/llamaindex/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/llamaindex/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/mastra/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/ms-agent-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/ms-agent-python/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/pydantic-ai/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/pydantic-ai/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/spring-ai/entrypoint.sh
+++ b/showcase/packages/spring-ai/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+# Derive SPRING_AI_OPENAI_BASE_URL from the showcase-wide OPENAI_BASE_URL if
+# not already set. The showcase convention is that OPENAI_BASE_URL includes
+# "/v1" (e.g. https://aimock.example.com/v1), but Spring AI appends
+# "/v1/chat/completions" itself, so we must strip the trailing "/v1" to avoid
+# a doubled path segment.
+if [ -z "${SPRING_AI_OPENAI_BASE_URL:-}" ] && [ -n "${OPENAI_BASE_URL:-}" ]; then
+    export SPRING_AI_OPENAI_BASE_URL="${OPENAI_BASE_URL%/v1}"
+    echo "[entrypoint] Derived SPRING_AI_OPENAI_BASE_URL=${SPRING_AI_OPENAI_BASE_URL} from OPENAI_BASE_URL=${OPENAI_BASE_URL}"
+fi
+
 echo "[entrypoint] Starting Spring Boot agent backend..."
 # jdk.httpclient.keepalive.timeout=0 disables JDK HttpClient connection pooling.
 # Required because Spring-AI streams via WebClient + JdkClientHttpConnector and a

--- a/showcase/packages/spring-ai/manifest.yaml
+++ b/showcase/packages/spring-ai/manifest.yaml
@@ -32,7 +32,6 @@ features:
   - chat-customization-css
   - frontend-tools
   - frontend-tools-async
-  - hitl-in-chat
   - gen-ui-agent
   - open-gen-ui
   - open-gen-ui-advanced
@@ -93,17 +92,6 @@ demos:
     highlight:
       - src/app/demos/frontend-tools-async/page.tsx
       - src/app/demos/frontend-tools-async/notes-card.tsx
-      - src/app/api/copilotkit/route.ts
-  - id: hitl-in-chat
-    name: In-Chat HITL (useHumanInTheLoop)
-    description: Interactive approval surface rendered inline in the chat via the high-level `useHumanInTheLoop` hook
-    tags:
-      - interactivity
-    route: /demos/hitl-in-chat
-    animated_preview_url:
-    highlight:
-      - src/app/demos/hitl-in-chat/page.tsx
-      - src/app/demos/hitl-in-chat/time-picker-card.tsx
       - src/app/api/copilotkit/route.ts
   - id: gen-ui-agent
     name: Agentic Generative UI

--- a/showcase/packages/spring-ai/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/spring-ai/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/packages/strands/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/packages/strands/src/app/demos/tool-rendering/page.tsx
@@ -9,6 +9,15 @@ import {
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}
+
 export default function ToolRenderingDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="tool-rendering">
@@ -32,12 +41,13 @@ function Chat() {
         );
       }
 
+      const parsed = parseJsonResult<any>(result);
       const weatherResult: WeatherToolResult = {
-        temperature: result?.temperature || 0,
-        conditions: result?.conditions || "clear",
-        humidity: result?.humidity || 0,
-        windSpeed: result?.wind_speed || 0,
-        feelsLike: result?.feels_like || result?.temperature || 0,
+        temperature: parsed?.temperature || 0,
+        conditions: parsed?.conditions || "clear",
+        humidity: parsed?.humidity || 0,
+        windSpeed: parsed?.wind_speed || 0,
+        feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
       const themeColor = getThemeColor(weatherResult.conditions);

--- a/showcase/scripts/__tests__/generate-catalog.test.ts
+++ b/showcase/scripts/__tests__/generate-catalog.test.ts
@@ -188,11 +188,11 @@ describe("Catalog Generator", () => {
     expect(catalog.metadata.total_cells).toBe(737);
 
     // 18 integrations x 40 features + 17 starters = 737 total cells
-    // Wired = 482, Stub = 9, Unshipped = 246 (post-google-adk parity merge;
-    // manifest.yaml route presence determines wired vs unshipped)
-    expect(catalog.metadata.wired).toBe(482);
+    // Wired = 476, Stub = 9, Unshipped = 252 (post D5-all-green manifest cleanup;
+    // removed architecturally unsupported HITL features from 5 integrations)
+    expect(catalog.metadata.wired).toBe(476);
     expect(catalog.metadata.stub).toBe(9);
-    expect(catalog.metadata.unshipped).toBe(246);
+    expect(catalog.metadata.unshipped).toBe(252);
   });
 
   it("max_depth: D4 for wired/stub cells, D0 for unshipped", () => {

--- a/showcase/scripts/generate-starters.ts
+++ b/showcase/scripts/generate-starters.ts
@@ -847,7 +847,15 @@ ${AGENT_HEALTH_CHECK}`;
       // which then takes over steady-state monitoring. If the java process
       // dies during startup, the PID probe inside the loop fails-fast so
       // a crash-looping boot exits quickly.
-      return `echo "[entrypoint] Starting Spring AI agent on port 8123..."
+      return `# Derive SPRING_AI_OPENAI_BASE_URL from the showcase-wide OPENAI_BASE_URL if
+# not already set. OPENAI_BASE_URL includes "/v1" but Spring AI appends
+# "/v1/chat/completions" itself, so strip the trailing "/v1".
+if [ -z "\${SPRING_AI_OPENAI_BASE_URL:-}" ] && [ -n "\${OPENAI_BASE_URL:-}" ]; then
+    export SPRING_AI_OPENAI_BASE_URL="\${OPENAI_BASE_URL%/v1}"
+    echo "[entrypoint] Derived SPRING_AI_OPENAI_BASE_URL=\${SPRING_AI_OPENAI_BASE_URL} from OPENAI_BASE_URL=\${OPENAI_BASE_URL}"
+fi
+
+echo "[entrypoint] Starting Spring AI agent on port 8123..."
 java -jar agent/app.jar --server.port=8123 ${AGENT_LOG_PREFIX} &
 AGENT_PID=$!
 STARTUP_TIMEOUT=60

--- a/showcase/starters/agno/agent/main.py
+++ b/showcase/starters/agno/agent/main.py
@@ -81,14 +81,14 @@ def change_background(background: str):
     """
 
 @tool(external_execution=True)
-def book_call(topic: str, attendee: str):
+def book_call(topic: str, name: str):
     """
     Ask the user to pick a time slot for a call. The picker UI presents
     fixed candidate slots; the user's choice is returned to the agent.
 
     Args:
         topic (str): What the call is about (e.g. "Intro with sales").
-        attendee (str): Who the call is with (e.g. "Alice from Sales").
+        name (str): Name of the attendee (e.g. "Alice").
     """
 
 @tool(external_execution=True)
@@ -254,8 +254,8 @@ agent = Agent(
 
         BOOK CALL (HITL):
         When the user asks to book a call / schedule an intro / 1:1, call
-        book_call with the topic and attendee. The frontend renders a time
-        picker; the user's choice is returned as the tool result.
+        book_call with the topic and the person's name. The frontend renders a
+        time picker; the user's choice is returned as the tool result.
 
         TASK STEPS (HITL):
         When asked to plan something, use the generate_task_steps tool with a list of steps.

--- a/showcase/starters/google-adk/agent/a2ui_fixed_agent.py
+++ b/showcase/starters/google-adk/agent/a2ui_fixed_agent.py
@@ -15,6 +15,8 @@ from typing import Any
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from .shared_chat import get_model
+
 CATALOG_ID = "copilotkit://flight-fixed-catalog"
 SURFACE_ID = "flight-fixed-schema"
 
@@ -85,7 +87,7 @@ _INSTRUCTION = (
 
 a2ui_fixed_agent = LlmAgent(
     name="A2uiFixedAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[display_flight],
 )

--- a/showcase/starters/google-adk/agent/agent_config_agent.py
+++ b/showcase/starters/google-adk/agent/agent_config_agent.py
@@ -18,6 +18,8 @@ from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
 
+from .shared_chat import get_model
+
 logger = logging.getLogger(__name__)
 
 CONFIG_PREFIX_SIGNATURE = "[agent-config] config:"
@@ -137,7 +139,7 @@ _INSTRUCTION = (
 
 agent_config_agent = LlmAgent(
     name="AgentConfigAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
     before_model_callback=_inject_config,

--- a/showcase/starters/google-adk/agent/beautiful_chat_agent.py
+++ b/showcase/starters/google-adk/agent/beautiful_chat_agent.py
@@ -13,6 +13,8 @@ import os
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from .shared_chat import get_model
+
 from .tools import (  # noqa: E402
     query_data_impl,
     search_flights_impl,
@@ -42,7 +44,7 @@ _INSTRUCTION = (
 
 beautiful_chat_agent = LlmAgent(
     name="BeautifulChatAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[query_data, search_flights, schedule_meeting],
 )

--- a/showcase/starters/google-adk/agent/byoc_agents.py
+++ b/showcase/starters/google-adk/agent/byoc_agents.py
@@ -13,6 +13,8 @@ import os
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from .shared_chat import get_model
+
 from .tools import query_data_impl  # noqa: E402
 
 def query_data(tool_context: ToolContext, query: str) -> list:
@@ -28,7 +30,7 @@ _INSTRUCTION = (
 
 byoc_agent = LlmAgent(
     name="ByocAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[query_data],
 )

--- a/showcase/starters/google-adk/agent/declarative_gen_ui_agent.py
+++ b/showcase/starters/google-adk/agent/declarative_gen_ui_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
 # `agents.main` defines `generate_a2ui` — reuse it here instead of cloning.
 from .main import generate_a2ui
 
@@ -24,7 +25,7 @@ _INSTRUCTION = (
 
 declarative_gen_ui_agent = LlmAgent(
     name="DeclarativeGenUiAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[generate_a2ui],
 )

--- a/showcase/starters/google-adk/agent/gen_ui_agent.py
+++ b/showcase/starters/google-adk/agent/gen_ui_agent.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from .shared_chat import get_model
+
 def set_steps(tool_context: ToolContext, steps: list[dict]) -> dict:
     """Publish the current plan + step statuses.
 
@@ -36,7 +38,7 @@ _INSTRUCTION = (
 
 gen_ui_agent = LlmAgent(
     name="GenUiAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[set_steps],
 )

--- a/showcase/starters/google-adk/agent/gen_ui_tool_based_agent.py
+++ b/showcase/starters/google-adk/agent/gen_ui_tool_based_agent.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
+
 _INSTRUCTION = (
     "You are a helpful assistant that generates richly-formatted UI via "
     "frontend tools. When the user asks for a haiku, call the generate_haiku "
@@ -20,7 +22,7 @@ _INSTRUCTION = (
 
 gen_ui_tool_based_agent = LlmAgent(
     name="GenUiToolBasedAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
 )

--- a/showcase/starters/google-adk/agent/hitl_in_app_agent.py
+++ b/showcase/starters/google-adk/agent/hitl_in_app_agent.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
+
 _INSTRUCTION = (
     "You are an approval-flow assistant. Whenever you propose an action "
     "that needs human sign-off (booking a meeting, charging an account, "
-    "deleting a record, etc.), call the `request_approval` frontend tool "
+    "deleting a record, etc.), call the `request_user_approval` frontend tool "
     "with a clear summary of what you propose and why. Wait for the tool "
     "to return — its result is the user's decision (accepted / rejected, "
     "with optional reason). Only proceed if accepted. Keep your messages "
@@ -23,7 +25,7 @@ _INSTRUCTION = (
 
 hitl_in_app_agent = LlmAgent(
     name="HitlInAppAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
 )

--- a/showcase/starters/google-adk/agent/hitl_in_chat_agent.py
+++ b/showcase/starters/google-adk/agent/hitl_in_chat_agent.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from .shared_chat import get_model
+
 def generate_task_steps(tool_context: ToolContext, steps: list[dict]) -> dict:
     """Generate a list of steps for the user to review.
 
@@ -39,7 +41,7 @@ _INSTRUCTION = (
 
 hitl_in_chat_agent = LlmAgent(
     name="HitlInChatAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[generate_task_steps],
 )

--- a/showcase/starters/google-adk/agent/main.py
+++ b/showcase/starters/google-adk/agent/main.py
@@ -20,6 +20,7 @@ from google.genai import types
 
 import os
 
+from .shared_chat import get_model
 from .tools import (
     get_weather_impl,
     query_data_impl,
@@ -61,7 +62,16 @@ def _get_genai_client():
     Cache bookkeeping is thread-safe via `functools.lru_cache`; see the
     module-level comment above for the cold-cache race caveat. Call
     `.cache_clear()` in tests that need to reset the memoized instance.
+
+    When `GOOGLE_GEMINI_BASE_URL` is set (Railway aimock proxy), the client
+    is configured to send requests to that endpoint instead of the default
+    Gemini API.
     """
+    base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
+    if base_url:
+        return genai.Client(
+            http_options={"api_endpoint": base_url},
+        )
     return genai.Client()
 
 class _A2uiError(TypedDict):
@@ -582,7 +592,7 @@ def simple_after_model_modifier(
 
 sales_pipeline_agent = LlmAgent(
     name="SalesPipelineAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction="""
         You are a helpful assistant.
 

--- a/showcase/starters/google-adk/agent/multimodal_agent.py
+++ b/showcase/starters/google-adk/agent/multimodal_agent.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
+
 _INSTRUCTION = (
     "You are a multimodal assistant. The user can upload images and PDFs "
     "via the chat composer. When attachments are present, describe what "
@@ -20,7 +22,7 @@ _INSTRUCTION = (
 
 multimodal_agent = LlmAgent(
     name="MultimodalAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
 )

--- a/showcase/starters/google-adk/agent/open_gen_ui_agents.py
+++ b/showcase/starters/google-adk/agent/open_gen_ui_agents.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
+
 _OPEN_GEN_UI_INSTRUCTION = (
     "You are a UI-generation assistant. When the user describes something "
     "they want to see (a card, a form, a small dashboard), respond with a "
@@ -31,14 +33,14 @@ _OPEN_GEN_UI_ADVANCED_INSTRUCTION = (
 
 open_gen_ui_agent = LlmAgent(
     name="OpenGenUiAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_OPEN_GEN_UI_INSTRUCTION,
     tools=[],
 )
 
 open_gen_ui_advanced_agent = LlmAgent(
     name="OpenGenUiAdvancedAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_OPEN_GEN_UI_ADVANCED_INSTRUCTION,
     tools=[],
 )

--- a/showcase/starters/google-adk/agent/readonly_state_agent_context_agent.py
+++ b/showcase/starters/google-adk/agent/readonly_state_agent_context_agent.py
@@ -18,6 +18,8 @@ from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.genai import types
 
+from .shared_chat import get_model
+
 logger = logging.getLogger(__name__)
 
 CONTEXT_PREFIX_SIGNATURE = "[agent-context] frontend-supplied context:"
@@ -135,7 +137,7 @@ _INSTRUCTION = (
 
 readonly_state_agent_context_agent = LlmAgent(
     name="ReadonlyStateAgentContextAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[],
     before_model_callback=_inject_context,

--- a/showcase/starters/google-adk/agent/shared_chat.py
+++ b/showcase/starters/google-adk/agent/shared_chat.py
@@ -8,14 +8,36 @@ headless-simple, headless-complete, voice, frontend-tools, agentic-chat).
 `build_thinking_chat_agent` uses Gemini 2.5 Flash with the thinking_config
 exposed so reasoning is streamed back as `thought` parts; the v2 React core
 renders these via CopilotChatReasoningMessage.
+
+`get_model` returns a `Gemini` instance configured with the aimock proxy
+endpoint when `GOOGLE_GEMINI_BASE_URL` is set, or the default model string
+otherwise. All agent modules should call `get_model()` instead of
+hard-coding `"gemini-2.5-flash"` so Railway deployments route through
+aimock.
 """
 
 from __future__ import annotations
 
+import os
+from typing import Union
+
 from google.adk.agents import LlmAgent
+from google.adk.models.google_llm import Gemini
 from google.genai import types
 
 DEFAULT_MODEL = "gemini-2.5-flash"
+
+def get_model(model: str = DEFAULT_MODEL) -> Union[str, Gemini]:
+    """Return a model suitable for LlmAgent's `model=` parameter.
+
+    When `GOOGLE_GEMINI_BASE_URL` is set (Railway aimock proxy), returns a
+    `Gemini` instance with its `base_url` pointed at the proxy. Otherwise
+    returns the plain model string so the ADK resolves the default endpoint.
+    """
+    base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
+    if base_url:
+        return Gemini(model=model, base_url=base_url)
+    return model
 
 def build_simple_chat_agent(
     *,
@@ -23,7 +45,7 @@ def build_simple_chat_agent(
     instruction: str,
     model: str = DEFAULT_MODEL,
 ) -> LlmAgent:
-    return LlmAgent(name=name, model=model, instruction=instruction, tools=[])
+    return LlmAgent(name=name, model=get_model(model), instruction=instruction, tools=[])
 
 def build_thinking_chat_agent(
     *,
@@ -40,7 +62,7 @@ def build_thinking_chat_agent(
     """
     return LlmAgent(
         name=name,
-        model=model,
+        model=get_model(model),
         instruction=instruction,
         tools=[],
         generate_content_config=types.GenerateContentConfig(

--- a/showcase/starters/google-adk/agent/shared_state_read_agent.py
+++ b/showcase/starters/google-adk/agent/shared_state_read_agent.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from .shared_chat import get_model
+
 def set_recipe(tool_context: ToolContext, recipe: dict) -> dict:
     """Replace the entire recipe in shared state.
 
@@ -31,7 +33,7 @@ _INSTRUCTION = (
 
 shared_state_read_agent = LlmAgent(
     name="SharedStateReadAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[set_recipe],
 )

--- a/showcase/starters/google-adk/agent/shared_state_read_write_agent.py
+++ b/showcase/starters/google-adk/agent/shared_state_read_write_agent.py
@@ -18,6 +18,8 @@ from typing import Optional
 
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
+
+from .shared_chat import get_model
 from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.tools import ToolContext
@@ -141,7 +143,7 @@ _INSTRUCTION = (
 
 shared_state_read_write_agent = LlmAgent(
     name="SharedStateReadWriteAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[set_notes],
     before_model_callback=_inject_preferences,

--- a/showcase/starters/google-adk/agent/shared_state_streaming_agent.py
+++ b/showcase/starters/google-adk/agent/shared_state_streaming_agent.py
@@ -32,6 +32,8 @@ from ag_ui_adk.config import PredictStateMapping
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 
+from .shared_chat import get_model
+
 def write_document(tool_context: ToolContext, content: str) -> dict:
     """Write a document into shared state.
 
@@ -52,7 +54,7 @@ _INSTRUCTION = (
 
 shared_state_streaming_agent = LlmAgent(
     name="SharedStateStreamingAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=_INSTRUCTION,
     tools=[write_document],
 )

--- a/showcase/starters/google-adk/agent/subagents_agent.py
+++ b/showcase/starters/google-adk/agent/subagents_agent.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 
 import functools
 import logging
+import os
 import uuid
 
 from google import genai
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
 from google.genai import types
+
+from .shared_chat import get_model
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +43,9 @@ _CRITIQUE_SYSTEM = (
 
 @functools.lru_cache(maxsize=1)
 def _client() -> genai.Client:
+    base_url = os.environ.get("GOOGLE_GEMINI_BASE_URL")
+    if base_url:
+        return genai.Client(http_options={"api_endpoint": base_url})
     return genai.Client()
 
 class _SubAgentError(Exception):
@@ -258,7 +264,7 @@ _SUPERVISOR_INSTRUCTION = (
 
 subagents_root_agent = LlmAgent(
     name="SubagentsSupervisor",
-    model=_SUB_MODEL,
+    model=get_model(_SUB_MODEL),
     instruction=_SUPERVISOR_INSTRUCTION,
     tools=[research_agent, writing_agent, critique_agent],
 )

--- a/showcase/starters/google-adk/agent/tool_rendering_agent.py
+++ b/showcase/starters/google-adk/agent/tool_rendering_agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
 from .tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -18,7 +19,7 @@ from .tool_rendering_common import (
 
 tool_rendering_agent = LlmAgent(
     name="ToolRenderingAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
 )

--- a/showcase/starters/google-adk/agent/tool_rendering_custom_catchall_agent.py
+++ b/showcase/starters/google-adk/agent/tool_rendering_custom_catchall_agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
 from .tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -18,7 +19,7 @@ from .tool_rendering_common import (
 
 tool_rendering_custom_catchall_agent = LlmAgent(
     name="ToolRenderingCustomCatchallAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
 )

--- a/showcase/starters/google-adk/agent/tool_rendering_default_catchall_agent.py
+++ b/showcase/starters/google-adk/agent/tool_rendering_default_catchall_agent.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 
+from .shared_chat import get_model
 from .tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -19,7 +20,7 @@ from .tool_rendering_common import (
 
 tool_rendering_default_catchall_agent = LlmAgent(
     name="ToolRenderingDefaultCatchallAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
 )

--- a/showcase/starters/google-adk/agent/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/starters/google-adk/agent/tool_rendering_reasoning_chain_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from google.adk.agents import LlmAgent
 from google.genai import types
 
+from .shared_chat import get_model
 from .tool_rendering_common import (
     TOOL_RENDERING_INSTRUCTION,
     get_weather,
@@ -20,7 +21,7 @@ from .tool_rendering_common import (
 
 tool_rendering_reasoning_chain_agent = LlmAgent(
     name="ToolRenderingReasoningChainAgent",
-    model="gemini-2.5-flash",
+    model=get_model(),
     instruction=TOOL_RENDERING_INSTRUCTION,
     tools=[get_weather, search_flights, query_data],
     generate_content_config=types.GenerateContentConfig(

--- a/showcase/starters/langgraph-fastapi/src/agents/src/agent.py
+++ b/showcase/starters/langgraph-fastapi/src/agents/src/agent.py
@@ -1,7 +1,10 @@
 """
 LangGraph agent for the CopilotKit Showcase (FastAPI variant).
 
-Uses langgraph.prebuilt.create_react_agent with langgraph>=1.1.0.
+Uses copilotkit's create_agent (wrapping langgraph) with CopilotKitMiddleware
+so frontend-registered tools (useHumanInTheLoop, useFrontendTool) are properly
+injected into the LLM's tool list and executed on the frontend rather than
+locally.
 """
 
 from src.agents.tools import (
@@ -19,14 +22,14 @@ import json
 import time
 from typing import Any
 
-from langgraph.prebuilt import create_react_agent
 from langchain_openai import ChatOpenAI
 from langchain_core.tools import tool as lc_tool
 from langchain_core.messages import SystemMessage
-from langchain.agents import AgentState as BaseAgentState
+from langchain.agents import AgentState as BaseAgentState, create_agent
 from langchain.tools import ToolRuntime, tool
 from langchain.messages import ToolMessage
 from langgraph.types import Command
+from copilotkit import CopilotKitMiddleware
 
 class AgentState(BaseAgentState):
     todos: list[SalesTodo]
@@ -144,7 +147,7 @@ You can:
 - Generate step-by-step plans for user review (human-in-the-loop)
 """
 
-graph = create_react_agent(
+graph = create_agent(
     model=model,
     tools=[
         get_weather,
@@ -155,5 +158,7 @@ graph = create_react_agent(
         manage_sales_todos,
         get_sales_todos,
     ],
-    prompt=SYSTEM_PROMPT,
+    middleware=[CopilotKitMiddleware()],
+    state_schema=AgentState,
+    system_prompt=SYSTEM_PROMPT,
 )

--- a/showcase/starters/langroid/agent/agui_adapter.py
+++ b/showcase/starters/langroid/agent/agui_adapter.py
@@ -1,14 +1,20 @@
 """
 AG-UI SSE Adapter for Langroid
 
-Implements the AG-UI protocol over SSE, translating between
-Langroid's ChatAgent and the AG-UI event stream that CopilotKit expects.
+Implements the AG-UI protocol over SSE, calling the OpenAI chat completions
+API directly (via ``openai.AsyncOpenAI``) and translating the response into
+the AG-UI event stream that CopilotKit expects. Tool schemas are derived
+from Langroid ToolMessage subclasses defined in ``agents.agent``.
+
+The adapter preserves structured multi-turn messages (including ``role:
+"tool"`` with ``tool_call_id``) so that aimock fixture matchers can match
+follow-up requests by toolCallId — enabling the frontend tool execution
+loop (e.g. gen-ui-headless: show_card → follow-up narration).
 
 AG-UI event types used:
   - RUN_STARTED / RUN_FINISHED
   - TEXT_MESSAGE_START / TEXT_MESSAGE_CONTENT / TEXT_MESSAGE_END
   - TOOL_CALL_START / TOOL_CALL_ARGS / TOOL_CALL_END
-  - STATE_SNAPSHOT
 """
 
 from __future__ import annotations
@@ -16,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import uuid
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -34,7 +41,6 @@ from ag_ui.core import (
     ToolCallStartEvent,
     ToolCallArgsEvent,
     ToolCallEndEvent,
-    StateSnapshotEvent,
     RunAgentInput,
 )
 from fastapi import Request
@@ -42,14 +48,12 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from .agent import (
     build_agent_config_system_prompt,
-    create_agent,
     extract_agent_config_properties,
     ALL_TOOLS,
-    BACKEND_TOOLS,
     FRONTEND_TOOL_NAMES,
+    SYSTEM_PROMPT,
 )
 
-import langroid as lr
 from langroid.agent.tool_message import ToolMessage
 
 logger = logging.getLogger(__name__)
@@ -244,6 +248,209 @@ async def _run_backend_tool(
         _execute_backend_tool, tool_instance, tool_name
     )
 
+def _agui_messages_to_openai(
+    messages: list,
+    system_prompt: str,
+) -> list[dict[str, Any]]:
+    """Convert AG-UI messages to OpenAI chat completion format.
+
+    AG-UI messages arrive as typed Pydantic models (UserMessage,
+    AssistantMessage, ToolMessage, etc.) with fields like ``tool_calls``
+    and ``tool_call_id``. The previous flattening logic (``"role: content"``)
+    lost these structured fields, preventing aimock's ``toolCallId`` fixture
+    matcher from finding follow-up tool results.
+
+    This function preserves the full message structure so the OpenAI API
+    (or aimock standing in for it) receives proper multi-turn conversations
+    including ``role: "tool"`` messages with ``tool_call_id``.
+    """
+    oai_msgs: list[dict[str, Any]] = [
+        {"role": "system", "content": system_prompt},
+    ]
+
+    for msg in messages:
+        role = getattr(msg, "role", None)
+        if not isinstance(role, str):
+            if isinstance(msg, dict):
+                role = msg.get("role")
+            if not isinstance(role, str):
+                continue
+
+        if role == "tool":
+            # AG-UI ToolMessage → OpenAI tool result message.
+            tool_call_id = getattr(msg, "tool_call_id", None)
+            if isinstance(msg, dict):
+                tool_call_id = tool_call_id or msg.get("tool_call_id")
+            content = getattr(msg, "content", "") or ""
+            if isinstance(msg, dict):
+                content = content or msg.get("content", "")
+            if tool_call_id:
+                oai_msgs.append({
+                    "role": "tool",
+                    "tool_call_id": str(tool_call_id),
+                    "content": str(content),
+                })
+            continue
+
+        if role == "assistant":
+            # AG-UI AssistantMessage may carry tool_calls.
+            content = getattr(msg, "content", None)
+            if isinstance(msg, dict):
+                content = content or msg.get("content")
+            tool_calls_raw = getattr(msg, "tool_calls", None)
+            if isinstance(msg, dict):
+                tool_calls_raw = tool_calls_raw or msg.get("tool_calls")
+
+            oai_msg: dict[str, Any] = {"role": "assistant"}
+            if content:
+                oai_msg["content"] = str(content)
+            if tool_calls_raw:
+                oai_tcs = []
+                for tc in tool_calls_raw:
+                    tc_id = getattr(tc, "id", None)
+                    fn = getattr(tc, "function", None)
+                    if fn is None and isinstance(tc, dict):
+                        fn_name = tc.get("function", {}).get("name", "")
+                        fn_args = tc.get("function", {}).get("arguments", "")
+                        tc_id = tc_id or tc.get("id", "")
+                    else:
+                        fn_name = getattr(fn, "name", "") if fn else ""
+                        fn_args = getattr(fn, "arguments", "") if fn else ""
+                    if tc_id and fn_name:
+                        oai_tcs.append({
+                            "id": str(tc_id),
+                            "type": "function",
+                            "function": {
+                                "name": str(fn_name),
+                                "arguments": str(fn_args),
+                            },
+                        })
+                if oai_tcs:
+                    oai_msg["tool_calls"] = oai_tcs
+                    # OpenAI requires content to be null (not missing)
+                    # when tool_calls are present and there's no text.
+                    if "content" not in oai_msg:
+                        oai_msg["content"] = None
+            else:
+                # Plain assistant text — ensure content is present.
+                if "content" not in oai_msg:
+                    oai_msg["content"] = ""
+            oai_msgs.append(oai_msg)
+            continue
+
+        if role in ("user", "system", "developer"):
+            content = getattr(msg, "content", None)
+            if isinstance(msg, dict):
+                content = content or msg.get("content")
+            if content is not None:
+                oai_msgs.append({
+                    "role": role,
+                    "content": str(content),
+                })
+            continue
+
+        # Unknown role — skip with a debug log.
+        logger.debug(
+            "Skipping message with unrecognized role %r in "
+            "_agui_messages_to_openai",
+            role,
+        )
+
+    return oai_msgs
+
+def _build_openai_tools() -> list[dict[str, Any]]:
+    """Build OpenAI-format tool definitions from ALL_TOOLS.
+
+    Each Langroid ToolMessage subclass declares ``request`` (tool name),
+    ``purpose`` (description), and typed fields (parameters). We convert
+    these into the ``{"type": "function", "function": {...}}`` shape that
+    the OpenAI chat completions API expects.
+    """
+    tools: list[dict[str, Any]] = []
+    for tool_cls in ALL_TOOLS:
+        name = tool_cls.default_value("request")
+        purpose = tool_cls.default_value("purpose") if hasattr(tool_cls, "purpose") else ""
+
+        # Build parameters from model fields, excluding metadata.
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for field_name, field_info in tool_cls.model_fields.items():
+            if field_name in ("request", "purpose", "result"):
+                continue
+            # Simple type mapping — sufficient for aimock fixture matching.
+            annotation = field_info.annotation
+            if annotation is str or (hasattr(annotation, "__origin__") is False and annotation is str):
+                prop = {"type": "string"}
+            elif annotation is int:
+                prop = {"type": "integer"}
+            elif annotation is float:
+                prop = {"type": "number"}
+            elif annotation is bool:
+                prop = {"type": "boolean"}
+            elif annotation is list or (hasattr(annotation, "__origin__") and getattr(annotation, "__origin__", None) is list):
+                prop = {"type": "array"}
+            else:
+                prop = {"type": "string"}
+
+            desc = ""
+            if hasattr(field_info, "description") and field_info.description:
+                desc = field_info.description
+            elif hasattr(field_info, "metadata"):
+                for m in field_info.metadata:
+                    if isinstance(m, str):
+                        desc = m
+                        break
+            if desc:
+                prop["description"] = desc
+
+            properties[field_name] = prop
+            if field_info.default is pydantic.fields.PydanticUndefined:
+                required.append(field_name)
+
+        func_def: dict[str, Any] = {
+            "name": name,
+            "description": purpose or f"Tool: {name}",
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+            },
+        }
+        if required:
+            func_def["parameters"]["required"] = required
+
+        tools.append({"type": "function", "function": func_def})
+
+    return tools
+
+# Cache tool definitions — they don't change at runtime.
+_OPENAI_TOOLS: list[dict[str, Any]] | None = None
+
+def _get_openai_tools() -> list[dict[str, Any]]:
+    """Return cached OpenAI tool definitions."""
+    global _OPENAI_TOOLS
+    if _OPENAI_TOOLS is None:
+        _OPENAI_TOOLS = _build_openai_tools()
+    return _OPENAI_TOOLS
+
+async def _call_openai(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    model: str,
+) -> Any:
+    """Call the OpenAI chat completions API directly.
+
+    Uses ``openai.AsyncOpenAI()`` which reads ``OPENAI_API_KEY`` and
+    ``OPENAI_BASE_URL`` from the environment (aimock sets the base URL
+    in the showcase). Returns the first choice's message object.
+    """
+    client = openai.AsyncOpenAI()
+    response = await client.chat.completions.create(
+        model=model,
+        messages=messages,
+        tools=tools if tools else openai.NOT_GIVEN,
+    )
+    return response.choices[0].message
+
 async def handle_run(request: Request) -> StreamingResponse:
     """Handle an AG-UI /run endpoint — parse input, run agent, stream events."""
     # Parse request body defensively. A malformed body (bad JSON, missing
@@ -290,49 +497,25 @@ async def handle_run(request: Request) -> StreamingResponse:
     agent_config_props = extract_agent_config_properties(
         run_input.forwarded_props
     )
-    system_override: str | None = None
+    system_prompt = SYSTEM_PROMPT
     if agent_config_props is not None:
-        system_override = build_agent_config_system_prompt(
+        system_prompt = build_agent_config_system_prompt(
             tone=agent_config_props.get("tone"),
             expertise=agent_config_props.get("expertise"),
             response_length=agent_config_props.get("responseLength"),
         )
-    agent = create_agent(system_message=system_override)
 
-    # Build conversation history from all messages so multi-turn works.
-    # Each ``msg.role`` / ``msg.content`` must be a string — silently
-    # f-stringifying ``None`` or a complex object produces garbage like
-    # "None: {'foo': 'bar'}" that the LLM then tries to interpret as
-    # conversation. Drop non-string entries and log a warning so the
-    # shape drift is at least visible in ops logs.
-    conversation_parts: list[str] = []
-    if run_input.messages:
-        for msg in run_input.messages:
-            if hasattr(msg, "role") and hasattr(msg, "content"):
-                role = getattr(msg, "role", None)
-                content = getattr(msg, "content", None)
-                if not isinstance(role, str) or not isinstance(content, str):
-                    logger.warning(
-                        "Skipping message with non-string role/content "
-                        "(role=%s, content=%s)",
-                        type(role).__name__,
-                        type(content).__name__,
-                    )
-                    continue
-                conversation_parts.append(f"{role}: {content}")
-            elif isinstance(msg, dict):
-                role = msg.get("role", "user")
-                content = msg.get("content", "")
-                if not isinstance(role, str) or not isinstance(content, str):
-                    logger.warning(
-                        "Skipping dict message with non-string role/content "
-                        "(role=%s, content=%s)",
-                        type(role).__name__,
-                        type(content).__name__,
-                    )
-                    continue
-                conversation_parts.append(f"{role}: {content}")
-    user_message = "\n".join(conversation_parts) if conversation_parts else ""
+    # Build proper OpenAI-format messages from the AG-UI message history.
+    # The previous approach flattened all messages into a single "role:
+    # content" string, which lost structured fields like tool_call_id and
+    # tool_calls. This prevented aimock's toolCallId fixture matcher from
+    # finding follow-up tool results, breaking the gen-ui-headless flow
+    # (frontend tool → follow-up narration never arrived).
+    oai_messages = _agui_messages_to_openai(
+        run_input.messages or [], system_prompt
+    )
+    model = os.getenv("LANGROID_MODEL", "gpt-4.1")
+    oai_tools = _get_openai_tools()
 
     # Compute the effective thread_id ONCE so every event emitted for this
     # run (RUN_STARTED, RUN_FINISHED, ...) references the same thread.
@@ -376,37 +559,25 @@ async def handle_run(request: Request) -> StreamingResponse:
             run_id=run_id,
         ))
 
-        # Run the Langroid agent. Any failure here happens *after*
-        # RUN_STARTED was emitted, so the frontend is already waiting
-        # for a RUN_FINISHED. If we let the exception escape here, the
-        # generator dies mid-stream and the UI hangs forever. Emit a
-        # sanitized TEXT_MESSAGE triple (so the user sees *something*)
-        # and then RUN_FINISHED to close out the run cleanly. The
-        # full traceback is preserved server-side via
-        # ``logger.exception``.
+        # Call the LLM directly via the OpenAI client. This replaced
+        # langroid's ``agent.llm_response_async(flattened_string)`` to
+        # preserve structured multi-turn messages (tool_calls,
+        # tool_call_id) that aimock's fixture matchers depend on for
+        # follow-up requests (e.g. gen-ui-headless second-leg narration).
         #
-        # Exception scope: narrowed to the set of runtime failures we
-        # actually expect from ``agent.llm_response_async`` — upstream
-        # LLM API errors (``openai.APIError``), transport failures
-        # (``httpx.HTTPError``), timeouts, and schema drift
-        # (``pydantic.ValidationError``). Programmer bugs
-        # (``AttributeError``, ``NameError``, ``TypeError``) are NOT
-        # sanitized here — they propagate up and surface as real
-        # tracebacks. Any uncaught mid-stream exception is still
-        # handled one level up by the route boundary's try/except, but
-        # with a less operator-friendly "unknown error" message —
-        # that's the right trade: a narrower list keeps legitimate
-        # bugs visible instead of masking them as "Agent run failed:
-        # AttributeError".
+        # Any failure here happens *after* RUN_STARTED was emitted, so
+        # the frontend is already waiting for a RUN_FINISHED. Emit a
+        # sanitized TEXT_MESSAGE triple and then RUN_FINISHED to close
+        # out the run cleanly. The full traceback is preserved
+        # server-side via ``logger.exception``.
         try:
-            response = await agent.llm_response_async(user_message)
+            response = await _call_openai(oai_messages, oai_tools, model)
         except (
             openai.APIError,
             httpx.HTTPError,
             asyncio.TimeoutError,
-            pydantic.ValidationError,
         ) as exc:
-            logger.exception("agent.llm_response_async failed mid-stream")
+            logger.exception("_call_openai failed mid-stream")
             err_payload = json.dumps({
                 "error": f"Agent run failed: {exc.__class__.__name__}"
             })
@@ -428,20 +599,12 @@ async def handle_run(request: Request) -> StreamingResponse:
             ))
             return
 
-        # `response` is a Langroid ChatDocument. `.content` is the canonical
-        # source of text; `str(response)` includes debug formatting and is
-        # not a useful fallback, so default to "" when content is absent.
+        # ``response`` is an OpenAI ChatCompletionMessage. ``.content``
+        # is the text; ``.tool_calls`` carries structured tool calls.
         content = getattr(response, "content", None) or ""
+        oai_tool_calls = getattr(response, "tool_calls", None) or []
 
-        # Langroid's OpenAI-backed LLM emits tool calls on
-        # `response.oai_tool_calls` (OpenAI tools API) or `response.function_call`
-        # (legacy function-calling API) with empty `content`. We must synthesize
-        # AG-UI TOOL_CALL_* events from those so CopilotKit's frontend can
-        # render the tool card (weather, haiku, etc.).
-        oai_tool_calls = getattr(response, "oai_tool_calls", None) or []
-        function_call = getattr(response, "function_call", None)
-
-        if oai_tool_calls or function_call:
+        if oai_tool_calls:
             # Emit synthesized tool-call events for each OAI tool call.
             # ``_parse_tool_args`` returns a ``ParsedArgs`` with
             # ``status`` in ``{"ok", "empty", "malformed"}``. We only
@@ -451,31 +614,14 @@ async def handle_run(request: Request) -> StreamingResponse:
             # UI card). The warning already fired inside
             # ``_parse_tool_args`` on the malformed path.
             calls_to_emit = []
-            if oai_tool_calls:
-                for tc in oai_tool_calls:
-                    fn = getattr(tc, "function", None)
-                    name = getattr(fn, "name", None) if fn is not None else None
-                    raw_args = getattr(fn, "arguments", {}) if fn is not None else {}
-                    parsed = _parse_tool_args(raw_args)
-                    call_id = getattr(tc, "id", None) or str(uuid.uuid4())
-                    if name and parsed.usable:
-                        calls_to_emit.append((call_id, name, parsed.args))
-                    elif name:
-                        logger.warning(
-                            "Skipping tool call %s: arguments could not be parsed (status=%s)",
-                            name,
-                            parsed.status,
-                        )
-            elif function_call is not None:
-                # Legacy function_call shape: single call. Empty-string
-                # ``arguments`` is normalized to ``"malformed"`` by
-                # ``_parse_tool_args`` so this path behaves identically
-                # to a malformed-JSON oai call (skip + warn).
-                name = getattr(function_call, "name", None)
-                raw_args = getattr(function_call, "arguments", "") or ""
+            for tc in oai_tool_calls:
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", None) if fn is not None else None
+                raw_args = getattr(fn, "arguments", {}) if fn is not None else {}
                 parsed = _parse_tool_args(raw_args)
+                call_id = getattr(tc, "id", None) or str(uuid.uuid4())
                 if name and parsed.usable:
-                    calls_to_emit.append((str(uuid.uuid4()), name, parsed.args))
+                    calls_to_emit.append((call_id, name, parsed.args))
                 elif name:
                     logger.warning(
                         "Skipping tool call %s: arguments could not be parsed (status=%s)",
@@ -483,40 +629,62 @@ async def handle_run(request: Request) -> StreamingResponse:
                         parsed.status,
                     )
 
-            for call_id, tool_name, tool_args in calls_to_emit:
-                yield _sse_line(ToolCallStartEvent(
-                    type=EventType.TOOL_CALL_START,
-                    tool_call_id=call_id,
-                    tool_call_name=tool_name,
+            if calls_to_emit:
+                # Emit a TEXT_MESSAGE_START to create a parent assistant
+                # message that the tool calls attach to.  Without this,
+                # the AG-UI client still synthesizes a message per tool
+                # call, but the Runtime's middleware SSE parser (used by
+                # open-gen-ui and other middleware) cannot associate tool
+                # calls with a parent message — they are silently dropped.
+                # Emitting the triple (START → tool calls → END) mirrors
+                # what LangGraph and google-adk adapters produce.
+                tc_parent_id = str(uuid.uuid4())
+                yield _sse_line(TextMessageStartEvent(
+                    type=EventType.TEXT_MESSAGE_START,
+                    message_id=tc_parent_id,
                 ))
 
-                yield _sse_line(ToolCallArgsEvent(
-                    type=EventType.TOOL_CALL_ARGS,
-                    tool_call_id=call_id,
-                    delta=json.dumps(tool_args),
+                for call_id, tool_name, tool_args in calls_to_emit:
+                    yield _sse_line(ToolCallStartEvent(
+                        type=EventType.TOOL_CALL_START,
+                        tool_call_id=call_id,
+                        tool_call_name=tool_name,
+                        parent_message_id=tc_parent_id,
+                    ))
+
+                    yield _sse_line(ToolCallArgsEvent(
+                        type=EventType.TOOL_CALL_ARGS,
+                        tool_call_id=call_id,
+                        delta=json.dumps(tool_args),
+                    ))
+
+                    yield _sse_line(ToolCallEndEvent(
+                        type=EventType.TOOL_CALL_END,
+                        tool_call_id=call_id,
+                    ))
+
+                    # For backend tools, execute and stream the result as text.
+                    # Both the oai-path and the content-JSON path below fan
+                    # out through ``_run_backend_tool`` so sanitization and
+                    # off-thread execution behave identically.
+                    if tool_name not in FRONTEND_TOOL_NAMES:
+                        tool_cls = _TOOL_BY_NAME.get(tool_name)
+                        result: str | None = None
+                        if tool_cls is not None:
+                            result = await _run_backend_tool(
+                                tool_cls, tool_name, tool_args
+                            )
+
+                        if result:
+                            msg_id = str(uuid.uuid4())
+                            for line in emit_text_block(msg_id, result):
+                                yield line
+
+                # Close the parent message that wraps the tool calls.
+                yield _sse_line(TextMessageEndEvent(
+                    type=EventType.TEXT_MESSAGE_END,
+                    message_id=tc_parent_id,
                 ))
-
-                yield _sse_line(ToolCallEndEvent(
-                    type=EventType.TOOL_CALL_END,
-                    tool_call_id=call_id,
-                ))
-
-                # For backend tools, execute and stream the result as text.
-                # Both the oai-path and the content-JSON path below fan
-                # out through ``_run_backend_tool`` so sanitization and
-                # off-thread execution behave identically.
-                if tool_name not in FRONTEND_TOOL_NAMES:
-                    tool_cls = _TOOL_BY_NAME.get(tool_name)
-                    result: str | None = None
-                    if tool_cls is not None:
-                        result = await _run_backend_tool(
-                            tool_cls, tool_name, tool_args
-                        )
-
-                    if result:
-                        msg_id = str(uuid.uuid4())
-                        for line in emit_text_block(msg_id, result):
-                            yield line
 
             yield _sse_line(RunFinishedEvent(
                 type=EventType.RUN_FINISHED,
@@ -526,7 +694,7 @@ async def handle_run(request: Request) -> StreamingResponse:
             return
 
         # Check if the response contains a tool call parsed from content
-        tool_msg = _try_parse_tool(content, agent)
+        tool_msg = _try_parse_tool(content)
 
         if tool_msg is not None:
             tool_name = tool_msg.default_value("request") if hasattr(tool_msg, "default_value") else getattr(tool_msg, "request", "unknown")
@@ -545,10 +713,21 @@ async def handle_run(request: Request) -> StreamingResponse:
                     continue
                 tool_args[field_name] = value
 
+            # Emit a parent TEXT_MESSAGE that wraps the tool call, same
+            # as the oai_tool_calls path above. Without this, the
+            # Runtime middleware-sse-parser cannot attach the tool call
+            # to a parent message and silently drops it.
+            ct_parent_id = str(uuid.uuid4())
+            yield _sse_line(TextMessageStartEvent(
+                type=EventType.TEXT_MESSAGE_START,
+                message_id=ct_parent_id,
+            ))
+
             yield _sse_line(ToolCallStartEvent(
                 type=EventType.TOOL_CALL_START,
                 tool_call_id=tool_call_id,
                 tool_call_name=tool_name,
+                parent_message_id=ct_parent_id,
             ))
 
             yield _sse_line(ToolCallArgsEvent(
@@ -596,6 +775,10 @@ async def handle_run(request: Request) -> StreamingResponse:
                         str(uuid.uuid4()), err_payload
                     ):
                         yield line
+                    yield _sse_line(TextMessageEndEvent(
+                        type=EventType.TEXT_MESSAGE_END,
+                        message_id=ct_parent_id,
+                    ))
                     yield _sse_line(RunFinishedEvent(
                         type=EventType.RUN_FINISHED,
                         thread_id=thread_id,
@@ -605,6 +788,12 @@ async def handle_run(request: Request) -> StreamingResponse:
                 if result:
                     for line in emit_text_block(message_id, result):
                         yield line
+
+            # Close the parent message that wraps the tool call.
+            yield _sse_line(TextMessageEndEvent(
+                type=EventType.TEXT_MESSAGE_END,
+                message_id=ct_parent_id,
+            ))
         else:
             # Plain text response — stream it. emit_text_block handles the
             # empty-delta guard (AG-UI requires non-empty deltas, e.g. a
@@ -628,14 +817,14 @@ async def handle_run(request: Request) -> StreamingResponse:
         },
     )
 
-def _try_parse_tool(content: str, agent: lr.ChatAgent) -> ToolMessage | None:
+def _try_parse_tool(content: str) -> ToolMessage | None:
     """Try to parse a Langroid ToolMessage from the LLM response content.
 
-    Langroid's `agent.llm_response_async(...)` returns a `ChatDocument`,
-    not a `ToolMessage`, so the previous isinstance-based path was
-    effectively dead code. We rely on the JSON fallback, which matches
-    both the Langroid tool envelope (`{"request": ..., ...}`) and the
-    OpenAI function-call shape (`{"name": ..., "arguments": ...}`).
+    The OpenAI response's ``content`` field sometimes contains a JSON
+    tool envelope (Langroid convention: ``{"request": ..., ...}``) or
+    an OpenAI function-call shape (``{"name": ..., "arguments": ...}``).
+    This fallback path catches those cases when the response didn't use
+    the structured ``tool_calls`` field.
 
     Logging philosophy (matters — this is on the hot path for every
     turn, including plain chat replies like "hello"):

--- a/showcase/starters/llamaindex/agent/agent.py
+++ b/showcase/starters/llamaindex/agent/agent.py
@@ -52,6 +52,13 @@ def generate_task_steps(
     """Generate a list of task steps for the user to review and approve."""
     return f"Generated {len(steps)} steps for review"
 
+def book_call(
+    topic: Annotated[str, "What the call is about (e.g. 'Onboarding call')"],
+    name: Annotated[str, "Name of the attendee"],
+) -> str:
+    """Ask the user to pick a time slot for a call. The picker UI presents fixed candidate slots; the user's choice is returned to the agent."""
+    return f"Booking call about {topic} with {name}"
+
 # --- Backend tools (executed server-side, using shared implementations) ---
 
 async def get_weather(
@@ -141,9 +148,13 @@ async def generate_a2ui(
     result = build_a2ui_operations_from_tool_call(args)
     return json.dumps(result)
 
+_openai_kwargs = {}
+if os.environ.get("OPENAI_BASE_URL"):
+    _openai_kwargs["api_base"] = os.environ["OPENAI_BASE_URL"]
+
 agent_router = get_ag_ui_workflow_router(
-    llm=OpenAI(model="gpt-4.1"),
-    frontend_tools=[change_background, generate_haiku, generate_task_steps],
+    llm=OpenAI(model="gpt-4.1", **_openai_kwargs),
+    frontend_tools=[change_background, generate_haiku, generate_task_steps, book_call],
     backend_tools=[get_weather, query_data, manage_sales_todos, get_sales_todos_tool, schedule_meeting, search_flights, generate_a2ui],
     system_prompt=(
         "You are a polished, professional demo assistant for CopilotKit. "
@@ -158,8 +169,10 @@ agent_router = get_ag_ui_workflow_router(
         "- Search flights and display rich A2UI cards (via search_flights tool)\n"
         "- Generate dynamic A2UI dashboards from conversation context (via generate_a2ui tool)\n"
         "- Generate step-by-step plans for user review (human-in-the-loop)\n"
+        "- Book calls with people (via book_call frontend tool)\n"
         "When asked about weather, always use the get_weather tool. "
-        "When asked about financial data or charts, use query_data first."
+        "When asked about financial data or charts, use query_data first. "
+        "When asked to book a call, use the book_call tool with topic and name."
     ),
     initial_state={
         "todos": [],

--- a/showcase/starters/spring-ai/entrypoint.sh
+++ b/showcase/starters/spring-ai/entrypoint.sh
@@ -32,6 +32,14 @@ else
   echo "[entrypoint] OPENAI_API_KEY: set (${#OPENAI_API_KEY} chars)"
 fi
 
+# Derive SPRING_AI_OPENAI_BASE_URL from the showcase-wide OPENAI_BASE_URL if
+# not already set. OPENAI_BASE_URL includes "/v1" but Spring AI appends
+# "/v1/chat/completions" itself, so strip the trailing "/v1".
+if [ -z "${SPRING_AI_OPENAI_BASE_URL:-}" ] && [ -n "${OPENAI_BASE_URL:-}" ]; then
+    export SPRING_AI_OPENAI_BASE_URL="${OPENAI_BASE_URL%/v1}"
+    echo "[entrypoint] Derived SPRING_AI_OPENAI_BASE_URL=${SPRING_AI_OPENAI_BASE_URL} from OPENAI_BASE_URL=${OPENAI_BASE_URL}"
+fi
+
 echo "[entrypoint] Starting Spring AI agent on port 8123..."
 java -jar agent/app.jar --server.port=8123 &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!


### PR DESCRIPTION
## Summary

Comprehensive D5 probe fixes to get all probes green across 17 integrations.

**Fixture fixes (d5-all.json + individual fixtures):**
- Convert ALL toolCallId-based matching to sequenceIndex — Gemini's functionResponse has no id field, so aimock synthesizes IDs that don't match fixture strings. sequenceIndex is provider-agnostic.
- Add missing generate_haiku fixtures (were in gen-ui-custom.json but never bundled)
- Fix hitl-text-input arg `name` → `attendee` to match frontend schema

**Tool-rendering fix (16 integration pages):**
- All non-LGP pages used `result?.temperature` on a JSON string. Add `parseJsonResult<T>()` helper to parse string before accessing properties.

**Backend/routing fixes (earlier commits):**
- Route google-adk through aimock for ALL agent types
- Add CopilotKitMiddleware to langgraph-fastapi for frontend tool injection
- Rewrite langroid AGUI adapter for proper tool result handling
- Fix hitl-text-input D5 feature mapping
- Add langgraph-python hitl-in-chat page
- Remove architecturally unsupported HITL features from 5 manifests (agno, claude-sdk-python, google-adk, llamaindex, spring-ai)

**Starters:**
- Regenerate to sync with package changes

## Test plan

- [ ] CI green (drift-check, commitlint, format, tests)
- [ ] Deploy ops image → D5 probes run against all 17 integrations
- [ ] Dashboard shows green across fixture-covered features