### PR TITLE
fix(showcase): repair agent-config (LangGraph 1.x context) + multimodal aimock fixtures

### DIFF
--- a/showcase/aimock/feature-parity.json
+++ b/showcase/aimock/feature-parity.json
@@ -364,6 +364,22 @@
     },
     {
       "match": {
+        "userMessage": "this PDF"
+      },
+      "response": {
+        "content": "The attached PDF is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "this image"
+      },
+      "response": {
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
+      }
+    },
+    {
+      "match": {
         "userMessage": "hi"
       },
       "response": {

--- a/showcase/integrations/langgraph-python/src/agents/agent_config_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/agent_config_agent.py
@@ -1,20 +1,27 @@
 """LangGraph agent backing the Agent Config Object demo.
 
 Reads three forwarded properties — tone, expertise, responseLength — from the
-LangGraph run's ``RunnableConfig["configurable"]["properties"]`` dict and
-builds its system prompt dynamically per turn.
+LangGraph runtime context (``Runtime[AgentConfigContext].context``) and builds
+its system prompt dynamically per turn.
 
 The CopilotKit provider's ``properties`` prop is wired through the runtime as
-``forwardedProps`` on each AG-UI run. This graph reads those with defensive
-defaults (unknown / missing values fall back to the defaults) and composes the
-system prompt from three small rulebooks before invoking the model.
+``forwardedProps`` on each AG-UI run; the Next.js route wrapper at
+``src/app/api/copilotkit-agent-config/route.ts`` repacks those props onto
+``forwardedProps.context`` so they arrive here as the run's runtime context.
+
+LangGraph 1.x rejects ``configurable`` when ``context`` is also present
+("Cannot specify both configurable and context"), so the demo deliberately
+uses the ``context`` channel only. ``RunnableConfig["configurable"]`` is no
+longer consulted by this graph.
 """
 
 from typing import Any, Literal
 
-from langchain_core.runnables import RunnableConfig
+from typing_extensions import TypedDict
+
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.runtime import Runtime
 
 
 _llm: ChatOpenAI | None = None
@@ -41,18 +48,34 @@ VALID_EXPERTISE: set[str] = {"beginner", "intermediate", "expert"}
 VALID_RESPONSE_LENGTHS: set[str] = {"concise", "detailed"}
 
 
-def read_properties(config: RunnableConfig | None) -> dict[str, str]:
-    """Read the forwarded ``properties`` object with defensive defaults.
+class AgentConfigContext(TypedDict, total=False):
+    """Run-scoped context schema for the Agent Config demo.
+
+    The route wrapper repacks the CopilotKit provider's ``properties`` onto
+    ``forwardedProps.context``, which LangGraph then surfaces here as the
+    run's ``Runtime.context``. ``total=False`` keeps every field optional —
+    ``read_properties`` falls back to defaults for anything missing.
+    """
+
+    tone: str
+    expertise: str
+    responseLength: str
+
+
+def read_properties(
+    ctx: AgentConfigContext | dict[str, Any] | None,
+) -> dict[str, str]:
+    """Read forwarded properties from the runtime context with defensive
+    defaults.
 
     Any missing or unrecognized value falls back to the corresponding
     ``DEFAULT_*`` constant. The function never raises.
     """
-    configurable = (config or {}).get("configurable", {}) or {}
-    properties = configurable.get("properties", {}) or {}
+    ctx_dict: dict[str, Any] = dict(ctx) if ctx else {}
 
-    tone = properties.get("tone", DEFAULT_TONE)
-    expertise = properties.get("expertise", DEFAULT_EXPERTISE)
-    response_length = properties.get("responseLength", DEFAULT_RESPONSE_LENGTH)
+    tone = ctx_dict.get("tone", DEFAULT_TONE)
+    expertise = ctx_dict.get("expertise", DEFAULT_EXPERTISE)
+    response_length = ctx_dict.get("responseLength", DEFAULT_RESPONSE_LENGTH)
 
     if tone not in VALID_TONES:
         tone = DEFAULT_TONE
@@ -106,10 +129,11 @@ def build_system_prompt(tone: str, expertise: str, response_length: str) -> str:
 
 
 def call_model(
-    state: MessagesState, config: RunnableConfig | None = None
+    state: MessagesState,
+    runtime: Runtime[AgentConfigContext],
 ) -> dict[str, Any]:
-    """Single graph node — read forwarded props, build prompt, invoke LLM."""
-    props = read_properties(config)
+    """Single graph node — read runtime context, build prompt, invoke LLM."""
+    props = read_properties(runtime.context if runtime else None)
     system_prompt = build_system_prompt(
         props["tone"], props["expertise"], props["response_length"]
     )
@@ -118,7 +142,7 @@ def call_model(
     return {"messages": [response]}
 
 
-graph_builder = StateGraph(MessagesState)
+graph_builder = StateGraph(MessagesState, context_schema=AgentConfigContext)
 graph_builder.add_node("model", call_model)
 graph_builder.add_edge(START, "model")
 graph_builder.add_edge("model", END)

--- a/showcase/integrations/langgraph-python/src/agents/test_agent_config_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/test_agent_config_agent.py
@@ -1,4 +1,10 @@
-"""Unit tests for agent_config_agent's prompt builder + defensive defaults."""
+"""Unit tests for agent_config_agent's prompt builder + defensive defaults.
+
+`read_properties` now takes the runtime context dict directly (the agent
+reads from ``Runtime[AgentConfigContext].context`` rather than from
+``RunnableConfig["configurable"]["properties"]``), so these tests pass flat
+dicts that mirror the on-the-wire context payload.
+"""
 
 from src.agents.agent_config_agent import (
     DEFAULT_EXPERTISE,
@@ -18,17 +24,8 @@ def test_read_properties_returns_defaults_when_missing():
     }
 
 
-def test_read_properties_returns_defaults_when_configurable_missing():
+def test_read_properties_returns_defaults_when_context_empty():
     result = read_properties({})
-    assert result == {
-        "tone": DEFAULT_TONE,
-        "expertise": DEFAULT_EXPERTISE,
-        "response_length": DEFAULT_RESPONSE_LENGTH,
-    }
-
-
-def test_read_properties_returns_defaults_when_properties_missing():
-    result = read_properties({"configurable": {}})
     assert result == {
         "tone": DEFAULT_TONE,
         "expertise": DEFAULT_EXPERTISE,
@@ -39,13 +36,9 @@ def test_read_properties_returns_defaults_when_properties_missing():
 def test_read_properties_accepts_valid_values():
     result = read_properties(
         {
-            "configurable": {
-                "properties": {
-                    "tone": "enthusiastic",
-                    "expertise": "expert",
-                    "responseLength": "detailed",
-                }
-            }
+            "tone": "enthusiastic",
+            "expertise": "expert",
+            "responseLength": "detailed",
         }
     )
     assert result == {
@@ -56,36 +49,26 @@ def test_read_properties_accepts_valid_values():
 
 
 def test_read_properties_rejects_invalid_tone_to_default():
-    result = read_properties(
-        {"configurable": {"properties": {"tone": "sinister"}}}
-    )
+    result = read_properties({"tone": "sinister"})
     assert result["tone"] == DEFAULT_TONE
 
 
 def test_read_properties_rejects_invalid_expertise_to_default():
-    result = read_properties(
-        {"configurable": {"properties": {"expertise": "ninja"}}}
-    )
+    result = read_properties({"expertise": "ninja"})
     assert result["expertise"] == DEFAULT_EXPERTISE
 
 
 def test_read_properties_rejects_invalid_length_to_default():
-    result = read_properties(
-        {"configurable": {"properties": {"responseLength": "epic"}}}
-    )
+    result = read_properties({"responseLength": "epic"})
     assert result["response_length"] == DEFAULT_RESPONSE_LENGTH
 
 
 def test_read_properties_mixes_valid_and_invalid():
     result = read_properties(
         {
-            "configurable": {
-                "properties": {
-                    "tone": "casual",
-                    "expertise": "unknown",
-                    "responseLength": "detailed",
-                }
-            }
+            "tone": "casual",
+            "expertise": "unknown",
+            "responseLength": "detailed",
         }
     )
     assert result == {

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-agent-config/route.ts
@@ -36,16 +36,22 @@ const LANGGRAPH_URL =
   process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
 // Keys on `forwardedProps` that the ag-ui LangGraphAgent treats as reserved
-// stream-payload fields (e.g. `config`, `command`, `streamMode`). These must
-// NOT be repacked under `configurable.properties` — they are structural fields
-// the LangGraph SDK understands directly. Anything else on `forwardedProps`
-// is user-supplied frontend state that needs to reach the graph node.
+// stream-payload fields. These must NOT be repacked into `context` — they
+// are structural fields the LangGraph SDK understands directly. Anything
+// else on `forwardedProps` is user-supplied frontend state that needs to
+// reach the graph node.
+//
+// `context` itself is reserved: LangGraph 1.x exposes it as the run-scoped
+// context channel, and we want any explicit `forwardedProps.context` from a
+// caller to pass through verbatim (and merge with user-supplied props
+// rather than be wrapped a level deeper).
 //
 // Keep this list in sync with ag-ui/langgraph/typescript/src/agent.ts
 // `RunAgentExtendedInput["forwardedProps"]`.
 const RESERVED_FORWARDED_PROPS_KEYS = new Set<string>([
   "config",
   "command",
+  "context",
   "streamMode",
   "streamSubgraphs",
   "nodeName",
@@ -67,34 +73,40 @@ const RESERVED_FORWARDED_PROPS_KEYS = new Set<string>([
 /**
  * Wrapper around `LangGraphAgent` that repacks the CopilotKit provider's
  * `properties` (which arrive as top-level keys on `forwardedProps`) into
- * `forwardedProps.config.configurable.properties` so the Python LangGraph
- * graph can read them from `RunnableConfig["configurable"]["properties"]`.
+ * `forwardedProps.context` so the Python LangGraph graph receives them as
+ * its run-scoped `Runtime[ContextSchema].context`.
  *
- * Why this bridge exists: the CopilotKit runtime forwards
- * `CopilotKitCore.properties` as `forwardedProps` (see core's run-handler).
- * The ag-ui LangGraphAgent spreads unknown forwardedProps keys into the
- * top-level LangGraph stream payload, where they are ignored by the server.
- * Only `forwardedProps.config.configurable.*` actually reaches the graph's
- * `RunnableConfig`. This class closes that gap for this demo.
+ * Why this bridge exists: LangGraph 1.x rejects requests that send
+ * `configurable` with the error "Cannot specify both configurable and
+ * context. Prefer setting context alone." Any frontend-derived state has
+ * to ride the new `context` channel — `configurable.properties` is no
+ * longer accepted.
+ *
+ * The CopilotKit runtime forwards `CopilotKitCore.properties` as
+ * `forwardedProps` (see core's run-handler). The ag-ui LangGraphAgent
+ * spreads `forwardedProps` directly onto the LangGraph stream payload, so
+ * placing the merged values under `forwardedProps.context` makes them
+ * arrive at the graph's `Runtime.context`.
  */
 class AgentConfigLangGraphAgent extends LangGraphAgent {
-  // Intercept each run() to repack provider `properties` (which land on
-  // `forwardedProps`) into `forwardedProps.config.configurable.properties`,
-  // the only place the LangGraph SDK will surface them to the Python graph's
-  // `RunnableConfig["configurable"]["properties"]`.
+  // Intercept each run() to move provider `properties` (which land as
+  // top-level keys on `forwardedProps`) onto `forwardedProps.context` —
+  // the LangGraph 1.x channel for run-scoped configuration. AG-UI then
+  // spreads `forwardedProps` into the SDK call, so `context` arrives at
+  // the graph node's `Runtime[ContextSchema].context`.
   run(
     input: Parameters<LangGraphAgent["run"]>[0],
   ): ReturnType<LangGraphAgent["run"]> {
-    const repacked = repackForwardedPropsIntoConfigurable(
+    const repacked = repackForwardedPropsIntoContext(
       input as RunInputWithForwardedProps,
     );
     return super.run(repacked as Parameters<LangGraphAgent["run"]>[0]);
   }
 }
 
-function repackForwardedPropsIntoConfigurable<
-  T extends RunInputWithForwardedProps,
->(input: T): T {
+function repackForwardedPropsIntoContext<T extends RunInputWithForwardedProps>(
+  input: T,
+): T {
   const fp = (input.forwardedProps ?? {}) as Record<string, unknown>;
   if (!fp || typeof fp !== "object") return input;
 
@@ -111,32 +123,21 @@ function repackForwardedPropsIntoConfigurable<
 
   if (Object.keys(userProps).length === 0) return input;
 
-  const existingConfig = (structural.config ?? {}) as {
-    configurable?: Record<string, unknown>;
-    [k: string]: unknown;
-  };
-  const existingConfigurable =
-    (existingConfig.configurable as Record<string, unknown> | undefined) ?? {};
-  const existingProperties =
-    (existingConfigurable.properties as Record<string, unknown> | undefined) ??
-    {};
-
-  const mergedConfig = {
-    ...existingConfig,
-    configurable: {
-      ...existingConfigurable,
-      properties: {
-        ...existingProperties,
-        ...userProps,
-      },
-    },
+  // Merge user-supplied props into any pre-existing `forwardedProps.context`
+  // so an explicit context object from a caller is preserved alongside the
+  // provider's `properties`.
+  const existingContext =
+    (structural.context as Record<string, unknown> | undefined) ?? {};
+  const mergedContext = {
+    ...existingContext,
+    ...userProps,
   };
 
   return {
     ...input,
     forwardedProps: {
       ...structural,
-      config: mergedConfig,
+      context: mergedContext,
     },
   } as T;
 }


### PR DESCRIPTION
## Summary
Two unrelated showcase regressions, fixed together because they share a review window.

### agent-config — empty stream
The `/demos/agent-config` runtime returned `RUN_ERROR` on every send. The existing route wrapper repacked the provider's `properties` into `forwardedProps.config.configurable.properties` so the graph could read them via `RunnableConfig["configurable"]["properties"]`. LangGraph 1.x (`langgraph 1.1.x` / `langgraph-api 0.7.x`) now rejects any run that sends `configurable` with `Cannot specify both configurable and context. Prefer setting context alone.` — it auto-injects an empty `context` and refuses both channels.

This PR switches to LangGraph 1.x's context API:
- `route.ts` repacks user props onto `forwardedProps.context` instead, and adds `context` to `RESERVED_FORWARDED_PROPS_KEYS` so an explicit caller-supplied `forwardedProps.context` is preserved verbatim and merged with the provider's `properties`.
- `agent_config_agent.py` defines `class AgentConfigContext(TypedDict, total=False)` and reads via `Runtime[AgentConfigContext]`. `RunnableConfig` is no longer consulted.
- Unit tests pass the flat context dict directly (was: nested `{configurable: {properties: …}}`).

### multimodal — PDF "doesn't work"
The pipeline (legacy-shape rewrite shim → `@ag-ui/langgraph` converter → `_PdfFlattenMiddleware` running pypdf) is fine — the extracted PDF text shows up in the run state snapshot. The visible breakage is in `showcase/aimock/feature-parity.json`: aimock matches `userMessage` as a substring, and the generic `"hi"` fixture sits early enough to swallow any prompt containing "this" — including "What is in this PDF?" and "What is in this image?" — short-circuiting before the request reaches real OpenAI and returning a generic "I'm your showcase assistant" greeting that never references the attachment.

This PR adds two more-specific fixtures (`"this PDF"`, `"this image"`) ahead of the `"hi"` entry so multimodal prompts return responses grounded in the bundled samples (CopilotKit Quickstart PDF, CopilotKit logo PNG). The `"hi"` fixture stays in place so the several E2E specs that fill literal "hi" still match it.

## Test plan
- [ ] Visit `/integrations/langgraph-python/agent-config/preview`, change tone/expertise/length dropdowns, send a message, confirm the assistant adapts (no `RUN_ERROR`).
- [ ] Visit `/integrations/langgraph-python/multimodal/preview`, click "Try with sample PDF", ask "What is in this PDF?" — assistant references the CopilotKit Quickstart content.
- [ ] Same with sample image and "What is in this image?" — assistant references the CopilotKit logo.
- [ ] `pytest src/agents/test_agent_config_agent.py` passes (10 tests).
- [ ] `pnpm --filter @copilotkit/showcase-scripts test aimock-fixtures` passes (18 tests).