### PR TITLE
fix(showcase): update stale showcase/packages refs in ops Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,8 @@ __pycache__/
 docs/next-env.d.ts
 
 # Showcase: staged shared contexts for Docker builds (see showcase/scripts/dev-local.sh)
-showcase/packages/*/shared_python/
-showcase/packages/*/shared_typescript/
+showcase/integrations/*/shared_python/
+showcase/integrations/*/shared_typescript/
 
 # External repos (cloned for development)
 ext-apps/

--- a/showcase/ops/Dockerfile
+++ b/showcase/ops/Dockerfile
@@ -66,7 +66,7 @@ FROM node:22-bookworm-slim
 WORKDIR /app
 ENV NODE_ENV=production
 # qa probe: repo-root override so the walk-up from dist/probes/drivers/
-# (3 levels to /app) matches the showcase/packages/ layout copied above.
+# (3 levels to /app) matches the showcase/integrations/ layout copied above.
 ENV QA_REPO_ROOT=/app
 # Playwright cache lives outside /home/node so `chown` below doesn't
 # have to recurse over the ~300MB chromium tree on every build. Setting
@@ -97,11 +97,11 @@ RUN node ./node_modules/playwright/cli.js install --with-deps chromium \
 # keep the image lean until another probe config actually needs those trees.
 COPY --from=build /repo/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=build /repo/packages ./packages
-# qa probe: the driver reads showcase/packages/<slug>/manifest.yaml to
+# qa probe: the driver reads showcase/integrations/<slug>/manifest.yaml to
 # check QA file coverage. Copy only the manifests (not full source) to
 # keep the runtime image lean. The qa/ subdirectories are also needed
 # since the driver file-stats qa/<featureId>.md per demo.
-COPY --from=build /repo/showcase/packages ./showcase/packages
+COPY --from=build /repo/showcase/integrations ./showcase/integrations
 # e2e-smoke probe: the driver's default demos resolver reads
 # `/app/data/registry.json` to look up each Railway service slug's demo
 # list (`tool-rendering` gates the L4 tool-rendering check). The registry

--- a/showcase/ops/src/probes/discovery/railway-services.test.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.test.ts
@@ -999,8 +999,15 @@ describe("railwayServicesSource", () => {
             demos: [
               { id: "agentic-chat", route: "/demos/agentic-chat" },
               { id: "human-in-the-loop", route: "/demos/human-in-the-loop" },
-              { id: "tool-based-generative-ui", route: "/demos/tool-based-generative-ui" },
-              { id: "cli-start", name: "CLI Start Command", command: "npx create-copilotkit@latest" },
+              {
+                id: "tool-based-generative-ui",
+                route: "/demos/tool-based-generative-ui",
+              },
+              {
+                id: "cli-start",
+                name: "CLI Start Command",
+                command: "npx create-copilotkit@latest",
+              },
             ],
           },
           {
@@ -1053,7 +1060,12 @@ describe("railwayServicesSource", () => {
     // as "no demos" rather than poisoning the tick.
     const registryPath = await writeRegistry(
       JSON.stringify({
-        integrations: [{ slug: "ag2", demos: [{ id: "agentic-chat", route: "/demos/agentic-chat" }] }],
+        integrations: [
+          {
+            slug: "ag2",
+            demos: [{ id: "agentic-chat", route: "/demos/agentic-chat" }],
+          },
+        ],
       }),
     );
     const { fetchImpl } = makeFetch([
@@ -1228,7 +1240,9 @@ describe("railwayServicesSource", () => {
         integrations: [
           {
             slug: "ag2",
-            demos: [{ id: "demo-from-override", route: "/demos/demo-from-override" }],
+            demos: [
+              { id: "demo-from-override", route: "/demos/demo-from-override" },
+            ],
           },
         ],
       }),
@@ -1264,7 +1278,12 @@ describe("railwayServicesSource", () => {
     // empty demos map (NOT an exception that aborts the whole tick).
     const registryPath = await writeRegistry(
       JSON.stringify({
-        integrations: [{ slug: "ag2", demos: [{ id: "agentic-chat", route: "/demos/agentic-chat" }] }],
+        integrations: [
+          {
+            slug: "ag2",
+            demos: [{ id: "agentic-chat", route: "/demos/agentic-chat" }],
+          },
+        ],
       }),
     );
     const { fetchImpl } = makeFetch([
@@ -1890,7 +1909,12 @@ describe("railwayServicesSource", () => {
     it("starter service slug strips only `showcase-` prefix; demos lookup misses gracefully", async () => {
       const registryPath = await writeRegistry(
         JSON.stringify({
-          integrations: [{ slug: "ag2", demos: [{ id: "agentic-chat", route: "/demos/agentic-chat" }] }],
+          integrations: [
+            {
+              slug: "ag2",
+              demos: [{ id: "agentic-chat", route: "/demos/agentic-chat" }],
+            },
+          ],
         }),
       );
       const { fetchImpl } = makeFetch([

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -491,7 +491,8 @@ async function loadDemosMap(
     if (!it.slug) continue;
     const demos: string[] = [];
     for (const d of it.demos ?? []) {
-      if (typeof d.id === "string" && typeof d.route === "string") demos.push(d.id);
+      if (typeof d.id === "string" && typeof d.route === "string")
+        demos.push(d.id);
     }
     map.set(it.slug, demos);
   }

--- a/showcase/ops/src/probes/drivers/e2e-demos.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-demos.test.ts
@@ -633,7 +633,9 @@ describe("e2e-demos driver", () => {
     // A single compound selector is tried (all selectors at once).
     expect(selectorsTried).toHaveLength(1);
     expect(selectorsTried[0]).toContain("textarea");
-    expect(selectorsTried[0]).toContain('[data-testid="copilot-chat-textarea"]');
+    expect(selectorsTried[0]).toContain(
+      '[data-testid="copilot-chat-textarea"]',
+    );
 
     expect(writes).toHaveLength(1);
     expect(writes[0]?.state).toBe("green");
@@ -685,7 +687,9 @@ describe("e2e-demos driver", () => {
     expect(result.state).toBe("red");
     // Single compound selector tried (not 6 individual ones).
     expect(selectorsTried).toHaveLength(1);
-    expect(selectorsTried[0]).toContain('[data-testid="copilot-chat-textarea"]');
+    expect(selectorsTried[0]).toContain(
+      '[data-testid="copilot-chat-textarea"]',
+    );
     expect(selectorsTried[0]).toContain('[role="textbox"]');
     expect(writes).toHaveLength(1);
     expect(writes[0]?.state).toBe("red");


### PR DESCRIPTION
## Summary
- Fix showcase-ops Docker build failure: `COPY` still referenced deleted `showcase/packages/` path (now `showcase/integrations/` after #4351)
- Update `.gitignore` patterns from `showcase/packages/` to `showcase/integrations/`
- Fix pre-existing format issues in 3 showcase-ops probe files

## Test plan
- [ ] showcase-ops Docker build passes in CI (was failing: `"/repo/showcase/packages": not found`)
- [ ] format check passes
- [ ] No remaining stale `showcase/packages` refs in Dockerfiles or gitignore