### PR TITLE
docs(showcase): region markers across 5 small-backlog frameworks (batch 1)

### DIFF
--- a/showcase/integrations/ag2/src/agents/agent.py
+++ b/showcase/integrations/ag2/src/agents/agent.py
@@ -34,6 +34,7 @@ from tools.types import Flight
 # =====
 # Tools
 # =====
+# @region[weather-tool-backend]
 async def get_weather(
     location: Annotated[str, "City name to get weather for"],
 ) -> dict[str, str | float]:
@@ -47,6 +48,7 @@ async def get_weather(
         "wind_speed": result["wind_speed"],
         "conditions": result["conditions"],
     }
+# @endregion[weather-tool-backend]
 
 
 async def query_data(

--- a/showcase/integrations/ag2/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/ag2/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/ag2/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/ag2/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/ag2/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-ogui/route.ts
@@ -29,6 +29,8 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -36,6 +38,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/langgraph-fastapi/manifest.yaml
+++ b/showcase/integrations/langgraph-fastapi/manifest.yaml
@@ -78,6 +78,9 @@ demos:
       - agent-capabilities
     route: /demos/tool-rendering
     animated_preview_url:
+    highlight:
+      - src/agents/src/tool_rendering_agent.py
+      - src/app/demos/tool-rendering/page.tsx
   - id: hitl
     name: In-Chat Human in the Loop (Original)
     description: User approves agent actions before execution

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/langgraph-typescript/manifest.yaml
+++ b/showcase/integrations/langgraph-typescript/manifest.yaml
@@ -87,6 +87,9 @@ demos:
       - agent-capabilities
     route: /demos/tool-rendering
     animated_preview_url:
+    highlight:
+      - src/agent/tool-rendering.ts
+      - src/app/demos/tool-rendering/page.tsx
   - id: gen-ui-agent
     name: Agentic Generative UI
     description: Long-running agent tasks with generated UI

--- a/showcase/integrations/langgraph-typescript/src/agent/tool-rendering.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/tool-rendering.ts
@@ -37,6 +37,7 @@ const SYSTEM_PROMPT =
   "atomic answer and more tool calls would feel intrusive. Never " +
   "fabricate data that a tool could provide.";
 
+// @region[weather-tool-backend]
 const getWeather = tool(
   async ({ location }) => ({
     city: location,
@@ -55,6 +56,7 @@ const getWeather = tool(
     }),
   },
 );
+// @endregion[weather-tool-backend]
 
 const searchFlights = tool(
   async ({ origin, destination }) => ({

--- a/showcase/integrations/langgraph-typescript/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/langgraph-typescript/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/langgraph-typescript/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/strands/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-ogui/route.ts
@@ -33,6 +33,8 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -40,6 +42,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/strands/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/strands/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/strands/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/strands/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -18,6 +18,10 @@ import { openGenUiSuggestions } from "./suggestions";
 
 export default function OpenGenUiAdvancedDemo() {
   return (
+    // @region[sandbox-function-registration]
+    // Pass the sandbox-function array on the `openGenerativeUI` provider prop.
+    // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
+    // remotes inside the agent-authored iframe.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
@@ -29,6 +33,7 @@ export default function OpenGenUiAdvancedDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[sandbox-function-registration]
   );
 }
 

--- a/showcase/integrations/strands/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+++ b/showcase/integrations/strands/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
  * Host-side functions that agent-authored, sandboxed UIs can invoke from
  * inside the iframe via `Websandbox.connection.remote.<name>(args)`.
  */
+// @region[sandbox-function-registration]
 export const openGenUiSandboxFunctions = [
   {
     name: "evaluateExpression",
@@ -55,3 +56,4 @@ export const openGenUiSandboxFunctions = [
     },
   },
 ];
+// @endregion[sandbox-function-registration]

--- a/showcase/integrations/strands/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/open-gen-ui/page.tsx
@@ -85,6 +85,7 @@ const minimalSuggestions = [
 ];
 
 export default function OpenGenUiDemo() {
+  // @region[minimal-provider-setup]
   return (
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
@@ -98,6 +99,7 @@ export default function OpenGenUiDemo() {
       </div>
     </CopilotKit>
   );
+  // @endregion[minimal-provider-setup]
 }
 
 function Chat() {


### PR DESCRIPTION
## Summary

Per-framework region-marker pass across the 5 frameworks with the smallest B-cell backlog, following the pattern established in #4326 (mastra). Each commit is one framework so reviewers can navigate.

| Framework | Cells advanced | Files changed |
|---|---|---|
| langgraph-typescript | agentic-chat, tool-rendering | 6 |
| langgraph-fastapi | agentic-chat, tool-rendering | 5 |
| strands | agentic-chat, open-gen-ui, open-gen-ui-advanced | 6 |
| claude-sdk-typescript | agentic-chat, open-gen-ui, open-gen-ui-advanced | 3 |
| ag2 | agentic-chat (chat-component only — provider-setup + configure-suggestions already existed), tool-rendering | 4 |

12 (framework × cell) targets advanced from B (regions missing) to A (ready). 0 yellow boxes introduced; existing yellow boxes elsewhere are unchanged.

## Patterns applied (same as #4326)

- **In-place markers** for code that already reads as a clean teaching example (provider-setup, configure-suggestions, render-weather-tool, weather-tool-backend, minimal-provider-setup, minimal-runtime-flag / advanced-runtime-config, sandbox-function-registration).
- **Sibling `<region>.snippet.tsx` files** for cases where the production demo carries QA hooks irrelevant to the docs page being taught:
  - `chat-component.snippet.tsx` × 5 (every framework's `agentic-chat/page.tsx` carries a 96-line QA-laden Chat function).
  - `render-flight-tool.snippet.tsx` × 3 (the 3 frameworks' tool-rendering only registers a weather renderer; this sibling teaches both `render-flight-tool` and `catchall-renderer`).

All sibling files are non-imported, non-rendered. Bundler picks them up via the `@region[...]` markers; runtime demos are unchanged.

## Manifest changes

- **langgraph-typescript** `tool-rendering` gains a `highlight:` entry so the bundler picks up `weather-tool-backend` from `src/agent/tool-rendering.ts`.
- **langgraph-fastapi** `tool-rendering` gains the same for `src/agents/src/tool_rendering_agent.py` (the region marker already existed in source).

## Deferred (out of scope, picks up in a future pass)

- **strands × `a2ui-fixed-schema`** (`backend-render-operations`, `backend-schema-json-load`) — strands has the demo folder but no a2ui backend agent in `src/agents/`. No local source to wrap. Will pick up once the showcase team ships strands' a2ui_fixed implementation.
- **`declarative-gen-ui::runtime-inject-tool` across 4 frameworks** — cross-cutting authoring needed first; tracked separately.

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; all 12 targets resolve in `demo-content.json`
- [ ] Spot-check at `localhost:<port>/<framework>/prebuilt-components/chat` for each of the 5 frameworks — the `chat-component` snippet renders the minimal Chat from the sibling file
- [ ] Spot-check `localhost:<port>/<framework>/generative-ui/tool-rendering` for langgraph-typescript, langgraph-fastapi, ag2 — all four snippets resolve
- [ ] Spot-check `localhost:<port>/strands/generative-ui/open-generative-ui` — both minimal and advanced runtime regions resolve
- [ ] Manifest YAML still parses (langgraph-typescript and langgraph-fastapi)