### PR TITLE
fix(showcase): raise PocketBase fetch cap to fix dashboard D2 regression

### DIFF
--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -13,13 +13,13 @@ export interface UseLiveStatusResult {
 }
 
 const MAX_RECONNECT_ATTEMPTS = 3;
-// Hard cap on initial fetch size so the dashboard doesn't blow up on load if
-// the `status` collection grows to thousands of rows. 500 comfortably covers
-// the current surface (17 integrations * ~40 features * 4 dimensions ≈ 2.7k,
-// bounded further by dimension filter) and keeps first-paint snappy.
-// Implemented via a paginated `getList` loop (NOT `getFullList({ batch })` —
-// pb's `batch` is per-request page size, not an overall cap).
-const INITIAL_CAP = 500;
+// Hard cap on initial fetch size. The `status` collection contains ~1300+
+// records across all probe dimensions (smoke, health, agent, e2e per-cell,
+// d5 per-feature, chat, tools, image-drift, etc.). Records are fetched in
+// rowid order; with a cap below the total, later-created dimensions (e2e
+// per-cell) get truncated and those cells show D2 instead of D4.
+// 2000 covers the current surface with headroom for growth.
+const INITIAL_CAP = 2000;
 const INITIAL_PAGE_SIZE = 200;
 // Heartbeat interval for detecting silent SSE drops. PB's realtime client
 // auto-reconnects internally but gives no explicit error callback; if the


### PR DESCRIPTION
## Summary
- Root-cause fix for dashboard showing all cells as D2 (red) instead of D4 (blue)
- `INITIAL_CAP = 500` in `useLiveStatus.ts` was too low — PocketBase now has ~1300+ records
- The paginated fetch loads records in rowid order; the 500 cap filled with smoke/health/agent/d5/chat records and **zero** `e2e:<slug>/<featureId>` per-cell records made it through (created later by the 6-hourly e2e-demos probe)
- Without e2e records in the LiveStatusMap, the depth ladder stopped at D2 for every cell
- Raised cap to 2000

## Test plan
- [ ] Dashboard cells return to D4 (blue) after deploy
- [ ] No performance regression on dashboard load (2000 records vs 500 is still <100KB)