### PR TITLE
docs(showcase): region markers across ms-agent-python + ms-agent-dotnet (batch 2)

### DIFF
--- a/showcase/integrations/ms-agent-dotnet/agent/A2uiFixedSchemaAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/A2uiFixedSchemaAgent.cs
@@ -122,6 +122,7 @@ string like ""$289"". Keep any chat reply to one short sentence.",
         new { id = "bookButtonLabel", component = "Text", text = "Book flight" },
     };
 
+    // @region[backend-render-operations]
     [Description("Show a flight card for the given trip. Use short airport codes (e.g. SFO, JFK) for origin/destination and a price string like $289.")]
     private string SearchFlights(
         [Description("Origin airport code (e.g. SFO)")] string origin,
@@ -151,4 +152,5 @@ string like ""$289"". Keep any chat reply to one short sentence.",
 
         return JsonSerializer.Serialize(new { a2ui_operations = operations });
     }
+    // @endregion[backend-render-operations]
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/Program.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/Program.cs
@@ -475,6 +475,7 @@ public class SalesAgentFactory
         return JsonSerializer.Serialize(results);
     }
 
+    // @region[weather-tool-backend]
     [Description("Get the weather for a given location. Ensure location is fully spelled out.")]
     private WeatherInfo GetWeather([Description("The location to get the weather for")] string location)
     {
@@ -489,6 +490,7 @@ public class SalesAgentFactory
             FeelsLike = 25
         };
     }
+    // @endregion[weather-tool-backend]
 
     [Description("Search for available flights between two cities. Returns flight data with A2UI rendering.")]
     private string SearchFlights(

--- a/showcase/integrations/ms-agent-dotnet/manifest.yaml
+++ b/showcase/integrations/ms-agent-dotnet/manifest.yaml
@@ -166,6 +166,9 @@ demos:
       - agent-capabilities
     route: /demos/tool-rendering
     animated_preview_url:
+    highlight:
+      - agent/Program.cs
+      - src/app/demos/tool-rendering/page.tsx
   - id: gen-ui-agent
     name: Agentic Generative UI
     description: Long-running agent tasks with generated UI

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-mcp-apps/route.ts
@@ -26,6 +26,7 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 console.log("[copilotkit-mcp-apps/route] Initializing CopilotKit runtime");
 console.log(`[copilotkit-mcp-apps/route] AGENT_URL: ${AGENT_URL}`);
 
+// @region[runtime-mcpapps-config]
 // The `mcpApps.servers` config is all you need server-side. The runtime
 // auto-applies the MCP Apps middleware to every registered agent: on each
 // MCP tool call it fetches the associated UI resource and emits an
@@ -49,6 +50,7 @@ const runtime = new CopilotRuntime({
     ],
   },
 });
+// @endregion[runtime-mcpapps-config]
 
 export const POST = async (req: NextRequest) => {
   const contentType = req.headers.get("content-type");

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-ogui/route.ts
@@ -44,6 +44,8 @@ export const POST = async (req: NextRequest) => {
       // Open Generative UI for the listed agent(s); the runtime middleware
       // converts each agent's streamed `generateSandboxedUi` tool call into
       // `open-generative-ui` activity events.
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -51,6 +53,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/mcp-apps/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/mcp-apps/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@copilotkit/react-core/v2";
 
 export default function McpAppsDemo() {
+  // @region[no-frontend-renderer-needed]
   // No `renderActivityMessages`, no `useRenderActivityMessage` — the
   // CopilotKitProvider auto-registers the built-in `MCPAppsActivityRenderer`
   // for the "mcp-apps" activity type. A plain <CopilotChat /> is enough.
@@ -39,6 +40,7 @@ export default function McpAppsDemo() {
       </div>
     </CopilotKit>
   );
+  // @endregion[no-frontend-renderer-needed]
 }
 
 function Chat() {

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/ms-agent-python/manifest.yaml
+++ b/showcase/integrations/ms-agent-python/manifest.yaml
@@ -150,6 +150,9 @@ demos:
       - agent-capabilities
     route: /demos/tool-rendering
     animated_preview_url:
+    highlight:
+      - src/agents/agent.py
+      - src/app/demos/tool-rendering/page.tsx
   - id: gen-ui-agent
     name: Agentic Generative UI
     description: Long-running agent tasks with generated UI

--- a/showcase/integrations/ms-agent-python/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/ms-agent-python/src/agents/a2ui_fixed.py
@@ -34,10 +34,13 @@ def _load_schema(path: Path) -> list[dict]:
         return json.load(f)
 
 
+# @region[backend-schema-json-load]
 FLIGHT_SCHEMA = _load_schema(_SCHEMAS_DIR / "flight_schema.json")
 BOOKED_SCHEMA = _load_schema(_SCHEMAS_DIR / "booked_schema.json")  # noqa: F841 — kept for parity with LangGraph reference
+# @endregion[backend-schema-json-load]
 
 
+# @region[backend-render-operations]
 def _build_a2ui_ops(
     *, origin: str, destination: str, airline: str, price: str
 ) -> dict:
@@ -77,6 +80,7 @@ def _build_a2ui_ops(
         },
     ]
     return {"a2ui_operations": ops}
+# @endregion[backend-render-operations]
 
 
 @tool(

--- a/showcase/integrations/ms-agent-python/src/agents/agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/agent.py
@@ -89,6 +89,7 @@ def get_sales_todos() -> str:
     return json.dumps(result)
 
 
+# @region[weather-tool-backend]
 @tool(
     name="get_weather",
     description="Get the current weather for a location. Use this to render the frontend weather card.",
@@ -99,6 +100,7 @@ def get_weather(
     """Return weather data as JSON for UI rendering."""
     result = get_weather_impl(location)
     return json.dumps(result)
+# @endregion[weather-tool-backend]
 
 
 @tool(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-ogui/route.ts
@@ -39,6 +39,8 @@ export const POST = async (req: NextRequest) => {
       // Open Generative UI for the listed agent(s); the runtime middleware
       // converts each agent's streamed `generateSandboxedUi` tool call into
       // `open-generative-ui` activity events.
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts for type-comment rationale
         agents,
@@ -46,6 +48,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/ms-agent-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -32,6 +32,7 @@ import { openGenUiSuggestions } from "./suggestions";
 
 export default function OpenGenUiAdvancedDemo() {
   return (
+    // @region[sandbox-function-registration]
     // Pass the sandbox-function array on the `openGenerativeUI` provider prop.
     // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
     // remotes inside the agent-authored iframe.
@@ -46,6 +47,7 @@ export default function OpenGenUiAdvancedDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[sandbox-function-registration]
   );
 }
 

--- a/showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+++ b/showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
  * Keep the surface small and obvious — these are the demo's "app-side
  * tools" that the sandbox-generated UI can call.
  */
+// @region[sandbox-function-registration]
 export const openGenUiSandboxFunctions = [
   {
     name: "evaluateExpression",
@@ -67,3 +68,4 @@ export const openGenUiSandboxFunctions = [
     },
   },
 ];
+// @endregion[sandbox-function-registration]

--- a/showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/open-gen-ui/page.tsx
@@ -111,6 +111,7 @@ export default function OpenGenUiDemo() {
   // no custom tool renderers, no activity-renderer registration.
   // We DO pass `openGenerativeUI.designSkill` to swap in visualisation-tuned
   // guidance in place of the default shadcn design skill.
+  // @region[minimal-provider-setup]
   return (
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
@@ -124,6 +125,7 @@ export default function OpenGenUiDemo() {
       </div>
     </CopilotKit>
   );
+  // @endregion[minimal-provider-setup]
 }
 
 function Chat() {

--- a/showcase/integrations/ms-agent-python/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/ms-agent-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/ms-agent-python/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}


### PR DESCRIPTION
## Summary

Per-framework region pass on the MS Agent Framework integrations (positions 5 + 6 in the dashboard left-to-right). Frontends are byte-identical between the two; backends diverge (Python in `src/agents/*.py` vs C# in `agent/*.cs`). One commit per framework so reviewers can navigate.

15 (framework × cell) targets advanced from B (regions missing) to A (ready). 0 yellow boxes introduced.

## Cells covered

| Cell | ms-agent-python | ms-agent-dotnet |
|---|---|---|
| agentic-chat | 3 regions (provider-setup, configure-suggestions, chat-component sibling) | same |
| tool-rendering | 4 regions (render-weather-tool, weather-tool-backend on `src/agents/agent.py`, render-flight-tool + catchall-renderer sibling) | same shape, weather-tool-backend on `agent/Program.cs` |
| frontend-tools | 2 regions (frontend-tool-handler, frontend-tool-registration) | same |
| readonly-state-agent-context | 2 regions (context-provider-sketch, use-agent-context-call) | same |
| open-gen-ui | minimal-provider-setup + minimal-runtime-flag | minimal-runtime-flag only (advanced-runtime-config existed already) |
| open-gen-ui-advanced | advanced-runtime-config + multi-file sandbox-function-registration | advanced-runtime-config |
| a2ui-fixed-schema | backend-schema-json-load + backend-render-operations on `src/agents/a2ui_fixed.py` | backend-render-operations on `agent/A2uiFixedSchemaAgent.cs` (schema-json-load deferred — see below) |
| mcp-apps | — | no-frontend-renderer-needed + runtime-mcpapps-config |

## Patterns applied (same as #4326, #4361)

- **In-place markers** for all frontend cells where the existing code reads as a clean teaching example.
- **Sibling `<region>.snippet.tsx` files** for the QA-laden Chat case (`chat-component`) and the partial-feature tool-rendering case (`render-flight-tool` + `catchall-renderer`). Same content as mastra's siblings.
- **Multi-file region** for `sandbox-function-registration` on ms-agent-python (page.tsx + sandbox-functions.ts).
- **Manifest highlight additions** for tool-rendering on both frameworks (the backend agent file wasn't previously bundled).

## Deferred

These cells need either showcase-team alignment or the auto-config infrastructure to ship before regions can be added without misrepresenting the framework:

| Deferred cell | Why |
|---|---|
| `gen-ui-interrupt` (both frameworks) | MS Agent Framework lacks a native interrupt primitive — the demos use `useFrontendTool` + Promise-based handler instead of `useInterrupt`. The canonical regions (`backend-interrupt-tool`, `frontend-useinterrupt-render`) don't apply. |
| `interrupt-headless` (both) | Same reason — `useFrontendTool` shim instead of the langgraph `useHeadlessInterrupt` pattern. |
| `chat-slots` (ms-agent-python disclaimer + assistant-message slots) | Production demo only registers the welcome slot. Adding sibling teaching files would invent demo content. |
| `a2ui-fixed-schema::backend-schema-json-load` (ms-agent-dotnet only) | .NET keeps the schema inline as a C# array (`FlightSchema` in `A2uiFixedSchemaAgent.cs`) rather than loading from a JSON file. The docs region's "load JSON at startup" framing doesn't match. The ms-agent-python equivalent uses `_load_schema(...)` and is wrapped. |
| `declarative-gen-ui::runtime-inject-tool` (both) | Cross-cutting; tracked separately. |

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; all 15 targets resolve in `demo-content.json`
- [ ] Spot-check `localhost:<port>/<ms-agent-{python,dotnet}>/prebuilt-components/chat` — chat-component snippet renders the minimal Chat from the sibling file
- [ ] Spot-check `localhost:<port>/<ms-agent-{python,dotnet}>/generative-ui/tool-rendering` — all four tool-rendering snippets resolve
- [ ] Spot-check `localhost:<port>/<ms-agent-{python,dotnet}>/generative-ui/a2ui/fixed-schema` — backend-render-operations resolves; ms-agent-dotnet's backend-schema-json-load is expected to remain yellow (deferred per above)
- [ ] Spot-check `localhost:<port>/ms-agent-dotnet/generative-ui/mcp-apps` — both regions resolve
- [ ] Manifest YAML still parses (both)