### PR TITLE
feat(shell-docs): Built-in Agent as soft-default + sidebar chrome cleanup

### DIFF
--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -23,12 +23,7 @@ function DocsOverview() {
     <div className="flex" style={{ height: "calc(100vh - 53px)" }}>
       <SidebarNav className="w-[240px] shrink-0 border-r border-[var(--border)] bg-[var(--bg)] overflow-y-auto p-4">
         <SidebarFrameworkSelector />
-        <Link
-          href="/"
-          className="block text-xs font-mono uppercase tracking-widest text-[var(--accent)] mb-4"
-        >
-          CopilotKit Docs
-        </Link>
+        <div className="mb-4" />
         {navTree.map((node) => (
           <OverviewNavItem key={nodeKey(node)} node={node} />
         ))}

--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -145,7 +145,6 @@ function OverviewNavItem({
       <div style={{ paddingLeft: `${indent}px` }}>
         <SidebarLink
           slug={node.slug}
-          hideWhenUnscoped={node.slug === "quickstart"}
           className="block py-[5px] text-[13px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
         >
           {node.title}

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -243,8 +243,6 @@ export default async function FrameworkScopedDocsPage({
     notFound();
   }
 
-  const backLink = { label: "\u2190 All docs", href: "/" };
-
   // Detect whether this page's default cell (the feature) has any
   // snippets tagged for the current framework. When it doesn't, show
   // a prominent banner pointing the user at a framework that does.
@@ -308,7 +306,6 @@ export default async function FrameworkScopedDocsPage({
       slugHrefPrefix={`/${framework}`}
       frameworkOverride={framework}
       sidebarTitle={integration.name}
-      backLink={backLink}
       navTree={navTree}
       bannerSlot={banner}
     />
@@ -334,12 +331,6 @@ function FrameworkLandingPage({ framework }: { framework: string }) {
     <div className="flex" style={{ height: "calc(100vh - 53px)" }}>
       <aside className="w-[240px] shrink-0 border-r border-[var(--border)] bg-[var(--bg)] overflow-y-auto p-4">
         <SidebarFrameworkSelector />
-        <Link
-          href="/"
-          className="block text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] mb-3 transition-colors"
-        >
-          ← All docs
-        </Link>
         <Link
           href={`/${framework}`}
           className="block text-xs font-mono uppercase tracking-widest text-[var(--accent)] mb-4"
@@ -449,12 +440,6 @@ function NotAvailableForFrameworkPage({
     <div className="flex" style={{ height: "calc(100vh - 53px)" }}>
       <aside className="w-[240px] shrink-0 border-r border-[var(--border)] bg-[var(--bg)] overflow-y-auto p-4">
         <SidebarFrameworkSelector />
-        <Link
-          href="/"
-          className="block text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] mb-3 transition-colors"
-        >
-          ← All docs
-        </Link>
         <Link
           href={`/${framework.slug}`}
           className="block text-xs font-mono uppercase tracking-widest text-[var(--accent)] mb-4"

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -305,7 +305,6 @@ export default async function FrameworkScopedDocsPage({
       contentSlugPath={contentSlugPath}
       slugHrefPrefix={`/${framework}`}
       frameworkOverride={framework}
-      sidebarTitle={integration.name}
       navTree={navTree}
       bannerSlot={banner}
     />
@@ -331,12 +330,6 @@ function FrameworkLandingPage({ framework }: { framework: string }) {
     <div className="flex" style={{ height: "calc(100vh - 53px)" }}>
       <aside className="w-[240px] shrink-0 border-r border-[var(--border)] bg-[var(--bg)] overflow-y-auto p-4">
         <SidebarFrameworkSelector />
-        <Link
-          href={`/${framework}`}
-          className="block text-xs font-mono uppercase tracking-widest text-[var(--accent)] mb-4"
-        >
-          {integration.name}
-        </Link>
         {tree.map((node, i) => (
           <RenderNav key={i} node={node} framework={framework} />
         ))}

--- a/showcase/shell-docs/src/components/docs-landing-next.tsx
+++ b/showcase/shell-docs/src/components/docs-landing-next.tsx
@@ -33,8 +33,11 @@ function FrameworkPicker({
   heading: string;
   description: string;
 }) {
+  // Drop Built-in Agent: it's the soft-default the page is already
+  // rendering as, so showing it under "Switch backend" would just be a
+  // no-op tile.
   const integrations = getIntegrations()
-    .slice()
+    .filter((i) => i.slug !== "built-in-agent")
     .sort((a, b) => (a.sort_order ?? 999) - (b.sort_order ?? 999));
 
   // Bucket integrations by category, honoring the canonical ordering.

--- a/showcase/shell-docs/src/components/docs-landing-next.tsx
+++ b/showcase/shell-docs/src/components/docs-landing-next.tsx
@@ -1,26 +1,20 @@
 "use client";
 
 // DocsLandingNext — the "what comes after the product overview" block on
-// the docs landing at `/`. Renders one of two layouts based on whether
-// the user has a stored framework preference:
+// the docs landing at `/`. Always renders the "Continue with {framework}"
+// pointers using `effectiveFramework` (Built-in Agent by default; the
+// user's stored pick or URL-active framework if either is set), then a
+// "Switch framework" picker grid below so other backends remain one
+// click away.
 //
-//   - null  → "Pick your agent framework" heading + the categorized
-//             integrations grid (Popular / Agent Frameworks /
-//             Provider SDKs / …), so a fresh visitor's first action is
-//             clearly to choose a backend. Mirrors the old docs-landing
-//             picker shape so users see the same UI shell-internally
-//             whether they arrived from the marketing landing or the
-//             docs root.
-//   - set   → "Continue with {FrameworkName}" heading + a small pointer
-//             grid (Quickstart, framework landing, switch framework),
-//             so a returning visitor lands on actionable next steps
-//             instead of being prompted to re-pick.
-//
-// Renders null until mounted to avoid the SSR/CSR hydration mismatch that
-// `storedFramework` reads from localStorage cause — same pattern as
-// StoredFrameworkHighlight.
+// Old behaviour: branched on `storedFramework`. Null showed a forced
+// picker, set showed "Continue with X". The forced-picker branch was a
+// dead end for fresh visitors who hadn't yet decided which backend to
+// build against. Soft-defaulting to BIA via `effectiveFramework` lets
+// us collapse the two branches into one and keep the picker as a
+// secondary affordance instead of a gate.
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Link from "next/link";
 import { useFramework } from "./framework-provider";
 import { StoredFrameworkHighlight } from "./stored-framework-highlight";
@@ -94,39 +88,17 @@ function FrameworkPicker({
 }
 
 export function DocsLandingNext() {
-  const { framework, storedFramework, setStoredFramework } = useFramework();
-  const [mounted, setMounted] = useState(false);
+  const { effectiveFramework } = useFramework();
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  // Prefer the URL-active framework, then fall back to the stored
-  // preference. On `/<framework>`, framework is set in SSR and we can
-  // render the "Continue with X" branch immediately. On `/`, framework
-  // is null and we wait for mount to read storedFramework — same shape
-  // as the previous mount-then-stored flow.
-  const activeFramework = framework ?? (mounted ? storedFramework : null);
-
-  if (!framework && !mounted) return null;
-
-  if (!activeFramework) {
-    return (
-      <FrameworkPicker
-        heading="Pick your agent framework"
-        description="We store your choice locally so every page renders the right code. Once you pick a framework you can switch any time from the sidebar."
-      />
-    );
-  }
-
-  const integration = getIntegration(activeFramework);
+  const integration = getIntegration(effectiveFramework);
   if (!integration) {
-    // Stored slug doesn't match any current integration (renamed,
-    // removed, or stale localStorage). Fall back to the picker.
+    // Defensive: the registry has dropped the default framework. Should
+    // not happen — DEFAULT_FRAMEWORK is a known slug — but rendering
+    // the picker as a last resort beats throwing.
     return (
       <FrameworkPicker
         heading="Pick your agent framework"
-        description="Your previous choice is no longer available. Pick a framework to continue."
+        description="Pick a backend to continue."
       />
     );
   }
@@ -138,9 +110,9 @@ export function DocsLandingNext() {
       </h2>
       <p className="text-sm text-[var(--text-secondary)] leading-relaxed mb-5">
         We&apos;ll render every code snippet using {integration.name}. Pick up
-        where you left off, or switch frameworks any time from the sidebar.
+        where you left off — or switch backends below or from the sidebar.
       </p>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-10">
         <Link
           href={`/${integration.slug}/quickstart`}
           className="group flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 no-underline hover:border-[var(--accent)] hover:shadow-sm transition"
@@ -163,19 +135,12 @@ export function DocsLandingNext() {
             Every topic rendered with {integration.name} snippets.
           </div>
         </Link>
-        <button
-          type="button"
-          onClick={() => setStoredFramework(null)}
-          className="group flex flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] p-4 no-underline hover:border-[var(--accent)] hover:shadow-sm transition text-left cursor-pointer"
-        >
-          <div className="font-semibold text-[var(--text)] group-hover:text-[var(--accent)]">
-            Switch framework
-          </div>
-          <div className="text-sm text-[var(--text-secondary)] leading-relaxed">
-            Show the framework picker again.
-          </div>
-        </button>
       </div>
+
+      <FrameworkPicker
+        heading="Switch backend"
+        description="Pick another backend and the rest of the docs will render with its code."
+      />
     </div>
   );
 }

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -19,7 +19,7 @@ import { Snippet } from "@/components/snippet";
 import { DocsToc } from "@/components/docs-toc";
 import { Tabs as DocsTabs } from "@/components/docs-tabs";
 import { docsComponents } from "@/lib/mdx-registry";
-import { getTabDefault } from "@/lib/registry";
+import { getIntegration, getTabDefault } from "@/lib/registry";
 import {
   NavNode,
   buildBreadcrumbs,
@@ -50,10 +50,6 @@ export interface DocsPageViewProps {
   slugHrefPrefix: string;
   /** Optional framework slug to thread into <Snippet> as a default. */
   frameworkOverride?: string | null;
-  /** Label for the sidebar's root link. */
-  sidebarTitle?: string;
-  /** Optional "back" link shown above the sidebar title. */
-  backLink?: { label: string; href: string } | null;
   /** Pre-built nav tree. When omitted, defaults to the full docs tree. */
   navTree?: NavNode[];
   /** Banner slot rendered above the main content column. */
@@ -74,8 +70,6 @@ export async function DocsPageView({
   contentSlugPath,
   slugHrefPrefix,
   frameworkOverride,
-  sidebarTitle = "CopilotKit Docs",
-  backLink = null,
   navTree,
   bannerSlot,
   hideBody = false,
@@ -109,8 +103,15 @@ export async function DocsPageView({
   const defaultCell = doc.fm.defaultCell;
 
   const tree = navTree ?? buildNavTree(CONTENT_DIR);
+  // Breadcrumb root label tracks the framework whose content is being
+  // rendered. On framework-scoped pages this reads "LangGraph (Python)";
+  // on unscoped pages it falls back to "Docs". The sidebar no longer
+  // surfaces this label as a separate link — the selector pill at the
+  // top of the sidebar already names the framework.
+  const rootLabel =
+    (frameworkOverride && getIntegration(frameworkOverride)?.name) || "Docs";
   const breadcrumbs = buildBreadcrumbs(slugPath, {
-    rootLabel: sidebarTitle,
+    rootLabel,
     rootHref: slugHrefPrefix || "/",
     slugHrefPrefix,
   });
@@ -170,20 +171,7 @@ export async function DocsPageView({
     <div className="flex" style={{ height: "calc(100vh - 53px)" }}>
       <SidebarNav className="w-[240px] shrink-0 border-r border-[var(--border)] bg-[var(--bg)] overflow-y-auto p-4">
         <SidebarFrameworkSelector />
-        {backLink && (
-          <Link
-            href={backLink.href}
-            className="block text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] mb-3 transition-colors"
-          >
-            {backLink.label}
-          </Link>
-        )}
-        <Link
-          href={slugHrefPrefix || "/"}
-          className="block text-xs font-mono uppercase tracking-widest text-[var(--accent)] mb-4"
-        >
-          {sidebarTitle}
-        </Link>
+        <div className="mb-4" />
         {tree.map((node) => renderNavItem(node))}
       </SidebarNav>
 

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -140,7 +140,6 @@ export async function DocsPageView({
             scope={scope}
             fallbackHref={`${slugHrefPrefix}/${node.slug}`}
             active={isActive}
-            hideWhenUnscoped={node.slug === "quickstart"}
             className={`block py-[5px] text-[13px] transition-colors ${
               isActive
                 ? "text-[var(--accent)] font-medium"

--- a/showcase/shell-docs/src/components/framework-provider.tsx
+++ b/showcase/shell-docs/src/components/framework-provider.tsx
@@ -2,18 +2,23 @@
 
 // FrameworkProvider — tracks the currently "active" agentic backend.
 //
-// IMPORTANT: `framework` is STRICTLY URL-derived. It's non-null only when
-// the user is actually on a framework-scoped route (`/<framework>/...`).
-// On `/docs/...`, `/`, and other non-scoped routes, `framework` is null
-// and the page renders the "no agentic backend selected" state.
+// Three fields, three different jobs:
 //
-// `storedFramework` is a separate, advisory signal: the user's last
-// remembered choice from localStorage. Consumers use it to mark "this
-// was your last pick" (e.g. highlight that card in the framework picker)
-// WITHOUT treating it as the active framework. Visiting `/docs/` after
-// previously picking LangChain must still show the unselected state —
-// only explicit navigation to `/langgraph-python/...` (or clicking the
-// card) makes LangChain active.
+// - `framework` — STRICTLY URL-derived. Non-null only on `/<framework>/...`
+//   routes. Use this when chrome legitimately needs to know "is the URL
+//   scoped to a framework?" (e.g. RouterPivot's redirect-target logic, or
+//   a banner that only shows when the URL is genuinely scoped).
+//
+// - `storedFramework` — last REMEMBERED choice from localStorage. Use to
+//   mark the user's last pick in a picker UI (e.g. ring around their card)
+//   without treating it as the active selection.
+//
+// - `effectiveFramework` — what the page renders as. Falls back through
+//   URL → stored → DEFAULT_FRAMEWORK so it's never null. This is the
+//   field every snippet renderer, sidebar link, and "Continue with X"
+//   pointer should read. Treating no-choice as Built-in Agent removes
+//   the dead-end where fresh visitors saw a forced picker before any
+//   working code.
 //
 // Whenever the URL asserts a framework, we persist it as the new
 // storedFramework so the preference carries.
@@ -29,18 +34,24 @@ import { usePathname } from "next/navigation";
 
 export interface FrameworkContextValue {
   /**
-   * Currently ACTIVE framework — strictly URL-derived. Non-null only on
-   * `/<framework>/...` routes. Consumers that render "is this a
-   * framework-scoped view?" chrome (selectors, banners, snippets) should
-   * branch on this field.
+   * URL-derived framework. Non-null only on `/<framework>/...` routes.
+   * Use only when chrome needs to know "is the URL scoped to a
+   * framework?" (e.g. redirect logic). For rendering content, prefer
+   * `effectiveFramework`.
    */
   framework: string | null;
   /**
-   * Last REMEMBERED framework from localStorage — advisory, does NOT
-   * auto-activate. Use to mark the user's last pick in a picker UI
-   * without implying the current view is scoped to it.
+   * Last remembered framework from localStorage — advisory only. Use to
+   * mark the user's last pick in a picker UI without implying the
+   * current view is scoped to it.
    */
   storedFramework: string | null;
+  /**
+   * Framework the page should render as — never null. Falls through
+   * URL → stored → DEFAULT_FRAMEWORK. Snippet renderers, sidebar links,
+   * and "Continue with X" affordances should read this.
+   */
+  effectiveFramework: string;
   /** All known framework slugs derived from the registry. */
   knownFrameworks: string[];
   /** Persist a new framework preference (does not navigate). */
@@ -50,6 +61,14 @@ export interface FrameworkContextValue {
 const FrameworkContext = createContext<FrameworkContextValue | null>(null);
 
 const STORAGE_KEY = "selectedFramework";
+
+/**
+ * Built-in Agent is the default integration: zero config, runs in-process
+ * via the Next.js runtime, no external agent server. Treating fresh
+ * visitors as if they'd picked it removes the forced-picker dead end and
+ * gives them working code on first paint.
+ */
+export const DEFAULT_FRAMEWORK = "built-in-agent";
 
 // Log each failure mode once per session so we don't spam the console
 // on repeated reads/writes when localStorage is unavailable (SSR, private
@@ -132,6 +151,14 @@ export function FrameworkProvider({
   // scoped to it.
   const framework = urlFramework;
 
+  // Effective framework falls through URL → stored → default so content
+  // always has a target to render against. Validate `stored` against the
+  // known registry before honouring it, so a stale entry from a renamed
+  // or removed integration doesn't poison the render.
+  const storedIsValid = stored !== null && knownFrameworks.includes(stored);
+  const effectiveFramework =
+    framework ?? (storedIsValid ? stored! : DEFAULT_FRAMEWORK);
+
   const setStoredFramework = (slug: string | null) => {
     // Validate the slug against the known registry. Callers passing a
     // slug we don't recognise would poison the stored preference (e.g.
@@ -149,6 +176,7 @@ export function FrameworkProvider({
   const value: FrameworkContextValue = {
     framework,
     storedFramework: stored,
+    effectiveFramework,
     knownFrameworks,
     setStoredFramework,
   };

--- a/showcase/shell-docs/src/components/framework-selector.tsx
+++ b/showcase/shell-docs/src/components/framework-selector.tsx
@@ -117,7 +117,17 @@ export function FrameworkSelector({
   // (Built-in Agent). The selector should never read "Pick a backend"
   // when the docs are actually rendering BIA code — that's misleading.
   const current = options.find((o) => o.slug === effectiveFramework);
-  const label = current?.name ?? "Pick an agentic backend";
+
+  // BIA is the soft-default and the framing on the sidebar is "you're
+  // reading CopilotKit's docs" rather than "you've picked the Built-in
+  // Agent backend." Show "CopilotKit" in the sidebar selector chrome
+  // (closed pill + dropdown row) but keep the registry name elsewhere
+  // so DocsLandingNext, IntegrationGrid, etc. still call it Built-in
+  // Agent where the framing is about choosing a backend.
+  const isSidebar = variant === "sidebar";
+  const displayNameFor = (opt: FrameworkOption) =>
+    isSidebar && opt.slug === "built-in-agent" ? "CopilotKit" : opt.name;
+  const label = current ? displayNameFor(current) : "Pick an agentic backend";
 
   // Compute the target href for a given framework option given the current
   // path. Preserves feature slug when possible.
@@ -158,11 +168,19 @@ export function FrameworkSelector({
   for (const cat of categoryOrder) grouped.set(cat.id, []);
   grouped.set("other", []);
   for (const opt of options) {
+    // Sidebar variant lifts BIA out of its category bucket and renders
+    // it at the top of the dropdown — see render path below. Skip it
+    // here so it doesn't also appear under Popular.
+    if (isSidebar && opt.slug === "built-in-agent") continue;
     const bucket = grouped.has(opt.category) ? opt.category : "other";
     grouped.get(bucket)!.push(opt);
   }
 
-  const isSidebar = variant === "sidebar";
+  // BIA pinned at the top of the sidebar dropdown — only the sidebar
+  // variant (the topbar selector keeps the standard category layout).
+  const pinnedBIA = isSidebar
+    ? (options.find((o) => o.slug === "built-in-agent") ?? null)
+    : null;
 
   // Sidebar variant: full-width pill with integration logo on the left,
   // framework name centered, chevron right. Violet accent border when a
@@ -202,7 +220,7 @@ export function FrameworkSelector({
             )}
             <span className="flex-1 min-w-0 text-left">
               {current ? (
-                <span className="block truncate">{current.name}</span>
+                <span className="block truncate">{label}</span>
               ) : (
                 <span className="block truncate text-[var(--text-muted)]">
                   Pick a backend
@@ -292,6 +310,35 @@ export function FrameworkSelector({
             </button>
           )}
 
+          {pinnedBIA && (
+            <div className="mb-2">
+              <button
+                key={pinnedBIA.slug}
+                type="button"
+                onClick={() => selectFramework(pinnedBIA.slug)}
+                className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer ${
+                  pinnedBIA.slug === effectiveFramework
+                    ? "bg-[var(--accent-light)] text-[var(--accent)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
+                }`}
+              >
+                {pinnedBIA.logo ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={pinnedBIA.logo}
+                    alt=""
+                    className="w-4 h-4 shrink-0"
+                  />
+                ) : (
+                  <span className="w-4 h-4 shrink-0" />
+                )}
+                <span className="flex-1 text-left truncate">
+                  {displayNameFor(pinnedBIA)}
+                </span>
+              </button>
+            </div>
+          )}
+
           {[...grouped.entries()].map(([catId, opts]) => {
             if (opts.length === 0) return null;
             const catLabel =
@@ -326,7 +373,7 @@ export function FrameworkSelector({
                         <span className="w-4 h-4 shrink-0" />
                       )}
                       <span className="flex-1 text-left truncate">
-                        {opt.name}
+                        {displayNameFor(opt)}
                       </span>
                     </button>
                   );

--- a/showcase/shell-docs/src/components/framework-selector.tsx
+++ b/showcase/shell-docs/src/components/framework-selector.tsx
@@ -72,8 +72,13 @@ export function FrameworkSelector({
 }: FrameworkSelectorProps) {
   const router = useRouter();
   const pathname = usePathname() ?? "";
-  const { framework, storedFramework, knownFrameworks, setStoredFramework } =
-    useFramework();
+  const {
+    framework,
+    storedFramework,
+    effectiveFramework,
+    knownFrameworks,
+    setStoredFramework,
+  } = useFramework();
   const [open, setOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -107,13 +112,11 @@ export function FrameworkSelector({
     };
   }, [open]);
 
-  // Display the URL-derived framework when present; fall back to the
-  // stored choice so unscoped pages (/, /quickstart, etc.) still show
-  // the user's last pick instead of resetting to the placeholder. Same
-  // precedence used by the Clear-Selection button below (line ~262).
-  const current = options.find(
-    (o) => o.slug === (framework ?? storedFramework),
-  );
+  // Display whatever the page is currently rendering as: URL framework
+  // when present, then stored choice, then the soft-default
+  // (Built-in Agent). The selector should never read "Pick a backend"
+  // when the docs are actually rendering BIA code — that's misleading.
+  const current = options.find((o) => o.slug === effectiveFramework);
   const label = current?.name ?? "Pick an agentic backend";
 
   // Compute the target href for a given framework option given the current
@@ -265,18 +268,16 @@ export function FrameworkSelector({
               : "absolute top-full left-0 mt-1 w-[340px] max-h-[70vh] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] shadow-lg z-50 p-2"
           }
         >
-          {(framework || storedFramework) && (
+          {storedFramework && (
             <button
               type="button"
               className="w-full text-left px-2 py-1.5 text-[11px] text-[var(--text-muted)] hover:text-[var(--text)] cursor-pointer"
               onClick={() => {
                 setStoredFramework(null);
-                // If we're on a framework-scoped route, flip back to the
-                // equivalent `/docs/<feature>` page. On `/docs/*` and
-                // other non-scoped routes, clearing a stale stored pick
-                // is purely a preference change — no navigation needed,
-                // which is why the escape hatch is reachable even when
-                // `framework` is null.
+                // If we're on a framework-scoped route, flip back to
+                // the unscoped equivalent so the soft-default takes
+                // over. On already-unscoped pages, clearing is just a
+                // preference change with no navigation needed.
                 const frameworkTail = stripFrameworkPrefix(
                   pathname,
                   knownFrameworks,
@@ -287,7 +288,7 @@ export function FrameworkSelector({
                 setOpen(false);
               }}
             >
-              Clear selection
+              Reset to default (Built-in Agent)
             </button>
           )}
 
@@ -302,7 +303,7 @@ export function FrameworkSelector({
                   {catLabel}
                 </div>
                 {opts.map((opt) => {
-                  const isActive = opt.slug === framework;
+                  const isActive = opt.slug === effectiveFramework;
                   return (
                     <button
                       key={opt.slug}

--- a/showcase/shell-docs/src/components/framework-selector.tsx
+++ b/showcase/shell-docs/src/components/framework-selector.tsx
@@ -72,13 +72,8 @@ export function FrameworkSelector({
 }: FrameworkSelectorProps) {
   const router = useRouter();
   const pathname = usePathname() ?? "";
-  const {
-    framework,
-    storedFramework,
-    effectiveFramework,
-    knownFrameworks,
-    setStoredFramework,
-  } = useFramework();
+  const { effectiveFramework, knownFrameworks, setStoredFramework } =
+    useFramework();
   const [open, setOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -286,30 +281,6 @@ export function FrameworkSelector({
               : "absolute top-full left-0 mt-1 w-[340px] max-h-[70vh] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] shadow-lg z-50 p-2"
           }
         >
-          {storedFramework && (
-            <button
-              type="button"
-              className="w-full text-left px-2 py-1.5 text-[11px] text-[var(--text-muted)] hover:text-[var(--text)] cursor-pointer"
-              onClick={() => {
-                setStoredFramework(null);
-                // If we're on a framework-scoped route, flip back to
-                // the unscoped equivalent so the soft-default takes
-                // over. On already-unscoped pages, clearing is just a
-                // preference change with no navigation needed.
-                const frameworkTail = stripFrameworkPrefix(
-                  pathname,
-                  knownFrameworks,
-                );
-                if (frameworkTail !== null) {
-                  router.replace(frameworkTail ? `/${frameworkTail}` : "/");
-                }
-                setOpen(false);
-              }}
-            >
-              Reset to default (Built-in Agent)
-            </button>
-          )}
-
           {pinnedBIA && (
             <div className="mb-2">
               <button

--- a/showcase/shell-docs/src/components/router-pivot.tsx
+++ b/showcase/shell-docs/src/components/router-pivot.tsx
@@ -1,229 +1,51 @@
 "use client";
 
-// RouterPivot — client-side "pick an agentic backend" UI rendered at
-// the top of every `/docs/<feature>` page. When a framework is already
-// selected (via URL or localStorage) we auto-redirect the user to
-// `/<framework>/<feature>`; when none is selected we show a grid of
-// integration cards that link to the framework-scoped equivalent.
+// RouterPivot — client-side redirect from `/docs/<feature>` to
+// `/<effectiveFramework>/<feature>`. With Built-in Agent as the soft
+// default, every visitor has an effectiveFramework, so this component's
+// only job is to issue the redirect and render a brief placeholder.
 //
-// The MDX body for the page is also conditionally hidden when no
-// framework is selected — the router-page's job is to pivot, not to
-// serve code without the relevant backend context.
+// The picker grid that previously rendered when neither URL nor stored
+// framework was set has been removed — the FrameworkProvider's
+// soft-default makes that branch unreachable, and the categorized
+// picker on the docs landing handles the explicit "switch backend"
+// affordance.
 
 import React, { useEffect } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useFramework } from "./framework-provider";
-import type { FrameworkOption } from "./framework-selector";
 
 export interface RouterPivotProps {
   /** Slug path (no leading slash). */
   slugPath: string;
-  /** All framework options, pre-sorted by preference. */
-  options: FrameworkOption[];
-  /**
-   * Subset of framework slugs that have a cell tagged for this
-   * feature — those are highlighted/promoted. Frameworks without a
-   * cell are rendered dim/disabled with a "coming soon" label.
-   */
-  frameworksWithCell?: string[];
-  /** Optional preview (gif / mp4) URL for the feature. */
-  previewUrl?: string | null;
-  /** Feature display name (e.g. "Tool Rendering"). */
-  featureName?: string;
-  /** Short feature description. */
-  featureDescription?: string;
 }
 
 /**
- * Wrap MDX body so it only renders when the user has no framework to
- * land on. On `/docs/<feature>`:
- *   - URL has a framework → impossible (handled by a framework-scoped
- *     route, not this one).
- *   - User has a storedFramework → they're about to be redirected by
- *     RouterPivot; hide the body to avoid flashing docs that will be
- *     replaced in a tick.
- *   - Neither → render the body so the user sees the pivot + any MDX
- *     copy that accompanies it.
- *
- * Covered by: visit /docs/foo with no localStorage entry → MDX body
- * visible alongside the pivot; visit with localStorage=langgraph-python
- * → body hidden while redirect runs.
+ * Hide the MDX body on `/docs/<feature>` while RouterPivot redirects to
+ * the framework-scoped URL. With BIA as the soft-default the redirect
+ * always fires, so this just keeps the body from flashing during the
+ * tick before navigation completes.
  */
 export function FrameworkGuardedContent({
-  children,
+  children: _children,
 }: {
   children: React.ReactNode;
 }) {
-  const { framework, storedFramework } = useFramework();
-  // Hide only when we're about to redirect to a framework-scoped page
-  // (URL framework present, or a stored preference will trigger
-  // redirect). When neither exists we want the pivot + MDX body.
-  if (framework || storedFramework) return null;
-  return <>{children}</>;
+  return null;
 }
 
-export function RouterPivot({
-  slugPath,
-  options,
-  frameworksWithCell,
-  previewUrl,
-  featureName,
-  featureDescription,
-}: RouterPivotProps) {
+export function RouterPivot({ slugPath }: RouterPivotProps) {
   const router = useRouter();
-  const { framework, storedFramework } = useFramework();
-
-  // Redirect target: prefer URL framework (should never happen on
-  // `/docs/*` since that route prefix isn't a known framework, but we
-  // still honour it if a future route passes us a framework-scoped
-  // URL), then fall back to the user's stored preference.
-  //
-  // NOTE: this used to read `framework` only, which on `/docs/*` is
-  // always null because the URL prefix `docs` is never in
-  // `knownFrameworks`. That silently broke the "picked-once, sticks"
-  // feature — users with a stored preference never got redirected.
-  //
-  // Covered by: visit /docs/<feature> with localStorage set → redirected
-  // to /<framework>/<feature>; visit with no localStorage → pivot grid
-  // rendered.
-  const target = framework ?? storedFramework;
+  const { effectiveFramework } = useFramework();
 
   useEffect(() => {
-    if (target) {
-      router.replace(`/${target}/${slugPath}`);
-    }
-  }, [target, router, slugPath]);
-
-  // If we have a redirect target we'll be redirected in a tick —
-  // render a lightweight placeholder instead of the full pivot to
-  // avoid flashing the grid at the user.
-  if (target) {
-    return (
-      <div className="text-xs text-[var(--text-muted)]">
-        Loading {target} view…
-      </div>
-    );
-  }
-
-  const withCell = new Set(frameworksWithCell ?? []);
-
-  // Promote frameworks that are deployed AND have a cell tagged for
-  // this feature. Deployed frameworks without a cell are shown under
-  // "coming soon". Undeployed frameworks are omitted entirely —
-  // surfacing them in either bucket would point users at a dead link.
-  const supported = options.filter((o) => o.deployed && withCell.has(o.slug));
-  const unsupported = options.filter(
-    (o) => o.deployed && !withCell.has(o.slug),
-  );
+    router.replace(`/${effectiveFramework}/${slugPath}`);
+  }, [effectiveFramework, router, slugPath]);
 
   return (
-    <div className="space-y-6">
-      {/* Hero block */}
-      <div className="rounded-xl border border-[var(--border)] bg-[var(--bg-surface)] overflow-hidden">
-        <div className="px-6 py-5">
-          {featureName && (
-            <div className="text-[10px] font-mono uppercase tracking-widest text-[var(--text-faint)] mb-2">
-              Feature
-            </div>
-          )}
-          <h2 className="text-xl font-semibold text-[var(--text)] mb-2">
-            {featureName ?? "This feature"}
-          </h2>
-          {featureDescription && (
-            <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-              {featureDescription}
-            </p>
-          )}
-        </div>
-        {previewUrl && (
-          <div className="border-t border-[var(--border)] bg-[var(--bg-elevated)]">
-            {previewUrl.endsWith(".mp4") ? (
-              <video
-                src={previewUrl}
-                className="w-full"
-                autoPlay
-                muted
-                loop
-                playsInline
-              />
-            ) : (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={previewUrl}
-                alt=""
-                className="w-full block"
-                loading="lazy"
-              />
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Pivot CTA */}
-      <div>
-        <div className="text-[10px] font-mono uppercase tracking-widest text-[var(--text-faint)] mb-2">
-          Step 1
-        </div>
-        <h3 className="text-lg font-semibold text-[var(--text)] mb-1">
-          Pick an agentic backend to see the implementation
-        </h3>
-        <p className="text-sm text-[var(--text-secondary)] mb-4">
-          Every integration ships a live cell wired to these docs. Choose your
-          backend and the rest of the page will render against that
-          framework&apos;s code.
-        </p>
-
-        {supported.length > 0 && (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-6">
-            {supported.map((opt) => (
-              <Link
-                key={opt.slug}
-                href={`/${opt.slug}/${slugPath}`}
-                className="group flex items-center gap-2 p-3 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] hover:border-[var(--accent)] hover:shadow-sm transition-all"
-              >
-                {opt.logo ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={opt.logo} alt="" className="w-5 h-5 shrink-0" />
-                ) : (
-                  <span className="w-5 h-5 shrink-0" />
-                )}
-                <span className="text-sm font-medium text-[var(--text)] group-hover:text-[var(--accent)] truncate">
-                  {opt.name}
-                </span>
-              </Link>
-            ))}
-          </div>
-        )}
-
-        {unsupported.length > 0 && (
-          <details className="text-sm text-[var(--text-muted)]">
-            <summary className="cursor-pointer hover:text-[var(--text-secondary)]">
-              Other frameworks ({unsupported.length}) — not yet tagged for this
-              feature
-            </summary>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-3">
-              {unsupported.map((opt) => (
-                <Link
-                  key={opt.slug}
-                  href={`/${opt.slug}/${slugPath}`}
-                  className="group flex items-center gap-2 p-2 rounded-md border border-[var(--border)] bg-[var(--bg-elevated)] hover:border-[var(--text-muted)] transition-all"
-                >
-                  {opt.logo ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={opt.logo} alt="" className="w-4 h-4 shrink-0" />
-                  ) : (
-                    <span className="w-4 h-4 shrink-0" />
-                  )}
-                  <span className="text-xs text-[var(--text-secondary)] truncate">
-                    {opt.name}
-                  </span>
-                </Link>
-              ))}
-            </div>
-          </details>
-        )}
-      </div>
+    <div className="text-xs text-[var(--text-muted)]">
+      Loading {effectiveFramework} view…
     </div>
   );
 }
+

--- a/showcase/shell-docs/src/components/router-pivot.tsx
+++ b/showcase/shell-docs/src/components/router-pivot.tsx
@@ -48,4 +48,3 @@ export function RouterPivot({ slugPath }: RouterPivotProps) {
     </div>
   );
 }
-

--- a/showcase/shell-docs/src/components/search-modal.tsx
+++ b/showcase/shell-docs/src/components/search-modal.tsx
@@ -5,6 +5,11 @@ import { useRouter } from "next/navigation";
 import searchIndex from "@/data/search-index.json";
 import type { Registry } from "@/lib/registry";
 
+// Integrations explorer + per-integration demo pages live on the shell
+// host (showcase.copilotkit.ai), not on shell-docs. Search results that
+// surface an integration or one of its demos route there directly.
+const SHELL_HOST = process.env.NEXT_PUBLIC_SHELL_URL ?? "http://localhost:3000";
+
 interface SearchResult {
   type: "integration" | "feature" | "demo" | "page" | "reference" | "ag-ui";
   title: string;
@@ -115,7 +120,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
             type: "integration",
             title: i.name,
             subtitle: (i.description || "").slice(0, 80),
-            href: `/integrations/${i.slug}`,
+            href: `${SHELL_HOST}/integrations/${i.slug}`,
           });
         }
         for (const d of i.demos || []) {
@@ -128,7 +133,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
               type: "demo",
               title: d.name,
               subtitle: `${i.name} · ${d.description}`,
-              href: `/integrations/${i.slug}/${d.id}`,
+              href: `${SHELL_HOST}/integrations/${i.slug}/${d.id}`,
             });
           }
         }

--- a/showcase/shell-docs/src/components/sidebar-link.tsx
+++ b/showcase/shell-docs/src/components/sidebar-link.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-// SidebarLink — framework-aware client-side anchor used for every
-// entry in the docs sidebar. Resolves its final href based on the
-// active FrameworkContext: when a framework is selected, the href is
-// `/<framework>/<slug>`; otherwise it falls through to `/<slug>`.
-//
-// `framework` is URL-derived (see framework-provider) so the resolved
-// href is identical during SSR and post-hydration — no transient
-// fallback path needed.
+// SidebarLink — framework-aware client-side anchor used for every entry
+// in the docs sidebar. Resolves its final href against
+// `effectiveFramework`, which falls through URL → stored → default
+// (Built-in Agent), so every sidebar click lands on a real
+// `/<framework>/<slug>` URL.
 
 import React from "react";
 import Link from "next/link";
@@ -34,14 +31,6 @@ export interface SidebarLinkProps {
    * interface for call-site compatibility.
    */
   fallbackHref?: string;
-  /**
-   * When true, the link does not render unless a framework is active
-   * (URL-scoped) or stored in localStorage. Used for sidebar entries
-   * whose root MDX is a routing shim — e.g. Quickstart, whose real
-   * content lives per-framework. Without this, the entry shows on `/`
-   * but clicks land on the shim page.
-   */
-  hideWhenUnscoped?: boolean;
 }
 
 export function SidebarLink({
@@ -51,18 +40,9 @@ export function SidebarLink({
   active,
   scope: _scope,
   fallbackHref: _fallbackHref,
-  hideWhenUnscoped,
 }: SidebarLinkProps) {
-  const { framework, storedFramework } = useFramework();
-
-  // Prefer URL-active framework, then stored preference, then bare slug.
-  // Using storedFramework here means sidebar links on unscoped pages (like
-  // the root overview) navigate directly to the framework-scoped URL —
-  // avoiding the visible RouterPivot redirect that would otherwise flicker
-  // in the URL bar.
-  const activeFramework = framework ?? storedFramework;
-  if (hideWhenUnscoped && !activeFramework) return null;
-  const href = activeFramework ? `/${activeFramework}/${slug}` : `/${slug}`;
+  const { effectiveFramework } = useFramework();
+  const href = `/${effectiveFramework}/${slug}`;
 
   return (
     <Link

--- a/showcase/shell-docs/src/components/unscoped-docs-page.tsx
+++ b/showcase/shell-docs/src/components/unscoped-docs-page.tsx
@@ -1,13 +1,15 @@
-// UnscopedDocsPage — server component that renders a framework-agnostic
-// doc page with a RouterPivot banner for picking an agentic backend.
+// UnscopedDocsPage — server component for routes that aren't already
+// framework-scoped. Two cases:
 //
-// Shared between two routes:
-//   app/[[...slug]]/page.tsx    — handles `/` (overview) + unscoped slugs
-//   app/[framework]/[[...slug]]/page.tsx — falls through here when the
-//     first URL segment is not a registered integration slug. This is
-//     necessary because Next.js routes `/<slug>` to [framework] before
-//     [[...slug]] (dynamic segment has higher priority than optional
-//     catch-all), so without this fallthrough `/<slug>` would always 404.
+//   - `/<feature>` where `<feature>` isn't a registered integration slug
+//     (e.g. `/threads`, `/frontend-tools`). RouterPivot redirects the
+//     visitor to `/<effectiveFramework>/<feature>` on mount.
+//   - `/integrations/<framework>/...` legacy URLs. Renders the
+//     framework-scoped sidebar inline; no pivot redirect needed.
+//
+// Shared between `app/[[...slug]]/page.tsx` and the
+// `app/[framework]/[[...slug]]/page.tsx` fall-through (when the first
+// URL segment isn't a registered integration).
 
 import React from "react";
 import { notFound } from "next/navigation";
@@ -16,22 +18,8 @@ import {
   FrameworkGuardedContent,
   RouterPivot,
 } from "@/components/router-pivot";
-import {
-  CONTENT_DIR,
-  buildNavTree,
-  findFrameworksWithCell,
-  loadDoc,
-  readMeta,
-} from "@/lib/docs-render";
-import { getIntegration, getIntegrations, getFeature } from "@/lib/registry";
-import demoContent from "@/data/demo-content.json";
-
-interface DemoRecord {
-  regions?: Record<string, unknown>;
-}
-const demos: Record<string, DemoRecord> = (
-  demoContent as { demos: Record<string, DemoRecord> }
-).demos;
+import { CONTENT_DIR, buildNavTree, loadDoc, readMeta } from "@/lib/docs-render";
+import { getIntegration } from "@/lib/registry";
 
 export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
   const doc = loadDoc(slugPath);
@@ -57,63 +45,13 @@ export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
     navTree = buildNavTree(CONTENT_DIR);
   }
 
-  const options = getIntegrations()
-    .slice()
-    .sort((a, b) => (a.sort_order ?? 999) - (b.sort_order ?? 999))
-    .map((i) => ({
-      slug: i.slug,
-      name: i.name,
-      category: i.category ?? "other",
-      logo: i.logo ?? null,
-      deployed: i.deployed,
-    }));
-
-  const frameworksWithCell = doc.fm.defaultCell
-    ? findFrameworksWithCell(
-        doc.fm.defaultCell,
-        getIntegrations()
-          .filter((i) => i.deployed === true)
-          .map((i) => i.slug),
-        demos,
-      )
-    : [];
-
-  const featureFromCell = doc.fm.defaultCell
-    ? getFeature(doc.fm.defaultCell)
-    : undefined;
-
-  let previewUrl: string | null | undefined = undefined;
-  if (doc.fm.defaultCell) {
-    const sortedIntegrations = getIntegrations()
-      .filter((i) => i.deployed === true)
-      .sort((a, b) => {
-        const orderA = a.sort_order ?? 999;
-        const orderB = b.sort_order ?? 999;
-        if (orderA !== orderB) return orderA - orderB;
-        return a.slug.localeCompare(b.slug);
-      });
-    for (const integration of sortedIntegrations) {
-      const demo = integration.demos?.find((d) => d.id === doc.fm.defaultCell);
-      if (demo?.animated_preview_url) {
-        previewUrl = demo.animated_preview_url;
-        break;
-      }
-    }
-  }
-
+  // Pivot redirects to /<effectiveFramework>/<slugPath>. Only feature
+  // pages (those declaring a defaultCell in frontmatter) use the pivot —
+  // generic doc pages render their body directly.
   const pivot =
     showPivot && doc.fm.defaultCell ? (
       <div className="mb-8">
-        <RouterPivot
-          slugPath={slugPath}
-          options={options}
-          frameworksWithCell={frameworksWithCell}
-          previewUrl={previewUrl}
-          featureName={featureFromCell?.name ?? doc.fm.title}
-          featureDescription={
-            featureFromCell?.description ?? doc.fm.description
-          }
-        />
+        <RouterPivot slugPath={slugPath} />
       </div>
     ) : null;
 

--- a/showcase/shell-docs/src/components/unscoped-docs-page.tsx
+++ b/showcase/shell-docs/src/components/unscoped-docs-page.tsx
@@ -1,11 +1,8 @@
-// UnscopedDocsPage — server component for routes that aren't already
-// framework-scoped. Two cases:
-//
-//   - `/<feature>` where `<feature>` isn't a registered integration slug
-//     (e.g. `/threads`, `/frontend-tools`). RouterPivot redirects the
-//     visitor to `/<effectiveFramework>/<feature>` on mount.
-//   - `/integrations/<framework>/...` legacy URLs. Renders the
-//     framework-scoped sidebar inline; no pivot redirect needed.
+// UnscopedDocsPage — server component for `/<feature>` URLs where the
+// first segment isn't a registered integration slug (e.g. `/threads`,
+// `/frontend-tools`). RouterPivot redirects the visitor to
+// `/<effectiveFramework>/<feature>` on mount; with the soft-default,
+// that's always Built-in Agent for fresh visitors.
 //
 // Shared between `app/[[...slug]]/page.tsx` and the
 // `app/[framework]/[[...slug]]/page.tsx` fall-through (when the first
@@ -18,56 +15,34 @@ import {
   FrameworkGuardedContent,
   RouterPivot,
 } from "@/components/router-pivot";
-import { CONTENT_DIR, buildNavTree, loadDoc, readMeta } from "@/lib/docs-render";
-import { getIntegration } from "@/lib/registry";
+import { loadDoc } from "@/lib/docs-render";
 
 export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
+  // The legacy `/integrations/<framework>/<slug>` URL scheme is dead.
+  // The canonical short form `/<framework>/<slug>` is served by the
+  // framework-scoped route. Refuse to render a doc page from
+  // `loadDoc("integrations/...")` here so the legacy URL surfaces as a
+  // 404 rather than rendering with a stray, unscoped sidebar.
+  if (slugPath.startsWith("integrations/")) notFound();
+
   const doc = loadDoc(slugPath);
   if (!doc) notFound();
-
-  let navTree;
-  let sidebarTitle = "CopilotKit Docs";
-  let backLink = null;
-  let showPivot = true;
-  const integrationMatch = slugPath.match(/^integrations\/([^/]+)/);
-  if (integrationMatch) {
-    const framework = integrationMatch[1];
-    if (!getIntegration(framework)) notFound();
-    const frameworkDir = `${CONTENT_DIR}/integrations/${framework}`;
-    const frameworkMeta = readMeta(frameworkDir);
-    sidebarTitle =
-      frameworkMeta?.title ||
-      framework.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-    navTree = buildNavTree(frameworkDir, `integrations/${framework}`);
-    backLink = { label: "← Back to Docs", href: "/" };
-    showPivot = false;
-  } else {
-    navTree = buildNavTree(CONTENT_DIR);
-  }
 
   // Pivot redirects to /<effectiveFramework>/<slugPath>. Only feature
   // pages (those declaring a defaultCell in frontmatter) use the pivot —
   // generic doc pages render their body directly.
-  const pivot =
-    showPivot && doc.fm.defaultCell ? (
-      <div className="mb-8">
-        <RouterPivot slugPath={slugPath} />
-      </div>
-    ) : null;
-
-  const contentIsFrameworkScoped = showPivot && !!doc.fm.defaultCell;
+  const pivot = doc.fm.defaultCell ? (
+    <div className="mb-8">
+      <RouterPivot slugPath={slugPath} />
+    </div>
+  ) : null;
 
   return (
     <DocsPageView
       slugPath={slugPath}
       slugHrefPrefix=""
-      sidebarTitle={sidebarTitle}
-      backLink={backLink}
-      navTree={navTree}
       bannerSlot={pivot}
-      ContentWrapper={
-        contentIsFrameworkScoped ? FrameworkGuardedContent : undefined
-      }
+      ContentWrapper={doc.fm.defaultCell ? FrameworkGuardedContent : undefined}
     />
   );
 }


### PR DESCRIPTION
## Summary

Promotes Built-in Agent to the default integration so fresh visitors land on working code instead of a forced framework picker. Bundles the chrome cleanup that falls out of the soft-default — sidebar rename, redundant nav affordances removed, legacy URL scheme retired.

`unselected/` editorial cleanup is split out as a follow-up PR ([PDX-49](https://linear.app/copilotkit/issue/PDX-49)) since it's 47 file operations + 2 editorial merge calls and benefits from independent review.

## What changes

### Built-in Agent as the soft-default

`FrameworkProvider` gains `effectiveFramework`, which falls through URL → `storedFramework` → `DEFAULT_FRAMEWORK ("built-in-agent")`. Snippet renderers, sidebar links, and "Continue with X" affordances read this; the original `framework` field stays URL-strict for the few call sites that genuinely need to know "is the URL scoped?"

Behavioural impact:

- Fresh visitor on `/` sees "Continue with Built-in Agent" + the docs landing's pointer cards (no forced picker)
- Fresh visitor on `/threads`, `/frontend-tools`, etc. → `RouterPivot` redirects to `/built-in-agent/<feature>` on mount
- Returning visitor with a stored framework still gets their pick honoured; the soft-default only kicks in when both URL and stored are null
- Sidebar quickstart entry no longer needs `hideWhenUnscoped` — `effectiveFramework` is always set

### Sidebar chrome cleanup

- **Built-in Agent → "CopilotKit"** in the sidebar selector. The framing in the sidebar is "you're reading CopilotKit's docs," not "you've picked the BIA backend." Other surfaces (DocsLandingNext, IntegrationGrid, page bodies) keep the registry name where the framing is about choosing a backend.
- **CopilotKit pinned to the top** of the dropdown, outside the "Popular" category bucket. It's the default; reads more naturally as the always-there starting point than as one of several Popular options.
- **Built-in Agent dropped from the "Switch backend" picker** on `/`. Showing "switch to BIA" inside a "Switch backend" affordance is a no-op tile when BIA is already the soft-default.
- **"← All docs" link removed** from the framework-scoped sidebar (3 call sites). Vestige of the pre-IA-restructure world where `/` was a distinct picker view; with `/` and `/<framework>` rendering the same docs-landing shell now, the link just changed the URL with no visible effect.
- **Framework-name link removed** from the sidebar (4 call sites). The selector pill above already names the active framework; the breadcrumb at the top of the body covers "go to root"; the CopilotKit logo in the top header is the canonical "go home." Drops `sidebarTitle` / `backLink` props from `DocsPageView`.
- **"Reset to default (Built-in Agent)" dropdown row removed.** With CopilotKit pinned at the top of the dropdown, picking it does the same thing end-to-end (`effectiveFramework` becomes BIA either way).

### Legacy `/integrations/<framework>/<slug>` URLs retired

`UnscopedDocsPage`'s `integrationMatch` branch is gone. Any `/integrations/...` URL now 404s. The `integrations/<framework>/` content tree on disk stays — it's still loaded by the framework router's per-framework override fallback (e.g. `/built-in-agent/quickstart` serves `integrations/built-in-agent/quickstart.mdx`). Only the URL scheme is retired.

`search-modal.tsx` integration and demo result links now point at the shell host's integrations explorer (`${SHELL_HOST}/integrations/...`) instead of the now-404 shell-docs paths.

### `RouterPivot` simplified

With `effectiveFramework` always resolving, the no-framework branch in `RouterPivot` is unreachable. Stripped to a pure redirect component; legacy picker grid (~140 lines) deleted. `FrameworkGuardedContent` now always returns null (the body is hidden during the brief redirect tick).

`UnscopedDocsPage` drops the props that fed RouterPivot's old picker (`frameworksWithCell`, `previewUrl`, `featureName`, `featureDescription`).

## Test plan

- [ ] `/` (no localStorage) renders "Continue with Built-in Agent" + the picker grid below; sidebar selector reads "CopilotKit"
- [ ] `/<framework>` (e.g. `/langgraph-python`) renders "Continue with LangGraph (Python)"; sidebar selector reads "LangGraph (Python)"
- [ ] `/threads` redirects to `/built-in-agent/threads`; `/frontend-tools` → `/built-in-agent/frontend-tools`
- [ ] Sidebar dropdown: CopilotKit pinned at top above the Popular category header; checkmark on the active framework; no "Reset to default" row
- [ ] No "← All docs" or framework-name header anywhere in the sidebar
- [ ] After picking LangGraph from the dropdown → "Continue with LangGraph (Python)" everywhere; closing tab and reopening `/` keeps LangGraph picked
- [ ] Picking CopilotKit from the dropdown returns to BIA
- [ ] `/integrations/built-in-agent/quickstart` returns 404 (legacy URL retired)
- [ ] `/built-in-agent/quickstart` renders the BIA quickstart MDX (canonical short form unchanged)
- [ ] Cmd-K → search "LangGraph" → integration result links to `${SHELL_HOST}/integrations/langgraph-python`
- [ ] No regressions on existing framework-scoped feature pages (`/<framework>/<feature>`)

## Closes

- PDX-46 — BIA-as-default UX decision (soft-default chosen and shipped)

## Follow-ups (not in this PR)

- PDX-49 — `unselected/` editorial cleanup. 47 file operations: 17 deletes redirecting to root, 8 deletes redirecting to `/built-in-agent/*`, 7 promotions over root stubs, 13 promotions for unique content (interrupt-based + 12 tutorials), 1 delete (agent-app-context). Plus content-merge calls for `troubleshooting/{common-issues,error-debugging}.mdx`. Verified diff audit produced; will ship as a follow-up branch.
- New ticket TBD — merge `/learn/*` content into the Concepts subgroup. The upstream learn pages are largely duplicative with the new Concepts primer pages; consolidation pass needed.
- BIA showcase package + `deployed: true` flip. PR #4321 (Alem) is the showcase package; once it lands, flipping `deployed: true` is a one-line registry change.
