### PR TITLE
style: format spring-ai headless-simple page

### DIFF
--- a/showcase/integrations/spring-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/headless-simple/page.tsx
@@ -176,7 +176,9 @@ function HeadlessChat() {
                   </div>
                 )}
                 {toolCalls.map((tc: { id: string }) => (
-                  <div key={tc.id}>{renderToolCall({ toolCall: tc as any })}</div>
+                  <div key={tc.id}>
+                    {renderToolCall({ toolCall: tc as any })}
+                  </div>
                 ))}
               </div>
             );


### PR DESCRIPTION
## Summary
- Runs `oxfmt` on `showcase/integrations/spring-ai/src/app/demos/headless-simple/page.tsx`
- Fixes CI format check failure introduced by #4365

## Test plan
- [ ] CI format check passes