### PR TITLE
docs(showcase/google-adk): region markers across 18 cells (batch 3)

### DIFF
--- a/showcase/integrations/google-adk/src/agents/a2ui_fixed_agent.py
+++ b/showcase/integrations/google-adk/src/agents/a2ui_fixed_agent.py
@@ -28,6 +28,7 @@ def _load_schema(name: str) -> list[dict[str, Any]]:
         return json.load(f)
 
 
+# @region[backend-schema-json-load]
 FLIGHT_SCHEMA = _load_schema("flight_schema.json")
 # Loaded for parity with the langgraph-python sibling; the A2UI Python SDK's
 # `a2ui.render(...)` does not yet accept the `action_handlers={...}` kwarg
@@ -35,8 +36,10 @@ FLIGHT_SCHEMA = _load_schema("flight_schema.json")
 # action, so the schema sits read-only here. See langgraph-python's
 # `a2ui_fixed.py` for the canonical reference.
 BOOKED_SCHEMA = _load_schema("booked_schema.json")  # noqa: F841
+# @endregion[backend-schema-json-load]
 
 
+# @region[backend-render-operations]
 def _build_flight_operations(
     *, origin: str, destination: str, airline: str, price: str
 ) -> dict[str, Any]:
@@ -65,6 +68,7 @@ def _build_flight_operations(
             },
         ]
     }
+# @endregion[backend-render-operations]
 
 
 def display_flight(

--- a/showcase/integrations/google-adk/src/agents/shared_state_streaming_agent.py
+++ b/showcase/integrations/google-adk/src/agents/shared_state_streaming_agent.py
@@ -54,6 +54,7 @@ _INSTRUCTION = (
     "belongs in shared state and the UI renders it live as you type."
 )
 
+# @region[state-streaming-middleware]
 shared_state_streaming_agent = LlmAgent(
     name="SharedStateStreamingAgent",
     model=get_model(),
@@ -71,3 +72,4 @@ SHARED_STATE_STREAMING_PREDICT_STATE = [
         stream_tool_call=True,
     ),
 ]
+# @endregion[state-streaming-middleware]

--- a/showcase/integrations/google-adk/src/agents/subagents_agent.py
+++ b/showcase/integrations/google-adk/src/agents/subagents_agent.py
@@ -210,6 +210,7 @@ def _delegate(
     return {"status": "completed", "result": result}
 
 
+# @region[supervisor-delegation-tools]
 def research_agent(tool_context: ToolContext, topic: str) -> dict:
     """Delegate a research task to the research sub-agent.
 
@@ -253,6 +254,7 @@ def critique_agent(tool_context: ToolContext, draft: str) -> dict:
         system_prompt=_CRITIQUE_SYSTEM,
         task=draft,
     )
+# @endregion[supervisor-delegation-tools]
 
 
 _SUPERVISOR_INSTRUCTION = (
@@ -273,9 +275,11 @@ _SUPERVISOR_INSTRUCTION = (
     "every sub-agent delegation, including the in-flight 'running' state."
 )
 
+# @region[subagent-setup]
 subagents_root_agent = LlmAgent(
     name="SubagentsSupervisor",
     model=get_model(_SUB_MODEL),
     instruction=_SUPERVISOR_INSTRUCTION,
     tools=[research_agent, writing_agent, critique_agent],
 )
+# @endregion[subagent-setup]

--- a/showcase/integrations/google-adk/src/agents/tool_rendering_common.py
+++ b/showcase/integrations/google-adk/src/agents/tool_rendering_common.py
@@ -19,9 +19,11 @@ from tools import (
 )
 
 
+# @region[weather-tool-backend]
 def get_weather(tool_context: ToolContext, location: str) -> dict:
     """Get the weather for a given location."""
     return get_weather_impl(location)
+# @endregion[weather-tool-backend]
 
 
 def search_flights(tool_context: ToolContext, flights: list[dict]) -> dict:

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-ogui/route.ts
@@ -12,6 +12,8 @@ import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// @region[minimal-runtime-flag]
+// @region[advanced-runtime-config]
 const runtime = new CopilotRuntime({
   // @ts-expect-error -- see main route.ts
   agents: {
@@ -29,6 +31,8 @@ const runtime = new CopilotRuntime({
     agents: ["open-gen-ui", "open-gen-ui-advanced"],
   },
 });
+// @endregion[advanced-runtime-config]
+// @endregion[minimal-runtime-flag]
 
 export const POST = async (req: NextRequest) => {
   try {

--- a/showcase/integrations/google-adk/src/app/demos/agentic-chat-reasoning/reasoning-block-render.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/agentic-chat-reasoning/reasoning-block-render.snippet.tsx
@@ -1,0 +1,29 @@
+// Docs-only snippet — not imported or rendered. google-adk's
+// agentic-chat-reasoning production demo uses default reasoning rendering
+// (see page.tsx); the ReasoningBlock component file exists in the demo
+// folder but isn't wired into the messageView slot. The docs page teaches
+// the custom reasoning slot pattern, which is framework-agnostic. This
+// file gives the reasoning-block-render region a real teaching example
+// without changing the production demo's runtime behavior. See
+// chat-component.snippet.tsx in agentic-chat for the same sibling-file
+// pattern.
+
+import {
+  CopilotChat,
+  CopilotChatReasoningMessage,
+} from "@copilotkit/react-core/v2";
+import { ReasoningBlock } from "./reasoning-block";
+
+export function ReasoningChat() {
+  // @region[reasoning-block-render]
+  return (
+    <CopilotChat
+      agentId="agentic_chat_reasoning"
+      className="h-full rounded-2xl"
+      messageView={{
+        reasoningMessage: ReasoningBlock as typeof CopilotChatReasoningMessage,
+      }}
+    />
+  );
+  // @endregion[reasoning-block-render]
+}

--- a/showcase/integrations/google-adk/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/google-adk/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/google-adk/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/chat-customization-css/page.tsx
@@ -7,7 +7,9 @@ import {
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
 
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/google-adk/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/google-adk/src/app/demos/chat-customization-css/theme.css
@@ -5,6 +5,7 @@
  * https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
  */
 
+/* @region[css-variables] */
 /* CopilotKit CSS variable overrides */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #1a73e8;
@@ -16,6 +17,7 @@
   --copilot-kit-separator-color: #1a73e8;
   --copilot-kit-muted-color: #4a6f9c;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Inter", "Helvetica Neue", system-ui, sans-serif;

--- a/showcase/integrations/google-adk/src/app/demos/chat-slots/disclaimer-and-assistant-message.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/chat-slots/disclaimer-and-assistant-message.snippet.tsx
@@ -1,0 +1,27 @@
+// Docs-only snippet — not imported or rendered. google-adk's chat-slots
+// production demo only registers the welcome slot (see page.tsx). The
+// docs page also teaches the disclaimer and assistant-message slot
+// patterns, which are framework-agnostic CopilotKit primitives. This
+// file gives those two regions a real teaching example without changing
+// the production demo's runtime behavior. See chat-component.snippet.tsx
+// in agentic-chat for the same sibling-file pattern.
+
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+
+declare const CustomDisclaimer: React.ComponentType;
+declare const CustomAssistantMessage: React.ComponentType;
+
+export function ChatSlotsExtras() {
+  // @region[register-disclaimer-slot]
+  const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+
+  // @region[register-assistant-message-slot]
+  const messageView = {
+    assistantMessage:
+      CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
+  };
+  // @endregion[register-assistant-message-slot]
+
+  return { input, messageView };
+}

--- a/showcase/integrations/google-adk/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/chat-slots/page.tsx
@@ -29,11 +29,15 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
+  const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+
   return (
     <CopilotChat
       agentId="chat_slots"
       className="h-full rounded-2xl"
-      welcomeScreen={CustomWelcomeScreen}
+      welcomeScreen={welcomeScreen}
     />
   );
 }

--- a/showcase/integrations/google-adk/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless_simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
         Headless Chat (Simple) — Google ADK
       </h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/google-adk/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/prebuilt-popup/page.tsx
@@ -9,9 +9,11 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_popup">
       <DemoContent />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/google-adk/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,9 +9,11 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_sidebar">
       <DemoContent />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 
@@ -44,10 +46,12 @@ function DemoContent() {
           tools, no state. All the polish is on the frontend.
         </p>
       </main>
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar
         defaultOpen={true}
         labels={{ modalHeaderTitle: "AI Assistant" }}
       />
+      {/* @endregion[sidebar-configuration] */}
     </div>
   );
 }

--- a/showcase/integrations/google-adk/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/readonly-state-agent-context/page.tsx
@@ -20,15 +20,19 @@ export default function ReadonlyStateAgentContextDemo() {
 }
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Daisy");
   const [role, setRole] = useState("Frontend engineer");
   const [project, setProject] = useState(
     "Building a CopilotKit + Google ADK showcase",
   );
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({ description: "User name", value: userName });
   useAgentContext({ description: "User role", value: role });
   useAgentContext({ description: "Current project", value: project });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/reasoning-default-render/page.tsx
@@ -33,10 +33,12 @@ function Chat() {
   return (
     <div className="flex justify-center items-center h-screen w-full bg-gray-50">
       <div className="h-full w-full max-w-4xl">
+        {/* @region[default-reasoning-zero-config] */}
         <CopilotChat
           agentId="reasoning_default_render"
           className="h-full rounded-2xl"
         />
+        {/* @endregion[default-reasoning-zero-config] */}
       </div>
     </div>
   );

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[notes-card-render]
 export function NotesCard({
   notes,
   onClear,
@@ -58,3 +59,4 @@ export function NotesCard({
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/page.tsx
@@ -34,10 +34,12 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   const { agent } = useAgent({
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -89,6 +91,7 @@ function DemoContent() {
   // before React re-renders can still write the same snapshot twice —
   // CopilotKit's STATE_DELTA stream resolves the merge upstream and
   // either order is correct because both writes carry the full pair.
+  // @region[use-agent-write]
   const handlePreferencesChange = (next: Preferences) => {
     agent.setState({
       ...(agentState as object | undefined),
@@ -96,6 +99,7 @@ function DemoContent() {
       notes: agentState?.notes ?? [],
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   const handleClearNotes = () => {
     agent.setState({

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -24,6 +24,7 @@ export interface PreferencesCardProps {
   onChange: (next: Preferences) => void;
 }
 
+// @region[preferences-card-render]
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -132,3 +133,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-streaming/page.tsx
@@ -24,10 +24,12 @@ export default function SharedStateStreamingDemo() {
 }
 
 function DemoContent() {
+  // @region[frontend-use-coagent-state]
   const { agent } = useAgent({
     agentId: "shared-state-streaming",
     updates: [UseAgentUpdate.OnStateChanged, UseAgentUpdate.OnRunStatusChanged],
   });
+  // @endregion[frontend-use-coagent-state]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/subagents/delegation-log.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[delegation-log-frontend]
 export interface Delegation {
   id: string;
   sub_agent: "research_agent" | "writing_agent" | "critique_agent";
@@ -104,3 +105,4 @@ export function DelegationLog({ delegations }: { delegations: Delegation[] }) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -31,6 +31,7 @@ function Chat() {
   // runtime emits `"inProgress" | "executing" | "complete"`; both
   // pre-completion states render identically, so collapse them to
   // "executing" before handing off to the renderer.
+  // @region[use-default-render-tool-wildcard]
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }) => (
@@ -44,6 +45,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -37,10 +37,12 @@ function DemoContent() {
   return (
     <div className="flex justify-center items-center h-screen w-full bg-gray-50">
       <div className="h-full w-full max-w-4xl">
+        {/* @region[default-catchall-zero-config] */}
         <CopilotChat
           agentId="tool_rendering_default_catchall"
           className="h-full rounded-2xl"
         />
+        {/* @endregion[default-catchall-zero-config] */}
       </div>
     </div>
   );

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}


### PR DESCRIPTION
## Summary

Per-framework region pass on **google-adk** (dashboard position 4 — biggest single-framework backlog). 18 (framework × cell) targets advanced from B (regions missing) to A (ready). Same patterns as mastra ([#4326](https://github.com/CopilotKit/CopilotKit/pull/4326)), smalls batch 1 ([#4361](https://github.com/CopilotKit/CopilotKit/pull/4361)), and ms-agent batch 2 ([#4363](https://github.com/CopilotKit/CopilotKit/pull/4363)).

Linear: [PDX-67](https://linear.app/copilotkit/issue/PDX-67) tracker (this is the first ticked-off framework from the remaining-frameworks list).

## Cells covered

**Frontend regions** (in-place markers): `agentic-chat`, `prebuilt-popup`, `prebuilt-sidebar`, `frontend-tools`, `chat-customization-css`, `chat-slots`, `reasoning-default-render`, `tool-rendering`, `tool-rendering-default-catchall`, `tool-rendering-custom-catchall`, `headless-simple`, `readonly-state-agent-context`, `open-gen-ui`, `open-gen-ui-advanced`, `shared-state-read-write`, `shared-state-streaming` (frontend), `subagents` (frontend).

**Backend regions** (Python files, all already in manifest `highlight:`):
- `tool-rendering::weather-tool-backend` — `src/agents/tool_rendering_common.py`
- `shared-state-streaming::state-streaming-middleware` — `src/agents/shared_state_streaming_agent.py`
- `subagents::supervisor-delegation-tools` + `subagent-setup` — `src/agents/subagents_agent.py` (wraps google-adk's idiom: plain functions + `LlmAgent(tools=[...])`)
- `a2ui-fixed-schema::backend-schema-json-load` + `backend-render-operations` — `src/agents/a2ui_fixed_agent.py`

**Sibling teaching files** (same pattern as mastra):
- `agentic-chat/chat-component.snippet.tsx` — production Chat carries QA hooks irrelevant to the prebuilt-chat docs page
- `tool-rendering/render-flight-tool.snippet.tsx` — covers both `render-flight-tool` and `catchall-renderer` regions; production demo only registers a weather renderer

**Small refactor**: `chat-slots/page.tsx` lifts the inline `welcomeScreen={CustomWelcomeScreen}` prop into a named `welcomeScreen` variable so the canonical `register-welcome-slot` region applies in place. No behavior change.

## Deferred (documented divergence)

| Cell / Region | Why |
|---|---|
| `chat-slots` disclaimer + assistant-message slots | Production demo only registers the welcome slot. |
| `agentic-chat-reasoning::reasoning-block-render` | `reasoning-block.tsx` file exists but isn't wired into `page.tsx`; the production demo uses default rendering, not the custom slot the docs region wraps. |
| `gen-ui-tool-based` (bar-chart-renderer, pie-chart-renderer) | google-adk's demo implements `generate_haiku` (matches Jordan's prune-commit note: *"all implement generate_haiku, not the pie-chart the D5 probe tests"*). Shape mismatch between production demo and docs teaching content. Resolves via [PDX-68](https://linear.app/copilotkit/issue/PDX-68) auto-config infrastructure or when the demo is realigned. |
| `declarative-gen-ui::runtime-inject-tool` | Cross-cutting; tracked in [PDX-70](https://linear.app/copilotkit/issue/PDX-70). |
| `headless-complete` (5 regions) | google-adk's `headless-complete` is structurally simpler than the canonical pattern: single `MessageList` component, no separate bubble components, no `useRenderedMessages` hook. The canonical regions (`custom-bubbles`, `manual-activity-message-rendering`, `manual-tool-call-rendering`, `page-send-message`, `use-rendered-messages-hook`) don't fit. Defer until showcase team expands the demo or PDX-68 auto-config ships. |

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; all 18 targets resolve in `demo-content.json`
- [ ] `localhost:<port>/google-adk/prebuilt-components/chat` — `chat-component` snippet renders the minimal Chat from the sibling file
- [ ] `localhost:<port>/google-adk/generative-ui/tool-rendering` — all four tool-rendering snippets resolve (in-place + sibling + highlight-file backend)
- [ ] `localhost:<port>/google-adk/state/shared-state-read-write` — all four regions resolve, including the multi-file pair from `notes-card.tsx` + `preferences-card.tsx`
- [ ] `localhost:<port>/google-adk/multi-agent/subagents` — `delegation-log-frontend` (frontend) + `subagent-setup` + `supervisor-delegation-tools` (backend) resolve; snippet shows google-adk's idiom (LlmAgent + plain functions) rather than langgraph-python's @tool/create_agent pattern
- [ ] Expected yellow boxes (deferred per above) on `chat-slots` (disclaimer/assistant-message), `agentic-chat-reasoning`, `gen-ui-tool-based`, `declarative-gen-ui::runtime-inject-tool`, `headless-complete`