### PR TITLE
docs(showcase/claude-sdk-python): region markers across 10 cells

### DIFF
--- a/showcase/integrations/claude-sdk-python/src/agents/subagents_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/subagents_agent.py
@@ -54,6 +54,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_ANTHROPIC_MODEL = "claude-3-5-sonnet-20241022"
 
 
+# @region[subagent-setup]
+# Each sub-agent is defined by its own system prompt; `_invoke_sub_agent`
+# (below) issues a single-shot Anthropic call as that sub-agent. They
+# don't share memory or tools with the supervisor — the supervisor only
+# ever sees what the sub-agent returns as a tool result.
 # @region[subagents-system-prompts]
 SUB_AGENT_PROMPTS: dict[str, str] = {
     "research_agent": (
@@ -89,6 +94,14 @@ SUPERVISOR_SYSTEM_PROMPT = (
 )
 
 
+# @region[supervisor-delegation-tools]
+# The supervisor delegates by calling tools. Each entry in
+# `SUPERVISOR_TOOLS` is an Anthropic tool schema that the supervisor LLM
+# "calls" to delegate work; the run loop in `run_subagents_agent` (see
+# the subagents-delegation-flow region) runs the matching sub-agent
+# synchronously, records the delegation into shared agent state, and
+# returns the sub-agent's output as a tool_result the supervisor can
+# read on its next step.
 def _delegation_tool_schema(name: str, description: str) -> dict[str, Any]:
     return {
         "name": name,
@@ -128,6 +141,7 @@ SUPERVISOR_TOOLS: list[dict[str, Any]] = [
         "Delegate a critique task. Returns 2-3 actionable critiques.",
     ),
 ]
+# @endregion[supervisor-delegation-tools]
 
 
 # @region[subagents-invocation]
@@ -156,6 +170,7 @@ async def _invoke_sub_agent(
         raise RuntimeError("sub-agent returned empty response")
     return text
 # @endregion[subagents-invocation]
+# @endregion[subagent-setup]
 
 
 def _convert_messages(input_data: RunAgentInput) -> list[dict[str, Any]]:

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
@@ -29,6 +29,8 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       // Server-side config is identical for minimal and advanced cells —
       // the advanced behaviour (sandbox -> host function calls) is wired
       // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
@@ -43,6 +45,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/headless-complete/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/headless-complete/page.tsx
@@ -51,6 +51,7 @@ export default function HeadlessCompleteDemo() {
 }
 
 function Chat() {
+  // @region[page-send-message]
   const threadId = useMemo(() => crypto.randomUUID(), []);
   const { agent } = useAgent({ agentId: AGENT_ID, threadId });
   const { copilotkit } = useCopilotKit();
@@ -101,6 +102,7 @@ function Chat() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent]);
+  // @endregion[page-send-message]
 
   return (
     <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={threadId}>

--- a/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -23,6 +23,10 @@ import { openGenUiSuggestions } from "./suggestions";
 
 export default function OpenGenUiAdvancedDemo() {
   return (
+    // @region[sandbox-function-registration]
+    // Pass the sandbox-function array on the `openGenerativeUI` provider prop.
+    // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
+    // remotes inside the agent-authored iframe.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
@@ -34,6 +38,7 @@ export default function OpenGenUiAdvancedDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[sandbox-function-registration]
   );
 }
 

--- a/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+// @region[sandbox-function-registration]
 /**
  * Host-side functions that agent-authored, sandboxed UIs can invoke from
  * inside the iframe via `Websandbox.connection.remote.<name>(args)`.
@@ -54,3 +55,4 @@ export const openGenUiSandboxFunctions = [
     },
   },
 ];
+// @endregion[sandbox-function-registration]

--- a/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
@@ -87,6 +87,12 @@ const minimalSuggestions = [
 
 export default function OpenGenUiDemo() {
   return (
+    // @region[minimal-provider-setup]
+    // Minimal Open Generative UI frontend: the built-in activity renderer is
+    // registered by CopilotKitProvider, so a plain <CopilotChat /> is enough —
+    // no custom tool renderers, no activity-renderer registration.
+    // We DO pass `openGenerativeUI.designSkill` to swap in visualisation-tuned
+    // guidance in place of the default shadcn design skill.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
@@ -98,6 +104,7 @@ export default function OpenGenUiDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[minimal-provider-setup]
   );
 }
 

--- a/showcase/integrations/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -36,6 +36,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }) => (
@@ -49,6 +53,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -33,10 +33,12 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
   // Opt in to CopilotKit's built-in default tool-call card. Called with
   // no config so the package-provided `DefaultToolCallRenderer` is used
   // as the wildcard renderer.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. The claude-sdk-python
+// tool-rendering demo at page.tsx exercises the get_weather renderer
+// only; the docs page at /generative-ui/tool-rendering also teaches the
+// search_flights per-tool pattern and the wildcard catch-all. These two
+// regions show what those would look like in the same demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/weather_tool.snippet.py
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/weather_tool.snippet.py
@@ -1,0 +1,52 @@
+# Docs-only snippet — not imported or executed. The runtime agent in
+# `src/agents/agent.py` declares `get_weather` as one entry in a shared
+# `TOOLS` list of Anthropic tool schemas and dispatches via
+# `_execute_tool`, which is great for the production demo but doesn't
+# read as a clean single-tool teaching example. This sibling shows the
+# Claude Agent SDK idiom for "one backend tool" so the
+# /generative-ui/tool-rendering docs can render real teaching code
+# rather than a missing-snippet box.
+#
+# Why a sibling file: the bundler walks every file in the demo folder
+# and extracts region markers from each, so a docs-targeted teaching
+# example can live alongside the production demo without being wired
+# into the route. See: showcase/scripts/bundle-demo-content.ts.
+
+from typing import Any
+
+
+# @region[weather-tool-backend]
+# Anthropic tool schema — passed via the `tools` parameter on
+# `client.messages.create(...)` / `.stream(...)`. Claude calls this
+# tool by name; the runtime dispatches to the matching handler below.
+GET_WEATHER_TOOL: dict[str, Any] = {
+    "name": "get_weather",
+    "description": (
+        "Get the current weather for a given location. Useful on its "
+        "own for weather questions, and a great companion to "
+        "`search_flights` — always consider checking the weather at a "
+        "destination the user is flying to."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "location": {
+                "type": "string",
+                "description": "The city or region to get weather for.",
+            },
+        },
+        "required": ["location"],
+    },
+}
+
+
+def get_weather(location: str) -> dict[str, Any]:
+    """Handler invoked when Claude calls the `get_weather` tool."""
+    return {
+        "city": location,
+        "temperature": 68,
+        "humidity": 55,
+        "wind_speed": 10,
+        "conditions": "Sunny",
+    }
+# @endregion[weather-tool-backend]


### PR DESCRIPTION
## Summary

Per-framework region pass on **claude-sdk-python**. 10 (framework x cell) targets advanced from B (regions missing) to A (ready). Same patterns as mastra ([#4326](https://github.com/CopilotKit/CopilotKit/pull/4326)), smalls batch 1 ([#4361](https://github.com/CopilotKit/CopilotKit/pull/4361)), ms-agent ([#4363](https://github.com/CopilotKit/CopilotKit/pull/4363)), and google-adk ([#4369](https://github.com/CopilotKit/CopilotKit/pull/4369)).

Linear: [PDX-67](https://linear.app/copilotkit/issue/PDX-67) tracker.

## Cells covered

**Frontend regions** (in-place markers):
- `agentic-chat` — `configure-suggestions`, `provider-setup`
- `frontend-tools` — `frontend-tool-handler`, `frontend-tool-registration`
- `headless-complete` — `page-send-message`
- `open-gen-ui` — `minimal-provider-setup`
- `open-gen-ui-advanced` — `sandbox-function-registration` (multi-file: `page.tsx` + `sandbox-functions.ts`)
- `readonly-state-agent-context` — `context-provider-sketch`, `use-agent-context-call`
- `tool-rendering` — `render-weather-tool`
- `tool-rendering-custom-catchall` — `use-default-render-tool-wildcard`
- `tool-rendering-default-catchall` — `default-catchall-zero-config`

**Runtime regions** (`route.ts`):
- `open-gen-ui::minimal-runtime-flag` and `open-gen-ui-advanced::advanced-runtime-config` — both names share one block; server config is identical for the minimal and advanced cells.

**Backend regions** (Python, in-place on `src/agents/subagents_agent.py`):
- `subagents::subagent-setup` wraps `SUB_AGENT_PROMPTS` + `_invoke_sub_agent`
- `subagents::supervisor-delegation-tools` wraps `_delegation_tool_schema` + `SUPERVISOR_TOOLS`

These wrap claude-sdk-python's idiom — Anthropic tool schemas + a manual run loop — rather than langgraph-python's `@tool` / `create_agent` shape, so the docs render real teaching code that matches what a claude-sdk-python user would actually write.

**Sibling teaching files** (production demo carries QA hooks or a different shape):
- `agentic-chat/chat-component.snippet.tsx` — minimal `Chat` for the prebuilt-chat docs page; production `Chat` carries `useFrontendTool`, `useRenderTool`, `useAgentContext`, weather rendering.
- `tool-rendering/render-flight-tool.snippet.tsx` — covers both `render-flight-tool` and `catchall-renderer`; production demo only registers a weather renderer.
- `tool-rendering/weather_tool.snippet.py` — single-tool teaching example for the Anthropic tool-schema idiom; production `agent.py` declares `get_weather` inside a shared `TOOLS` list with dispatch via `_execute_tool`, which doesn't read as a clean isolated example.

## Out of scope (not regressions)

No deferrals on claude-sdk-python this round — all B-cells flipped to A. Cells where the manifest doesn't include a demo (e.g. `gen-ui-tool-based`, `declarative-gen-ui`, `agentic-chat-reasoning`, `chat-slots` slot-disclaimer/assistant-message variants) aren't in scope here.

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; all 10 targets resolve in `demo-content.json`
- [ ] `localhost:<port>/claude-sdk-python/prebuilt-components/chat` — `chat-component` snippet renders the minimal Chat from the sibling file
- [ ] `localhost:<port>/claude-sdk-python/generative-ui/tool-rendering` — all four tool-rendering snippets resolve (in-place + sibling + sibling Python)
- [ ] `localhost:<port>/claude-sdk-python/state/agent-context` — both `useAgentContext` regions resolve
- [ ] `localhost:<port>/claude-sdk-python/multi-agent/subagents` — `subagent-setup` and `supervisor-delegation-tools` resolve and show the Anthropic SDK idiom (schemas + run loop)
- [ ] `localhost:<port>/claude-sdk-python/generative-ui/open-generative-ui` (minimal + advanced) — provider, runtime flag, and sandbox-function-registration regions all resolve