### PR TITLE
docs(showcase/pydantic-ai): region markers across 16 cells

### DIFF
--- a/showcase/integrations/pydantic-ai/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/pydantic-ai/src/agents/a2ui_fixed.py
@@ -39,11 +39,15 @@ def _load_schema(path: Path) -> list[dict]:
         return json.load(f)
 
 
+# @region[backend-schema-json-load]
+# Schemas are JSON so they can be authored and reviewed independently of
+# the Python code. ``_load_schema`` is just a thin ``json.load`` wrapper.
 FLIGHT_SCHEMA = _load_schema(_SCHEMAS_DIR / "flight_schema.json")
 # Kept for future use once action_handlers land on the PydanticAI A2UI
 # bridge; the frontend's ActionButton drives an optimistic transition
 # locally today.
 BOOKED_SCHEMA = _load_schema(_SCHEMAS_DIR / "booked_schema.json")
+# @endregion[backend-schema-json-load]
 
 
 class EmptyState(BaseModel):
@@ -81,6 +85,10 @@ def display_flight(
     Use short airport codes (e.g. "SFO", "JFK") for origin/destination and a
     price string like "$289".
     """
+    # @region[backend-render-operations]
+    # The A2UI middleware detects the `a2ui_operations` container in this
+    # tool result and forwards the ops to the frontend renderer. The
+    # frontend catalog resolves component names to local React components.
     operations = [
         {
             "type": "create_surface",
@@ -104,3 +112,4 @@ def display_flight(
         },
     ]
     return json.dumps({"a2ui_operations": operations})
+    # @endregion[backend-render-operations]

--- a/showcase/integrations/pydantic-ai/src/agents/agent.py
+++ b/showcase/integrations/pydantic-ai/src/agents/agent.py
@@ -64,10 +64,18 @@ agent = Agent(
 # =====
 # Tools
 # =====
+# @region[weather-tool-backend]
 @agent.tool
 def get_weather(ctx: RunContext[StateDeps[SalesTodosState]], location: str) -> str:
-    """Get the weather for a given location. Ensure location is fully spelled out."""
+    """Get the weather for a given location. Ensure location is fully spelled out.
+
+    Useful on its own for weather questions, and a great companion to
+    `search_flights` — always consider checking the weather at a
+    destination the user is flying to, and checking flights to any
+    city whose weather the user has just asked about.
+    """
     return json.dumps(get_weather_impl(location))
+# @endregion[weather-tool-backend]
 
 
 @agent.tool

--- a/showcase/integrations/pydantic-ai/src/agents/subagents.py
+++ b/showcase/integrations/pydantic-ai/src/agents/subagents.py
@@ -66,6 +66,10 @@ class SubagentsState(BaseModel):
 # ── Sub-agents (real PydanticAI Agents) ─────────────────────────────
 
 
+# @region[subagent-setup]
+# Each sub-agent is a full-fledged ``Agent(model=..., system_prompt=...)``
+# with its own system prompt. They don't share memory or tools with the
+# supervisor — the supervisor only sees their return value.
 _SUB_MODEL = OpenAIResponsesModel("gpt-4o-mini")
 
 _research_agent: Agent[None, str] = Agent(
@@ -92,6 +96,7 @@ _critique_agent: Agent[None, str] = Agent(
         "2-3 crisp, actionable critiques. No preamble."
     ),
 )
+# @endregion[subagent-setup]
 
 
 async def _invoke_sub_agent(sub_agent: Agent[None, str], task: str) -> str:
@@ -216,6 +221,12 @@ async def _delegate(
     return result
 
 
+# @region[supervisor-delegation-tools]
+# Each ``@agent.tool`` wraps a sub-agent invocation. The supervisor LLM
+# "calls" these tools to delegate work; each call asynchronously runs the
+# matching sub-agent, records the delegation into shared state, and
+# returns the sub-agent's output as a string the supervisor can read on
+# its next step.
 @agent.tool
 async def research_agent(
     ctx: RunContext[StateDeps[SubagentsState]],
@@ -267,6 +278,7 @@ async def critique_agent(
         sub_agent_obj=_critique_agent,
         task=task,
     )
+# @endregion[supervisor-delegation-tools]
 
 
 __all__: list[str] = [

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-ogui/route.ts
@@ -24,16 +24,24 @@ const agents: Record<string, AbstractAgent> = {
   }),
 };
 
+// @region[minimal-runtime-flag]
+// @region[advanced-runtime-config]
+// Server-side config is identical for the minimal and advanced cells —
+// the advanced behaviour (sandbox -> host function calls) is wired
+// entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
+// the provider. The single `openGenerativeUI` flag below turns on
+// Open Generative UI for the listed agent(s); the runtime middleware
+// converts each agent's streamed `generateSandboxedUi` tool call into
+// `open-generative-ui` activity events.
 const runtime = new CopilotRuntime({
   // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
   agents,
-  // Turns on Open Generative UI for the listed agent(s); the runtime
-  // middleware converts each agent's streamed `generateSandboxedUi` tool
-  // call into `open-generative-ui` activity events.
   openGenerativeUI: {
     agents: ["open-gen-ui", "open-gen-ui-advanced"],
   },
 });
+// @endregion[advanced-runtime-config]
+// @endregion[minimal-runtime-flag]
 
 export const POST = async (req: NextRequest) => {
   try {

--- a/showcase/integrations/pydantic-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/agentic-chat/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
@@ -16,16 +17,21 @@ export default function AgenticChatDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
+// @region[chat-component]
 function Chat() {
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       { title: "Write a sonnet", message: "Write a short sonnet about AI." },
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
 }
+// @endregion[chat-component]

--- a/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
@@ -5,7 +5,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/theme.css
@@ -3,6 +3,8 @@
  * leak out and affect the rest of the showcase app.
  */
 
+/* @region[css-variables] */
+/* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
   --copilot-kit-contrast-color: #ffffff;
@@ -13,6 +15,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Georgia", "Cambria", "Times New Roman", serif;

--- a/showcase/integrations/pydantic-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/chat-slots/page.tsx
@@ -32,12 +32,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/pydantic-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless-simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -10,6 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -21,6 +22,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,11 +10,15 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/pydantic-ai/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -7,6 +7,7 @@ export interface NotesCardProps {
   onClear: () => void;
 }
 
+// @region[notes-card-render]
 /**
  * Sidebar card that READS agent-authored notes out of shared state.
  *
@@ -68,3 +69,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -37,6 +37,7 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   // Subscribe the component to agent state changes. Any time the agent
   // mutates its state (e.g. via its `set_notes` tool) this hook fires,
   // we re-render, and the sidebar panels reflect the new values.
@@ -44,6 +45,7 @@ function DemoContent() {
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -77,6 +79,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state.
   // On the agent's next turn, the dynamic `@agent.system_prompt` reads
   // this back out of state and adds it to the system prompt — so the
@@ -87,6 +90,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -25,6 +25,7 @@ export interface PreferencesCardProps {
   onChange: (next: Preferences) => void;
 }
 
+// @region[preferences-card-render]
 /**
  * Sidebar card — the *only* place where the user edits their preferences.
  *
@@ -141,3 +142,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/pydantic-ai/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/subagents/delegation-log.tsx
@@ -48,6 +48,7 @@ const STATUS_STYLE: Record<Delegation["status"], string> = {
   failed: "text-[#FA5F67]",
 };
 
+// @region[delegation-log-frontend]
 /**
  * Live delegation log — renders the `delegations` slot of agent state.
  *
@@ -139,3 +140,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -30,6 +30,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }) => (
@@ -43,6 +47,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -28,7 +28,13 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
+  // Opt in to CopilotKit's built-in default tool-call card. Called with
+  // no config so the package-provided `DefaultToolCallRenderer` is used
+  // as the wildcard renderer — this is the "out-of-the-box" UI the cell
+  // is meant to showcase.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,135 @@
+// Docs-only snippet — not imported or rendered. The pydantic-ai
+// tool-rendering demo at page.tsx exercises the get_weather renderer
+// only (using a different render-prop signature `{ args, ... }`).
+// The docs page at /generative-ui/tool-rendering teaches the
+// `{ parameters, ... }` shape and also covers the search_flights
+// per-tool renderer plus the wildcard catch-all. These regions show
+// what those would look like in a pydantic-ai demo, so the docs render
+// real teaching code rather than a missing-snippet box.
+//
+// See mastra's render-flight-tool.snippet.tsx for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface WeatherResult {
+  city?: string;
+  temperature?: number;
+  humidity?: number;
+  wind_speed?: number;
+  conditions?: string;
+}
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function WeatherCard(_props: {
+  loading: boolean;
+  location: string;
+  temperature?: number;
+  humidity?: number;
+  windSpeed?: number;
+  conditions?: string;
+}) {
+  return null;
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function ToolRenderers() {
+  // @region[render-weather-tool]
+  // Per-tool renderer #1: get_weather → branded WeatherCard.
+  useRenderTool(
+    {
+      name: "get_weather",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<WeatherResult>(result);
+        return (
+          <WeatherCard
+            loading={loading}
+            location={parameters?.location ?? parsed.city ?? ""}
+            temperature={parsed.temperature}
+            humidity={parsed.humidity}
+            windSpeed={parsed.wind_speed}
+            conditions={parsed.conditions}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-weather-tool]
+
+  // @region[render-flight-tool]
+  // Per-tool renderer #2: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool (anything the agent
+  // might call that doesn't have a dedicated useRenderTool registration).
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}


### PR DESCRIPTION
## Summary

Per-framework region marker pass for **pydantic-ai**, bringing it to feature parity with langgraph-python's region coverage so shell-docs renders real teaching code instead of "Missing snippet" boxes. Round 5+ of the established sweep (#4326 mastra, #4361 smalls, #4363 ms-agent, #4369 google-adk).

## Cells advanced (16)

In-place `@region[...]` markers, mirroring langgraph-python:

- agentic-chat — provider-setup, chat-component, configure-suggestions
- chat-customization-css — css-variables, theme-css-import
- chat-slots — register-welcome-slot, register-disclaimer-slot, register-assistant-message-slot
- frontend-tools — frontend-tool-registration, frontend-tool-handler
- headless-simple — use-agent-simple, message-list-simple
- open-gen-ui — minimal-runtime-flag (in copilotkit-ogui/route.ts)
- open-gen-ui-advanced — advanced-runtime-config (same route)
- prebuilt-popup — popup-basic-setup
- prebuilt-sidebar — sidebar-basic-setup, sidebar-configuration
- readonly-state-agent-context — context-provider-sketch, use-agent-context-call
- shared-state-read-write — use-agent-read, use-agent-write, notes-card-render, preferences-card-render
- subagents — subagent-setup, supervisor-delegation-tools (in agents/subagents.py), delegation-log-frontend
- tool-rendering-custom-catchall — use-default-render-tool-wildcard
- tool-rendering-default-catchall — default-catchall-zero-config
- a2ui-fixed-schema — backend-schema-json-load, backend-render-operations (in agents/a2ui_fixed.py)

Cell with sibling file:

- tool-rendering — production `page.tsx` renders only `get_weather` and uses an `{ args, ... }` render-prop shape, while the docs teach the canonical `{ parameters, ... }` shape and also cover `search_flights` + wildcard catch-all. Added `render-flight-tool.snippet.tsx` mirroring mastra's pattern (covers render-weather-tool, render-flight-tool, catchall-renderer regions). The backend `weather-tool-backend` region is marked in-place on `agents/agent.py`.

## Manifest changes

None.

## Deferred

- `declarative-gen-ui::runtime-inject-tool` — cross-cutting, tracked as PDX-70.

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` shows expected region counts for each touched pydantic-ai cell
- [ ] Re-running the audit script reports no missing regions for pydantic-ai except the deferred PDX-70 entry
- [ ] Visit shell-docs locally and spot-check each touched cell renders teaching code (no "Missing snippet" warning)