### PR TITLE
docs(showcase/agno): region markers across 12 cells

### DIFF
--- a/showcase/integrations/agno/src/agents/main.py
+++ b/showcase/integrations/agno/src/agents/main.py
@@ -20,6 +20,7 @@ from tools.types import Flight
 load_dotenv()
 
 
+# @region[weather-tool-backend]
 @tool
 def get_weather(location: str):
     """
@@ -32,6 +33,7 @@ def get_weather(location: str):
         str: Weather data as JSON.
     """
     return json.dumps(get_weather_impl(location))
+# @endregion[weather-tool-backend]
 
 
 @tool

--- a/showcase/integrations/agno/src/agents/subagents.py
+++ b/showcase/integrations/agno/src/agents/subagents.py
@@ -37,6 +37,11 @@ logger = logging.getLogger(__name__)
 _SUB_MODEL_ID = "gpt-4o-mini"
 
 
+# @region[subagent-setup]
+# Each sub-agent is a full Agno `Agent(...)` with its own system prompt.
+# They don't share memory or tools with the supervisor — the supervisor
+# only sees their final text response, which is returned via the
+# delegation tool below.
 _research_agent = Agent(
     model=OpenAIChat(id=_SUB_MODEL_ID, timeout=120),
     description="Research sub-agent.",
@@ -64,6 +69,7 @@ _critique_agent = Agent(
         "2-3 crisp, actionable critiques. No preamble."
     ),
 )
+# @endregion[subagent-setup]
 
 
 def _invoke_sub_agent(sub_agent: Agent, task: str) -> str:
@@ -182,6 +188,12 @@ def _delegate(
 # ---------------------------------------------------------------------------
 
 
+# @region[supervisor-delegation-tools]
+# Each function is a tool exposed to the supervisor agent. The supervisor
+# LLM "calls" these to delegate work; each call synchronously runs the
+# matching sub-agent, records the delegation into shared state, and
+# returns the sub-agent's output as the tool result the supervisor reads
+# on its next step.
 def research_agent(run_context: RunContext, task: str) -> dict[str, Any]:
     """Delegate a research task to the research sub-agent.
 
@@ -224,6 +236,7 @@ def critique_agent(run_context: RunContext, task: str) -> dict[str, Any]:
         sub_agent=_critique_agent,
         task=task,
     )
+# @endregion[supervisor-delegation-tools]
 
 
 # ---------------------------------------------------------------------------

--- a/showcase/integrations/agno/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/agno/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,46 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component / configure-suggestions / provider-setup regions without
+// disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import { CopilotKit } from "@copilotkit/react-core";
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+function Chat() {
+  // @region[configure-suggestions]
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+  // @endregion[configure-suggestions]
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]
+
+export function AgenticChatPage() {
+  return (
+    // @region[provider-setup]
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+    // @endregion[provider-setup]
+  );
+}

--- a/showcase/integrations/agno/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/chat-customization-css/page.tsx
@@ -7,7 +7,9 @@
 import React from "react";
 import { CopilotKit } from "@copilotkit/react-core";
 import { CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/agno/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/agno/src/app/demos/chat-customization-css/theme.css
@@ -3,6 +3,7 @@
  * leak out and affect the rest of the showcase app.
  */
 
+/* @region[css-variables] */
 /* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
@@ -14,6 +15,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 /* Messages container */
 .chat-css-demo-scope .copilotKitMessages {

--- a/showcase/integrations/agno/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/chat-slots/page.tsx
@@ -33,12 +33,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/agno/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless-simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/agno/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/prebuilt-popup/page.tsx
@@ -10,6 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -21,6 +22,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/agno/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,11 +10,15 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/agno/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/agno/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/agno/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -18,6 +18,11 @@ export interface NotesCardProps {
  * The "Clear" button is a write-back (UI -> agent state) to demonstrate
  * both directions on the same field.
  */
+// @region[notes-card-render]
+// Read-side render: this card reflects the agent-authored `notes` slice
+// of shared state. The parent page passes `state.notes` in; we never
+// touch agent state ourselves — we just render it. The Clear button is
+// a small write-back, exposed as an `onClear` prop.
 export function NotesCard({ notes, onClear }: NotesCardProps) {
   return (
     <div
@@ -69,3 +74,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/agno/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/shared-state-read-write/page.tsx
@@ -37,6 +37,7 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   // Subscribe to agent state changes. The custom AGUI router for this
   // agent (see agent_server.py) emits a STATE_SNAPSHOT event after every
   // run, which fires this hook and re-renders the panels below.
@@ -44,6 +45,7 @@ function DemoContent() {
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -77,6 +79,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state.
   // On the agent's next turn, the dynamic instructions function reads
   // this back out of session_state and adds it to the system prompt —
@@ -87,6 +90,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/agno/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/agno/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -34,6 +34,12 @@ export interface PreferencesCardProps {
  * and prepends a preferences block to the system prompt, so the agent's
  * reply visibly adapts.
  */
+// @region[preferences-card-render]
+// Write-side render: every edit here bubbles up through `onChange`, and
+// the parent pipes it straight into `agent.setState({ preferences: ... })`.
+// Nothing in this component knows about the agent directly — that's
+// intentional: the card is a plain controlled form, and the agent state
+// wiring lives one layer up.
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -142,3 +148,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/agno/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/agno/src/app/demos/subagents/delegation-log.tsx
@@ -51,6 +51,7 @@ export interface DelegationLogProps {
   isRunning?: boolean;
 }
 
+// @region[delegation-log-frontend]
 /**
  * Live delegation log — renders the `delegations` slot of agent state.
  *
@@ -151,3 +152,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/agno/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -31,6 +31,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }: any) => (
@@ -44,6 +48,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/agno/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -28,7 +28,13 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
+  // Opt in to CopilotKit's built-in default tool-call card. Called with
+  // no config so the package-provided `DefaultToolCallRenderer` is used
+  // as the wildcard renderer — this is the "out-of-the-box" UI the cell
+  // is meant to showcase.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/agno/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/agno/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,134 @@
+// Docs-only snippet — not imported or rendered. Agno's tool-rendering
+// demo at page.tsx exercises the `get_weather` renderer against the
+// shared `main.py` agent; the docs page at /generative-ui/tool-rendering
+// also teaches the `search_flights` per-tool pattern, the standalone
+// weather card, and the wildcard catch-all. These three regions show
+// what those would look like in the same Agno demo shape, so the docs
+// can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+interface WeatherResult {
+  city?: string;
+  temperature?: number;
+  humidity?: number;
+  wind_speed?: number;
+  conditions?: string;
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function WeatherCard(_props: {
+  loading: boolean;
+  location: string;
+  temperature?: number;
+  humidity?: number;
+  windSpeed?: number;
+  conditions?: string;
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function ToolRenderers() {
+  // @region[render-weather-tool]
+  // Per-tool renderer #1: get_weather → branded WeatherCard.
+  useRenderTool(
+    {
+      name: "get_weather",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<WeatherResult>(result);
+        return (
+          <WeatherCard
+            loading={loading}
+            location={parameters?.location ?? parsed.city ?? ""}
+            temperature={parsed.temperature}
+            humidity={parsed.humidity}
+            windSpeed={parsed.wind_speed}
+            conditions={parsed.conditions}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-weather-tool]
+
+  // @region[render-flight-tool]
+  // Per-tool renderer #2: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool (get_stock_price,
+  // roll_dice, anything the agent might add later).
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}


### PR DESCRIPTION
## Summary

Round 5 of the per-framework region-marker sweep — brings **agno** to parity with the langgraph-python reference. Predecessors: mastra (#4326), smalls batch (#4361), ms-agent (#4363), google-adk (#4369).

The bundler (`showcase/scripts/bundle-demo-content.ts`) extracts `// @region[name]` markers from each integration's demo folder + `highlight:`-listed manifest files. When a region is missing, shell-docs renders a yellow "Missing snippet" warning. This pass authors markers (or sibling teaching files where production code carries unrelated QA hooks) so 12 agno cells stop warning.

## Cells covered (12)

In-place markers:

- `chat-customization-css` — `css-variables` (theme.css), `theme-css-import` (page.tsx)
- `chat-slots` — `register-welcome-slot`, `register-disclaimer-slot`, `register-assistant-message-slot`
- `headless-simple` — `use-agent-simple`, `message-list-simple`
- `prebuilt-popup` — `popup-basic-setup`
- `prebuilt-sidebar` — `sidebar-basic-setup`, `sidebar-configuration`
- `readonly-state-agent-context` — `context-provider-sketch`, `use-agent-context-call`
- `shared-state-read-write` — `use-agent-read`, `use-agent-write` (page.tsx); `preferences-card-render` (preferences-card.tsx); `notes-card-render` (notes-card.tsx)
- `subagents` — `delegation-log-frontend` (delegation-log.tsx); `subagent-setup`, `supervisor-delegation-tools` (agents/subagents.py)
- `tool-rendering-custom-catchall` — `use-default-render-tool-wildcard`
- `tool-rendering-default-catchall` — `default-catchall-zero-config`
- `tool-rendering` (Python only) — `weather-tool-backend` on `get_weather` in agents/main.py

Sibling `.snippet.tsx` files (production page.tsx mixes QA hooks the docs page does not teach):

- `agentic-chat/chat-component.snippet.tsx` — `chat-component`, `configure-suggestions`, `provider-setup`. Production page.tsx layers in `useFrontendTool` (`change_background`), `useRenderTool` (`get_weather`), `useAgentContext` for QA.
- `tool-rendering/render-flight-tool.snippet.tsx` — `render-weather-tool`, `render-flight-tool`, `catchall-renderer`. Production page.tsx renders only `get_weather` and points at the shared agno god-file backend (`agents/main.py`); the docs page also teaches per-flight rendering and a wildcard catch-all.

## Manifest changes

None — the bundler walks the demo folder, so sibling `.snippet.tsx` files are picked up automatically without explicit `highlight:` entries.

## Deferred items

None for this batch. agno already had a reasoning-tier story implemented in production cells (`agentic-chat-reasoning`, `reasoning-default-render`, `tool-rendering-reasoning-chain`) and those cells were not flagged as missing in the audit.

## Test plan

- [x] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; agno cells show region counts matching expectations
- [x] Audit script reports 0 missing cells for agno (down from 12)
- [ ] Local `nx run shell-docs:dev` — confirm none of the 12 cells render the yellow "Missing snippet" warning on agno
- [ ] Spot-check rendered snippets for `agentic-chat` (sibling), `tool-rendering` (sibling), `subagents` (in-place across .py + .tsx)