### PR TITLE
docs(showcase/llamaindex): region markers across 16 cells

### DIFF
--- a/showcase/integrations/llamaindex/manifest.yaml
+++ b/showcase/integrations/llamaindex/manifest.yaml
@@ -99,6 +99,7 @@ demos:
     route: /demos/tool-rendering
     animated_preview_url:
     highlight:
+      - src/agents/agent.py
       - src/app/demos/tool-rendering/agent.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts

--- a/showcase/integrations/llamaindex/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/llamaindex/src/agents/a2ui_fixed.py
@@ -24,12 +24,16 @@ SURFACE_ID = "flight-fixed-schema"
 _SCHEMAS_DIR = Path(__file__).parent / "a2ui_schemas"
 
 
+# @region[backend-schema-json-load]
+# Schemas are JSON so they can be authored and reviewed independently of the
+# Python code. `_load_schema` is just a thin `json.load` wrapper.
 def _load_schema(path: Path) -> list[dict]:
     with path.open("r", encoding="utf-8") as fh:
         return json.load(fh)
 
 
 FLIGHT_SCHEMA = _load_schema(_SCHEMAS_DIR / "flight_schema.json")
+# @endregion[backend-schema-json-load]
 
 
 async def display_flight(
@@ -45,6 +49,10 @@ async def display_flight(
     the Next.js runtime detects this shape in the tool result and forwards
     the ops to the frontend renderer.
     """
+    # @region[backend-render-operations]
+    # The A2UI middleware detects the `a2ui_operations` container in this
+    # tool result and forwards the ops to the frontend renderer. The frontend
+    # catalog resolves component names to the local React components.
     ops = [
         {
             "type": "create_surface",
@@ -68,6 +76,7 @@ async def display_flight(
         },
     ]
     return json.dumps({"a2ui_operations": ops})
+    # @endregion[backend-render-operations]
 
 
 SYSTEM_PROMPT = (

--- a/showcase/integrations/llamaindex/src/agents/agent.py
+++ b/showcase/integrations/llamaindex/src/agents/agent.py
@@ -66,11 +66,13 @@ def book_call(
 
 # --- Backend tools (executed server-side, using shared implementations) ---
 
+# @region[weather-tool-backend]
 async def get_weather(
     location: Annotated[str, "The location to get the weather for."],
 ) -> str:
     """Get the weather for a given location. Returns temperature, conditions, humidity, wind speed, and feels-like temperature."""
     return json.dumps(get_weather_impl(location))
+# @endregion[weather-tool-backend]
 
 
 async def query_data(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-ogui/route.ts
@@ -30,6 +30,15 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
+      // Server-side config is identical for the minimal and advanced cells —
+      // the advanced behaviour (sandbox -> host function calls) is wired
+      // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
+      // the provider. The single `openGenerativeUI` flag below turns on
+      // Open Generative UI for the listed agent(s); the runtime middleware
+      // converts each agent's streamed `generateSandboxedUi` tool call into
+      // `open-generative-ui` activity events.
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -37,6 +46,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/llamaindex/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/llamaindex/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/page.tsx
@@ -2,7 +2,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/theme.css
@@ -3,6 +3,7 @@
  * `.chat-css-demo-scope` so they do not leak out.
  */
 
+/* @region[css-variables] */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
   --copilot-kit-contrast-color: #ffffff;
@@ -13,6 +14,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Georgia", "Cambria", "Times New Roman", serif;

--- a/showcase/integrations/llamaindex/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-slots/page.tsx
@@ -29,11 +29,15 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
+  const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+
   return (
     <CopilotChat
       agentId="chat_slots"
       className="h-full rounded-2xl"
-      welcomeScreen={CustomWelcomeScreen}
+      welcomeScreen={welcomeScreen}
     />
   );
 }

--- a/showcase/integrations/llamaindex/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless_simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/llamaindex/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/prebuilt-popup/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_popup">
       <MainContent />
       <CopilotPopup
@@ -18,6 +19,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,11 +9,15 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt_sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/llamaindex/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -17,6 +17,7 @@ export interface NotesCardProps {
  * The "Clear" button is a write-back (UI -> agent state) to demonstrate
  * both directions on the same field.
  */
+// @region[notes-card-render]
 export function NotesCard({ notes, onClear }: NotesCardProps) {
   return (
     <div
@@ -68,3 +69,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/page.tsx
@@ -38,6 +38,7 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   // Subscribe the component to agent state changes. LlamaIndex's
   // AGUIChatWorkflow emits a StateSnapshotEvent on InputEvent and after
   // every tool call, so any time the agent's `set_notes` tool runs, this
@@ -46,6 +47,7 @@ function DemoContent() {
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -79,6 +81,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state.
   // On the agent's next turn, AGUIChatWorkflow injects this state into
   // the user message via its <state>...</state> prelude — so the UI's
@@ -89,6 +92,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -34,6 +34,7 @@ export interface PreferencesCardProps {
  * preferences) into the latest user message via the `<state>...</state>`
  * prelude, and our system prompt teaches the model to honor them.
  */
+// @region[preferences-card-render]
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -142,3 +143,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/llamaindex/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/subagents/delegation-log.tsx
@@ -51,6 +51,7 @@ const ENTRY_BG_BY_STATUS: Record<Delegation["status"], string> = {
   failed: "border-red-200 bg-red-50/40",
 };
 
+// @region[delegation-log-frontend]
 /**
  * Live delegation log — renders the `delegations` slot of agent state.
  *
@@ -149,3 +150,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -36,6 +36,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }: any) => (
@@ -49,6 +53,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -31,7 +31,13 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
+  // Opt in to CopilotKit's built-in default tool-call card. Called with
+  // no config so the package-provided `DefaultToolCallRenderer` is used
+  // as the wildcard renderer — this is the "out-of-the-box" UI the cell
+  // is meant to showcase.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool(
     {
       name: "get_weather",
@@ -65,6 +66,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. LlamaIndex's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same LlamaIndex demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}


### PR DESCRIPTION
## Summary

Per-framework region pass on **llamaindex**. 16 (framework x cell) targets advanced from B (regions missing) to A (ready). Same patterns as mastra ([#4326](https://github.com/CopilotKit/CopilotKit/pull/4326)), smalls batch 1 ([#4361](https://github.com/CopilotKit/CopilotKit/pull/4361)), ms-agent batch 2 ([#4363](https://github.com/CopilotKit/CopilotKit/pull/4363)), and google-adk ([#4369](https://github.com/CopilotKit/CopilotKit/pull/4369)).

Linear: [PDX-67](https://linear.app/copilotkit/issue/PDX-67) tracker.

## Cells covered

**Frontend regions** (in-place markers): `agentic-chat`, `prebuilt-popup`, `prebuilt-sidebar`, `frontend-tools`, `chat-customization-css`, `chat-slots`, `tool-rendering`, `tool-rendering-default-catchall`, `tool-rendering-custom-catchall`, `headless-simple`, `readonly-state-agent-context`, `open-gen-ui`, `open-gen-ui-advanced`, `shared-state-read-write`, `subagents`.

**Backend regions** (Python files):
- `tool-rendering::weather-tool-backend` - `src/agents/agent.py` (manifest highlight extended)
- `a2ui-fixed-schema::backend-schema-json-load` + `backend-render-operations` - `src/agents/a2ui_fixed.py` (wraps llamaindex's raw `a2ui_operations` dict-ops idiom rather than langgraph-python's `a2ui.render(...)` helper)

**Sibling teaching files** (mirror mastra/google-adk pattern):
- `agentic-chat/chat-component.snippet.tsx` - production Chat carries QA hooks (useFrontendTool, useRenderTool, useAgentContext) that aren't relevant to the prebuilt-chat docs page
- `tool-rendering/render-flight-tool.snippet.tsx` - covers both `render-flight-tool` and `catchall-renderer` regions; production demo only registers a weather renderer

**Small refactor**: `chat-slots/page.tsx` lifts the inline `welcomeScreen={CustomWelcomeScreen}` prop into a named `welcomeScreen` variable so the canonical `register-welcome-slot` region applies in place. No behavior change.

**Manifest change**: `tool-rendering` highlight extended to include `src/agents/agent.py` so the `weather-tool-backend` region is bundled with the cell.

## Deferred (documented divergence)

| Cell / Region | Why |
|---|---|
| `chat-slots` disclaimer + assistant-message slots | Production demo only registers the welcome slot. |
| `declarative-gen-ui::runtime-inject-tool` | Cross-cutting; tracked in [PDX-70](https://linear.app/copilotkit/issue/PDX-70). |
| `headless-complete` (5 regions) | llamaindex's `headless-complete` is structurally simpler than the canonical pattern: single `MessageList` component, no separate bubble components, no `useRenderedMessages` hook. The canonical regions (`custom-bubbles`, `manual-activity-message-rendering`, `manual-tool-call-rendering`, `page-send-message`, `use-rendered-messages-hook`) don't fit. Defer until showcase team expands the demo or [PDX-68](https://linear.app/copilotkit/issue/PDX-68) auto-config ships. |
| `shared-state-streaming` | llamaindex demo is a TODO stub (`page.tsx` contains `TODO: Implement State Streaming demo`); skip until the demo is implemented. |

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; all 16 targets resolve in `demo-content.json`
- [ ] `localhost:<port>/llamaindex/prebuilt-components/chat` - `chat-component` snippet renders the minimal Chat from the sibling file
- [ ] `localhost:<port>/llamaindex/generative-ui/tool-rendering` - all four tool-rendering snippets resolve (in-place + sibling + highlight-file backend)
- [ ] `localhost:<port>/llamaindex/state/shared-state-read-write` - all four regions resolve, including the multi-file pair from `notes-card.tsx` + `preferences-card.tsx`
- [ ] `localhost:<port>/llamaindex/multi-agent/subagents` - `delegation-log-frontend` resolves (subagent backend regions already authored on `src/agents/subagents_agent.py`)
- [ ] `localhost:<port>/llamaindex/generative-ui/a2ui/fixed-schema` - `backend-schema-json-load` + `backend-render-operations` regions resolve from `src/agents/a2ui_fixed.py`
- [ ] Expected yellow boxes (deferred per above) on `chat-slots` (disclaimer/assistant-message), `declarative-gen-ui::runtime-inject-tool`, `headless-complete`, `shared-state-streaming`