### PR TITLE
docs(showcase/crewai-crews): region markers across 16 cells

### DIFF
--- a/showcase/integrations/crewai-crews/manifest.yaml
+++ b/showcase/integrations/crewai-crews/manifest.yaml
@@ -184,6 +184,9 @@ demos:
       - generative-ui
     route: /demos/open-gen-ui
     animated_preview_url:
+    highlight:
+      - src/app/demos/open-gen-ui/page.tsx
+      - src/app/api/copilotkit-ogui/route.ts
   - id: open-gen-ui-advanced
     name: "Open-Ended Gen UI (Advanced)"
     description: Agent-authored UI that invokes host sandbox functions from inside the iframe
@@ -191,6 +194,10 @@ demos:
       - generative-ui
     route: /demos/open-gen-ui-advanced
     animated_preview_url:
+    highlight:
+      - src/app/demos/open-gen-ui-advanced/page.tsx
+      - src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+      - src/app/api/copilotkit-ogui/route.ts
   - id: agent-config
     name: Agent Config Object
     description: Forward a typed config object (tone / expertise / response length) from the provider to the agent
@@ -233,6 +240,9 @@ demos:
       - generative-ui
     route: /demos/a2ui-fixed-schema
     animated_preview_url:
+    highlight:
+      - src/agents/a2ui_fixed.py
+      - src/app/demos/a2ui-fixed-schema/page.tsx
   - id: byoc-hashbrown
     name: BYOC (Hashbrown)
     description: Streaming structured output via @hashbrownai/react against a custom catalog

--- a/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
@@ -32,10 +32,13 @@ CREW_NAME = "A2UIFixedSchema"
 
 _SCHEMAS_DIR = Path(__file__).parent / "a2ui_schemas"
 
+# @region[backend-schema-json-load]
 # Load flight schema at module load so the first request does not pay I/O
-# for the JSON parse.
+# for the JSON parse. The schema is authored as JSON so it can be reviewed
+# independently of the Python code.
 with (_SCHEMAS_DIR / "flight_schema.json").open() as _fp:
     _FLIGHT_SCHEMA = json.load(_fp)
+# @endregion[backend-schema-json-load]
 
 
 class DisplayFlightInput(BaseModel):
@@ -65,6 +68,10 @@ class DisplayFlightTool(BaseTool):
     args_schema: Type[BaseModel] = DisplayFlightInput
 
     def _run(self, origin: str, destination: str, airline: str, price: str) -> str:
+        # @region[backend-render-operations]
+        # The A2UI middleware detects the `a2ui_operations` container in this
+        # tool result and forwards the ops to the frontend renderer. The
+        # frontend catalog resolves component names to local React components.
         ops: list[dict[str, Any]] = [
             {
                 "type": "create_surface",
@@ -88,6 +95,7 @@ class DisplayFlightTool(BaseTool):
             },
         ]
         return json.dumps({"a2ui_operations": ops})
+        # @endregion[backend-render-operations]
 
 
 A2UI_FIXED_BACKSTORY = (

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-ogui/route.ts
@@ -27,6 +27,8 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -34,6 +36,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -24,6 +24,7 @@ export default function AgenticChatReasoningDemo() {
 }
 
 function Chat() {
+  // @region[reasoning-block-render]
   return (
     <CopilotChat
       agentId="agentic-chat-reasoning"
@@ -33,4 +34,5 @@ function Chat() {
       }}
     />
   );
+  // @endregion[reasoning-block-render]
 }

--- a/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/page.tsx
@@ -5,7 +5,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/theme.css
@@ -6,6 +6,7 @@
  * https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
  */
 
+/* @region[css-variables] */
 /* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
@@ -17,6 +18,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 /* Messages container – swap the font for the entire chat */
 .chat-css-demo-scope .copilotKitMessages {

--- a/showcase/integrations/crewai-crews/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/chat-slots/page.tsx
@@ -34,12 +34,21 @@ function Chat() {
     available: "always",
   });
 
+  // Extracting the slot overrides up here keeps the JSX readable and gives
+  // the docs something to point at with `@region` markers for the slot
+  // system guide.
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/page.tsx
@@ -29,6 +29,7 @@ import { myCatalog } from "./a2ui/catalog";
 
 export default function DeclarativeGenUIDemo() {
   return (
+    // @region[provider-a2ui-prop]
     <CopilotKit
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
@@ -43,6 +44,7 @@ export default function DeclarativeGenUIDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[provider-a2ui-prop]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,8 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool]
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +33,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +41,10 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
+  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/assistant-bubble.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/assistant-bubble.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[custom-bubbles]
 export function AssistantBubble({ children }: { children: React.ReactNode }) {
   if (isEmpty(children)) return null;
 
@@ -15,6 +16,7 @@ export function AssistantBubble({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
+// @endregion[custom-bubbles]
 
 function isEmpty(node: React.ReactNode): boolean {
   if (node == null || node === false) return true;

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/page.tsx
@@ -43,6 +43,7 @@ export default function HeadlessCompleteDemo() {
 }
 
 function Chat() {
+  // @region[page-send-message]
   const threadId = useMemo(() => crypto.randomUUID(), []);
   const { agent } = useAgent({ agentId: AGENT_ID, threadId });
   const { copilotkit } = useCopilotKit();
@@ -91,6 +92,7 @@ function Chat() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent]);
+  // @endregion[page-send-message]
 
   return (
     <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={threadId}>

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/use-rendered-messages.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/use-rendered-messages.tsx
@@ -16,6 +16,7 @@ import {
   useRenderCustomMessages,
 } from "@copilotkit/react-core/v2";
 
+// @region[use-rendered-messages-hook]
 export type RenderedMessage = Message & { renderedContent: React.ReactNode };
 
 export function useRenderedMessages(
@@ -46,6 +47,7 @@ export function useRenderedMessages(
     renderCustomMessage,
   ]);
 }
+// @endregion[use-rendered-messages-hook]
 
 function renderMessageContent(args: {
   message: Message;
@@ -79,6 +81,7 @@ function renderMessageContent(args: {
 
   let body: React.ReactNode = null;
 
+  // @region[manual-activity-message-rendering]
   if (message.role === "assistant") {
     body = renderAssistantBody({
       message: message as AssistantMessage,
@@ -98,6 +101,7 @@ function renderMessageContent(args: {
   } else if (message.role === "activity") {
     body = renderActivityMessage(message as ActivityMessage);
   }
+  // @endregion[manual-activity-message-rendering]
 
   if (!customBefore && !customAfter) {
     return body;
@@ -111,6 +115,7 @@ function renderMessageContent(args: {
   );
 }
 
+// @region[manual-tool-call-rendering]
 function renderAssistantBody(args: {
   message: AssistantMessage;
   messages: Message[];
@@ -137,6 +142,7 @@ function renderAssistantBody(args: {
     </>
   );
 }
+// @endregion[manual-tool-call-rendering]
 
 function renderUserBody(message: UserMessage): React.ReactNode {
   const { content } = message;

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/user-bubble.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/user-bubble.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[custom-bubbles]
 export function UserBubble({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex justify-end">
@@ -11,3 +12,4 @@ export function UserBubble({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
+// @endregion[custom-bubbles]

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,8 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
+  // @region[headless-hooks]
   const { agent } = useAgent({ agentId: "headless-simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +51,8 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[headless-hooks]
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +70,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +111,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
@@ -10,12 +10,14 @@ import {
 import { z } from "zod";
 import { TimePickerCard, TimeSlot } from "./time-picker-card";
 
+// @region[time-slots]
 const DEFAULT_SLOTS: TimeSlot[] = [
   { label: "Tomorrow 10:00 AM", iso: "2026-04-19T10:00:00-07:00" },
   { label: "Tomorrow 2:00 PM", iso: "2026-04-19T14:00:00-07:00" },
   { label: "Monday 9:00 AM", iso: "2026-04-21T09:00:00-07:00" },
   { label: "Monday 3:30 PM", iso: "2026-04-21T15:30:00-07:00" },
 ];
+// @endregion[time-slots]
 
 export default function HitlInChatDemo() {
   return (
@@ -45,6 +47,7 @@ function Chat() {
     available: "always",
   });
 
+  // @region[hitl-hook]
   useHumanInTheLoop({
     agentId: "hitl-in-chat",
     name: "book_call",
@@ -68,6 +71,7 @@ function Chat() {
       />
     ),
   });
+  // @endregion[hitl-hook]
 
   return <CopilotChat agentId="hitl-in-chat" className="h-full rounded-2xl" />;
 }

--- a/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -17,6 +17,10 @@ import { openGenUiSuggestions } from "./suggestions";
 
 export default function OpenGenUiAdvancedDemo() {
   return (
+    // @region[sandbox-function-registration]
+    // Pass the sandbox-function array on the `openGenerativeUI` provider prop.
+    // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
+    // remotes inside the agent-authored iframe.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
@@ -28,6 +32,7 @@ export default function OpenGenUiAdvancedDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[sandbox-function-registration]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui/page.tsx
@@ -39,6 +39,7 @@ const minimalSuggestions = [
 ];
 
 export default function OpenGenUiDemo() {
+  // @region[minimal-provider-setup]
   return (
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
@@ -52,6 +53,7 @@ export default function OpenGenUiDemo() {
       </div>
     </CopilotKit>
   );
+  // @endregion[minimal-provider-setup]
 }
 
 function Chat() {

--- a/showcase/integrations/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
@@ -10,6 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -21,6 +22,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,11 +10,15 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
@@ -12,10 +12,12 @@ export default function ReasoningDefaultRenderDemo() {
     <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
+          {/* @region[default-reasoning-zero-config] */}
           <CopilotChat
             agentId="reasoning-default-render"
             className="h-full rounded-2xl"
           />
+          {/* @endregion[default-reasoning-zero-config] */}
         </div>
       </div>
     </CopilotKit>


### PR DESCRIPTION
## Summary

Round 5 of the per-framework region marker sweep, bringing **crewai-crews** to feature parity with `langgraph-python`. Without these markers, every `<Snippet region=... cell=...>` tag in the crewai-crews shell-docs surfaces renders the yellow "Missing snippet" warning instead of teaching code.

Established by mastra batch 1 (#4326), smalls batch 1 (#4361), ms-agent batch 2 (#4363), google-adk batch 3 (#4369). This is batch 4 for crewai-crews.

## Cells advanced (16)

| Cell | Regions added |
| --- | --- |
| `a2ui-fixed-schema` | `backend-render-operations`, `backend-schema-json-load` (Python backend; manifest highlight added) |
| `agentic-chat` | `chat-component` (sibling snippet), `configure-suggestions`, `provider-setup` |
| `agentic-chat-reasoning` | `reasoning-block-render` |
| `chat-customization-css` | `css-variables`, `theme-css-import` |
| `chat-slots` | `register-assistant-message-slot`, `register-disclaimer-slot`, `register-welcome-slot` |
| `declarative-gen-ui` | `provider-a2ui-prop` |
| `frontend-tools` | `frontend-tool`, `frontend-tool-handler`, `frontend-tool-registration` |
| `headless-complete` | `custom-bubbles`, `manual-activity-message-rendering`, `manual-tool-call-rendering`, `page-send-message`, `use-rendered-messages-hook` |
| `headless-simple` | `headless-hooks`, `message-list-simple`, `use-agent-simple` |
| `hitl-in-chat` | `hitl-hook`, `time-slots` |
| `open-gen-ui` | `minimal-provider-setup`, `advanced-runtime-config`, `minimal-runtime-flag` (manifest highlight added for the ogui route) |
| `open-gen-ui-advanced` | `sandbox-function-registration`, `advanced-runtime-config`, `minimal-runtime-flag` (manifest highlight) |
| `prebuilt-popup` | `popup-basic-setup` |
| `prebuilt-sidebar` | `sidebar-basic-setup`, `sidebar-configuration` |
| `readonly-state-agent-context` | `context-provider-sketch`, `use-agent-context-call` |
| `reasoning-default-render` | `default-reasoning-zero-config` |

## Sibling files added

- `agentic-chat/chat-component.snippet.tsx` — production `page.tsx` wires `useFrontendTool` / `useRenderTool` / `useAgentContext` (QA hooks the prebuilt-chat docs page isn't trying to teach). Sibling carries a minimal `Chat` definition for the `chat-component` region. Pattern established by mastra/strands.

## Manifest changes

Added `highlight` arrays to bring backend / API-route files into the bundler's region-extraction scope:

- `a2ui-fixed-schema`: `src/agents/a2ui_fixed.py`, `src/app/demos/a2ui-fixed-schema/page.tsx`
- `open-gen-ui`: `src/app/demos/open-gen-ui/page.tsx`, `src/app/api/copilotkit-ogui/route.ts`
- `open-gen-ui-advanced`: `src/app/demos/open-gen-ui-advanced/page.tsx`, `src/app/demos/open-gen-ui-advanced/sandbox-functions.ts`, `src/app/api/copilotkit-ogui/route.ts`

## Deferred

| Cell | Region | Reason |
| --- | --- | --- |
| `declarative-gen-ui` | `runtime-inject-tool` | Cross-cutting / always-defer (PDX-70) |
| `shared-state-streaming` | `frontend-use-coagent-state`, `state-streaming-middleware` | Production `page.tsx` is a `TODO: Implement` stub; the underlying shared-state implementation needs to land before docs regions can be wired |

## Test plan

- [ ] Run `npx tsx showcase/scripts/bundle-demo-content.ts` and confirm zero unresolved regions for crewai-crews across the 16 cells above
- [ ] Visit each cell's docs page on shell-docs (framework picker -> CrewAI (Crews)) and confirm `<Snippet>` tags render code instead of the yellow "Missing snippet" warning
- [ ] Confirm production demo routes for `agentic-chat` (sibling snippet must not be imported) and `open-gen-ui` / `open-gen-ui-advanced` (new manifest highlights must not change runtime behaviour) still load and behave correctly