### PR TITLE
docs(showcase/spring-ai): region markers across 13 cells

### DIFF
--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-ogui/route.ts
@@ -36,6 +36,15 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
+      // Server-side config is identical for the minimal and advanced cells —
+      // the advanced behaviour (sandbox -> host function calls) is wired
+      // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
+      // the provider. The single `openGenerativeUI` flag below turns on
+      // Open Generative UI for the listed agent(s); the runtime middleware
+      // converts each agent's streamed `generateSandboxedUi` tool call into
+      // `open-generative-ui` activity events.
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -43,6 +52,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/spring-ai/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/spring-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/page.tsx
@@ -9,7 +9,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/theme.css
@@ -6,6 +6,8 @@
  * https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
  */
 
+/* @region[css-variables] */
+/* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
   --copilot-kit-contrast-color: #ffffff;
@@ -16,6 +18,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Georgia", "Cambria", "Times New Roman", serif;

--- a/showcase/integrations/spring-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/chat-slots/page.tsx
@@ -32,12 +32,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/spring-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/spring-ai/src/app/demos/headless-simple/headless-chat.snippet.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/headless-simple/headless-chat.snippet.tsx
@@ -1,0 +1,131 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries a `deduplicateMessages` pass to defend against
+// the Spring AI AG-UI adapter's multi-run tool-call loop (see the comment
+// on that helper in page.tsx). That dedup logic is QA scaffolding, not part
+// of the headless-chat teaching content. This file gives the docs a clean
+// minimal surface to point at via `use-agent-simple` and
+// `message-list-simple` regions without the dedup distraction.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import React, { useState } from "react";
+import {
+  useAgent,
+  useComponent,
+  useCopilotKit,
+  useRenderToolCall,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+function ShowCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="my-2 rounded-lg border border-gray-300 bg-white p-4 shadow-sm">
+      <div className="font-semibold text-gray-900">{title}</div>
+      <div className="mt-1 text-sm text-gray-700 whitespace-pre-wrap">
+        {body}
+      </div>
+    </div>
+  );
+}
+
+export function HeadlessChat() {
+  // @region[use-agent-simple]
+  const { agent } = useAgent({ agentId: "headless-simple" });
+  const { copilotkit } = useCopilotKit();
+  const [input, setInput] = useState("");
+
+  useComponent({
+    name: "show_card",
+    description: "Display a titled card with a short body of text.",
+    parameters: z.object({
+      title: z.string().describe("Short heading for the card."),
+      body: z.string().describe("Body text for the card."),
+    }),
+    render: ShowCard,
+  });
+
+  const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
+
+  const send = () => {
+    const text = input.trim();
+    if (!text || agent.isRunning) return;
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    });
+    void copilotkit.runAgent({ agent }).catch(() => {});
+    setInput("");
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
+        {agent.messages.length === 0 && (
+          <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
+        )}
+        {agent.messages.map((m) => {
+          if (m.role === "user") {
+            return (
+              <div
+                key={m.id}
+                data-message-role="user"
+                className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
+              >
+                {typeof m.content === "string" ? m.content : ""}
+              </div>
+            );
+          }
+          if (m.role === "assistant") {
+            const toolCalls =
+              "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
+            return (
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
+                {m.content && (
+                  <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
+                    {m.content as React.ReactNode}
+                  </div>
+                )}
+                {toolCalls.map((tc: { id: string }) => (
+                  <div key={tc.id}>
+                    {renderToolCall({ toolCall: tc as any })}
+                  </div>
+                ))}
+              </div>
+            );
+          }
+          return null;
+        })}
+        {agent.isRunning && (
+          <div className="text-xs text-gray-400">Agent is thinking...</div>
+        )}
+        {/* @endregion[message-list-simple] */}
+      </div>
+      <div className="flex gap-2">
+        <textarea
+          className="flex-1 rounded-lg border border-gray-300 p-2 text-sm"
+          rows={2}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message..."
+        />
+        <button
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-50"
+          onClick={send}
+          disabled={agent.isRunning || !input.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/showcase/integrations/spring-ai/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/open-gen-ui/page.tsx
@@ -84,6 +84,12 @@ const minimalSuggestions = [
 
 export default function OpenGenUiDemo() {
   return (
+    // @region[minimal-provider-setup]
+    // Minimal Open Generative UI frontend: the built-in activity renderer is
+    // registered by CopilotKitProvider, so a plain <CopilotChat /> is enough —
+    // no custom tool renderers, no activity-renderer registration.
+    // We DO pass `openGenerativeUI.designSkill` to swap in visualisation-tuned
+    // guidance in place of the default shadcn design skill.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
@@ -95,6 +101,7 @@ export default function OpenGenUiDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[minimal-provider-setup]
   );
 }
 

--- a/showcase/integrations/spring-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -20,6 +21,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,11 +9,15 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/spring-ai/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -18,6 +18,7 @@ export interface NotesCardProps {
  * The "Clear" button is a write-back (UI -> agent state) to demonstrate
  * both directions on the same field.
  */
+// @region[notes-card-render]
 export function NotesCard({ notes, onClear }: NotesCardProps) {
   return (
     <div
@@ -69,3 +70,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -54,10 +54,15 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
+  // Subscribe the component to agent state changes. Any time the agent
+  // mutates its state (e.g. via its `set_notes` tool) this hook fires,
+  // we re-render, and the sidebar panels reflect the new values.
   const { agent } = useAgent({
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -91,6 +96,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state. On
   // the agent's next turn, the Spring controller reads the same object off
   // the AG-UI state envelope and adds it to the system prompt.
@@ -100,6 +106,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -34,6 +34,7 @@ export interface PreferencesCardProps {
  * controller reads that same object out of the AG-UI state envelope and
  * injects it into the system prompt so the agent's reply visibly adapts.
  */
+// @region[preferences-card-render]
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -142,3 +143,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/spring-ai/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/subagents/delegation-log.tsx
@@ -57,6 +57,7 @@ const STATUS_COLOR: Record<Delegation["status"], string> = {
  * STATE_SNAPSHOT, the frontend's `useAgent({ updates: [OnStateChanged] })`
  * subscription fires, and a new entry appears below.
  */
+// @region[delegation-log-frontend]
 export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
   return (
     <div
@@ -134,3 +135,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
@@ -103,6 +103,11 @@ public class SubagentsController {
             of every sub-agent delegation.
             """;
 
+    // @region[subagent-setup]
+    // Each sub-agent is its own Spring AI ChatClient call (built per-request
+    // in SubAgentHandler.apply), with its own system prompt. They don't
+    // share memory or tools with the supervisor — the supervisor only sees
+    // their return value as a tool result.
     private static final String RESEARCH_PROMPT =
             "You are a research sub-agent. Given a topic, produce a concise "
             + "bulleted list of 3-5 key facts. No preamble, no closing.";
@@ -113,6 +118,7 @@ public class SubagentsController {
     private static final String CRITIQUE_PROMPT =
             "You are an editorial critique sub-agent. Given a draft, give "
             + "2-3 crisp, actionable critiques. No preamble.";
+    // @endregion[subagent-setup]
 
     private final AgUiService agUiService;
     private final ChatModel chatModel;
@@ -190,6 +196,13 @@ public class SubagentsController {
             // tool-call ids returned by ChatResponse.
             List<HandlerInvocation> handlerInvocations = new CopyOnWriteArrayList<>();
 
+            // @region[supervisor-delegation-tools]
+            // Each sub-agent is exposed to the supervisor LLM as a Spring AI
+            // ToolCallback. When the supervisor invokes one, the matching
+            // SubAgentHandler runs a fresh ChatClient call with that
+            // sub-agent's system prompt, appends a Delegation entry to
+            // shared state, and returns the sub-agent's output to the
+            // supervisor as a tool result.
             ToolCallback researchTool = subAgentTool(
                     "research_agent", RESEARCH_PROMPT, runState, deferredEvents,
                     handlerInvocations, messageId,
@@ -207,6 +220,7 @@ public class SubagentsController {
                     handlerInvocations, messageId,
                     "Delegate a critique task to the critique sub-agent. "
                     + "Use for: reviewing a draft and suggesting concrete improvements.");
+            // @endregion[supervisor-delegation-tools]
 
             AssistantMessage assistantMessage = new AssistantMessage();
             assistantMessage.setId(messageId);

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java
@@ -62,6 +62,11 @@ public class DisplayFlightTool implements Function<DisplayFlightTool.Request, St
     @Override
     public String apply(Request request) {
         try {
+            // @region[backend-render-operations]
+            // The A2UI middleware detects the `a2ui_operations` container in
+            // this tool result and forwards the ops to the frontend renderer.
+            // The frontend catalog resolves component names to the local
+            // React components.
             var ops = List.of(
                     Map.of("type", "create_surface",
                             "surfaceId", SURFACE_ID,
@@ -79,6 +84,7 @@ public class DisplayFlightTool implements Function<DisplayFlightTool.Request, St
                             ))
             );
             return MAPPER.writeValueAsString(Map.of("a2ui_operations", ops));
+            // @endregion[backend-render-operations]
         } catch (Exception e) {
             return "{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}";
         }


### PR DESCRIPTION
## Summary

Per-framework region pass on **spring-ai** (Java backend — distinct from the Python and TypeScript framework batches). 13 cells advanced from B (regions missing) to A (ready). 28 regions resolved. Same patterns as mastra ([#4326](https://github.com/CopilotKit/CopilotKit/pull/4326)), smalls batch 1 ([#4361](https://github.com/CopilotKit/CopilotKit/pull/4361)), ms-agent ([#4363](https://github.com/CopilotKit/CopilotKit/pull/4363)), and google-adk ([#4369](https://github.com/CopilotKit/CopilotKit/pull/4369)).

Linear: PDX-67 tracker (next ticked-off framework after google-adk).

## Cells covered

**Frontend regions** (in-place markers): `agentic-chat` (provider-setup + configure-suggestions), `chat-customization-css` (css-variables in theme.css + theme-css-import), `chat-slots` (welcome + disclaimer + assistant-message slots — all three already wired), `frontend-tools` (handler + registration), `open-gen-ui` (minimal-provider-setup), `open-gen-ui-advanced` (no new front regions; the existing sandbox-function-registration covers it), `prebuilt-popup` (popup-basic-setup), `prebuilt-sidebar` (sidebar-basic-setup + sidebar-configuration), `readonly-state-agent-context` (context-provider-sketch + use-agent-context-call), `shared-state-read-write` (use-agent-read + use-agent-write on page.tsx; notes-card-render + preferences-card-render on the sibling components), `subagents` (delegation-log-frontend).

**Runtime regions**: `open-gen-ui::minimal-runtime-flag` and `open-gen-ui-advanced::advanced-runtime-config` both on the shared `src/app/api/copilotkit-ogui/route.ts` file (server-side config is identical for the minimal and advanced cells — the advanced behaviour is wired entirely on the frontend via `openGenerativeUI.sandboxFunctions`).

**Backend regions** (Java files, all already in manifest `highlight:`):
- `subagents::subagent-setup` + `supervisor-delegation-tools` — `src/main/java/com/copilotkit/showcase/springai/SubagentsController.java`. Wraps spring-ai's idiom (Spring AI `ToolCallback` factory + per-handler `ChatClient` invocation) rather than langgraph-python's `@tool` / `create_agent` pattern.
- `a2ui-fixed-schema::backend-render-operations` — `src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java`

Backend region markers use Java syntax: `// @region[name]` / `// @endregion[name]`.

**Sibling teaching files** (same pattern as mastra / google-adk):
- `agentic-chat/chat-component.snippet.tsx` — production `Chat` carries `useFrontendTool` + `useRenderTool` + `useAgentContext` + `data-testid` QA hooks irrelevant to the prebuilt-chat docs page.
- `headless-simple/headless-chat.snippet.tsx` — production carries a `deduplicateMessages` pass against the AG-UI Spring AI adapter's multi-run tool-call loop. That dedup logic is QA scaffolding, not part of the headless-chat teaching content; the sibling exposes a clean `useAgent` + `agent.messages.map` surface.

## Deferred (documented divergence)

| Cell / Region | Why |
|---|---|
| `a2ui-fixed-schema::backend-schema-json-load` | spring-ai keeps the schema inline as a Java `List.of(Map.of(...))` in `DisplayFlightTool.java` (same divergence as ms-agent-dotnet, [#4363](https://github.com/CopilotKit/CopilotKit/pull/4363)). The docs region's "load JSON at startup" framing doesn't match. |
| `declarative-gen-ui::runtime-inject-tool` | Cross-cutting; tracked in PDX-70. |

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; all 28 regions resolve in `demo-content.json` (re-audit confirms only the two deferred items remain)
- [ ] `localhost:<port>/spring-ai/prebuilt-components/chat` — chat-component snippet renders the minimal `Chat` from the sibling file
- [ ] `localhost:<port>/spring-ai/headless/simple` — use-agent-simple + message-list-simple resolve from the sibling file (no dedup noise in the docs surface)
- [ ] `localhost:<port>/spring-ai/multi-agent/subagents` — delegation-log-frontend (frontend) + subagent-setup + supervisor-delegation-tools (backend) resolve; backend snippet shows spring-ai's idiom (`ToolCallback` factory + `ChatClient.builder`) rather than langgraph's `@tool` / `create_agent`
- [ ] `localhost:<port>/spring-ai/state/shared-state-read-write` — all four regions resolve including the multi-file pair from notes-card.tsx + preferences-card.tsx
- [ ] `localhost:<port>/spring-ai/generative-ui/a2ui/fixed-schema` — backend-render-operations resolves; backend-schema-json-load remains yellow (deferred per above)
- [ ] Expected yellow boxes (deferred per above) on `a2ui-fixed-schema::backend-schema-json-load` and `declarative-gen-ui::runtime-inject-tool`