### PR TITLE
fix(showcase): add bare /api/copilotkit + /api/smoke routes for built-in-agent

### DIFF
--- a/showcase/integrations/built-in-agent/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/built-in-agent/src/app/api/copilotkit/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST, OPTIONS } from "./[[...slug]]/route";

--- a/showcase/integrations/built-in-agent/src/app/api/smoke/route.ts
+++ b/showcase/integrations/built-in-agent/src/app/api/smoke/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+
+const INTEGRATION_SLUG = "built-in-agent";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET() {
+  const start = Date.now();
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    `http://localhost:${process.env.PORT || 3000}`;
+
+  try {
+    const res = await fetch(`${baseUrl}/api/copilotkit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        method: "agent/run",
+        params: { agentId: "default" },
+        body: {
+          threadId: `smoke-${Date.now()}`,
+          runId: `smoke-run-${Date.now()}`,
+          state: {},
+          messages: [
+            {
+              id: `smoke-msg-${Date.now()}`,
+              role: "user",
+              content: "Respond with exactly: OK",
+            },
+          ],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        },
+      }),
+      signal: AbortSignal.timeout(45000),
+    });
+
+    const latency = Date.now() - start;
+
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "");
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "runtime_response",
+          error: `Runtime returned ${res.status}: ${errBody.slice(0, 200)}`,
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    const reader = res.body?.getReader();
+    if (!reader) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned no readable body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+    const { value, done } = await reader.read();
+    reader.cancel();
+    if (done || !value || value.length === 0) {
+      return NextResponse.json(
+        {
+          status: "error",
+          integration: INTEGRATION_SLUG,
+          stage: "response_empty",
+          error: "Runtime returned empty response body",
+          latency_ms: latency,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({
+      status: "ok",
+      integration: INTEGRATION_SLUG,
+      latency_ms: latency,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (e: unknown) {
+    const err = e instanceof Error ? e : new Error(String(e));
+    const latency = Date.now() - start;
+
+    let stage = "unknown";
+    if (err.name === "AbortError" || err.message.includes("timeout"))
+      stage = "timeout";
+    else if (
+      err.message.includes("fetch") ||
+      err.message.includes("ECONNREFUSED")
+    )
+      stage = "agent_unreachable";
+    else stage = "pipeline_error";
+
+    return NextResponse.json(
+      {
+        status: "error",
+        integration: INTEGRATION_SLUG,
+        stage,
+        error: err.message,
+        latency_ms: latency,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 502 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `/api/copilotkit/route.ts` re-exporting from the `[[...slug]]` catch-all so the bare path returns non-404
- Add `/api/smoke/route.ts` matching the standard contract all other integrations follow

## Why
The smoke probe POSTs to `/api/copilotkit` (bare path) and interprets 404 as "route not wired", marking `agent:built-in-agent` red. This blocks the depth ladder at D2, so all dashboard cells show D0 despite e2e probes passing 35/35.

## Test plan
- [ ] CI green (build proves the routes compile)
- [ ] After deploy, verify `curl -X POST https://showcase-built-in-agent-production.up.railway.app/api/copilotkit` returns non-404
- [ ] Verify `curl https://showcase-built-in-agent-production.up.railway.app/api/smoke` returns 200
- [ ] Next probe tick shows `agent:built-in-agent` green, depth ladder unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)