### PR TITLE
fix(showcase/ops): hydrate probe lastRun from PocketBase on boot

### DIFF
--- a/showcase/ops/src/http/probes.test.ts
+++ b/showcase/ops/src/http/probes.test.ts
@@ -1,17 +1,14 @@
 import { Hono } from "hono";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import {
-  registerProbesRoutes,
-  TRIGGER_RATE_LIMIT_MS,
-  type ProbesRouteDeps,
-} from "./probes.js";
-import {
-  type Scheduler,
-  type EntryStatus,
-  type ScheduleEntry,
-  type TriggerOptions,
-  type TriggerResult,
-  InflightConflictError,
+import { registerProbesRoutes, TRIGGER_RATE_LIMIT_MS } from "./probes.js";
+import type { ProbesRouteDeps } from "./probes.js";
+import { InflightConflictError } from "../scheduler/scheduler.js";
+import type {
+  Scheduler,
+  EntryStatus,
+  ScheduleEntry,
+  TriggerOptions,
+  TriggerResult,
 } from "../scheduler/scheduler.js";
 import { ProbeRunTracker } from "../probes/run-tracker.js";
 import type { ProbeRunRecord, ProbeRunWriter } from "../probes/run-history.js";
@@ -37,6 +34,8 @@ interface FakeScheduler extends Scheduler {
   setTriggerBehavior(behavior: { throw?: Error; result?: TriggerResult }): void;
   /** Test-only: capture last trigger() invocation. */
   lastTriggerOpts: TriggerOptions | undefined;
+  /** Test-only: direct access to entries map for seedEntryLastRun verification. */
+  _entries: Map<string, FakeEntryRow>;
 }
 
 function makeFakeScheduler(): FakeScheduler {
@@ -70,12 +69,24 @@ function makeFakeScheduler(): FakeScheduler {
     // no-op — kept structural so a future test that wants to assert the
     // invoker called it can override on the fake instance.
     setEntryTracker: () => {},
+    // Mirror the real scheduler's seedEntryLastRun: only writes when
+    // lastRunFinishedAt is still null (race guard), no-op for unknown ids.
+    seedEntryLastRun: (id, opts) => {
+      const row = entries.get(id);
+      if (!row) return;
+      if (row.status.lastRunFinishedAt !== null) return;
+      row.status.lastRunStartedAt = opts.startedAt;
+      row.status.lastRunFinishedAt = opts.finishedAt;
+      row.status.lastRunDurationMs = opts.durationMs;
+      row.status.lastRunSummary = opts.summary;
+    },
     setEntry: (row) => entries.set(row.entry.id, row),
     setTriggerBehavior: ({ throw: t, result }) => {
       triggerThrow = t;
       triggerResult = result;
     },
     lastTriggerOpts: undefined,
+    _entries: entries,
   };
   return fake;
 }
@@ -303,6 +314,46 @@ describe("GET /api/probes", () => {
     expect(config.discovery).toEqual({
       source: "railway-services",
       key_template: "{slug}",
+    });
+  });
+
+  it("returns seeded lastRun after seedEntryLastRun (hydrate-on-boot path)", async () => {
+    const sched = makeFakeScheduler();
+    const writer = makeFakeWriter();
+    const configs = new Map<string, ProbeConfig>([
+      ["smoke", baseConfig("smoke", "smoke")],
+    ]);
+    // Register with no lastRun data (simulates fresh boot before any tick).
+    sched.setEntry({
+      entry: { id: "smoke", cron: "*/5 * * * *", handler: async () => {} },
+      status: baseStatus({ id: "smoke", cron: "*/5 * * * *" }),
+      nextRunAt: new Date("2026-04-28T10:05:00Z"),
+    });
+
+    // Seed historical run data (mirrors what hydrateProbeLastRuns does).
+    sched.seedEntryLastRun("smoke", {
+      startedAt: Date.parse("2026-04-28T10:00:00.000Z"),
+      finishedAt: Date.parse("2026-04-28T10:00:30.000Z"),
+      durationMs: 30000,
+      summary: { total: 34, passed: 34, failed: 0 },
+    });
+
+    const app = buildApp(sched, writer, configs);
+    const res = await app.request("/api/probes");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      probes: Array<Record<string, unknown>>;
+    };
+    expect(body.probes).toHaveLength(1);
+    const smoke = body.probes[0];
+    expect(smoke.id).toBe("smoke");
+    expect(smoke.lastRun).not.toBeNull();
+    expect(smoke.lastRun).toEqual({
+      startedAt: "2026-04-28T10:00:00.000Z",
+      finishedAt: "2026-04-28T10:00:30.000Z",
+      durationMs: 30000,
+      state: "completed",
+      summary: { total: 34, passed: 34, failed: 0 },
     });
   });
 });

--- a/showcase/ops/src/orchestrator.test.ts
+++ b/showcase/ops/src/orchestrator.test.ts
@@ -11,6 +11,7 @@ import {
   envForCfg,
   createRailwayAdapter,
   registerAllProbeDrivers,
+  hydrateProbeLastRuns,
 } from "./orchestrator.js";
 import { createProbeRegistry } from "./probes/drivers/index.js";
 import { createScheduler } from "./scheduler/scheduler.js";
@@ -1819,6 +1820,216 @@ describe("orchestrator.registerAllProbeDrivers (post-#4292 hotfix guard)", () =>
     const kinds = registry.list();
     expect(kinds).toContain("e2e_deep");
     expect(kinds).toContain("e2e_parity");
+  });
+});
+
+/**
+ * hydrateProbeLastRuns: reads the most recent completed probe_run from PB
+ * for each `probe:*` scheduler entry and seeds the scheduler's lastRun
+ * bookkeeping so the dashboard shows historical data immediately after
+ * restart (instead of "never run" until the first cron tick).
+ */
+describe("hydrateProbeLastRuns", () => {
+  function makeStubScheduler() {
+    const entries = new Map<
+      string,
+      {
+        id: string;
+        cron: string;
+        seeded: {
+          startedAt: number;
+          finishedAt: number;
+          durationMs: number;
+          summary: unknown;
+        } | null;
+      }
+    >();
+    return {
+      register(entry: { id: string; cron: string }) {
+        entries.set(entry.id, { ...entry, seeded: null });
+      },
+      unregister: vi.fn(async () => true),
+      hasEntry: (id: string) => entries.has(id),
+      list: () =>
+        Array.from(entries.values()).map((e) => ({
+          id: e.id,
+          cron: e.cron,
+          handler: async () => undefined,
+        })),
+      start: vi.fn(),
+      stop: vi.fn(async () => undefined),
+      isStarted: () => false,
+      isStopped: () => false,
+      getJobCount: () => entries.size,
+      getEntry: (id: string) => {
+        const e = entries.get(id);
+        if (!e) return undefined;
+        return {
+          id: e.id,
+          cron: e.cron,
+          inflight: 0,
+          lastRunStartedAt: e.seeded?.startedAt ?? null,
+          lastRunFinishedAt: e.seeded?.finishedAt ?? null,
+          lastRunDurationMs: e.seeded?.durationMs ?? null,
+          lastRunSummary: e.seeded?.summary ?? null,
+          triggeredRun: false,
+          tracker: null,
+        };
+      },
+      setEntryTracker: vi.fn(),
+      seedEntryLastRun: vi.fn(
+        (
+          id: string,
+          opts: {
+            startedAt: number;
+            finishedAt: number;
+            durationMs: number;
+            summary: unknown;
+          },
+        ) => {
+          const e = entries.get(id);
+          if (e) e.seeded = opts;
+        },
+      ),
+      trigger: vi.fn(),
+      nextRunAt: vi.fn(() => null),
+    };
+  }
+
+  function makeStubRunWriter() {
+    return {
+      start: vi.fn(),
+      finish: vi.fn(),
+      recent: vi.fn().mockResolvedValue([]),
+    };
+  }
+
+  function makeStubLogger() {
+    return {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+  }
+
+  it("seeds scheduler entries from completed probe_runs", async () => {
+    const scheduler = makeStubScheduler();
+    scheduler.register({ id: "probe:smoke-all", cron: "0 * * * *" });
+    scheduler.register({ id: "probe:pin-drift", cron: "0 9 * * 1" });
+    const runWriter = makeStubRunWriter();
+    runWriter.recent
+      .mockImplementation(async (probeId: string) => {
+        if (probeId === "smoke-all") {
+          return [
+            {
+              id: "run1",
+              probeId: "smoke-all",
+              startedAt: "2025-01-01T00:00:00.000Z",
+              finishedAt: "2025-01-01T00:01:00.000Z",
+              durationMs: 60000,
+              triggered: false,
+              state: "completed",
+              summary: { total: 5, passed: 5, failed: 0 },
+            },
+          ];
+        }
+        return [];
+      });
+    const log = makeStubLogger();
+
+    await hydrateProbeLastRuns({
+      scheduler: scheduler as any,
+      runWriter: runWriter as any,
+      logger: log as any,
+    });
+
+    // smoke-all was seeded
+    expect(scheduler.seedEntryLastRun).toHaveBeenCalledWith("probe:smoke-all", {
+      startedAt: Date.parse("2025-01-01T00:00:00.000Z"),
+      finishedAt: Date.parse("2025-01-01T00:01:00.000Z"),
+      durationMs: 60000,
+      summary: { total: 5, passed: 5, failed: 0 },
+    });
+    // pin-drift had no runs — should NOT have been seeded
+    expect(scheduler.seedEntryLastRun).toHaveBeenCalledTimes(1);
+    // Info log emitted
+    expect(log.info).toHaveBeenCalledWith("orchestrator.hydrate-lastrun", {
+      seeded: 1,
+      total: 2,
+    });
+  });
+
+  it("skips non-probe entries (only fetches runs for probe:* ids)", async () => {
+    const scheduler = makeStubScheduler();
+    scheduler.register({ id: "internal:s3-backup", cron: "0 3 * * *" });
+    scheduler.register({ id: "probe:smoke", cron: "0 * * * *" });
+    scheduler.register({ id: "ruleA:cron:0", cron: "0 9 * * 1" });
+    const runWriter = makeStubRunWriter();
+    const log = makeStubLogger();
+
+    await hydrateProbeLastRuns({
+      scheduler: scheduler as any,
+      runWriter: runWriter as any,
+      logger: log as any,
+    });
+
+    // recent() called only for the probe entry's bare id
+    expect(runWriter.recent).toHaveBeenCalledTimes(1);
+    expect(runWriter.recent).toHaveBeenCalledWith("smoke", 1);
+  });
+
+  it("tolerates runWriter.recent() failures gracefully (never throws)", async () => {
+    const scheduler = makeStubScheduler();
+    scheduler.register({ id: "probe:broken", cron: "0 * * * *" });
+    const runWriter = makeStubRunWriter();
+    runWriter.recent.mockRejectedValue(new Error("PB is down"));
+    const log = makeStubLogger();
+
+    // Must NOT throw
+    await expect(
+      hydrateProbeLastRuns({
+        scheduler: scheduler as any,
+        runWriter: runWriter as any,
+        logger: log as any,
+      }),
+    ).resolves.toBeUndefined();
+
+    // Warn log emitted for the failure
+    expect(log.warn).toHaveBeenCalledWith(
+      "orchestrator.hydrate-lastrun-failed",
+      expect.objectContaining({ err: expect.stringContaining("PB is down") }),
+    );
+    // seedEntryLastRun NOT called
+    expect(scheduler.seedEntryLastRun).not.toHaveBeenCalled();
+  });
+
+  it("skips runs with finishedAt=null (incomplete)", async () => {
+    const scheduler = makeStubScheduler();
+    scheduler.register({ id: "probe:in-progress", cron: "0 * * * *" });
+    const runWriter = makeStubRunWriter();
+    runWriter.recent.mockResolvedValue([
+      {
+        id: "run-incomplete",
+        probeId: "in-progress",
+        startedAt: "2025-01-01T00:00:00.000Z",
+        finishedAt: null,
+        durationMs: null,
+        triggered: false,
+        state: "running",
+        summary: null,
+      },
+    ]);
+    const log = makeStubLogger();
+
+    await hydrateProbeLastRuns({
+      scheduler: scheduler as any,
+      runWriter: runWriter as any,
+      logger: log as any,
+    });
+
+    // Entry stays un-seeded because the run is incomplete
+    expect(scheduler.seedEntryLastRun).not.toHaveBeenCalled();
   });
 });
 

--- a/showcase/ops/src/orchestrator.test.ts
+++ b/showcase/ops/src/orchestrator.test.ts
@@ -2004,6 +2004,55 @@ describe("hydrateProbeLastRuns", () => {
     expect(scheduler.seedEntryLastRun).not.toHaveBeenCalled();
   });
 
+  it("skips runs with malformed date strings (NaN guard)", async () => {
+    const scheduler = makeStubScheduler();
+    scheduler.register({ id: "probe:bad-dates", cron: "0 * * * *" });
+    const runWriter = makeStubRunWriter();
+    runWriter.recent.mockResolvedValue([
+      {
+        id: "run-bad",
+        probeId: "bad-dates",
+        startedAt: "not-a-date",
+        finishedAt: "also-bad",
+        durationMs: 1000,
+        triggered: false,
+        state: "completed",
+        summary: null,
+      },
+    ]);
+    const log = makeStubLogger();
+
+    await hydrateProbeLastRuns({
+      scheduler: scheduler as any,
+      runWriter: runWriter as any,
+      logger: log as any,
+    });
+
+    expect(scheduler.seedEntryLastRun).not.toHaveBeenCalled();
+  });
+
+  it("includes probeId in warn log when runWriter.recent() rejects", async () => {
+    const scheduler = makeStubScheduler();
+    scheduler.register({ id: "probe:broken", cron: "0 * * * *" });
+    const runWriter = makeStubRunWriter();
+    runWriter.recent.mockRejectedValue(new Error("PB is down"));
+    const log = makeStubLogger();
+
+    await hydrateProbeLastRuns({
+      scheduler: scheduler as any,
+      runWriter: runWriter as any,
+      logger: log as any,
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "orchestrator.hydrate-lastrun-failed",
+      expect.objectContaining({
+        probeId: "probe:broken",
+        err: expect.stringContaining("PB is down"),
+      }),
+    );
+  });
+
   it("skips runs with finishedAt=null (incomplete)", async () => {
     const scheduler = makeStubScheduler();
     scheduler.register({ id: "probe:in-progress", cron: "0 * * * *" });

--- a/showcase/ops/src/orchestrator.test.ts
+++ b/showcase/ops/src/orchestrator.test.ts
@@ -14,7 +14,7 @@ import {
   hydrateProbeLastRuns,
 } from "./orchestrator.js";
 import { createProbeRegistry } from "./probes/drivers/index.js";
-import { createScheduler } from "./scheduler/scheduler.js";
+import type { createScheduler } from "./scheduler/scheduler.js";
 import { createEventBus } from "./events/event-bus.js";
 import { logger } from "./logger.js";
 import type { CompiledRule } from "./rules/rule-loader.js";
@@ -1918,24 +1918,23 @@ describe("hydrateProbeLastRuns", () => {
     scheduler.register({ id: "probe:smoke-all", cron: "0 * * * *" });
     scheduler.register({ id: "probe:pin-drift", cron: "0 9 * * 1" });
     const runWriter = makeStubRunWriter();
-    runWriter.recent
-      .mockImplementation(async (probeId: string) => {
-        if (probeId === "smoke-all") {
-          return [
-            {
-              id: "run1",
-              probeId: "smoke-all",
-              startedAt: "2025-01-01T00:00:00.000Z",
-              finishedAt: "2025-01-01T00:01:00.000Z",
-              durationMs: 60000,
-              triggered: false,
-              state: "completed",
-              summary: { total: 5, passed: 5, failed: 0 },
-            },
-          ];
-        }
-        return [];
-      });
+    runWriter.recent.mockImplementation(async (probeId: string) => {
+      if (probeId === "smoke-all") {
+        return [
+          {
+            id: "run1",
+            probeId: "smoke-all",
+            startedAt: "2025-01-01T00:00:00.000Z",
+            finishedAt: "2025-01-01T00:01:00.000Z",
+            durationMs: 60000,
+            triggered: false,
+            state: "completed",
+            summary: { total: 5, passed: 5, failed: 0 },
+          },
+        ];
+      }
+      return [];
+    });
     const log = makeStubLogger();
 
     await hydrateProbeLastRuns({

--- a/showcase/ops/src/orchestrator.ts
+++ b/showcase/ops/src/orchestrator.ts
@@ -12,6 +12,7 @@ import { createRuleLoader, type CompiledRule } from "./rules/rule-loader.js";
 import { createRenderer } from "./render/renderer.js";
 import { createAlertEngine } from "./alerts/alert-engine.js";
 import { createScheduler } from "./scheduler/scheduler.js";
+import type { Scheduler } from "./scheduler/scheduler.js";
 import { createStatusWriter } from "./writers/status-writer.js";
 import { createSlackWebhookTarget } from "./targets/slack-webhook.js";
 import { createMetricsRegistry } from "./http/metrics.js";
@@ -30,6 +31,7 @@ import { buildProbeInvoker } from "./probes/loader/probe-invoker.js";
 import type { ProbeConfig } from "./probes/loader/schema.js";
 import type { ProbeRegistry } from "./probes/types.js";
 import { createProbeRunWriter } from "./probes/run-history.js";
+import type { ProbeRunWriter } from "./probes/run-history.js";
 import { aimockWiringDriver } from "./probes/drivers/aimock-wiring.js";
 import { pinDriftDriver } from "./probes/drivers/pin-drift.js";
 import { smokeDriver } from "./probes/drivers/smoke.js";
@@ -46,7 +48,7 @@ import { pnpmPackagesDiscoverySource } from "./probes/discovery/pnpm-packages.js
 import { logger, reloadLogLevel } from "./logger.js";
 import { logErrorWithStack } from "./probes/loader/probe-invoker.js";
 import { makeGql } from "./probes/discovery/railway-services.js";
-import type { State, StatusRecord, Target } from "./types/index.js";
+import type { Logger, State, StatusRecord, Target } from "./types/index.js";
 
 export interface BootOptions {
   configDir?: string;
@@ -691,6 +693,13 @@ export async function boot(opts: BootOptions = {}): Promise<{
   // probes accept callbacks that read scheduler liveness lazily), so the
   // reorder is safe and obviates needing a try/catch around start() to
   // close the server before rethrowing.
+
+  // Hydrate scheduler lastRun bookkeeping from PB probe_runs before the
+  // first cron tick fires, so the dashboard immediately reflects historical
+  // data instead of "never run" until each probe's first post-restart tick.
+  // Non-fatal — PB being down at boot logs a warn and continues.
+  await hydrateProbeLastRuns({ scheduler, runWriter, logger });
+
   scheduler.start();
   schedulerRunning = true;
   // R2-B.2: wrap serve() so a synchronous throw (EADDRINUSE, etc.) doesn't
@@ -1142,6 +1151,63 @@ export function buildCronProbeResolver(
  * Exported for unit-test access. Production callers go through
  * `buildCronProbeResolver`.
  */
+
+/**
+ * Hydrate scheduler `lastRun*` bookkeeping from the PocketBase `probe_runs`
+ * collection at boot time so the dashboard doesn't show "never run" for
+ * probes that haven't ticked since the last restart.
+ *
+ * Non-fatal: PB being down at boot must NOT prevent the orchestrator from
+ * starting. Individual fetch failures are logged at warn level and skipped.
+ */
+export async function hydrateProbeLastRuns(deps: {
+  scheduler: Scheduler;
+  runWriter: ProbeRunWriter;
+  logger: Logger;
+}): Promise<void> {
+  const { scheduler, runWriter, logger: log } = deps;
+  const entries = scheduler.list();
+  const probeIds = entries
+    .filter((e) => e.id.startsWith("probe:"))
+    .map((e) => e.id);
+
+  const results = await Promise.allSettled(
+    probeIds.map(async (schedulerId) => {
+      const probeId = schedulerId.slice("probe:".length);
+      const runs = await runWriter.recent(probeId, 1);
+      return { schedulerId, runs };
+    }),
+  );
+
+  let seeded = 0;
+  for (const result of results) {
+    if (result.status === "rejected") {
+      log.warn("orchestrator.hydrate-lastrun-failed", {
+        err: String(result.reason),
+      });
+      continue;
+    }
+    const { schedulerId, runs } = result.value;
+    if (runs.length === 0) continue;
+    const run = runs[0];
+    if (!run.finishedAt || run.durationMs === null) continue;
+    scheduler.seedEntryLastRun(schedulerId, {
+      startedAt: Date.parse(run.startedAt),
+      finishedAt: Date.parse(run.finishedAt),
+      durationMs: run.durationMs,
+      summary: run.summary ?? null,
+    });
+    seeded++;
+  }
+
+  if (seeded > 0) {
+    log.info("orchestrator.hydrate-lastrun", {
+      seeded,
+      total: probeIds.length,
+    });
+  }
+}
+
 export function createRailwayAdapter(
   opts: {
     token: string;

--- a/showcase/ops/src/orchestrator.ts
+++ b/showcase/ops/src/orchestrator.ts
@@ -1180,9 +1180,11 @@ export async function hydrateProbeLastRuns(deps: {
   );
 
   let seeded = 0;
-  for (const result of results) {
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
     if (result.status === "rejected") {
       log.warn("orchestrator.hydrate-lastrun-failed", {
+        probeId: probeIds[i],
         err: String(result.reason),
       });
       continue;
@@ -1191,9 +1193,12 @@ export async function hydrateProbeLastRuns(deps: {
     if (runs.length === 0) continue;
     const run = runs[0];
     if (!run.finishedAt || run.durationMs === null) continue;
+    const startedMs = Date.parse(run.startedAt);
+    const finishedMs = Date.parse(run.finishedAt);
+    if (!Number.isFinite(startedMs) || !Number.isFinite(finishedMs)) continue;
     scheduler.seedEntryLastRun(schedulerId, {
-      startedAt: Date.parse(run.startedAt),
-      finishedAt: Date.parse(run.finishedAt),
+      startedAt: startedMs,
+      finishedAt: finishedMs,
       durationMs: run.durationMs,
       summary: run.summary ?? null,
     });

--- a/showcase/ops/src/scheduler/scheduler.test.ts
+++ b/showcase/ops/src/scheduler/scheduler.test.ts
@@ -526,6 +526,86 @@ describe("scheduler", () => {
     expect(entered).toBeGreaterThanOrEqual(1);
   }, 10_000);
 
+  // ---------------------------------------------------------------------
+  // seedEntryLastRun: boot-time hydration from PocketBase
+  // ---------------------------------------------------------------------
+  it("seedEntryLastRun populates all four fields on a registered entry", () => {
+    const s = createScheduler({ logger });
+    s.register({ id: "seed", cron: "* * * * *", handler: () => {} });
+    s.seedEntryLastRun("seed", {
+      startedAt: 1000,
+      finishedAt: 2000,
+      durationMs: 1000,
+      summary: { total: 5, passed: 3, failed: 2 },
+    });
+    const status = s.getEntry("seed")!;
+    expect(status.lastRunStartedAt).toBe(1000);
+    expect(status.lastRunFinishedAt).toBe(2000);
+    expect(status.lastRunDurationMs).toBe(1000);
+    expect(status.lastRunSummary).toEqual({ total: 5, passed: 3, failed: 2 });
+  });
+
+  it("seedEntryLastRun is a no-op for unknown entry id (no throw)", () => {
+    const s = createScheduler({ logger });
+    expect(() =>
+      s.seedEntryLastRun("does-not-exist", {
+        startedAt: 1000,
+        finishedAt: 2000,
+        durationMs: 1000,
+        summary: null,
+      }),
+    ).not.toThrow();
+  });
+
+  it("seedEntryLastRun accepts null summary", () => {
+    const s = createScheduler({ logger });
+    s.register({ id: "seed-null", cron: "* * * * *", handler: () => {} });
+    s.seedEntryLastRun("seed-null", {
+      startedAt: 500,
+      finishedAt: 600,
+      durationMs: 100,
+      summary: null,
+    });
+    const status = s.getEntry("seed-null")!;
+    expect(status.lastRunStartedAt).toBe(500);
+    expect(status.lastRunFinishedAt).toBe(600);
+    expect(status.lastRunDurationMs).toBe(100);
+    expect(status.lastRunSummary).toBeNull();
+  });
+
+  it("seedEntryLastRun does NOT overwrite when lastRunFinishedAt is already set (race guard)", async () => {
+    const s = createScheduler({ logger });
+    s.register({
+      id: "race",
+      cron: "0 0 1 1 *",
+      handler: async () => ({ total: 10, passed: 10, failed: 0 }),
+    });
+    s.start();
+    // Fire a manual trigger to populate real run data.
+    await s.trigger("race");
+    await new Promise((r) => setTimeout(r, 100));
+    const realStatus = s.getEntry("race")!;
+    expect(realStatus.lastRunFinishedAt).not.toBeNull();
+    const realFinishedAt = realStatus.lastRunFinishedAt;
+    const realDurationMs = realStatus.lastRunDurationMs;
+    // Now attempt to seed — should be a no-op because real data exists.
+    s.seedEntryLastRun("race", {
+      startedAt: 1,
+      finishedAt: 2,
+      durationMs: 1,
+      summary: { total: 1, passed: 0, failed: 1 },
+    });
+    const afterSeed = s.getEntry("race")!;
+    expect(afterSeed.lastRunFinishedAt).toBe(realFinishedAt);
+    expect(afterSeed.lastRunDurationMs).toBe(realDurationMs);
+    expect(afterSeed.lastRunSummary).toEqual({
+      total: 10,
+      passed: 10,
+      failed: 0,
+    });
+    await s.stop();
+  }, 10_000);
+
   // CR-C-sched.1: runId counter must be per-instance, not module-scoped.
   // Two independent Scheduler instances must each start their counter at 1
   // so test fixtures (and any future multi-instance use case) get isolated

--- a/showcase/ops/src/scheduler/scheduler.ts
+++ b/showcase/ops/src/scheduler/scheduler.ts
@@ -126,6 +126,22 @@ export interface Scheduler {
    */
   setEntryTracker(id: string, tracker: ProbeRunTracker | null): void;
   /**
+   * Inject historical run data from PocketBase at boot time so the
+   * dashboard doesn't show "never run" for probes that haven't ticked
+   * yet since the last restart. Only writes when `lastRunFinishedAt` is
+   * still null — if a cron tick already fired between register() and
+   * seed(), the real data takes priority.
+   */
+  seedEntryLastRun(
+    id: string,
+    opts: {
+      startedAt: number;
+      finishedAt: number;
+      durationMs: number;
+      summary: RunSummary | null;
+    },
+  ): void;
+  /**
    * Manually invoke the handler associated with `id`, off the cron
    * schedule. Throws `InflightConflictError` if a tick (cron or trigger)
    * is already running for that id. Returns immediately with a generated
@@ -446,6 +462,15 @@ export function createScheduler(opts: SchedulerOptions): Scheduler {
       const e = entries.get(id);
       if (!e) return;
       e.tracker = tracker;
+    },
+    seedEntryLastRun(id, opts) {
+      const e = entries.get(id);
+      if (!e) return;
+      if (e.lastRunFinishedAt !== null) return;
+      e.lastRunStartedAt = opts.startedAt;
+      e.lastRunFinishedAt = opts.finishedAt;
+      e.lastRunDurationMs = opts.durationMs;
+      e.lastRunSummary = opts.summary ?? null;
     },
     async trigger(id, triggerOpts) {
       const e = entries.get(id);


### PR DESCRIPTION
## Summary

- Adds `seedEntryLastRun` to the Scheduler interface for one-time boot
  hydration of lastRun fields from PocketBase history
- Adds `hydrateProbeLastRuns` to the orchestrator, wired into boot()
  before scheduler.start() -- queries the most recent completed run per
  probe and seeds the scheduler state
- Race guard: seedEntryLastRun only writes if no real cron tick has
  already completed (lastRunFinishedAt === null)
- Resilience: Promise.allSettled ensures one PB failure does not block
  other probes; the function never throws
- NaN guard on Date.parse results prevents malformed PB dates from
  crashing the /api/probes route
- Hydration warn log includes probeId so operators can identify which
  probe PB fetch failed

## Why

After service restarts, the dashboard showed "never run" for all probes
until their first cron tick because scheduler EntrySlot fields are
in-memory only. This hydrates from PocketBase probe_runs history on boot
so probes immediately show their last known run state.

## Test plan

- 4 unit tests for seedEntryLastRun (populates fields, no-op unknown id,
  null summary, race guard)
- 4 unit tests for hydrateProbeLastRuns (seeds completed runs, skips
  non-probe entries, tolerates PB failures, skips incomplete runs)
- 2 tests for NaN guard and probeId in warn log
- 1 integration test verifying seeded lastRun surfaces through
  GET /api/probes
- All 121 existing tests pass