### PR TITLE
fix(showcase): fix PR #4359 build breaks — ms-agent-dotnet C# error + ag2 Pydantic crash

### DIFF
--- a/showcase/integrations/ag2/src/agents/shared_state_read_write.py
+++ b/showcase/integrations/ag2/src/agents/shared_state_read_write.py
@@ -17,8 +17,6 @@ Together this gives bidirectional shared state: frontend writes,
 backend reads AND writes, frontend re-renders.
 """
 
-from __future__ import annotations
-
 import logging
 from textwrap import dedent
 from typing import List, Optional

--- a/showcase/integrations/ag2/src/agents/subagents.py
+++ b/showcase/integrations/ag2/src/agents/subagents.py
@@ -17,8 +17,6 @@ adapted to surface delegation events to the frontend via AG-UI's
 shared-state channel.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import uuid

--- a/showcase/integrations/ms-agent-dotnet/agent/SubagentsAgent.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/SubagentsAgent.cs
@@ -69,7 +69,7 @@ internal sealed class SubagentsAgent : DelegatingAIAgent
         // exposes a per-thread "active" handle that the static tool
         // function reads. We restore the previous value on exit so nested /
         // overlapping runs don't trample each other.
-        var previous = _store.SetActiveThread(thread);
+        var previous = (AgentThread?)_store.SetActiveThread(thread);
         try
         {
             await foreach (var update in InnerAgent.RunStreamingAsync(messageList, thread, options, cancellationToken).ConfigureAwait(false))


### PR DESCRIPTION
## Summary

Fixes two build-breaking bugs introduced by PR #4359 (shared-state-read-write + subagents demos):

- **ms-agent-dotnet**: `SubagentsAgent.cs` line 72 — `SetActiveThread()` returns `object?` but the `finally` block passes it back to `SetActiveThread()` which expects `AgentThread?`. Cast the return value to fix the compile error.

- **ag2**: `shared_state_read_write.py` and `subagents.py` both had `from __future__ import annotations` which turns all type annotations into lazy string forward references (PEP 563). When autogen's `ConversableAgent` registered `@tool()`-decorated functions, Pydantic's `TypeAdapter` couldn't resolve `ForwardRef('ContextVariables')` and crashed on startup. Removed the import — neither file uses PEP 585/604 syntax so it was unnecessary.

## Test plan

- [ ] ms-agent-dotnet Docker image builds successfully (C# compiles)
- [ ] ag2 Railway deploy succeeds (no Pydantic crash on startup)
- [ ] CI green