### PR TITLE
docs(showcase): region markers across 8 frameworks (consolidated)

### DIFF
--- a/showcase/integrations/agno/src/agents/main.py
+++ b/showcase/integrations/agno/src/agents/main.py
@@ -20,6 +20,7 @@ from tools.types import Flight
 load_dotenv()
 
 
+# @region[weather-tool-backend]
 @tool
 def get_weather(location: str):
     """
@@ -32,6 +33,7 @@ def get_weather(location: str):
         str: Weather data as JSON.
     """
     return json.dumps(get_weather_impl(location))
+# @endregion[weather-tool-backend]
 
 
 @tool

--- a/showcase/integrations/agno/src/agents/subagents.py
+++ b/showcase/integrations/agno/src/agents/subagents.py
@@ -37,6 +37,11 @@ logger = logging.getLogger(__name__)
 _SUB_MODEL_ID = "gpt-4o-mini"
 
 
+# @region[subagent-setup]
+# Each sub-agent is a full Agno `Agent(...)` with its own system prompt.
+# They don't share memory or tools with the supervisor — the supervisor
+# only sees their final text response, which is returned via the
+# delegation tool below.
 _research_agent = Agent(
     model=OpenAIChat(id=_SUB_MODEL_ID, timeout=120),
     description="Research sub-agent.",
@@ -64,6 +69,7 @@ _critique_agent = Agent(
         "2-3 crisp, actionable critiques. No preamble."
     ),
 )
+# @endregion[subagent-setup]
 
 
 def _invoke_sub_agent(sub_agent: Agent, task: str) -> str:
@@ -182,6 +188,12 @@ def _delegate(
 # ---------------------------------------------------------------------------
 
 
+# @region[supervisor-delegation-tools]
+# Each function is a tool exposed to the supervisor agent. The supervisor
+# LLM "calls" these to delegate work; each call synchronously runs the
+# matching sub-agent, records the delegation into shared state, and
+# returns the sub-agent's output as the tool result the supervisor reads
+# on its next step.
 def research_agent(run_context: RunContext, task: str) -> dict[str, Any]:
     """Delegate a research task to the research sub-agent.
 
@@ -224,6 +236,7 @@ def critique_agent(run_context: RunContext, task: str) -> dict[str, Any]:
         sub_agent=_critique_agent,
         task=task,
     )
+# @endregion[supervisor-delegation-tools]
 
 
 # ---------------------------------------------------------------------------

--- a/showcase/integrations/agno/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/agno/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,46 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component / configure-suggestions / provider-setup regions without
+// disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import { CopilotKit } from "@copilotkit/react-core";
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+function Chat() {
+  // @region[configure-suggestions]
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+  // @endregion[configure-suggestions]
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]
+
+export function AgenticChatPage() {
+  return (
+    // @region[provider-setup]
+    <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
+      <div className="flex justify-center items-center h-screen w-full">
+        <div className="h-full w-full max-w-4xl">
+          <Chat />
+        </div>
+      </div>
+    </CopilotKit>
+    // @endregion[provider-setup]
+  );
+}

--- a/showcase/integrations/agno/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/chat-customization-css/page.tsx
@@ -7,7 +7,9 @@
 import React from "react";
 import { CopilotKit } from "@copilotkit/react-core";
 import { CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/agno/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/agno/src/app/demos/chat-customization-css/theme.css
@@ -3,6 +3,7 @@
  * leak out and affect the rest of the showcase app.
  */
 
+/* @region[css-variables] */
 /* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
@@ -14,6 +15,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 /* Messages container */
 .chat-css-demo-scope .copilotKitMessages {

--- a/showcase/integrations/agno/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/chat-slots/page.tsx
@@ -33,12 +33,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/agno/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless-simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/agno/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/prebuilt-popup/page.tsx
@@ -10,6 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -21,6 +22,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/agno/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,11 +10,15 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/agno/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/agno/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/agno/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -18,6 +18,11 @@ export interface NotesCardProps {
  * The "Clear" button is a write-back (UI -> agent state) to demonstrate
  * both directions on the same field.
  */
+// @region[notes-card-render]
+// Read-side render: this card reflects the agent-authored `notes` slice
+// of shared state. The parent page passes `state.notes` in; we never
+// touch agent state ourselves — we just render it. The Clear button is
+// a small write-back, exposed as an `onClear` prop.
 export function NotesCard({ notes, onClear }: NotesCardProps) {
   return (
     <div
@@ -69,3 +74,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/agno/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/shared-state-read-write/page.tsx
@@ -37,6 +37,7 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   // Subscribe to agent state changes. The custom AGUI router for this
   // agent (see agent_server.py) emits a STATE_SNAPSHOT event after every
   // run, which fires this hook and re-renders the panels below.
@@ -44,6 +45,7 @@ function DemoContent() {
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -77,6 +79,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state.
   // On the agent's next turn, the dynamic instructions function reads
   // this back out of session_state and adds it to the system prompt —
@@ -87,6 +90,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/agno/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/agno/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -34,6 +34,12 @@ export interface PreferencesCardProps {
  * and prepends a preferences block to the system prompt, so the agent's
  * reply visibly adapts.
  */
+// @region[preferences-card-render]
+// Write-side render: every edit here bubbles up through `onChange`, and
+// the parent pipes it straight into `agent.setState({ preferences: ... })`.
+// Nothing in this component knows about the agent directly — that's
+// intentional: the card is a plain controlled form, and the agent state
+// wiring lives one layer up.
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -142,3 +148,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/agno/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/agno/src/app/demos/subagents/delegation-log.tsx
@@ -51,6 +51,7 @@ export interface DelegationLogProps {
   isRunning?: boolean;
 }
 
+// @region[delegation-log-frontend]
 /**
  * Live delegation log — renders the `delegations` slot of agent state.
  *
@@ -151,3 +152,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/agno/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -31,6 +31,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }: any) => (
@@ -44,6 +48,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/agno/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -28,7 +28,13 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
+  // Opt in to CopilotKit's built-in default tool-call card. Called with
+  // no config so the package-provided `DefaultToolCallRenderer` is used
+  // as the wildcard renderer — this is the "out-of-the-box" UI the cell
+  // is meant to showcase.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/agno/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/agno/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,134 @@
+// Docs-only snippet — not imported or rendered. Agno's tool-rendering
+// demo at page.tsx exercises the `get_weather` renderer against the
+// shared `main.py` agent; the docs page at /generative-ui/tool-rendering
+// also teaches the `search_flights` per-tool pattern, the standalone
+// weather card, and the wildcard catch-all. These three regions show
+// what those would look like in the same Agno demo shape, so the docs
+// can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+interface WeatherResult {
+  city?: string;
+  temperature?: number;
+  humidity?: number;
+  wind_speed?: number;
+  conditions?: string;
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function WeatherCard(_props: {
+  loading: boolean;
+  location: string;
+  temperature?: number;
+  humidity?: number;
+  windSpeed?: number;
+  conditions?: string;
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function ToolRenderers() {
+  // @region[render-weather-tool]
+  // Per-tool renderer #1: get_weather → branded WeatherCard.
+  useRenderTool(
+    {
+      name: "get_weather",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<WeatherResult>(result);
+        return (
+          <WeatherCard
+            loading={loading}
+            location={parameters?.location ?? parsed.city ?? ""}
+            temperature={parsed.temperature}
+            humidity={parsed.humidity}
+            windSpeed={parsed.wind_speed}
+            conditions={parsed.conditions}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-weather-tool]
+
+  // @region[render-flight-tool]
+  // Per-tool renderer #2: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool (get_stock_price,
+  // roll_dice, anything the agent might add later).
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/claude-sdk-python/src/agents/subagents_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/subagents_agent.py
@@ -54,6 +54,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_ANTHROPIC_MODEL = "claude-3-5-sonnet-20241022"
 
 
+# @region[subagent-setup]
+# Each sub-agent is defined by its own system prompt; `_invoke_sub_agent`
+# (below) issues a single-shot Anthropic call as that sub-agent. They
+# don't share memory or tools with the supervisor — the supervisor only
+# ever sees what the sub-agent returns as a tool result.
 # @region[subagents-system-prompts]
 SUB_AGENT_PROMPTS: dict[str, str] = {
     "research_agent": (
@@ -89,6 +94,14 @@ SUPERVISOR_SYSTEM_PROMPT = (
 )
 
 
+# @region[supervisor-delegation-tools]
+# The supervisor delegates by calling tools. Each entry in
+# `SUPERVISOR_TOOLS` is an Anthropic tool schema that the supervisor LLM
+# "calls" to delegate work; the run loop in `run_subagents_agent` (see
+# the subagents-delegation-flow region) runs the matching sub-agent
+# synchronously, records the delegation into shared agent state, and
+# returns the sub-agent's output as a tool_result the supervisor can
+# read on its next step.
 def _delegation_tool_schema(name: str, description: str) -> dict[str, Any]:
     return {
         "name": name,
@@ -128,6 +141,7 @@ SUPERVISOR_TOOLS: list[dict[str, Any]] = [
         "Delegate a critique task. Returns 2-3 actionable critiques.",
     ),
 ]
+# @endregion[supervisor-delegation-tools]
 
 
 # @region[subagents-invocation]
@@ -156,6 +170,7 @@ async def _invoke_sub_agent(
         raise RuntimeError("sub-agent returned empty response")
     return text
 # @endregion[subagents-invocation]
+# @endregion[subagent-setup]
 
 
 def _convert_messages(input_data: RunAgentInput) -> list[dict[str, Any]]:

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
@@ -29,6 +29,8 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       // Server-side config is identical for minimal and advanced cells —
       // the advanced behaviour (sandbox -> host function calls) is wired
       // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
@@ -43,6 +45,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/headless-complete/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/headless-complete/page.tsx
@@ -51,6 +51,7 @@ export default function HeadlessCompleteDemo() {
 }
 
 function Chat() {
+  // @region[page-send-message]
   const threadId = useMemo(() => crypto.randomUUID(), []);
   const { agent } = useAgent({ agentId: AGENT_ID, threadId });
   const { copilotkit } = useCopilotKit();
@@ -101,6 +102,7 @@ function Chat() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent]);
+  // @endregion[page-send-message]
 
   return (
     <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={threadId}>

--- a/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -23,6 +23,10 @@ import { openGenUiSuggestions } from "./suggestions";
 
 export default function OpenGenUiAdvancedDemo() {
   return (
+    // @region[sandbox-function-registration]
+    // Pass the sandbox-function array on the `openGenerativeUI` provider prop.
+    // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
+    // remotes inside the agent-authored iframe.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
@@ -34,6 +38,7 @@ export default function OpenGenUiAdvancedDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[sandbox-function-registration]
   );
 }
 

--- a/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+// @region[sandbox-function-registration]
 /**
  * Host-side functions that agent-authored, sandboxed UIs can invoke from
  * inside the iframe via `Websandbox.connection.remote.<name>(args)`.
@@ -54,3 +55,4 @@ export const openGenUiSandboxFunctions = [
     },
   },
 ];
+// @endregion[sandbox-function-registration]

--- a/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/open-gen-ui/page.tsx
@@ -87,6 +87,12 @@ const minimalSuggestions = [
 
 export default function OpenGenUiDemo() {
   return (
+    // @region[minimal-provider-setup]
+    // Minimal Open Generative UI frontend: the built-in activity renderer is
+    // registered by CopilotKitProvider, so a plain <CopilotChat /> is enough —
+    // no custom tool renderers, no activity-renderer registration.
+    // We DO pass `openGenerativeUI.designSkill` to swap in visualisation-tuned
+    // guidance in place of the default shadcn design skill.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
@@ -98,6 +104,7 @@ export default function OpenGenUiDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[minimal-provider-setup]
   );
 }
 

--- a/showcase/integrations/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -36,6 +36,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }) => (
@@ -49,6 +53,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -33,10 +33,12 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
   // Opt in to CopilotKit's built-in default tool-call card. Called with
   // no config so the package-provided `DefaultToolCallRenderer` is used
   // as the wildcard renderer.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. The claude-sdk-python
+// tool-rendering demo at page.tsx exercises the get_weather renderer
+// only; the docs page at /generative-ui/tool-rendering also teaches the
+// search_flights per-tool pattern and the wildcard catch-all. These two
+// regions show what those would look like in the same demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/weather_tool.snippet.py
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/tool-rendering/weather_tool.snippet.py
@@ -1,0 +1,52 @@
+# Docs-only snippet — not imported or executed. The runtime agent in
+# `src/agents/agent.py` declares `get_weather` as one entry in a shared
+# `TOOLS` list of Anthropic tool schemas and dispatches via
+# `_execute_tool`, which is great for the production demo but doesn't
+# read as a clean single-tool teaching example. This sibling shows the
+# Claude Agent SDK idiom for "one backend tool" so the
+# /generative-ui/tool-rendering docs can render real teaching code
+# rather than a missing-snippet box.
+#
+# Why a sibling file: the bundler walks every file in the demo folder
+# and extracts region markers from each, so a docs-targeted teaching
+# example can live alongside the production demo without being wired
+# into the route. See: showcase/scripts/bundle-demo-content.ts.
+
+from typing import Any
+
+
+# @region[weather-tool-backend]
+# Anthropic tool schema — passed via the `tools` parameter on
+# `client.messages.create(...)` / `.stream(...)`. Claude calls this
+# tool by name; the runtime dispatches to the matching handler below.
+GET_WEATHER_TOOL: dict[str, Any] = {
+    "name": "get_weather",
+    "description": (
+        "Get the current weather for a given location. Useful on its "
+        "own for weather questions, and a great companion to "
+        "`search_flights` — always consider checking the weather at a "
+        "destination the user is flying to."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "location": {
+                "type": "string",
+                "description": "The city or region to get weather for.",
+            },
+        },
+        "required": ["location"],
+    },
+}
+
+
+def get_weather(location: str) -> dict[str, Any]:
+    """Handler invoked when Claude calls the `get_weather` tool."""
+    return {
+        "city": location,
+        "temperature": 68,
+        "humidity": 55,
+        "wind_speed": 10,
+        "conditions": "Sunny",
+    }
+# @endregion[weather-tool-backend]

--- a/showcase/integrations/crewai-crews/manifest.yaml
+++ b/showcase/integrations/crewai-crews/manifest.yaml
@@ -193,6 +193,9 @@ demos:
       - generative-ui
     route: /demos/open-gen-ui
     animated_preview_url:
+    highlight:
+      - src/app/demos/open-gen-ui/page.tsx
+      - src/app/api/copilotkit-ogui/route.ts
   - id: open-gen-ui-advanced
     name: "Open-Ended Gen UI (Advanced)"
     description: Agent-authored UI that invokes host sandbox functions from inside the iframe
@@ -200,6 +203,10 @@ demos:
       - generative-ui
     route: /demos/open-gen-ui-advanced
     animated_preview_url:
+    highlight:
+      - src/app/demos/open-gen-ui-advanced/page.tsx
+      - src/app/demos/open-gen-ui-advanced/sandbox-functions.ts
+      - src/app/api/copilotkit-ogui/route.ts
   - id: agent-config
     name: Agent Config Object
     description: Forward a typed config object (tone / expertise / response length) from the provider to the agent
@@ -242,6 +249,9 @@ demos:
       - generative-ui
     route: /demos/a2ui-fixed-schema
     animated_preview_url:
+    highlight:
+      - src/agents/a2ui_fixed.py
+      - src/app/demos/a2ui-fixed-schema/page.tsx
   - id: byoc-hashbrown
     name: BYOC (Hashbrown)
     description: Streaming structured output via @hashbrownai/react against a custom catalog

--- a/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/crewai-crews/src/agents/a2ui_fixed.py
@@ -32,10 +32,13 @@ CREW_NAME = "A2UIFixedSchema"
 
 _SCHEMAS_DIR = Path(__file__).parent / "a2ui_schemas"
 
+# @region[backend-schema-json-load]
 # Load flight schema at module load so the first request does not pay I/O
-# for the JSON parse.
+# for the JSON parse. The schema is authored as JSON so it can be reviewed
+# independently of the Python code.
 with (_SCHEMAS_DIR / "flight_schema.json").open() as _fp:
     _FLIGHT_SCHEMA = json.load(_fp)
+# @endregion[backend-schema-json-load]
 
 
 class DisplayFlightInput(BaseModel):
@@ -65,6 +68,10 @@ class DisplayFlightTool(BaseTool):
     args_schema: Type[BaseModel] = DisplayFlightInput
 
     def _run(self, origin: str, destination: str, airline: str, price: str) -> str:
+        # @region[backend-render-operations]
+        # The A2UI middleware detects the `a2ui_operations` container in this
+        # tool result and forwards the ops to the frontend renderer. The
+        # frontend catalog resolves component names to local React components.
         ops: list[dict[str, Any]] = [
             {
                 "type": "create_surface",
@@ -88,6 +95,7 @@ class DisplayFlightTool(BaseTool):
             },
         ]
         return json.dumps({"a2ui_operations": ops})
+        # @endregion[backend-render-operations]
 
 
 A2UI_FIXED_BACKSTORY = (

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-ogui/route.ts
@@ -27,6 +27,8 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -34,6 +36,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -24,6 +24,7 @@ export default function AgenticChatReasoningDemo() {
 }
 
 function Chat() {
+  // @region[reasoning-block-render]
   return (
     <CopilotChat
       agentId="agentic-chat-reasoning"
@@ -33,4 +34,5 @@ function Chat() {
       }}
     />
   );
+  // @endregion[reasoning-block-render]
 }

--- a/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/page.tsx
@@ -5,7 +5,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/crewai-crews/src/app/demos/chat-customization-css/theme.css
@@ -6,6 +6,7 @@
  * https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
  */
 
+/* @region[css-variables] */
 /* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
@@ -17,6 +18,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 /* Messages container – swap the font for the entire chat */
 .chat-css-demo-scope .copilotKitMessages {

--- a/showcase/integrations/crewai-crews/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/chat-slots/page.tsx
@@ -34,12 +34,21 @@ function Chat() {
     available: "always",
   });
 
+  // Extracting the slot overrides up here keeps the JSX readable and gives
+  // the docs something to point at with `@region` markers for the slot
+  // system guide.
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/declarative-gen-ui/page.tsx
@@ -29,6 +29,7 @@ import { myCatalog } from "./a2ui/catalog";
 
 export default function DeclarativeGenUIDemo() {
   return (
+    // @region[provider-a2ui-prop]
     <CopilotKit
       runtimeUrl="/api/copilotkit-declarative-gen-ui"
       agent="declarative-gen-ui"
@@ -43,6 +44,7 @@ export default function DeclarativeGenUIDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[provider-a2ui-prop]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,8 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool]
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +33,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +41,10 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
+  // @endregion[frontend-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/assistant-bubble.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/assistant-bubble.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[custom-bubbles]
 export function AssistantBubble({ children }: { children: React.ReactNode }) {
   if (isEmpty(children)) return null;
 
@@ -15,6 +16,7 @@ export function AssistantBubble({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
+// @endregion[custom-bubbles]
 
 function isEmpty(node: React.ReactNode): boolean {
   if (node == null || node === false) return true;

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/page.tsx
@@ -43,6 +43,7 @@ export default function HeadlessCompleteDemo() {
 }
 
 function Chat() {
+  // @region[page-send-message]
   const threadId = useMemo(() => crypto.randomUUID(), []);
   const { agent } = useAgent({ agentId: AGENT_ID, threadId });
   const { copilotkit } = useCopilotKit();
@@ -91,6 +92,7 @@ function Chat() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent]);
+  // @endregion[page-send-message]
 
   return (
     <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={threadId}>

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/use-rendered-messages.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/use-rendered-messages.tsx
@@ -16,6 +16,7 @@ import {
   useRenderCustomMessages,
 } from "@copilotkit/react-core/v2";
 
+// @region[use-rendered-messages-hook]
 export type RenderedMessage = Message & { renderedContent: React.ReactNode };
 
 export function useRenderedMessages(
@@ -46,6 +47,7 @@ export function useRenderedMessages(
     renderCustomMessage,
   ]);
 }
+// @endregion[use-rendered-messages-hook]
 
 function renderMessageContent(args: {
   message: Message;
@@ -79,6 +81,7 @@ function renderMessageContent(args: {
 
   let body: React.ReactNode = null;
 
+  // @region[manual-activity-message-rendering]
   if (message.role === "assistant") {
     body = renderAssistantBody({
       message: message as AssistantMessage,
@@ -98,6 +101,7 @@ function renderMessageContent(args: {
   } else if (message.role === "activity") {
     body = renderActivityMessage(message as ActivityMessage);
   }
+  // @endregion[manual-activity-message-rendering]
 
   if (!customBefore && !customAfter) {
     return body;
@@ -111,6 +115,7 @@ function renderMessageContent(args: {
   );
 }
 
+// @region[manual-tool-call-rendering]
 function renderAssistantBody(args: {
   message: AssistantMessage;
   messages: Message[];
@@ -137,6 +142,7 @@ function renderAssistantBody(args: {
     </>
   );
 }
+// @endregion[manual-tool-call-rendering]
 
 function renderUserBody(message: UserMessage): React.ReactNode {
   const { content } = message;

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-complete/user-bubble.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-complete/user-bubble.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[custom-bubbles]
 export function UserBubble({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex justify-end">
@@ -11,3 +12,4 @@ export function UserBubble({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
+// @endregion[custom-bubbles]

--- a/showcase/integrations/crewai-crews/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,8 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
+  // @region[headless-hooks]
   const { agent } = useAgent({ agentId: "headless-simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +51,8 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[headless-hooks]
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +70,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +111,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/hitl-in-chat/page.tsx
@@ -10,12 +10,14 @@ import {
 import { z } from "zod";
 import { TimePickerCard, TimeSlot } from "./time-picker-card";
 
+// @region[time-slots]
 const DEFAULT_SLOTS: TimeSlot[] = [
   { label: "Tomorrow 10:00 AM", iso: "2026-04-19T10:00:00-07:00" },
   { label: "Tomorrow 2:00 PM", iso: "2026-04-19T14:00:00-07:00" },
   { label: "Monday 9:00 AM", iso: "2026-04-21T09:00:00-07:00" },
   { label: "Monday 3:30 PM", iso: "2026-04-21T15:30:00-07:00" },
 ];
+// @endregion[time-slots]
 
 export default function HitlInChatDemo() {
   return (
@@ -45,6 +47,7 @@ function Chat() {
     available: "always",
   });
 
+  // @region[hitl-hook]
   useHumanInTheLoop({
     agentId: "hitl-in-chat",
     name: "book_call",
@@ -68,6 +71,7 @@ function Chat() {
       />
     ),
   });
+  // @endregion[hitl-hook]
 
   return <CopilotChat agentId="hitl-in-chat" className="h-full rounded-2xl" />;
 }

--- a/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui-advanced/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui-advanced/page.tsx
@@ -17,6 +17,10 @@ import { openGenUiSuggestions } from "./suggestions";
 
 export default function OpenGenUiAdvancedDemo() {
   return (
+    // @region[sandbox-function-registration]
+    // Pass the sandbox-function array on the `openGenerativeUI` provider prop.
+    // The built-in `OpenGenerativeUIActivityRenderer` wires these as callable
+    // remotes inside the agent-authored iframe.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui-advanced"
@@ -28,6 +32,7 @@ export default function OpenGenUiAdvancedDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[sandbox-function-registration]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/open-gen-ui/page.tsx
@@ -39,6 +39,7 @@ const minimalSuggestions = [
 ];
 
 export default function OpenGenUiDemo() {
+  // @region[minimal-provider-setup]
   return (
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
@@ -52,6 +53,7 @@ export default function OpenGenUiDemo() {
       </div>
     </CopilotKit>
   );
+  // @endregion[minimal-provider-setup]
 }
 
 function Chat() {

--- a/showcase/integrations/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/prebuilt-popup/page.tsx
@@ -10,6 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -21,6 +22,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,11 +10,15 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/crewai-crews/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/reasoning-default-render/page.tsx
@@ -12,10 +12,12 @@ export default function ReasoningDefaultRenderDemo() {
     <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
+          {/* @region[default-reasoning-zero-config] */}
           <CopilotChat
             agentId="reasoning-default-render"
             className="h-full rounded-2xl"
           />
+          {/* @endregion[default-reasoning-zero-config] */}
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/google-adk/src/agents/a2ui_fixed_agent.py
+++ b/showcase/integrations/google-adk/src/agents/a2ui_fixed_agent.py
@@ -28,6 +28,7 @@ def _load_schema(name: str) -> list[dict[str, Any]]:
         return json.load(f)
 
 
+# @region[backend-schema-json-load]
 FLIGHT_SCHEMA = _load_schema("flight_schema.json")
 # Loaded for parity with the langgraph-python sibling; the A2UI Python SDK's
 # `a2ui.render(...)` does not yet accept the `action_handlers={...}` kwarg
@@ -35,8 +36,10 @@ FLIGHT_SCHEMA = _load_schema("flight_schema.json")
 # action, so the schema sits read-only here. See langgraph-python's
 # `a2ui_fixed.py` for the canonical reference.
 BOOKED_SCHEMA = _load_schema("booked_schema.json")  # noqa: F841
+# @endregion[backend-schema-json-load]
 
 
+# @region[backend-render-operations]
 def _build_flight_operations(
     *, origin: str, destination: str, airline: str, price: str
 ) -> dict[str, Any]:
@@ -65,6 +68,7 @@ def _build_flight_operations(
             },
         ]
     }
+# @endregion[backend-render-operations]
 
 
 def display_flight(

--- a/showcase/integrations/google-adk/src/agents/shared_state_streaming_agent.py
+++ b/showcase/integrations/google-adk/src/agents/shared_state_streaming_agent.py
@@ -54,6 +54,7 @@ _INSTRUCTION = (
     "belongs in shared state and the UI renders it live as you type."
 )
 
+# @region[state-streaming-middleware]
 shared_state_streaming_agent = LlmAgent(
     name="SharedStateStreamingAgent",
     model=get_model(),
@@ -71,3 +72,4 @@ SHARED_STATE_STREAMING_PREDICT_STATE = [
         stream_tool_call=True,
     ),
 ]
+# @endregion[state-streaming-middleware]

--- a/showcase/integrations/google-adk/src/agents/subagents_agent.py
+++ b/showcase/integrations/google-adk/src/agents/subagents_agent.py
@@ -210,6 +210,7 @@ def _delegate(
     return {"status": "completed", "result": result}
 
 
+# @region[supervisor-delegation-tools]
 def research_agent(tool_context: ToolContext, topic: str) -> dict:
     """Delegate a research task to the research sub-agent.
 
@@ -253,6 +254,7 @@ def critique_agent(tool_context: ToolContext, draft: str) -> dict:
         system_prompt=_CRITIQUE_SYSTEM,
         task=draft,
     )
+# @endregion[supervisor-delegation-tools]
 
 
 _SUPERVISOR_INSTRUCTION = (
@@ -273,9 +275,11 @@ _SUPERVISOR_INSTRUCTION = (
     "every sub-agent delegation, including the in-flight 'running' state."
 )
 
+# @region[subagent-setup]
 subagents_root_agent = LlmAgent(
     name="SubagentsSupervisor",
     model=get_model(_SUB_MODEL),
     instruction=_SUPERVISOR_INSTRUCTION,
     tools=[research_agent, writing_agent, critique_agent],
 )
+# @endregion[subagent-setup]

--- a/showcase/integrations/google-adk/src/agents/tool_rendering_common.py
+++ b/showcase/integrations/google-adk/src/agents/tool_rendering_common.py
@@ -19,9 +19,11 @@ from tools import (
 )
 
 
+# @region[weather-tool-backend]
 def get_weather(tool_context: ToolContext, location: str) -> dict:
     """Get the weather for a given location."""
     return get_weather_impl(location)
+# @endregion[weather-tool-backend]
 
 
 def search_flights(tool_context: ToolContext, flights: list[dict]) -> dict:

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-ogui/route.ts
@@ -12,6 +12,8 @@ import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
+// @region[minimal-runtime-flag]
+// @region[advanced-runtime-config]
 const runtime = new CopilotRuntime({
   // @ts-expect-error -- see main route.ts
   agents: {
@@ -29,6 +31,8 @@ const runtime = new CopilotRuntime({
     agents: ["open-gen-ui", "open-gen-ui-advanced"],
   },
 });
+// @endregion[advanced-runtime-config]
+// @endregion[minimal-runtime-flag]
 
 export const POST = async (req: NextRequest) => {
   try {

--- a/showcase/integrations/google-adk/src/app/demos/agentic-chat-reasoning/reasoning-block-render.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/agentic-chat-reasoning/reasoning-block-render.snippet.tsx
@@ -1,0 +1,29 @@
+// Docs-only snippet — not imported or rendered. google-adk's
+// agentic-chat-reasoning production demo uses default reasoning rendering
+// (see page.tsx); the ReasoningBlock component file exists in the demo
+// folder but isn't wired into the messageView slot. The docs page teaches
+// the custom reasoning slot pattern, which is framework-agnostic. This
+// file gives the reasoning-block-render region a real teaching example
+// without changing the production demo's runtime behavior. See
+// chat-component.snippet.tsx in agentic-chat for the same sibling-file
+// pattern.
+
+import {
+  CopilotChat,
+  CopilotChatReasoningMessage,
+} from "@copilotkit/react-core/v2";
+import { ReasoningBlock } from "./reasoning-block";
+
+export function ReasoningChat() {
+  // @region[reasoning-block-render]
+  return (
+    <CopilotChat
+      agentId="agentic_chat_reasoning"
+      className="h-full rounded-2xl"
+      messageView={{
+        reasoningMessage: ReasoningBlock as typeof CopilotChatReasoningMessage,
+      }}
+    />
+  );
+  // @endregion[reasoning-block-render]
+}

--- a/showcase/integrations/google-adk/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/google-adk/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/google-adk/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/chat-customization-css/page.tsx
@@ -7,7 +7,9 @@ import {
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
 
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/google-adk/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/google-adk/src/app/demos/chat-customization-css/theme.css
@@ -5,6 +5,7 @@
  * https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
  */
 
+/* @region[css-variables] */
 /* CopilotKit CSS variable overrides */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #1a73e8;
@@ -16,6 +17,7 @@
   --copilot-kit-separator-color: #1a73e8;
   --copilot-kit-muted-color: #4a6f9c;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Inter", "Helvetica Neue", system-ui, sans-serif;

--- a/showcase/integrations/google-adk/src/app/demos/chat-slots/disclaimer-and-assistant-message.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/chat-slots/disclaimer-and-assistant-message.snippet.tsx
@@ -1,0 +1,27 @@
+// Docs-only snippet — not imported or rendered. google-adk's chat-slots
+// production demo only registers the welcome slot (see page.tsx). The
+// docs page also teaches the disclaimer and assistant-message slot
+// patterns, which are framework-agnostic CopilotKit primitives. This
+// file gives those two regions a real teaching example without changing
+// the production demo's runtime behavior. See chat-component.snippet.tsx
+// in agentic-chat for the same sibling-file pattern.
+
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+
+declare const CustomDisclaimer: React.ComponentType;
+declare const CustomAssistantMessage: React.ComponentType;
+
+export function ChatSlotsExtras() {
+  // @region[register-disclaimer-slot]
+  const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+
+  // @region[register-assistant-message-slot]
+  const messageView = {
+    assistantMessage:
+      CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
+  };
+  // @endregion[register-assistant-message-slot]
+
+  return { input, messageView };
+}

--- a/showcase/integrations/google-adk/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/chat-slots/page.tsx
@@ -29,11 +29,15 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
+  const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+
   return (
     <CopilotChat
       agentId="chat_slots"
       className="h-full rounded-2xl"
-      welcomeScreen={CustomWelcomeScreen}
+      welcomeScreen={welcomeScreen}
     />
   );
 }

--- a/showcase/integrations/google-adk/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless_simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
         Headless Chat (Simple) — Google ADK
       </h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/google-adk/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/prebuilt-popup/page.tsx
@@ -9,9 +9,11 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_popup">
       <DemoContent />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/google-adk/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,9 +9,11 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_sidebar">
       <DemoContent />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 
@@ -44,10 +46,12 @@ function DemoContent() {
           tools, no state. All the polish is on the frontend.
         </p>
       </main>
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar
         defaultOpen={true}
         labels={{ modalHeaderTitle: "AI Assistant" }}
       />
+      {/* @endregion[sidebar-configuration] */}
     </div>
   );
 }

--- a/showcase/integrations/google-adk/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/readonly-state-agent-context/page.tsx
@@ -20,15 +20,19 @@ export default function ReadonlyStateAgentContextDemo() {
 }
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Daisy");
   const [role, setRole] = useState("Frontend engineer");
   const [project, setProject] = useState(
     "Building a CopilotKit + Google ADK showcase",
   );
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({ description: "User name", value: userName });
   useAgentContext({ description: "User role", value: role });
   useAgentContext({ description: "Current project", value: project });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/reasoning-default-render/page.tsx
@@ -33,10 +33,12 @@ function Chat() {
   return (
     <div className="flex justify-center items-center h-screen w-full bg-gray-50">
       <div className="h-full w-full max-w-4xl">
+        {/* @region[default-reasoning-zero-config] */}
         <CopilotChat
           agentId="reasoning_default_render"
           className="h-full rounded-2xl"
         />
+        {/* @endregion[default-reasoning-zero-config] */}
       </div>
     </div>
   );

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[notes-card-render]
 export function NotesCard({
   notes,
   onClear,
@@ -58,3 +59,4 @@ export function NotesCard({
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/page.tsx
@@ -34,10 +34,12 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   const { agent } = useAgent({
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -89,6 +91,7 @@ function DemoContent() {
   // before React re-renders can still write the same snapshot twice —
   // CopilotKit's STATE_DELTA stream resolves the merge upstream and
   // either order is correct because both writes carry the full pair.
+  // @region[use-agent-write]
   const handlePreferencesChange = (next: Preferences) => {
     agent.setState({
       ...(agentState as object | undefined),
@@ -96,6 +99,7 @@ function DemoContent() {
       notes: agentState?.notes ?? [],
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   const handleClearNotes = () => {
     agent.setState({

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -24,6 +24,7 @@ export interface PreferencesCardProps {
   onChange: (next: Preferences) => void;
 }
 
+// @region[preferences-card-render]
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -132,3 +133,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/google-adk/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/shared-state-streaming/page.tsx
@@ -24,10 +24,12 @@ export default function SharedStateStreamingDemo() {
 }
 
 function DemoContent() {
+  // @region[frontend-use-coagent-state]
   const { agent } = useAgent({
     agentId: "shared-state-streaming",
     updates: [UseAgentUpdate.OnStateChanged, UseAgentUpdate.OnRunStatusChanged],
   });
+  // @endregion[frontend-use-coagent-state]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/subagents/delegation-log.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 
+// @region[delegation-log-frontend]
 export interface Delegation {
   id: string;
   sub_agent: "research_agent" | "writing_agent" | "critique_agent";
@@ -104,3 +105,4 @@ export function DelegationLog({ delegations }: { delegations: Delegation[] }) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -31,6 +31,7 @@ function Chat() {
   // runtime emits `"inProgress" | "executing" | "complete"`; both
   // pre-completion states render identically, so collapse them to
   // "executing" before handing off to the renderer.
+  // @region[use-default-render-tool-wildcard]
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }) => (
@@ -44,6 +45,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -37,10 +37,12 @@ function DemoContent() {
   return (
     <div className="flex justify-center items-center h-screen w-full bg-gray-50">
       <div className="h-full w-full max-w-4xl">
+        {/* @region[default-catchall-zero-config] */}
         <CopilotChat
           agentId="tool_rendering_default_catchall"
           className="h-full rounded-2xl"
         />
+        {/* @endregion[default-catchall-zero-config] */}
       </div>
     </div>
   );

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool({
     name: "get_weather",
     parameters: z.object({
@@ -61,6 +62,7 @@ function Chat() {
       );
     },
   });
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/google-adk/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. Mastra's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same Mastra demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -28,6 +28,7 @@ export default function AgenticChatReasoningDemo() {
 }
 
 function Chat() {
+  // @region[reasoning-block-render]
   return (
     <CopilotChat
       agentId="agentic-chat-reasoning"
@@ -37,4 +38,5 @@ function Chat() {
       }}
     />
   );
+  // @endregion[reasoning-block-render]
 }

--- a/showcase/integrations/langroid/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/langroid/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/langroid/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/langroid/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/chat-customization-css/page.tsx
@@ -8,7 +8,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/langroid/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/langroid/src/app/demos/chat-customization-css/theme.css
@@ -3,6 +3,8 @@
  * leak out and affect the rest of the showcase app.
  */
 
+/* @region[css-variables] */
+/* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
   --copilot-kit-contrast-color: #ffffff;
@@ -13,6 +15,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Georgia", "Cambria", "Times New Roman", serif;

--- a/showcase/integrations/langroid/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/chat-slots/page.tsx
@@ -32,12 +32,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/langroid/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/langroid/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless-simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/langroid/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/prebuilt-popup/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -20,6 +21,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/langroid/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,11 +9,15 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/langroid/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/langroid/src/app/demos/reasoning-default-render/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/reasoning-default-render/page.tsx
@@ -16,10 +16,12 @@ export default function ReasoningDefaultRenderDemo() {
     <CopilotKit runtimeUrl="/api/copilotkit" agent="reasoning-default-render">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
+          {/* @region[default-reasoning-zero-config] */}
           <CopilotChat
             agentId="reasoning-default-render"
             className="h-full rounded-2xl"
           />
+          {/* @endregion[default-reasoning-zero-config] */}
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/langroid/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/langroid/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -7,6 +7,7 @@ export interface NotesCardProps {
   onClear: () => void;
 }
 
+// @region[notes-card-render]
 /**
  * Sidebar card that READS agent-authored notes out of shared state.
  *
@@ -68,3 +69,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/langroid/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/shared-state-read-write/page.tsx
@@ -40,6 +40,7 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   // Subscribe the component to agent state changes. Any time the agent
   // mutates its state (e.g. via its `set_notes` tool) the SSE pipeline
   // emits a STATE_SNAPSHOT, this hook fires, we re-render, and the
@@ -48,6 +49,7 @@ function DemoContent() {
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -81,6 +83,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state.
   // On the agent's next turn, the Langroid handler reads this back out
   // of `RunAgentInput.state` and prepends a system message describing
@@ -91,6 +94,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE-BACK: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/langroid/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/langroid/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -25,6 +25,7 @@ export interface PreferencesCardProps {
   onChange: (next: Preferences) => void;
 }
 
+// @region[preferences-card-render]
 /**
  * Sidebar card — the *only* place where the user edits their preferences.
  *
@@ -142,3 +143,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/langroid/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/langroid/src/app/demos/subagents/delegation-log.tsx
@@ -48,6 +48,7 @@ const STATUS_COLOR: Record<Delegation["status"], string> = {
   failed: "text-[#FA5F67]",
 };
 
+// @region[delegation-log-frontend]
 /**
  * Live delegation log — renders the `delegations` slot of agent state.
  *
@@ -140,3 +141,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/llamaindex/manifest.yaml
+++ b/showcase/integrations/llamaindex/manifest.yaml
@@ -92,6 +92,7 @@ demos:
     route: /demos/tool-rendering
     animated_preview_url:
     highlight:
+      - src/agents/agent.py
       - src/app/demos/tool-rendering/agent.py
       - src/app/demos/tool-rendering/page.tsx
       - src/app/api/copilotkit/route.ts

--- a/showcase/integrations/llamaindex/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/llamaindex/src/agents/a2ui_fixed.py
@@ -24,12 +24,16 @@ SURFACE_ID = "flight-fixed-schema"
 _SCHEMAS_DIR = Path(__file__).parent / "a2ui_schemas"
 
 
+# @region[backend-schema-json-load]
+# Schemas are JSON so they can be authored and reviewed independently of the
+# Python code. `_load_schema` is just a thin `json.load` wrapper.
 def _load_schema(path: Path) -> list[dict]:
     with path.open("r", encoding="utf-8") as fh:
         return json.load(fh)
 
 
 FLIGHT_SCHEMA = _load_schema(_SCHEMAS_DIR / "flight_schema.json")
+# @endregion[backend-schema-json-load]
 
 
 async def display_flight(
@@ -45,6 +49,10 @@ async def display_flight(
     the Next.js runtime detects this shape in the tool result and forwards
     the ops to the frontend renderer.
     """
+    # @region[backend-render-operations]
+    # The A2UI middleware detects the `a2ui_operations` container in this
+    # tool result and forwards the ops to the frontend renderer. The frontend
+    # catalog resolves component names to the local React components.
     ops = [
         {
             "type": "create_surface",
@@ -68,6 +76,7 @@ async def display_flight(
         },
     ]
     return json.dumps({"a2ui_operations": ops})
+    # @endregion[backend-render-operations]
 
 
 SYSTEM_PROMPT = (

--- a/showcase/integrations/llamaindex/src/agents/agent.py
+++ b/showcase/integrations/llamaindex/src/agents/agent.py
@@ -66,11 +66,13 @@ def book_call(
 
 # --- Backend tools (executed server-side, using shared implementations) ---
 
+# @region[weather-tool-backend]
 async def get_weather(
     location: Annotated[str, "The location to get the weather for."],
 ) -> str:
     """Get the weather for a given location. Returns temperature, conditions, humidity, wind speed, and feels-like temperature."""
     return json.dumps(get_weather_impl(location))
+# @endregion[weather-tool-backend]
 
 
 async def query_data(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-ogui/route.ts
@@ -30,6 +30,15 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
+      // Server-side config is identical for the minimal and advanced cells —
+      // the advanced behaviour (sandbox -> host function calls) is wired
+      // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
+      // the provider. The single `openGenerativeUI` flag below turns on
+      // Open Generative UI for the listed agent(s); the runtime middleware
+      // converts each agent's streamed `generateSandboxedUi` tool call into
+      // `open-generative-ui` activity events.
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -37,6 +46,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/llamaindex/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/llamaindex/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/page.tsx
@@ -2,7 +2,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-customization-css/theme.css
@@ -3,6 +3,7 @@
  * `.chat-css-demo-scope` so they do not leak out.
  */
 
+/* @region[css-variables] */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
   --copilot-kit-contrast-color: #ffffff;
@@ -13,6 +14,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Georgia", "Cambria", "Times New Roman", serif;

--- a/showcase/integrations/llamaindex/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-slots/page.tsx
@@ -29,11 +29,15 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
+  const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+
   return (
     <CopilotChat
       agentId="chat_slots"
       className="h-full rounded-2xl"
-      welcomeScreen={CustomWelcomeScreen}
+      welcomeScreen={welcomeScreen}
     />
   );
 }

--- a/showcase/integrations/llamaindex/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless_simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/llamaindex/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/prebuilt-popup/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_popup">
       <MainContent />
       <CopilotPopup
@@ -18,6 +19,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,11 +9,15 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt_sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt_sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/llamaindex/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -17,6 +17,7 @@ export interface NotesCardProps {
  * The "Clear" button is a write-back (UI -> agent state) to demonstrate
  * both directions on the same field.
  */
+// @region[notes-card-render]
 export function NotesCard({ notes, onClear }: NotesCardProps) {
   return (
     <div
@@ -68,3 +69,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/page.tsx
@@ -38,6 +38,7 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   // Subscribe the component to agent state changes. LlamaIndex's
   // AGUIChatWorkflow emits a StateSnapshotEvent on InputEvent and after
   // every tool call, so any time the agent's `set_notes` tool runs, this
@@ -46,6 +47,7 @@ function DemoContent() {
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -79,6 +81,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state.
   // On the agent's next turn, AGUIChatWorkflow injects this state into
   // the user message via its <state>...</state> prelude — so the UI's
@@ -89,6 +92,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -34,6 +34,7 @@ export interface PreferencesCardProps {
  * preferences) into the latest user message via the `<state>...</state>`
  * prelude, and our system prompt teaches the model to honor them.
  */
+// @region[preferences-card-render]
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -142,3 +143,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/llamaindex/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/subagents/delegation-log.tsx
@@ -51,6 +51,7 @@ const ENTRY_BG_BY_STATUS: Record<Delegation["status"], string> = {
   failed: "border-red-200 bg-red-50/40",
 };
 
+// @region[delegation-log-frontend]
 /**
  * Live delegation log — renders the `delegations` slot of agent state.
  *
@@ -149,3 +150,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -36,6 +36,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }: any) => (
@@ -49,6 +53,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -31,7 +31,13 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
+  // Opt in to CopilotKit's built-in default tool-call card. Called with
+  // no config so the package-provided `DefaultToolCallRenderer` is used
+  // as the wildcard renderer — this is the "out-of-the-box" UI the cell
+  // is meant to showcase.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering/page.tsx
@@ -27,6 +27,7 @@ export default function ToolRenderingDemo() {
 }
 
 function Chat() {
+  // @region[render-weather-tool]
   useRenderTool(
     {
       name: "get_weather",
@@ -65,6 +66,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[render-weather-tool]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/llamaindex/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,87 @@
+// Docs-only snippet — not imported or rendered. LlamaIndex's tool-rendering
+// demo at page.tsx exercises the get_weather renderer only; the docs
+// page at /generative-ui/tool-rendering also teaches the search_flights
+// per-tool pattern and the wildcard catch-all. These two regions show
+// what those would look like in the same LlamaIndex demo shape, so the
+// docs can render real teaching code rather than a missing-snippet box.
+//
+// See chat-component.snippet.tsx in agentic-chat for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function FlightToolRenderers() {
+  // @region[render-flight-tool]
+  // Per-tool renderer: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool — anything the agent might
+  // call that doesn't have a dedicated useRenderTool registration.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/pydantic-ai/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/pydantic-ai/src/agents/a2ui_fixed.py
@@ -39,11 +39,15 @@ def _load_schema(path: Path) -> list[dict]:
         return json.load(f)
 
 
+# @region[backend-schema-json-load]
+# Schemas are JSON so they can be authored and reviewed independently of
+# the Python code. ``_load_schema`` is just a thin ``json.load`` wrapper.
 FLIGHT_SCHEMA = _load_schema(_SCHEMAS_DIR / "flight_schema.json")
 # Kept for future use once action_handlers land on the PydanticAI A2UI
 # bridge; the frontend's ActionButton drives an optimistic transition
 # locally today.
 BOOKED_SCHEMA = _load_schema(_SCHEMAS_DIR / "booked_schema.json")
+# @endregion[backend-schema-json-load]
 
 
 class EmptyState(BaseModel):
@@ -81,6 +85,10 @@ def display_flight(
     Use short airport codes (e.g. "SFO", "JFK") for origin/destination and a
     price string like "$289".
     """
+    # @region[backend-render-operations]
+    # The A2UI middleware detects the `a2ui_operations` container in this
+    # tool result and forwards the ops to the frontend renderer. The
+    # frontend catalog resolves component names to local React components.
     operations = [
         {
             "type": "create_surface",
@@ -104,3 +112,4 @@ def display_flight(
         },
     ]
     return json.dumps({"a2ui_operations": operations})
+    # @endregion[backend-render-operations]

--- a/showcase/integrations/pydantic-ai/src/agents/agent.py
+++ b/showcase/integrations/pydantic-ai/src/agents/agent.py
@@ -64,10 +64,18 @@ agent = Agent(
 # =====
 # Tools
 # =====
+# @region[weather-tool-backend]
 @agent.tool
 def get_weather(ctx: RunContext[StateDeps[SalesTodosState]], location: str) -> str:
-    """Get the weather for a given location. Ensure location is fully spelled out."""
+    """Get the weather for a given location. Ensure location is fully spelled out.
+
+    Useful on its own for weather questions, and a great companion to
+    `search_flights` — always consider checking the weather at a
+    destination the user is flying to, and checking flights to any
+    city whose weather the user has just asked about.
+    """
     return json.dumps(get_weather_impl(location))
+# @endregion[weather-tool-backend]
 
 
 @agent.tool

--- a/showcase/integrations/pydantic-ai/src/agents/subagents.py
+++ b/showcase/integrations/pydantic-ai/src/agents/subagents.py
@@ -66,6 +66,10 @@ class SubagentsState(BaseModel):
 # ── Sub-agents (real PydanticAI Agents) ─────────────────────────────
 
 
+# @region[subagent-setup]
+# Each sub-agent is a full-fledged ``Agent(model=..., system_prompt=...)``
+# with its own system prompt. They don't share memory or tools with the
+# supervisor — the supervisor only sees their return value.
 _SUB_MODEL = OpenAIResponsesModel("gpt-4o-mini")
 
 _research_agent: Agent[None, str] = Agent(
@@ -92,6 +96,7 @@ _critique_agent: Agent[None, str] = Agent(
         "2-3 crisp, actionable critiques. No preamble."
     ),
 )
+# @endregion[subagent-setup]
 
 
 async def _invoke_sub_agent(sub_agent: Agent[None, str], task: str) -> str:
@@ -216,6 +221,12 @@ async def _delegate(
     return result
 
 
+# @region[supervisor-delegation-tools]
+# Each ``@agent.tool`` wraps a sub-agent invocation. The supervisor LLM
+# "calls" these tools to delegate work; each call asynchronously runs the
+# matching sub-agent, records the delegation into shared state, and
+# returns the sub-agent's output as a string the supervisor can read on
+# its next step.
 @agent.tool
 async def research_agent(
     ctx: RunContext[StateDeps[SubagentsState]],
@@ -267,6 +278,7 @@ async def critique_agent(
         sub_agent_obj=_critique_agent,
         task=task,
     )
+# @endregion[supervisor-delegation-tools]
 
 
 __all__: list[str] = [

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-ogui/route.ts
@@ -24,16 +24,24 @@ const agents: Record<string, AbstractAgent> = {
   }),
 };
 
+// @region[minimal-runtime-flag]
+// @region[advanced-runtime-config]
+// Server-side config is identical for the minimal and advanced cells —
+// the advanced behaviour (sandbox -> host function calls) is wired
+// entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
+// the provider. The single `openGenerativeUI` flag below turns on
+// Open Generative UI for the listed agent(s); the runtime middleware
+// converts each agent's streamed `generateSandboxedUi` tool call into
+// `open-generative-ui` activity events.
 const runtime = new CopilotRuntime({
   // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
   agents,
-  // Turns on Open Generative UI for the listed agent(s); the runtime
-  // middleware converts each agent's streamed `generateSandboxedUi` tool
-  // call into `open-generative-ui` activity events.
   openGenerativeUI: {
     agents: ["open-gen-ui", "open-gen-ui-advanced"],
   },
 });
+// @endregion[advanced-runtime-config]
+// @endregion[minimal-runtime-flag]
 
 export const POST = async (req: NextRequest) => {
   try {

--- a/showcase/integrations/pydantic-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/agentic-chat/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
@@ -16,16 +17,21 @@ export default function AgenticChatDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
+// @region[chat-component]
 function Chat() {
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       { title: "Write a sonnet", message: "Write a short sonnet about AI." },
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
 }
+// @endregion[chat-component]

--- a/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/page.tsx
@@ -5,7 +5,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/pydantic-ai/src/app/demos/chat-customization-css/theme.css
@@ -3,6 +3,8 @@
  * leak out and affect the rest of the showcase app.
  */
 
+/* @region[css-variables] */
+/* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
   --copilot-kit-contrast-color: #ffffff;
@@ -13,6 +15,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Georgia", "Cambria", "Times New Roman", serif;

--- a/showcase/integrations/pydantic-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/chat-slots/page.tsx
@@ -32,12 +32,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/pydantic-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/headless-simple/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/headless-simple/page.tsx
@@ -34,6 +34,7 @@ function ShowCard({ title, body }: { title: string; body: string }) {
 }
 
 function HeadlessChat() {
+  // @region[use-agent-simple]
   const { agent } = useAgent({ agentId: "headless-simple" });
   const { copilotkit } = useCopilotKit();
   const [input, setInput] = useState("");
@@ -49,6 +50,7 @@ function HeadlessChat() {
   });
 
   const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
 
   const send = () => {
     const text = input.trim();
@@ -66,6 +68,7 @@ function HeadlessChat() {
     <div className="flex flex-col gap-3">
       <h1 className="text-xl font-semibold">Headless Chat (Simple)</h1>
       <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
         {agent.messages.length === 0 && (
           <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
         )}
@@ -106,6 +109,7 @@ function HeadlessChat() {
         {agent.isRunning && (
           <div className="text-xs text-gray-400">Agent is thinking...</div>
         )}
+        {/* @endregion[message-list-simple] */}
       </div>
       <div className="flex gap-2">
         <textarea

--- a/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -10,6 +10,7 @@ import {
 // Outer layer — provider + main content + floating popup launcher.
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -21,6 +22,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -10,11 +10,15 @@ import {
 // Outer layer — provider + main content + sidebar.
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/pydantic-ai/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -7,6 +7,7 @@ export interface NotesCardProps {
   onClear: () => void;
 }
 
+// @region[notes-card-render]
 /**
  * Sidebar card that READS agent-authored notes out of shared state.
  *
@@ -68,3 +69,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -37,6 +37,7 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
   // Subscribe the component to agent state changes. Any time the agent
   // mutates its state (e.g. via its `set_notes` tool) this hook fires,
   // we re-render, and the sidebar panels reflect the new values.
@@ -44,6 +45,7 @@ function DemoContent() {
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -77,6 +79,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state.
   // On the agent's next turn, the dynamic `@agent.system_prompt` reads
   // this back out of state and adds it to the system prompt — so the
@@ -87,6 +90,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -25,6 +25,7 @@ export interface PreferencesCardProps {
   onChange: (next: Preferences) => void;
 }
 
+// @region[preferences-card-render]
 /**
  * Sidebar card — the *only* place where the user edits their preferences.
  *
@@ -141,3 +142,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/pydantic-ai/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/subagents/delegation-log.tsx
@@ -48,6 +48,7 @@ const STATUS_STYLE: Record<Delegation["status"], string> = {
   failed: "text-[#FA5F67]",
 };
 
+// @region[delegation-log-frontend]
 /**
  * Live delegation log — renders the `delegations` slot of agent state.
  *
@@ -139,3 +140,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-custom-catchall/page.tsx
@@ -30,6 +30,10 @@ export default function ToolRenderingCustomCatchallDemo() {
 }
 
 function Chat() {
+  // @region[use-default-render-tool-wildcard]
+  // `useDefaultRenderTool` is a convenience wrapper around
+  // `useRenderTool({ name: "*", ... })` — a single wildcard renderer
+  // that handles every tool call not claimed by a named renderer.
   useDefaultRenderTool(
     {
       render: ({ name, parameters, status, result }) => (
@@ -43,6 +47,7 @@ function Chat() {
     },
     [],
   );
+  // @endregion[use-default-render-tool-wildcard]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -28,7 +28,13 @@ export default function ToolRenderingDefaultCatchallDemo() {
 }
 
 function Chat() {
+  // @region[default-catchall-zero-config]
+  // Opt in to CopilotKit's built-in default tool-call card. Called with
+  // no config so the package-provided `DefaultToolCallRenderer` is used
+  // as the wildcard renderer — this is the "out-of-the-box" UI the cell
+  // is meant to showcase.
   useDefaultRenderTool();
+  // @endregion[default-catchall-zero-config]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/tool-rendering/render-flight-tool.snippet.tsx
@@ -1,0 +1,135 @@
+// Docs-only snippet — not imported or rendered. The pydantic-ai
+// tool-rendering demo at page.tsx exercises the get_weather renderer
+// only (using a different render-prop signature `{ args, ... }`).
+// The docs page at /generative-ui/tool-rendering teaches the
+// `{ parameters, ... }` shape and also covers the search_flights
+// per-tool renderer plus the wildcard catch-all. These regions show
+// what those would look like in a pydantic-ai demo, so the docs render
+// real teaching code rather than a missing-snippet box.
+//
+// See mastra's render-flight-tool.snippet.tsx for the same pattern.
+
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+type CatchallToolStatus = "in_progress" | "complete" | "error";
+
+interface WeatherResult {
+  city?: string;
+  temperature?: number;
+  humidity?: number;
+  wind_speed?: number;
+  conditions?: string;
+}
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: unknown[];
+}
+
+function WeatherCard(_props: {
+  loading: boolean;
+  location: string;
+  temperature?: number;
+  humidity?: number;
+  windSpeed?: number;
+  conditions?: string;
+}) {
+  return null;
+}
+
+function FlightListCard(_props: {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: unknown[];
+}) {
+  return null;
+}
+
+function CustomCatchallRenderer(_props: {
+  name: string;
+  parameters: unknown;
+  status: CatchallToolStatus;
+  result: unknown;
+}) {
+  return null;
+}
+
+function parseJsonResult<T>(_result: unknown): T {
+  return {} as T;
+}
+
+export function ToolRenderers() {
+  // @region[render-weather-tool]
+  // Per-tool renderer #1: get_weather → branded WeatherCard.
+  useRenderTool(
+    {
+      name: "get_weather",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<WeatherResult>(result);
+        return (
+          <WeatherCard
+            loading={loading}
+            location={parameters?.location ?? parsed.city ?? ""}
+            temperature={parsed.temperature}
+            humidity={parsed.humidity}
+            windSpeed={parsed.wind_speed}
+            conditions={parsed.conditions}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-weather-tool]
+
+  // @region[render-flight-tool]
+  // Per-tool renderer #2: search_flights → branded FlightListCard.
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for every remaining tool (anything the agent
+  // might call that doesn't have a dedicated useRenderTool registration).
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-ogui/route.ts
@@ -36,6 +36,15 @@ export const POST = async (req: NextRequest) => {
     const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
       endpoint: "/api/copilotkit-ogui",
       serviceAdapter: new ExperimentalEmptyAdapter(),
+      // @region[minimal-runtime-flag]
+      // @region[advanced-runtime-config]
+      // Server-side config is identical for the minimal and advanced cells —
+      // the advanced behaviour (sandbox -> host function calls) is wired
+      // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
+      // the provider. The single `openGenerativeUI` flag below turns on
+      // Open Generative UI for the listed agent(s); the runtime middleware
+      // converts each agent's streamed `generateSandboxedUi` tool call into
+      // `open-generative-ui` activity events.
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -43,6 +52,8 @@ export const POST = async (req: NextRequest) => {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
+      // @endregion[advanced-runtime-config]
+      // @endregion[minimal-runtime-flag]
     });
     return await handleRequest(req);
   } catch (error: unknown) {

--- a/showcase/integrations/spring-ai/src/app/demos/agentic-chat/chat-component.snippet.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/agentic-chat/chat-component.snippet.tsx
@@ -1,0 +1,28 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries QA hooks (frontend tools, render tools, agent
+// context) that aren't relevant to the prebuilt-chat docs page. This file
+// gives the docs a minimal Chat definition to point at via the
+// chat-component region without disturbing the runtime demo.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
+
+// @region[chat-component]
+export function Chat() {
+  useConfigureSuggestions({
+    suggestions: [
+      { title: "Write a sonnet", message: "Write a short sonnet about AI." },
+    ],
+    available: "always",
+  });
+
+  return <CopilotChat agentId="agentic_chat" className="h-full rounded-2xl" />;
+}
+// @endregion[chat-component]

--- a/showcase/integrations/spring-ai/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/agentic-chat/page.tsx
@@ -13,9 +13,11 @@ import { z } from "zod";
 
 export default function AgenticChatDemo() {
   return (
+    // @region[provider-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic_chat">
       <Chat />
     </CopilotKit>
+    // @endregion[provider-setup]
   );
 }
 
@@ -68,6 +70,7 @@ function Chat() {
     },
   });
 
+  // @region[configure-suggestions]
   useConfigureSuggestions({
     suggestions: [
       {
@@ -81,6 +84,7 @@ function Chat() {
     ],
     available: "always",
   });
+  // @endregion[configure-suggestions]
 
   return (
     <div

--- a/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/page.tsx
@@ -9,7 +9,9 @@
 
 import React from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+// @region[theme-css-import]
 import "./theme.css";
+// @endregion[theme-css-import]
 
 export default function ChatCustomizationCssDemo() {
   return (

--- a/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/theme.css
+++ b/showcase/integrations/spring-ai/src/app/demos/chat-customization-css/theme.css
@@ -6,6 +6,8 @@
  * https://docs.copilotkit.ai/custom-look-and-feel/customize-built-in-ui-components
  */
 
+/* @region[css-variables] */
+/* CopilotKit CSS variable overrides (accent colors, etc.) */
 .chat-css-demo-scope {
   --copilot-kit-primary-color: #ff006e;
   --copilot-kit-contrast-color: #ffffff;
@@ -16,6 +18,7 @@
   --copilot-kit-separator-color: #ff006e;
   --copilot-kit-muted-color: #c2185b;
 }
+/* @endregion[css-variables] */
 
 .chat-css-demo-scope .copilotKitMessages {
   font-family: "Georgia", "Cambria", "Times New Roman", serif;

--- a/showcase/integrations/spring-ai/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/chat-slots/page.tsx
@@ -32,12 +32,18 @@ function Chat() {
     available: "always",
   });
 
+  // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
+  // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
   const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
   const messageView = {
     assistantMessage:
       CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
   };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat

--- a/showcase/integrations/spring-ai/src/app/demos/frontend-tools/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/frontend-tools/page.tsx
@@ -22,6 +22,7 @@ function Chat() {
     "var(--copilot-kit-background-color)",
   );
 
+  // @region[frontend-tool-registration]
   useFrontendTool({
     name: "change_background",
     description:
@@ -31,6 +32,7 @@ function Chat() {
         .string()
         .describe("The CSS background value. Prefer gradients."),
     }),
+    // @region[frontend-tool-handler]
     handler: async ({ background }: { background: string }) => {
       setBackground(background);
       return {
@@ -38,7 +40,9 @@ function Chat() {
         message: `Background changed to ${background}`,
       };
     },
+    // @endregion[frontend-tool-handler]
   });
+  // @endregion[frontend-tool-registration]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/spring-ai/src/app/demos/headless-simple/headless-chat.snippet.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/headless-simple/headless-chat.snippet.tsx
@@ -1,0 +1,131 @@
+// Docs-only snippet — not imported or rendered. The actual route is served
+// by page.tsx, which carries a `deduplicateMessages` pass to defend against
+// the Spring AI AG-UI adapter's multi-run tool-call loop (see the comment
+// on that helper in page.tsx). That dedup logic is QA scaffolding, not part
+// of the headless-chat teaching content. This file gives the docs a clean
+// minimal surface to point at via `use-agent-simple` and
+// `message-list-simple` regions without the dedup distraction.
+//
+// Why a sibling file: the bundler walks every file in the demo folder and
+// extracts region markers from each, so a docs-targeted teaching example
+// can live alongside the production demo without being wired into the
+// route. See: showcase/scripts/bundle-demo-content.ts.
+
+import React, { useState } from "react";
+import {
+  useAgent,
+  useComponent,
+  useCopilotKit,
+  useRenderToolCall,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+
+function ShowCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="my-2 rounded-lg border border-gray-300 bg-white p-4 shadow-sm">
+      <div className="font-semibold text-gray-900">{title}</div>
+      <div className="mt-1 text-sm text-gray-700 whitespace-pre-wrap">
+        {body}
+      </div>
+    </div>
+  );
+}
+
+export function HeadlessChat() {
+  // @region[use-agent-simple]
+  const { agent } = useAgent({ agentId: "headless-simple" });
+  const { copilotkit } = useCopilotKit();
+  const [input, setInput] = useState("");
+
+  useComponent({
+    name: "show_card",
+    description: "Display a titled card with a short body of text.",
+    parameters: z.object({
+      title: z.string().describe("Short heading for the card."),
+      body: z.string().describe("Body text for the card."),
+    }),
+    render: ShowCard,
+  });
+
+  const renderToolCall = useRenderToolCall();
+  // @endregion[use-agent-simple]
+
+  const send = () => {
+    const text = input.trim();
+    if (!text || agent.isRunning) return;
+    agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+    });
+    void copilotkit.runAgent({ agent }).catch(() => {});
+    setInput("");
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 min-h-[300px]">
+        {/* @region[message-list-simple] */}
+        {agent.messages.length === 0 && (
+          <div className="text-sm text-gray-400">No messages yet. Say hi!</div>
+        )}
+        {agent.messages.map((m) => {
+          if (m.role === "user") {
+            return (
+              <div
+                key={m.id}
+                data-message-role="user"
+                className="self-end rounded-lg bg-blue-600 px-3 py-2 text-white max-w-[80%]"
+              >
+                {typeof m.content === "string" ? m.content : ""}
+              </div>
+            );
+          }
+          if (m.role === "assistant") {
+            const toolCalls =
+              "toolCalls" in m && Array.isArray(m.toolCalls) ? m.toolCalls : [];
+            return (
+              <div
+                key={m.id}
+                data-message-role="assistant"
+                className="self-start max-w-[90%]"
+              >
+                {m.content && (
+                  <div className="rounded-lg bg-gray-100 px-3 py-2 text-gray-900">
+                    {m.content as React.ReactNode}
+                  </div>
+                )}
+                {toolCalls.map((tc: { id: string }) => (
+                  <div key={tc.id}>
+                    {renderToolCall({ toolCall: tc as any })}
+                  </div>
+                ))}
+              </div>
+            );
+          }
+          return null;
+        })}
+        {agent.isRunning && (
+          <div className="text-xs text-gray-400">Agent is thinking...</div>
+        )}
+        {/* @endregion[message-list-simple] */}
+      </div>
+      <div className="flex gap-2">
+        <textarea
+          className="flex-1 rounded-lg border border-gray-300 p-2 text-sm"
+          rows={2}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message..."
+        />
+        <button
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-50"
+          onClick={send}
+          disabled={agent.isRunning || !input.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/showcase/integrations/spring-ai/src/app/demos/open-gen-ui/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/open-gen-ui/page.tsx
@@ -84,6 +84,12 @@ const minimalSuggestions = [
 
 export default function OpenGenUiDemo() {
   return (
+    // @region[minimal-provider-setup]
+    // Minimal Open Generative UI frontend: the built-in activity renderer is
+    // registered by CopilotKitProvider, so a plain <CopilotChat /> is enough —
+    // no custom tool renderers, no activity-renderer registration.
+    // We DO pass `openGenerativeUI.designSkill` to swap in visualisation-tuned
+    // guidance in place of the default shadcn design skill.
     <CopilotKit
       runtimeUrl="/api/copilotkit-ogui"
       agent="open-gen-ui"
@@ -95,6 +101,7 @@ export default function OpenGenUiDemo() {
         </div>
       </div>
     </CopilotKit>
+    // @endregion[minimal-provider-setup]
   );
 }
 

--- a/showcase/integrations/spring-ai/src/app/demos/prebuilt-popup/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/prebuilt-popup/page.tsx
@@ -9,6 +9,7 @@ import {
 
 export default function PrebuiltPopupDemo() {
   return (
+    // @region[popup-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-popup">
       <MainContent />
       <CopilotPopup
@@ -20,6 +21,7 @@ export default function PrebuiltPopupDemo() {
       />
       <Suggestions />
     </CopilotKit>
+    // @endregion[popup-basic-setup]
   );
 }
 

--- a/showcase/integrations/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/prebuilt-sidebar/page.tsx
@@ -9,11 +9,15 @@ import {
 
 export default function PrebuiltSidebarDemo() {
   return (
+    // @region[sidebar-basic-setup]
     <CopilotKit runtimeUrl="/api/copilotkit" agent="prebuilt-sidebar">
       <MainContent />
+      {/* @region[sidebar-configuration] */}
       <CopilotSidebar agentId="prebuilt-sidebar" defaultOpen={true} />
+      {/* @endregion[sidebar-configuration] */}
       <Suggestions />
     </CopilotKit>
+    // @endregion[sidebar-basic-setup]
   );
 }
 

--- a/showcase/integrations/spring-ai/src/app/demos/readonly-state-agent-context/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/readonly-state-agent-context/page.tsx
@@ -37,13 +37,16 @@ const ACTIVITIES = [
 ];
 
 function DemoContent() {
+  // @region[context-provider-sketch]
   const [userName, setUserName] = useState("Atai");
   const [userTimezone, setUserTimezone] = useState("America/Los_Angeles");
   const [recentActivity, setRecentActivity] = useState<string[]>([
     ACTIVITIES[0],
     ACTIVITIES[2],
   ]);
+  // @endregion[context-provider-sketch]
 
+  // @region[use-agent-context-call]
   useAgentContext({
     description: "The currently logged-in user's display name",
     value: userName,
@@ -56,6 +59,7 @@ function DemoContent() {
     description: "The user's recent activity in the app, newest first",
     value: recentActivity,
   });
+  // @endregion[use-agent-context-call]
 
   useConfigureSuggestions({
     suggestions: [

--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/notes-card.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/notes-card.tsx
@@ -18,6 +18,7 @@ export interface NotesCardProps {
  * The "Clear" button is a write-back (UI -> agent state) to demonstrate
  * both directions on the same field.
  */
+// @region[notes-card-render]
 export function NotesCard({ notes, onClear }: NotesCardProps) {
   return (
     <div
@@ -69,3 +70,4 @@ export function NotesCard({ notes, onClear }: NotesCardProps) {
     </div>
   );
 }
+// @endregion[notes-card-render]

--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/page.tsx
@@ -54,10 +54,15 @@ export default function SharedStateReadWriteDemo() {
 }
 
 function DemoContent() {
+  // @region[use-agent-read]
+  // Subscribe the component to agent state changes. Any time the agent
+  // mutates its state (e.g. via its `set_notes` tool) this hook fires,
+  // we re-render, and the sidebar panels reflect the new values.
   const { agent } = useAgent({
     agentId: "shared-state-read-write",
     updates: [UseAgentUpdate.OnStateChanged],
   });
+  // @endregion[use-agent-read]
 
   useConfigureSuggestions({
     suggestions: [
@@ -91,6 +96,7 @@ function DemoContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // @region[use-agent-write]
   // WRITE: every edit in the sidebar goes straight into agent state. On
   // the agent's next turn, the Spring controller reads the same object off
   // the AG-UI state envelope and adds it to the system prompt.
@@ -100,6 +106,7 @@ function DemoContent() {
       notes, // preserve what the agent has written
     } as RWAgentState);
   };
+  // @endregion[use-agent-write]
 
   // WRITE: let the user clear the agent-authored notes from the UI.
   const handleClearNotes = () => {

--- a/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/shared-state-read-write/preferences-card.tsx
@@ -34,6 +34,7 @@ export interface PreferencesCardProps {
  * controller reads that same object out of the AG-UI state envelope and
  * injects it into the system prompt so the agent's reply visibly adapts.
  */
+// @region[preferences-card-render]
 export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
   const set = <K extends keyof Preferences>(key: K, v: Preferences[K]) =>
     onChange({ ...value, [key]: v });
@@ -142,3 +143,4 @@ export function PreferencesCard({ value, onChange }: PreferencesCardProps) {
     </div>
   );
 }
+// @endregion[preferences-card-render]

--- a/showcase/integrations/spring-ai/src/app/demos/subagents/delegation-log.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/subagents/delegation-log.tsx
@@ -57,6 +57,7 @@ const STATUS_COLOR: Record<Delegation["status"], string> = {
  * STATE_SNAPSHOT, the frontend's `useAgent({ updates: [OnStateChanged] })`
  * subscription fires, and a new entry appears below.
  */
+// @region[delegation-log-frontend]
 export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
   return (
     <div
@@ -134,3 +135,4 @@ export function DelegationLog({ delegations, isRunning }: DelegationLogProps) {
     </div>
   );
 }
+// @endregion[delegation-log-frontend]

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
@@ -103,6 +103,11 @@ public class SubagentsController {
             of every sub-agent delegation.
             """;
 
+    // @region[subagent-setup]
+    // Each sub-agent is its own Spring AI ChatClient call (built per-request
+    // in SubAgentHandler.apply), with its own system prompt. They don't
+    // share memory or tools with the supervisor — the supervisor only sees
+    // their return value as a tool result.
     private static final String RESEARCH_PROMPT =
             "You are a research sub-agent. Given a topic, produce a concise "
             + "bulleted list of 3-5 key facts. No preamble, no closing.";
@@ -113,6 +118,7 @@ public class SubagentsController {
     private static final String CRITIQUE_PROMPT =
             "You are an editorial critique sub-agent. Given a draft, give "
             + "2-3 crisp, actionable critiques. No preamble.";
+    // @endregion[subagent-setup]
 
     private final AgUiService agUiService;
     private final ChatModel chatModel;
@@ -190,6 +196,13 @@ public class SubagentsController {
             // tool-call ids returned by ChatResponse.
             List<HandlerInvocation> handlerInvocations = new CopyOnWriteArrayList<>();
 
+            // @region[supervisor-delegation-tools]
+            // Each sub-agent is exposed to the supervisor LLM as a Spring AI
+            // ToolCallback. When the supervisor invokes one, the matching
+            // SubAgentHandler runs a fresh ChatClient call with that
+            // sub-agent's system prompt, appends a Delegation entry to
+            // shared state, and returns the sub-agent's output to the
+            // supervisor as a tool result.
             ToolCallback researchTool = subAgentTool(
                     "research_agent", RESEARCH_PROMPT, runState, deferredEvents,
                     handlerInvocations, messageId,
@@ -207,6 +220,7 @@ public class SubagentsController {
                     handlerInvocations, messageId,
                     "Delegate a critique task to the critique sub-agent. "
                     + "Use for: reviewing a draft and suggesting concrete improvements.");
+            // @endregion[supervisor-delegation-tools]
 
             AssistantMessage assistantMessage = new AssistantMessage();
             assistantMessage.setId(messageId);

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/tools/DisplayFlightTool.java
@@ -62,6 +62,11 @@ public class DisplayFlightTool implements Function<DisplayFlightTool.Request, St
     @Override
     public String apply(Request request) {
         try {
+            // @region[backend-render-operations]
+            // The A2UI middleware detects the `a2ui_operations` container in
+            // this tool result and forwards the ops to the frontend renderer.
+            // The frontend catalog resolves component names to the local
+            // React components.
             var ops = List.of(
                     Map.of("type", "create_surface",
                             "surfaceId", SURFACE_ID,
@@ -79,6 +84,7 @@ public class DisplayFlightTool implements Function<DisplayFlightTool.Request, St
                             ))
             );
             return MAPPER.writeValueAsString(Map.of("a2ui_operations", ops));
+            // @endregion[backend-render-operations]
         } catch (Exception e) {
             return "{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}";
         }


### PR DESCRIPTION
## Summary

Consolidates the per-framework region marker work for **8 frameworks** into a single PR. Supersedes [#4369](https://github.com/CopilotKit/CopilotKit/pull/4369), [#4371](https://github.com/CopilotKit/CopilotKit/pull/4371), [#4372](https://github.com/CopilotKit/CopilotKit/pull/4372), [#4373](https://github.com/CopilotKit/CopilotKit/pull/4373), [#4374](https://github.com/CopilotKit/CopilotKit/pull/4374), [#4375](https://github.com/CopilotKit/CopilotKit/pull/4375), [#4376](https://github.com/CopilotKit/CopilotKit/pull/4376), [#4377](https://github.com/CopilotKit/CopilotKit/pull/4377). Same patterns established by mastra ([#4326](https://github.com/CopilotKit/CopilotKit/pull/4326)), smalls batch 1 ([#4361](https://github.com/CopilotKit/CopilotKit/pull/4361)), and ms-agent batch 2 ([#4363](https://github.com/CopilotKit/CopilotKit/pull/4363)). One commit per framework so reviewers can navigate.

**110 (framework × cell) targets** advanced from B (regions missing) to A (ready). Comment-only changes plus sibling teaching files; production demo runtime behavior is unchanged.

## Cells covered per framework

| Framework | Cells | Sibling files | Notes |
|---|---|---|---|
| google-adk | 18 + 2 (chat-slots extras + reasoning-block-render) | 4 | Largest single-framework round; biggest backlog at audit time |
| claude-sdk-python | 10 | 3 | New `weather_tool.snippet.py` Python sibling — production agent uses dict-based Anthropic schemas through a shared dispatch |
| pydantic-ai | 16 | 1 | tool-rendering uses sibling for all 3 regions; production uses `{ args, ... }` render-prop shape |
| agno | 12 | 2 | Backend region in-place on `agents/main.py` god-file |
| langroid | 12 | 1 | Subagents architectural divergence deferred — Langroid uses `ToolMessage` subclasses + adapter intercept rather than LangGraph `@tool`+`Command` |
| llamaindex | 16 | 2 | a2ui-fixed-schema backend wraps llamaindex's raw dict-ops idiom rather than `a2ui.render(...)` helper |
| crewai-crews | 16 | 1 | Only framework with full `hitl-in-chat` and full `declarative-gen-ui::provider-a2ui-prop` coverage |
| spring-ai | 13 | 2 | New `headless-simple/headless-chat.snippet.tsx` — production carries `deduplicateMessages` defensive pass against AG-UI Spring AI adapter's multi-run tool-call loop. Java backend uses same `// @region[name]` syntax as TS/JS/Python |

## Patterns applied (consistent with predecessor PRs)

- **In-place markers** for cells where production code is a clean teaching example (most cells, comment-only `@region[...]` markers, no behavior change)
- **Sibling `<region>.snippet.tsx` files** for cells where production demo carries QA hooks irrelevant to the docs page being taught (chat-component case) or where production demo doesn't use the slots/customizations the docs teach (chat-slots disclaimer/assistant-message case, reasoning-block-render case)
- **Multi-file regions** (e.g. `sandbox-function-registration` across `page.tsx` + `sandbox-functions.ts`) work via the bundler's name-based concatenation
- **Manifest `highlight:` additions** for backend region files outside the demo folder

## Architectural-divergence regions (framework-idiom rather than canonical shape)

Cells got framework-idiom regions instead of forcing the langgraph-python shape. Auto-config infrastructure ([PDX-68](https://linear.app/copilotkit/issue/PDX-68)) will eventually let docs render per-framework variants of these sections:

- Langroid sub-agents: `ToolMessage` subclasses + adapter-side intercept
- Spring AI a2ui-fixed-schema: Java `List.of(Map.of(...))` inline schema (same divergence as ms-agent-dotnet C# inline)
- claude-sdk-python sub-agents: Anthropic tool schemas + manual run loop

## Deferred

Common across most frameworks:

- `declarative-gen-ui::runtime-inject-tool` — cross-cutting, tracked as [PDX-70](https://linear.app/copilotkit/issue/PDX-70)
- Various `shared-state-streaming` cells where the production demo is a `TODO: Implement` stub (engineering work)
- `headless-complete` on llamaindex — structurally simpler than canonical (single `MessageList`, no separate bubble components, no `useRenderedMessages` hook)
- `gen-ui-tool-based` on google-adk — `generate_haiku` shape vs pie-chart/bar-chart docs (Jordan's prune-commit shape mismatch)

## Test plan

- [ ] `npx tsx showcase/scripts/bundle-demo-content.ts` succeeds; all 110 targets resolve in `demo-content.json`
- [ ] Spot-check `localhost:<port>/<framework>/prebuilt-components/chat` for each of the 8 frameworks — `chat-component` snippet renders the minimal Chat from the sibling file (where present)
- [ ] Spot-check `localhost:<port>/<framework>/generative-ui/tool-rendering` for frameworks with tool-rendering regions
- [ ] Spot-check `localhost:<port>/<framework>/state/shared-state-read-write` for multi-file regions
- [ ] Manifest YAMLs still parse (10 modified across 8 frameworks)