### PR TITLE
refactor(showcase): rename probe drivers for clarity, reorder drilldown popup

### DIFF
--- a/showcase/ops/README.md
+++ b/showcase/ops/README.md
@@ -247,15 +247,15 @@ Every `kind` resolves to a driver registered in `src/probes/drivers/index.ts`. T
 
 | YAML `kind`             | Driver file                        | Emitted key prefix(es)                 | Shape     |
 | ----------------------- | ---------------------------------- | -------------------------------------- | --------- |
-| `smoke`                 | `drivers/smoke.ts`                 | `smoke:<slug>` **and** `health:<slug>` | static    |
-| `e2e_smoke` (deferred)  | `drivers/e2e-smoke.ts`             | `e2e_smoke:<suite>`                    | static    |
+| `smoke`                 | `drivers/liveness.ts`              | `smoke:<slug>` **and** `health:<slug>` | static    |
+| `e2e_smoke` (deferred)  | `drivers/e2e-chat-tools.ts`        | `e2e_smoke:<suite>`                    | static    |
 | `image_drift`           | `drivers/image-drift.ts`           | `image_drift:<service>`                | discovery |
 | `version_drift`         | `drivers/version-drift.ts`         | `version_drift:<pkg>`                  | discovery |
 | `pin_drift`             | `drivers/pin-drift.ts`             | `pin_drift:overall`                    | single    |
 | `redirect_decommission` | `drivers/redirect-decommission.ts` | `redirect_decommission:overall`        | single    |
 | `aimock_wiring`         | `drivers/aimock-wiring.ts`         | `aimock_wiring:global`                 | single    |
 
-The `smoke` driver is the only one that emits **two** keys per target invocation: the primary `smoke:<slug>` ProbeResult is the driver's return value (written by the invoker), and the paired `health:<slug>` ProbeResult is side-emitted through `ctx.writer.write()` before returning. One YAML static target = two writer ticks per cycle. See the JSDoc on `smokeDriver` for why the paired emission is a writer side-channel rather than an array return.
+The `smoke` driver is the only one that emits **two** keys per target invocation: the primary `smoke:<slug>` ProbeResult is the driver's return value (written by the invoker), and the paired `health:<slug>` ProbeResult is side-emitted through `ctx.writer.write()` before returning. One YAML static target = two writer ticks per cycle. See the JSDoc on `livenessDriver` for why the paired emission is a writer side-channel rather than an array return.
 
 ### Discovery sources
 
@@ -357,7 +357,7 @@ src/
 ├── probes/
 │   ├── types.ts                  # ProbeDriver / DiscoverySource / registry interfaces
 │   ├── deploy-result.ts          # webhook deploy-event → ProbeResult mapper
-│   ├── smoke.ts                  # legacy smoke probe (deriveHealthUrl + SMOKE_SLACK_SAFE_FIELDS)
+│   ├── liveness.ts               # legacy liveness probe (deriveHealthUrl + LIVENESS_SLACK_SAFE_FIELDS)
 │   ├── pin-drift.ts              # pinDriftProbe state-machine authority
 │   ├── aimock-wiring.ts          # aimockWiringProbe (used by driver + legacy cron resolver)
 │   ├── redirect-decommission.ts  # legacy probe + REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS

--- a/showcase/ops/config/probes/e2e-demos.yml
+++ b/showcase/ops/config/probes/e2e-demos.yml
@@ -46,7 +46,7 @@
 # driver's runDemo() shares one 30s budget across goto + all 5
 # fallback selector waits, so a single demo cannot exceed 30s
 # regardless of how many selectors it tries (enforced via a single
-# wall-clock deadline in `drivers/e2e-demos.ts`'s runDemo()). For
+# wall-clock deadline in `drivers/e2e-readiness.ts`'s runDemo()). For
 # the largest 38-demo service the
 # absolute worst case is therefore ~38 × 30s ≈ ~19 min — bounded by
 # the 20-min outer cap below (which the driver's internal hard-cap is
@@ -78,7 +78,7 @@
 # outer cap is set to 20 min. The driver's internal hard-cap is
 # threaded from this YAML value at orchestrator boot (see
 # orchestrator.ts: `process.env.E2E_DEMOS_TIMEOUT_MS = cfg.timeout_ms`,
-# read per-`run()` by drivers/e2e-demos.ts), so the driver's own timer
+# read per-`run()` by drivers/e2e-readiness.ts), so the driver's own timer
 # fires at exactly the same wall-clock as the invoker's outer race —
 # no premature internal-cap edge that would short-circuit the YAML's
 # documented behaviour at the driver's pre-threading default of 5 min.

--- a/showcase/ops/src/alerts/render-red-tick.test.ts
+++ b/showcase/ops/src/alerts/render-red-tick.test.ts
@@ -198,7 +198,7 @@ describe("red-tick YAML rendering — Items 2 & 3", () => {
   });
 
   // A3: the smoke template historically referenced `signal.links.smoke` /
-  // `signal.links.health` — the DRIVER signal (probes/drivers/smoke.ts) has
+  // `signal.links.health` — the DRIVER signal (probes/drivers/liveness.ts) has
   // `slug, url, status, errorDesc, latencyMs` and no `links` object, so those
   // section-guards were always empty. The template should pull `signal.url`
   // directly and render an "endpoint" link.

--- a/showcase/ops/src/orchestrator.ts
+++ b/showcase/ops/src/orchestrator.ts
@@ -22,7 +22,7 @@ import {
 } from "./storage/s3-backup.js";
 import { deployEventToProbeResult } from "./probes/deploy-result.js";
 import { REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS } from "./probes/redirect-decommission.js";
-import { SMOKE_SLACK_SAFE_FIELDS } from "./probes/smoke.js";
+import { LIVENESS_SLACK_SAFE_FIELDS } from "./probes/liveness.js";
 import { aimockWiringProbe } from "./probes/aimock-wiring.js";
 import { createProbeRegistry } from "./probes/drivers/index.js";
 import { createDiscoveryRegistry } from "./probes/discovery/index.js";
@@ -34,12 +34,12 @@ import { createProbeRunWriter } from "./probes/run-history.js";
 import type { ProbeRunWriter } from "./probes/run-history.js";
 import { aimockWiringDriver } from "./probes/drivers/aimock-wiring.js";
 import { pinDriftDriver } from "./probes/drivers/pin-drift.js";
-import { smokeDriver } from "./probes/drivers/smoke.js";
+import { livenessDriver } from "./probes/drivers/liveness.js";
 import { imageDriftDriver } from "./probes/drivers/image-drift.js";
 import { versionDriftDriver } from "./probes/drivers/version-drift.js";
 import { redirectDecommissionDriver } from "./probes/drivers/redirect-decommission.js";
-import { e2eSmokeDriver } from "./probes/drivers/e2e-smoke.js";
-import { e2eDemosDriver } from "./probes/drivers/e2e-demos.js";
+import { e2eChatToolsDriver } from "./probes/drivers/e2e-chat-tools.js";
+import { e2eReadinessDriver } from "./probes/drivers/e2e-readiness.js";
 import { e2eDeepDriver } from "./probes/drivers/e2e-deep.js";
 import { e2eParityDriver } from "./probes/drivers/e2e-parity.js";
 import { qaDriver } from "./probes/drivers/qa.js";
@@ -136,15 +136,15 @@ export async function boot(opts: BootOptions = {}): Promise<{
     opts.configDir ?? path.resolve(process.cwd(), "config/alerts");
   // L1-L4 per-starter dimensions (agent/chat/tools) don't have dedicated probe
   // modules today — their signals flow through the same smoke/e2e-smoke drivers
-  // as side-emissions (see probes/drivers/smoke.ts). The safe-field sets for
+  // as side-emissions (see probes/drivers/liveness.ts). The safe-field sets for
   // them mirror smoke's sanitized-errorDesc allow-list so triple-brace
   // {{{signal.errorDesc}}} in the red-tick YAMLs loads. Keep these in lockstep
-  // with SMOKE_SLACK_SAFE_FIELDS — any new sanitized field added there SHOULD
+  // with LIVENESS_SLACK_SAFE_FIELDS — any new sanitized field added there SHOULD
   // be added here too unless there's a dimension-specific reason otherwise.
   const L1_L4_SLACK_SAFE_FIELDS = ["errorDesc"] as const;
   const slackSafeFields: Record<string, Set<string>> = {
     redirect_decommission: new Set(REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS),
-    smoke: new Set(SMOKE_SLACK_SAFE_FIELDS),
+    smoke: new Set(LIVENESS_SLACK_SAFE_FIELDS),
     agent: new Set(L1_L4_SLACK_SAFE_FIELDS),
     chat: new Set(L1_L4_SLACK_SAFE_FIELDS),
     tools: new Set(L1_L4_SLACK_SAFE_FIELDS),
@@ -323,7 +323,7 @@ export async function boot(opts: BootOptions = {}): Promise<{
     // we compute a PER-CFG env overlay via `envForCfg(cfg, baseEnv)` and
     // hand it to `buildProbeInvoker` as the invoker's `env`. Drivers
     // read the timeout via `ctx.env.E2E_DEMOS_TIMEOUT_MS` (see
-    // drivers/e2e-demos.ts — `TIMEOUT_ENV_VAR`).
+    // drivers/e2e-readiness.ts — `TIMEOUT_ENV_VAR`).
     //
     // Pre-fix this loop wrote `process.env.E2E_DEMOS_TIMEOUT_MS = ...`
     // directly. Three problems with that:
@@ -847,12 +847,12 @@ export function registerAllProbeDrivers(
 ): void {
   probeRegistry.register(aimockWiringDriver);
   probeRegistry.register(pinDriftDriver);
-  probeRegistry.register(smokeDriver);
+  probeRegistry.register(livenessDriver);
   probeRegistry.register(imageDriftDriver);
   probeRegistry.register(versionDriftDriver);
   probeRegistry.register(redirectDecommissionDriver);
-  probeRegistry.register(e2eSmokeDriver);
-  probeRegistry.register(e2eDemosDriver);
+  probeRegistry.register(e2eChatToolsDriver);
+  probeRegistry.register(e2eReadinessDriver);
   probeRegistry.register(e2eDeepDriver);
   probeRegistry.register(e2eParityDriver);
   probeRegistry.register(qaDriver);

--- a/showcase/ops/src/probes/discovery/railway-services.ts
+++ b/showcase/ops/src/probes/discovery/railway-services.ts
@@ -44,7 +44,7 @@ import {
  * Service shape — distinguishes the two deployment archetypes that share
  * the `showcase-*` naming scheme on Railway but have wildly different URL
  * surfaces. Drivers branch on this field to pick the right probe contract
- * (see `drivers/smoke.ts` and `drivers/e2e-smoke.ts`).
+ * (see `drivers/liveness.ts` and `drivers/e2e-chat-tools.ts`).
  *
  *   - `package`  Shell-based showcases (`showcase-ag2`, `showcase-mastra`,
  *                ...). They expose `/smoke`, `/health`, `/demos/*`, and
@@ -386,7 +386,7 @@ const VariablesSchema = z.object({
 
 /**
  * Read `registry.json` and build a `slug -> demos[].id[]` map. Mirrors
- * the parsing logic in `drivers/e2e-demos.ts`'s `defaultDemosResolver`
+ * the parsing logic in `drivers/e2e-readiness.ts`'s `defaultDemosResolver`
  * so behaviour stays consistent across the two readers — the discovery
  * source feeds the invoker's pre-dispatch sort while the driver's
  * resolver feeds the per-service fan-out at execute time.

--- a/showcase/ops/src/probes/drivers/e2e-chat-tools.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-chat-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
-  e2eSmokeDriver,
+  e2eChatToolsDriver,
   createE2eSmokeDriver,
   type E2eBrowser,
   type E2eBrowserContext,
@@ -9,7 +9,7 @@ import {
   type E2eSmokePackageSignal,
   type E2eSmokeSignal,
   type E2eSmokeStarterSignal,
-} from "./e2e-smoke.js";
+} from "./e2e-chat-tools.js";
 import { logger } from "../../logger.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
@@ -133,9 +133,9 @@ class CapturingWriter {
 
 // --- Schema --------------------------------------------------------------
 
-describe("e2eSmokeDriver.inputSchema", () => {
+describe("e2eChatToolsDriver.inputSchema", () => {
   it("accepts { key, backendUrl, demos }", () => {
-    const parsed = e2eSmokeDriver.inputSchema.safeParse({
+    const parsed = e2eChatToolsDriver.inputSchema.safeParse({
       key: "e2e-smoke:foo",
       backendUrl: "https://example.com",
       demos: ["agentic-chat", "tool-rendering"],
@@ -144,7 +144,7 @@ describe("e2eSmokeDriver.inputSchema", () => {
   });
 
   it("accepts omitted demos (no L4)", () => {
-    const parsed = e2eSmokeDriver.inputSchema.safeParse({
+    const parsed = e2eChatToolsDriver.inputSchema.safeParse({
       key: "e2e-smoke:foo",
       backendUrl: "https://example.com",
     });
@@ -152,7 +152,7 @@ describe("e2eSmokeDriver.inputSchema", () => {
   });
 
   it("rejects empty key", () => {
-    const parsed = e2eSmokeDriver.inputSchema.safeParse({
+    const parsed = e2eChatToolsDriver.inputSchema.safeParse({
       key: "",
       backendUrl: "https://example.com",
     });
@@ -160,7 +160,7 @@ describe("e2eSmokeDriver.inputSchema", () => {
   });
 
   it("rejects non-URL backendUrl", () => {
-    const parsed = e2eSmokeDriver.inputSchema.safeParse({
+    const parsed = e2eChatToolsDriver.inputSchema.safeParse({
       key: "e2e-smoke:foo",
       backendUrl: "not-a-url",
     });
@@ -170,7 +170,7 @@ describe("e2eSmokeDriver.inputSchema", () => {
 
 // --- L3 behaviour --------------------------------------------------------
 
-describe("e2eSmokeDriver L3 (chat)", () => {
+describe("e2eChatToolsDriver L3 (chat)", () => {
   it("green when chat returns any non-empty response", async () => {
     const { browser, state } = makeBrowser([{ assistantText: "Hi there!" }]);
     const driver = createE2eSmokeDriver({ launcher: async () => browser });
@@ -287,7 +287,7 @@ describe("e2eSmokeDriver L3 (chat)", () => {
 
 // --- L4 behaviour --------------------------------------------------------
 
-describe("e2eSmokeDriver L4 (tools)", () => {
+describe("e2eChatToolsDriver L4 (tools)", () => {
   it("skipped when demos does not include 'tool-rendering'", async () => {
     const { browser, state } = makeBrowser([
       { assistantText: "Hi" },
@@ -377,7 +377,7 @@ describe("e2eSmokeDriver L4 (tools)", () => {
 
 // --- Launcher / error paths ---------------------------------------------
 
-describe("e2eSmokeDriver error paths", () => {
+describe("e2eChatToolsDriver error paths", () => {
   it("red with launcher-error when chromium launch throws", async () => {
     const driver = createE2eSmokeDriver({
       launcher: async () => {
@@ -446,7 +446,7 @@ describe("e2eSmokeDriver error paths", () => {
 
 // --- Side-emit / writer plumbing ----------------------------------------
 
-describe("e2eSmokeDriver side-emits", () => {
+describe("e2eChatToolsDriver side-emits", () => {
   it("survives writer failure on chat side-emit without swallowing L3 result", async () => {
     const { browser } = makeBrowser([
       { assistantText: "Hi" },
@@ -498,7 +498,7 @@ describe("e2eSmokeDriver side-emits", () => {
 // rather than silently producing a red page-error. This also avoids the
 // registry-lookup path (starters aren't keyed in registry.json).
 
-describe("e2eSmokeDriver starter shape", () => {
+describe("e2eChatToolsDriver starter shape", () => {
   it("aggregate green-skipped when shape='starter' — full signal contract locked in", async () => {
     // The fake browser is never used, but we still wire it in to verify
     // the driver short-circuits BEFORE launching chromium (no newContext
@@ -654,7 +654,7 @@ describe("e2eSmokeDriver starter shape", () => {
 // would yield `hasToolRendering === false` silently and skip every L4
 // row. These tests pin the end-to-end flow.
 
-describe("e2eSmokeDriver package shape: deriveSlug + demosResolver", () => {
+describe("e2eChatToolsDriver package shape: deriveSlug + demosResolver", () => {
   it("calls demosResolver with the stripped slug for a `showcase-<multi-seg>` name", async () => {
     const resolverCalls: string[] = [];
     const { browser } = makeBrowser([
@@ -708,9 +708,9 @@ describe("e2eSmokeDriver package shape: deriveSlug + demosResolver", () => {
   });
 });
 
-describe("e2eSmokeDriver module export", () => {
-  it("module-level e2eSmokeDriver has kind === 'e2e_smoke'", () => {
-    expect(e2eSmokeDriver.kind).toBe("e2e_smoke");
-    expect(typeof e2eSmokeDriver.run).toBe("function");
+describe("e2eChatToolsDriver module export", () => {
+  it("module-level e2eChatToolsDriver has kind === 'e2e_smoke'", () => {
+    expect(e2eChatToolsDriver.kind).toBe("e2e_smoke");
+    expect(typeof e2eChatToolsDriver.run).toBe("function");
   });
 });

--- a/showcase/ops/src/probes/drivers/e2e-chat-tools.ts
+++ b/showcase/ops/src/probes/drivers/e2e-chat-tools.ts
@@ -344,7 +344,7 @@ function createDefaultDemosResolver(): DemosResolver {
 }
 
 /** Create a configured e2e-smoke driver. Exported for tests; production
- * callers use the module-level `e2eSmokeDriver`. */
+ * callers use the module-level `e2eChatToolsDriver`. */
 export function createE2eSmokeDriver(
   deps: E2eSmokeDriverDeps = {},
 ): ProbeDriver<E2eSmokeDriverInput, E2eSmokeSignal> {
@@ -871,4 +871,4 @@ function deriveSlug(key: string, name?: string): string {
 
 /** Default driver instance with the real Playwright launcher. Registered
  * by the orchestrator at boot. */
-export const e2eSmokeDriver = createE2eSmokeDriver();
+export const e2eChatToolsDriver = createE2eSmokeDriver();

--- a/showcase/ops/src/probes/drivers/e2e-readiness.test.ts
+++ b/showcase/ops/src/probes/drivers/e2e-readiness.test.ts
@@ -4,13 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { z } from "zod";
 import {
-  e2eDemosDriver,
+  e2eReadinessDriver,
   createE2eDemosDriver,
   type E2eDemosBrowser,
   type E2eDemosBrowserContext,
   type E2eDemosPage,
   type E2eDemosAggregateSignal,
-} from "./e2e-demos.js";
+} from "./e2e-readiness.js";
 import { buildProbeInvoker } from "../loader/probe-invoker.js";
 import { createDiscoveryRegistry } from "../discovery/index.js";
 import type { DiscoverySource } from "../types.js";
@@ -56,7 +56,7 @@ function mkSpyLogger(): { logger: Logger; entries: LogEntry[] } {
 //
 // Real chromium is never touched — tests inject a pluggable launcher that
 // returns a scripted fake browser. Mirrors the e2e-smoke driver's test
-// pattern (see e2e-smoke.test.ts).
+// pattern (see e2e-chat-tools.test.ts).
 
 // --- Fakes ---------------------------------------------------------------
 
@@ -179,7 +179,7 @@ describe("e2e-demos driver", () => {
   });
 
   it("exposes kind === 'e2e_demos'", () => {
-    expect(e2eDemosDriver.kind).toBe("e2e_demos");
+    expect(e2eReadinessDriver.kind).toBe("e2e_demos");
   });
 
   it("emits one e2e:<slug>/<feature> row per declared demo", async () => {

--- a/showcase/ops/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/ops/src/probes/drivers/e2e-readiness.ts
@@ -945,4 +945,4 @@ function deriveSlug(key: string, name?: string): string {
 }
 
 /** Default driver instance — registered by the orchestrator at boot. */
-export const e2eDemosDriver = createE2eDemosDriver();
+export const e2eReadinessDriver = createE2eDemosDriver();

--- a/showcase/ops/src/probes/drivers/liveness.test.ts
+++ b/showcase/ops/src/probes/drivers/liveness.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as http from "node:http";
 import type { AddressInfo } from "node:net";
-import { smokeDriver, type SmokeDriverSignal } from "./smoke.js";
+import { livenessDriver, type SmokeDriverSignal } from "./liveness.js";
 import { logger } from "../../logger.js";
 import type {
   ProbeContext,
@@ -10,8 +10,8 @@ import type {
 } from "../../types/index.js";
 
 // Driver-level tests for the smoke ProbeDriver. Deep behavioural coverage of
-// `deriveHealthUrl` + the legacy `smokeProbe.run` path lives in
-// `../smoke.test.ts`; this file verifies the driver-adapter layer:
+// `deriveHealthUrl` + the legacy `livenessProbe.run` path lives in
+// `../liveness.test.ts`; this file verifies the driver-adapter layer:
 //   - schema accepts/rejects the expected YAML-static input shape
 //   - primary return value (smoke tick) matches the canonical ProbeResult
 //     shape per status code
@@ -94,7 +94,7 @@ function fakeFetch(opts: {
   }) as unknown as typeof fetch;
 }
 
-describe("smokeDriver", () => {
+describe("livenessDriver", () => {
   beforeEach(() => {
     // Each test stubs globalThis.fetch via vi.stubGlobal so parallel test
     // runs don't cross-contaminate and a failure in one test restores a
@@ -106,11 +106,11 @@ describe("smokeDriver", () => {
   });
 
   it("exposes kind === 'smoke'", () => {
-    expect(smokeDriver.kind).toBe("smoke");
+    expect(livenessDriver.kind).toBe("smoke");
   });
 
   it("inputSchema accepts { key, url }", () => {
-    const parsed = smokeDriver.inputSchema.safeParse({
+    const parsed = livenessDriver.inputSchema.safeParse({
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -118,21 +118,21 @@ describe("smokeDriver", () => {
   });
 
   it("inputSchema rejects missing url", () => {
-    const parsed = smokeDriver.inputSchema.safeParse({
+    const parsed = livenessDriver.inputSchema.safeParse({
       key: "smoke:mastra",
     });
     expect(parsed.success).toBe(false);
   });
 
   it("inputSchema rejects missing key", () => {
-    const parsed = smokeDriver.inputSchema.safeParse({
+    const parsed = livenessDriver.inputSchema.safeParse({
       url: "https://x.example/smoke",
     });
     expect(parsed.success).toBe(false);
   });
 
   it("inputSchema rejects non-url url", () => {
-    const parsed = smokeDriver.inputSchema.safeParse({
+    const parsed = livenessDriver.inputSchema.safeParse({
       key: "smoke:mastra",
       url: "not-a-url",
     });
@@ -145,7 +145,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
     );
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -165,7 +165,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 500, healthStatus: 200, agentStatus: 200 }),
     );
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -189,7 +189,7 @@ describe("smokeDriver", () => {
       }),
     );
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:ag2",
       url: "https://x.example/smoke",
     });
@@ -223,7 +223,7 @@ describe("smokeDriver", () => {
       env: { SMOKE_TIMEOUT_MS: "5" },
       writer,
     };
-    const r = await smokeDriver.run(ctx, {
+    const r = await livenessDriver.run(ctx, {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -250,7 +250,7 @@ describe("smokeDriver", () => {
       }),
     );
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -268,7 +268,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 503, agentStatus: 200 }),
     );
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -285,7 +285,7 @@ describe("smokeDriver", () => {
 
   it("missing writer logs a warning and does not throw", async () => {
     vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 200, healthStatus: 200 }));
-    const r = await smokeDriver.run(mkCtx(undefined), {
+    const r = await livenessDriver.run(mkCtx(undefined), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -299,7 +299,7 @@ describe("smokeDriver", () => {
         throw new Error("writer exploded");
       },
     };
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -313,7 +313,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -343,7 +343,7 @@ describe("smokeDriver", () => {
     const ctx = mkCtx(writer);
     const results = await Promise.all(
       slugs.map((slug) =>
-        smokeDriver.run(ctx, {
+        livenessDriver.run(ctx, {
           key: `smoke:${slug}`,
           url: `https://x-${slug}.example/smoke`,
         }),
@@ -380,7 +380,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 500, smokeBody: longBody, healthStatus: 200 }),
     );
     const { writer } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -407,7 +407,7 @@ describe("smokeDriver", () => {
       brokenResponse) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -424,7 +424,7 @@ describe("smokeDriver", () => {
       env: { SMOKE_TIMEOUT_MS: "nonsense" },
       writer,
     };
-    const r = await smokeDriver.run(ctx, {
+    const r = await livenessDriver.run(ctx, {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -441,7 +441,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -455,7 +455,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
     );
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "bare",
       url: "https://x.example/smoke",
     });
@@ -474,7 +474,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
     );
     const { writer, writes } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -492,7 +492,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 400 }),
     );
     const { writer, writes } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -512,7 +512,7 @@ describe("smokeDriver", () => {
       }),
     );
     const { writer, writes } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -534,7 +534,7 @@ describe("smokeDriver", () => {
       }),
     );
     const { writer, writes } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -560,7 +560,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer, writes } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -590,7 +590,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
@@ -634,7 +634,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:ag2",
       name: "showcase-ag2",
       imageRef: "ghcr.io/copilotkit/showcase-ag2:latest",
@@ -659,7 +659,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
     );
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:starter-ag2",
       name: "showcase-starter-ag2",
       imageRef: "ghcr.io/copilotkit/showcase-starter-ag2:latest",
@@ -698,7 +698,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:starter-ag2",
       name: "showcase-starter-ag2",
       publicUrl: "https://showcase-starter-ag2-production.up.railway.app",
@@ -743,7 +743,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:starter-ag2",
       name: "showcase-starter-ag2",
       publicUrl: "https://showcase-starter-ag2-production.up.railway.app",
@@ -769,7 +769,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer, writes } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:starter-ag2",
       name: "showcase-starter-ag2",
       publicUrl: "https://showcase-starter-ag2-production.up.railway.app",
@@ -802,7 +802,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:starter-mastra",
       name: "showcase-starter-mastra",
       publicUrl: "https://showcase-starter-mastra.up.railway.app",
@@ -828,7 +828,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:ag2",
       name: "showcase-ag2",
       publicUrl: "https://showcase-ag2.up.railway.app",
@@ -864,7 +864,7 @@ describe("smokeDriver", () => {
       // Restore real fetch — we're intentionally talking to a real socket.
       vi.unstubAllGlobals();
       const { writer, writes } = mkWriter();
-      await smokeDriver.run(mkCtx(writer), {
+      await livenessDriver.run(mkCtx(writer), {
         key: "smoke:mastra",
         url: `${url}/smoke`,
       });
@@ -884,7 +884,7 @@ describe("smokeDriver", () => {
     try {
       vi.unstubAllGlobals();
       const { writer, writes } = mkWriter();
-      await smokeDriver.run(mkCtx(writer), {
+      await livenessDriver.run(mkCtx(writer), {
         key: "smoke:mastra",
         url: `${url}/smoke`,
       });
@@ -919,7 +919,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:ag2",
       name: "showcase-ag2",
       publicUrl: "https://showcase-ag2.up.railway.app",
@@ -947,7 +947,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:starter-ag2",
       name: "showcase-starter-ag2",
       publicUrl: "https://showcase-starter-ag2.up.railway.app",
@@ -968,7 +968,7 @@ describe("smokeDriver", () => {
     );
     const { writer } = mkWriter();
     await expect(
-      smokeDriver.run(mkCtx(writer), {
+      livenessDriver.run(mkCtx(writer), {
         key: "smoke:starter-ag2",
         name: "showcase-starter-ag2",
         publicUrl: "https://showcase-starter-ag2.up.railway.app",
@@ -978,7 +978,7 @@ describe("smokeDriver", () => {
   });
 
   it("inputSchema rejects `url` + `shape` combo (shape only valid with publicUrl)", () => {
-    const parsed = smokeDriver.inputSchema.safeParse({
+    const parsed = livenessDriver.inputSchema.safeParse({
       key: "smoke:mastra",
       url: "https://x.example/smoke",
       shape: "starter",
@@ -990,12 +990,12 @@ describe("smokeDriver", () => {
   // get a unified rejection for structural mistakes regardless of which
   // arm's strictness would otherwise absorb them.
   it("inputSchema rejects bare `{ key }` (no url, no name+publicUrl)", () => {
-    const parsed = smokeDriver.inputSchema.safeParse({ key: "k" });
+    const parsed = livenessDriver.inputSchema.safeParse({ key: "k" });
     expect(parsed.success).toBe(false);
   });
 
   it("inputSchema rejects `{ key, name }` (discovery missing publicUrl)", () => {
-    const parsed = smokeDriver.inputSchema.safeParse({
+    const parsed = livenessDriver.inputSchema.safeParse({
       key: "k",
       name: "showcase-ag2",
     });
@@ -1006,7 +1006,7 @@ describe("smokeDriver", () => {
     // Discovery arm's .passthrough() would otherwise absorb the stray
     // `url` field; the union-level superRefine enforces XOR across the
     // two modes.
-    const parsed = smokeDriver.inputSchema.safeParse({
+    const parsed = livenessDriver.inputSchema.safeParse({
       key: "k",
       url: "http://x.example/smoke",
       name: "showcase-ag2",
@@ -1026,7 +1026,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
     );
     const { writer } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:showcase-ag2",
       name: "showcase-ag2",
       publicUrl: "https://showcase-ag2.up.railway.app",
@@ -1047,7 +1047,7 @@ describe("smokeDriver", () => {
       return new Response("", { status: 404 });
     }) as unknown as typeof fetch);
     const { writer } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:showcase-starter-ag2",
       name: "showcase-starter-ag2",
       publicUrl: "https://showcase-starter-ag2.up.railway.app",
@@ -1062,7 +1062,7 @@ describe("smokeDriver", () => {
       fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
     );
     const { writer } = mkWriter();
-    const r = await smokeDriver.run(mkCtx(writer), {
+    const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:custom-yaml-key",
       url: "https://x.example/smoke",
     });
@@ -1097,7 +1097,7 @@ describe("smokeDriver", () => {
       env: { FOO: "bar" },
       shape: "starter" as const,
     };
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       ...discoveryRecord,
       key: "smoke:starter-ag2",
     });
@@ -1120,7 +1120,7 @@ describe("smokeDriver", () => {
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
-    await smokeDriver.run(mkCtx(writer), {
+    await livenessDriver.run(mkCtx(writer), {
       key: "smoke:ag2",
       name: "showcase-ag2",
       imageRef: "",
@@ -1137,11 +1137,11 @@ describe("smokeDriver", () => {
 /**
  * Proxy helper for the two schema-level assertions above. Not exposed
  * from the module itself (drivers keep their schemas private); the tests
- * pull it through the existing `smokeDriver` import so the tested shape
+ * pull it through the existing `livenessDriver` import so the tested shape
  * matches exactly what the invoker hands in.
  */
 function smokeInputSchema_safeParse(input: unknown): { success: boolean } {
-  return smokeDriver.inputSchema.safeParse(input);
+  return livenessDriver.inputSchema.safeParse(input);
 }
 
 /**

--- a/showcase/ops/src/probes/drivers/liveness.ts
+++ b/showcase/ops/src/probes/drivers/liveness.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { deriveHealthUrl } from "../smoke.js";
+import { deriveHealthUrl } from "../liveness.js";
 import {
   resolveShape,
   showcaseShapeSchema,
@@ -213,7 +213,7 @@ export interface SmokeDriverSignal {
   latencyMs: number;
 }
 
-export const smokeDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
+export const livenessDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
   kind: "smoke",
   inputSchema: smokeInputSchema,
   async run(ctx, rawInput) {

--- a/showcase/ops/src/probes/drivers/liveness.ts
+++ b/showcase/ops/src/probes/drivers/liveness.ts
@@ -213,98 +213,100 @@ export interface SmokeDriverSignal {
   latencyMs: number;
 }
 
-export const livenessDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> = {
-  kind: "smoke",
-  inputSchema: smokeInputSchema,
-  async run(ctx, rawInput) {
-    // Normalise mode at the boundary. Schema-parsed inputs (orchestrator
-    // path) carry `mode` via the union default; tests that hand a raw
-    // object to `driver.run()` omit it. Field presence is the runtime
-    // discriminator: `url` present ⇒ static, `name`+`publicUrl` ⇒
-    // discovery. After this cast the rest of the function narrows via
-    // `input.mode` alone.
-    const input = normaliseMode(rawInput);
-    const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
-    const timeoutMs = readTimeoutMs(ctx);
-    const slug = deriveSlug(input);
-    // Shape resolution delegates to the shared resolveShape helper in
-    // `discovery/railway-services.ts` — classifier wins on `name`, throws
-    // on explicit-vs-classifier disagreement, honours explicit `shape`
-    // otherwise. Thread `ctx.logger` so the classifier's audit-warn fires
-    // on the driver path too.
-    const shape = resolveShape(
-      input.mode === "discovery"
-        ? { name: input.name, shape: input.shape }
-        : {},
-      { logger: ctx.logger },
-    );
-    const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input, shape);
-    // Primary key for the smoke ProbeResult. In DISCOVERY mode,
-    // `input.key` arrives as `smoke:showcase-ag2` because the
-    // `key_template` in YAML interpolates `${name}` and the template
-    // language has no string-munge function to strip the prefix.
-    // Rewrite to `smoke:<slug>` here so dashboards/alerts that match on
-    // `smoke:ag2` / `smoke:starter-ag2` stay intact. In STATIC mode,
-    // pass the YAML-authored key through verbatim so legacy callers
-    // keep their exact `input.key` in the primary result.
-    const primaryKey = input.mode === "discovery" ? `smoke:${slug}` : input.key;
+export const livenessDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> =
+  {
+    kind: "smoke",
+    inputSchema: smokeInputSchema,
+    async run(ctx, rawInput) {
+      // Normalise mode at the boundary. Schema-parsed inputs (orchestrator
+      // path) carry `mode` via the union default; tests that hand a raw
+      // object to `driver.run()` omit it. Field presence is the runtime
+      // discriminator: `url` present ⇒ static, `name`+`publicUrl` ⇒
+      // discovery. After this cast the rest of the function narrows via
+      // `input.mode` alone.
+      const input = normaliseMode(rawInput);
+      const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
+      const timeoutMs = readTimeoutMs(ctx);
+      const slug = deriveSlug(input);
+      // Shape resolution delegates to the shared resolveShape helper in
+      // `discovery/railway-services.ts` — classifier wins on `name`, throws
+      // on explicit-vs-classifier disagreement, honours explicit `shape`
+      // otherwise. Thread `ctx.logger` so the classifier's audit-warn fires
+      // on the driver path too.
+      const shape = resolveShape(
+        input.mode === "discovery"
+          ? { name: input.name, shape: input.shape }
+          : {},
+        { logger: ctx.logger },
+      );
+      const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input, shape);
+      // Primary key for the smoke ProbeResult. In DISCOVERY mode,
+      // `input.key` arrives as `smoke:showcase-ag2` because the
+      // `key_template` in YAML interpolates `${name}` and the template
+      // language has no string-munge function to strip the prefix.
+      // Rewrite to `smoke:<slug>` here so dashboards/alerts that match on
+      // `smoke:ag2` / `smoke:starter-ag2` stay intact. In STATIC mode,
+      // pass the YAML-authored key through verbatim so legacy callers
+      // keep their exact `input.key` in the primary result.
+      const primaryKey =
+        input.mode === "discovery" ? `smoke:${slug}` : input.key;
 
-    // Sequential issue of smoke + health + agent to keep inflight socket
-    // count bounded at max_concurrency × 3 — Railway's edge has
-    // historically rate-limited at higher parallelism, so we eat the
-    // wall-clock cost to stay well under any edge threshold.
-    //
-    // Starter shape hits the same endpoint (`/api/health`) for both the
-    // primary smoke tick and the health side-emit. We intentionally run
-    // TWO independent GETs rather than reusing the first result: the
-    // `smoke:<slug>` and `health:<slug>` rows feed separate alert
-    // dimensions (`dimension: smoke` vs `dimension: health`) that
-    // dashboards compare for correlation, and a single-GET-reuse would
-    // make the two rows byte-identical and defeat that signal. The extra
-    // round-trip is a cheap liveness check against the same endpoint.
-    const smokeResult = await probeOne({
-      fetchImpl,
-      url: smokeUrl,
-      key: primaryKey,
-      slug,
-      timeoutMs,
-      now: ctx.now,
-      method: "GET",
-    });
+      // Sequential issue of smoke + health + agent to keep inflight socket
+      // count bounded at max_concurrency × 3 — Railway's edge has
+      // historically rate-limited at higher parallelism, so we eat the
+      // wall-clock cost to stay well under any edge threshold.
+      //
+      // Starter shape hits the same endpoint (`/api/health`) for both the
+      // primary smoke tick and the health side-emit. We intentionally run
+      // TWO independent GETs rather than reusing the first result: the
+      // `smoke:<slug>` and `health:<slug>` rows feed separate alert
+      // dimensions (`dimension: smoke` vs `dimension: health`) that
+      // dashboards compare for correlation, and a single-GET-reuse would
+      // make the two rows byte-identical and defeat that signal. The extra
+      // round-trip is a cheap liveness check against the same endpoint.
+      const smokeResult = await probeOne({
+        fetchImpl,
+        url: smokeUrl,
+        key: primaryKey,
+        slug,
+        timeoutMs,
+        now: ctx.now,
+        method: "GET",
+      });
 
-    // Side-emit #1: health tick. Always a fresh GET — even when smokeUrl
-    // === healthUrl (starter shape), see the comment block above for why
-    // we do NOT reuse the smoke result.
-    const healthKey = `health:${slug}`;
-    const healthResult = await probeOne({
-      fetchImpl,
-      url: healthUrl,
-      key: healthKey,
-      slug,
-      timeoutMs,
-      now: ctx.now,
-      method: "GET",
-    });
-    await sideEmit(ctx, healthResult, healthKey);
+      // Side-emit #1: health tick. Always a fresh GET — even when smokeUrl
+      // === healthUrl (starter shape), see the comment block above for why
+      // we do NOT reuse the smoke result.
+      const healthKey = `health:${slug}`;
+      const healthResult = await probeOne({
+        fetchImpl,
+        url: healthUrl,
+        key: healthKey,
+        slug,
+        timeoutMs,
+        now: ctx.now,
+        method: "GET",
+      });
+      await sideEmit(ctx, healthResult, healthKey);
 
-    // Side-emit #2: agent endpoint POST. Non-404 2xx-5xx response is
-    // green (proves the CopilotKit runtime is mounted); 404 and
-    // transport failures are red. This mirrors the L2 `@agent`
-    // assertion in `integration-smoke.spec.ts:311`.
-    const agentKey = `agent:${slug}`;
-    const agentResult = await probeAgent({
-      fetchImpl,
-      url: agentUrl,
-      key: agentKey,
-      slug,
-      timeoutMs,
-      now: ctx.now,
-    });
-    await sideEmit(ctx, agentResult, agentKey);
+      // Side-emit #2: agent endpoint POST. Non-404 2xx-5xx response is
+      // green (proves the CopilotKit runtime is mounted); 404 and
+      // transport failures are red. This mirrors the L2 `@agent`
+      // assertion in `integration-smoke.spec.ts:311`.
+      const agentKey = `agent:${slug}`;
+      const agentResult = await probeAgent({
+        fetchImpl,
+        url: agentUrl,
+        key: agentKey,
+        slug,
+        timeoutMs,
+        now: ctx.now,
+      });
+      await sideEmit(ctx, agentResult, agentKey);
 
-    return smokeResult;
-  },
-};
+      return smokeResult;
+    },
+  };
 
 /**
  * Normalise a driver input into the `SmokeDriverInput` discriminated

--- a/showcase/ops/src/probes/liveness.test.ts
+++ b/showcase/ops/src/probes/liveness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { smokeProbe } from "./smoke.js";
+import { livenessProbe } from "./liveness.js";
 import { logger } from "../logger.js";
 import type { ProbeContext } from "../types/index.js";
 
@@ -19,7 +19,7 @@ function fakeFetch(status: number, okBody = ""): typeof fetch {
 
 describe("smoke probe", () => {
   it("returns green on 200", async () => {
-    const r = await smokeProbe.run(
+    const r = await livenessProbe.run(
       { slug: "mastra", url: "https://x/api/smoke", fetchImpl: fakeFetch(200) },
       ctx,
     );
@@ -31,7 +31,7 @@ describe("smoke probe", () => {
   });
 
   it("returns red on 5xx with errorDesc", async () => {
-    const r = await smokeProbe.run(
+    const r = await livenessProbe.run(
       { slug: "mastra", url: "https://x/api/smoke", fetchImpl: fakeFetch(503) },
       ctx,
     );
@@ -43,7 +43,7 @@ describe("smoke probe", () => {
     const fetchImpl: typeof fetch = (async () => {
       throw new Error("ECONNRESET");
     }) as unknown as typeof fetch;
-    const r = await smokeProbe.run(
+    const r = await livenessProbe.run(
       { slug: "mastra", url: "https://x/api/smoke", fetchImpl },
       ctx,
     );
@@ -52,7 +52,7 @@ describe("smoke probe", () => {
   });
 
   it("derives health URL from /smoke with trailing slash (/smoke/)", async () => {
-    const r = await smokeProbe.run(
+    const r = await livenessProbe.run(
       {
         slug: "mastra",
         url: "https://x/api/smoke/",
@@ -64,7 +64,7 @@ describe("smoke probe", () => {
   });
 
   it("derives health URL by appending /health when URL has no /smoke suffix", async () => {
-    const r = await smokeProbe.run(
+    const r = await livenessProbe.run(
       { slug: "mastra", url: "https://x/", fetchImpl: fakeFetch(200) },
       ctx,
     );
@@ -90,7 +90,7 @@ describe("smoke probe", () => {
       });
     }) as unknown as typeof fetch;
 
-    const r = await smokeProbe.run(
+    const r = await livenessProbe.run(
       {
         slug: "mastra",
         url: "https://x/api/smoke",
@@ -104,7 +104,7 @@ describe("smoke probe", () => {
   });
 
   it("returns empty health URL when smoke URL is unparseable", async () => {
-    const r = await smokeProbe.run(
+    const r = await livenessProbe.run(
       { slug: "mastra", url: "not a url", fetchImpl: fakeFetch(200) },
       ctx,
     );

--- a/showcase/ops/src/probes/liveness.ts
+++ b/showcase/ops/src/probes/liveness.ts
@@ -1,13 +1,13 @@
 import type { Probe, ProbeContext, ProbeResult } from "../types/index.js";
 
-export interface SmokeInput {
+export interface LivenessInput {
   slug: string;
   url: string;
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
 }
 
-export interface SmokeSignal {
+export interface LivenessSignal {
   slug: string;
   url: string;
   status?: number;
@@ -16,12 +16,12 @@ export interface SmokeSignal {
   links: { smoke: string; health: string };
 }
 
-export const smokeProbe: Probe<SmokeInput, SmokeSignal> = {
+export const livenessProbe: Probe<LivenessInput, LivenessSignal> = {
   dimension: "smoke",
   async run(
-    input: SmokeInput,
+    input: LivenessInput,
     ctx: ProbeContext,
-  ): Promise<ProbeResult<SmokeSignal>> {
+  ): Promise<ProbeResult<LivenessSignal>> {
     // Some runtimes (undici, certain bun builds) throw when `fetch` is invoked
     // without its `this` bound to globalThis. Bind defensively at dependency
     // construction so all call sites benefit.
@@ -43,7 +43,7 @@ export const smokeProbe: Probe<SmokeInput, SmokeSignal> = {
       const res = await fetchImpl(input.url, { signal: controller.signal });
       const latencyMs = ctx.now().getTime() - started;
       const state = res.ok ? "green" : "red";
-      const signal: SmokeSignal = {
+      const signal: LivenessSignal = {
         slug: input.slug,
         url: input.url,
         status: res.status,
@@ -105,15 +105,15 @@ export const smokeProbe: Probe<SmokeInput, SmokeSignal> = {
  * `deriveHealthUrl`). Neither flows from untrusted user input — they're
  * operator-configured service URLs. Safe to emit without HTML-escape.
  */
-export const SMOKE_SLACK_SAFE_FIELDS = [
-  // A3: the `links` object lives on the old `SmokeSignal` shape below (still
+export const LIVENESS_SLACK_SAFE_FIELDS = [
+  // A3: the `links` object lives on the old `LivenessSignal` shape below (still
   // exported for backward compatibility). The driver-emitted
-  // `SmokeDriverSignal` (probes/drivers/smoke.ts) carries `url` instead —
+  // `SmokeDriverSignal` (probes/drivers/liveness.ts) carries `url` instead —
   // the URL that was actually probed — which is now the canonical field
   // template authors reference for endpoint links.
   "url",
   // errorDesc is pre-sanitized at the probe driver's 8 assignment sites
-  // (probes/drivers/smoke.ts via sanitizeErrorDesc) — triple-brace is
+  // (probes/drivers/liveness.ts via sanitizeErrorDesc) — triple-brace is
   // intentional so already-stripped HTML / mrkdwn control tokens render
   // as literal characters in Slack rather than being double-escaped.
   "errorDesc",

--- a/showcase/ops/src/probes/loader/probe-invoker.ts
+++ b/showcase/ops/src/probes/loader/probe-invoker.ts
@@ -17,7 +17,7 @@ import type { ProbeRunWriter, ProbeRunSummary } from "../run-history.js";
  * console dumps; without truncation those propagate untouched into
  * Pocketbase rows and Slack alerts, blowing past render budgets and
  * making the dashboard unreadable. Same budget the e2e drivers use
- * (`drivers/e2e-demos.ts`, `drivers/e2e-smoke.ts` — both at 1200) so the
+ * (`drivers/e2e-readiness.ts`, `drivers/e2e-chat-tools.ts` — both at 1200) so the
  * synthetic path matches what drivers self-truncate to.
  */
 const SYNTHETIC_ERROR_MSG_BUDGET = 1200;

--- a/showcase/ops/src/rules/rule-loader.test.ts
+++ b/showcase/ops/src/rules/rule-loader.test.ts
@@ -978,7 +978,7 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
     // event.*/env.* which are handled by validateTripleBrace.
     const { REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS } =
       await import("../probes/redirect-decommission.js");
-    const { SMOKE_SLACK_SAFE_FIELDS } = await import("../probes/smoke.js");
+    const { LIVENESS_SLACK_SAFE_FIELDS } = await import("../probes/liveness.js");
     // Mirror orchestrator.ts L1-L4 safe-field wiring: agent/chat/tools have
     // no probe module, so their safe-field set is defined inline (errorDesc
     // only, pre-sanitized by the shared smoke driver).
@@ -988,7 +988,7 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
       logger,
       slackSafeFields: {
         redirect_decommission: new Set(REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS),
-        smoke: new Set(SMOKE_SLACK_SAFE_FIELDS),
+        smoke: new Set(LIVENESS_SLACK_SAFE_FIELDS),
         agent: new Set(L1_L4_SLACK_SAFE_FIELDS),
         chat: new Set(L1_L4_SLACK_SAFE_FIELDS),
         tools: new Set(L1_L4_SLACK_SAFE_FIELDS),
@@ -1431,7 +1431,7 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
       ).text;
       expect(text).toContain("coagents-starter");
       expect(text).toContain("down, error: http 503");
-      // Triple-brace signal.url (marked slackSafe in SMOKE_SLACK_SAFE_FIELDS)
+      // Triple-brace signal.url (marked slackSafe in LIVENESS_SLACK_SAFE_FIELDS)
       // preserves the raw URL inside `<URL|label>` Slack link markup; prior
       // double-brace would HTML-escape `/` → `&#x2F;` and break the link at
       // Slack render time.

--- a/showcase/ops/src/rules/rule-loader.test.ts
+++ b/showcase/ops/src/rules/rule-loader.test.ts
@@ -978,7 +978,8 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
     // event.*/env.* which are handled by validateTripleBrace.
     const { REDIRECT_DECOMMISSION_SLACK_SAFE_FIELDS } =
       await import("../probes/redirect-decommission.js");
-    const { LIVENESS_SLACK_SAFE_FIELDS } = await import("../probes/liveness.js");
+    const { LIVENESS_SLACK_SAFE_FIELDS } =
+      await import("../probes/liveness.js");
     // Mirror orchestrator.ts L1-L4 safe-field wiring: agent/chat/tools have
     // no probe module, so their safe-field set is defined inline (errorDesc
     // only, pre-sanitized by the shared smoke driver).

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -7,12 +7,12 @@
  * label, tooltip, and — for red/amber badges — failure metadata: fail_count,
  * first_failure_at, and the signal payload.
  */
-import {
-  resolveCell,
-  type CellState,
-  type BadgeRender,
-  type LiveStatusMap,
-  type ConnectionStatus,
+import { resolveCell } from "@/lib/live-status";
+import type {
+  CellState,
+  BadgeRender,
+  LiveStatusMap,
+  ConnectionStatus,
 } from "@/lib/live-status";
 import { TONE_CLASS, DOT_BG } from "./badges";
 
@@ -31,11 +31,11 @@ const DIMENSIONS: Array<{
   key: keyof Omit<CellState, "rollup">;
   label: string;
 }> = [
-  { key: "health", label: "Health" },
-  { key: "e2e", label: "E2E" },
-  { key: "smoke", label: "Smoke" },
-  { key: "d5", label: "D5 (Deep)" },
   { key: "d6", label: "D6 (Parity)" },
+  { key: "d5", label: "D5 (Deep)" },
+  { key: "e2e", label: "E2E" },
+  { key: "health", label: "Health" },
+  { key: "smoke", label: "Smoke" },
 ];
 
 function formatTimestamp(ts: string | null): string {


### PR DESCRIPTION
## Summary

- Rename 3 confusingly-named probe driver files to reflect what they actually do:
  - `smoke` → `liveness` (HTTP liveness check, not a smoke test)
  - `e2e-smoke` → `e2e-chat-tools` (Playwright chat + tool-rendering test)
  - `e2e-demos` → `e2e-readiness` (Playwright structural check across all demos)
- Reorder cell drilldown popup: D6 Parity → D5 Deep → E2E → Health → Smoke (highest depth first)

Kind strings, PB dimension keys, and YAML configs are intentionally unchanged — this is a file/export rename only with no data migration.

## Test plan

- [x] All 1343 showcase/ops tests pass
- [x] All imports verified via grep — zero stale references
- [x] YAML→driver mapping verified (loader uses kind strings, not file paths)
- [x] 7-agent CR converged Round 1 with 0 findings