### PR TITLE
fix: switch built-in-agent to single-route mode for smoke compatibility

### DIFF
--- a/showcase/integrations/built-in-agent/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/built-in-agent/src/app/api/copilotkit/route.ts
@@ -13,17 +13,9 @@ const runtime = new CopilotRuntime({
 const handler = createCopilotRuntimeHandler({
   runtime,
   basePath: "/api/copilotkit",
+  mode: "single-route",
 });
 
-async function withProbeCompat(req: Request): Promise<Response> {
-  const res = await handler(req);
-  if (res.status === 404) {
-    const body = await res.text();
-    return new Response(body, { status: 400, headers: res.headers });
-  }
-  return res;
-}
-
 export const GET = (req: Request) => handler(req);
-export const POST = (req: Request) => withProbeCompat(req);
+export const POST = (req: Request) => handler(req);
 export const OPTIONS = (req: Request) => handler(req);


### PR DESCRIPTION
## Summary
- Switch the built-in-agent copilotkit route from multi-route (default) to single-route mode
- Remove the `withProbeCompat` 404-to-400 wrapper (no longer needed)

## Why
The smoke probe POSTs a v1-style JSON envelope `{method, params, body}` to `/api/copilotkit`. In multi-route mode, the v2 runtime tries to match URL patterns (e.g. `/agent/:agentId/run`) and returns 404 for bare `/api/copilotkit` POSTs. The `withProbeCompat` wrapper converted 404 to 400, but the smoke probe needs the runtime to actually parse the request and return a real response, not just a non-404 status.

Single-route mode accepts the JSON envelope format directly, so the smoke probe's `{method: "agent/run", params: {agentId: "default"}, body: {...}}` payload is properly parsed and dispatched to the agent handler.

## Test plan
- [ ] Verify smoke:built-in-agent turns green after deploy
- [ ] Verify the copilotkit endpoint still handles normal agent/run requests