### PR TITLE
fix: probe:smoke discovery + e2e-smoke built-in-agent timeout

### DIFF
--- a/showcase/integrations/built-in-agent/src/app/demos/agentic-chat/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/agentic-chat/page.tsx
@@ -10,7 +10,7 @@ import { z } from "zod";
 
 export default function AgenticChat() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/gen-ui-agent/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/gen-ui-agent/page.tsx
@@ -14,7 +14,7 @@ type Step = {
 
 export default function GenUiAgent() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/gen-ui-tool-based/page.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function GenUiToolBased() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/hitl/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/hitl/page.tsx
@@ -9,7 +9,7 @@ import { z } from "zod";
 
 export default function HITL() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/shared-state-read-write/page.tsx
@@ -25,7 +25,7 @@ const defaultRecipe: Recipe = {
 
 export default function SharedStateReadWrite() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/shared-state-streaming/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/shared-state-streaming/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function SharedStateStreaming() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/subagents/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/subagents/page.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function Subagents() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/page.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function ToolRendering() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Demo />
     </CopilotKitProvider>
   );

--- a/showcase/ops/config/probes/smoke.yml
+++ b/showcase/ops/config/probes/smoke.yml
@@ -34,9 +34,22 @@
 # red→green transitions and a cron-only heartbeat tick so silent
 # green runs still produce observable liveness.
 #
-# timeout_ms (10s) bounds the WHOLE driver invocation at the invoker
-# level; the driver re-applies the same bound inside each HTTP call
-# so one hung endpoint can't steal budget from its paired probes.
+# timeout_ms (30s) bounds BOTH the discovery enumerate phase AND each
+# per-target driver invocation at the invoker level. The driver also
+# re-applies the timeout inside each HTTP call so one hung endpoint
+# can't steal budget from its paired probes.
+#
+# This was originally 10s when the probe used a static target list.
+# After migrating to discovery-driven (railway-services), the same
+# timeout_ms governs the Railway enumerate call — a project-level
+# GraphQL query PLUS per-service variable lookups (bounded at
+# concurrency 8). With 35+ services, each variable round-trip ~1s,
+# enumerate alone takes ceil(35/8) × 1s ≈ 5s on a good tick, and
+# easily >10s on a slow one. The 10s cap caused persistent
+# discoveryFailed:true — enumerate timed out before reaching the
+# driver fan-out. 30s matches image-drift and qa (both Railway-
+# discovery probes that work reliably at this fleet size).
+#
 # max_concurrency (6) caps simultaneous per-tick driver invocations —
 # at 34 services the tick takes ≤ 6 pool-cycles and stays well under
 # any Railway edge rate limit. Per-tick socket bound:
@@ -44,7 +57,7 @@
 kind: smoke
 id: smoke
 schedule: "*/15 * * * *"
-timeout_ms: 10000
+timeout_ms: 30000
 max_concurrency: 6
 discovery:
   source: railway-services


### PR DESCRIPTION
## Summary
- **probe:smoke discovery failure**: `timeout_ms` was 10s — too tight for Railway enumeration of 35+ services. Increased to 30s (matching image-drift/qa probes), fixing `discoveryFailed: true`.
- **e2e_smoke:built-in-agent timeout**: Transport auto-detect race in `CopilotKitProvider` when using `mode: "single-route"`. Without `useSingleEndpoint`, auto-detect creates a provisional agent that constructs REST-pattern URLs (`/agent/:id/run`) which don't exist in single-route mode. Added `useSingleEndpoint` to all 8 built-in-agent demo pages.

## Test plan
- [ ] Merge and deploy; trigger probe:smoke — should discover 35/35
- [ ] Trigger e2e-smoke — built-in-agent should complete instead of timing out
- [ ] Verify other probes unaffected (image-drift, e2e-deep already green)