### PR TITLE
feat(shell-dashboard): dashboard UX fixes — collapsible rows, drilldown, sticky bars, centering

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -172,7 +172,7 @@ export default function Page() {
       {/* Tab content */}
       {activeTab === "matrix" && (
         <>
-          <div className="px-8 pt-4 flex flex-col gap-3">
+          <div className="sticky top-0 z-30 px-8 py-3 flex flex-col gap-3 bg-[var(--bg-surface)] border-b border-[var(--border)]">
             <OverlayToggleBar
               overlays={overlays}
               onToggle={toggle}

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -140,7 +140,7 @@ export default function Page() {
   );
 
   return (
-    <div data-testid="tab-shell">
+    <div data-testid="tab-shell" className="pb-20">
       {/* 2-tab bar: Matrix | Ops */}
       <div className="flex items-center gap-0 border-b border-[var(--border)] px-8">
         <button

--- a/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
@@ -244,10 +244,10 @@ describe("ComposedCell", () => {
     ).toBeTruthy();
   });
 
-  it("renders all 4 layers when all active (excluding parity)", () => {
+  it("renders 3 layers when all active — docs deduped by health", () => {
     const ctx = makeCtx();
     const catalogCell = makeCatalogCell();
-    const { getByText, getByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <ComposedCell
         ctx={ctx}
         overlays={overlaySet("links", "depth", "health", "docs", "parity")}
@@ -255,16 +255,15 @@ describe("ComposedCell", () => {
       />,
     );
 
-    // All content layers present
     expect(getByText("Demo")).toBeInTheDocument();
     expect(getByTestId("depth-layer")).toBeInTheDocument();
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByTestId("docs-layer")).toBeInTheDocument();
+    // DocsLayer suppressed when health is active (CellStatus already includes docs)
+    expect(queryByTestId("docs-layer")).toBeNull();
 
-    // Verify stacking order: links, depth, health, docs
     const composedCell = getByTestId("composed-cell");
     const children = Array.from(composedCell.children);
-    expect(children.length).toBe(4);
+    expect(children.length).toBe(3);
   });
 
   it("applies opacity-60 for testing-kind features", () => {

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -166,7 +166,7 @@ export function AdaptiveLegend({ overlays }: AdaptiveLegendProps) {
   return (
     <div
       data-testid="adaptive-legend"
-      className="px-8 pb-8 mt-4 flex flex-wrap gap-x-6 gap-y-2 text-xs text-[var(--text-muted)]"
+      className="fixed bottom-0 left-0 right-0 z-40 px-8 py-3 flex flex-wrap gap-x-6 gap-y-2 text-xs text-[var(--text-muted)] bg-[var(--bg-surface)] border-t border-[var(--border)]"
     >
       {overlays.has("links") && <LinksLegend />}
       {overlays.has("depth") && <DepthLegend />}

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -7,8 +7,10 @@
  * a single composable component that stacks only the active layers.
  */
 
+import { useState, useEffect, useRef, useCallback } from "react";
 import type { CellContext } from "@/components/feature-grid";
 import { CellStatus, DocsRow, urlsFor } from "@/components/cell-pieces";
+import { CellDrilldown } from "@/components/cell-drilldown";
 import { CommandCell } from "@/components/command-cell";
 import { DepthChip } from "@/components/depth-chip";
 import { deriveDepth } from "@/components/depth-utils";
@@ -59,6 +61,7 @@ function LinksLayer({ ctx }: { ctx: CellContext }) {
 
 /**
  * Render the Depth layer: DepthChip showing D0-D4 with regression marker.
+ * Clicking the chip opens a CellDrilldown popup with per-badge dimension details.
  */
 function DepthLayer({
   ctx,
@@ -67,17 +70,59 @@ function DepthLayer({
   ctx: CellContext;
   catalogCell?: CatalogCell;
 }) {
+  const [drilldownOpen, setDrilldownOpen] = useState<boolean>(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const closeDrilldown = useCallback(() => setDrilldownOpen(false), []);
+
+  // Close drilldown on click-outside
+  useEffect(() => {
+    if (!drilldownOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setDrilldownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [drilldownOpen]);
+
   if (!catalogCell) return null;
 
   const depth = deriveDepth(catalogCell, ctx.liveStatus);
 
   return (
-    <div className="flex items-center gap-1" data-testid="depth-layer">
-      <DepthChip
-        depth={depth.achieved}
-        status={catalogCell.status}
-        regression={depth.isRegression}
-      />
+    <div
+      ref={containerRef}
+      className="flex items-center gap-1 relative"
+      data-testid="depth-layer"
+    >
+      <button
+        type="button"
+        data-testid={`depth-btn-${ctx.integration.slug}-${ctx.feature.id}`}
+        className="cursor-pointer bg-transparent border-none p-0"
+        onClick={() => setDrilldownOpen((prev) => !prev)}
+      >
+        <DepthChip
+          depth={depth.achieved}
+          status={catalogCell.status}
+          regression={depth.isRegression}
+        />
+      </button>
+      {drilldownOpen && (
+        <CellDrilldown
+          slug={ctx.integration.slug}
+          featureId={ctx.feature.id}
+          integrationName={ctx.integration.name}
+          featureName={ctx.feature.name}
+          liveStatus={ctx.liveStatus}
+          connection={ctx.connection}
+          onClose={closeDrilldown}
+        />
+      )}
     </div>
   );
 }

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -184,7 +184,7 @@ export function ComposedCell({
   return (
     <div
       data-testid="composed-cell"
-      className={`flex flex-col gap-1 text-[11px] ${isTesting ? "opacity-60" : ""}`}
+      className={`flex flex-col items-center gap-1 text-[11px] ${isTesting ? "opacity-60" : ""}`}
     >
       {hasLinks && <LinksLayer ctx={ctx} />}
       {hasDepth && <DepthLayer ctx={ctx} catalogCell={catalogCell} />}

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -144,7 +144,7 @@ export function ComposedCell({
       {hasLinks && <LinksLayer ctx={ctx} />}
       {hasDepth && <DepthLayer ctx={ctx} catalogCell={catalogCell} />}
       {hasHealth && <HealthLayer ctx={ctx} />}
-      {hasDocs && <DocsLayer ctx={ctx} />}
+      {hasDocs && !hasHealth && <DocsLayer ctx={ctx} />}
     </div>
   );
 }

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -240,7 +240,7 @@ function CategorySection({
                 return (
                   <td
                     key={integration.slug}
-                    className="border-l border-[var(--border)] px-3 py-2 align-top text-left"
+                    className="border-l border-[var(--border)] px-3 py-2 align-top text-center"
                   >
                     {demo ? (
                       renderCell({

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -5,7 +5,12 @@ import {
   getFeatures,
   getFeatureCategories,
 } from "@/lib/registry";
-import type { Integration, Feature, Demo } from "@/lib/registry";
+import type {
+  Integration,
+  Feature,
+  Demo,
+  FeatureCategory,
+} from "@/lib/registry";
 import { keyFor, resolveCell } from "@/lib/live-status";
 import type { ConnectionStatus, LiveStatusMap } from "@/lib/live-status";
 import { LevelStrip } from "@/components/level-strip";
@@ -16,6 +21,10 @@ import type { CatalogCell } from "@/components/depth-utils";
 import type { Overlay } from "@/lib/overlay-types";
 import type { ParityTier } from "@/components/parity-badge";
 import type { CatalogData } from "@/data/catalog-types";
+import {
+  useCollapsible,
+  CategoryHeaderRow,
+} from "@/components/collapsible-category";
 
 export interface CellContext {
   integration: Integration;
@@ -126,6 +135,146 @@ function resolveShellUrl(): string {
   }
   return "http://localhost:3000";
 }
+
+/* ------------------------------------------------------------------ */
+/*  CategorySection — one collapsible group of feature rows            */
+/* ------------------------------------------------------------------ */
+
+interface CategorySectionProps {
+  cat: FeatureCategory & { features: Feature[] };
+  integrations: Integration[];
+  renderCell: CellRenderer;
+  shellUrl: string;
+  liveStatus: LiveStatusMap;
+  connection: ConnectionStatus;
+  showRefDepth: boolean;
+  refCellsByFeature: Map<string, CatalogCell>;
+  categoryColSpan: number;
+}
+
+function CategorySection({
+  cat,
+  integrations,
+  renderCell,
+  shellUrl,
+  liveStatus,
+  connection,
+  showRefDepth,
+  refCellsByFeature,
+  categoryColSpan,
+}: CategorySectionProps) {
+  const { isOpen, toggle } = useCollapsible({
+    name: cat.name,
+    defaultOpen: true,
+  });
+
+  const wiredCount = cat.features.reduce((acc, feature) => {
+    return (
+      acc +
+      integrations.filter((int) => int.demos.some((d) => d.id === feature.id))
+        .length
+    );
+  }, 0);
+  const totalCount = cat.features.length * integrations.length;
+  const countString = `${wiredCount}/${totalCount}`;
+
+  return (
+    <Fragment>
+      <CategoryHeaderRow
+        name={cat.name}
+        count={countString}
+        colSpan={categoryColSpan}
+        isOpen={isOpen}
+        onToggle={toggle}
+      />
+      {isOpen &&
+        cat.features.map((feature) => {
+          const testing = feature.kind === "testing";
+          const refCell = showRefDepth
+            ? refCellsByFeature.get(feature.id)
+            : undefined;
+          const refDepth = refCell
+            ? deriveDepth(refCell, liveStatus)
+            : undefined;
+          return (
+            <tr
+              key={feature.id}
+              className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
+            >
+              <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-2 border-r border-[var(--border)] align-top">
+                <div
+                  className={
+                    testing
+                      ? "font-normal text-[var(--text-muted)] italic"
+                      : "font-medium text-[var(--text)]"
+                  }
+                  title={feature.description}
+                >
+                  {feature.name}
+                  {testing && (
+                    <span className="ml-2 text-[9px] uppercase tracking-wider text-[var(--text-muted)]">
+                      testing
+                    </span>
+                  )}
+                </div>
+              </td>
+              {showRefDepth &&
+                (refCell && refDepth ? (
+                  <RefDepthCell
+                    depth={refDepth.achieved}
+                    status={refCell.status}
+                    regression={refDepth.isRegression}
+                  />
+                ) : (
+                  <td
+                    className="sticky left-[260px] z-10 px-3 py-2 border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] align-top"
+                    style={{ backgroundColor: "#f5f0ff" }}
+                  >
+                    <span className="text-[var(--text-muted)] text-[10px]">
+                      --
+                    </span>
+                  </td>
+                ))}
+              {integrations.map((integration) => {
+                const demo = integration.demos.find((d) => d.id === feature.id);
+                return (
+                  <td
+                    key={integration.slug}
+                    className="border-l border-[var(--border)] px-3 py-2 align-top text-left"
+                  >
+                    {demo ? (
+                      renderCell({
+                        integration,
+                        feature,
+                        demo,
+                        hostedUrl: demo.route
+                          ? `${integration.backend_url}${demo.route}`
+                          : "",
+                        shellUrl,
+                        liveStatus,
+                        connection,
+                      })
+                    ) : (
+                      <div
+                        className="text-center text-base text-[var(--danger)]"
+                        title="No demo"
+                      >
+                        ✗
+                      </div>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+    </Fragment>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  FeatureGrid                                                        */
+/* ------------------------------------------------------------------ */
 
 export interface FeatureGridProps {
   title: string;
@@ -324,99 +473,18 @@ export function FeatureGrid({
           </thead>
           <tbody>
             {featuresByCategory.map((cat) => (
-              <Fragment key={cat.id}>
-                <tr>
-                  <td
-                    colSpan={categoryColSpan}
-                    className="sticky left-0 px-4 pt-5 pb-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)] bg-[var(--bg-surface)]"
-                  >
-                    {cat.name}
-                  </td>
-                </tr>
-                {cat.features.map((feature) => {
-                  const testing = feature.kind === "testing";
-                  // Ref-depth cell data for this feature row
-                  const refCell = showRefDepth
-                    ? refCellsByFeature.get(feature.id)
-                    : undefined;
-                  const refDepth = refCell
-                    ? deriveDepth(refCell, liveStatus)
-                    : undefined;
-                  return (
-                    <tr
-                      key={feature.id}
-                      className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
-                    >
-                      <td className="sticky left-0 z-10 bg-[var(--bg-surface)] px-4 py-2 border-r border-[var(--border)] align-top">
-                        <div
-                          className={
-                            testing
-                              ? "font-normal text-[var(--text-muted)] italic"
-                              : "font-medium text-[var(--text)]"
-                          }
-                          title={feature.description}
-                        >
-                          {feature.name}
-                          {testing && (
-                            <span className="ml-2 text-[9px] uppercase tracking-wider text-[var(--text-muted)]">
-                              testing
-                            </span>
-                          )}
-                        </div>
-                      </td>
-                      {showRefDepth &&
-                        (refCell && refDepth ? (
-                          <RefDepthCell
-                            depth={refDepth.achieved}
-                            status={refCell.status}
-                            regression={refDepth.isRegression}
-                          />
-                        ) : (
-                          <td
-                            className="sticky left-[260px] z-10 px-3 py-2 border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] align-top"
-                            style={{ backgroundColor: "#f5f0ff" }}
-                          >
-                            <span className="text-[var(--text-muted)] text-[10px]">
-                              --
-                            </span>
-                          </td>
-                        ))}
-                      {integrations.map((integration) => {
-                        const demo = integration.demos.find(
-                          (d) => d.id === feature.id,
-                        );
-                        return (
-                          <td
-                            key={integration.slug}
-                            className="border-l border-[var(--border)] px-3 py-2 align-top text-left"
-                          >
-                            {demo ? (
-                              renderCell({
-                                integration,
-                                feature,
-                                demo,
-                                hostedUrl: demo.route
-                                  ? `${integration.backend_url}${demo.route}`
-                                  : "",
-                                shellUrl,
-                                liveStatus,
-                                connection,
-                              })
-                            ) : (
-                              <div
-                                className="text-center text-base text-[var(--danger)]"
-                                title="No demo"
-                              >
-                                ✗
-                              </div>
-                            )}
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  );
-                })}
-              </Fragment>
+              <CategorySection
+                key={cat.id}
+                cat={cat}
+                integrations={integrations}
+                renderCell={renderCell}
+                shellUrl={shellUrl}
+                liveStatus={liveStatus}
+                connection={connection}
+                showRefDepth={showRefDepth}
+                refCellsByFeature={refCellsByFeature}
+                categoryColSpan={categoryColSpan}
+              />
             ))}
           </tbody>
         </table>

--- a/showcase/shell-dashboard/src/components/overlay-toggle-bar.tsx
+++ b/showcase/shell-dashboard/src/components/overlay-toggle-bar.tsx
@@ -58,6 +58,29 @@ export function OverlayToggleBar({
       data-testid="overlay-toggle-bar"
       className="flex items-center gap-[6px] px-2 py-[6px] bg-[var(--bg-muted)] rounded-[6px] border border-[var(--border)]"
     >
+      {/* Preset buttons */}
+      {PRESETS.map((preset) => {
+        const isPresetActive = activePreset === preset.id;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            data-testid={`preset-btn-${preset.id}`}
+            onClick={() => onApplyPreset(preset.id)}
+            className={`px-[6px] py-[2px] rounded-[4px] text-[9px] font-medium transition-colors cursor-pointer border ${
+              isPresetActive
+                ? "bg-[var(--accent)]/10 text-[var(--accent)] border-[var(--accent)]"
+                : "text-[var(--text-muted)] border-[var(--border)] hover:text-[var(--accent)] hover:border-[var(--accent)]"
+            }`}
+          >
+            {preset.label}
+          </button>
+        );
+      })}
+
+      {/* Separator */}
+      <div className="w-px h-4 bg-[var(--border)] mx-[2px]" />
+
       {/* Label */}
       <span className="text-[9px] uppercase tracking-wider text-[var(--text-muted)] font-medium select-none">
         Show:
@@ -82,29 +105,6 @@ export function OverlayToggleBar({
             }`}
           >
             {OVERLAY_LABELS[overlay]}
-          </button>
-        );
-      })}
-
-      {/* Separator */}
-      <div className="w-px h-4 bg-[var(--border)] mx-[2px]" />
-
-      {/* Preset buttons */}
-      {PRESETS.map((preset) => {
-        const isPresetActive = activePreset === preset.id;
-        return (
-          <button
-            key={preset.id}
-            type="button"
-            data-testid={`preset-btn-${preset.id}`}
-            onClick={() => onApplyPreset(preset.id)}
-            className={`px-[6px] py-[2px] rounded-[4px] text-[9px] font-medium transition-colors cursor-pointer border ${
-              isPresetActive
-                ? "bg-[var(--accent)]/10 text-[var(--accent)] border-[var(--accent)]"
-                : "text-[var(--text-muted)] border-[var(--border)] hover:text-[var(--accent)] hover:border-[var(--accent)]"
-            }`}
-          >
-            {preset.label}
           </button>
         );
       })}


### PR DESCRIPTION
## Summary

- **Collapsible category rows**: Restored `CategoryHeaderRow` + `useCollapsible` in FeatureGrid — categories expand/collapse with chevron, state persisted to localStorage
- **Cell drilldown popup**: Restored `CellDrilldown` on depth chip click in ComposedCell — shows per-badge dimension detail (health, e2e, smoke, d5, d6) with click-outside-to-close
- **Docs dedup**: Fixed duplicate docs-og/docs-shell rows when both health and docs overlays active (CellStatus already includes docs internally)
- **Sticky legend footer**: Pinned AdaptiveLegend to viewport bottom with `position: fixed`, solid background, and 80px bottom padding on content
- **Sticky toggle bar**: Pinned OverlayToggleBar + AdaptiveStatsBar to viewport top on scroll with `position: sticky`
- **Toggle bar reorder**: Moved preset buttons (Catalog, Assessment, Parity Review) before individual overlay toggles
- **Cell centering**: Changed cell `<td>` from `text-left` to `text-center` and added `items-center` to ComposedCell flex column so depth chips align with X marks

## Test plan

- [ ] 322 tests passing locally (4 pre-existing transform failures from missing generated data)
- [ ] Verify collapsible categories expand/collapse with chevron click
- [ ] Verify depth chip click opens drilldown popup with dimension details
- [ ] Verify docs row appears once (not twice) in Catalog preset
- [ ] Verify legend footer stays fixed at viewport bottom during scroll
- [ ] Verify toggle bar stays sticky at viewport top during scroll
- [ ] Verify preset buttons appear before overlay toggles left-to-right
- [ ] Verify depth chips and X marks are center-aligned in cells