### PR TITLE
feat(showcase): local CLI for Dn parity testing

### DIFF
--- a/showcase/README.md
+++ b/showcase/README.md
@@ -94,17 +94,22 @@ The showcase harness includes a CLI that runs the same probe drivers (liveness, 
 ### Quick start
 
 ```sh
+# All commands run from showcase/harness
+cd showcase/harness
+
 # 1. Make sure Docker is running (Colima, Docker Desktop, or OrbStack)
 
 # 2. Start infra + one integration
-./showcase/scripts/dev-local.sh up langgraph-python
+npx tsx src/cli.ts up langgraph-python
 
 # 3. Run smoke probes
-cd showcase/harness
 npx tsx src/cli.ts test langgraph-python --smoke
 
 # 4. Run full D5 depth
 npx tsx src/cli.ts test langgraph-python --d5 --headed
+
+# 5. Tear down when done
+npx tsx src/cli.ts down
 ```
 
 ### Commands

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -113,39 +113,39 @@ The showcase harness includes a CLI that runs the same probe drivers (liveness, 
 
 ### Commands
 
-| Command | Description |
-|---------|-------------|
-| `test <target>` | Run probes. Target is a slug (`langgraph-python`), slug:demo (`langgraph-python:chat`), or `all` |
-| `up [slugs...]` | Start infra (aimock, pocketbase, dashboard) + named packages. No args = infra only |
-| `down [slugs...]` | Stop services. No args = stop everything |
-| `rebuild [slugs...]` | Rebuild Docker images |
-| `ps` | Show running services |
-| `logs <slug>` | Tail logs for a service |
-| `status` | Print dashboard URL for full results |
+| Command              | Description                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| `test <target>`      | Run probes. Target is a slug (`langgraph-python`), slug:demo (`langgraph-python:chat`), or `all` |
+| `up [slugs...]`      | Start infra (aimock, pocketbase, dashboard) + named packages. No args = infra only               |
+| `down [slugs...]`    | Stop services. No args = stop everything                                                         |
+| `rebuild [slugs...]` | Rebuild Docker images                                                                            |
+| `ps`                 | Show running services                                                                            |
+| `logs <slug>`        | Tail logs for a service                                                                          |
+| `status`             | Print dashboard URL for full results                                                             |
 
 ### Test levels
 
 Specify depth with `--level` or shorthand flags (mutually exclusive):
 
-| Flag | Level | What it runs |
-|------|-------|-------------|
-| `--smoke` | smoke | Liveness healthchecks (L1–L3) — container up, routes reachable, no JS errors |
-| `--d4` | d4 | E2E chat-tools — Playwright drives the demo UI, sends a message, asserts tool calls render |
-| `--d5` | d5 | E2E deep — full conversation flow with aimock fixtures, asserts feature-specific behavior |
-| `--level all` | all | Runs smoke → d4 → d5 sequentially |
+| Flag          | Level | What it runs                                                                               |
+| ------------- | ----- | ------------------------------------------------------------------------------------------ |
+| `--smoke`     | smoke | Liveness healthchecks (L1–L3) — container up, routes reachable, no JS errors               |
+| `--d4`        | d4    | E2E chat-tools — Playwright drives the demo UI, sends a message, asserts tool calls render |
+| `--d5`        | d5    | E2E deep — full conversation flow with aimock fixtures, asserts feature-specific behavior  |
+| `--level all` | all   | Runs smoke → d4 → d5 sequentially                                                          |
 
 Default level is `smoke` when no flag is given.
 
 ### Additional options
 
-| Option | Description |
-|--------|-------------|
-| `--headed` | Run Playwright visibly (not headless) — useful for debugging D4/D5 failures |
-| `--verbose` | Verbose logging output |
-| `--repeat <n>` | Run the test suite N times (flake detection) |
-| `--keep` | Don't stop auto-started containers after the test finishes |
-| `--live` | Write results to PocketBase so the dashboard reflects them |
-| `--rebuild` | Force Docker rebuild before running tests |
+| Option         | Description                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| `--headed`     | Run Playwright visibly (not headless) — useful for debugging D4/D5 failures |
+| `--verbose`    | Verbose logging output                                                      |
+| `--repeat <n>` | Run the test suite N times (flake detection)                                |
+| `--keep`       | Don't stop auto-started containers after the test finishes                  |
+| `--live`       | Write results to PocketBase so the dashboard reflects them                  |
+| `--rebuild`    | Force Docker rebuild before running tests                                   |
 
 ### Config file (optional)
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -94,7 +94,7 @@ The showcase harness includes a CLI that runs the same probe drivers (liveness, 
 ### Quick start
 
 ```sh
-# from the repo root — all examples below use showcase/bin/showcase
+# runs from any directory — all paths are resolved relative to the script itself
 
 # 1. Make sure Docker is running (Colima, Docker Desktop, or OrbStack)
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -87,9 +87,100 @@ cp showcase/.env.example showcase/.env
 
 Only `OPENAI_API_KEY` is strictly required. Missing optional keys fail gracefully (per-package).
 
-## Local Docker workflow
+## Local CLI — parity testing without Railway
 
-`scripts/dev-local.sh` wraps `docker compose` and handles the `shared_python/` / `shared_typescript/` staging step that CI also performs.
+The showcase harness includes a CLI that runs the same probe drivers (liveness, D4, D5) used in CI/Railway against local Docker Compose containers. This lets you debug Dn failures, iterate on new demos, or run background parity checks without pushing to a branch.
+
+### Quick start
+
+```sh
+# 1. Make sure Docker is running (Colima, Docker Desktop, or OrbStack)
+
+# 2. Start infra + one integration
+./showcase/scripts/dev-local.sh up langgraph-python
+
+# 3. Run smoke probes
+cd showcase/harness
+npx tsx src/cli.ts test langgraph-python --smoke
+
+# 4. Run full D5 depth
+npx tsx src/cli.ts test langgraph-python --d5 --headed
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `test <target>` | Run probes. Target is a slug (`langgraph-python`), slug:demo (`langgraph-python:chat`), or `all` |
+| `up [slugs...]` | Start infra (aimock, pocketbase, dashboard) + named packages. No args = infra only |
+| `down [slugs...]` | Stop services. No args = stop everything |
+| `rebuild [slugs...]` | Rebuild Docker images |
+| `ps` | Show running services |
+| `logs <slug>` | Tail logs for a service |
+| `status` | Print dashboard URL for full results |
+
+### Test levels
+
+Specify depth with `--level` or shorthand flags (mutually exclusive):
+
+| Flag | Level | What it runs |
+|------|-------|-------------|
+| `--smoke` | smoke | Liveness healthchecks (L1–L3) — container up, routes reachable, no JS errors |
+| `--d4` | d4 | E2E chat-tools — Playwright drives the demo UI, sends a message, asserts tool calls render |
+| `--d5` | d5 | E2E deep — full conversation flow with aimock fixtures, asserts feature-specific behavior |
+| `--level all` | all | Runs smoke → d4 → d5 sequentially |
+
+Default level is `smoke` when no flag is given.
+
+### Additional options
+
+| Option | Description |
+|--------|-------------|
+| `--headed` | Run Playwright visibly (not headless) — useful for debugging D4/D5 failures |
+| `--verbose` | Verbose logging output |
+| `--repeat <n>` | Run the test suite N times (flake detection) |
+| `--keep` | Don't stop auto-started containers after the test finishes |
+| `--live` | Write results to PocketBase so the dashboard reflects them |
+| `--rebuild` | Force Docker rebuild before running tests |
+
+### Config file (optional)
+
+Create `showcase/showcase.local.json` to override defaults:
+
+```json
+{
+  "pocketbase": {
+    "url": "http://localhost:8090",
+    "email": "admin@localhost",
+    "password": "showcase-local-dev"
+  },
+  "dashboardUrl": "http://localhost:3200"
+}
+```
+
+The CLI works without this file — it uses sensible defaults matching docker-compose.local.yml.
+
+### How it works
+
+The CLI reuses the same probe drivers that the showcase-harness service runs on Railway. The difference is infrastructure: Railway probes hit Railway-deployed containers; the CLI probes hit local Docker Compose containers. Same assertions, same aimock fixtures, same Playwright flows.
+
+```
+┌─────────┐     ┌──────────────────┐     ┌─────────────────────┐
+│  CLI    │────▸│  Probe Drivers   │────▸│  Docker Compose     │
+│  cli.ts │     │  liveness/d4/d5  │     │  containers         │
+└─────────┘     └──────────────────┘     │  (aimock + integs)  │
+                                         └─────────────────────┘
+```
+
+### Use cases
+
+1. **Debugging Dn failures** — reproduce a CI/Railway failure locally with `--d5 --headed` to watch Playwright step through the flow
+2. **Building new demos** — `up` the integration, iterate on code, `test --d4` to verify, repeat
+3. **Background automation** — `test all --level all --repeat 3` as a pre-push sanity check
+
+## Low-level Docker Compose workflow
+
+For manual container management without the CLI, `scripts/dev-local.sh` wraps `docker compose` and handles the `shared_python/` / `shared_typescript/` staging step that CI also performs.
 
 ```sh
 # from the repo root

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -94,22 +94,21 @@ The showcase harness includes a CLI that runs the same probe drivers (liveness, 
 ### Quick start
 
 ```sh
-# All commands run from showcase/harness
-cd showcase/harness
+# from the repo root — all examples below use showcase/bin/showcase
 
 # 1. Make sure Docker is running (Colima, Docker Desktop, or OrbStack)
 
 # 2. Start infra + one integration
-npx tsx src/cli.ts up langgraph-python
+./showcase/bin/showcase up langgraph-python
 
 # 3. Run smoke probes
-npx tsx src/cli.ts test langgraph-python --smoke
+./showcase/bin/showcase test langgraph-python --smoke
 
 # 4. Run full D5 depth
-npx tsx src/cli.ts test langgraph-python --d5 --headed
+./showcase/bin/showcase test langgraph-python --d5 --headed
 
 # 5. Tear down when done
-npx tsx src/cli.ts down
+./showcase/bin/showcase down
 ```
 
 ### Commands

--- a/showcase/bin/showcase
+++ b/showcase/bin/showcase
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec npx tsx "$SCRIPT_DIR/../harness/src/cli.ts" "$@"

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -2,168 +2,235 @@
 # Prereq: run scripts/dev-local.sh which dereferences tools/ and shared-tools/ symlinks into each package build context first.
 # Ports come from shared/local-ports.json; internal port is always 10000 (Railway convention).
 
+x-integration-defaults: &integration-defaults
+  env_file: .env
+  environment:
+    - OPENAI_API_KEY=${OPENAI_API_KEY:-sk-mock}
+    - OPENAI_BASE_URL=http://aimock:4010/v1
+    - AIMOCK_URL=http://aimock:4010
+  depends_on:
+    aimock:
+      condition: service_healthy
+  restart: unless-stopped
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:10000/health"]
+    interval: 5s
+    timeout: 3s
+    retries: 5
+    start_period: 15s
+
 services:
   aimock:
     # Local aimock so the 17 integration containers can hit a stable LLM mock
     # on the compose network at http://aimock:4010 instead of the prod Railway
     # aimock (which can OOM) or direct-to-OpenAI (which costs).
-    build: ./aimock
-    image: showcase-aimock:local
+    image: ghcr.io/copilotkit/aimock:latest
     container_name: showcase-aimock
     env_file: .env
     ports:
       - "4010:4010"
+    profiles: ["infra", "all"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4010/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+  pocketbase:
+    build: ./pocketbase
+    image: showcase-pocketbase:local
+    container_name: showcase-pocketbase
+    environment:
+      - POCKETBASE_SUPERUSER_EMAIL=admin@localhost
+      - POCKETBASE_SUPERUSER_PASSWORD=showcase-local-dev
+    ports:
+      - "8090:8090"
+    volumes:
+      - showcase-pb-data:/pb_data
+    profiles: ["infra", "all"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/api/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+  dashboard:
+    build: ./shell-dashboard
+    image: showcase-dashboard:local
+    container_name: showcase-dashboard
+    environment:
+      - POCKETBASE_URL=http://pocketbase:8090
+      - SHOWCASE_LOCAL=1
+    ports:
+      - "3200:10000"
+    depends_on:
+      pocketbase:
+        condition: service_healthy
+    profiles: ["infra", "all"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:10000/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
   langgraph-python:
+    <<: *integration-defaults
     build: ./integrations/langgraph-python
     image: showcase-langgraph-python:local
     container_name: showcase-langgraph-python
-    env_file: .env
     ports:
       - "3100:10000"
-    restart: unless-stopped
+    profiles: ["langgraph-python", "all"]
 
   langgraph-typescript:
+    <<: *integration-defaults
     build: ./integrations/langgraph-typescript
     image: showcase-langgraph-typescript:local
     container_name: showcase-langgraph-typescript
-    env_file: .env
     ports:
       - "3101:10000"
-    restart: unless-stopped
+    profiles: ["langgraph-typescript", "all"]
 
   langgraph-fastapi:
+    <<: *integration-defaults
     build: ./integrations/langgraph-fastapi
     image: showcase-langgraph-fastapi:local
     container_name: showcase-langgraph-fastapi
-    env_file: .env
     ports:
       - "3102:10000"
-    restart: unless-stopped
+    profiles: ["langgraph-fastapi", "all"]
 
   google-adk:
+    <<: *integration-defaults
     build: ./integrations/google-adk
     image: showcase-google-adk:local
     container_name: showcase-google-adk
-    env_file: .env
     ports:
       - "3103:10000"
-    restart: unless-stopped
+    profiles: ["google-adk", "all"]
 
   mastra:
+    <<: *integration-defaults
     build: ./integrations/mastra
     image: showcase-mastra:local
     container_name: showcase-mastra
-    env_file: .env
     ports:
       - "3104:10000"
-    restart: unless-stopped
+    profiles: ["mastra", "all"]
 
   crewai-crews:
+    <<: *integration-defaults
     build: ./integrations/crewai-crews
     image: showcase-crewai-crews:local
     container_name: showcase-crewai-crews
-    env_file: .env
     ports:
       - "3105:10000"
-    restart: unless-stopped
+    profiles: ["crewai-crews", "all"]
 
   pydantic-ai:
+    <<: *integration-defaults
     build: ./integrations/pydantic-ai
     image: showcase-pydantic-ai:local
     container_name: showcase-pydantic-ai
-    env_file: .env
     ports:
       - "3106:10000"
-    restart: unless-stopped
+    profiles: ["pydantic-ai", "all"]
 
   claude-sdk-python:
+    <<: *integration-defaults
     build: ./integrations/claude-sdk-python
     image: showcase-claude-sdk-python:local
     container_name: showcase-claude-sdk-python
-    env_file: .env
     ports:
       - "3107:10000"
-    restart: unless-stopped
+    profiles: ["claude-sdk-python", "all"]
 
   claude-sdk-typescript:
+    <<: *integration-defaults
     build: ./integrations/claude-sdk-typescript
     image: showcase-claude-sdk-typescript:local
     container_name: showcase-claude-sdk-typescript
-    env_file: .env
     ports:
       - "3108:10000"
-    restart: unless-stopped
+    profiles: ["claude-sdk-typescript", "all"]
 
   agno:
+    <<: *integration-defaults
     build: ./integrations/agno
     image: showcase-agno:local
     container_name: showcase-agno
-    env_file: .env
     ports:
       - "3109:10000"
-    restart: unless-stopped
+    profiles: ["agno", "all"]
 
   ag2:
+    <<: *integration-defaults
     build: ./integrations/ag2
     image: showcase-ag2:local
     container_name: showcase-ag2
-    env_file: .env
     ports:
       - "3110:10000"
-    restart: unless-stopped
+    profiles: ["ag2", "all"]
 
   llamaindex:
+    <<: *integration-defaults
     build: ./integrations/llamaindex
     image: showcase-llamaindex:local
     container_name: showcase-llamaindex
-    env_file: .env
     ports:
       - "3111:10000"
-    restart: unless-stopped
+    profiles: ["llamaindex", "all"]
 
   strands:
+    <<: *integration-defaults
     build: ./integrations/strands
     image: showcase-strands:local
     container_name: showcase-strands
-    env_file: .env
     ports:
       - "3112:10000"
-    restart: unless-stopped
+    profiles: ["strands", "all"]
 
   langroid:
+    <<: *integration-defaults
     build: ./integrations/langroid
     image: showcase-langroid:local
     container_name: showcase-langroid
-    env_file: .env
     ports:
       - "3113:10000"
-    restart: unless-stopped
+    profiles: ["langroid", "all"]
 
   ms-agent-python:
+    <<: *integration-defaults
     build: ./integrations/ms-agent-python
     image: showcase-ms-agent-python:local
     container_name: showcase-ms-agent-python
-    env_file: .env
     ports:
       - "3114:10000"
-    restart: unless-stopped
+    profiles: ["ms-agent-python", "all"]
 
   ms-agent-dotnet:
+    <<: *integration-defaults
     build: ./integrations/ms-agent-dotnet
     image: showcase-ms-agent-dotnet:local
     container_name: showcase-ms-agent-dotnet
-    env_file: .env
     ports:
       - "3115:10000"
-    restart: unless-stopped
+    profiles: ["ms-agent-dotnet", "all"]
 
   spring-ai:
+    <<: *integration-defaults
     build: ./integrations/spring-ai
     image: showcase-spring-ai:local
     container_name: showcase-spring-ai
-    env_file: .env
     ports:
       - "3116:10000"
-    restart: unless-stopped
+    profiles: ["spring-ai", "all"]
+
+volumes:
+  showcase-pb-data:

--- a/showcase/harness/src/cli.ts
+++ b/showcase/harness/src/cli.ts
@@ -33,12 +33,14 @@ program
 // ── test ────────────────────────────────────────────────────────────────
 program
   .command("test <target>")
-  .description(
-    "Run probe tests (target: <slug>, <slug>:<demo>, or all)",
-  )
+  .description("Run probe tests (target: <slug>, <slug>:<demo>, or all)")
   .addOption(
-    new Option("--level <level>", "probe depth (smoke|d4|d5|all)")
-      .choices(["smoke", "d4", "d5", "all"]),
+    new Option("--level <level>", "probe depth (smoke|d4|d5|all)").choices([
+      "smoke",
+      "d4",
+      "d5",
+      "all",
+    ]),
   )
   .option("--d5", "shorthand for --level d5")
   .option("--d4", "shorthand for --level d4")
@@ -79,12 +81,21 @@ program
         process.exit(1);
       }
 
-      const shorthand = opts.smoke ? "smoke" : opts.d4 ? "d4" : opts.d5 ? "d5" : null;
+      const shorthand = opts.smoke
+        ? "smoke"
+        : opts.d4
+          ? "d4"
+          : opts.d5
+            ? "d5"
+            : null;
       if (shorthand && opts.level) {
-        console.error("Error: --level and shorthand flags (--smoke, --d4, --d5) are mutually exclusive");
+        console.error(
+          "Error: --level and shorthand flags (--smoke, --d4, --d5) are mutually exclusive",
+        );
         process.exit(1);
       }
-      const level: TestLevel = shorthand ?? (opts.level as TestLevel) ?? "smoke";
+      const level: TestLevel =
+        shorthand ?? (opts.level as TestLevel) ?? "smoke";
 
       const result = await run(target, { ...opts, level }, config);
 

--- a/showcase/harness/src/cli.ts
+++ b/showcase/harness/src/cli.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import { Command, Option, InvalidArgumentError } from "commander";
+import { loadConfig } from "./cli/config.js";
+import { up, down, rebuild, ps, logs } from "./cli/lifecycle.js";
+import { run } from "./cli/runner.js";
+import type { TestLevel } from "./cli/targets.js";
+
+const program = new Command();
+
+program
+  .name("showcase")
+  .description("Local showcase depth-level (smoke/D4/D5) test infrastructure")
+  .version("0.1.0");
+
+// ── up ──────────────────────────────────────────────────────────────────
+program
+  .command("up [slugs...]")
+  .description("Start infrastructure and named packages")
+  .action(async (slugs: string[]) => {
+    loadConfig(); // validate config before starting
+    await up(slugs);
+  });
+
+// ── down ────────────────────────────────────────────────────────────────
+program
+  .command("down [slugs...]")
+  .description("Stop services")
+  .action(async (slugs: string[]) => {
+    loadConfig();
+    await down(slugs);
+  });
+
+// ── test ────────────────────────────────────────────────────────────────
+program
+  .command("test <target>")
+  .description(
+    "Run probe tests (target: <slug>, <slug>:<demo>, or all)",
+  )
+  .addOption(
+    new Option("--level <level>", "probe depth (smoke|d4|d5|all)")
+      .choices(["smoke", "d4", "d5", "all"]),
+  )
+  .option("--d5", "shorthand for --level d5")
+  .option("--d4", "shorthand for --level d4")
+  .option("--smoke", "shorthand for --level smoke")
+  .option("--verbose", "Enable verbose logging output")
+  .option("--headed", "run Playwright in headed mode")
+  .option("--repeat <n>", "run N times", (val: string) => {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n < 1) {
+      throw new InvalidArgumentError("must be a positive integer");
+    }
+    return n;
+  })
+  .option("--keep", "don't stop auto-started packages after test")
+  .option("--live", "write results to PocketBase for dashboard")
+  .option("--rebuild", "force Docker rebuild before running")
+  .action(
+    async (
+      target: string,
+      opts: {
+        level?: string;
+        d5?: boolean;
+        d4?: boolean;
+        smoke?: boolean;
+        verbose?: boolean;
+        headed?: boolean;
+        repeat?: number;
+        keep?: boolean;
+        live?: boolean;
+        rebuild?: boolean;
+      },
+    ) => {
+      const config = loadConfig();
+
+      const shorthands = [opts.smoke, opts.d4, opts.d5].filter(Boolean);
+      if (shorthands.length > 1) {
+        console.error("Error: specify at most one of --smoke, --d4, --d5");
+        process.exit(1);
+      }
+
+      const shorthand = opts.smoke ? "smoke" : opts.d4 ? "d4" : opts.d5 ? "d5" : null;
+      if (shorthand && opts.level) {
+        console.error("Error: --level and shorthand flags (--smoke, --d4, --d5) are mutually exclusive");
+        process.exit(1);
+      }
+      const level: TestLevel = shorthand ?? (opts.level as TestLevel) ?? "smoke";
+
+      const result = await run(target, { ...opts, level }, config);
+
+      if (result.failed > 0) {
+        process.exit(1);
+      }
+    },
+  );
+
+// ── rebuild ─────────────────────────────────────────────────────────────
+program
+  .command("rebuild [slugs...]")
+  .description("Rebuild Docker images")
+  .action(async (slugs: string[]) => {
+    loadConfig();
+    await rebuild(slugs);
+  });
+
+// ── ps ──────────────────────────────────────────────────────────────────
+program
+  .command("ps")
+  .description("Show running services")
+  .action(async () => {
+    loadConfig();
+    const output = await ps();
+    console.log(output);
+  });
+
+// ── logs ────────────────────────────────────────────────────────────────
+program
+  .command("logs <slug>")
+  .description("Tail logs for a service")
+  .action(async (slug: string) => {
+    loadConfig();
+    await logs(slug);
+  });
+
+// ── status ──────────────────────────────────────────────────────────────
+program
+  .command("status")
+  .description("Show last test results summary")
+  .action(async () => {
+    const config = loadConfig();
+    console.log(
+      `Visit the showcase dashboard at ${config.dashboardUrl} for test results and status.`,
+    );
+  });
+
+// ── error handling & entry point ────────────────────────────────────────
+process.on("unhandledRejection", (err) => {
+  console.error(
+    `\x1b[31m[showcase] Unhandled error:\x1b[0m ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+});
+
+program.parseAsync().catch((err: unknown) => {
+  console.error(
+    `\x1b[31m[showcase] Error:\x1b[0m ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+});

--- a/showcase/harness/src/cli/config.ts
+++ b/showcase/harness/src/cli/config.ts
@@ -1,0 +1,52 @@
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHOWCASE_DIR = path.resolve(__dirname, "../../..");
+
+export interface LocalConfig {
+  showcaseDir: string;
+  composeFile: string;
+  localPorts: Record<string, number>;
+  pocketbase: {
+    url: string;
+    email: string;
+    password: string;
+  };
+  aimockUrl: string;
+  dashboardUrl: string;
+  dashboardPort: number;
+}
+
+export function loadConfig(): LocalConfig {
+  const portsFile = path.join(SHOWCASE_DIR, "shared/local-ports.json");
+  const localPorts = JSON.parse(fs.readFileSync(portsFile, "utf-8")) as Record<
+    string,
+    number
+  >;
+
+  return {
+    showcaseDir: SHOWCASE_DIR,
+    composeFile: path.join(SHOWCASE_DIR, "docker-compose.local.yml"),
+    localPorts,
+    pocketbase: {
+      url: "http://localhost:8090",
+      email: "admin@localhost",
+      password: "showcase-local-dev",
+    },
+    aimockUrl: "http://localhost:4010",
+    dashboardUrl: "http://localhost:3200",
+    dashboardPort: 3200,
+  };
+}
+
+export function getPackageUrl(slug: string, config: LocalConfig): string {
+  const port = config.localPorts[slug];
+  if (!port) {
+    throw new Error(
+      `No local port mapping for slug "${slug}". Check shared/local-ports.json.`,
+    );
+  }
+  return `http://localhost:${port}`;
+}

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -1,4 +1,9 @@
-import { execSync, execFileSync, spawn, type SpawnOptions } from "node:child_process";
+import {
+  execSync,
+  execFileSync,
+  spawn,
+  type SpawnOptions,
+} from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -54,8 +59,14 @@ function compose(...args: string[]): string {
       cwd: SHOWCASE_DIR,
     }).trim();
   } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error("Docker not found. Please install Docker Desktop and ensure 'docker' is on your PATH.");
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      throw new Error(
+        "Docker not found. Please install Docker Desktop and ensure 'docker' is on your PATH.",
+      );
     }
     const e = err as { stderr?: string; status?: number };
     const stderr = typeof e.stderr === "string" ? e.stderr.trim() : "";
@@ -255,7 +266,7 @@ export async function down(
     compose("--profile", "all", "down");
   } else {
     log.info("stopping services", { slugs });
-    const profileArgs = slugs.flatMap(s => ["--profile", s]);
+    const profileArgs = slugs.flatMap((s) => ["--profile", s]);
     compose(...profileArgs, "stop", ...slugs);
   }
 }
@@ -290,7 +301,7 @@ export async function rebuild(
     });
 
     if (slugs.length > 0) {
-      const profileArgs = slugs.flatMap(s => ["--profile", s]);
+      const profileArgs = slugs.flatMap((s) => ["--profile", s]);
       compose(...profileArgs, "build", ...slugs);
     } else {
       compose("--profile", "all", "build");
@@ -300,7 +311,7 @@ export async function rebuild(
       log.info("restarting previously-running services", {
         services: runningBefore,
       });
-      const restartProfiles = runningBefore.flatMap(s => ["--profile", s]);
+      const restartProfiles = runningBefore.flatMap((s) => ["--profile", s]);
       compose(...restartProfiles, "up", "-d", ...runningBefore);
     }
   } finally {
@@ -334,9 +345,7 @@ export async function logs(
     );
 
     child.on("error", (err) => {
-      reject(
-        new Error(`Failed to stream logs for ${slug}: ${err.message}`),
-      );
+      reject(new Error(`Failed to stream logs for ${slug}: ${err.message}`));
     });
 
     child.on("close", (code) => {
@@ -393,7 +402,10 @@ export async function healthCheck(
           status: response.status,
         });
       } catch (err) {
-        log.debug("health check not ready yet", { service, error: err instanceof Error ? err.message : String(err) });
+        log.debug("health check not ready yet", {
+          service,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
 
       await sleep(intervalMs);
@@ -416,7 +428,14 @@ export async function healthCheck(
  */
 export async function isRunning(slug: string): Promise<boolean> {
   try {
-    const output = compose("--profile", "all", "ps", "--status", "running", slug);
+    const output = compose(
+      "--profile",
+      "all",
+      "ps",
+      "--status",
+      "running",
+      slug,
+    );
     const lines = output.split("\n").filter((l) => l.trim().length > 0);
     return lines.length > 1;
   } catch (err) {

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -1,0 +1,457 @@
+import { execSync, execFileSync, spawn, type SpawnOptions } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "lifecycle" });
+
+// Resolve paths relative to the showcase directory.
+// This file lives at showcase/ops/src/cli/lifecycle.ts, so we walk up:
+//   cli/ -> src/ -> ops/ -> showcase/
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHOWCASE_DIR = path.resolve(__dirname, "../../..");
+const COMPOSE_FILE = path.join(SHOWCASE_DIR, "docker-compose.local.yml");
+const INTEGRATIONS_DIR = path.join(SHOWCASE_DIR, "integrations");
+const PORTS_FILE = path.join(SHOWCASE_DIR, "shared/local-ports.json");
+
+/** Well-known infra service ports that aren't in local-ports.json. */
+const INFRA_PORTS: Record<string, number> = {
+  aimock: 4010,
+  pocketbase: 8090,
+  dashboard: 3200,
+};
+
+/** Health-check endpoint overrides per service type. */
+const HEALTH_ENDPOINTS: Record<string, string> = {
+  aimock: "/health",
+  pocketbase: "/api/health",
+  dashboard: "/",
+};
+
+/** Default health endpoint for integration services. */
+const DEFAULT_HEALTH_ENDPOINT = "/health";
+
+export interface LifecycleOptions {
+  verbose?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: run docker compose
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `docker compose -f <compose-file> <args>` synchronously.
+ * Returns stdout. Throws on non-zero exit, including stderr in the message.
+ */
+function compose(...args: string[]): string {
+  const fullArgs = ["compose", "-f", COMPOSE_FILE, ...args];
+  log.debug("exec", { cmd: ["docker", ...fullArgs].join(" ") });
+  try {
+    return execFileSync("docker", fullArgs, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: SHOWCASE_DIR,
+    }).trim();
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("Docker not found. Please install Docker Desktop and ensure 'docker' is on your PATH.");
+    }
+    const e = err as { stderr?: string; status?: number };
+    const stderr = typeof e.stderr === "string" ? e.stderr.trim() : "";
+    throw new Error(
+      `docker compose failed (exit ${e.status ?? "?"}): docker ${fullArgs.join(" ")}\n${stderr}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Port resolution
+// ---------------------------------------------------------------------------
+
+let _portsCache: Record<string, number> | null = null;
+
+function loadPortsFile(): Record<string, number> {
+  if (_portsCache) return _portsCache;
+  try {
+    const raw = fs.readFileSync(PORTS_FILE, "utf-8");
+    _portsCache = JSON.parse(raw) as Record<string, number>;
+    return _portsCache;
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      log.warn("local-ports.json not found, health checks may fail", {
+        path: PORTS_FILE,
+      });
+      return {};
+    }
+    throw err;
+  }
+}
+
+function resolvePort(service: string): number | undefined {
+  if (INFRA_PORTS[service] !== undefined) return INFRA_PORTS[service];
+  const ports = loadPortsFile();
+  return ports[service];
+}
+
+function resolveHealthEndpoint(service: string): string {
+  return HEALTH_ENDPOINTS[service] ?? DEFAULT_HEALTH_ENDPOINT;
+}
+
+// ---------------------------------------------------------------------------
+// Shared-module staging (mirrors dev-local.sh stage_shared)
+// ---------------------------------------------------------------------------
+
+/**
+ * For each integration package directory, replace `tools` and `shared-tools`
+ * symlinks with real directory copies so Docker can access them inside the
+ * build context. This mirrors the `stage_shared()` function in dev-local.sh.
+ */
+export function stageSharedModules(): void {
+  log.info("staging shared modules for Docker build contexts");
+
+  if (!fs.existsSync(INTEGRATIONS_DIR)) {
+    log.warn("integrations directory not found, skipping staging", {
+      path: INTEGRATIONS_DIR,
+    });
+    return;
+  }
+
+  const packages = fs
+    .readdirSync(INTEGRATIONS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory());
+
+  for (const pkg of packages) {
+    const pkgDir = path.join(INTEGRATIONS_DIR, pkg.name);
+
+    for (const linkName of ["tools", "shared-tools"]) {
+      const linkPath = path.join(pkgDir, linkName);
+
+      // Only process if it's a symlink
+      try {
+        const stat = fs.lstatSync(linkPath);
+        if (!stat.isSymbolicLink()) continue;
+      } catch {
+        // Doesn't exist -- skip
+        continue;
+      }
+
+      // Resolve the symlink target
+      let target = fs.readlinkSync(linkPath);
+      if (!path.isAbsolute(target)) {
+        target = path.resolve(path.dirname(linkPath), target);
+      }
+
+      if (!fs.existsSync(target) || !fs.statSync(target).isDirectory()) {
+        log.warn("symlink target missing or not a directory", {
+          link: linkPath,
+          target,
+        });
+        continue;
+      }
+
+      // Remove the symlink, copy the real directory in its place
+      fs.rmSync(linkPath);
+      fs.cpSync(target, linkPath, { recursive: true });
+      log.debug("staged shared module", {
+        pkg: pkg.name,
+        link: linkName,
+        from: target,
+      });
+    }
+  }
+
+  log.info("shared module staging complete");
+}
+
+/**
+ * Restore symlinks that `stageSharedModules()` replaced with real dirs.
+ * Delegates to `git checkout` on the known paths, same as dev-local.sh.
+ */
+export function restoreSymlinks(): void {
+  log.debug("restoring symlinks via git checkout");
+  try {
+    execSync(
+      "git checkout -- integrations/*/tools integrations/*/shared-tools",
+      {
+        cwd: SHOWCASE_DIR,
+        stdio: "pipe",
+        encoding: "utf-8",
+      },
+    );
+  } catch {
+    // Non-fatal: some dirs may not have symlinks
+    log.debug("git checkout for symlink restore returned non-zero (ok)");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Start services via docker compose.
+ *
+ * - If `slugs` is empty, starts only the `infra` profile.
+ * - If `slugs` are provided, starts the `infra` profile plus one profile per slug.
+ * - After starting, runs health checks on all started services.
+ */
+export async function up(
+  slugs: string[],
+  opts?: LifecycleOptions,
+): Promise<void> {
+  try {
+    stageSharedModules();
+    const profileArgs: string[] = ["--profile", "infra"];
+    for (const slug of slugs) {
+      profileArgs.push("--profile", slug);
+    }
+
+    const verboseFlag = opts?.verbose ? ["--progress", "plain"] : [];
+    const args = [...profileArgs, "up", "-d", "--build", ...verboseFlag];
+
+    log.info("starting services", { slugs: slugs.length ? slugs : ["infra"] });
+    compose(...args);
+
+    // Determine which services to health-check
+    const servicesToCheck =
+      slugs.length > 0
+        ? [...Object.keys(INFRA_PORTS), ...slugs]
+        : Object.keys(INFRA_PORTS);
+
+    const results = await healthCheck(servicesToCheck);
+    const unhealthy = [...results.entries()]
+      .filter(([, ok]) => !ok)
+      .map(([name]) => name);
+
+    if (unhealthy.length > 0) {
+      throw new Error(
+        `Health check failed for: ${unhealthy.join(", ")}. Check logs with: showcase logs <slug>`,
+      );
+    }
+
+    log.info("all services healthy");
+  } finally {
+    restoreSymlinks();
+  }
+}
+
+/**
+ * Stop services via docker compose.
+ *
+ * - If `slugs` is empty, tears down the entire compose stack.
+ * - If `slugs` are provided, stops only those specific services.
+ */
+export async function down(
+  slugs: string[],
+  _opts?: LifecycleOptions,
+): Promise<void> {
+  if (slugs.length === 0) {
+    log.info("tearing down all services");
+    compose("--profile", "all", "down");
+  } else {
+    log.info("stopping services", { slugs });
+    const profileArgs = slugs.flatMap(s => ["--profile", s]);
+    compose(...profileArgs, "stop", ...slugs);
+  }
+}
+
+/**
+ * Rebuild Docker images, optionally for specific services.
+ *
+ * Stages shared modules first, builds images, then restarts any services
+ * that were running before the rebuild.
+ */
+export async function rebuild(
+  slugs: string[],
+  _opts?: LifecycleOptions,
+): Promise<void> {
+  try {
+    stageSharedModules();
+    // When no specific slugs, check ALL running services for restart
+    const servicesToCheck = slugs.length > 0 ? slugs : listRunningServices();
+    const runningBefore: string[] = [];
+    if (slugs.length > 0) {
+      for (const slug of servicesToCheck) {
+        if (await isRunning(slug)) {
+          runningBefore.push(slug);
+        }
+      }
+    } else {
+      runningBefore.push(...servicesToCheck);
+    }
+
+    log.info("rebuilding images", {
+      slugs: slugs.length ? slugs : ["all"],
+    });
+
+    if (slugs.length > 0) {
+      const profileArgs = slugs.flatMap(s => ["--profile", s]);
+      compose(...profileArgs, "build", ...slugs);
+    } else {
+      compose("--profile", "all", "build");
+    }
+
+    if (runningBefore.length > 0) {
+      log.info("restarting previously-running services", {
+        services: runningBefore,
+      });
+      const restartProfiles = runningBefore.flatMap(s => ["--profile", s]);
+      compose(...restartProfiles, "up", "-d", ...runningBefore);
+    }
+  } finally {
+    restoreSymlinks();
+  }
+}
+
+/**
+ * Return docker compose ps output as a string.
+ */
+export function ps(_opts?: LifecycleOptions): string {
+  return compose("--profile", "all", "ps");
+}
+
+/**
+ * Stream logs for a specific service to the terminal.
+ * Uses spawn with inherited stdio so output streams directly.
+ */
+export async function logs(
+  slug: string,
+  _opts?: LifecycleOptions,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      "docker",
+      ["compose", "-f", COMPOSE_FILE, "logs", "-f", slug],
+      {
+        cwd: SHOWCASE_DIR,
+        stdio: "inherit",
+      } satisfies SpawnOptions,
+    );
+
+    child.on("error", (err) => {
+      reject(
+        new Error(`Failed to stream logs for ${slug}: ${err.message}`),
+      );
+    });
+
+    child.on("close", (code) => {
+      if (code === 0 || code === null) {
+        resolve();
+      } else {
+        reject(new Error(`Log streaming for ${slug} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+/**
+ * Check health of the given services by hitting their HTTP health endpoints.
+ *
+ * Retries each service for up to 30 seconds with 2-second intervals.
+ * Returns a map of service name to healthy boolean.
+ */
+export async function healthCheck(
+  services: string[],
+): Promise<Map<string, boolean>> {
+  const results = new Map<string, boolean>();
+  const maxWaitMs = 30_000;
+  const intervalMs = 2_000;
+
+  log.info("running health checks", { services });
+
+  const checks = services.map(async (service) => {
+    const port = resolvePort(service);
+    if (port === undefined) {
+      log.error("no port mapping for service — marking unhealthy", { service });
+      results.set(service, false);
+      return;
+    }
+
+    const endpoint = resolveHealthEndpoint(service);
+    const url = `http://localhost:${port}${endpoint}`;
+    const deadline = Date.now() + maxWaitMs;
+
+    log.info("waiting for service", { service, url });
+
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(url, {
+          signal: AbortSignal.timeout(5_000),
+        });
+        if (response.ok) {
+          log.info("service healthy", { service, status: response.status });
+          results.set(service, true);
+          return;
+        }
+        log.debug("health check returned non-ok", {
+          service,
+          status: response.status,
+        });
+      } catch (err) {
+        log.debug("health check not ready yet", { service, error: err instanceof Error ? err.message : String(err) });
+      }
+
+      await sleep(intervalMs);
+    }
+
+    log.error("service failed health check after timeout", {
+      service,
+      url,
+      timeoutMs: maxWaitMs,
+    });
+    results.set(service, false);
+  });
+
+  await Promise.all(checks);
+  return results;
+}
+
+/**
+ * Check whether a specific docker compose service is currently running.
+ */
+export async function isRunning(slug: string): Promise<boolean> {
+  try {
+    const output = compose("--profile", "all", "ps", "--status", "running", slug);
+    const lines = output.split("\n").filter((l) => l.trim().length > 0);
+    return lines.length > 1;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("no such service") || msg.includes("is not valid")) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function listRunningServices(): string[] {
+  try {
+    const output = compose(
+      "--profile",
+      "all",
+      "ps",
+      "--status",
+      "running",
+      "--format",
+      "{{.Service}}",
+    );
+    return output
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/showcase/harness/src/cli/results.ts
+++ b/showcase/harness/src/cli/results.ts
@@ -1,0 +1,220 @@
+/**
+ * CLI results module — terminal formatting and PocketBase persistence for
+ * local probe runs. Two output paths:
+ *
+ *   1. Terminal: colour-coded pass/fail lines with a final summary.
+ *   2. PocketBase: best-effort write through the existing status-writer
+ *      pipeline so local runs show up in the dashboard.
+ *
+ * PocketBase writes are best-effort: a downed PB instance logs a warning
+ * but never crashes the run. The terminal path is always synchronous and
+ * side-effect-free (pure console output).
+ */
+
+import type { ProbeResult, ProbeState, Logger } from "../types/index.js";
+import { createPbClient } from "../storage/pb-client.js";
+import type { StatusWriter } from "../writers/status-writer.js";
+import { createStatusWriter } from "../writers/status-writer.js";
+import type { TypedEventBus } from "../events/event-bus.js";
+
+// ---------------------------------------------------------------------------
+// Terminal result types
+// ---------------------------------------------------------------------------
+
+export interface TerminalResult {
+  key: string;
+  state: ProbeState;
+  durationMs: number;
+  signal?: Record<string, unknown>;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// ANSI helpers
+// ---------------------------------------------------------------------------
+
+const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const DIM = "\x1b[2m";
+
+function stateColor(state: ProbeState): string {
+  if (state === "green") return GREEN;
+  if (state === "red" || state === "error") return RED;
+  return YELLOW; // degraded
+}
+
+function stateIcon(state: ProbeState): string {
+  if (state === "green") return "\u2713"; // checkmark
+  if (state === "red" || state === "error") return "\u2717"; // x-mark
+  return "~"; // degraded
+}
+
+// ---------------------------------------------------------------------------
+// Terminal output
+// ---------------------------------------------------------------------------
+
+/**
+ * Print a single probe result line. Format:
+ *   [icon] key state (duration)
+ *       error detail (if present)
+ */
+export function printResult(result: TerminalResult): void {
+  const icon = stateIcon(result.state);
+  const color = stateColor(result.state);
+  const duration = `${(result.durationMs / 1000).toFixed(1)}s`;
+
+  console.log(
+    `  ${color}${icon}${RESET} ${result.key} ${color}${result.state}${RESET} ${DIM}(${duration})${RESET}`,
+  );
+
+  if (result.error) {
+    console.log(`    ${RED}${result.error}${RESET}`);
+  }
+}
+
+/**
+ * Print a summary after all results. Shows pass/fail counts and lists
+ * failures with their keys and error messages.
+ */
+export function printSummary(results: TerminalResult[]): void {
+  const passed = results.filter((r) => r.state === "green").length;
+  const failed = results.filter((r) => r.state !== "green").length;
+  const totalMs = results.reduce((sum, r) => sum + r.durationMs, 0);
+
+  console.log("");
+  if (failed === 0) {
+    console.log(
+      `  ${GREEN}${passed} passed${RESET} ${DIM}(${(totalMs / 1000).toFixed(1)}s)${RESET}`,
+    );
+  } else {
+    console.log(
+      `  ${GREEN}${passed} passed${RESET}, ${RED}${failed} failed${RESET} ${DIM}(${(totalMs / 1000).toFixed(1)}s)${RESET}`,
+    );
+    console.log("");
+    console.log(`  ${RED}Failed:${RESET}`);
+    for (const r of results.filter((r) => r.state !== "green")) {
+      console.log(
+        `    ${RED}${stateIcon(r.state)}${RESET} ${r.key}: ${r.state}${r.error ? ` \u2014 ${r.error}` : ""}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ProbeResult -> TerminalResult conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a ProbeResult (from a driver) to a TerminalResult for display.
+ * Extracts duration from the signal's `latencyMs` field when present,
+ * calculates from observedAt otherwise, and pulls error descriptions from
+ * the signal's common `errorDesc` / `failureSummary` fields.
+ */
+export function probeResultToTerminal(
+  result: ProbeResult<unknown>,
+  startedAt?: number,
+): TerminalResult {
+  const signal =
+    result.signal && typeof result.signal === "object"
+      ? (result.signal as Record<string, unknown>)
+      : undefined;
+
+  // Duration: prefer signal.latencyMs (set by smoke/liveness drivers),
+  // fall back to wall-clock delta from startedAt.
+  let durationMs = 0;
+  if (signal?.latencyMs && typeof signal.latencyMs === "number") {
+    durationMs = signal.latencyMs;
+  } else if (startedAt) {
+    durationMs = Date.now() - startedAt;
+  }
+
+  // Error: prefer errorDesc, then failureSummary, then generic.
+  let error: string | undefined;
+  if (result.state !== "green") {
+    if (signal?.errorDesc && typeof signal.errorDesc === "string") {
+      error = signal.errorDesc;
+    } else if (
+      signal?.failureSummary &&
+      typeof signal.failureSummary === "string" &&
+      signal.failureSummary.length > 0
+    ) {
+      error = signal.failureSummary;
+    } else {
+      error = result.state === "error" ? "probe error" : "failed";
+    }
+  }
+
+  return {
+    key: result.key,
+    state: result.state,
+    durationMs,
+    signal: signal ?? undefined,
+    error,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PocketBase write
+// ---------------------------------------------------------------------------
+
+export interface PbWriteConfig {
+  url: string;
+  email: string;
+  password: string;
+}
+
+export function createPbWriter(
+  pbConfig: PbWriteConfig,
+  logger: Logger,
+): StatusWriter {
+  const pb = createPbClient({
+    url: pbConfig.url,
+    email: pbConfig.email,
+    password: pbConfig.password,
+    logger,
+  });
+  const noopBus: TypedEventBus = {
+    emit: () => {},
+    on: () => () => {},
+    removeAll: () => {},
+  };
+  return createStatusWriter({ pb, bus: noopBus, logger });
+}
+
+export async function writeResultToPocketBase(
+  result: ProbeResult<unknown>,
+  pbConfig: PbWriteConfig,
+  logger: Logger,
+): Promise<void> {
+  try {
+    const pb = createPbClient({
+      url: pbConfig.url,
+      email: pbConfig.email,
+      password: pbConfig.password,
+      logger,
+    });
+
+    // StatusWriter needs a bus — create a minimal no-op event bus since
+    // the CLI doesn't need alert-engine integration.
+    const noopBus: TypedEventBus = {
+      emit: () => {},
+      on: () => () => {},
+      removeAll: () => {},
+    };
+
+    const writer: StatusWriter = createStatusWriter({
+      pb,
+      bus: noopBus,
+      logger,
+    });
+
+    await writer.write(result);
+  } catch (err) {
+    logger.warn("cli.pb-write-failed", {
+      key: result.key,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/showcase/harness/src/cli/runner.ts
+++ b/showcase/harness/src/cli/runner.ts
@@ -1,0 +1,502 @@
+/**
+ * CLI test runner — orchestrates probe execution against locally running
+ * showcase services. Wires targets (from B4), lifecycle management (from
+ * B3), and existing probe drivers into a single `run()` entry point that
+ * the CLI command handler calls.
+ *
+ * Flow:
+ *   1. Parse and resolve targets into concrete services + test levels.
+ *   2. Start missing services via docker-compose (lifecycle.up).
+ *   3. Wait for health checks.
+ *   4. Build ProbeContext with AbortSignal for Ctrl+C.
+ *   5. Run probe drivers at the requested depth levels.
+ *   6. Print results and optionally write to PocketBase.
+ *   7. Optionally stop auto-started services.
+ */
+
+import type { ProbeContext, Logger } from "../types/index.js";
+import type { ProbeResult } from "../types/index.js";
+import type { ProbeDriver } from "../probes/types.js";
+
+import type { TestLevel, TestTarget } from "./targets.js";
+import type { LocalConfig } from "./config.js";
+import {
+  resolveTargets,
+  buildSmokeInputs,
+  buildChatToolsInputs,
+  buildDeepInputs,
+} from "./targets.js";
+
+
+import { up, down, rebuild, isRunning } from "./lifecycle.js";
+
+import {
+  type TerminalResult,
+  type PbWriteConfig,
+  printResult,
+  printSummary,
+  probeResultToTerminal,
+  createPbWriter,
+} from "./results.js";
+
+import { livenessDriver } from "../probes/drivers/liveness.js";
+import { e2eChatToolsDriver } from "../probes/drivers/e2e-chat-tools.js";
+import { createE2eDeepDriver } from "../probes/drivers/e2e-deep.js";
+import type { E2eDeepBrowser } from "../probes/drivers/e2e-deep.js";
+import type { StatusWriter } from "../writers/status-writer.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RunOptions {
+  level: TestLevel;
+  /** Launch Playwright in headed mode (visible browser window). */
+  headed?: boolean;
+  /** Number of times to repeat the probe execution. */
+  repeat?: number;
+  /** Keep auto-started services running after the run completes. */
+  keep?: boolean;
+  /** Write results to PocketBase in real-time. */
+  live?: boolean;
+  /** Rebuild docker images before starting services. */
+  rebuild?: boolean;
+  /** Enable verbose logging output. */
+  verbose?: boolean;
+}
+
+export interface RunResult {
+  target: string;
+  results: TerminalResult[];
+  passed: number;
+  failed: number;
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// CLI logger
+// ---------------------------------------------------------------------------
+
+function createCliLogger(verbose?: boolean): Logger {
+  return {
+    info: (msg, meta) => {
+      if (verbose) {
+        if (meta) {
+          console.log(`\x1b[36m[info]\x1b[0m ${msg}`, JSON.stringify(meta));
+        } else {
+          console.log(`\x1b[36m[info]\x1b[0m ${msg}`);
+        }
+      }
+    },
+    warn: (msg, meta) => {
+      if (meta) {
+        console.warn(`\x1b[33m[warn]\x1b[0m ${msg}`, JSON.stringify(meta));
+      } else {
+        console.warn(`\x1b[33m[warn]\x1b[0m ${msg}`);
+      }
+    },
+    error: (msg, meta) => {
+      if (meta) {
+        console.error(`\x1b[31m[error]\x1b[0m ${msg}`, JSON.stringify(meta));
+      } else {
+        console.error(`\x1b[31m[error]\x1b[0m ${msg}`);
+      }
+    },
+    debug: (msg, meta) => {
+      if (verbose) {
+        if (meta) {
+          console.log(`\x1b[2m[debug]\x1b[0m ${msg}`, JSON.stringify(meta));
+        } else {
+          console.log(`\x1b[2m[debug]\x1b[0m ${msg}`);
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PocketBase config resolution
+// ---------------------------------------------------------------------------
+
+function resolvePbConfig(config: LocalConfig): PbWriteConfig {
+  return {
+    url: config.pocketbase.url,
+    email: config.pocketbase.email,
+    password: config.pocketbase.password,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run probes against a target at the specified depth level. This is the
+ * primary entry point for the CLI's `test` command.
+ *
+ * @param target - Raw target string (e.g. "langgraph-python", "all")
+ * @param options - Run configuration (level, headed, repeat, etc.)
+ * @param config - Local configuration (ports, PB creds, etc.)
+ * @returns RunResult with aggregated pass/fail counts and timing
+ */
+export async function run(
+  target: string,
+  options: RunOptions,
+  config: LocalConfig,
+): Promise<RunResult> {
+  const logger = createCliLogger(options.verbose);
+  const runStart = Date.now();
+  const allResults: TerminalResult[] = [];
+
+  // -- 1. Resolve targets ----------------------------------------------------
+  const targets = resolveTargets(target, options.level, config);
+
+  logger.info("cli.runner.resolved-targets", {
+    target,
+    level: options.level,
+    count: targets.length,
+  });
+
+  // -- 2. Determine which services need to be running -----------------------
+  const slugs = [...new Set(targets.map((t) => t.slug))];
+  const autoStarted: string[] = [];
+
+  for (const slug of slugs) {
+    const running = await isRunning(slug);
+    if (!running) {
+      autoStarted.push(slug);
+    }
+  }
+
+  // -- 3. Set up abort signal for Ctrl+C ------------------------------------
+  const abortController = new AbortController();
+  const onSigint = (): void => {
+    console.log("\n\x1b[33mAborting...\x1b[0m");
+    abortController.abort();
+  };
+  process.on("SIGINT", onSigint);
+
+  // -- 4. Start missing services (with optional rebuild) --------------------
+  if (autoStarted.length > 0) {
+    console.log(
+      `\n  \x1b[36mStarting services:\x1b[0m ${autoStarted.join(", ")}`,
+    );
+
+    if (options.rebuild) {
+      logger.info("cli.runner.rebuilding", { slugs: autoStarted });
+      await rebuild(autoStarted);
+    }
+
+    await up(autoStarted);
+
+    // up() already runs healthCheck internally, so services are healthy here
+    console.log("  \x1b[32mAll services healthy\x1b[0m\n");
+  }
+
+  // -- 5. Build ProbeContext ------------------------------------------------
+  const pbConfig = options.live ? resolvePbConfig(config) : null;
+  const pbWriter = pbConfig ? createPbWriter(pbConfig, logger) : null;
+
+  const ctx: ProbeContext = {
+    now: () => new Date(),
+    logger,
+    env: { ...process.env, SHOWCASE_LOCAL: "1" },
+    abortSignal: abortController.signal,
+  };
+
+  // -- 6. Create headed-mode deep driver if needed --------------------------
+  // The D5 driver launches Playwright internally. For --headed mode, we
+  // create a custom driver instance with a launcher that passes
+  // headless: false. The e2e-chat-tools driver also launches Playwright
+  // but doesn't expose a headed toggle — we pass HEADED=1 via env.
+  if (options.headed) {
+    ctx.env = { ...ctx.env, HEADED: "1", PLAYWRIGHT_HEADLESS: "0" };
+  }
+
+  const deepDriver = options.headed
+    ? createE2eDeepDriver({
+        launcher: async (): Promise<E2eDeepBrowser> => {
+          const mod = (await import(
+            "playwright"
+          )) as typeof import("playwright");
+          const browser = await mod.chromium.launch({
+            headless: false,
+            args: ["--no-sandbox", "--disable-dev-shm-usage"],
+          });
+          return {
+            async newContext() {
+              const bCtx = await browser.newContext();
+              return {
+                async newPage() {
+                  const page = await bCtx.newPage();
+                  const consoleLogs: string[] = [];
+                  const requestFailures: string[] = [];
+                  page.on("console", (msg: { type(): string; text(): string }) => {
+                    const t = msg.type();
+                    if (t === "error" || t === "warning") {
+                      consoleLogs.push(`[${t}] ${msg.text().slice(0, 200)}`);
+                    }
+                  });
+                  page.on("requestfailed", (request: { method(): string; url(): string; failure(): { errorText: string } | null }) => {
+                    requestFailures.push(
+                      `${request.method()} ${request.url().slice(0, 200)} => ${
+                        request.failure()?.errorText || "unknown"
+                      }`,
+                    );
+                  });
+                  return Object.assign(page, {
+                    getDiagnostics: () => ({
+                      consoleLogs: consoleLogs.slice(-20),
+                      requestFailures: requestFailures.slice(-10),
+                    }),
+                  }) as unknown as import("../probes/drivers/e2e-deep.js").E2eDeepPage;
+                },
+                close: () => bCtx.close(),
+              };
+            },
+            close: () => browser.close(),
+          };
+        },
+      })
+    : createE2eDeepDriver();
+
+  // -- 7. Run probes --------------------------------------------------------
+  const repeatCount = Math.max(1, options.repeat ?? 1);
+
+  try {
+    for (let iteration = 0; iteration < repeatCount; iteration++) {
+      if (abortController.signal.aborted) break;
+
+      if (repeatCount > 1) {
+        console.log(
+          `\n  \x1b[36mIteration ${iteration + 1}/${repeatCount}\x1b[0m`,
+        );
+      }
+
+      for (const testTarget of targets) {
+        if (abortController.signal.aborted) break;
+
+        const { level } = testTarget;
+        const levelList = expandLevel(level);
+
+        for (const depth of levelList) {
+          if (abortController.signal.aborted) break;
+
+          const iterResults = await runLevel(
+            depth,
+            testTarget,
+            ctx,
+            config,
+            deepDriver,
+            pbWriter,
+            logger,
+          );
+
+          allResults.push(...iterResults);
+        }
+      }
+    }
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+
+    // -- 8. Stop auto-started services if not --keep -------------------------
+    if (!options.keep && autoStarted.length > 0) {
+      console.log(
+        `\n  \x1b[2mStopping auto-started services: ${autoStarted.join(", ")}\x1b[0m`,
+      );
+      try {
+        await down(autoStarted, {});
+      } catch (err) {
+        logger.warn("cli.runner.down-failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  // -- 9. Print summary -----------------------------------------------------
+  printSummary(allResults);
+
+  const passed = allResults.filter((r) => r.state === "green").length;
+  const failed = allResults.filter((r) => r.state !== "green").length;
+
+  return {
+    target,
+    results: allResults,
+    passed,
+    failed,
+    durationMs: Date.now() - runStart,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Level expansion
+// ---------------------------------------------------------------------------
+
+type DepthLevel = "smoke" | "d4" | "d5";
+
+/**
+ * Expand a TestLevel into the ordered sequence of depth levels to run.
+ * "all" runs smoke -> d4 -> d5 in sequence.
+ */
+function expandLevel(level: TestLevel): DepthLevel[] {
+  switch (level) {
+    case "smoke":
+      return ["smoke"];
+    case "d4":
+      return ["d4"];
+    case "d5":
+      return ["d5"];
+    case "all":
+      return ["smoke", "d4", "d5"];
+    default:
+      throw new Error(`Unknown test level: ${level}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-level driver execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Run probes at a single depth level for a single target. Returns the
+ * TerminalResult array for all inputs at that level.
+ */
+async function runLevel(
+  depth: DepthLevel,
+  testTarget: TestTarget,
+  ctx: ProbeContext,
+  config: LocalConfig,
+  deepDriver: ProbeDriver<unknown, unknown>,
+  pbWriter: StatusWriter | null,
+  logger: Logger,
+): Promise<TerminalResult[]> {
+  const results: TerminalResult[] = [];
+  const { slug } = testTarget;
+
+  console.log(`\n  \x1b[1m${slug}\x1b[0m \x1b[2m[${depth}]\x1b[0m`);
+
+  switch (depth) {
+    case "smoke": {
+      const inputs = buildSmokeInputs(
+        testTarget,
+        config,
+      );
+      for (const input of inputs) {
+        if (ctx.abortSignal?.aborted) break;
+        const startedAt = Date.now();
+        try {
+          const result = await livenessDriver.run(ctx, input);
+          const terminal = probeResultToTerminal(result, startedAt);
+          printResult(terminal);
+          results.push(terminal);
+          await bestEffortPbWrite(result, pbWriter, logger);
+        } catch (err) {
+          const terminal = errorToTerminal(
+            `smoke:${slug}`,
+            err,
+            Date.now() - startedAt,
+          );
+          printResult(terminal);
+          results.push(terminal);
+        }
+      }
+      break;
+    }
+
+    case "d4": {
+      const inputs = buildChatToolsInputs(
+        testTarget,
+        config,
+      );
+      for (const input of inputs) {
+        if (ctx.abortSignal?.aborted) break;
+        const startedAt = Date.now();
+        try {
+          const result = await e2eChatToolsDriver.run(ctx, input);
+          const terminal = probeResultToTerminal(result, startedAt);
+          printResult(terminal);
+          results.push(terminal);
+          await bestEffortPbWrite(result, pbWriter, logger);
+        } catch (err) {
+          const terminal = errorToTerminal(
+            `d4:${slug}`,
+            err,
+            Date.now() - startedAt,
+          );
+          printResult(terminal);
+          results.push(terminal);
+        }
+      }
+      break;
+    }
+
+    case "d5": {
+      const inputs = buildDeepInputs(
+        testTarget,
+        config,
+      );
+      for (const input of inputs) {
+        if (ctx.abortSignal?.aborted) break;
+        const startedAt = Date.now();
+        try {
+          const result = await deepDriver.run(ctx, input);
+          const terminal = probeResultToTerminal(result, startedAt);
+          printResult(terminal);
+          results.push(terminal);
+          await bestEffortPbWrite(result, pbWriter, logger);
+        } catch (err) {
+          const terminal = errorToTerminal(
+            `e2e-deep:${slug}`,
+            err,
+            Date.now() - startedAt,
+          );
+          printResult(terminal);
+          results.push(terminal);
+        }
+      }
+      break;
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort PocketBase write. Silently catches and logs errors.
+ */
+async function bestEffortPbWrite(
+  result: ProbeResult<unknown>,
+  writer: StatusWriter | null,
+  logger: Logger,
+): Promise<void> {
+  if (!writer) return;
+  try {
+    await writer.write(result);
+  } catch (err) {
+    logger.warn("cli.pb-write-failed", {
+      key: result.key,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Convert a caught error into a TerminalResult for display.
+ */
+function errorToTerminal(
+  key: string,
+  err: unknown,
+  durationMs: number,
+): TerminalResult {
+  return {
+    key,
+    state: "error",
+    durationMs,
+    error: err instanceof Error ? err.message : String(err),
+  };
+}

--- a/showcase/harness/src/cli/runner.ts
+++ b/showcase/harness/src/cli/runner.ts
@@ -27,7 +27,6 @@ import {
   buildDeepInputs,
 } from "./targets.js";
 
-
 import { up, down, rebuild, isRunning } from "./lifecycle.js";
 
 import {
@@ -216,9 +215,8 @@ export async function run(
   const deepDriver = options.headed
     ? createE2eDeepDriver({
         launcher: async (): Promise<E2eDeepBrowser> => {
-          const mod = (await import(
-            "playwright"
-          )) as typeof import("playwright");
+          const mod =
+            (await import("playwright")) as typeof import("playwright");
           const browser = await mod.chromium.launch({
             headless: false,
             args: ["--no-sandbox", "--disable-dev-shm-usage"],
@@ -231,19 +229,29 @@ export async function run(
                   const page = await bCtx.newPage();
                   const consoleLogs: string[] = [];
                   const requestFailures: string[] = [];
-                  page.on("console", (msg: { type(): string; text(): string }) => {
-                    const t = msg.type();
-                    if (t === "error" || t === "warning") {
-                      consoleLogs.push(`[${t}] ${msg.text().slice(0, 200)}`);
-                    }
-                  });
-                  page.on("requestfailed", (request: { method(): string; url(): string; failure(): { errorText: string } | null }) => {
-                    requestFailures.push(
-                      `${request.method()} ${request.url().slice(0, 200)} => ${
-                        request.failure()?.errorText || "unknown"
-                      }`,
-                    );
-                  });
+                  page.on(
+                    "console",
+                    (msg: { type(): string; text(): string }) => {
+                      const t = msg.type();
+                      if (t === "error" || t === "warning") {
+                        consoleLogs.push(`[${t}] ${msg.text().slice(0, 200)}`);
+                      }
+                    },
+                  );
+                  page.on(
+                    "requestfailed",
+                    (request: {
+                      method(): string;
+                      url(): string;
+                      failure(): { errorText: string } | null;
+                    }) => {
+                      requestFailures.push(
+                        `${request.method()} ${request.url().slice(0, 200)} => ${
+                          request.failure()?.errorText || "unknown"
+                        }`,
+                      );
+                    },
+                  );
                   return Object.assign(page, {
                     getDiagnostics: () => ({
                       consoleLogs: consoleLogs.slice(-20),
@@ -378,10 +386,7 @@ async function runLevel(
 
   switch (depth) {
     case "smoke": {
-      const inputs = buildSmokeInputs(
-        testTarget,
-        config,
-      );
+      const inputs = buildSmokeInputs(testTarget, config);
       for (const input of inputs) {
         if (ctx.abortSignal?.aborted) break;
         const startedAt = Date.now();
@@ -405,10 +410,7 @@ async function runLevel(
     }
 
     case "d4": {
-      const inputs = buildChatToolsInputs(
-        testTarget,
-        config,
-      );
+      const inputs = buildChatToolsInputs(testTarget, config);
       for (const input of inputs) {
         if (ctx.abortSignal?.aborted) break;
         const startedAt = Date.now();
@@ -432,10 +434,7 @@ async function runLevel(
     }
 
     case "d5": {
-      const inputs = buildDeepInputs(
-        testTarget,
-        config,
-      );
+      const inputs = buildDeepInputs(testTarget, config);
       for (const input of inputs) {
         if (ctx.abortSignal?.aborted) break;
         const startedAt = Date.now();

--- a/showcase/harness/src/cli/targets.ts
+++ b/showcase/harness/src/cli/targets.ts
@@ -1,0 +1,306 @@
+import path from "node:path";
+import fs from "node:fs";
+import yaml from "js-yaml";
+import type { LocalConfig } from "./config.js";
+import { getPackageUrl } from "./config.js";
+
+export type TestLevel = "smoke" | "d4" | "d5" | "all";
+
+export interface TestTarget {
+  slug: string;
+  /** Undefined means all demos for this slug. */
+  demo?: string;
+  level: TestLevel;
+}
+
+/**
+ * Manifest shape — subset of each integration's manifest.yaml that the
+ * CLI consumes. The full manifest has many more fields (category, logo,
+ * partner_docs, etc.) that aren't relevant for local test execution.
+ */
+interface Manifest {
+  slug: string;
+  name: string;
+  demos: Array<{ id: string; features?: string[] }>;
+  features?: string[];
+  deployed?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Driver input types — these match the Zod inputSchema shapes declared in
+// the actual probe drivers so the CLI can construct valid inputs without
+// going through the driver module (which may pull in Playwright, etc.).
+// ---------------------------------------------------------------------------
+
+/**
+ * Liveness (smoke) driver input — mirrors the `discoverySmokeInputSchema`
+ * branch in `src/probes/drivers/liveness.ts`. The CLI always uses the
+ * discovery shape (key + name + publicUrl) rather than the static shape
+ * (key + url) because local port mapping naturally produces a base URL,
+ * not a full `/smoke` endpoint path.
+ */
+export interface SmokeInput {
+  key: string;
+  name: string;
+  publicUrl: string;
+  shape: "package";
+}
+
+/**
+ * e2e-chat-tools (L4) driver input — mirrors the `inputSchema` in
+ * `src/probes/drivers/e2e-chat-tools.ts`. `backendUrl` or `publicUrl`
+ * is required (the schema has a `.refine()` enforcing this). The CLI
+ * sets `backendUrl` from local-ports and populates `demos` from the
+ * manifest so the driver knows which demo routes to exercise.
+ */
+export interface ChatToolsInput {
+  key: string;
+  backendUrl: string;
+  name: string;
+  demos: string[];
+  shape: "package";
+}
+
+/**
+ * e2e-deep (D5) driver input — mirrors the `inputSchema` in
+ * `src/probes/drivers/e2e-deep.ts`. `backendUrl` or `publicUrl` is
+ * required. The CLI sets `backendUrl` from local-ports and populates
+ * `features` from the manifest's top-level `features` array.
+ */
+export interface DeepInput {
+  key: string;
+  backendUrl: string;
+  name: string;
+  features: string[];
+  shape: "package";
+}
+
+// ---------------------------------------------------------------------------
+// Parsing & resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a raw target string like `"crewai-crews"` or
+ * `"crewai-crews:agentic-chat"` into slug + optional demo.
+ */
+export function parseTarget(raw: string): { slug: string; demo?: string } {
+  const idx = raw.indexOf(":");
+  if (idx === -1) {
+    return { slug: raw };
+  }
+  return {
+    slug: raw.slice(0, idx),
+    demo: raw.slice(idx + 1) || undefined,
+  };
+}
+
+/** Return all slugs that have a local port mapping. */
+export function listAvailableSlugs(config: LocalConfig): string[] {
+  return Object.keys(config.localPorts);
+}
+
+/**
+ * Load and parse an integration's manifest.yaml. Looks under
+ * `showcase/integrations/<slug>/manifest.yaml` first, then falls back
+ * to the legacy `showcase/packages/<slug>/manifest.yaml` path.
+ */
+export function loadManifest(slug: string, config: LocalConfig): Manifest {
+  const integrationsPath = path.join(
+    config.showcaseDir,
+    "integrations",
+    slug,
+    "manifest.yaml",
+  );
+  const packagesPath = path.join(
+    config.showcaseDir,
+    "packages",
+    slug,
+    "manifest.yaml",
+  );
+
+  let manifestPath: string;
+  if (fs.existsSync(integrationsPath)) {
+    manifestPath = integrationsPath;
+  } else if (fs.existsSync(packagesPath)) {
+    manifestPath = packagesPath;
+  } else {
+    throw new Error(
+      `Manifest not found for slug "${slug}". Checked:\n  ${integrationsPath}\n  ${packagesPath}`,
+    );
+  }
+
+  const raw = fs.readFileSync(manifestPath, "utf-8");
+  const parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(
+      `Invalid manifest for ${slug}: expected YAML mapping`,
+    );
+  }
+
+  const manifest = parsed as Record<string, unknown>;
+
+  if (typeof manifest.slug !== "string") {
+    throw new Error(
+      `Manifest for ${slug} missing required "slug" field`,
+    );
+  }
+
+  if (Array.isArray(manifest.demos)) {
+    for (const demo of manifest.demos) {
+      if (typeof demo !== "object" || demo === null || typeof (demo as Record<string, unknown>).id !== "string") {
+        throw new Error(
+          `Invalid demo entry in manifest for ${slug}: each demo must have a string "id" field`,
+        );
+      }
+    }
+  }
+
+  if (manifest.features !== undefined && !Array.isArray(manifest.features)) {
+    throw new Error(
+      `Invalid "features" in manifest for ${slug}: expected array`,
+    );
+  }
+
+  return {
+    slug: manifest.slug as string,
+    name: (manifest.name as string) ?? slug,
+    demos: Array.isArray(manifest.demos)
+      ? (manifest.demos as Array<{ id: string; features?: string[] }>)
+      : [],
+    features: Array.isArray(manifest.features)
+      ? (manifest.features as string[])
+      : undefined,
+    deployed: manifest.deployed as boolean | undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Driver input builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build smoke (liveness) driver inputs for the given target.
+ */
+export function buildSmokeInputs(
+  target: TestTarget,
+  config: LocalConfig,
+): SmokeInput[] {
+  const slugs = [target.slug];
+
+  return slugs.map((slug) => {
+    const manifest = loadManifest(slug, config);
+    return {
+      key: `smoke:${slug}`,
+      name: manifest.name,
+      publicUrl: getPackageUrl(slug, config),
+      shape: "package" as const,
+    };
+  });
+}
+
+/**
+ * Build e2e-chat-tools (L4) driver inputs. Reads each manifest to
+ * populate the `demos` array so the driver knows which demo routes to
+ * exercise. When `target.demo` is set, filters to just that demo.
+ */
+export function buildChatToolsInputs(
+  target: TestTarget,
+  config: LocalConfig,
+): ChatToolsInput[] {
+  const slugs = [target.slug];
+
+  return slugs.map((slug) => {
+    const manifest = loadManifest(slug, config);
+    let demoIds = manifest.demos.map((d) => d.id);
+
+    if (target.demo) {
+      demoIds = demoIds.filter((id) => id === target.demo);
+      if (demoIds.length === 0) {
+        const available = manifest.demos.map((d) => d.id).join(", ");
+        throw new Error(
+          `Demo "${target.demo}" not found in ${slug}. Available: ${available}`,
+        );
+      }
+    }
+
+    return {
+      key: `d4:${slug}`,
+      backendUrl: getPackageUrl(slug, config),
+      name: manifest.name,
+      demos: demoIds,
+      shape: "package" as const,
+    };
+  });
+}
+
+/**
+ * Build e2e-deep (D5) driver inputs. Reads the manifest's top-level
+ * `features` array. When `target.demo` is set, filters features to
+ * just that demo ID (the features list in the manifest uses the same
+ * identifiers as demo IDs).
+ */
+export function buildDeepInputs(
+  target: TestTarget,
+  config: LocalConfig,
+): DeepInput[] {
+  const slugs = [target.slug];
+
+  return slugs.map((slug) => {
+    const manifest = loadManifest(slug, config);
+    let features = manifest.features ?? [];
+
+    if (target.demo) {
+      features = features.filter((f) => f === target.demo);
+      if (features.length === 0) {
+        const available = (manifest.features ?? []).join(", ");
+        throw new Error(
+          `Feature "${target.demo}" not found in ${slug}. Available: ${available}`,
+        );
+      }
+    }
+
+    return {
+      key: `e2e-deep:${slug}`,
+      backendUrl: getPackageUrl(slug, config),
+      name: manifest.name,
+      features,
+      shape: "package" as const,
+    };
+  })
+  .filter((input) => input.features.length > 0);
+}
+
+/**
+ * Parse a raw target string, expand `"all"` to every slug with a local
+ * port mapping, and return a `TestTarget[]`.
+ */
+export function resolveTargets(
+  raw: string,
+  level: TestLevel,
+  config: LocalConfig,
+): TestTarget[] {
+  const { slug, demo } = parseTarget(raw);
+
+  if (slug === "all" && demo) {
+    throw new Error(
+      'Cannot specify a demo filter with target "all". Use a specific slug instead.',
+    );
+  }
+
+  if (slug === "all") {
+    return listAvailableSlugs(config).map((s) => ({
+      slug: s,
+      level,
+    }));
+  }
+
+  // Validate the slug has a port mapping.
+  if (!config.localPorts[slug]) {
+    throw new Error(
+      `Unknown slug "${slug}". Available: ${listAvailableSlugs(config).join(", ")}`,
+    );
+  }
+
+  return [{ slug, demo, level }];
+}

--- a/showcase/harness/src/cli/targets.ts
+++ b/showcase/harness/src/cli/targets.ts
@@ -133,22 +133,22 @@ export function loadManifest(slug: string, config: LocalConfig): Manifest {
   const parsed = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
 
   if (!parsed || typeof parsed !== "object") {
-    throw new Error(
-      `Invalid manifest for ${slug}: expected YAML mapping`,
-    );
+    throw new Error(`Invalid manifest for ${slug}: expected YAML mapping`);
   }
 
   const manifest = parsed as Record<string, unknown>;
 
   if (typeof manifest.slug !== "string") {
-    throw new Error(
-      `Manifest for ${slug} missing required "slug" field`,
-    );
+    throw new Error(`Manifest for ${slug} missing required "slug" field`);
   }
 
   if (Array.isArray(manifest.demos)) {
     for (const demo of manifest.demos) {
-      if (typeof demo !== "object" || demo === null || typeof (demo as Record<string, unknown>).id !== "string") {
+      if (
+        typeof demo !== "object" ||
+        demo === null ||
+        typeof (demo as Record<string, unknown>).id !== "string"
+      ) {
         throw new Error(
           `Invalid demo entry in manifest for ${slug}: each demo must have a string "id" field`,
         );
@@ -246,29 +246,30 @@ export function buildDeepInputs(
 ): DeepInput[] {
   const slugs = [target.slug];
 
-  return slugs.map((slug) => {
-    const manifest = loadManifest(slug, config);
-    let features = manifest.features ?? [];
+  return slugs
+    .map((slug) => {
+      const manifest = loadManifest(slug, config);
+      let features = manifest.features ?? [];
 
-    if (target.demo) {
-      features = features.filter((f) => f === target.demo);
-      if (features.length === 0) {
-        const available = (manifest.features ?? []).join(", ");
-        throw new Error(
-          `Feature "${target.demo}" not found in ${slug}. Available: ${available}`,
-        );
+      if (target.demo) {
+        features = features.filter((f) => f === target.demo);
+        if (features.length === 0) {
+          const available = (manifest.features ?? []).join(", ");
+          throw new Error(
+            `Feature "${target.demo}" not found in ${slug}. Available: ${available}`,
+          );
+        }
       }
-    }
 
-    return {
-      key: `e2e-deep:${slug}`,
-      backendUrl: getPackageUrl(slug, config),
-      name: manifest.name,
-      features,
-      shape: "package" as const,
-    };
-  })
-  .filter((input) => input.features.length > 0);
+      return {
+        key: `e2e-deep:${slug}`,
+        backendUrl: getPackageUrl(slug, config),
+        name: manifest.name,
+        features,
+        shape: "package" as const,
+      };
+    })
+    .filter((input) => input.features.length > 0);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a local CLI (`showcase/harness/src/cli.ts`) that lets developers run Dn parity tests against Docker Compose containers without Railway or CI
- Hardens `docker-compose.local.yml` with YAML anchors, healthchecks on all 20 services, profiles, and switches aimock to the published GHCR image
- CLI supports `up`/`down`/`test`/`rebuild`/`ps`/`logs`/`status` commands with `--smoke`/`--d4`/`--d5` shorthand flags

## Why

Debugging Dn failures currently requires pushing to a branch and waiting for CI + Railway. This gives Claude and developers a fully local loop: `showcase test --d5 langgraph-python` spins up the container, runs probes, and reports results in seconds. Three use cases: (1) Claude debugging Dn failures by cutting Railway out of the loop, (2) developers building new columns/cells/rows and testing iteratively, (3) background automation testing during development.

## What changed

| Commit | Area |
|--------|------|
| `fix(showcase): harden docker-compose.local.yml` | x-integration-defaults anchor, aimock→GHCR, healthchecks, profiles, pocketbase/dashboard infra |
| `feat: CLI entry point + config` | Commander CLI, flags, mutual exclusion, config loader |
| `feat: lifecycle manager` | Profile-aware compose wrapper, ENOENT detection, caching |
| `feat: target resolution` | Driver input builders, manifest validation |
| `feat: test runner` | Probe orchestration, Playwright adapter, SIGINT, PB reuse |
| `feat: results formatter` | Console table output, createPbWriter factory |
| `chore: format` | oxfmt cleanup |

## Test plan

- [ ] `docker compose -f showcase/docker-compose.local.yml --profile infra up -d` starts aimock + pocketbase + dashboard with healthchecks passing
- [ ] `docker compose -f showcase/docker-compose.local.yml --profile langgraph-python up -d` starts the integration container and depends_on aimock healthy
- [ ] CLI `--smoke` and `--level smoke` produce equivalent behavior
- [ ] CLI `--smoke --level d4` exits with mutual exclusion error
- [ ] `down` with no args tears down all profiled services
- [ ] `isRunning` correctly reports infra services (which have `["infra", "all"]` profiles, not per-name profiles)