### PR TITLE
feat(shell-dashboard): tally breakdown tooltips on column header counts

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
+import type { Integration, Feature } from "@/lib/registry";
+
+// Mock registry module — registry.json is generated at build time and
+// not available in the test environment.
+vi.mock("@/lib/registry", () => ({
+  getIntegrations: vi.fn(() => []),
+  getFeatures: vi.fn(() => []),
+  getFeatureCategories: vi.fn(() => []),
+}));
+
+// Mock live-status module before importing the function under test
+vi.mock("@/lib/live-status", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/live-status")>(
+    "@/lib/live-status",
+  );
+  return {
+    ...actual,
+    keyFor: vi.fn(actual.keyFor),
+    resolveCell: vi.fn(),
+  };
+});
+
+import { computeColumnTallyDetail } from "@/components/feature-grid";
+import { keyFor, resolveCell } from "@/lib/live-status";
+import type { CellState, BadgeRender } from "@/lib/live-status";
+
+const mockedResolveCell = vi.mocked(resolveCell);
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function makeRow(overrides: Partial<StatusRow> = {}): StatusRow {
+  return {
+    id: "row-1",
+    key: "health:test-slug",
+    dimension: "health",
+    state: "green",
+    signal: null,
+    observed_at: "2026-04-28T00:00:00Z",
+    transitioned_at: "2026-04-28T00:00:00Z",
+    fail_count: 0,
+    first_failure_at: null,
+    ...overrides,
+  };
+}
+
+function makeBadge(tone: string): BadgeRender {
+  return {
+    tone: tone as BadgeRender["tone"],
+    label: tone,
+    tooltip: "",
+    row: null,
+  };
+}
+
+function makeCellState(e2eTone: string): CellState {
+  return {
+    e2e: makeBadge(e2eTone),
+    smoke: makeBadge("gray"),
+    health: makeBadge("gray"),
+    d5: makeBadge("gray"),
+    d6: makeBadge("gray"),
+    rollup: e2eTone as CellState["rollup"],
+  };
+}
+
+function makeIntegration(
+  slug: string,
+  demoIds: string[],
+): Integration {
+  return {
+    slug,
+    name: slug,
+    language: "python",
+    backend_url: `https://${slug}.example.com`,
+    docs_url: "",
+    source_url: "",
+    demos: demoIds.map((id) => ({
+      id,
+      route: `/${id}`,
+      command: "",
+    })),
+  } as Integration;
+}
+
+function makeFeature(id: string, name: string): Feature {
+  return {
+    id,
+    name,
+    description: "",
+    category: "core",
+    kind: "standard",
+  } as Feature;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("computeColumnTallyDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns unknown: true with empty arrays when connection is error", () => {
+    const integration = makeIntegration("test-int", ["feat-1"]);
+    const features = [makeFeature("feat-1", "Feature 1")];
+    const liveStatus: LiveStatusMap = new Map();
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "error",
+    );
+
+    expect(result).toEqual({
+      green: [],
+      amber: [],
+      red: [],
+      unknown: true,
+    });
+    // resolveCell should NOT be called when connection is error
+    expect(mockedResolveCell).not.toHaveBeenCalled();
+  });
+
+  it("collects health green + 1 e2e green + 1 e2e red", () => {
+    const integration = makeIntegration("my-int", ["feat-a", "feat-b"]);
+    const features = [
+      makeFeature("feat-a", "Feature A"),
+      makeFeature("feat-b", "Feature B"),
+    ];
+
+    const healthKey = keyFor("health", "my-int");
+    const liveStatus: LiveStatusMap = new Map([
+      [healthKey, makeRow({ key: healthKey, state: "green" })],
+    ]);
+
+    // feat-a e2e → green, feat-b e2e → red
+    mockedResolveCell
+      .mockReturnValueOnce(makeCellState("green"))
+      .mockReturnValueOnce(makeCellState("red"));
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.unknown).toBe(false);
+    expect(result.green).toEqual([
+      { label: "Health (Up)", dimension: "health" },
+      { label: "Feature A", dimension: "e2e", featureId: "feat-a" },
+    ]);
+    expect(result.red).toEqual([
+      { label: "Feature B", dimension: "e2e", featureId: "feat-b" },
+    ]);
+    expect(result.amber).toEqual([]);
+  });
+
+  it("collects amber e2e features when no health data exists", () => {
+    const integration = makeIntegration("no-health", ["feat-x", "feat-y"]);
+    const features = [
+      makeFeature("feat-x", "Feature X"),
+      makeFeature("feat-y", "Feature Y"),
+    ];
+    const liveStatus: LiveStatusMap = new Map();
+
+    // Both features → amber
+    mockedResolveCell
+      .mockReturnValueOnce(makeCellState("amber"))
+      .mockReturnValueOnce(makeCellState("amber"));
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.unknown).toBe(false);
+    expect(result.green).toEqual([]);
+    expect(result.red).toEqual([]);
+    expect(result.amber).toEqual([
+      { label: "Feature X", dimension: "e2e", featureId: "feat-x" },
+      { label: "Feature Y", dimension: "e2e", featureId: "feat-y" },
+    ]);
+  });
+
+  it("skips features that have no matching demo", () => {
+    // Integration only has demo for feat-1, not feat-2
+    const integration = makeIntegration("partial", ["feat-1"]);
+    const features = [
+      makeFeature("feat-1", "Feature 1"),
+      makeFeature("feat-2", "Feature 2"),
+    ];
+    const liveStatus: LiveStatusMap = new Map();
+
+    mockedResolveCell.mockReturnValueOnce(makeCellState("green"));
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.unknown).toBe(false);
+    // Only feat-1 appears (has a demo); feat-2 is absent
+    expect(result.green).toEqual([
+      { label: "Feature 1", dimension: "e2e", featureId: "feat-1" },
+    ]);
+    expect(result.amber).toEqual([]);
+    expect(result.red).toEqual([]);
+    // resolveCell was only called once (for feat-1)
+    expect(mockedResolveCell).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes degraded health to amber bucket", () => {
+    const integration = makeIntegration("degraded-int", []);
+    const features: Feature[] = [];
+
+    const healthKey = keyFor("health", "degraded-int");
+    const liveStatus: LiveStatusMap = new Map([
+      [healthKey, makeRow({ key: healthKey, state: "degraded" })],
+    ]);
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.amber).toEqual([
+      { label: "Health (Up)", dimension: "health" },
+    ]);
+    expect(result.green).toEqual([]);
+    expect(result.red).toEqual([]);
+    expect(result.unknown).toBe(false);
+  });
+
+  it("routes red health to red bucket", () => {
+    const integration = makeIntegration("red-int", []);
+    const features: Feature[] = [];
+
+    const healthKey = keyFor("health", "red-int");
+    const liveStatus: LiveStatusMap = new Map([
+      [healthKey, makeRow({ key: healthKey, state: "red" })],
+    ]);
+
+    const result = computeColumnTallyDetail(
+      integration,
+      features,
+      liveStatus,
+      "live",
+    );
+
+    expect(result.red).toEqual([
+      { label: "Health (Up)", dimension: "health" },
+    ]);
+    expect(result.green).toEqual([]);
+    expect(result.amber).toEqual([]);
+    expect(result.unknown).toBe(false);
+  });
+});

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -12,9 +12,10 @@ vi.mock("@/lib/registry", () => ({
 
 // Mock live-status module before importing the function under test
 vi.mock("@/lib/live-status", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/live-status")>(
-    "@/lib/live-status",
-  );
+  const actual =
+    await vi.importActual<typeof import("@/lib/live-status")>(
+      "@/lib/live-status",
+    );
   return {
     ...actual,
     keyFor: vi.fn(actual.keyFor),
@@ -67,10 +68,7 @@ function makeCellState(e2eTone: string): CellState {
   };
 }
 
-function makeIntegration(
-  slug: string,
-  demoIds: string[],
-): Integration {
+function makeIntegration(slug: string, demoIds: string[]): Integration {
   return {
     slug,
     name: slug,
@@ -260,9 +258,7 @@ describe("computeColumnTallyDetail", () => {
       "live",
     );
 
-    expect(result.red).toEqual([
-      { label: "Health (Up)", dimension: "health" },
-    ]);
+    expect(result.red).toEqual([{ label: "Health (Up)", dimension: "health" }]);
     expect(result.green).toEqual([]);
     expect(result.amber).toEqual([]);
     expect(result.unknown).toBe(false);

--- a/showcase/shell-dashboard/src/components/__tests__/tally-breakdown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/tally-breakdown.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for TallyTrigger / TallyBreakdownPopover.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, act } from "@testing-library/react";
+import { TallyTrigger } from "../tally-breakdown";
+import type { TallyItem } from "@/components/tally-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeItems(count: number, tone?: string): TallyItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    label: `Feature ${tone ?? ""}${i + 1}`,
+    dimension: i % 2 === 0 ? ("health" as const) : ("e2e" as const),
+    featureId: `feat-${i + 1}`,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TallyTrigger", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders children without button wrapper when items is empty", () => {
+    const { getByText, queryByRole } = render(
+      <TallyTrigger items={[]} tone="green">
+        <span>✓ 5</span>
+      </TallyTrigger>,
+    );
+
+    expect(getByText("✓ 5")).toBeInTheDocument();
+    expect(queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders button wrapper when items are provided", () => {
+    const items = makeItems(3, "green");
+    const { getByTestId, getByText } = render(
+      <TallyTrigger items={items} tone="green">
+        <span>✓ 3</span>
+      </TallyTrigger>,
+    );
+
+    expect(getByText("✓ 3")).toBeInTheDocument();
+    expect(getByTestId("tally-trigger-green")).toBeInTheDocument();
+  });
+
+  it("opens popover on click and shows items", () => {
+    const items = makeItems(2, "amber");
+    const { getByTestId, getByText, queryByTestId } = render(
+      <TallyTrigger items={items} tone="amber">
+        <span>~ 2</span>
+      </TallyTrigger>,
+    );
+
+    // Popover not visible initially
+    expect(queryByTestId("tally-popover")).not.toBeInTheDocument();
+
+    // Click opens it
+    fireEvent.click(getByTestId("tally-trigger-amber"));
+    expect(getByTestId("tally-popover")).toBeInTheDocument();
+
+    // Items rendered
+    expect(getByText("Feature amber1")).toBeInTheDocument();
+    expect(getByText("Feature amber2")).toBeInTheDocument();
+  });
+
+  it("shows correct item count in the popover", () => {
+    const items = makeItems(4, "red");
+    const { getByTestId } = render(
+      <TallyTrigger items={items} tone="red">
+        <span>✗ 4</span>
+      </TallyTrigger>,
+    );
+
+    fireEvent.click(getByTestId("tally-trigger-red"));
+    const popover = getByTestId("tally-popover");
+    const listItems = popover.querySelectorAll("li");
+    expect(listItems.length).toBe(4);
+  });
+
+  it("displays dimension tags on items", () => {
+    const items: TallyItem[] = [
+      { label: "Health Signal", dimension: "health", featureId: "h1" },
+      { label: "E2E Signal", dimension: "e2e", featureId: "e1" },
+    ];
+    const { getByTestId, getByText } = render(
+      <TallyTrigger items={items} tone="green">
+        <span>✓ 2</span>
+      </TallyTrigger>,
+    );
+
+    fireEvent.click(getByTestId("tally-trigger-green"));
+    expect(getByText("health")).toBeInTheDocument();
+    expect(getByText("e2e")).toBeInTheDocument();
+  });
+
+  it("closes popover on click-outside", () => {
+    const items = makeItems(1, "green");
+    const { getByTestId, queryByTestId } = render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <TallyTrigger items={items} tone="green">
+          <span>✓ 1</span>
+        </TallyTrigger>
+      </div>,
+    );
+
+    // Open the popover
+    fireEvent.click(getByTestId("tally-trigger-green"));
+    expect(getByTestId("tally-popover")).toBeInTheDocument();
+
+    // Click outside
+    fireEvent.mouseDown(getByTestId("outside"));
+    expect(queryByTestId("tally-popover")).not.toBeInTheDocument();
+  });
+
+  it("does not open popover on click when items is empty", () => {
+    const { getByText, queryByTestId, queryByRole } = render(
+      <TallyTrigger items={[]} tone="red">
+        <span>✗ 0</span>
+      </TallyTrigger>,
+    );
+
+    // No button wrapper, so nothing to click for opening
+    expect(getByText("✗ 0")).toBeInTheDocument();
+    expect(queryByRole("button")).not.toBeInTheDocument();
+    expect(queryByTestId("tally-popover")).not.toBeInTheDocument();
+  });
+
+  it("toggles popover closed on second click (pin/unpin)", () => {
+    const items = makeItems(1, "amber");
+    const { getByTestId, queryByTestId } = render(
+      <TallyTrigger items={items} tone="amber">
+        <span>~ 1</span>
+      </TallyTrigger>,
+    );
+
+    const trigger = getByTestId("tally-trigger-amber");
+
+    // First click opens
+    fireEvent.click(trigger);
+    expect(getByTestId("tally-popover")).toBeInTheDocument();
+
+    // Second click closes
+    fireEvent.click(trigger);
+    expect(queryByTestId("tally-popover")).not.toBeInTheDocument();
+  });
+
+  it("opens popover on hover after delay", () => {
+    const items = makeItems(1, "green");
+    const { getByTestId, queryByTestId } = render(
+      <TallyTrigger items={items} tone="green">
+        <span>✓ 1</span>
+      </TallyTrigger>,
+    );
+
+    const trigger = getByTestId("tally-trigger-green");
+    const container = trigger.parentElement!;
+
+    // Mouse enter
+    fireEvent.mouseEnter(container);
+    // Not open yet (200ms delay)
+    expect(queryByTestId("tally-popover")).not.toBeInTheDocument();
+
+    // Advance past delay
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(getByTestId("tally-popover")).toBeInTheDocument();
+  });
+
+  it("closes hover-opened popover on mouse leave", () => {
+    const items = makeItems(1, "green");
+    const { getByTestId, queryByTestId } = render(
+      <TallyTrigger items={items} tone="green">
+        <span>✓ 1</span>
+      </TallyTrigger>,
+    );
+
+    const trigger = getByTestId("tally-trigger-green");
+    const container = trigger.parentElement!;
+
+    // Hover open
+    fireEvent.mouseEnter(container);
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(getByTestId("tally-popover")).toBeInTheDocument();
+
+    // Mouse leave should close after 150ms (not pinned)
+    fireEvent.mouseLeave(container);
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(queryByTestId("tally-popover")).not.toBeInTheDocument();
+  });
+});

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -21,6 +21,7 @@ import type { CatalogCell } from "@/components/depth-utils";
 import type { Overlay } from "@/lib/overlay-types";
 import type { ParityTier } from "@/components/parity-badge";
 import type { CatalogData } from "@/data/catalog-types";
+import type { TallyDetail, TallyItem } from "@/components/tally-types";
 import {
   useCollapsible,
   CategoryHeaderRow,
@@ -102,6 +103,67 @@ export function computeColumnTally(
     });
 
     tallyTone(cell.e2e.tone);
+  }
+
+  return { green, amber, red, unknown: false };
+}
+
+/**
+ * Per-bucket feature lists for a single integration column — companion to
+ * `computeColumnTally()` that returns `TallyItem[]` arrays instead of counts.
+ *
+ * Logic mirrors `computeColumnTally()` exactly: same signal scoping (health
+ * counted once, e2e per feature-with-demo) and same connection-error guard.
+ */
+export function computeColumnTallyDetail(
+  integration: Integration,
+  features: Feature[],
+  liveStatus: LiveStatusMap,
+  connection: ConnectionStatus,
+): TallyDetail {
+  if (connection === "error") {
+    return { green: [], amber: [], red: [], unknown: true };
+  }
+
+  const green: TallyItem[] = [];
+  const amber: TallyItem[] = [];
+  const red: TallyItem[] = [];
+
+  // Integration-level health — counted once per integration.
+  const healthRow = liveStatus.get(keyFor("health", integration.slug)) ?? null;
+  if (healthRow) {
+    const item: TallyItem = { label: "Health (Up)", dimension: "health" };
+    switch (healthRow.state) {
+      case "green":
+        green.push(item);
+        break;
+      case "red":
+        red.push(item);
+        break;
+      case "degraded":
+        amber.push(item);
+        break;
+    }
+  }
+
+  // Feature-level dimensions: e2e per feature-with-demo.
+  for (const feature of features) {
+    const demo = integration.demos.find((d) => d.id === feature.id);
+    if (!demo) continue;
+
+    const cell = resolveCell(liveStatus, integration.slug, feature.id, {
+      connection,
+    });
+
+    const item: TallyItem = {
+      label: feature.name,
+      dimension: "e2e",
+      featureId: feature.id,
+    };
+
+    if (cell.e2e.tone === "green") green.push(item);
+    else if (cell.e2e.tone === "amber") amber.push(item);
+    else if (cell.e2e.tone === "red") red.push(item);
   }
 
   return { green, amber, red, unknown: false };
@@ -324,6 +386,18 @@ export function FeatureGrid({
     return out;
   }, [integrations, features, liveStatus, connection]);
 
+  // Per-bucket feature lists — mirrors tallies but with TallyItem arrays.
+  const tallyDetails = useMemo(() => {
+    const out = new Map<string, TallyDetail>();
+    for (const integration of integrations) {
+      out.set(
+        integration.slug,
+        computeColumnTallyDetail(integration, features, liveStatus, connection),
+      );
+    }
+    return out;
+  }, [integrations, features, liveStatus, connection]);
+
   // Whether to show the parity ref-depth column
   const showRefDepth = overlays ? overlays.has("parity") : false;
 
@@ -404,6 +478,7 @@ export function FeatureGrid({
                       key={integration.slug}
                       integration={integration}
                       tally={tally}
+                      tallyDetail={tallyDetails.get(integration.slug)}
                       overlays={overlays}
                       liveStatus={liveStatus}
                       connection={connection}

--- a/showcase/shell-dashboard/src/components/overlay-column-header.tsx
+++ b/showcase/shell-dashboard/src/components/overlay-column-header.tsx
@@ -6,6 +6,8 @@
 import { LevelStrip } from "@/components/level-strip";
 import { ParityBadge } from "@/components/parity-badge";
 import type { ParityTier } from "@/components/parity-badge";
+import { TallyTrigger } from "@/components/tally-breakdown";
+import type { TallyDetail } from "@/components/tally-types";
 import type { Integration } from "@/lib/registry";
 import type { ConnectionStatus, LiveStatusMap } from "@/lib/live-status";
 
@@ -15,6 +17,7 @@ type Overlay = "links" | "depth" | "health" | "parity" | "docs";
 export interface OverlayColumnHeaderProps {
   integration: Integration;
   tally?: { green: number; amber: number; red: number; unknown: boolean };
+  tallyDetail?: TallyDetail;
   overlays: Set<Overlay>;
   liveStatus: LiveStatusMap;
   connection: ConnectionStatus;
@@ -26,6 +29,7 @@ export interface OverlayColumnHeaderProps {
 export function OverlayColumnHeader({
   integration,
   tally,
+  tallyDetail,
   overlays,
   liveStatus,
   connection: _connection,
@@ -81,15 +85,21 @@ export function OverlayColumnHeader({
             <span className="text-[var(--text-muted)]">? offline</span>
           ) : (
             <>
-              <span className="text-[var(--ok)]">
-                {"\u2713"} {tally.green}
-              </span>
+              <TallyTrigger items={tallyDetail?.green ?? []} tone="green">
+                <span className="text-[var(--ok)]">
+                  {"\u2713"} {tally.green}
+                </span>
+              </TallyTrigger>
               <span className="mx-1 text-[var(--text-muted)]">{"\u00b7"}</span>
-              <span className="text-[var(--amber)]">~ {tally.amber}</span>
+              <TallyTrigger items={tallyDetail?.amber ?? []} tone="amber">
+                <span className="text-[var(--amber)]">~ {tally.amber}</span>
+              </TallyTrigger>
               <span className="mx-1 text-[var(--text-muted)]">{"\u00b7"}</span>
-              <span className="text-[var(--danger)]">
-                {"\u2717"} {tally.red}
-              </span>
+              <TallyTrigger items={tallyDetail?.red ?? []} tone="red">
+                <span className="text-[var(--danger)]">
+                  {"\u2717"} {tally.red}
+                </span>
+              </TallyTrigger>
             </>
           )}
         </div>

--- a/showcase/shell-dashboard/src/components/tally-breakdown.tsx
+++ b/showcase/shell-dashboard/src/components/tally-breakdown.tsx
@@ -1,0 +1,178 @@
+"use client";
+/**
+ * TallyBreakdownPopover — popover showing which features/signals fall in a
+ * particular tally bucket (green / amber / red).  TallyTrigger wraps each
+ * tally count span and handles hover-open + click-pin semantics.
+ */
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { TallyItem } from "@/components/tally-types";
+
+// ---------------------------------------------------------------------------
+// Popover (internal)
+// ---------------------------------------------------------------------------
+
+interface TallyBreakdownPopoverProps {
+  items: TallyItem[];
+  tone: "green" | "amber" | "red";
+  onClose: () => void;
+}
+
+const TONE_DOT: Record<string, string> = {
+  green: "bg-[var(--ok)]",
+  amber: "bg-[var(--amber)]",
+  red: "bg-[var(--danger)]",
+};
+
+function TallyBreakdownPopover({
+  items,
+  tone,
+  onClose: _onClose,
+}: TallyBreakdownPopoverProps) {
+  return (
+    <div
+      data-testid="tally-popover"
+      className="absolute z-50 mt-1 min-w-[180px] max-w-[280px] max-h-[200px] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] shadow-lg"
+      role="dialog"
+      aria-label={`${tone} tally breakdown`}
+    >
+      <ul className="py-1.5 px-2 space-y-1">
+        {items.map((item, i) => (
+          <li
+            key={item.featureId ?? `${item.label}-${i}`}
+            className="flex items-center gap-2 py-0.5"
+          >
+            <span
+              className={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${TONE_DOT[tone]}`}
+            />
+            <span className="text-[11px] text-[var(--text)] truncate">
+              {item.label}
+            </span>
+            <span className="ml-auto text-[9px] text-[var(--text-muted)] uppercase tracking-wider shrink-0">
+              {item.dimension}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trigger wrapper (exported)
+// ---------------------------------------------------------------------------
+
+interface TallyTriggerProps {
+  items: TallyItem[];
+  tone: "green" | "amber" | "red";
+  children: React.ReactNode;
+}
+
+export function TallyTrigger({ items, tone, children }: TallyTriggerProps) {
+  const [open, setOpen] = useState(false);
+  const pinned = useRef(false);
+  const hoverTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const leaveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const clearTimers = useCallback(() => {
+    if (hoverTimeout.current) {
+      clearTimeout(hoverTimeout.current);
+      hoverTimeout.current = null;
+    }
+    if (leaveTimeout.current) {
+      clearTimeout(leaveTimeout.current);
+      leaveTimeout.current = null;
+    }
+  }, []);
+
+  // Close on click-outside (same pattern as DepthLayer in composed-cell.tsx)
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+        pinned.current = false;
+        clearTimers();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open, clearTimers]);
+
+  // Cleanup timers on unmount
+  useEffect(() => clearTimers, [clearTimers]);
+
+  // No interaction when there are no items
+  if (items.length === 0) {
+    return <>{children}</>;
+  }
+
+  const handleClick = () => {
+    clearTimers();
+    if (open && pinned.current) {
+      // Click again while pinned → close
+      setOpen(false);
+      pinned.current = false;
+    } else {
+      // Pin open
+      setOpen(true);
+      pinned.current = true;
+    }
+  };
+
+  const handleMouseEnter = () => {
+    if (leaveTimeout.current) {
+      clearTimeout(leaveTimeout.current);
+      leaveTimeout.current = null;
+    }
+    if (!open) {
+      hoverTimeout.current = setTimeout(() => {
+        setOpen(true);
+      }, 200);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (hoverTimeout.current) {
+      clearTimeout(hoverTimeout.current);
+      hoverTimeout.current = null;
+    }
+    // Don't close if click-pinned
+    if (!pinned.current) {
+      leaveTimeout.current = setTimeout(() => {
+        setOpen(false);
+      }, 150);
+    }
+  };
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    pinned.current = false;
+    clearTimers();
+  }, [clearTimers]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative inline-block"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <button
+        type="button"
+        data-testid={`tally-trigger-${tone}`}
+        className="cursor-pointer bg-transparent border-none p-0 inline-flex"
+        onClick={handleClick}
+      >
+        {children}
+      </button>
+      {open && (
+        <TallyBreakdownPopover items={items} tone={tone} onClose={handleClose} />
+      )}
+    </div>
+  );
+}

--- a/showcase/shell-dashboard/src/components/tally-breakdown.tsx
+++ b/showcase/shell-dashboard/src/components/tally-breakdown.tsx
@@ -171,7 +171,11 @@ export function TallyTrigger({ items, tone, children }: TallyTriggerProps) {
         {children}
       </button>
       {open && (
-        <TallyBreakdownPopover items={items} tone={tone} onClose={handleClose} />
+        <TallyBreakdownPopover
+          items={items}
+          tone={tone}
+          onClose={handleClose}
+        />
       )}
     </div>
   );

--- a/showcase/shell-dashboard/src/components/tally-types.ts
+++ b/showcase/shell-dashboard/src/components/tally-types.ts
@@ -1,0 +1,12 @@
+export interface TallyItem {
+  label: string;
+  dimension: "health" | "e2e";
+  featureId?: string;
+}
+
+export interface TallyDetail {
+  green: TallyItem[];
+  amber: TallyItem[];
+  red: TallyItem[];
+  unknown: boolean;
+}


### PR DESCRIPTION
## Summary

- Hovering/clicking a tally count (✓ N, ~ N, × N) in column headers now shows a popover listing which features/signals fall in that bucket
- `computeColumnTallyDetail()` returns per-bucket feature lists (health + e2e dimensions) alongside the existing aggregate counts
- `TallyTrigger` wrapper handles hover-to-preview (200ms delay) + click-to-pin semantics with click-outside-to-close
- 16 new unit tests (6 for the data function, 10 for the popover component)

## Test plan

- [ ] Verify tally breakdown popover appears on hover/click of ✓/~/× counts
- [ ] Verify popover lists correct feature names per bucket
- [ ] Verify click-outside closes the popover
- [ ] Verify 0-count items show no interaction
- [ ] Run `npx vitest run src/components/__tests__/` — 110 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)