### PR TITLE
fix(showcase): replace sequenceIndex with toolCallId in D5 fixtures

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -28,7 +28,7 @@
     {
       "match": {
         "userMessage": "Show me a pie chart of revenue by category",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_render_pie_chart_001"
       },
       "response": {
         "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
@@ -36,8 +36,7 @@
     },
     {
       "match": {
-        "userMessage": "Show me a pie chart of revenue by category",
-        "sequenceIndex": 0
+        "userMessage": "Show me a pie chart of revenue by category"
       },
       "response": {
         "toolCalls": [
@@ -52,7 +51,7 @@
     {
       "match": {
         "userMessage": "Write me a haiku about nature",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_generate_haiku_001"
       },
       "response": {
         "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
@@ -60,8 +59,7 @@
     },
     {
       "match": {
-        "userMessage": "Write me a haiku about nature",
-        "sequenceIndex": 0
+        "userMessage": "Write me a haiku about nature"
       },
       "response": {
         "toolCalls": [
@@ -76,7 +74,7 @@
     {
       "match": {
         "userMessage": "Show me a profile card for Ada Lovelace",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_show_card_001"
       },
       "response": {
         "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
@@ -84,8 +82,7 @@
     },
     {
       "match": {
-        "userMessage": "Show me a profile card for Ada Lovelace",
-        "sequenceIndex": 0
+        "userMessage": "Show me a profile card for Ada Lovelace"
       },
       "response": {
         "toolCalls": [
@@ -100,7 +97,7 @@
     {
       "match": {
         "userMessage": "Issue a $50 refund to customer #12345",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_request_approval_001"
       },
       "response": {
         "content": "Approved — processing the $50 refund to customer #12345 now."
@@ -108,8 +105,7 @@
     },
     {
       "match": {
-        "userMessage": "Issue a $50 refund to customer #12345",
-        "sequenceIndex": 0
+        "userMessage": "Issue a $50 refund to customer #12345"
       },
       "response": {
         "toolCalls": [
@@ -124,7 +120,7 @@
     {
       "match": {
         "userMessage": "trip to mars",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_generate_steps_001"
       },
       "response": {
         "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
@@ -132,8 +128,7 @@
     },
     {
       "match": {
-        "userMessage": "trip to mars",
-        "sequenceIndex": 0
+        "userMessage": "trip to mars"
       },
       "response": {
         "toolCalls": [
@@ -148,7 +143,7 @@
     {
       "match": {
         "userMessage": "Book a 30-minute onboarding call for Alice",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_book_call_001"
       },
       "response": {
         "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
@@ -156,8 +151,7 @@
     },
     {
       "match": {
-        "userMessage": "Book a 30-minute onboarding call for Alice",
-        "sequenceIndex": 0
+        "userMessage": "Book a 30-minute onboarding call for Alice"
       },
       "response": {
         "toolCalls": [
@@ -172,7 +166,7 @@
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 3
+        "toolCallId": "call_d5_critique_agent_001"
       },
       "response": {
         "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
@@ -181,7 +175,7 @@
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 2
+        "toolCallId": "call_d5_writing_agent_001"
       },
       "response": {
         "toolCalls": [
@@ -196,7 +190,7 @@
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_research_agent_001"
       },
       "response": {
         "toolCalls": [
@@ -210,8 +204,7 @@
     },
     {
       "match": {
-        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 0
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary"
       },
       "response": {
         "toolCalls": [
@@ -226,7 +219,15 @@
     {
       "match": {
         "userMessage": "remember that my favorite color is blue",
-        "sequenceIndex": 0
+        "toolCallId": "call_d5_set_notes_001"
+      },
+      "response": {
+        "content": "Got it — I have noted that your favorite color is blue."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "remember that my favorite color is blue"
       },
       "response": {
         "toolCalls": [
@@ -240,15 +241,6 @@
     },
     {
       "match": {
-        "userMessage": "remember that my favorite color is blue",
-        "sequenceIndex": 1
-      },
-      "response": {
-        "content": "Got it — I have noted that your favorite color is blue."
-      }
-    },
-    {
-      "match": {
         "userMessage": "favorite color"
       },
       "response": {
@@ -258,7 +250,7 @@
     {
       "match": {
         "userMessage": "weather in Tokyo",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_get_weather_001"
       },
       "response": {
         "content": "Tokyo is 22°C and partly cloudy."
@@ -266,8 +258,7 @@
     },
     {
       "match": {
-        "userMessage": "weather in Tokyo",
-        "sequenceIndex": 0
+        "userMessage": "weather in Tokyo"
       },
       "response": {
         "toolCalls": [

--- a/showcase/harness/fixtures/d5/gen-ui-custom.json
+++ b/showcase/harness/fixtures/d5/gen-ui-custom.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). The fixture carries BOTH tool patterns keyed by different user messages so the probe script can branch on integrationSlug. Uses sequenceIndex matching instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixtures above sequenceIndex:0 fixtures to avoid infinite-loop re-matching.",
+  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). The fixture carries BOTH tool patterns keyed by different user messages so the probe script can branch on integrationSlug. Uses toolCallId matching: the toolCallId fixture is tried first; on the initial request (no tool result yet) it skips and the userMessage-only fixture matches. On the second request (tool result present) the toolCallId fixture matches.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Show me a pie chart of revenue by category",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_render_pie_chart_001"
       },
       "response": {
         "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
@@ -12,8 +12,7 @@
     },
     {
       "match": {
-        "userMessage": "Show me a pie chart of revenue by category",
-        "sequenceIndex": 0
+        "userMessage": "Show me a pie chart of revenue by category"
       },
       "response": {
         "toolCalls": [
@@ -28,7 +27,7 @@
     {
       "match": {
         "userMessage": "Write me a haiku about nature",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_generate_haiku_001"
       },
       "response": {
         "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
@@ -36,8 +35,7 @@
     },
     {
       "match": {
-        "userMessage": "Write me a haiku about nature",
-        "sequenceIndex": 0
+        "userMessage": "Write me a haiku about nature"
       },
       "response": {
         "toolCalls": [

--- a/showcase/harness/fixtures/d5/gen-ui-headless.json
+++ b/showcase/harness/fixtures/d5/gen-ui-headless.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/headless-simple against LangGraph Python (LGP). Headless gen-UI via the frontend-defined `show_card` tool (useComponent — see src/app/demos/headless-simple/page.tsx). The backend agent (src/agents/main.py) has no backend tools; the frontend injects show_card at runtime. The agent calls show_card with title+body; the frontend's headless chat surface renders the ShowCard component. After the tool result is appended (the headless surface synthesizes a tool result), the agent re-invokes the LLM — second-leg fixture matches by sequenceIndex. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching.",
+  "_comment": "D5 fixture for /demos/headless-simple against LangGraph Python (LGP). Headless gen-UI via the frontend-defined `show_card` tool (useComponent — see src/app/demos/headless-simple/page.tsx). The backend agent (src/agents/main.py) has no backend tools; the frontend injects show_card at runtime. The agent calls show_card with title+body; the frontend's headless chat surface renders the ShowCard component. After the tool result is appended (the headless surface synthesizes a tool result), the agent re-invokes the LLM — second-leg fixture matches by toolCallId. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Show me a profile card for Ada Lovelace",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_show_card_001"
       },
       "response": {
         "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
@@ -12,8 +12,7 @@
     },
     {
       "match": {
-        "userMessage": "Show me a profile card for Ada Lovelace",
-        "sequenceIndex": 0
+        "userMessage": "Show me a profile card for Ada Lovelace"
       },
       "response": {
         "toolCalls": [

--- a/showcase/harness/fixtures/d5/hitl-approve-deny.json
+++ b/showcase/harness/fixtures/d5/hitl-approve-deny.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl-in-app against LangGraph Python (LGP). Approve/deny HITL via the frontend-defined `request_user_approval` tool (see src/app/demos/hitl-in-app/page.tsx and src/agents/hitl_in_app.py). The agent calls request_user_approval; the frontend opens an out-of-chat modal; on approval the async handler resolves with {approved: true, reason: ...} and the tool result is appended back to the conversation. The agent then re-invokes the LLM — second-leg fixture matches on sequenceIndex. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. Per the system prompt the agent then issues a one-sentence acknowledgement, no further tool calls. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching (the user message has not changed across the agent loop).",
+  "_comment": "D5 fixture for /demos/hitl-in-app against LangGraph Python (LGP). Approve/deny HITL via the frontend-defined `request_user_approval` tool (see src/app/demos/hitl-in-app/page.tsx and src/agents/hitl_in_app.py). The agent calls request_user_approval; the frontend opens an out-of-chat modal; on approval the async handler resolves with {approved: true, reason: ...} and the tool result is appended back to the conversation. The agent then re-invokes the LLM — second-leg fixture matches on toolCallId. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Issue a $50 refund to customer #12345",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_request_approval_001"
       },
       "response": {
         "content": "Approved — processing the $50 refund to customer #12345 now."
@@ -12,8 +12,7 @@
     },
     {
       "match": {
-        "userMessage": "Issue a $50 refund to customer #12345",
-        "sequenceIndex": 0
+        "userMessage": "Issue a $50 refund to customer #12345"
       },
       "response": {
         "toolCalls": [

--- a/showcase/harness/fixtures/d5/hitl-steps.json
+++ b/showcase/harness/fixtures/d5/hitl-steps.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool. Uses sequenceIndex matching instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs.",
+  "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool. Uses toolCallId matching: toolCallId fixture tried first, skips on initial request (no tool result), matches on second request when tool result is present.",
   "fixtures": [
     {
       "match": {
         "userMessage": "trip to mars",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_generate_steps_001"
       },
       "response": {
         "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
@@ -12,8 +12,7 @@
     },
     {
       "match": {
-        "userMessage": "trip to mars",
-        "sequenceIndex": 0
+        "userMessage": "trip to mars"
       },
       "response": {
         "toolCalls": [

--- a/showcase/harness/fixtures/d5/hitl-text-input.json
+++ b/showcase/harness/fixtures/d5/hitl-text-input.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl-in-chat against LangGraph Python (LGP). Text-input HITL via the frontend-defined `book_call` tool (see src/app/demos/hitl-in-chat/page.tsx and src/agents/hitl_in_chat_agent.py). The agent calls book_call with topic and name; the frontend renders an inline time-picker card via useHumanInTheLoop; the user picks a slot and the value is sent back as the tool result; the agent re-invokes with that result and emits a short acknowledgement. We match the second leg by sequenceIndex because the user's original message has not changed. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching.",
+  "_comment": "D5 fixture for /demos/hitl-in-chat against LangGraph Python (LGP). Text-input HITL via the frontend-defined `book_call` tool (see src/app/demos/hitl-in-chat/page.tsx and src/agents/hitl_in_chat_agent.py). The agent calls book_call with topic and name; the frontend renders an inline time-picker card via useHumanInTheLoop; the user picks a slot and the value is sent back as the tool result; the agent re-invokes with that result and emits a short acknowledgement. We match the second leg by toolCallId. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Book a 30-minute onboarding call for Alice",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_book_call_001"
       },
       "response": {
         "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
@@ -12,8 +12,7 @@
     },
     {
       "match": {
-        "userMessage": "Book a 30-minute onboarding call for Alice",
-        "sequenceIndex": 0
+        "userMessage": "Book a 30-minute onboarding call for Alice"
       },
       "response": {
         "toolCalls": [

--- a/showcase/harness/fixtures/d5/mcp-subagents.json
+++ b/showcase/harness/fixtures/d5/mcp-subagents.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). The supervisor agent in src/agents/subagents.py exposes three sub-agents as tools — research_agent, writing_agent, critique_agent — with a delegations log in shared state. A typical chained run: supervisor calls research_agent → gets facts → calls writing_agent → gets a draft → calls critique_agent → gets a review → composes a final reply. Each delegation appends a Delegation entry to shared state which the UI renders live in DelegationLog. We model the chain as four sequential fixtures (one per turn through the agent loop) disambiguated by sequenceIndex. Uses sequenceIndex instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:3 → 2 → 1 → 0 so higher-index fixtures win on later loop iterations.",
+  "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). The supervisor agent in src/agents/subagents.py exposes three sub-agents as tools — research_agent, writing_agent, critique_agent — with a delegations log in shared state. A typical chained run: supervisor calls research_agent -> gets facts -> calls writing_agent -> gets a draft -> calls critique_agent -> gets a review -> composes a final reply. Each delegation appends a Delegation entry to shared state which the UI renders live in DelegationLog. We model the chain as four sequential fixtures disambiguated by toolCallId matching on the LAST tool message. ORDER: most-specific (critique) first, then writing, then research, then fallback (no toolCallId = initial request).",
   "fixtures": [
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 3
+        "toolCallId": "call_d5_critique_agent_001"
       },
       "response": {
         "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
@@ -13,7 +13,7 @@
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 2
+        "toolCallId": "call_d5_writing_agent_001"
       },
       "response": {
         "toolCalls": [
@@ -28,7 +28,7 @@
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_research_agent_001"
       },
       "response": {
         "toolCalls": [
@@ -42,8 +42,7 @@
     },
     {
       "match": {
-        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "sequenceIndex": 0
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary"
       },
       "response": {
         "toolCalls": [

--- a/showcase/harness/fixtures/d5/shared-state.json
+++ b/showcase/harness/fixtures/d5/shared-state.json
@@ -1,10 +1,18 @@
 {
-  "_comment": "D5 multi-turn fixture for /demos/shared-state-read-write. Demonstrates the agent-write half of bidirectional shared state: turn 1 the user asks the agent to remember something, the agent calls the backend `set_notes` tool which mutates shared state. After the tool result is appended, the agent re-invokes the LLM — we match that second leg via sequenceIndex (not toolCallId, because Gemini's function_response format doesn't preserve tool call IDs and aimock synthesizes provider-specific IDs that would not match a fixed string). Turn 2 the user asks the agent to recall what it remembered. The UI-write half (preferences via agent.setState) does not flow through the LLM, so it is not part of this fixture. ORDER: the two sequenced fixtures share the same userMessage; sequenceIndex=0 fires on the first match (tool call), sequenceIndex=1 fires on the second match (text response after tool result).",
+  "_comment": "D5 multi-turn fixture for /demos/shared-state-read-write. Demonstrates the agent-write half of bidirectional shared state: turn 1 the user asks the agent to remember something, the agent calls the backend `set_notes` tool which mutates shared state. After the tool result is appended, the agent re-invokes the LLM — we match that second leg via toolCallId on the last tool message. Turn 2 the user asks the agent to recall what it remembered. The UI-write half (preferences via agent.setState) does not flow through the LLM, so it is not part of this fixture. ORDER: toolCallId fixture first (tried first, skips when no tool result), then userMessage-only fallback.",
   "fixtures": [
     {
       "match": {
         "userMessage": "remember that my favorite color is blue",
-        "sequenceIndex": 0
+        "toolCallId": "call_d5_set_notes_001"
+      },
+      "response": {
+        "content": "Got it — I have noted that your favorite color is blue."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "remember that my favorite color is blue"
       },
       "response": {
         "toolCalls": [
@@ -14,15 +22,6 @@
             "arguments": "{\"notes\":[\"Favorite color: blue\"]}"
           }
         ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "remember that my favorite color is blue",
-        "sequenceIndex": 1
-      },
-      "response": {
-        "content": "Got it — I have noted that your favorite color is blue."
       }
     },
     {

--- a/showcase/harness/fixtures/d5/tool-rendering.json
+++ b/showcase/harness/fixtures/d5/tool-rendering.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). The frontend only registers get_weather, so the fixture returns a single tool call. Uses sequenceIndex matching instead of toolCallId because Gemini's functionResponse does not preserve tool call IDs. ORDER: sequenceIndex:1 fixture above sequenceIndex:0 fixture to avoid infinite-loop re-matching.",
+  "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). The frontend only registers get_weather, so the fixture returns a single tool call. Uses toolCallId matching: toolCallId fixture tried first, skips on initial request (no tool result), matches on second request when tool result is present. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
   "fixtures": [
     {
       "match": {
         "userMessage": "weather in Tokyo",
-        "sequenceIndex": 1
+        "toolCallId": "call_d5_get_weather_001"
       },
       "response": {
         "content": "Tokyo is 22°C and partly cloudy."
@@ -12,8 +12,7 @@
     },
     {
       "match": {
-        "userMessage": "weather in Tokyo",
-        "sequenceIndex": 0
+        "userMessage": "weather in Tokyo"
       },
       "response": {
         "toolCalls": [


### PR DESCRIPTION
## Summary

- Replaced `sequenceIndex` (stateful server-global counter) with `toolCallId` (stateless per-request matching) across all 9 D5 aimock fixture files
- Reordered fixtures so `toolCallId`-bearing fixtures appear before `userMessage`-only fallbacks (first-match-wins)
- Fixes the root cause of 9 integrations failing hitl-steps in e2e-deep probes: the shared `__default__` testId counter made fixture pairs unreachable after one successful match across concurrent integrations

## Why

The `sequenceIndex` matching in aimock uses a server-global counter keyed to `__default__` testId. When multiple showcase integrations hit the same aimock instance concurrently (as D5 probes do), the counter increments non-deterministically. The sibling increment logic in `journal.ts` makes both fixtures in a pair unreachable after one integration successfully matches — causing all subsequent integrations to fall through to plain LLM responses instead of fixture-controlled tool calls.

`toolCallId` matching is stateless: it checks the `tool_call_id` on the last `role: "tool"` message in the conversation. No counters, concurrent-safe, restart-safe.

## Test plan

- [x] All 9 JSON files validate as parseable
- [x] Zero `sequenceIndex` references remain in showcase/
- [x] 11 `toolCallId` values cross-verified against response `toolCalls[].id`
- [x] Fixture ordering correct (toolCallId before fallback in each group)
- [x] d5-all.json matches concatenation of 8 source files
- [ ] Deploy showcase-harness, trigger e2e-deep probe, confirm pass rate improvement