### PR TITLE
fix: TallyTrigger hydration mismatch causing production crash

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/tally-breakdown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/tally-breakdown.test.tsx
@@ -31,15 +31,18 @@ describe("TallyTrigger", () => {
     vi.useRealTimers();
   });
 
-  it("renders children without button wrapper when items is empty", () => {
-    const { getByText, queryByRole } = render(
+  it("renders children inside inert button wrapper when items is empty", () => {
+    const { getByText, getByTestId } = render(
       <TallyTrigger items={[]} tone="green">
         <span>✓ 5</span>
       </TallyTrigger>,
     );
 
     expect(getByText("✓ 5")).toBeInTheDocument();
-    expect(queryByRole("button")).not.toBeInTheDocument();
+    // Always renders same DOM structure (div > button) to avoid hydration mismatch
+    const trigger = getByTestId("tally-trigger-green");
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.className).not.toContain("cursor-pointer");
   });
 
   it("renders button wrapper when items are provided", () => {
@@ -125,15 +128,16 @@ describe("TallyTrigger", () => {
   });
 
   it("does not open popover on click when items is empty", () => {
-    const { getByText, queryByTestId, queryByRole } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <TallyTrigger items={[]} tone="red">
         <span>✗ 0</span>
       </TallyTrigger>,
     );
 
-    // No button wrapper, so nothing to click for opening
     expect(getByText("✗ 0")).toBeInTheDocument();
-    expect(queryByRole("button")).not.toBeInTheDocument();
+    // Button wrapper exists (stable DOM) but clicking does not open popover
+    const trigger = getByTestId("tally-trigger-red");
+    fireEvent.click(trigger);
     expect(queryByTestId("tally-popover")).not.toBeInTheDocument();
   });
 

--- a/showcase/shell-dashboard/src/components/tally-breakdown.tsx
+++ b/showcase/shell-dashboard/src/components/tally-breakdown.tsx
@@ -106,12 +106,10 @@ export function TallyTrigger({ items, tone, children }: TallyTriggerProps) {
   // Cleanup timers on unmount
   useEffect(() => clearTimers, [clearTimers]);
 
-  // No interaction when there are no items
-  if (items.length === 0) {
-    return <>{children}</>;
-  }
+  const hasItems = items.length > 0;
 
   const handleClick = () => {
+    if (!hasItems) return;
     clearTimers();
     if (open && pinned.current) {
       // Click again while pinned → close
@@ -125,6 +123,7 @@ export function TallyTrigger({ items, tone, children }: TallyTriggerProps) {
   };
 
   const handleMouseEnter = () => {
+    if (!hasItems) return;
     if (leaveTimeout.current) {
       clearTimeout(leaveTimeout.current);
       leaveTimeout.current = null;
@@ -137,6 +136,7 @@ export function TallyTrigger({ items, tone, children }: TallyTriggerProps) {
   };
 
   const handleMouseLeave = () => {
+    if (!hasItems) return;
     if (hoverTimeout.current) {
       clearTimeout(hoverTimeout.current);
       hoverTimeout.current = null;
@@ -165,12 +165,12 @@ export function TallyTrigger({ items, tone, children }: TallyTriggerProps) {
       <button
         type="button"
         data-testid={`tally-trigger-${tone}`}
-        className="cursor-pointer bg-transparent border-none p-0 inline-flex"
+        className={`bg-transparent border-none p-0 inline-flex${hasItems ? " cursor-pointer" : ""}`}
         onClick={handleClick}
       >
         {children}
       </button>
-      {open && (
+      {open && hasItems && (
         <TallyBreakdownPopover
           items={items}
           tone={tone}


### PR DESCRIPTION
## Summary
- Remove conditional early return in `TallyTrigger` that rendered different DOM structures on server vs client (bare `<>{children}</>` vs `<div><button>{children}</button></div>`)
- All hooks now run unconditionally; interaction is disabled via guards when items array is empty
- Fixes React errors #418 (hydration mismatch) and #310 (fewer hooks rendered) that crash the dashboard on load

## Test plan
- [x] 10 existing tally-breakdown tests pass (updated for always-wrapper behavior)
- [ ] Dashboard loads without crash at `#matrix:depth,health`
- [ ] Tally breakdown tooltips work on hover/click for non-empty buckets