### PR TITLE
chore: encourage maintainer edits in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,3 +34,4 @@ Happy contributing!
 
 - [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
 - [ ] If the PR changes or adds functionality, I have updated the relevant documentation
+- [ ] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)


### PR DESCRIPTION
## Summary

Adds a checklist item to the PR template reminding contributors to keep "Allow edits by maintainers" checked. This lets us push fixes directly to contributor PRs instead of going back and forth in review comments.

## Test plan

- [x] Template renders correctly on new PR creation