### PR TITLE
fix(showcase): showcase-harness build + test fixes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,7 +463,7 @@ importers:
         version: 0.1.13
       eslint-config-next:
         specifier: ^15.0.2
-        version: 15.4.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+        version: 15.4.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       flowtoken:
         specifier: ^1.0.40
         version: 1.0.40(@types/react@19.2.7)(react@19.2.3)
@@ -2926,6 +2926,9 @@ importers:
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
       croner:
         specifier: ^9.0.0
         version: 9.1.0
@@ -12419,6 +12422,10 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -25635,6 +25642,11 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.39.2(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -32419,16 +32431,16 @@ snapshots:
       '@types/node': 22.19.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 7.2.0
-      '@typescript-eslint/type-utils': 7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -32455,14 +32467,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -32503,12 +32515,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -32561,15 +32573,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+  '@typescript-eslint/utils@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
@@ -32790,6 +32802,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@18.19.130)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@20.19.27)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@20.19.27)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.11)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -33451,6 +33471,14 @@ snapshots:
   axios@1.15.2(debug@4.3.2):
     dependencies:
       follow-redirects: 1.15.11(debug@4.3.2)
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.15.2(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -34306,6 +34334,8 @@ snapshots:
   commander@11.1.0: {}
 
   commander@13.1.0: {}
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -35769,19 +35799,19 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@15.4.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2):
+  eslint-config-next@15.4.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2):
     dependencies:
       '@next/eslint-plugin-next': 15.4.4
       '@rushstack/eslint-patch': 1.15.0
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@1.21.7))
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -35832,29 +35862,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -35869,7 +35899,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -35878,9 +35908,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -35892,7 +35922,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -35927,6 +35957,25 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.2(jiti@1.21.7)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 10.2.4
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
@@ -35946,9 +35995,9 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.2(jiti@1.21.7)
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -35960,6 +36009,28 @@ snapshots:
       zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.2
+      eslint: 9.39.2(jiti@1.21.7)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 10.2.4
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -36044,6 +36115,47 @@ snapshots:
       optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.2(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.2
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 10.2.4
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
     transitivePeerDependencies:
       - supports-color
 
@@ -37694,7 +37806,7 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 18.19.130
       '@types/tough-cookie': 4.0.5
-      axios: 1.15.2(debug@4.3.2)
+      axios: 1.15.2(debug@4.4.3)
       camelcase: 6.3.0
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.6.1
@@ -37704,7 +37816,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.15.2(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.15.2)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -43041,7 +43153,7 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  retry-axios@2.6.0(axios@1.15.2(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.15.2):
     dependencies:
       axios: 1.15.2(debug@4.3.2)
 
@@ -45739,7 +45851,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@18.19.130)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@20.19.27)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/showcase/harness/package.json
+++ b/showcase/harness/package.json
@@ -19,6 +19,7 @@
     "@aws-sdk/client-s3": "^3.710.0",
     "@hono/node-server": "^1.14.0",
     "chokidar": "^4.0.3",
+    "commander": "^14.0.3",
     "croner": "^9.0.0",
     "hono": "^4.6.0",
     "js-yaml": "^4.1.0",

--- a/showcase/harness/src/alerts/render-red-tick.test.ts
+++ b/showcase/harness/src/alerts/render-red-tick.test.ts
@@ -55,7 +55,6 @@ function ctx(partial: Partial<TemplateContext>): TemplateContext {
 }
 
 const YAMLS = [
-  "smoke-red-tick.yml",
   "agent-red-tick.yml",
   "chat-red-tick.yml",
   "tools-red-tick.yml",
@@ -116,36 +115,6 @@ describe("red-tick YAML rendering — Items 2 & 3", () => {
     });
   });
 
-  // Smoke has the only dimension with `signal.links.*` references — verify
-  // the present-link path emits the expected Slack-link shape after the guard
-  // wrap.
-  it("smoke: renders_link_when_present — <url|label> shape preserved", () => {
-    const text = loadTemplate("smoke-red-tick.yml");
-    const r = createRenderer();
-    const flags = { ...emptyTriggerFlags(), green_to_red: true };
-    const out = r.render(
-      { text },
-      ctx({
-        trigger: flags,
-        signal: {
-          slug: "mastra",
-          failCount: 1,
-          errorDesc: "http 503",
-          firstFailureAt: "2026-04-20T00:00:00Z",
-          url: "https://example.test/smoke",
-        },
-      }),
-    );
-    const rendered = String(out.payload.text);
-    // A3: smoke template now references `signal.url` directly (driver signal
-    // has no `links` object). Render label "endpoint" since the linked URL is
-    // the smoke endpoint that was actually probed.
-    expect(rendered).toContain("<https://example.test/smoke|endpoint>");
-    // Guard-wrap must not introduce empty/dangling artifacts even with links
-    // present.
-    expect(rendered).not.toMatch(/<\|/);
-  });
-
   // A2: the dashboard Run link must be wrapped in a `{{#event.runId}}…{{/event.runId}}`
   // section so a missing runId doesn't render a broken `/runs/|Run` link every
   // alert. Parametrize across all 4 red-tick YAMLs.
@@ -197,29 +166,4 @@ describe("red-tick YAML rendering — Items 2 & 3", () => {
     });
   });
 
-  // A3: the smoke template historically referenced `signal.links.smoke` /
-  // `signal.links.health` — the DRIVER signal (probes/drivers/liveness.ts) has
-  // `slug, url, status, errorDesc, latencyMs` and no `links` object, so those
-  // section-guards were always empty. The template should pull `signal.url`
-  // directly and render an "endpoint" link.
-  it("smoke: renders_endpoint_link_from_signal_url (A3)", () => {
-    const text = loadTemplate("smoke-red-tick.yml");
-    const r = createRenderer();
-    const flags = { ...emptyTriggerFlags(), green_to_red: true };
-    const out = r.render(
-      { text },
-      ctx({
-        trigger: flags,
-        signal: {
-          slug: "mastra",
-          failCount: 1,
-          errorDesc: "http 503",
-          firstFailureAt: "2026-04-20T00:00:00Z",
-          url: "https://starter.example/smoke",
-        },
-      }),
-    );
-    const rendered = String(out.payload.text);
-    expect(rendered).toContain("<https://starter.example/smoke|endpoint>");
-  });
 });

--- a/showcase/harness/src/cli/targets.ts
+++ b/showcase/harness/src/cli/targets.ts
@@ -44,6 +44,7 @@ export interface SmokeInput {
   name: string;
   publicUrl: string;
   shape: "package";
+  [k: string]: unknown;
 }
 
 /**
@@ -59,6 +60,7 @@ export interface ChatToolsInput {
   name: string;
   demos: string[];
   shape: "package";
+  [k: string]: unknown;
 }
 
 /**

--- a/showcase/harness/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.test.ts
@@ -336,7 +336,12 @@ describe("e2e-deep driver", () => {
     expect(fsig.failure_turn).toBe(1);
     expect(fsig.errorClass).toBe("conversation-error");
     expect(fsig.errorDesc).toMatch(/timeout/i);
-  });
+    // Timeout budget: fillAndVerifySend retries up to
+    // SEND_VERIFY_MAX_ATTEMPTS (3) × (SEND_VERIFY_INITIAL_DELAY_MS +
+    // remaining poll window) ≈ 6s when stallEvaluate prevents the user
+    // message count from growing, plus the 200ms responseTimeoutMs
+    // deadline. 15s absorbs CI variance without masking real hangs.
+  }, 15_000);
 
   it("emits red with goto-error when navigation fails", async () => {
     registerD5Script(

--- a/showcase/harness/src/rules/rule-loader.test.ts
+++ b/showcase/harness/src/rules/rule-loader.test.ts
@@ -14,7 +14,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES = path.resolve(__dirname, "../../test/fixtures/rules");
 
 describe("rule-loader: valid fixtures", () => {
-  it("loads smoke-red-tick.yml with merged defaults + escalation + guards", async () => {
+  it("loads agent-red-tick.yml with merged defaults + escalation + guards", async () => {
     const loader = createRuleLoader({
       dir: path.join(FIXTURES, "valid"),
       logger,
@@ -22,7 +22,7 @@ describe("rule-loader: valid fixtures", () => {
     const rules = await loader.load();
     expect(rules).toHaveLength(1);
     const r = rules[0]!;
-    expect(r.id).toBe("smoke-red-tick");
+    expect(r.id).toBe("agent-red-tick");
     expect(r.severity).toBe("warn");
     expect(r.stringTriggers).toEqual([
       "green_to_red",
@@ -579,8 +579,8 @@ describe("rule-loader: invalid fixtures (skipped, not fatal)", () => {
       path.join(tmp, "_defaults.yml"),
     );
     await fs.copyFile(
-      path.join(FIXTURES, "valid", "smoke-red-tick.yml"),
-      path.join(tmp, "smoke-red-tick.yml"),
+      path.join(FIXTURES, "valid", "agent-red-tick.yml"),
+      path.join(tmp, "agent-red-tick.yml"),
     );
     // Drop a broken file alongside.
     await fs.copyFile(
@@ -590,7 +590,7 @@ describe("rule-loader: invalid fixtures (skipped, not fatal)", () => {
     const loader = createRuleLoader({ dir: tmp, logger });
     const { rules, errors } = await loader.loadWithErrors();
     expect(rules).toHaveLength(1);
-    expect(rules[0]!.id).toBe("smoke-red-tick");
+    expect(rules[0]!.id).toBe("agent-red-tick");
     expect(errors).toHaveLength(1);
     expect(errors[0]!.file).toBe("missing-id.yml");
   });
@@ -612,8 +612,8 @@ describe("rule-loader: reload error propagation", () => {
       path.join(tmp, "_defaults.yml"),
     );
     await fs.copyFile(
-      path.join(FIXTURES, "valid", "smoke-red-tick.yml"),
-      path.join(tmp, "smoke-red-tick.yml"),
+      path.join(FIXTURES, "valid", "agent-red-tick.yml"),
+      path.join(tmp, "agent-red-tick.yml"),
     );
     await fs.copyFile(
       path.join(FIXTURES, "invalid", "missing-id.yml"),
@@ -621,7 +621,7 @@ describe("rule-loader: reload error propagation", () => {
     );
     const loader = createRuleLoader({ dir: tmp, logger });
     const { rules, errors } = await loader.loadWithErrors();
-    expect(rules.map((r) => r.id)).toEqual(["smoke-red-tick"]);
+    expect(rules.map((r) => r.id)).toEqual(["agent-red-tick"]);
     expect(errors.map((e) => e.file)).toEqual(["missing-id.yml"]);
   });
 
@@ -1418,108 +1418,6 @@ describe("rule-loader + renderer: full YAML contract coverage", () => {
     });
   });
 
-  // ---- smoke-red-tick.yml -------------------------------------------
-  describe("smoke-red-tick", () => {
-    it("green_to_red branch renders slug, errorDesc and endpoint link", async () => {
-      const { rules, errors, renderer } = await loadRealRules();
-      expect(
-        errors.find((e) => e.file.startsWith("smoke-red-tick")),
-      ).toBeUndefined();
-      const rule = rules.find((r) => r.id === "smoke-red-tick");
-      expect(rule).toBeDefined();
-      expect(rule!.stringTriggers).toEqual([
-        "green_to_red",
-        "sustained_red",
-        "red_to_green",
-      ]);
-      const ctx = makeCtx(
-        rule!,
-        {
-          slug: "coagents-starter",
-          errorDesc: "http 503",
-          // A3: driver signal carries `url` (endpoint that was probed)
-          // instead of a `links` object — the template now renders a single
-          // endpoint link rather than separate smoke/health pair.
-          url: "https://svc.example/smoke",
-          failCount: 1,
-        },
-        { trigger: { green_to_red: true, isRedTick: true } },
-      );
-      const text = (
-        renderer.render({ text: rule!.template!.text }, ctx).payload as {
-          text: string;
-        }
-      ).text;
-      expect(text).toContain("coagents-starter");
-      expect(text).toContain("down, error: http 503");
-      // Triple-brace signal.url (marked slackSafe in LIVENESS_SLACK_SAFE_FIELDS)
-      // preserves the raw URL inside `<URL|label>` Slack link markup; prior
-      // double-brace would HTML-escape `/` → `&#x2F;` and break the link at
-      // Slack render time.
-      expect(text).toContain("<https://svc.example/smoke|endpoint>");
-    });
-
-    it("sustained_red branch renders failCount (attempt: N) and error", async () => {
-      const { rules, renderer } = await loadRealRules();
-      const rule = rules.find((r) => r.id === "smoke-red-tick")!;
-      const ctx = makeCtx(
-        rule,
-        {
-          slug: "mastra-starter",
-          errorDesc: "timeout after 15000ms",
-          // A3: endpoint URL lives under `signal.url` now.
-          url: "https://m.example/smoke",
-          failCount: 3,
-        },
-        { trigger: { sustained_red: true, isRedTick: true } },
-      );
-      const text = (
-        renderer.render({ text: rule.template!.text }, ctx).payload as {
-          text: string;
-        }
-      ).text;
-      expect(text).toContain("mastra-starter");
-      expect(text).toContain("attempt: 3");
-      expect(text).toContain("timeout after 15000ms");
-    });
-
-    it("red_to_green branch renders recovery + firstFailureAt", async () => {
-      const { rules, renderer } = await loadRealRules();
-      const rule = rules.find((r) => r.id === "smoke-red-tick")!;
-      const ctx = makeCtx(
-        rule,
-        {
-          slug: "langgraph-starter",
-          firstFailureAt: "2026-04-19T23:00:00Z",
-        },
-        { trigger: { red_to_green: true } },
-      );
-      const text = (
-        renderer.render({ text: rule.template!.text }, ctx).payload as {
-          text: string;
-        }
-      ).text;
-      expect(text).toContain("langgraph-starter");
-      expect(text).toContain("recovered");
-      expect(text).toContain("was down since 2026-04-19T23:00:00Z");
-    });
-
-    it("fleet rule owns <!channel> escalation (migrated from per-service red-tick)", async () => {
-      // Plan Item 4: <!channel> moved off smoke-red-tick onto smoke-red-fleet.
-      // The per-service rule still fires per-match via its own targets; the
-      // fleet rule is the single pager for cross-service outages. Per-service
-      // red-tick template must NOT contain <!channel>; fleet rule template
-      // MUST. Both invariants asserted together so a future refactor can't
-      // silently drop one without the other surfacing.
-      const { rules } = await loadRealRules();
-      const perService = rules.find((r) => r.id === "smoke-red-tick")!;
-      const fleet = rules.find((r) => r.id === "smoke-red-fleet")!;
-      expect(perService.template!.text).not.toContain("<!channel>");
-      expect(fleet.aggregation).toBeDefined();
-      expect(fleet.aggregation!.template).toContain("<!channel>");
-    });
-  });
-
   // ---- deploy-result.yml (remaining branches R20 didn't cover) ------
   describe("deploy-result (R20 follow-up branches)", () => {
     it("green_to_red partial branch renders failed/succeeded lists", async () => {
@@ -1680,8 +1578,8 @@ describe("rule-loader: initial load emits rules.reload.failed on errors (R24 buc
       path.join(tmp, "_defaults.yml"),
     );
     await fs.copyFile(
-      path.join(FIXTURES, "valid", "smoke-red-tick.yml"),
-      path.join(tmp, "smoke-red-tick.yml"),
+      path.join(FIXTURES, "valid", "agent-red-tick.yml"),
+      path.join(tmp, "agent-red-tick.yml"),
     );
     // One malformed rule (missing id, fails schema).
     await fs.copyFile(
@@ -1707,7 +1605,7 @@ describe("rule-loader: initial load emits rules.reload.failed on errors (R24 buc
 
     // Good rule still loads.
     expect(rules).toHaveLength(1);
-    expect(rules[0]!.id).toBe("smoke-red-tick");
+    expect(rules[0]!.id).toBe("agent-red-tick");
     // Bad rule surfaces via errors.
     expect(errors).toHaveLength(1);
     expect(errors[0]!.file).toBe("missing-id.yml");

--- a/showcase/harness/test/fixtures/rules/valid/agent-red-tick.yml
+++ b/showcase/harness/test/fixtures/rules/valid/agent-red-tick.yml
@@ -1,0 +1,36 @@
+id: agent-red-tick
+name: "Starter agent reachability failing"
+owner: "@oss"
+
+signal:
+  dimension: agent
+
+triggers:
+  - green_to_red
+  - sustained_red
+  - red_to_green
+
+conditions:
+  escalations:
+    - whenFailCount: 4
+      mention: "!channel"
+      severity: critical
+  guards:
+    - minDeployAgeMin: 20
+  rate_limit:
+    perKey: "{{signal.slug}}:{{triggerName}}"
+    window: 15m
+  suppress:
+    when: 'trigger == "sustained_red" && lastAlertAgeMin < 15'
+
+targets:
+  - kind: slack_webhook
+    webhook: oss_alerts
+
+template:
+  text: |
+    {{#trigger.green_to_red}}:red_circle: *{{signal.slug}}* — agent unreachable, error: {{signal.errorDesc}}{{/trigger.green_to_red}}
+    {{#trigger.sustained_red}}:red_circle: *{{signal.slug}}* — agent attempt: {{signal.failCount}}, error: {{signal.errorDesc}}{{/trigger.sustained_red}}
+    {{#trigger.red_to_green}}:white_check_mark: *{{signal.slug}}* agent recovered (was down since {{signal.firstFailureAt}}){{/trigger.red_to_green}}
+
+    <{{env.dashboardUrl}}|Showcase>{{#event.runId}} · <{{env.dashboardUrl}}/runs/{{event.runId}}|Run>{{/event.runId}}


### PR DESCRIPTION
## Summary
- Add missing `commander` dependency to showcase-harness
- Fix CLI runner type alignment with renamed driver input schemas (SmokeInput, ChatToolsInput)
- Fix 16 pre-existing test failures from smoke-red-tick.yml deletion in #4388
- Fix e2e-deep test timeout (5s → 15s for stall-evaluate retry pattern)

## Test plan
- [x] `tsc -p tsconfig.build.json` passes
- [x] 1316/1316 tests pass locally (0 failures)