### PR TITLE
fix(showcase): migrate D5 fixtures from toolCallId to turnIndex

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Bundled D5 (e2e-deep) fixtures. Source files: showcase/harness/fixtures/d5/*.json. Loaded by aimock before feature-parity.json for match precedence.",
+  "_comment": "Bundled D5 (e2e-deep) fixtures. Source files: showcase/harness/fixtures/d5/*.json. Uses turnIndex matching for multi-turn disambiguation. Loaded by aimock before feature-parity.json for match precedence.",
   "fixtures": [
     {
       "match": {
@@ -28,15 +28,7 @@
     {
       "match": {
         "userMessage": "Show me a pie chart of revenue by category",
-        "toolCallId": "call_d5_render_pie_chart_001"
-      },
-      "response": {
-        "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Show me a pie chart of revenue by category"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -50,16 +42,17 @@
     },
     {
       "match": {
-        "userMessage": "Write me a haiku about nature",
-        "toolCallId": "call_d5_generate_haiku_001"
+        "userMessage": "Show me a pie chart of revenue by category",
+        "turnIndex": 1
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
       }
     },
     {
       "match": {
-        "userMessage": "Write me a haiku about nature"
+        "userMessage": "Write me a haiku about nature",
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -73,16 +66,17 @@
     },
     {
       "match": {
-        "userMessage": "Show me a profile card for Ada Lovelace",
-        "toolCallId": "call_d5_show_card_001"
+        "userMessage": "Write me a haiku about nature",
+        "turnIndex": 1
       },
       "response": {
-        "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
+        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
       }
     },
     {
       "match": {
-        "userMessage": "Show me a profile card for Ada Lovelace"
+        "userMessage": "Show me a profile card for Ada Lovelace",
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -96,16 +90,17 @@
     },
     {
       "match": {
-        "userMessage": "Issue a $50 refund to customer #12345",
-        "toolCallId": "call_d5_request_approval_001"
+        "userMessage": "Show me a profile card for Ada Lovelace",
+        "turnIndex": 1
       },
       "response": {
-        "content": "Approved — processing the $50 refund to customer #12345 now."
+        "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
       }
     },
     {
       "match": {
-        "userMessage": "Issue a $50 refund to customer #12345"
+        "userMessage": "Issue a $50 refund to customer #12345",
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -119,16 +114,17 @@
     },
     {
       "match": {
-        "userMessage": "trip to mars",
-        "toolCallId": "call_d5_generate_steps_001"
+        "userMessage": "Issue a $50 refund to customer #12345",
+        "turnIndex": 1
       },
       "response": {
-        "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
+        "content": "Approved — processing the $50 refund to customer #12345 now."
       }
     },
     {
       "match": {
-        "userMessage": "trip to mars"
+        "userMessage": "trip to mars",
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -142,16 +138,17 @@
     },
     {
       "match": {
-        "userMessage": "Book a 30-minute onboarding call for Alice",
-        "toolCallId": "call_d5_book_call_001"
+        "userMessage": "trip to mars",
+        "turnIndex": 1
       },
       "response": {
-        "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
+        "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
       }
     },
     {
       "match": {
-        "userMessage": "Book a 30-minute onboarding call for Alice"
+        "userMessage": "Book a 30-minute onboarding call for Alice",
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -165,17 +162,47 @@
     },
     {
       "match": {
-        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "toolCallId": "call_d5_critique_agent_001"
+        "userMessage": "Book a 30-minute onboarding call for Alice",
+        "turnIndex": 1
       },
       "response": {
-        "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
+        "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
       }
     },
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "toolCallId": "call_d5_writing_agent_001"
+        "turnIndex": 0
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_research_agent_001",
+            "name": "research_agent",
+            "arguments": "{\"topic\":\"Benefits of remote work\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "turnIndex": 1
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_writing_agent_001",
+            "name": "writing_agent",
+            "arguments": "{\"brief\":\"One-paragraph summary on the benefits of remote work, grounded in the research facts.\",\"facts\":\"- Eliminates commute, returning ~10 hours per week\\n- Higher reported job satisfaction in repeated surveys\\n- Wider talent pool for employers, no geographic limit\\n- Reduced office overhead\\n- Trade-offs: collaboration, mentorship, cultural cohesion\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "turnIndex": 2
       },
       "response": {
         "toolCalls": [
@@ -190,44 +217,16 @@
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "toolCallId": "call_d5_research_agent_001"
+        "turnIndex": 3
       },
       "response": {
-        "toolCalls": [
-          {
-            "id": "call_d5_writing_agent_001",
-            "name": "writing_agent",
-            "arguments": "{\"brief\":\"One-paragraph summary on the benefits of remote work, grounded in the research facts.\",\"facts\":\"- Eliminates commute, returning ~10 hours per week\\n- Higher reported job satisfaction in repeated surveys\\n- Wider talent pool for employers, no geographic limit\\n- Reduced office overhead\\n- Trade-offs: collaboration, mentorship, cultural cohesion\"}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d5_research_agent_001",
-            "name": "research_agent",
-            "arguments": "{\"topic\":\"Benefits of remote work\"}"
-          }
-        ]
+        "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
       }
     },
     {
       "match": {
         "userMessage": "remember that my favorite color is blue",
-        "toolCallId": "call_d5_set_notes_001"
-      },
-      "response": {
-        "content": "Got it — I have noted that your favorite color is blue."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "remember that my favorite color is blue"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -241,6 +240,15 @@
     },
     {
       "match": {
+        "userMessage": "remember that my favorite color is blue",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Got it — I have noted that your favorite color is blue."
+      }
+    },
+    {
+      "match": {
         "userMessage": "favorite color"
       },
       "response": {
@@ -250,15 +258,7 @@
     {
       "match": {
         "userMessage": "weather in Tokyo",
-        "toolCallId": "call_d5_get_weather_001"
-      },
-      "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "weather in Tokyo"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -268,6 +268,15 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "weather in Tokyo",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/gen-ui-custom.json
+++ b/showcase/harness/fixtures/d5/gen-ui-custom.json
@@ -1,18 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). The fixture carries BOTH tool patterns keyed by different user messages so the probe script can branch on integrationSlug. Uses toolCallId matching: the toolCallId fixture is tried first; on the initial request (no tool result yet) it skips and the userMessage-only fixture matches. On the second request (tool result present) the toolCallId fixture matches.",
+  "_comment": "D5 fixture for /demos/gen-ui-tool-based. Two integration families: (1) langgraph-python registers render_pie_chart via useComponent (PieChart SVG donut); (2) all other integrations register generate_haiku via useFrontendTool (HaikuCard div). Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered 0→N for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Show me a pie chart of revenue by category",
-        "toolCallId": "call_d5_render_pie_chart_001"
-      },
-      "response": {
-        "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Show me a pie chart of revenue by category"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -26,16 +18,17 @@
     },
     {
       "match": {
-        "userMessage": "Write me a haiku about nature",
-        "toolCallId": "call_d5_generate_haiku_001"
+        "userMessage": "Show me a pie chart of revenue by category",
+        "turnIndex": 1
       },
       "response": {
-        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
+        "content": "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books."
       }
     },
     {
       "match": {
-        "userMessage": "Write me a haiku about nature"
+        "userMessage": "Write me a haiku about nature",
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -45,6 +38,15 @@
             "arguments": "{\"japanese\":[\"古池や\",\"蛙飛び込む\",\"水の音\"],\"english\":[\"An old silent pond\",\"A frog jumps into the pond\",\"Splash! Silence again.\"],\"image_name\":\"Mount_Fuji_Lake_Reflection_Cherry_Blossoms_Sakura_Spring.jpg\",\"gradient\":\"linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Write me a haiku about nature",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Haiku generated above — a beautiful verse about nature with an accompanying image."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/gen-ui-headless.json
+++ b/showcase/harness/fixtures/d5/gen-ui-headless.json
@@ -1,18 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/headless-simple against LangGraph Python (LGP). Headless gen-UI via the frontend-defined `show_card` tool (useComponent — see src/app/demos/headless-simple/page.tsx). The backend agent (src/agents/main.py) has no backend tools; the frontend injects show_card at runtime. The agent calls show_card with title+body; the frontend's headless chat surface renders the ShowCard component. After the tool result is appended (the headless surface synthesizes a tool result), the agent re-invokes the LLM — second-leg fixture matches by toolCallId. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
+  "_comment": "D5 fixture for /demos/headless-simple against LangGraph Python (LGP). Headless gen-UI via the frontend-defined `show_card` tool (useComponent — see src/app/demos/headless-simple/page.tsx). Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered 0→N for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Show me a profile card for Ada Lovelace",
-        "toolCallId": "call_d5_show_card_001"
-      },
-      "response": {
-        "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Show me a profile card for Ada Lovelace"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -22,6 +14,15 @@
             "arguments": "{\"title\":\"Ada Lovelace\",\"body\":\"English mathematician (1815\\u20131852), credited as the first computer programmer for her notes on Charles Babbage's Analytical Engine \\u2014 including what is now recognized as the first algorithm intended to be carried out by a machine.\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Show me a profile card for Ada Lovelace",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Here is a quick card for Ada Lovelace — the rendered card above shows a short biography. Let me know if you want a deeper dive on her work or a different historical figure."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/hitl-approve-deny.json
+++ b/showcase/harness/fixtures/d5/hitl-approve-deny.json
@@ -1,18 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl-in-app against LangGraph Python (LGP). Approve/deny HITL via the frontend-defined `request_user_approval` tool (see src/app/demos/hitl-in-app/page.tsx and src/agents/hitl_in_app.py). The agent calls request_user_approval; the frontend opens an out-of-chat modal; on approval the async handler resolves with {approved: true, reason: ...} and the tool result is appended back to the conversation. The agent then re-invokes the LLM — second-leg fixture matches on toolCallId. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
+  "_comment": "D5 fixture for /demos/hitl-in-app against LangGraph Python (LGP). Approve/deny HITL via the frontend-defined `request_user_approval` tool. Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered 0→N for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Issue a $50 refund to customer #12345",
-        "toolCallId": "call_d5_request_approval_001"
-      },
-      "response": {
-        "content": "Approved — processing the $50 refund to customer #12345 now."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Issue a $50 refund to customer #12345"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -22,6 +14,15 @@
             "arguments": "{\"message\":\"Issue a $50 refund to customer #12345.\",\"context\":\"Per the standard goodwill-credit policy for shipping delays.\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Issue a $50 refund to customer #12345",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Approved — processing the $50 refund to customer #12345 now."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/hitl-steps.json
+++ b/showcase/harness/fixtures/d5/hitl-steps.json
@@ -1,18 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool. Uses toolCallId matching: toolCallId fixture tried first, skips on initial request (no tool result), matches on second request when tool result is present.",
+  "_comment": "D5 fixture for /demos/hitl — step selection via generate_task_steps frontend tool. Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered 0→N for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "trip to mars",
-        "toolCallId": "call_d5_generate_steps_001"
-      },
-      "response": {
-        "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "trip to mars"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -22,6 +14,15 @@
             "arguments": "{\"steps\":[{\"description\":\"Research Mars mission requirements and timeline\",\"status\":\"enabled\"},{\"description\":\"Design spacecraft and life support systems\",\"status\":\"enabled\"},{\"description\":\"Recruit and train the crew\",\"status\":\"enabled\"},{\"description\":\"Launch and navigate to Mars\",\"status\":\"enabled\"},{\"description\":\"Land and establish base camp\",\"status\":\"enabled\"}]}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "trip to mars",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Great choices! I will proceed with executing the selected steps for your trip to Mars. Let me work through each one."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/hitl-text-input.json
+++ b/showcase/harness/fixtures/d5/hitl-text-input.json
@@ -1,18 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/hitl-in-chat against LangGraph Python (LGP). Text-input HITL via the frontend-defined `book_call` tool (see src/app/demos/hitl-in-chat/page.tsx and src/agents/hitl_in_chat_agent.py). The agent calls book_call with topic and name; the frontend renders an inline time-picker card via useHumanInTheLoop; the user picks a slot and the value is sent back as the tool result; the agent re-invokes with that result and emits a short acknowledgement. We match the second leg by toolCallId. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
+  "_comment": "D5 fixture for /demos/hitl-in-chat against LangGraph Python (LGP). Text-input HITL via the frontend-defined `book_call` tool. Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered 0→N for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Book a 30-minute onboarding call for Alice",
-        "toolCallId": "call_d5_book_call_001"
-      },
-      "response": {
-        "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Book a 30-minute onboarding call for Alice"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -22,6 +14,15 @@
             "arguments": "{\"topic\":\"Onboarding call\",\"attendee\":\"Alice\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Book a 30-minute onboarding call for Alice",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Booked Alice's onboarding call for the time you selected — calendar invite is on its way."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/mcp-subagents.json
+++ b/showcase/harness/fixtures/d5/mcp-subagents.json
@@ -1,19 +1,40 @@
 {
-  "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). The supervisor agent in src/agents/subagents.py exposes three sub-agents as tools — research_agent, writing_agent, critique_agent — with a delegations log in shared state. A typical chained run: supervisor calls research_agent -> gets facts -> calls writing_agent -> gets a draft -> calls critique_agent -> gets a review -> composes a final reply. Each delegation appends a Delegation entry to shared state which the UI renders live in DelegationLog. We model the chain as four sequential fixtures disambiguated by toolCallId matching on the LAST tool message. ORDER: most-specific (critique) first, then writing, then research, then fallback (no toolCallId = initial request).",
+  "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). Four-step chain: supervisor calls research_agent -> writing_agent -> critique_agent -> final reply. Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate the four legs of the chain. Fixtures ordered 0→3 for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "toolCallId": "call_d5_critique_agent_001"
+        "turnIndex": 0
       },
       "response": {
-        "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
+        "toolCalls": [
+          {
+            "id": "call_d5_research_agent_001",
+            "name": "research_agent",
+            "arguments": "{\"topic\":\"Benefits of remote work\"}"
+          }
+        ]
       }
     },
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "toolCallId": "call_d5_writing_agent_001"
+        "turnIndex": 1
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_writing_agent_001",
+            "name": "writing_agent",
+            "arguments": "{\"brief\":\"One-paragraph summary on the benefits of remote work, grounded in the research facts.\",\"facts\":\"- Eliminates commute, returning ~10 hours per week\\n- Higher reported job satisfaction in repeated surveys\\n- Wider talent pool for employers, no geographic limit\\n- Reduced office overhead\\n- Trade-offs: collaboration, mentorship, cultural cohesion\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
+        "turnIndex": 2
       },
       "response": {
         "toolCalls": [
@@ -28,30 +49,10 @@
     {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
-        "toolCallId": "call_d5_research_agent_001"
+        "turnIndex": 3
       },
       "response": {
-        "toolCalls": [
-          {
-            "id": "call_d5_writing_agent_001",
-            "name": "writing_agent",
-            "arguments": "{\"brief\":\"One-paragraph summary on the benefits of remote work, grounded in the research facts.\",\"facts\":\"- Eliminates commute, returning ~10 hours per week\\n- Higher reported job satisfaction in repeated surveys\\n- Wider talent pool for employers, no geographic limit\\n- Reduced office overhead\\n- Trade-offs: collaboration, mentorship, cultural cohesion\"}"
-          }
-        ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Research the benefits of remote work and draft a one-paragraph summary"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d5_research_agent_001",
-            "name": "research_agent",
-            "arguments": "{\"topic\":\"Benefits of remote work\"}"
-          }
-        ]
+        "content": "Here is the summary, after research → drafting → critique:\n\nRemote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/shared-state.json
+++ b/showcase/harness/fixtures/d5/shared-state.json
@@ -1,18 +1,10 @@
 {
-  "_comment": "D5 multi-turn fixture for /demos/shared-state-read-write. Demonstrates the agent-write half of bidirectional shared state: turn 1 the user asks the agent to remember something, the agent calls the backend `set_notes` tool which mutates shared state. After the tool result is appended, the agent re-invokes the LLM — we match that second leg via toolCallId on the last tool message. Turn 2 the user asks the agent to recall what it remembered. The UI-write half (preferences via agent.setState) does not flow through the LLM, so it is not part of this fixture. ORDER: toolCallId fixture first (tried first, skips when no tool result), then userMessage-only fallback.",
+  "_comment": "D5 multi-turn fixture for /demos/shared-state-read-write. Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. The 'favorite color' fixture has a unique userMessage and needs no turnIndex. Fixtures ordered 0→N for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "remember that my favorite color is blue",
-        "toolCallId": "call_d5_set_notes_001"
-      },
-      "response": {
-        "content": "Got it — I have noted that your favorite color is blue."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "remember that my favorite color is blue"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -22,6 +14,15 @@
             "arguments": "{\"notes\":[\"Favorite color: blue\"]}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "remember that my favorite color is blue",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Got it — I have noted that your favorite color is blue."
       }
     },
     {

--- a/showcase/harness/fixtures/d5/tool-rendering.json
+++ b/showcase/harness/fixtures/d5/tool-rendering.json
@@ -1,18 +1,10 @@
 {
-  "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). The frontend only registers get_weather, so the fixture returns a single tool call. Uses toolCallId matching: toolCallId fixture tried first, skips on initial request (no tool result), matches on second request when tool result is present. ORDER: toolCallId fixture above userMessage-only fixture so it is tried first.",
+  "_comment": "D5 fixture for /demos/tool-rendering against LangGraph Python (LGP). Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate multi-turn fixtures sharing the same userMessage. Fixtures ordered 0→N for readability.",
   "fixtures": [
     {
       "match": {
         "userMessage": "weather in Tokyo",
-        "toolCallId": "call_d5_get_weather_001"
-      },
-      "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "weather in Tokyo"
+        "turnIndex": 0
       },
       "response": {
         "toolCalls": [
@@ -22,6 +14,15 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "weather in Tokyo",
+        "turnIndex": 1
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy."
       }
     }
   ]


### PR DESCRIPTION
## Summary

Migrates all D5 (e2e-deep) fixtures from the `toolCallId` workaround (PR #4398) to aimock's native `turnIndex` matching shipped in v1.16.0.

- Removes all `toolCallId` match criteria from 9 fixture files (8 source + 1 bundle)
- Adds `turnIndex` values (counts assistant messages in request history)
- Reorders fixtures to natural 0→N reading order
- Response bodies and tool call IDs in responses untouched

## Why

`toolCallId` was a stateless workaround for the broken `sequenceIndex` global counter. It required agent frameworks to return the exact `tool_call_id` from the fixture response — if they generated their own ID, the second-leg fixture never matched. This was the likely cause of the remaining 10 e2e-deep failures (shared-state: 9, subagents: 8).

`turnIndex` counts `role: "assistant"` messages in the request's message array. Zero server-side state, concurrent-safe, fixture-ordering-insensitive, and agnostic to what `tool_call_id` the agent framework generates.

## Test plan

- [ ] All JSON files parse successfully (validated locally)
- [ ] Merge to main → aimock restarts and fetches updated fixtures
- [ ] Trigger e2e-deep probe, verify improvement (expect shared-state + subagents to fix)