### PR TITLE
fix: dashboard timestamp localization, docs selector bug, selector tests, starter probe cleanup

### DIFF
--- a/showcase/ops/config/probes/e2e-deep.yml
+++ b/showcase/ops/config/probes/e2e-deep.yml
@@ -81,6 +81,24 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Decommissioned starters — Railway services stopped (PR #4390)
+      - showcase-starter-ag2
+      - showcase-starter-agno
+      - showcase-starter-claude-sdk-python
+      - showcase-starter-claude-sdk-typescript
+      - showcase-starter-crewai-crews
+      - showcase-starter-google-adk
+      - showcase-starter-langgraph-fastapi
+      - showcase-starter-langgraph-python
+      - showcase-starter-langgraph-typescript
+      - showcase-starter-langroid
+      - showcase-starter-llamaindex
+      - showcase-starter-mastra
+      - showcase-starter-ms-agent-dotnet
+      - showcase-starter-ms-agent-python
+      - showcase-starter-pydantic-ai
+      - showcase-starter-spring-ai
+      - showcase-starter-strands
   # Primary row key uses the Railway service name (not the stripped
   # slug) to stay consistent with sibling driver families. The driver
   # strips `showcase-` from the name internally for the per-feature

--- a/showcase/ops/config/probes/e2e-demos.yml
+++ b/showcase/ops/config/probes/e2e-demos.yml
@@ -150,6 +150,24 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Decommissioned starters — Railway services stopped (PR #4390)
+      - showcase-starter-ag2
+      - showcase-starter-agno
+      - showcase-starter-claude-sdk-python
+      - showcase-starter-claude-sdk-typescript
+      - showcase-starter-crewai-crews
+      - showcase-starter-google-adk
+      - showcase-starter-langgraph-fastapi
+      - showcase-starter-langgraph-python
+      - showcase-starter-langgraph-typescript
+      - showcase-starter-langroid
+      - showcase-starter-llamaindex
+      - showcase-starter-mastra
+      - showcase-starter-ms-agent-dotnet
+      - showcase-starter-ms-agent-python
+      - showcase-starter-pydantic-ai
+      - showcase-starter-spring-ai
+      - showcase-starter-strands
   #
   # `key_template` lives at the `discovery:` level (sibling of `source`
   # / `filter`), per `loader/schema.ts:DiscoveryBlockSchema`. The

--- a/showcase/ops/config/probes/e2e-parity.yml
+++ b/showcase/ops/config/probes/e2e-parity.yml
@@ -102,6 +102,24 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Decommissioned starters — Railway services stopped (PR #4390)
+      - showcase-starter-ag2
+      - showcase-starter-agno
+      - showcase-starter-claude-sdk-python
+      - showcase-starter-claude-sdk-typescript
+      - showcase-starter-crewai-crews
+      - showcase-starter-google-adk
+      - showcase-starter-langgraph-fastapi
+      - showcase-starter-langgraph-python
+      - showcase-starter-langgraph-typescript
+      - showcase-starter-langroid
+      - showcase-starter-llamaindex
+      - showcase-starter-mastra
+      - showcase-starter-ms-agent-dotnet
+      - showcase-starter-ms-agent-python
+      - showcase-starter-pydantic-ai
+      - showcase-starter-spring-ai
+      - showcase-starter-strands
   # Primary row key uses the Railway service name (not the stripped
   # slug) to stay consistent with sibling driver families. The driver
   # strips `showcase-` from the name internally for the per-feature

--- a/showcase/ops/config/probes/e2e-smoke.yml
+++ b/showcase/ops/config/probes/e2e-smoke.yml
@@ -53,4 +53,22 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
+      # Decommissioned starters — Railway services stopped (PR #4390)
+      - showcase-starter-ag2
+      - showcase-starter-agno
+      - showcase-starter-claude-sdk-python
+      - showcase-starter-claude-sdk-typescript
+      - showcase-starter-crewai-crews
+      - showcase-starter-google-adk
+      - showcase-starter-langgraph-fastapi
+      - showcase-starter-langgraph-python
+      - showcase-starter-langgraph-typescript
+      - showcase-starter-langroid
+      - showcase-starter-llamaindex
+      - showcase-starter-mastra
+      - showcase-starter-ms-agent-dotnet
+      - showcase-starter-ms-agent-python
+      - showcase-starter-pydantic-ai
+      - showcase-starter-spring-ai
+      - showcase-starter-strands
   key_template: "e2e_smoke:${name}"

--- a/showcase/ops/config/probes/image-drift.yml
+++ b/showcase/ops/config/probes/image-drift.yml
@@ -21,4 +21,23 @@ discovery:
   source: railway-services
   filter:
     namePrefix: "showcase-"
+    nameExcludes:
+      # Decommissioned starters — Railway services stopped (PR #4390)
+      - "showcase-starter-ag2"
+      - "showcase-starter-agno"
+      - "showcase-starter-claude-sdk-python"
+      - "showcase-starter-claude-sdk-typescript"
+      - "showcase-starter-crewai-crews"
+      - "showcase-starter-google-adk"
+      - "showcase-starter-langgraph-fastapi"
+      - "showcase-starter-langgraph-python"
+      - "showcase-starter-langgraph-typescript"
+      - "showcase-starter-langroid"
+      - "showcase-starter-llamaindex"
+      - "showcase-starter-mastra"
+      - "showcase-starter-ms-agent-dotnet"
+      - "showcase-starter-ms-agent-python"
+      - "showcase-starter-pydantic-ai"
+      - "showcase-starter-spring-ai"
+      - "showcase-starter-strands"
   key_template: "image_drift:${name}"

--- a/showcase/ops/config/probes/smoke.yml
+++ b/showcase/ops/config/probes/smoke.yml
@@ -60,6 +60,25 @@ discovery:
       - "showcase-shell-dashboard"
       - "showcase-shell-docs"
       - "showcase-shell-dojo"
+      # Decommissioned starters — Railway services stopped, deployments
+      # halted (PR #4390). Excluded so probes don't scan dead endpoints.
+      - "showcase-starter-ag2"
+      - "showcase-starter-agno"
+      - "showcase-starter-claude-sdk-python"
+      - "showcase-starter-claude-sdk-typescript"
+      - "showcase-starter-crewai-crews"
+      - "showcase-starter-google-adk"
+      - "showcase-starter-langgraph-fastapi"
+      - "showcase-starter-langgraph-python"
+      - "showcase-starter-langgraph-typescript"
+      - "showcase-starter-langroid"
+      - "showcase-starter-llamaindex"
+      - "showcase-starter-mastra"
+      - "showcase-starter-ms-agent-dotnet"
+      - "showcase-starter-ms-agent-python"
+      - "showcase-starter-pydantic-ai"
+      - "showcase-starter-spring-ai"
+      - "showcase-starter-strands"
   # key_template is interpolated against each RailwayServiceInfo record.
   # `${name}` is the full Railway service name (`showcase-ag2`). The
   # driver re-derives the slug by stripping the `showcase-` prefix, so

--- a/showcase/ops/src/probes/aimock-wiring.ts
+++ b/showcase/ops/src/probes/aimock-wiring.ts
@@ -60,6 +60,25 @@ const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
   "showcase-shell-dojo",
   "showcase-pocketbase",
   "showcase-ops",
+  // Decommissioned starters — Railway services stopped, deployments
+  // halted (PR #4390). Keep in sync with nameExcludes in probe YAMLs.
+  "showcase-starter-ag2",
+  "showcase-starter-agno",
+  "showcase-starter-claude-sdk-python",
+  "showcase-starter-claude-sdk-typescript",
+  "showcase-starter-crewai-crews",
+  "showcase-starter-google-adk",
+  "showcase-starter-langgraph-fastapi",
+  "showcase-starter-langgraph-python",
+  "showcase-starter-langgraph-typescript",
+  "showcase-starter-langroid",
+  "showcase-starter-llamaindex",
+  "showcase-starter-mastra",
+  "showcase-starter-ms-agent-dotnet",
+  "showcase-starter-ms-agent-python",
+  "showcase-starter-pydantic-ai",
+  "showcase-starter-spring-ai",
+  "showcase-starter-strands",
 ]);
 
 export interface AimockWiringInput {

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -1,0 +1,577 @@
+/**
+ * Integration tests for overlay selectors — renders with REAL child
+ * components (CellStatus, DocsRow, DepthChip, etc.) and verifies that
+ * toggling overlay selectors actually controls what the user sees.
+ *
+ * Only the data layer is mocked (live-status, docs-status, useLastTransition,
+ * PocketBase client) to provide predictable test data.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { ComposedCell } from "../composed-cell";
+import type { Overlay } from "../composed-cell";
+import type { CellContext } from "@/components/feature-grid";
+import type { CatalogCell } from "@/components/depth-utils";
+import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
+
+// ---------------------------------------------------------------------------
+// Data-layer mocks — real UI components, fake data
+// ---------------------------------------------------------------------------
+
+// Mock PocketBase client (imported by useLastTransition)
+vi.mock("@/lib/pb", () => ({
+  pb: {
+    filter: vi.fn(() => ""),
+    collection: vi.fn(() => ({
+      getList: vi.fn(() => Promise.resolve({ items: [] })),
+    })),
+  },
+}));
+
+// Mock docs-status to return predictable doc state
+vi.mock("@/lib/docs-status", () => ({
+  getDocsStatus: vi.fn(() => ({ og: "ok", shell: "ok" })),
+}));
+
+// Mock useLastTransition (lazy tooltip fetch) — no PB calls in tests
+vi.mock("@/hooks/useLastTransition", () => ({
+  useLastTransition: vi.fn(() => ({ row: null, loaded: false, error: null })),
+  deriveFromTo: vi.fn(() => ({ from: null, to: null })),
+}));
+
+// Mock the docs-status.json data import used by docs-status.ts
+vi.mock("@/data/docs-status.json", () => ({
+  default: {
+    features: {
+      "chat-text": { og: "ok", shell: "ok" },
+      "agentic-chat": { og: "ok", shell: "ok" },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatusRow(
+  dimension: string,
+  slug: string,
+  featureId?: string,
+  state: "green" | "red" | "degraded" = "green",
+): StatusRow {
+  const key = featureId
+    ? `${dimension}:${slug}/${featureId}`
+    : `${dimension}:${slug}`;
+  return {
+    id: `row-${key}`,
+    key,
+    dimension,
+    state,
+    signal: null,
+    observed_at: "2026-04-20T00:00:00Z",
+    transitioned_at: "2026-04-20T00:00:00Z",
+    fail_count: 0,
+    first_failure_at: null,
+  };
+}
+
+function buildLiveStatusMap(slug: string, featureId: string): LiveStatusMap {
+  const map: LiveStatusMap = new Map();
+  const rows = [
+    makeStatusRow("health", slug),
+    makeStatusRow("e2e", slug, featureId),
+    makeStatusRow("smoke", slug),
+    makeStatusRow("d5", slug, featureId),
+    makeStatusRow("d6", slug, featureId),
+    makeStatusRow("agent", slug),
+    makeStatusRow("chat", slug),
+  ];
+  for (const r of rows) {
+    map.set(r.key, r);
+  }
+  return map;
+}
+
+function makeCtx(overrides?: Partial<CellContext>): CellContext {
+  const slug = "next";
+  const featureId = "chat-text";
+  return {
+    integration: {
+      name: "Next.js",
+      slug,
+      category: "framework",
+      language: "TypeScript",
+      description: "Next.js integration",
+      repo: "https://github.com/test/next",
+      backend_url: "https://next.test",
+      deployed: true,
+      features: [featureId],
+      demos: [
+        {
+          id: featureId,
+          name: "Chat Text",
+          description: "Basic text chat",
+          tags: [],
+          route: "/chat",
+        },
+      ],
+    },
+    feature: {
+      id: featureId,
+      name: "Chat Text",
+      category: "chat-ui",
+      description: "Basic text chat feature",
+      kind: "primary",
+    },
+    demo: {
+      id: featureId,
+      name: "Chat Text",
+      description: "Basic text chat",
+      tags: [],
+      route: "/chat",
+    },
+    hostedUrl: "https://next.test/chat",
+    shellUrl: "http://localhost:3000",
+    liveStatus: buildLiveStatusMap(slug, featureId),
+    connection: "live",
+    ...overrides,
+  };
+}
+
+function makeTestingCtx(): CellContext {
+  return makeCtx({
+    feature: {
+      id: "agentic-chat",
+      name: "Agentic Chat",
+      category: "chat-ui",
+      description: "Agentic chat feature",
+      kind: "testing",
+    },
+    demo: {
+      id: "agentic-chat",
+      name: "Agentic Chat",
+      description: "Agentic chat testing",
+      tags: [],
+      route: "/agentic-chat",
+    },
+    liveStatus: buildLiveStatusMap("next", "agentic-chat"),
+  });
+}
+
+function makeCatalogCell(overrides?: Partial<CatalogCell>): CatalogCell {
+  return {
+    id: "next/chat-text",
+    integration: "next",
+    integration_name: "Next.js",
+    feature: "chat-text",
+    feature_name: "Chat Text",
+    status: "wired",
+    max_depth: 3,
+    category: "chat-ui",
+    category_name: "Chat & UI",
+    ...overrides,
+  };
+}
+
+function overlaySet(...overlays: Overlay[]): Set<Overlay> {
+  return new Set(overlays);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Overlay selector integration — real UI components", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Links only
+  // -------------------------------------------------------------------------
+  it("links only: Demo/Code links visible, no depth/badges/docs", () => {
+    const ctx = makeCtx();
+    const { getByText, queryByTestId, queryByText } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("links")} />,
+    );
+
+    // Links layer content present
+    expect(getByText("Demo")).toBeInTheDocument();
+    expect(getByText("</>")).toBeInTheDocument();
+
+    // No depth chip
+    expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
+    expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+
+    // No health badges (E2E, D5, D6)
+    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("D5")).not.toBeInTheDocument();
+    expect(queryByText("D6")).not.toBeInTheDocument();
+
+    // No docs indicators
+    expect(queryByText("docs-og")).not.toBeInTheDocument();
+    expect(queryByText("docs-shell")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Depth only
+  // -------------------------------------------------------------------------
+  it("depth only: depth chip visible, no links/badges/docs", () => {
+    const ctx = makeCtx();
+    const catalogCell = makeCatalogCell();
+    const { getByTestId, queryByText } = render(
+      <ComposedCell
+        ctx={ctx}
+        overlays={overlaySet("depth")}
+        catalogCell={catalogCell}
+      />,
+    );
+
+    // Depth chip present — real DepthChip renders data-testid="depth-chip"
+    expect(getByTestId("depth-layer")).toBeInTheDocument();
+    expect(getByTestId("depth-chip")).toBeInTheDocument();
+
+    // No links
+    expect(queryByText("Demo")).not.toBeInTheDocument();
+    expect(queryByText("</>")).not.toBeInTheDocument();
+
+    // No health badges
+    expect(queryByText("E2E")).not.toBeInTheDocument();
+
+    // No docs indicators
+    expect(queryByText("docs-og")).not.toBeInTheDocument();
+    expect(queryByText("docs-shell")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Health only — the critical case (no docs indicators must appear)
+  // -------------------------------------------------------------------------
+  it("health only: E2E/D5/D6 badges visible, NO docs indicators", () => {
+    const ctx = makeCtx();
+    const { getByTestId, getByText, queryByText, queryByTestId } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
+    );
+
+    // Health layer present with real badges
+    expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("D5")).toBeInTheDocument();
+    expect(getByText("D6")).toBeInTheDocument();
+
+    // No docs indicators — this is the critical regression test for B2's fix
+    expect(queryByText("docs-og")).not.toBeInTheDocument();
+    expect(queryByText("docs-shell")).not.toBeInTheDocument();
+    expect(queryByTestId("docs-layer")).not.toBeInTheDocument();
+
+    // No links
+    expect(queryByText("Demo")).not.toBeInTheDocument();
+
+    // No depth chip
+    expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Docs only
+  // -------------------------------------------------------------------------
+  it("docs only: docs-og/docs-shell indicators visible, no links/badges/depth", () => {
+    const ctx = makeCtx();
+    const { getByTestId, getByText, queryByText, queryByTestId } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("docs")} />,
+    );
+
+    // Docs layer present with real DocsRow content
+    expect(getByTestId("docs-layer")).toBeInTheDocument();
+    // DocsRow renders "docs-og" and "docs-shell" labels
+    expect(getByText("docs-og")).toBeInTheDocument();
+    expect(getByText("docs-shell")).toBeInTheDocument();
+
+    // No links
+    expect(queryByText("Demo")).not.toBeInTheDocument();
+
+    // No health badges
+    expect(queryByText("E2E")).not.toBeInTheDocument();
+
+    // No depth chip
+    expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+    expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Parity only — empty cell
+  // -------------------------------------------------------------------------
+  it("parity only: renders empty cell (no per-cell content)", () => {
+    const ctx = makeCtx();
+    const { getByTestId, queryByTestId, queryByText } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("parity")} />,
+    );
+
+    // Parity produces no per-cell content → empty cell
+    expect(getByTestId("composed-cell-empty")).toBeInTheDocument();
+    expect(queryByTestId("composed-cell")).not.toBeInTheDocument();
+
+    // Nothing visible
+    expect(queryByText("Demo")).not.toBeInTheDocument();
+    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("docs-og")).not.toBeInTheDocument();
+    expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Health + Docs — both badges AND docs indicators visible
+  // -------------------------------------------------------------------------
+  it("health + docs: badges AND docs indicators both visible", () => {
+    const ctx = makeCtx();
+    const { getByTestId, getByText, queryByText, queryByTestId } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("health", "docs")} />,
+    );
+
+    // Health layer
+    expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("D5")).toBeInTheDocument();
+    expect(getByText("D6")).toBeInTheDocument();
+
+    // Docs layer
+    expect(getByTestId("docs-layer")).toBeInTheDocument();
+    expect(getByText("docs-og")).toBeInTheDocument();
+    expect(getByText("docs-shell")).toBeInTheDocument();
+
+    // No links
+    expect(queryByText("Demo")).not.toBeInTheDocument();
+
+    // No depth chip
+    expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. All overlays — everything visible, correct stacking order
+  // -------------------------------------------------------------------------
+  it("all overlays: every layer visible in correct stacking order", () => {
+    const ctx = makeCtx();
+    const catalogCell = makeCatalogCell();
+    const { getByTestId, getByText } = render(
+      <ComposedCell
+        ctx={ctx}
+        overlays={overlaySet("links", "depth", "health", "docs", "parity")}
+        catalogCell={catalogCell}
+      />,
+    );
+
+    // All content layers present
+    expect(getByText("Demo")).toBeInTheDocument();
+    expect(getByTestId("depth-layer")).toBeInTheDocument();
+    expect(getByTestId("depth-chip")).toBeInTheDocument();
+    expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByTestId("docs-layer")).toBeInTheDocument();
+    expect(getByText("docs-og")).toBeInTheDocument();
+    expect(getByText("docs-shell")).toBeInTheDocument();
+
+    // Verify stacking order: links, depth, health, docs
+    const composedCell = getByTestId("composed-cell");
+    const children = Array.from(composedCell.children);
+    expect(children.length).toBe(4); // parity adds no content layer
+
+    // First child: links (contains "Demo")
+    expect(children[0]?.textContent).toContain("Demo");
+    // Second child: depth (contains depth-chip)
+    expect(
+      children[1]?.querySelector("[data-testid='depth-chip']"),
+    ).toBeTruthy();
+    // Third child: health (contains E2E badge)
+    expect(children[2]?.textContent).toContain("E2E");
+    // Fourth child: docs (contains docs-og)
+    expect(children[3]?.textContent).toContain("docs-og");
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Health without Docs — the critical regression test for B2's fix
+  // -------------------------------------------------------------------------
+  it("health without docs: badges visible, docs-og/docs-shell NOT visible", () => {
+    const ctx = makeCtx();
+    const { getByTestId, getByText, queryByText, queryByTestId } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
+    );
+
+    // Health badges present
+    expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
+
+    // Docs explicitly absent — this is the bug B2 fixed: CellStatus used to
+    // render DocsRow, so "health only" would still show docs indicators.
+    // After B2's fix, DocsRow is only in DocsLayer (gated on overlays.has("docs")).
+    expect(queryByText("docs-og")).not.toBeInTheDocument();
+    expect(queryByText("docs-shell")).not.toBeInTheDocument();
+    expect(queryByTestId("docs-layer")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. Testing-kind features: D5/D6 badges hidden
+  // -------------------------------------------------------------------------
+  it("testing-kind feature with health: D5/D6 badges hidden, E2E still shown", () => {
+    const ctx = makeTestingCtx();
+    const { getByTestId, getByText, queryByText } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
+    );
+
+    // Health layer present
+    expect(getByTestId("health-layer")).toBeInTheDocument();
+
+    // E2E badge still visible for testing-kind
+    expect(getByText("E2E")).toBeInTheDocument();
+
+    // D5/D6 hidden for testing-kind features (CellStatus hides them)
+    expect(queryByText("D5")).not.toBeInTheDocument();
+    expect(queryByText("D6")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. Testing-kind feature with docs overlay: DocsLayer still renders
+  // -------------------------------------------------------------------------
+  it("testing-kind feature with docs overlay: docs indicators visible", () => {
+    const ctx = makeTestingCtx();
+    const { getByTestId, getByText } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("docs")} />,
+    );
+
+    // DocsLayer renders for testing features when docs overlay is active
+    expect(getByTestId("docs-layer")).toBeInTheDocument();
+    expect(getByText("docs-og")).toBeInTheDocument();
+    expect(getByText("docs-shell")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. Catalog preset (links + health + docs) — all three layers visible
+  // -------------------------------------------------------------------------
+  it("Catalog preset (links+health+docs): all three layers visible", () => {
+    const ctx = makeCtx();
+    // Catalog preset from overlay-types.ts: ["links", "health", "docs"]
+    const { getByText, getByTestId, queryByTestId } = render(
+      <ComposedCell
+        ctx={ctx}
+        overlays={overlaySet("links", "health", "docs")}
+      />,
+    );
+
+    // Links
+    expect(getByText("Demo")).toBeInTheDocument();
+    expect(getByText("</>")).toBeInTheDocument();
+
+    // Health badges
+    expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
+
+    // Docs indicators
+    expect(getByTestId("docs-layer")).toBeInTheDocument();
+    expect(getByText("docs-og")).toBeInTheDocument();
+    expect(getByText("docs-shell")).toBeInTheDocument();
+
+    // No depth chip (not in Catalog preset)
+    expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. Assessment preset (depth + health) — depth chips + badges, NO docs
+  // -------------------------------------------------------------------------
+  it("Assessment preset (depth+health): depth chip + badges, NO docs", () => {
+    const ctx = makeCtx();
+    const catalogCell = makeCatalogCell();
+    // Assessment preset from overlay-types.ts: ["depth", "health"]
+    const { getByTestId, getByText, queryByText, queryByTestId } = render(
+      <ComposedCell
+        ctx={ctx}
+        overlays={overlaySet("depth", "health")}
+        catalogCell={catalogCell}
+      />,
+    );
+
+    // Depth chip
+    expect(getByTestId("depth-layer")).toBeInTheDocument();
+    expect(getByTestId("depth-chip")).toBeInTheDocument();
+
+    // Health badges
+    expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
+
+    // No docs — critical: Assessment does NOT include docs
+    expect(queryByText("docs-og")).not.toBeInTheDocument();
+    expect(queryByText("docs-shell")).not.toBeInTheDocument();
+    expect(queryByTestId("docs-layer")).not.toBeInTheDocument();
+
+    // No links
+    expect(queryByText("Demo")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 13. Parity Review preset (depth + parity) — depth chips only
+  // -------------------------------------------------------------------------
+  it("Parity Review preset (depth+parity): depth chip only, no badges/docs/links", () => {
+    const ctx = makeCtx();
+    const catalogCell = makeCatalogCell();
+    // Parity Review preset from overlay-types.ts: ["depth", "parity"]
+    const { getByTestId, queryByText, queryByTestId } = render(
+      <ComposedCell
+        ctx={ctx}
+        overlays={overlaySet("depth", "parity")}
+        catalogCell={catalogCell}
+      />,
+    );
+
+    // Depth chip present
+    expect(getByTestId("depth-layer")).toBeInTheDocument();
+    expect(getByTestId("depth-chip")).toBeInTheDocument();
+
+    // No health badges
+    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("D5")).not.toBeInTheDocument();
+    expect(queryByText("D6")).not.toBeInTheDocument();
+
+    // No docs
+    expect(queryByText("docs-og")).not.toBeInTheDocument();
+    expect(queryByText("docs-shell")).not.toBeInTheDocument();
+    expect(queryByTestId("docs-layer")).not.toBeInTheDocument();
+
+    // No links
+    expect(queryByText("Demo")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // 14. Health badges show correct green tone from real resolveCell
+  // -------------------------------------------------------------------------
+  it("health layer renders real badge tones from live status data", () => {
+    const ctx = makeCtx();
+    const { getByText } = render(
+      <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
+    );
+
+    // With green live status rows, E2E badge should show the green check
+    const e2eBadge = getByText("E2E");
+    expect(e2eBadge).toBeInTheDocument();
+    // The badge label "✓" (green state) should appear as a sibling span
+    const e2eContainer = e2eBadge.closest("[class*='whitespace-nowrap']");
+    expect(e2eContainer?.textContent).toContain("✓");
+  });
+
+  // -------------------------------------------------------------------------
+  // 15. Depth chip shows correct depth from real deriveDepth
+  // -------------------------------------------------------------------------
+  it("depth layer renders real depth chip with correct D-level", () => {
+    const ctx = makeCtx();
+    const catalogCell = makeCatalogCell();
+    const { getByTestId } = render(
+      <ComposedCell
+        ctx={ctx}
+        overlays={overlaySet("depth")}
+        catalogCell={catalogCell}
+      />,
+    );
+
+    const chip = getByTestId("depth-chip");
+    expect(chip).toBeInTheDocument();
+    // The depth chip renders "D<n>" text — with full green live status and
+    // health+agent+e2e+chat all green, deriveDepth should yield D4
+    const depthAttr = chip.getAttribute("data-depth");
+    expect(depthAttr).toBeTruthy();
+    expect(chip.textContent).toMatch(/^D[0-4]$/);
+  });
+});

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -14,6 +14,7 @@ import type {
   LiveStatusMap,
   ConnectionStatus,
 } from "@/lib/live-status";
+import { formatTs } from "@/lib/format-ts";
 import { TONE_CLASS, DOT_BG } from "./badges";
 
 export interface CellDrilldownProps {
@@ -40,16 +41,7 @@ const DIMENSIONS: Array<{
 
 function formatTimestamp(ts: string | null): string {
   if (!ts) return "n/a";
-  try {
-    return new Date(ts).toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return ts;
-  }
+  return formatTs(ts);
 }
 
 function formatSignal(signal: unknown): string | null {

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -272,11 +272,12 @@ function formatTransitionLine(row: {
 }
 
 /**
- * Shared status row: docs-og/docs-shell line + E2E badge.
+ * Shared status row: E2E / D5 / D6 badges.
  * QA and HealthDot removed in Phase 3 (3.3 + 3.4). L1 health now in strip.
  * Smoke per-cell badge removed — integration-scoped smoke lives in the strip.
- * Consumes `liveStatus` from `ctx` (spec §5.4 wiring). Hides the docs row
- * for `testing`-kind features to match previous behavior.
+ * Docs rendering removed — handled exclusively by DocsLayer in ComposedCell,
+ * gated on the `overlays.has("docs")` toggle.
+ * Consumes `liveStatus` from `ctx` (spec §5.4 wiring).
  */
 export function CellStatus({ ctx }: { ctx: CellContext }) {
   const isTesting = ctx.feature.kind === "testing";
@@ -297,49 +298,40 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
   // worktree) and is tracked in the cross-worktree concerns of this fix.
 
   return (
-    <>
-      {!isTesting && (
-        <DocsRow
-          integration={ctx.integration}
-          feature={ctx.feature}
-          shellUrl={ctx.shellUrl}
-        />
-      )}
-      <div className="flex items-center gap-2.5">
-        <LiveBadge
-          name="E2E"
-          badge={cell.e2e}
-          dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
-        />
-        {/*
-          CP8: D5/D6 producers (`e2e-deep`, `e2e-parity`) only emit rows for
-          primary features per spec; testing-kind features never get a D5 or
-          D6 row, so the badge would render a perpetual gray "?" that adds
-          noise without information. Hide for `isTesting` to mirror the
-          docs-row visibility rule.
+    <div className="flex items-center gap-2.5">
+      <LiveBadge
+        name="E2E"
+        badge={cell.e2e}
+        dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
+      />
+      {/*
+        CP8: D5/D6 producers (`e2e-deep`, `e2e-parity`) only emit rows for
+        primary features per spec; testing-kind features never get a D5 or
+        D6 row, so the badge would render a perpetual gray "?" that adds
+        noise without information. Hide for `isTesting` so operators only
+        see badges backed by real data.
 
-          CP9: D5/D6 chips intentionally have no `href` — there is no
-          per-feature drilldown URL convention in shell-dashboard today.
-          When a drilldown route exists (e.g. a per-(slug, feature) D5 run
-          history page), wire the URL through `keyFor` here.
-          TODO(showcase-dashboard): D5/D6 drilldown URL — see
-          docs/spec §5.6 follow-up.
-        */}
-        {!isTesting && (
-          <>
-            <LiveBadge
-              name="D5"
-              badge={cell.d5}
-              dimensionKey={keyFor("d5", ctx.integration.slug, ctx.feature.id)}
-            />
-            <LiveBadge
-              name="D6"
-              badge={cell.d6}
-              dimensionKey={keyFor("d6", ctx.integration.slug, ctx.feature.id)}
-            />
-          </>
-        )}
-      </div>
-    </>
+        CP9: D5/D6 chips intentionally have no `href` — there is no
+        per-feature drilldown URL convention in shell-dashboard today.
+        When a drilldown route exists (e.g. a per-(slug, feature) D5 run
+        history page), wire the URL through `keyFor` here.
+        TODO(showcase-dashboard): D5/D6 drilldown URL — see
+        docs/spec §5.6 follow-up.
+      */}
+      {!isTesting && (
+        <>
+          <LiveBadge
+            name="D5"
+            badge={cell.d5}
+            dimensionKey={keyFor("d5", ctx.integration.slug, ctx.feature.id)}
+          />
+          <LiveBadge
+            name="D6"
+            badge={cell.d6}
+            dimensionKey={keyFor("d6", ctx.integration.slug, ctx.feature.id)}
+          />
+        </>
+      )}
+    </div>
   );
 }

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -7,6 +7,7 @@ import { Badge, FlashOnChange } from "@/components/badges";
 import { keyFor, resolveCell, type BadgeRender } from "@/lib/live-status";
 import type { Feature, Integration } from "@/lib/registry";
 import { useLastTransition, deriveFromTo } from "@/hooks/useLastTransition";
+import { formatTs } from "@/lib/format-ts";
 
 /**
  * Magic path segment used by the shell when no framework column is selected.
@@ -258,17 +259,17 @@ function formatTransitionLine(row: {
   observed_at: string;
 }): string {
   if (row.transition === "first") {
-    return ` — since ${row.observed_at} (initial: ${row.state})`;
+    return ` — since ${formatTs(row.observed_at)} (initial: ${row.state})`;
   }
   if (row.transition === "error") {
-    return ` — since ${row.observed_at} (error → ${row.state})`;
+    return ` — since ${formatTs(row.observed_at)} (error → ${row.state})`;
   }
   const { from, to } = deriveFromTo(row.transition);
   // Any non-first/non-error transition that deriveFromTo can't decode
   // (unexpected enum value) falls back to the row's current state so we
   // never render "null → null" copy.
   const pair = from && to ? `${from} → ${to}` : row.state;
-  return ` — since ${row.observed_at} (${pair})`;
+  return ` — since ${formatTs(row.observed_at)} (${pair})`;
 }
 
 /**

--- a/showcase/shell-dashboard/src/components/level-strip.tsx
+++ b/showcase/shell-dashboard/src/components/level-strip.tsx
@@ -5,6 +5,7 @@
  */
 import { ToneChip } from "@/components/badges";
 import { keyFor, type LiveStatusMap, type BadgeTone } from "@/lib/live-status";
+import { formatTs } from "@/lib/format-ts";
 import type { Integration } from "@/lib/registry";
 
 interface LevelBadge {
@@ -34,7 +35,7 @@ function resolveBadge(
   return {
     name: label,
     tone,
-    title: `${label}: ${row.state} since ${row.observed_at}`,
+    title: `${label}: ${row.state} since ${formatTs(row.observed_at)}`,
   };
 }
 

--- a/showcase/shell-dashboard/src/lib/format-ts.test.ts
+++ b/showcase/shell-dashboard/src/lib/format-ts.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatTs } from "./format-ts";
+
+describe("formatTs", () => {
+  it("converts an ISO 8601 UTC string to a locale-formatted string", () => {
+    const result = formatTs("2026-04-28T05:17:34.396Z");
+    // The exact output depends on the runtime's locale, but it must NOT
+    // contain the raw ISO marker 'T' or trailing 'Z'.
+    expect(result).not.toContain("T");
+    expect(result).not.toContain("Z");
+    // It should contain recognizable date fragments (month abbreviation,
+    // digits for day/time).
+    expect(result).toMatch(/Apr/);
+    expect(result).toMatch(/\d{1,2}/); // day
+    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/); // hh:mm:ss
+  });
+
+  it("returns a non-empty string for a valid ISO timestamp", () => {
+    const result = formatTs("2026-01-15T12:00:00Z");
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).not.toBe("2026-01-15T12:00:00Z");
+  });
+
+  it("falls back to the raw input for an invalid date string", () => {
+    expect(formatTs("not-a-date")).toBe("not-a-date");
+  });
+
+  it("handles timestamps with milliseconds", () => {
+    const result = formatTs("2026-04-20T00:00:00.000Z");
+    expect(result).not.toContain("T");
+    expect(result).not.toContain("Z");
+  });
+
+  it("handles timestamps without trailing Z (non-UTC offsets)", () => {
+    const result = formatTs("2026-04-20T08:00:00+00:00");
+    expect(result).not.toContain("+00:00");
+    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("returns the raw input for an empty string (Date constructor yields Invalid Date)", () => {
+    // new Date("") is NaN / Invalid Date — toLocaleString throws or
+    // returns "Invalid Date". Either way, the catch block returns the
+    // raw input.
+    const result = formatTs("");
+    // Accept either empty string passthrough or the string itself
+    expect(typeof result).toBe("string");
+  });
+});

--- a/showcase/shell-dashboard/src/lib/format-ts.ts
+++ b/showcase/shell-dashboard/src/lib/format-ts.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared timestamp formatter: converts an ISO 8601 UTC string into the
+ * user's local timezone via `toLocaleString()`. Falls back to the raw
+ * input if parsing fails so tooltips never render "Invalid Date".
+ */
+export function formatTs(ts: string): string {
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return ts;
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return ts;
+  }
+}

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -7,6 +7,7 @@ import {
   type LiveStatusMap,
   type StatusRow,
 } from "./live-status";
+import { formatTs } from "./format-ts";
 
 function row(
   key: string,
@@ -350,7 +351,7 @@ describe("formatTooltip behaviour (via resolveCell)", () => {
     const c = resolveCell(live, "a", "b");
     expect(c.e2e.tooltip).not.toMatch(/>6h/);
     expect(c.e2e.tooltip).toContain("stale");
-    expect(c.e2e.tooltip).toContain("2026-04-22T08:00:00Z");
+    expect(c.e2e.tooltip).toContain(formatTs("2026-04-22T08:00:00Z"));
   });
 
   // D1: `observed_at` on a degraded row is when the dim was last *seen*
@@ -365,7 +366,7 @@ describe("formatTooltip behaviour (via resolveCell)", () => {
       }),
     ]);
     const c = resolveCell(live, "a", "b");
-    expect(c.e2e.tooltip).toContain("last seen @ 2026-04-22T08:00:00Z");
+    expect(c.e2e.tooltip).toContain(`last seen @ ${formatTs("2026-04-22T08:00:00Z")}`);
     expect(c.e2e.tooltip).not.toContain("last pass");
   });
 
@@ -411,7 +412,7 @@ describe("formatTooltip behaviour (via resolveCell)", () => {
     expect(c.e2e.tooltip).toContain("dashboard offline (§5.3)");
     expect(c.e2e.tooltip).toContain("last observed");
     expect(c.e2e.tooltip).toContain("e2e red");
-    expect(c.e2e.tooltip).toContain("2026-04-22T09:00:00Z");
+    expect(c.e2e.tooltip).toContain(formatTs("2026-04-22T09:00:00Z"));
   });
 
   it("connection=error + green row: plain offline tooltip (no last-observed context)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -11,6 +11,8 @@
  * `agentic-chat`) so the existing per-cell lookup pattern stays uniform.
  */
 
+import { formatTs } from "./format-ts";
+
 export type State = "green" | "red" | "degraded";
 
 export interface StatusRow {
@@ -198,16 +200,16 @@ function formatTooltip(
     // surface the row's last-known state alongside the offline banner so
     // operators can triage without waiting for reconnect.
     if (row && (row.state === "red" || row.state === "degraded")) {
-      return `dashboard offline (§5.3) — last observed: ${dim} ${row.state} since ${row.transitioned_at}`;
+      return `dashboard offline (§5.3) — last observed: ${dim} ${row.state} since ${formatTs(row.transitioned_at)}`;
     }
     return "dashboard offline (§5.3)";
   }
   if (!row) return "no data — probe pending";
   switch (row.state) {
     case "green":
-      return `${dim} green since ${row.observed_at}`;
+      return `${dim} green since ${formatTs(row.observed_at)}`;
     case "red": {
-      const base = `${dim} red since ${row.first_failure_at ?? row.transitioned_at}`;
+      const base = `${dim} red since ${formatTs(row.first_failure_at ?? row.transitioned_at)}`;
       const sig = summarizeSignal(row.signal);
       return sig ? `${base} — ${sig}` : base;
     }
@@ -219,7 +221,7 @@ function formatTooltip(
       // for a degraded row that timestamp is when degradation was
       // last observed. Earlier copy ("last pass @ ...") was misleading
       // operators into reading it as the last green tick.
-      const base = `${dim} stale — last seen @ ${row.observed_at}`;
+      const base = `${dim} stale — last seen @ ${formatTs(row.observed_at)}`;
       const sig = summarizeSignal(row.signal);
       return sig ? `${base} — ${sig}` : base;
     }


### PR DESCRIPTION
## Summary

- **Timestamps → local timezone**: Created shared `formatTs()` utility and replaced all raw UTC timestamp interpolation in badge tooltips (`live-status.ts`), transition lines (`cell-pieces.tsx`), level strip titles (`level-strip.tsx`), and drilldown panel (`cell-drilldown.tsx`). Timestamps now render in the browser's locale (e.g. "Apr 28, 5:17:34 AM" instead of "2026-04-28 05:17:34.396Z").

- **Docs selector bug**: Removed the unconditional `DocsRow` rendering from `CellStatus` (Health layer). Docs indicators were leaking into cells when Health was active but Docs was toggled off. The `DocsLayer` in `ComposedCell` already handles docs correctly via `overlays.has("docs")`.

- **Comprehensive selector tests**: Added 15 integration-style tests in `overlay-selector-integration.test.tsx` that render `ComposedCell` with real child components (not mocked) to verify each SHOW overlay toggle actually controls content visibility. Covers all 5 overlays individually, key combinations, testing-kind features, and all 3 presets.

- **Starter probe cleanup**: Excluded all 17 decommissioned `showcase-starter-*` Railway service names from `nameExcludes` in all 6 probe YAML configs (`smoke`, `e2e-smoke`, `e2e-deep`, `e2e-demos`, `e2e-parity`, `image-drift`) and from `EXCLUDE_SERVICES` in `aimock-wiring.ts`.

## Test plan

- [x] 343 vitest tests pass on integrated branch (4 pre-existing failures from missing generated `registry.json` — unrelated)
- [x] 15 new overlay selector integration tests all pass
- [x] 6 new `formatTs()` unit tests pass
- [x] B1+B2 cell-pieces.tsx merge verified clean (different functions, no conflicts)