### PR TITLE
fix: Mastra D5 subagents — execute signature + sub-agent fixtures

### DIFF
--- a/showcase/aimock/d5-all.json
+++ b/showcase/aimock/d5-all.json
@@ -185,6 +185,15 @@
       }
     },
     {
+      "_comment": "Nested: research sub-agent single-turn LLM call",
+      "match": {
+        "userMessage": "Benefits of remote work"
+      },
+      "response": {
+        "content": "- Eliminates commute, returning ~10 hours/week to employees\n- Surveys consistently show higher job satisfaction among remote workers\n- Employers gain access to a geographically unbounded talent pool\n- Reduced office overhead (rent, utilities, maintenance)\n- Trade-offs: ad-hoc collaboration, mentorship of junior staff, and cultural cohesion degrade without intentional replacement rituals"
+      }
+    },
+    {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
         "turnIndex": 1
@@ -200,6 +209,15 @@
       }
     },
     {
+      "_comment": "Nested: writing sub-agent single-turn LLM call",
+      "match": {
+        "userMessage": "One-paragraph summary on the benefits of remote work"
+      },
+      "response": {
+        "content": "Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
+      }
+    },
+    {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
         "turnIndex": 2
@@ -212,6 +230,15 @@
             "arguments": "{\"draft\":\"Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly.\"}"
           }
         ]
+      }
+    },
+    {
+      "_comment": "Nested: critique sub-agent single-turn LLM call",
+      "match": {
+        "userMessage": "Review this draft"
+      },
+      "response": {
+        "content": "1. Add a specific citation or date range for the surveys mentioned — 'repeated surveys' is vague and weakens the empirical claim.\n2. The ten-hours figure needs sourcing; without it the opening reads as an unsupported assertion rather than a research finding.\n3. The final sentence about 'intentional rituals' is abstract — one concrete example (e.g., scheduled pair-programming sessions, virtual coffee chats) would make the counterweight more actionable."
       }
     },
     {

--- a/showcase/harness/fixtures/d5/mcp-subagents.json
+++ b/showcase/harness/fixtures/d5/mcp-subagents.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "D5 fixture for /demos/subagents against LangGraph Python (LGP). Four-step chain: supervisor calls research_agent -> writing_agent -> critique_agent -> final reply. Uses turnIndex matching: aimock counts assistant messages in the request to disambiguate the four legs of the chain. Fixtures ordered 0→3 for readability.",
+  "_comment": "D5 fixture for /demos/subagents. Two layers: (1) Supervisor chain — 4-step turnIndex progression: research_agent -> writing_agent -> critique_agent -> final reply. (2) Nested sub-agent fixtures — each tool spawns an independent LLM call; these fixtures serve those nested calls so they succeed without --proxy-only mode.",
   "fixtures": [
     {
       "match": {
@@ -14,6 +14,15 @@
             "arguments": "{\"topic\":\"Benefits of remote work\"}"
           }
         ]
+      }
+    },
+    {
+      "_comment": "Nested: research sub-agent single-turn LLM call",
+      "match": {
+        "userMessage": "Benefits of remote work"
+      },
+      "response": {
+        "content": "- Eliminates commute, returning ~10 hours/week to employees\n- Surveys consistently show higher job satisfaction among remote workers\n- Employers gain access to a geographically unbounded talent pool\n- Reduced office overhead (rent, utilities, maintenance)\n- Trade-offs: ad-hoc collaboration, mentorship of junior staff, and cultural cohesion degrade without intentional replacement rituals"
       }
     },
     {
@@ -32,6 +41,15 @@
       }
     },
     {
+      "_comment": "Nested: writing sub-agent single-turn LLM call",
+      "match": {
+        "userMessage": "One-paragraph summary on the benefits of remote work"
+      },
+      "response": {
+        "content": "Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly."
+      }
+    },
+    {
       "match": {
         "userMessage": "Research the benefits of remote work and draft a one-paragraph summary",
         "turnIndex": 2
@@ -44,6 +62,15 @@
             "arguments": "{\"draft\":\"Remote work returns roughly ten hours a week to employees by eliminating the commute, and repeated surveys show meaningfully higher job satisfaction among remote workers. Employers benefit too: a geographically unbounded talent pool and lower office overhead. The honest counterweight is that ad-hoc collaboration, mentorship of junior staff, and cultural cohesion all degrade without intentional rituals to replace what an office provided implicitly.\"}"
           }
         ]
+      }
+    },
+    {
+      "_comment": "Nested: critique sub-agent single-turn LLM call",
+      "match": {
+        "userMessage": "Review this draft"
+      },
+      "response": {
+        "content": "1. Add a specific citation or date range for the surveys mentioned — 'repeated surveys' is vague and weakens the empirical claim.\n2. The ten-hours figure needs sourcing; without it the opening reads as an unsupported assertion rather than a research finding.\n3. The final sentence about 'intentional rituals' is abstract — one concrete example (e.g., scheduled pair-programming sessions, virtual coffee chats) would make the counterweight more actionable."
       }
     },
     {

--- a/showcase/integrations/mastra/src/mastra/tools/shared-state-read-write.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/shared-state-read-write.ts
@@ -32,8 +32,8 @@ export const setNotesTool = createTool({
         "Full updated notes list (existing notes plus any new ones). NOT a diff.",
       ),
   }),
-  execute: async ({ context }, executionContext) => {
-    const notes = context.notes ?? [];
+  execute: async (inputData, executionContext) => {
+    const notes = inputData.notes ?? [];
     await writeNotesToWorkingMemory(executionContext, notes);
     return JSON.stringify({ notes, updated: true as const });
   },

--- a/showcase/integrations/mastra/src/mastra/tools/subagents.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/subagents.ts
@@ -140,8 +140,8 @@ export const researchAgentTool = createTool({
   inputSchema: z.object({
     task: z.string().describe("The research task / topic to investigate."),
   }),
-  execute: async ({ context }, executionContext) => {
-    const task = context.task ?? "";
+  execute: async (inputData, executionContext) => {
+    const task = inputData.task ?? "";
     const result = await invokeSubAgent(researchSubAgent, task);
     const { delegation, resultText } = buildDelegationPayload(
       "research_agent",
@@ -167,8 +167,8 @@ export const writingAgentTool = createTool({
         "The drafting brief, including any facts the writer should incorporate.",
       ),
   }),
-  execute: async ({ context }, executionContext) => {
-    const task = context.task ?? "";
+  execute: async (inputData, executionContext) => {
+    const task = inputData.task ?? "";
     const result = await invokeSubAgent(writingSubAgent, task);
     const { delegation, resultText } = buildDelegationPayload(
       "writing_agent",
@@ -194,8 +194,8 @@ export const critiqueAgentTool = createTool({
         "The draft to critique, plus any specific critique focus you want.",
       ),
   }),
-  execute: async ({ context }, executionContext) => {
-    const task = context.task ?? "";
+  execute: async (inputData, executionContext) => {
+    const task = inputData.task ?? "";
     const result = await invokeSubAgent(critiqueSubAgent, task);
     const { delegation, resultText } = buildDelegationPayload(
       "critique_agent",


### PR DESCRIPTION
## Summary

- **Fix Mastra `createTool` execute signature** in 4 tools (`subagents.ts` × 3, `shared-state-read-write.ts` × 1): the first param is raw validated input (`inputData`), not a destructured `{ context }` wrapper. The old code silently passed `undefined` as the task/notes to sub-agents.
- **Add 3 nested sub-agent fixtures** for the D5 mcp-subagents demo: research, writing, and critique sub-agents each make independent LLM calls that need their own fixture entries. Production masked this via `--proxy-only` fallthrough to real OpenAI; local aimock correctly 404s on unmatched requests.
- **Rebuild `d5-all.json`** bundled fixture file (24 → 27 fixtures).

## Test plan

- [ ] `bin/showcase test mastra --d5 --verbose` — all 3 probes green (tool-rendering, subagents, agentic-chat)
- [ ] Verify fixture JSON is valid: `jq . showcase/harness/fixtures/d5/mcp-subagents.json > /dev/null`
- [ ] Verify d5-all.json fixture count: `jq '.fixtures | length' showcase/aimock/d5-all.json` → 27

🤖 Generated with [Claude Code](https://claude.com/claude-code)