### PR TITLE
fix(showcase): correct Mastra createTool execute signatures across all tools

### DIFF
--- a/examples/canvas/mastra-pm/src/mastra/tools/index.ts
+++ b/examples/canvas/mastra-pm/src/mastra/tools/index.ts
@@ -20,7 +20,7 @@ export const weatherTool = createTool({
     temperature: z.number(),
     conditions: z.string(),
   }),
-  execute: async ({ context: { location } }) => {
+  execute: async ({ location }) => {
     console.log("Using tool to fetch weather information for", location);
     return await getWeatherInfo(location);
   },

--- a/examples/canvas/mastra/src/mastra/tools/index.ts
+++ b/examples/canvas/mastra/src/mastra/tools/index.ts
@@ -12,8 +12,8 @@ export const setPlan = createTool({
     initialized: z.literal(true),
     steps: z.array(z.string()),
   }),
-  execute: async ({ context }) => {
-    return { initialized: true as const, steps: context.steps };
+  execute: async ({ steps }) => {
+    return { initialized: true as const, steps };
   },
 });
 
@@ -37,12 +37,12 @@ export const updatePlanProgress = createTool({
     status: z.string(),
     note: z.string().nullable(),
   }),
-  execute: async ({ context }) => {
+  execute: async ({ step_index, status, note }) => {
     return {
       updated: true as const,
-      index: context.step_index,
-      status: context.status,
-      note: context.note ?? null,
+      index: step_index,
+      status,
+      note: note ?? null,
     };
   },
 });

--- a/showcase/integrations/mastra/src/mastra/tools/index.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/index.ts
@@ -29,8 +29,8 @@ export const weatherTool = createTool({
   inputSchema: z.object({
     location: z.string().describe("City name"),
   }),
-  execute: async ({ context }) =>
-    JSON.stringify(getWeatherImpl(context.location)),
+  execute: async ({ location }) =>
+    JSON.stringify(getWeatherImpl(location)),
 });
 // @endregion[weather-tool-backend]
 
@@ -44,8 +44,8 @@ export const stockPriceTool = createTool({
   inputSchema: z.object({
     ticker: z.string().describe("Stock ticker symbol, e.g. AAPL"),
   }),
-  execute: async ({ context }) => {
-    const ticker = (context.ticker ?? "").toUpperCase();
+  execute: async ({ ticker: rawTicker }) => {
+    const ticker = (rawTicker ?? "").toUpperCase();
     return JSON.stringify({
       ticker,
       price_usd: 189.42,
@@ -60,7 +60,7 @@ export const queryDataTool = createTool({
   inputSchema: z.object({
     query: z.string().describe("Natural language query"),
   }),
-  execute: async ({ context }) => JSON.stringify(queryDataImpl(context.query)),
+  execute: async ({ query }) => JSON.stringify(queryDataImpl(query)),
 });
 
 export const manageSalesTodosTool = createTool({
@@ -81,8 +81,8 @@ export const manageSalesTodosTool = createTool({
       )
       .describe("Array of sales todo items"),
   }),
-  execute: async ({ context }) =>
-    JSON.stringify(manageSalesTodosImpl(context.todos)),
+  execute: async ({ todos }) =>
+    JSON.stringify(manageSalesTodosImpl(todos)),
 });
 
 export const getSalesTodosTool = createTool({
@@ -105,8 +105,8 @@ export const getSalesTodosTool = createTool({
       .nullable()
       .describe("Current todos if any"),
   }),
-  execute: async ({ context }) =>
-    JSON.stringify(getSalesTodosImpl(context.currentTodos)),
+  execute: async ({ currentTodos }) =>
+    JSON.stringify(getSalesTodosImpl(currentTodos)),
 });
 
 export const scheduleMeetingTool = createTool({
@@ -116,9 +116,9 @@ export const scheduleMeetingTool = createTool({
     reason: z.string().describe("Reason for the meeting"),
     durationMinutes: z.number().optional().describe("Duration in minutes"),
   }),
-  execute: async ({ context }) =>
+  execute: async ({ reason, durationMinutes }) =>
     JSON.stringify(
-      scheduleMeetingImpl(context.reason, context.durationMinutes),
+      scheduleMeetingImpl(reason, durationMinutes),
     ),
 });
 
@@ -146,8 +146,8 @@ export const searchFlightsTool = createTool({
       )
       .describe("Array of flight results"),
   }),
-  execute: async ({ context }) =>
-    JSON.stringify(searchFlightsImpl(context.flights)),
+  execute: async ({ flights }) =>
+    JSON.stringify(searchFlightsImpl(flights)),
 });
 
 export const generateA2uiTool = createTool({
@@ -160,10 +160,10 @@ export const generateA2uiTool = createTool({
       .optional()
       .describe("Context entries"),
   }),
-  execute: async ({ context }) => {
+  execute: async ({ messages, contextEntries }) => {
     const prep = generateA2uiImpl({
-      messages: context.messages,
-      contextEntries: context.contextEntries,
+      messages,
+      contextEntries,
     });
 
     const result = await generateText({

--- a/showcase/integrations/mastra/src/mastra/tools/index.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/index.ts
@@ -29,8 +29,7 @@ export const weatherTool = createTool({
   inputSchema: z.object({
     location: z.string().describe("City name"),
   }),
-  execute: async ({ location }) =>
-    JSON.stringify(getWeatherImpl(location)),
+  execute: async ({ location }) => JSON.stringify(getWeatherImpl(location)),
 });
 // @endregion[weather-tool-backend]
 
@@ -81,8 +80,7 @@ export const manageSalesTodosTool = createTool({
       )
       .describe("Array of sales todo items"),
   }),
-  execute: async ({ todos }) =>
-    JSON.stringify(manageSalesTodosImpl(todos)),
+  execute: async ({ todos }) => JSON.stringify(manageSalesTodosImpl(todos)),
 });
 
 export const getSalesTodosTool = createTool({
@@ -117,9 +115,7 @@ export const scheduleMeetingTool = createTool({
     durationMinutes: z.number().optional().describe("Duration in minutes"),
   }),
   execute: async ({ reason, durationMinutes }) =>
-    JSON.stringify(
-      scheduleMeetingImpl(reason, durationMinutes),
-    ),
+    JSON.stringify(scheduleMeetingImpl(reason, durationMinutes)),
 });
 
 export const searchFlightsTool = createTool({
@@ -146,8 +142,7 @@ export const searchFlightsTool = createTool({
       )
       .describe("Array of flight results"),
   }),
-  execute: async ({ flights }) =>
-    JSON.stringify(searchFlightsImpl(flights)),
+  execute: async ({ flights }) => JSON.stringify(searchFlightsImpl(flights)),
 });
 
 export const generateA2uiTool = createTool({


### PR DESCRIPTION
## Summary

- Fix Mastra `createTool` execute callback signatures that incorrectly destructured `{ context }` instead of the actual Zod schema fields
- `showcase/integrations/mastra/` — 8 tools (weatherTool, stockPriceTool, queryDataTool, manageSalesTodosTool, getSalesTodosTool, scheduleMeetingTool, searchFlightsTool, generateA2uiTool)
- `examples/canvas/mastra/` — 2 tools (setPlan, updatePlanProgress)
- `examples/canvas/mastra-pm/` — 1 tool (weatherTool)

Mastra's runtime calls `originalExecute(data, organizedContext)` where `data` is the raw Zod-validated output. The `{ context }` pattern silently received `undefined` for every field.

## Test plan

- [x] 7-agent CR round — converged to 0 findings
- [x] All field names verified against inputSchema definitions