### PR TITLE
feat(showcase): unified CLI for local debugging

### DIFF
--- a/showcase/DEBUGGING.md
+++ b/showcase/DEBUGGING.md
@@ -1,0 +1,315 @@
+# Showcase Local Debugging Playbook
+
+Quick-reference for running, debugging, and iterating on showcase integrations locally.
+
+## Prerequisites
+
+See [README.md](README.md) for Docker/Colima/OrbStack setup, API key configuration, and the general layout of the showcase directory. This document assumes you have a working Docker engine and a populated `.env` file.
+
+## CLI Reference
+
+The unified CLI is at `bin/showcase`. It wraps Docker Compose and adds debugging-specific commands. All commands can be run from any directory -- paths are resolved relative to the script itself.
+
+```sh
+# From repo root:
+./showcase/bin/showcase <command> [args...]
+
+# Or from within showcase/:
+./bin/showcase <command> [args...]
+```
+
+### Core Commands
+
+| Command | Description |
+|---------|-------------|
+| `showcase up [slug...]` | Start containers (rebuilds if source changed). No args = infra only (aimock, pocketbase, dashboard) |
+| `showcase down [slug...]` | Stop containers. No args = stop everything |
+| `showcase build [slug...]` | Build Docker images without starting containers |
+| `showcase ps` | Show running containers and their status |
+| `showcase ports` | Print slug-to-host-port mapping (from `shared/local-ports.json`) |
+| `showcase logs <slug>` | Follow container logs (supports `--grep`, `--since`, `-n`, `--no-follow`) |
+
+### Debugging Commands
+
+| Command | Description |
+|---------|-------------|
+| `showcase aimock-rebuild` | Rebuild local aimock from a source checkout and redeploy the container |
+| `showcase recreate <slug>` | Force-recreate a service (picks up a newly built image) |
+| `showcase test <slug>` | Run probe tests against a running service |
+| `showcase fixtures validate` | Check fixture JSON files for structural errors, duplicates, and common mistakes |
+| `showcase doctor` | Diagnose common local stack issues (Docker engine, Depot interception, stale images, port conflicts) |
+| `showcase diff-logs <slug>` | Show log output for a specific time window, filtering out noise from before your change |
+
+## The Debugging Loop
+
+This is the iterative process for going from a red probe to green. Each section below is a phase you will cycle through. Most debugging sessions follow the same pattern: establish baseline, trace what aimock sees, fix, re-test.
+
+### Phase 1: Establish the Red Baseline
+
+Start the infrastructure and run the failing test to see the exact error:
+
+```sh
+showcase up aimock mastra        # or whatever slug is failing
+showcase test mastra --d5 --verbose
+```
+
+What to look for in the output -- the specific probe name and error message. Common patterns:
+
+- **"chained reply missing fragments after 30000ms"** -- fixture matching issue. The agent is sending requests that don't match any fixture, so aimock returns 404 and the agent stalls.
+- **"timeout"** -- container not responding. The service may not have started, may be crash-looping, or may be listening on the wrong port. Check logs first.
+- **"404"** -- endpoint not found. The demo route doesn't exist, or the agent backend path is wrong. Check the integration's routing config.
+- **"JS error on page"** -- a frontend error is crashing the demo. Use Playwright UI mode (`npx playwright test --ui`) from the integration directory to see the browser and open DevTools.
+
+### Phase 2: Trace Fixture Matching
+
+When an agent loops, stalls, or produces wrong output, the answer is almost always in what aimock is matching (or failing to match):
+
+```sh
+showcase logs aimock --grep "fixture|match|NO match|404"
+```
+
+What the log lines mean:
+
+- **"matched fixture X at turnIndex N"** -- aimock found a fixture for this request and is returning it. If the same turnIndex repeats, the supervisor is stuck in a loop (re-sending the same request and getting the same canned response).
+- **"NO match"** -- the request pattern doesn't match any fixture. This means either the fixture is missing, or the request shape has changed (different model, different system prompt, different tool definitions).
+- **Repeated matches at the same turnIndex** -- the agent's retry/loop logic is firing because it didn't get the response it expected from the previous turn. The fixture chain is broken somewhere upstream.
+
+### Phase 3: The aimock Edit-Build-Deploy-Test Cycle
+
+This is the most repeated cycle during debugging. When you need to change aimock's behavior (response format, fixture matching logic, streaming behavior), the `aimock-rebuild` command automates the full rebuild-and-redeploy:
+
+```sh
+# 1. Edit aimock source (e.g., src/responses.ts, src/fixture-matcher.ts)
+
+# 2. Rebuild and redeploy:
+showcase aimock-rebuild --from /path/to/aimock
+
+# 3. Run the test:
+showcase test mastra --d5 --verbose --cycle
+```
+
+The `--cycle` flag on `test` automatically dumps aimock's log delta on failure, saving you from running a separate `logs` command after each failed attempt.
+
+**Without the CLI** (the manual equivalent, for understanding what the commands do under the hood):
+
+```sh
+cd /path/to/aimock && npm run build
+DEPOT_DISABLE=1 docker buildx build --builder desktop-linux --load -t aimock:local .
+docker compose -f tests/docker-compose.integrations.yml up -d --force-recreate aimock
+sleep 5 && docker logs showcase-aimock 2>&1 | tail -3
+```
+
+The CLI version handles the Depot bypass, builder selection, compose file path, and container readiness check automatically.
+
+### Phase 4: Integration Code Fixes
+
+When aimock is behaving correctly but the integration itself has bugs (wrong tool definitions, broken agent wiring, frontend rendering issues):
+
+```sh
+# Edit integration source (integrations/<slug>/src/...)
+showcase build <slug>           # rebuild the Docker image
+showcase recreate <slug>        # pick up the new image
+showcase test <slug> --d5 --verbose
+```
+
+Or combine build + recreate in one step:
+
+```sh
+showcase recreate <slug> --build
+```
+
+Use the Playwright UI mode directly (`npx playwright test --ui` from the integration directory) for interactive debugging of frontend issues where the DOM isn't rendering what the probe expects.
+
+### Phase 5: Fixture Iteration
+
+When adding or modifying aimock fixtures (the JSON files that define canned responses):
+
+```sh
+# 1. Edit fixture JSON (showcase/aimock/*.json)
+
+# 2. Validate fixtures for common errors (malformed JSON, duplicate keys,
+#    missing required fields, turnIndex gaps):
+showcase fixtures validate
+
+# 3. Recreate aimock to pick up the changed fixture files:
+showcase recreate aimock
+
+# 4. Test:
+showcase test <slug> --d5 --verbose
+```
+
+Fixtures are baked into the aimock Docker image at build time. Simply editing the JSON file on disk does nothing until the container is recreated with the updated files. This is the most common "why isn't my fix working?" mistake.
+
+### Phase 6: Verify Green
+
+Once you believe the fix is in, run the full probe suite for the slug to confirm everything passes:
+
+```sh
+showcase test <slug> --d5 --verbose
+# Expected: all probes pass, no timeouts, no fixture mismatches
+```
+
+If you want extra confidence, run the test command multiple times to check for flakes.
+
+## Gotchas and Common Mistakes
+
+### restart vs recreate
+
+`docker compose restart` reuses the existing container and image. If you have rebuilt an image, the restarted container still runs the OLD image. This is the single most common source of "I rebuilt but nothing changed."
+
+Always use `showcase recreate` (which runs `docker compose up --force-recreate`) when you need the new image:
+
+```sh
+# WRONG -- still uses old image:
+docker compose restart mastra
+
+# RIGHT -- picks up new image:
+showcase recreate mastra
+```
+
+### Depot intercepts Docker builds
+
+On machines with Depot CLI installed, `docker build` is silently proxied through Depot's remote builders. This causes two problems:
+
+1. The `--load` flag may not work as expected (the image stays on the remote builder instead of being loaded locally).
+2. Build caching behaves differently, and local filesystem mounts may not resolve.
+
+The `aimock-rebuild` command handles this automatically by setting `DEPOT_DISABLE=1` and using `--builder desktop-linux`.
+
+If you are building manually:
+
+```sh
+DEPOT_DISABLE=1 docker buildx build --builder desktop-linux --load -t myimage:local .
+```
+
+Run `showcase doctor` to check if Depot is intercepting your builds. The doctor command tests for the Depot shim and warns you if it is active.
+
+### Aimock is stateless; the Responses API is not
+
+The OpenAI Responses API uses `item_reference` to point to previous response items by ID. Aimock does not track conversation state across requests, so it cannot resolve these references dynamically. The synthetic assistant message fix handles this for `turnIndex`-based matching, but other stateful API features (e.g., conversation branching, response chaining by ID) may surface similar issues.
+
+If you see errors about unresolvable item references, the fix is usually to ensure the fixture chain includes all necessary prior-turn context in each response, rather than relying on aimock to remember previous turns.
+
+### Sub-agent calls are independent LLM requests
+
+Each framework's sub-agent (e.g., Mastra's `Agent.generate()`, CrewAI's crew member, LangGraph's tool-calling node) hits aimock as a completely separate HTTP request with a different system prompt and user message. Fixtures for sub-agents must be added explicitly -- they do not inherit from the supervisor's fixture chain.
+
+When debugging multi-agent flows:
+
+1. Use `showcase logs aimock --grep "match"` to see ALL requests, not just the top-level one.
+2. Each sub-agent request needs its own fixture with the correct system prompt pattern and turnIndex.
+3. The order of sub-agent calls may not be deterministic -- fixtures should be robust to reordering.
+
+### Production vs local aimock behavior
+
+Production aimock uses `--proxy-only`, which silently forwards unmatched requests to real OpenAI. Local aimock returns 404 for unmatched requests. This difference matters:
+
+- **Production can mask missing fixtures** -- the real LLM fills in, and the test may pass by coincidence. You won't know the fixture is incomplete until something changes in the LLM's behavior.
+- **Local surfaces fixture gaps immediately** -- 404 errors make missing fixtures obvious. This is a feature, not a bug.
+- **Local is the better environment for catching fixture gaps early.** If your test passes locally with all requests matched by fixtures, it will pass in production. The reverse is not guaranteed.
+
+## Workflows by Use Case
+
+### "A D5 probe is failing on CI"
+
+This is the most common debugging scenario. The goal is to reproduce the failure locally, where you have full access to logs and can iterate quickly.
+
+1. `showcase doctor` -- verify your local stack is healthy before chasing red herrings.
+2. `showcase up aimock <slug>` -- start the failing integration plus aimock.
+3. `showcase test <slug> --d5 --verbose --cycle` -- reproduce the failure locally. The `--cycle` flag dumps aimock logs on failure.
+4. `showcase logs aimock --grep "fixture|match"` -- trace what aimock is seeing. Is the fixture matched? Is it the right turnIndex?
+5. Fix the issue (fixture, aimock source, or integration code), then:
+   - Fixture change: `showcase recreate aimock` then re-test.
+   - Aimock source change: `showcase aimock-rebuild --from ~/proj/cpk/aimock` then re-test.
+   - Integration code change: `showcase recreate <slug> --build` then re-test.
+
+### "I changed aimock source and need to test it"
+
+The `aimock-rebuild` command handles the full cycle: build the npm package, build the Docker image with Depot bypass, force-recreate the aimock container, and wait for readiness.
+
+```sh
+showcase aimock-rebuild --from ~/proj/cpk/aimock
+showcase test <slug> --d5 --verbose
+```
+
+### "I added a new fixture and it is not being matched"
+
+Fixture matching issues are the most subtle to debug. Work through this checklist:
+
+```sh
+# Check for JSON syntax errors, duplicate turnIndex values, missing fields:
+showcase fixtures validate
+
+# Recreate aimock to pick up the new fixture file:
+showcase recreate aimock
+
+# Watch what aimock is actually matching in real-time:
+showcase logs aimock --grep "match"
+
+# Run the test with log dump on failure:
+showcase test <slug> --d5 --cycle
+```
+
+If the fixture validates and aimock still says "NO match", the request pattern has diverged from what the fixture expects. Compare the logged request (system prompt, model, tools) against the fixture's match criteria.
+
+### "A container is running but returning errors"
+
+```sh
+# Check for stale images, port conflicts, missing env vars:
+showcase doctor
+
+# Look at recent logs only (skip startup noise):
+showcase diff-logs <slug> --since 5m
+
+# Try a fresh container (sometimes state gets corrupted):
+showcase recreate <slug>
+```
+
+### "I want to see only logs from my last test run"
+
+The test command writes a timestamp marker, and `diff-logs` can use it:
+
+```sh
+showcase test <slug> --d5 --verbose      # this writes .last-test-ts
+showcase diff-logs aimock --since last-test --grep "fixture"
+```
+
+This filters out all log output from before your test started, showing only what happened during the test run itself.
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `AIMOCK_SRC` | Path to local aimock checkout for `aimock-rebuild` | `../../aimock` relative to `showcase/` (sibling of repo root), then `../aimock` |
+| `SHOWCASE_LOCAL` | Use localhost ports instead of Railway URLs in the shell app | unset |
+| `DEPOT_DISABLE` | Bypass Depot CLI for local Docker builds | unset (set to `1` to disable) |
+| `OPENAI_API_KEY` | Required for all integrations (even with aimock, some init code validates the key) | none |
+| `ANTHROPIC_API_KEY` | Required for Claude Agent SDK demos | none |
+
+## Quick Diagnostic Commands
+
+```sh
+# Is everything OK?
+showcase doctor
+
+# What's running?
+showcase ps
+
+# What port is mastra on?
+showcase ports | grep mastra
+
+# Show aimock's fixture matching in real-time:
+showcase logs aimock --grep "fixture|match|NO match"
+
+# Last 5 minutes of error logs:
+showcase diff-logs <slug> --since 5m --grep "error|Error|ERR"
+
+# Validate all fixture files:
+showcase fixtures validate
+
+# Full reset -- stop everything, rebuild, restart:
+showcase down
+showcase build <slug>
+showcase up aimock <slug>
+showcase test <slug> --d5 --verbose
+```

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -6,7 +6,8 @@ Per-framework demos of CopilotKit (LangGraph, CrewAI, Mastra, Claude Agent SDK, 
 
 ```
 showcase/
-  integrations/<slug>/              # one per framework (17 total) — Dockerfile, src/app/demos/*/, src/agents/ or equivalent
+  bin/showcase                  # unified CLI — run showcase/bin/showcase <command> for help
+  integrations/<slug>/          # one per framework (17 total) — Dockerfile, src/app/demos/*/, src/agents/ or equivalent
   shell/                        # hub: home page, /matrix, canonical /integrations/[slug]/[demo]/{preview,code}
   shell-dashboard/              # internal-only feature × integration grid (port 3002)
   shared/
@@ -15,7 +16,8 @@ showcase/
     local-ports.json            # deterministic host ports per package for local Docker runs
     python/ typescript/tools/   # shared agent utility code; CI stages these into each build context
   scripts/
-    dev-local.sh                # local Docker workflow (see below)
+    dev-local.sh                # low-level Docker Compose wrapper (prefer bin/showcase)
+    cli/                        # command modules for bin/showcase
     generate-registry.ts        # builds shell/src/data/registry.json from all manifest.yaml
     bundle-demo-content.ts      # bundles per-demo source + README into shell/src/data/demo-content.json
   docker-compose.local.yml      # one service per package; ports from local-ports.json; env from .env
@@ -101,11 +103,11 @@ The showcase harness includes a CLI that runs the same probe drivers (liveness, 
 # 2. Start infra + one integration
 ./showcase/bin/showcase up langgraph-python
 
-# 3. Run smoke probes
-./showcase/bin/showcase test langgraph-python --smoke
+# 3. Run D5 probes
+./showcase/bin/showcase test langgraph-python --d5
 
-# 4. Run full D5 depth
-./showcase/bin/showcase test langgraph-python --d5 --headed
+# 4. Run with verbose output
+./showcase/bin/showcase test langgraph-python --d5 --verbose
 
 # 5. Tear down when done
 ./showcase/bin/showcase down
@@ -113,104 +115,88 @@ The showcase harness includes a CLI that runs the same probe drivers (liveness, 
 
 ### Commands
 
-| Command              | Description                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------------ |
-| `test <target>`      | Run probes. Target is a slug (`langgraph-python`), slug:demo (`langgraph-python:chat`), or `all` |
-| `up [slugs...]`      | Start infra (aimock, pocketbase, dashboard) + named packages. No args = infra only               |
-| `down [slugs...]`    | Stop services. No args = stop everything                                                         |
-| `rebuild [slugs...]` | Rebuild Docker images                                                                            |
-| `ps`                 | Show running services                                                                            |
-| `logs <slug>`        | Tail logs for a service                                                                          |
-| `status`             | Print dashboard URL for full results                                                             |
+| Command              | Description                                                                     |
+| -------------------- | ------------------------------------------------------------------------------- |
+| `test <slug>`        | Run probes against a running service                                            |
+| `up [slugs...]`      | Start infra (aimock, pocketbase, dashboard) + named packages. No args = infra only |
+| `down [slugs...]`    | Stop services. No args = stop everything                                        |
+| `build [slugs...]`   | Build Docker images                                                             |
+| `ps`                 | Show running services                                                           |
+| `ports`              | Print slug to host port mapping                                                 |
+| `logs <slug>`        | Follow container logs (supports `--grep`, `--since`, `-n`, `--no-follow`)       |
 
-### Test levels
+**Debugging commands** (see [DEBUGGING.md](DEBUGGING.md) for full details):
 
-Specify depth with `--level` or shorthand flags (mutually exclusive):
+| Command                  | Description                                              |
+| ------------------------ | -------------------------------------------------------- |
+| `aimock-rebuild`         | Rebuild aimock from local source                         |
+| `recreate <slug>`       | Force-recreate a service (picks up new image)            |
+| `fixtures validate`      | Validate fixture JSON files for common errors            |
+| `doctor`                 | Check local environment and stack health                 |
+| `diff-logs <slug>`       | Show log delta for a time window                         |
 
-| Flag          | Level | What it runs                                                                               |
-| ------------- | ----- | ------------------------------------------------------------------------------------------ |
-| `--smoke`     | smoke | Liveness healthchecks (L1–L3) — container up, routes reachable, no JS errors               |
-| `--d4`        | d4    | E2E chat-tools — Playwright drives the demo UI, sends a message, asserts tool calls render |
-| `--d5`        | d5    | E2E deep — full conversation flow with aimock fixtures, asserts feature-specific behavior  |
-| `--level all` | all   | Runs smoke → d4 → d5 sequentially                                                          |
+### Test options
 
-Default level is `smoke` when no flag is given.
+| Option           | Description                                                          |
+| ---------------- | -------------------------------------------------------------------- |
+| `--d5`           | Run D5 (subagents/tool-rendering/agentic-chat) probes only           |
+| `--d6`           | Run D6 probes only                                                   |
+| `--verbose`      | Verbose test output                                                  |
+| `--cycle`        | On failure, auto-dump aimock logs from the test window                |
+| `--timeout <ms>` | Test timeout in milliseconds (default: 30000)                        |
 
-### Additional options
-
-| Option         | Description                                                                 |
-| -------------- | --------------------------------------------------------------------------- |
-| `--headed`     | Run Playwright visibly (not headless) — useful for debugging D4/D5 failures |
-| `--verbose`    | Verbose logging output                                                      |
-| `--repeat <n>` | Run the test suite N times (flake detection)                                |
-| `--keep`       | Don't stop auto-started containers after the test finishes                  |
-| `--live`       | Write results to PocketBase so the dashboard reflects them                  |
-| `--rebuild`    | Force Docker rebuild before running tests                                   |
-
-### Config file (optional)
-
-Create `showcase/showcase.local.json` to override defaults:
-
-```json
-{
-  "pocketbase": {
-    "url": "http://localhost:8090",
-    "email": "admin@localhost",
-    "password": "showcase-local-dev"
-  },
-  "dashboardUrl": "http://localhost:3200"
-}
-```
-
-The CLI works without this file — it uses sensible defaults matching docker-compose.local.yml.
+`--d5` and `--d6` are mutually exclusive. When neither is given, all tests run.
 
 ### How it works
 
 The CLI reuses the same probe drivers that the showcase-harness service runs on Railway. The difference is infrastructure: Railway probes hit Railway-deployed containers; the CLI probes hit local Docker Compose containers. Same assertions, same aimock fixtures, same Playwright flows.
 
 ```
-┌─────────┐     ┌──────────────────┐     ┌─────────────────────┐
-│  CLI    │────▸│  Probe Drivers   │────▸│  Docker Compose     │
-│  cli.ts │     │  liveness/d4/d5  │     │  containers         │
-└─────────┘     └──────────────────┘     │  (aimock + integs)  │
-                                         └─────────────────────┘
+┌───────────────┐     ┌──────────────────┐     ┌─────────────────────┐
+│  CLI          │────▸│  Probe Drivers   │────▸│  Docker Compose     │
+│  bin/showcase │     │  d5/d6           │     │  containers         │
+└───────────────┘     └──────────────────┘     │  (aimock + integs)  │
+                                               └─────────────────────┘
 ```
 
 ### Use cases
 
-1. **Debugging Dn failures** — reproduce a CI/Railway failure locally with `--d5 --headed` to watch Playwright step through the flow
-2. **Building new demos** — `up` the integration, iterate on code, `test --d4` to verify, repeat
-3. **Background automation** — `test all --level all --repeat 3` as a pre-push sanity check
+1. **Debugging Dn failures** — reproduce a CI/Railway failure locally with `--d5 --verbose --cycle` to see what aimock matched
+2. **Building new demos** — `up` the integration, iterate on code, `test <slug> --d5` to verify, repeat
+3. **Background automation** — run `test <slug> --d5` as a pre-push sanity check
 
-## Low-level Docker Compose workflow
+## Local Docker workflow
 
-For manual container management without the CLI, `scripts/dev-local.sh` wraps `docker compose` and handles the `shared_python/` / `shared_typescript/` staging step that CI also performs.
+`bin/showcase` is the unified CLI for local development. It wraps Docker Compose and adds debugging commands.
 
 ```sh
 # from the repo root
 
-# inspect — no Docker calls
-./showcase/scripts/dev-local.sh ports            # slug → host port
-./showcase/scripts/dev-local.sh ps               # what's running
+# inspect
+showcase/bin/showcase ports              # slug → host port
+showcase/bin/showcase ps                 # what's running
 
-# build one (first build: 1–3 min; subsequent builds are cached)
-./showcase/scripts/dev-local.sh build langgraph-python
-
-# start one — rebuilds if source changed
-./showcase/scripts/dev-local.sh up langgraph-python
+# build + start
+showcase/bin/showcase build langgraph-python
+showcase/bin/showcase up langgraph-python
 
 # start everything (17 containers, heavy)
-./showcase/scripts/dev-local.sh up
+showcase/bin/showcase up
 
-# follow logs
-./showcase/scripts/dev-local.sh logs langgraph-python
+# follow logs (with optional grep filtering)
+showcase/bin/showcase logs langgraph-python
+showcase/bin/showcase logs aimock --grep "fixture|match"
 
 # stop
-./showcase/scripts/dev-local.sh down langgraph-python
-./showcase/scripts/dev-local.sh down            # all
+showcase/bin/showcase down langgraph-python
+showcase/bin/showcase down               # all
 ```
 
-Each container exposes port `10000` internally and is mapped to the host port in [`shared/local-ports.json`](shared/local-ports.json) (langgraph-python → 3100, langgraph-typescript → 3101, …). The image and entrypoint are **the same ones Railway runs** — no frontend-only shortcuts, no behavioral drift.
+Each container exposes port `10000` internally and is mapped to the host port in [`shared/local-ports.json`](shared/local-ports.json). The image and entrypoint are **the same ones Railway runs**.
+
+For debugging workflows (aimock rebuild cycles, fixture validation, probe testing, diagnostics), see [DEBUGGING.md](DEBUGGING.md).
+
+> **Note:** `scripts/dev-local.sh` still works for the core commands (`up`, `down`, `build`, `logs`, `ps`, `ports`). `bin/showcase` wraps the same logic and adds the debugging commands.
 
 ## Hooking the local containers into the shell
 
@@ -241,8 +227,19 @@ Column ordering lives in `shell-dashboard/src/lib/sort-order.ts` — internal to
 1. Edit the demo in `integrations/<slug>/src/app/demos/<demo-id>/page.tsx` (and the backend under `src/agents/` if applicable).
 2. Rebundle so `/code` in `shell` reflects the edit: `cd showcase && npx tsx scripts/bundle-demo-content.ts`.
 3. If you changed `manifest.yaml` or added a feature to `shared/feature-registry.json`: `npx tsx scripts/generate-registry.ts`.
-4. Rebuild + restart the container: `./scripts/dev-local.sh up <slug>`.
+4. Rebuild + restart the container: `showcase/bin/showcase up <slug>`.
 5. The grid in `shell-dashboard` and `/preview` in `shell` now show the new state.
+
+## Debugging
+
+For the full debugging playbook — including aimock rebuild cycles, fixture validation, probe testing, container diagnostics, and common gotchas — see [DEBUGGING.md](DEBUGGING.md).
+
+Quick start:
+```sh
+showcase/bin/showcase doctor              # check your stack
+showcase/bin/showcase test mastra --d5    # run D5 probes
+showcase/bin/showcase aimock-rebuild      # rebuild aimock from local source
+```
 
 ## Relationship to Railway
 

--- a/showcase/bin/showcase
+++ b/showcase/bin/showcase
@@ -1,3 +1,124 @@
 #!/usr/bin/env bash
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec npx tsx "$SCRIPT_DIR/../harness/src/cli.ts" "$@"
+# showcase — unified CLI for the CopilotKit showcase platform.
+#
+# Dispatches to built-in compose commands (up, down, build, ps, ports, logs)
+# and to plugin commands defined in scripts/cli/cmd-*.sh files.
+
+set -euo pipefail
+
+# ── Bootstrap ────────────────────────────────────────────────────────────────
+
+BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHOWCASE_ROOT="$(cd "$BIN_DIR/.." && pwd)"
+export SHOWCASE_ROOT
+
+# shellcheck source=../scripts/cli/_common.sh
+source "$SHOWCASE_ROOT/scripts/cli/_common.sh"
+
+# ── Auto-discover plugin commands (cmd-*.sh) ─────────────────────────────────
+
+# Plugin names and their descriptions, stored as parallel arrays for bash 3
+# compatibility (no associative arrays on macOS default bash).
+_plugin_names=()
+_plugin_descs=()
+
+for cmd_file in "$SHOWCASE_ROOT"/scripts/cli/cmd-*.sh; do
+  [ -f "$cmd_file" ] || continue
+  # shellcheck disable=SC1090
+  source "$cmd_file"
+  # Extract command name: cmd-foo-bar.sh → foo-bar
+  _name="$(basename "$cmd_file" .sh)"
+  _name="${_name#cmd-}"
+  _plugin_names+=("$_name")
+  # Each cmd file should define CMD_<NAME>_DESC (dashes→underscores, uppercased)
+  # e.g. cmd-aimock-rebuild.sh defines CMD_AIMOCK_REBUILD_DESC
+  _desc_var="CMD_${_name//-/_}"
+  _desc_var="$(echo "$_desc_var" | tr '[:lower:]' '[:upper:]')_DESC"
+  _plugin_descs+=("${!_desc_var:-}")
+done
+
+# ── Built-in commands ────────────────────────────────────────────────────────
+
+cmd_up() {
+  require_env
+  trap restore_symlinks EXIT
+  stage_shared
+  $COMPOSE_CMD up -d --build "$@"
+}
+
+cmd_down() {
+  $COMPOSE_CMD down "$@"
+}
+
+cmd_build() {
+  trap restore_symlinks EXIT
+  stage_shared
+  $COMPOSE_CMD build "$@"
+}
+
+cmd_ps() {
+  $COMPOSE_CMD ps "$@"
+}
+
+cmd_ports() {
+  if command -v jq &>/dev/null; then
+    jq -r 'to_entries[] | "\(.key)\t→ localhost:\(.value)"' "$PORTS_FILE"
+  else
+    cat "$PORTS_FILE"
+  fi
+}
+
+# ── Usage ────────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<'HEADER'
+Usage: showcase <command> [options]
+
+Core commands:
+  up [slug...]      Start containers (rebuilds if source changed)
+  down [slug...]    Stop containers
+  build [slug...]   Build Docker images
+  ps                Show running containers
+  ports             Print slug → host port mapping
+HEADER
+
+  # Print plugin commands if any are loaded
+  if [ ${#_plugin_names[@]} -gt 0 ]; then
+    echo ""
+    echo "Plugin commands:"
+    local i
+    for i in "${!_plugin_names[@]}"; do
+      printf "  %-17s %s\n" "${_plugin_names[$i]}" "${_plugin_descs[$i]}"
+    done
+  fi
+
+  cat <<'FOOTER'
+
+Run 'showcase <command> --help' for details on a specific command.
+FOOTER
+}
+
+# ── Dispatch ─────────────────────────────────────────────────────────────────
+
+subcmd="${1:-}"
+shift || true
+
+case "$subcmd" in
+  ""|"-h"|"--help"|"help")
+    usage
+    [ -z "$subcmd" ] && exit 1
+    exit 0
+    ;;
+  *)
+    # Convert dashes to underscores for function lookup: foo-bar → cmd_foo_bar
+    func_name="cmd_${subcmd//-/_}"
+    if type "$func_name" 2>/dev/null | head -1 | grep -q 'function'; then
+      "$func_name" "$@"
+    else
+      echo "Unknown command: $subcmd" >&2
+      echo ""
+      usage
+      exit 1
+    fi
+    ;;
+esac

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Shared variables and helper functions for the showcase CLI.
+# Sourced by bin/showcase — not meant to be executed directly.
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+
+SHOWCASE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
+COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+ENV_FILE="$SHOWCASE_ROOT/.env"
+PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
+AIMOCK_COMPOSE="$SHOWCASE_ROOT/tests/docker-compose.integrations.yml"
+
+# ── Output helpers ───────────────────────────────────────────────────────────
+
+die() {
+  printf '\033[1;31m✗ %s\033[0m\n' "$1" >&2
+  exit 1
+}
+
+info() {
+  printf '\033[0;36m▸ %s\033[0m\n' "$1"
+}
+
+warn() {
+  printf '\033[1;33m⚠ %s\033[0m\n' "$1" >&2
+}
+
+success() {
+  printf '\033[0;32m✓ %s\033[0m\n' "$1"
+}
+
+# ── Validation helpers ───────────────────────────────────────────────────────
+
+need_slug() {
+  [ -n "${1:-}" ] || die "slug required"
+}
+
+require_env() {
+  [ -f "$ENV_FILE" ] || die "Missing $ENV_FILE. Copy showcase/.env.example to showcase/.env and fill in keys."
+}
+
+# ── Docker / Compose helpers ─────────────────────────────────────────────────
+
+stage_shared() {
+  # Dereference tools/ and shared-tools/ symlinks into real copies so Docker
+  # COPY can follow them (Docker build contexts can't traverse symlinks that
+  # point outside the context).
+  for pkg_dir in "$SHOWCASE_ROOT"/integrations/*/; do
+    for link_name in tools shared-tools; do
+      local link_path="$pkg_dir/$link_name"
+      if [ -L "$link_path" ]; then
+        local target
+        target="$(readlink "$link_path")"
+        # Resolve relative symlink targets against the link's directory
+        if [[ "$target" != /* ]]; then
+          target="$(cd "$(dirname "$link_path")" && cd "$(dirname "$target")" && pwd)/$(basename "$target")"
+        fi
+        if [ -d "$target" ]; then
+          rm "$link_path"
+          rsync -a "$target/" "$link_path/"
+        fi
+      fi
+    done
+  done
+}
+
+restore_symlinks() {
+  # Restore tools/ and shared-tools/ symlinks replaced by stage_shared.
+  (cd "$SHOWCASE_ROOT" && git checkout -- integrations/*/tools integrations/*/shared-tools 2>/dev/null || true)
+}
+
+slug_to_container() {
+  echo "showcase-${1}"
+}
+
+slug_to_port() {
+  local slug="${1:?slug required}"
+  if command -v jq &>/dev/null; then
+    jq -r --arg s "$slug" '.[$s] // empty' "$PORTS_FILE"
+  else
+    # Fallback: simple grep/sed if jq is not available
+    grep "\"$slug\"" "$PORTS_FILE" | sed 's/[^0-9]//g'
+  fi
+}
+
+is_service_healthy() {
+  local slug="${1:?slug required}"
+  local container
+  container="$(slug_to_container "$slug")"
+  local health
+  health="$(docker inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || echo "missing")"
+  [ "$health" = "healthy" ]
+}
+
+wait_healthy() {
+  local slug="${1:?slug required}"
+  local timeout="${2:-30}"
+  local elapsed=0
+  info "Waiting for $slug to become healthy (timeout ${timeout}s)..."
+  while ! is_service_healthy "$slug"; do
+    if [ "$elapsed" -ge "$timeout" ]; then
+      die "$slug did not become healthy within ${timeout}s"
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  success "$slug is healthy (${elapsed}s)"
+}

--- a/showcase/scripts/cli/cmd-aimock-rebuild.sh
+++ b/showcase/scripts/cli/cmd-aimock-rebuild.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# showcase aimock-rebuild — rebuild local aimock from source checkout
+# Sourced by the main dispatcher; do not execute directly.
+
+CMD_AIMOCK_REBUILD_DESC="Rebuild local aimock from source checkout"
+
+usage_aimock_rebuild() {
+  cat <<'HELP'
+Usage: showcase aimock-rebuild [--from <path>]
+
+Rebuild aimock from a local source checkout and redeploy the container.
+
+Options:
+  --from <path>    Path to local aimock checkout
+                   Default: $AIMOCK_SRC or ../aimock (sibling repo)
+
+Steps performed:
+  1. npm run build (in aimock source)
+  2. Docker build (DEPOT_DISABLE=1, local --load)
+  3. Force-recreate aimock container
+  4. Wait for healthy
+
+Environment:
+  AIMOCK_SRC       Default aimock source directory
+HELP
+}
+
+cmd_aimock_rebuild() {
+  local aimock_src=""
+
+  # ── Parse arguments ──────────────────────────────────────────────
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --from)
+        [[ -z "${2:-}" ]] && die "--from requires a path argument"
+        aimock_src="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage_aimock_rebuild
+        return 0
+        ;;
+      *)
+        die "Unknown argument: $1 (see showcase aimock-rebuild --help)"
+        ;;
+    esac
+  done
+
+  # ── Resolve aimock source directory ──────────────────────────────
+  if [[ -z "$aimock_src" ]]; then
+    if [[ -n "${AIMOCK_SRC:-}" && -d "$AIMOCK_SRC" ]]; then
+      aimock_src="$AIMOCK_SRC"
+    elif [[ -d "$SHOWCASE_ROOT/../../aimock" ]]; then
+      aimock_src="$SHOWCASE_ROOT/../../aimock"
+    elif [[ -d "$SHOWCASE_ROOT/../aimock" ]]; then
+      aimock_src="$SHOWCASE_ROOT/../aimock"
+    else
+      die "Cannot find aimock source. Set AIMOCK_SRC or use --from <path>"
+    fi
+  fi
+
+  # Canonicalise and validate
+  aimock_src="$(cd "$aimock_src" 2>/dev/null && pwd)" \
+    || die "Cannot resolve aimock source path"
+  [[ -f "$aimock_src/package.json" ]] \
+    || die "No package.json in $aimock_src — is this an aimock checkout?"
+
+  info "aimock source: $aimock_src"
+
+  local step_start total_start
+  total_start=$(date +%s.%N 2>/dev/null || date +%s)
+
+  # ── Step 1: npm build ───────────────────────────────────────────
+  info "Step 1/4: npm run build"
+  step_start=$(date +%s.%N 2>/dev/null || date +%s)
+  (cd "$aimock_src" && npm run build) || die "npm run build failed in $aimock_src"
+  local build_elapsed
+  build_elapsed=$(awk "BEGIN{printf \"%.1f\", $(date +%s.%N 2>/dev/null || date +%s) - $step_start}")
+  success "npm build (${build_elapsed}s)"
+
+  # ── Step 2: Docker build ────────────────────────────────────────
+  info "Step 2/4: Docker build"
+  step_start=$(date +%s.%N 2>/dev/null || date +%s)
+
+  # Detect available builder
+  local builder
+  if docker buildx ls 2>/dev/null | grep -q desktop-linux; then
+    builder="desktop-linux"
+  else
+    builder="default"
+  fi
+  info "Using builder: $builder"
+
+  DEPOT_DISABLE=1 docker buildx build \
+    --builder "$builder" \
+    --load \
+    -t aimock:local \
+    "$aimock_src" \
+    || die "Docker build failed"
+
+  local docker_elapsed
+  docker_elapsed=$(awk "BEGIN{printf \"%.1f\", $(date +%s.%N 2>/dev/null || date +%s) - $step_start}")
+  success "Docker build (${docker_elapsed}s)"
+
+  # ── Step 3: Force-recreate container ────────────────────────────
+  info "Step 3/4: Force-recreate aimock container"
+  step_start=$(date +%s.%N 2>/dev/null || date +%s)
+
+  docker compose -f "$AIMOCK_COMPOSE" up -d --force-recreate aimock \
+    || die "Failed to recreate aimock container"
+
+  local recreate_elapsed
+  recreate_elapsed=$(awk "BEGIN{printf \"%.1f\", $(date +%s.%N 2>/dev/null || date +%s) - $step_start}")
+  success "Force-recreate (${recreate_elapsed}s)"
+
+  # ── Step 4: Wait for healthy ────────────────────────────────────
+  info "Step 4/4: Waiting for aimock to become healthy"
+  step_start=$(date +%s.%N 2>/dev/null || date +%s)
+
+  local container_name="showcase-aimock"
+  local timeout_secs=30
+  local deadline=$((SECONDS + timeout_secs))
+  local status=""
+
+  while [[ $SECONDS -lt $deadline ]]; do
+    status=$(docker inspect --format='{{.State.Health.Status}}' "$container_name" 2>/dev/null || echo "missing")
+    case "$status" in
+      healthy)
+        local health_elapsed
+        health_elapsed=$(awk "BEGIN{printf \"%.1f\", $(date +%s.%N 2>/dev/null || date +%s) - $step_start}")
+        success "Healthy (${health_elapsed}s)"
+
+        local total_elapsed
+        total_elapsed=$(awk "BEGIN{printf \"%.1f\", $(date +%s.%N 2>/dev/null || date +%s) - $total_start}")
+        success "aimock rebuilt and healthy (total ${total_elapsed}s)"
+        return 0
+        ;;
+      unhealthy)
+        warn "Container reports unhealthy — retrying..."
+        ;;
+    esac
+    printf "."
+    sleep 1
+  done
+
+  # Timed out
+  printf "\n"
+  local total_elapsed
+  total_elapsed=$(awk "BEGIN{printf \"%.1f\", $(date +%s.%N 2>/dev/null || date +%s) - $total_start}")
+  warn "aimock rebuilt but health check timed out after ${timeout_secs}s (container may still be starting)"
+  warn "Last status: $status (total ${total_elapsed}s)"
+  return 1
+}

--- a/showcase/scripts/cli/cmd-diff-logs.sh
+++ b/showcase/scripts/cli/cmd-diff-logs.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# showcase diff-logs — show log delta for a time window
+
+CMD_DIFF_LOGS_DESC="Show log delta for a time window"
+
+usage_diff_logs() {
+  cat <<'USAGE'
+Usage: showcase diff-logs <slug> --since <time> [options]
+
+Show container logs for a specific time window. Useful when running
+tests repeatedly — see only logs from the last run, not the full
+container lifetime.
+
+Options:
+  --since <time>    Start of window (required). Accepts:
+                      Duration: 10m, 1h, 30s
+                      Timestamp: 2024-01-15T10:30:00
+                      Special: "last-test" (reads .last-test-ts marker)
+  --until <time>    End of window (default: now)
+  --grep <pattern>  Filter output (regex, e.g. "fixture|match")
+
+Examples:
+  showcase diff-logs aimock --since 5m
+  showcase diff-logs mastra --since 10m --grep "error|warn"
+  showcase diff-logs aimock --since last-test
+  showcase diff-logs aimock --since 10:30:00 --until 10:35:00
+USAGE
+}
+
+cmd_diff_logs() {
+  [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && { usage_diff_logs; return 0; }
+
+  local slug=""
+  local since=""
+  local until_ts=""
+  local grep_pattern=""
+
+  # First positional arg is slug, rest are flags
+  slug="${1:-}"
+  need_slug "$slug"
+  shift
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --since)     [[ -n "${2:-}" ]] || die "--since requires a value"; since="$2"; shift 2 ;;
+      --until)     [[ -n "${2:-}" ]] || die "--until requires a value"; until_ts="$2"; shift 2 ;;
+      --grep)      [[ -n "${2:-}" ]] || die "--grep requires a value"; grep_pattern="$2"; shift 2 ;;
+      -h|--help)   usage_diff_logs; return 0 ;;
+      *)           die "Unknown option: $1" ;;
+    esac
+  done
+
+  [[ -z "$since" ]] && die "--since is required"
+
+  # Handle --since last-test convenience
+  if [[ "$since" == "last-test" ]]; then
+    local ts_file="$SHOWCASE_ROOT/.last-test-ts"
+    if [[ -f "$ts_file" ]]; then
+      since=$(cat "$ts_file")
+      info "Using last test timestamp: $since"
+    else
+      warn "No .last-test-ts found, falling back to 5m"
+      since="5m"
+    fi
+  fi
+
+  local container
+  container=$(slug_to_container "$slug")
+
+  local docker_args=("--since" "$since")
+  [[ -n "$until_ts" ]] && docker_args+=("--until" "$until_ts")
+
+  local output
+  if [[ -n "$grep_pattern" ]]; then
+    output=$(docker logs "${docker_args[@]}" "$container" 2>&1 | grep --color=auto -E "$grep_pattern") || true
+  else
+    output=$(docker logs "${docker_args[@]}" "$container" 2>&1)
+  fi
+
+  local line_count
+  if [[ -z "$output" ]]; then
+    line_count=0
+  else
+    line_count=$(printf '%s\n' "$output" | wc -l | tr -d ' ')
+  fi
+
+  local window_desc="$since"
+  [[ -n "$until_ts" ]] && window_desc="${since} → ${until_ts}"
+
+  printf '═══ %s logs (%s, %d lines) ═══\n' "$container" "$window_desc" "$line_count"
+  [[ -n "$output" ]] && printf '%s\n' "$output"
+  echo "═══════════════════════════════════════════════════════════════"
+}

--- a/showcase/scripts/cli/cmd-doctor.sh
+++ b/showcase/scripts/cli/cmd-doctor.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# showcase doctor — diagnose common local stack issues
+# Sourced by the main dispatcher; do not execute directly.
+
+CMD_DOCTOR_DESC="Diagnose common local stack issues"
+
+usage_doctor() {
+  cat <<'HELP'
+Usage: showcase doctor
+
+Diagnose common issues with the local showcase stack.
+
+Checks performed:
+  - Docker engine and Compose availability
+  - Depot CLI interception (common build gotcha)
+  - ENV file and API keys
+  - Compose file validity
+  - Container status and stale images
+  - Aimock health and fixture files
+  - Port conflicts
+HELP
+}
+
+# ── Color helpers ────────────────────────────────────────────────────────────
+
+_doctor_has_color() {
+  [ -t 1 ] && { [ "${TERM:-dumb}" != "dumb" ] || [ -n "${FORCE_COLOR:-}" ]; }
+}
+
+_doctor_pass() {
+  if _doctor_has_color; then
+    printf '\033[0;32m%-22s\033[0m %s\n' "  ✓ $1" "$2"
+  else
+    printf '%-22s %s\n' "  ✓ $1" "$2"
+  fi
+  _DOCTOR_PASS=$((_DOCTOR_PASS + 1))
+}
+
+_doctor_warn() {
+  if _doctor_has_color; then
+    printf '\033[1;33m%-22s\033[0m %s\n' "  ⚠ $1" "$2"
+  else
+    printf '%-22s %s\n' "  ⚠ $1" "$2"
+  fi
+  _DOCTOR_WARN=$((_DOCTOR_WARN + 1))
+}
+
+_doctor_fail() {
+  if _doctor_has_color; then
+    printf '\033[1;31m%-22s\033[0m %s\n' "  ✗ $1" "$2"
+  else
+    printf '%-22s %s\n' "  ✗ $1" "$2"
+  fi
+  _DOCTOR_FAIL=$((_DOCTOR_FAIL + 1))
+}
+
+# ── Individual checks ───────────────────────────────────────────────────────
+
+_check_docker_engine() {
+  if ! docker info >/dev/null 2>&1; then
+    _doctor_fail "Docker engine" "Not running — start Docker Desktop or dockerd"
+    return
+  fi
+  local version
+  version="$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "unknown")"
+  _doctor_pass "Docker engine" "Docker $version"
+}
+
+_check_docker_compose() {
+  if ! docker compose version >/dev/null 2>&1; then
+    _doctor_fail "Docker Compose" "Not available — install docker-compose-plugin"
+    return
+  fi
+  local version
+  version="$(docker compose version --short 2>/dev/null || echo "unknown")"
+  _doctor_pass "Docker Compose" "v$version"
+}
+
+_check_depot_interception() {
+  local docker_path
+  docker_path="$(which docker 2>/dev/null || true)"
+
+  if [ -n "$docker_path" ] && echo "$docker_path" | grep -qi "depot"; then
+    _doctor_warn "Depot CLI" "Detected — use DEPOT_DISABLE=1 for local builds"
+    return
+  fi
+
+  # Also check if depot's buildx builder is active even without shim
+  if DEPOT_DISABLE=1 docker buildx ls 2>/dev/null | grep -q "depot"; then
+    _doctor_warn "Depot CLI" "Depot buildx builder active — use --builder desktop-linux"
+    return
+  fi
+
+  _doctor_pass "Depot CLI" "No Depot interception detected"
+}
+
+_check_env_file() {
+  if [ ! -f "$ENV_FILE" ]; then
+    _doctor_fail "ENV file" ".env missing — copy showcase/.env.example"
+    return
+  fi
+
+  local key_count=0
+  local has_openai=false
+  while IFS= read -r line; do
+    # Skip comments and empty lines
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+    # Count lines with = sign (key=value pairs)
+    if [[ "$line" == *"="* ]]; then
+      key_count=$((key_count + 1))
+      if [[ "$line" == OPENAI_API_KEY=* ]]; then
+        local val="${line#OPENAI_API_KEY=}"
+        # Strip quotes
+        val="${val#\"}"
+        val="${val%\"}"
+        val="${val#\'}"
+        val="${val%\'}"
+        [ -n "$val" ] && has_openai=true
+      fi
+    fi
+  done < "$ENV_FILE"
+
+  if [ "$has_openai" = false ]; then
+    _doctor_warn "ENV file" ".env present ($key_count keys) but missing OPENAI_API_KEY"
+    return
+  fi
+
+  _doctor_pass "ENV file" ".env present ($key_count keys)"
+}
+
+_check_compose_file() {
+  if [ ! -f "$COMPOSE_FILE" ]; then
+    _doctor_fail "Compose file" "docker-compose.local.yml missing"
+    return
+  fi
+
+  if ! docker compose -f "$COMPOSE_FILE" config --quiet 2>/dev/null; then
+    _doctor_fail "Compose file" "docker-compose.local.yml failed to parse"
+    return
+  fi
+
+  local service_count
+  service_count="$(docker compose -f "$COMPOSE_FILE" config --services 2>/dev/null | wc -l | tr -d ' ')"
+  _doctor_pass "Compose file" "docker-compose.local.yml valid ($service_count services)"
+}
+
+_check_running_containers() {
+  local containers
+  containers="$(docker ps -a --filter "name=showcase-" --format '{{.Names}}|{{.Status}}|{{.Image}}' 2>/dev/null || true)"
+
+  if [ -z "$containers" ]; then
+    _doctor_warn "Running containers" "No showcase containers found"
+    return
+  fi
+
+  local running=0
+  local total=0
+  while IFS='|' read -r name status image; do
+    total=$((total + 1))
+    if echo "$status" | grep -qi "^up"; then
+      running=$((running + 1))
+    fi
+  done <<< "$containers"
+
+  if [ "$running" -eq 0 ]; then
+    _doctor_warn "Running containers" "0 of $total running"
+  else
+    _doctor_pass "Running containers" "$running of $total running"
+  fi
+}
+
+_check_stale_images() {
+  local containers
+  containers="$(docker ps --filter "name=showcase-" --format '{{.Names}}' 2>/dev/null || true)"
+
+  if [ -z "$containers" ]; then
+    # No running containers, nothing to check
+    _doctor_pass "Stale images" "No running containers to check"
+    return
+  fi
+
+  local stale_list=""
+  while IFS= read -r cname; do
+    local slug="${cname#showcase-}"
+
+    # Get the image ID the container is running
+    local container_image_id
+    container_image_id="$(docker inspect --format='{{.Image}}' "$cname" 2>/dev/null || true)"
+    [ -z "$container_image_id" ] && continue
+
+    # Get the latest local image ID for this slug
+    local latest_image_id
+    latest_image_id="$(docker images --format '{{.ID}}' "showcase-${slug}:local" 2>/dev/null | head -1)"
+    [ -z "$latest_image_id" ] && continue
+
+    # Compare (container image is sha256:xxx, local image is short hash)
+    if ! echo "$container_image_id" | grep -q "$latest_image_id"; then
+      if [ -n "$stale_list" ]; then
+        stale_list="$stale_list, $slug"
+      else
+        stale_list="$slug"
+      fi
+    fi
+  done <<< "$containers"
+
+  if [ -n "$stale_list" ]; then
+    _doctor_warn "Stale images" "$stale_list using old image (recreate to fix)"
+  else
+    _doctor_pass "Stale images" "All containers using latest images"
+  fi
+}
+
+_check_aimock_health() {
+  local container="showcase-aimock"
+
+  # Check if container exists and is running
+  local status
+  status="$(docker inspect --format='{{.State.Status}}' "$container" 2>/dev/null || echo "missing")"
+
+  if [ "$status" = "missing" ] || [ "$status" = "exited" ]; then
+    _doctor_warn "Aimock" "Container not running"
+    return
+  fi
+
+  local health
+  health="$(docker inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || echo "unknown")"
+
+  if [ "$health" = "healthy" ]; then
+    # Try to get fixture count from the health endpoint
+    local fixture_info=""
+    local health_response
+    health_response="$(curl -s --max-time 3 http://localhost:4010/health 2>/dev/null || true)"
+    if [ -n "$health_response" ] && command -v jq &>/dev/null; then
+      local fixture_count
+      fixture_count="$(echo "$health_response" | jq -r '.fixtures // .fixtureCount // empty' 2>/dev/null || true)"
+      [ -n "$fixture_count" ] && fixture_info=", $fixture_count fixtures loaded"
+    fi
+    _doctor_pass "Aimock" "Healthy${fixture_info}"
+  else
+    _doctor_warn "Aimock" "Running but $health"
+  fi
+}
+
+_check_fixture_files() {
+  local fixture_dir="$SHOWCASE_ROOT/aimock"
+  local file_count=0
+  local total_size=0
+
+  if [ ! -d "$fixture_dir" ]; then
+    _doctor_warn "Fixture files" "aimock/ directory not found"
+    return
+  fi
+
+  for f in "$fixture_dir"/*.json; do
+    [ -f "$f" ] || continue
+    file_count=$((file_count + 1))
+    local fsize
+    # macOS stat vs GNU stat
+    if stat --version >/dev/null 2>&1; then
+      fsize="$(stat -c%s "$f" 2>/dev/null || echo 0)"
+    else
+      fsize="$(stat -f%z "$f" 2>/dev/null || echo 0)"
+    fi
+    total_size=$((total_size + fsize))
+  done
+
+  if [ "$file_count" -eq 0 ]; then
+    _doctor_warn "Fixture files" "No .json files in aimock/"
+    return
+  fi
+
+  # Format size nicely
+  local size_str
+  if [ "$total_size" -ge 1048576 ]; then
+    size_str="$((total_size / 1048576)) MB"
+  elif [ "$total_size" -ge 1024 ]; then
+    size_str="$((total_size / 1024)) KB"
+  else
+    size_str="$total_size B"
+  fi
+
+  _doctor_pass "Fixture files" "$file_count files ($size_str)"
+}
+
+_check_port_conflicts() {
+  if [ ! -f "$PORTS_FILE" ]; then
+    _doctor_warn "Port conflicts" "local-ports.json not found"
+    return
+  fi
+
+  local conflicts=""
+  local port_list
+
+  if command -v jq &>/dev/null; then
+    port_list="$(jq -r 'to_entries[] | "\(.key):\(.value)"' "$PORTS_FILE" 2>/dev/null)"
+  else
+    # Fallback: parse JSON manually
+    port_list="$(grep -o '"[^"]*"[[:space:]]*:[[:space:]]*[0-9]*' "$PORTS_FILE" | sed 's/"//g; s/[[:space:]]*:[[:space:]]*/:/g')"
+  fi
+
+  # Also check well-known ports: aimock=4010, pocketbase=8090
+  port_list="$port_list
+aimock:4010
+pocketbase:8090"
+
+  while IFS=':' read -r slug port; do
+    [ -z "$port" ] && continue
+
+    # Check if port is in use by a non-Docker process
+    local listeners
+    listeners="$(lsof -i :"$port" -sTCP:LISTEN -P -n 2>/dev/null | tail -n +2 || true)"
+    [ -z "$listeners" ] && continue
+
+    # Filter out Docker/com.docker processes
+    local non_docker
+    non_docker="$(echo "$listeners" | grep -vi "docker\|com.docker" || true)"
+    [ -z "$non_docker" ] && continue
+
+    local proc_name
+    proc_name="$(echo "$non_docker" | head -1 | awk '{print $1}')"
+    if [ -n "$conflicts" ]; then
+      conflicts="$conflicts, :$port ($proc_name)"
+    else
+      conflicts=":$port ($proc_name)"
+    fi
+  done <<< "$port_list"
+
+  if [ -n "$conflicts" ]; then
+    _doctor_warn "Port conflicts" "$conflicts"
+  else
+    _doctor_pass "Port conflicts" "None detected"
+  fi
+}
+
+# ── Main entry point ────────────────────────────────────────────────────────
+
+cmd_doctor() {
+  _DOCTOR_PASS=0
+  _DOCTOR_WARN=0
+  _DOCTOR_FAIL=0
+
+  echo ""
+  echo "showcase doctor"
+  echo "─────────────────────────────────"
+
+  _check_docker_engine
+  _check_docker_compose
+  _check_depot_interception
+  _check_env_file
+  _check_compose_file
+  _check_running_containers
+  _check_stale_images
+  _check_aimock_health
+  _check_fixture_files
+  _check_port_conflicts
+
+  echo "─────────────────────────────────"
+
+  local summary="${_DOCTOR_PASS} passed, ${_DOCTOR_WARN} warning"
+  [ "$_DOCTOR_WARN" -ne 1 ] && summary="${summary}s"
+  summary="${summary}, ${_DOCTOR_FAIL} failed"
+
+  if [ "$_DOCTOR_FAIL" -gt 0 ]; then
+    if _doctor_has_color; then
+      printf '\033[1;31m%s\033[0m\n' "  $summary"
+    else
+      echo "  $summary"
+    fi
+    return 1
+  elif [ "$_DOCTOR_WARN" -gt 0 ]; then
+    if _doctor_has_color; then
+      printf '\033[1;33m%s\033[0m\n' "  $summary"
+    else
+      echo "  $summary"
+    fi
+  else
+    if _doctor_has_color; then
+      printf '\033[0;32m%s\033[0m\n' "  $summary"
+    else
+      echo "  $summary"
+    fi
+  fi
+  echo ""
+}

--- a/showcase/scripts/cli/cmd-fixtures.sh
+++ b/showcase/scripts/cli/cmd-fixtures.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# showcase fixtures — fixture management (validate)
+# Sourced by the main dispatcher; do not execute directly.
+
+CMD_FIXTURES_DESC="Fixture management (validate)"
+
+usage_fixtures() {
+  cat <<'HELP'
+Usage: showcase fixtures <subcommand>
+
+Subcommands:
+  validate    Check fixture JSON files for common errors
+
+Options (validate):
+  --fixture-dir <path>   Directory to scan (default: showcase/aimock/)
+
+Checks performed:
+  - JSON syntax errors
+  - Duplicate userMessage + turnIndex combinations
+  - turnIndex sequence gaps (e.g., 0, 1, 3 — missing 2)
+  - Empty or missing response fields
+  - Orphaned sub-agent references (heuristic)
+
+Examples:
+  showcase fixtures validate
+  showcase fixtures validate --fixture-dir /path/to/fixtures
+HELP
+}
+
+cmd_fixtures() {
+  local subcmd="${1:-}"
+  shift || true
+
+  case "$subcmd" in
+    validate) fixtures_validate "$@" ;;
+    *)        usage_fixtures; return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# fixtures_validate — run all validation checks on aimock fixture files
+# ---------------------------------------------------------------------------
+fixtures_validate() {
+  local fixture_dir="${SHOWCASE_ROOT}/aimock"
+
+  # Parse flags
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --fixture-dir) fixture_dir="$2"; shift 2 ;;
+      *) die "Unknown option: $1" ;;
+    esac
+  done
+
+  # Pre-flight: jq is required for all JSON inspection
+  command -v jq >/dev/null || die "jq is required for fixture validation"
+
+  if [[ ! -d "$fixture_dir" ]]; then
+    die "Fixture directory not found: $fixture_dir"
+  fi
+
+  local files=0 fixtures=0 warnings=0
+
+  for f in "$fixture_dir"/*.json; do
+    [[ -f "$f" ]] || continue
+    files=$((files + 1))
+
+    local basename_f
+    basename_f="$(basename "$f")"
+
+    # ------------------------------------------------------------------
+    # Check 1: JSON syntax
+    # ------------------------------------------------------------------
+    local parse_err
+    if ! parse_err=$(jq empty "$f" 2>&1); then
+      warn "$basename_f: invalid JSON — $parse_err"
+      warnings=$((warnings + 1))
+      continue
+    fi
+
+    # Count fixtures in this file (supports top-level array or .fixtures array)
+    local count
+    count=$(jq '
+      if type == "array" then length
+      elif .fixtures and (.fixtures | type) == "array" then .fixtures | length
+      else 1
+      end
+    ' "$f")
+    fixtures=$((fixtures + count))
+
+    # Normalize: always work with the fixtures array
+    local fixtures_expr
+    fixtures_expr='if type == "array" then . elif .fixtures then .fixtures else [.] end'
+
+    # ------------------------------------------------------------------
+    # Check 2: Duplicate userMessage + turnIndex combos
+    # ------------------------------------------------------------------
+    local dupes
+    dupes=$(jq -r "
+      [ ${fixtures_expr} | .[]
+        | select(.match.userMessage)
+        | { um: .match.userMessage, ti: (.match.turnIndex // \"none\") }
+      ]
+      | group_by([.um, .ti])
+      | map(select(length > 1))
+      | .[]
+      | \"  duplicate: userMessage=\\(.[0].um | tostring) turnIndex=\\(.[0].ti | tostring) (\\(length) occurrences)\"
+    " "$f" 2>/dev/null || true)
+
+    if [[ -n "$dupes" ]]; then
+      warn "$basename_f: duplicate userMessage+turnIndex combinations"
+      echo "$dupes"
+      # Count each duplicate group as one warning
+      local dupe_count
+      dupe_count=$(echo "$dupes" | wc -l | tr -d ' ')
+      warnings=$((warnings + dupe_count))
+    fi
+
+    # ------------------------------------------------------------------
+    # Check 3: turnIndex gaps
+    # ------------------------------------------------------------------
+    local gaps
+    gaps=$(jq -r "
+      [ ${fixtures_expr} | .[]
+        | select(.match.userMessage and .match.turnIndex != null)
+        | { um: .match.userMessage, ti: .match.turnIndex }
+      ]
+      | group_by(.um)
+      | .[]
+      | sort_by(.ti)
+      | { um: .[0].um, indices: [.[].ti] }
+      | select(.indices | length > 1)
+      | . as \$g
+      | [range(.indices[0]; .indices[-1] + 1)]
+        - .indices
+      | select(length > 0) as \$missing
+      | \"  gap: userMessage=\\(\$g.um) has indices \\(\$g.indices | tostring) — missing \\(\$missing | tostring)\"
+    " "$f" 2>/dev/null || true)
+
+    if [[ -n "$gaps" ]]; then
+      warn "$basename_f: turnIndex sequence gaps"
+      echo "$gaps"
+      local gap_count
+      gap_count=$(echo "$gaps" | wc -l | tr -d ' ')
+      warnings=$((warnings + gap_count))
+    fi
+
+    # ------------------------------------------------------------------
+    # Check 4: Empty or missing responses
+    # ------------------------------------------------------------------
+    local empty_resp
+    empty_resp=$(jq -r "
+      [ ${fixtures_expr} | to_entries[] | .key as \$idx | .value
+        | select(
+            (.response == null and .responses == null)
+            or (.response != null and .response == {})
+            or (.response != null and .response.content != null and (.response.content | length) == 0 and (.response.toolCalls == null or (.response.toolCalls | length) == 0))
+            or (.responses != null and (.responses | length) == 0)
+          )
+        | \"  empty: fixture[\(\$idx)] \(if .match.userMessage then \"userMessage=\" + .match.userMessage else if .match.toolCallId then \"toolCallId=\" + .match.toolCallId else \"(no match key)\" end end)\"
+      ] | .[]
+    " "$f" 2>/dev/null || true)
+
+    if [[ -n "$empty_resp" ]]; then
+      warn "$basename_f: empty or missing response fields"
+      echo "$empty_resp"
+      local empty_count
+      empty_count=$(echo "$empty_resp" | wc -l | tr -d ' ')
+      warnings=$((warnings + empty_count))
+    fi
+
+    # ------------------------------------------------------------------
+    # Check 5: Orphaned sub-agent references (heuristic)
+    # ------------------------------------------------------------------
+    # Find tool_calls that reference agent-like names, then check if any
+    # fixture in the same file could serve as the sub-agent's response.
+    # A match exists if:
+    #   - a fixture has toolCallId equal to the call's id, OR
+    #   - a fixture's userMessage matches the agent name, OR
+    #   - a fixture's userMessage appears inside the call's arguments
+    #     (sub-agents receive arguments as their prompt)
+    local orphans
+    orphans=$(jq -r "
+      (${fixtures_expr}) as \$all |
+      [ \$all[]
+        | select(.response.toolCalls)
+        | .response.toolCalls[]
+        | select(.name | test(\"agent\"; \"i\"))
+        | { name: .name, id: .id, args: (.arguments // \"\") }
+      ] as \$agent_calls |
+      if (\$agent_calls | length) == 0 then empty
+      else
+        [ \$agent_calls[]
+          | . as \$call
+          | select(
+              [\$all[] | . as \$fix
+                | select(
+                    (\$fix.match.toolCallId == \$call.id)
+                    or (\$fix.match.userMessage != null and (\$fix.match.userMessage | test(\$call.name; \"i\")))
+                    or (\$fix.match.userMessage != null and (\$call.args | length > 0) and (\$call.args | test(\$fix.match.userMessage; \"i\")))
+                  )
+              ] | length == 0
+            )
+          | \"  orphan: tool_call id=\(.id) name=\(.name) — no matching fixture found\"
+        ] | .[]
+      end
+    " "$f" 2>/dev/null || true)
+
+    if [[ -n "$orphans" ]]; then
+      warn "$basename_f: possible orphaned sub-agent references"
+      echo "$orphans"
+      local orphan_count
+      orphan_count=$(echo "$orphans" | wc -l | tr -d ' ')
+      warnings=$((warnings + orphan_count))
+    fi
+
+  done
+
+  echo ""
+  info "Checked $files files, $fixtures fixtures, $warnings warnings"
+  if [[ $warnings -eq 0 ]]; then
+    success "All fixtures valid"
+  fi
+}

--- a/showcase/scripts/cli/cmd-logs.sh
+++ b/showcase/scripts/cli/cmd-logs.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# showcase logs — follow container logs with optional grep filtering
+# Sourced by the main dispatcher; do not execute directly.
+
+CMD_LOGS_DESC="Follow container logs with optional filtering"
+
+usage_logs() {
+  cat <<'HELP'
+Usage: showcase logs <slug> [options]
+
+Follow container logs with optional grep filtering.
+
+Options:
+  --grep <pattern>   Filter log output (supports regex, e.g. "fixture|match")
+  --since <duration> Show logs since duration (e.g. 10m, 1h, 30s)
+  -n <lines>         Show last N lines (default: all)
+  --no-follow        Dump logs and exit (don't follow)
+
+Examples:
+  showcase logs mastra                          # follow all logs
+  showcase logs aimock --grep "fixture|match"   # filter for fixture matching
+  showcase logs mastra --since 5m --no-follow   # last 5 minutes, exit
+  showcase logs aimock -n 100 --grep "404"      # last 100 lines with 404s
+HELP
+}
+
+cmd_logs() {
+  [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && { usage_logs; return 0; }
+  need_slug "${1:-}"
+  local slug="$1"; shift
+
+  local container
+  container="$(slug_to_container "$slug")"
+
+  local pattern=""
+  local since=""
+  local tail=""
+  local follow=true
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --grep)
+        [[ -z "${2:-}" ]] && die "--grep requires a pattern argument"
+        pattern="$2"; shift 2
+        ;;
+      --since)
+        [[ -z "${2:-}" ]] && die "--since requires a duration argument"
+        since="$2"; shift 2
+        ;;
+      -n)
+        [[ -z "${2:-}" ]] && die "-n requires a number argument"
+        tail="$2"; shift 2
+        ;;
+      --no-follow)
+        follow=false; shift
+        ;;
+      *)
+        die "Unknown option: $1"
+        ;;
+    esac
+  done
+
+  # When --grep is used, we switch to docker logs (not compose logs)
+  # to avoid noisy service-name prefixes and get full history.
+  if [[ -n "$pattern" ]]; then
+    _logs_with_grep "$container" "$pattern" "$since" "$tail" "$follow"
+  else
+    _logs_plain "$slug" "$since" "$tail" "$follow"
+  fi
+}
+
+# Plain logs via docker compose (no grep filtering)
+_logs_plain() {
+  local slug="$1" since="$2" tail="$3" follow="$4"
+  local -a args=()
+
+  if [[ "$follow" == true ]]; then
+    args+=("-f")
+  fi
+  if [[ -n "$since" ]]; then
+    args+=("--since" "$since")
+  fi
+  if [[ -n "$tail" ]]; then
+    args+=("--tail" "$tail")
+  fi
+
+  docker compose -f "$COMPOSE_FILE" logs "${args[@]}" "$slug"
+}
+
+# Grep-filtered logs via docker logs (direct container)
+_logs_with_grep() {
+  local container="$1" pattern="$2" since="$3" tail="$4" follow="$5"
+  local -a args=()
+
+  if [[ "$follow" == true ]]; then
+    args+=("-f")
+  fi
+  if [[ -n "$since" ]]; then
+    args+=("--since" "$since")
+  fi
+  if [[ -n "$tail" ]]; then
+    args+=("--tail" "$tail")
+  fi
+
+  if [[ "$follow" == true ]]; then
+    # Follow mode: --line-buffered is critical so grep flushes immediately
+    docker logs "${args[@]}" "$container" 2>&1 \
+      | grep --line-buffered --color=auto -E "$pattern"
+  else
+    docker logs "${args[@]}" "$container" 2>&1 \
+      | grep --color=auto -E "$pattern"
+  fi
+}

--- a/showcase/scripts/cli/cmd-recreate.sh
+++ b/showcase/scripts/cli/cmd-recreate.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# showcase recreate — force-recreate services to pick up new images
+
+CMD_RECREATE_DESC="Force-recreate a service (picks up new image)"
+
+usage_recreate() {
+  cat <<'HELP'
+Usage: showcase recreate <slug> [slug...] [options]
+
+Force-recreate service containers to pick up a new Docker image.
+Unlike 'restart', this ensures the container uses the latest image.
+
+Options:
+  --build     Rebuild the image before recreating
+  --no-wait   Don't wait for the container to become healthy
+
+Examples:
+  showcase recreate mastra           # recreate with current image
+  showcase recreate aimock           # recreate aimock (uses test compose)
+  showcase recreate mastra --build   # rebuild + recreate
+  showcase recreate mastra aimock    # recreate multiple services
+HELP
+}
+
+cmd_recreate() {
+  local slugs=()
+  local no_wait=0
+  local build=0
+
+  # Parse args: separate slugs from flags
+  for arg in "$@"; do
+    case "$arg" in
+      --no-wait) no_wait=1 ;;
+      --build)   build=1 ;;
+      -h|--help) usage_recreate; return 0 ;;
+      -*)        die "Unknown option: $arg (see 'showcase recreate --help')" ;;
+      *)         slugs+=("$arg") ;;
+    esac
+  done
+
+  [ ${#slugs[@]} -gt 0 ] || die "Usage: showcase recreate <slug> [slug...] [--build] [--no-wait]"
+
+  for slug in "${slugs[@]}"; do
+    need_slug "$slug"
+
+    # Pick the right compose file: aimock uses the test compose, everything
+    # else uses the main local compose.
+    local compose
+    if [ "$slug" = "aimock" ]; then
+      compose="$AIMOCK_COMPOSE"
+    else
+      compose="$COMPOSE_FILE"
+    fi
+
+    info "Force-recreating showcase-${slug} (picks up new image, unlike restart)..."
+
+    if [ "$build" -eq 1 ]; then
+      trap restore_symlinks EXIT
+      stage_shared
+      docker compose -f "$compose" up -d --build --force-recreate "$slug"
+    else
+      docker compose -f "$compose" up -d --force-recreate "$slug"
+    fi
+
+    if [ "$no_wait" -eq 0 ]; then
+      wait_healthy "$slug" 30
+    fi
+
+    # Print the image ID so the user can verify it changed
+    local container
+    container="$(slug_to_container "$slug")"
+    local image_id
+    image_id="$(docker inspect --format='{{.Image}}' "$container" 2>/dev/null || echo "unknown")"
+    # Truncate sha256:... to first 12 hex chars
+    image_id="${image_id#sha256:}"
+    image_id="${image_id:0:12}"
+    success "showcase-${slug} recreated — image: ${image_id}"
+  done
+}

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# showcase test — run probe tests against a showcase service
+# Sourced by the main dispatcher; do not execute directly.
+
+CMD_TEST_DESC="Run probe tests against a service"
+
+usage_test() {
+  cat <<'HELP'
+Usage: showcase test <slug> [options]
+
+Run probe tests against a showcase service.
+
+Options:
+  --d5             Run D5 (subagents/tool-rendering/agentic-chat) probes only
+  --d6             Run D6 probes only
+  --verbose        Verbose test output
+  --cycle          On failure, auto-dump aimock logs from the test window
+  --timeout <ms>   Test timeout in milliseconds (default: 30000)
+
+Examples:
+  showcase test mastra --d5 --verbose         # D5 probes with verbose output
+  showcase test mastra --d5 --cycle           # D5 + aimock logs on failure
+  showcase test langgraph-python              # all tests for a slug
+  showcase test mastra --d5 --timeout 60000   # longer timeout
+HELP
+}
+
+cmd_test() {
+  local slug=""
+  local d5_flag=""
+  local d6_flag=""
+  local verbose=""
+  local cycle=""
+  local timeout="30000"
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --d5)      d5_flag=1;   shift ;;
+      --d6)      d6_flag=1;   shift ;;
+      --verbose) verbose=1;   shift ;;
+      --cycle)   cycle=1;     shift ;;
+      --timeout)
+        shift
+        timeout="${1:?--timeout requires a value}"
+        shift
+        ;;
+      -h|--help)
+        usage_test
+        return 0
+        ;;
+      -*)
+        die "Unknown option: $1 (see 'showcase test --help')"
+        ;;
+      *)
+        if [[ -z "$slug" ]]; then
+          slug="$1"
+        else
+          die "Unexpected argument: $1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  need_slug "$slug"
+
+  # Validate mutually-exclusive depth flags
+  if [[ -n "$d5_flag" ]] && [[ -n "$d6_flag" ]]; then
+    die "--d5 and --d6 are mutually exclusive"
+  fi
+
+  # Build filter argument
+  local filter=""
+  if [[ -n "$d5_flag" ]]; then
+    filter="--d5"
+  elif [[ -n "$d6_flag" ]]; then
+    filter="--d6"
+  fi
+
+  # If --cycle, record aimock log position before the test
+  local pre_test_ts=""
+  local aimock_container="showcase-aimock"
+  if [[ -n "$cycle" ]]; then
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${aimock_container}$"; then
+      pre_test_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    else
+      warn "aimock container '$aimock_container' not running; --cycle log capture disabled"
+    fi
+  fi
+
+  # Run the tests
+  info "Testing $slug${filter:+ ($filter)}..."
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$SHOWCASE_ROOT/.last-test-ts"
+
+  local test_exit=0
+
+  if [[ -f "$SHOWCASE_ROOT/scripts/run-e2e-with-aimock.sh" ]]; then
+    # Delegate to the existing e2e runner
+    bash "$SHOWCASE_ROOT/scripts/run-e2e-with-aimock.sh" \
+      "$slug" \
+      ${filter:+"$filter"} \
+      ${verbose:+--verbose} \
+      ${timeout:+--timeout "$timeout"} \
+      || test_exit=$?
+  else
+    # Fallback: direct Playwright invocation
+    local pkg_dir="$SHOWCASE_ROOT/integrations/$slug"
+    if [[ ! -d "$pkg_dir" ]]; then
+      die "Package directory not found: $pkg_dir"
+    fi
+
+    (
+      cd "$pkg_dir"
+
+      local pw_args=()
+      if [[ -n "$filter" ]]; then
+        pw_args+=(--grep "$filter")
+      fi
+      if [[ -n "$verbose" ]]; then
+        pw_args+=(--reporter=verbose)
+      fi
+      pw_args+=(--timeout "$timeout")
+
+      npx playwright test "${pw_args[@]}"
+    ) || test_exit=$?
+  fi
+
+  # --cycle: dump aimock log delta on failure
+  if [[ $test_exit -ne 0 ]] && [[ -n "$cycle" ]] && [[ -n "$pre_test_ts" ]]; then
+    echo ""
+    echo "═══ aimock logs since test start ($pre_test_ts) ═══"
+    docker logs --since "$pre_test_ts" "$aimock_container" 2>&1
+    echo "═══════════════════════════════════════════════════"
+  fi
+
+  # Report result
+  if [[ $test_exit -eq 0 ]]; then
+    success "Tests passed for $slug"
+  else
+    warn "Tests failed for $slug (exit $test_exit)"
+  fi
+
+  return $test_exit
+}


### PR DESCRIPTION
## Summary

- Adds `bin/showcase` CLI dispatcher with auto-discovered plugin commands
- 7 new commands: `logs`, `test`, `recreate`, `aimock-rebuild`, `diff-logs`, `doctor`, `fixtures validate`
- New `showcase/DEBUGGING.md` playbook: 6-phase debugging loop, workflow recipes, gotchas reference
- Updates `showcase/README.md` to align with implemented CLI

## Why

Local debugging of showcase integrations required memorizing Docker Compose incantations, Depot bypass flags, and timestamp juggling. This wraps the entire edit-build-test cycle into composable CLI commands that handle the sharp edges (Depot interception, restart-vs-recreate, fixture baking, aimock health checks) automatically.

## Test plan

- [ ] `showcase --help` shows core + plugin commands
- [ ] `showcase doctor` runs all 10 diagnostic checks
- [ ] `showcase fixtures validate` catches malformed JSON, duplicate turnIndex, gaps
- [ ] `showcase test <slug> --d5 --verbose --cycle` runs probes and dumps aimock logs on failure
- [ ] `showcase aimock-rebuild --from ~/proj/cpk/aimock` completes full rebuild cycle
- [ ] `showcase diff-logs aimock --since last-test` shows only logs from the test window