### PR TITLE
fix(showcase): D5 chip display + CLI debugging commands

### DIFF
--- a/showcase/harness/src/cli.ts
+++ b/showcase/harness/src/cli.ts
@@ -1,8 +1,22 @@
 #!/usr/bin/env node
 import { Command, Option, InvalidArgumentError } from "commander";
 import { loadConfig } from "./cli/config.js";
-import { up, down, rebuild, ps, logs } from "./cli/lifecycle.js";
+import {
+  up,
+  down,
+  rebuild,
+  build,
+  recreate,
+  ps,
+  logs,
+  ports,
+  diffLogs,
+  writeLastTestTimestamp,
+} from "./cli/lifecycle.js";
 import { run } from "./cli/runner.js";
+import { fixturesValidate, formatReport } from "./cli/fixtures.js";
+import { doctor } from "./cli/doctor.js";
+import { aimockRebuild } from "./cli/aimock-rebuild.js";
 import type { TestLevel } from "./cli/targets.js";
 
 const program = new Command();
@@ -97,6 +111,7 @@ program
       const level: TestLevel =
         shorthand ?? (opts.level as TestLevel) ?? "smoke";
 
+      writeLastTestTimestamp();
       const result = await run(target, { ...opts, level }, config);
 
       if (result.failed > 0) {
@@ -131,6 +146,83 @@ program
   .action(async (slug: string) => {
     loadConfig();
     await logs(slug);
+  });
+
+// ── build ──────────────────────────────────────────────────────────────
+program
+  .command("build [slugs...]")
+  .description("Build Docker images without starting containers")
+  .action(async (slugs: string[]) => {
+    loadConfig();
+    await build(slugs);
+  });
+
+// ── ports ──────────────────────────────────────────────────────────────
+program
+  .command("ports")
+  .description("Print slug-to-host-port mapping")
+  .action(() => {
+    loadConfig();
+    console.log(ports());
+  });
+
+// ── recreate ───────────────────────────────────────────────────────────
+program
+  .command("recreate <slug>")
+  .description("Force-recreate a service container")
+  .option("--build", "also rebuild the image first")
+  .action(async (slug: string, opts: { build?: boolean }) => {
+    loadConfig();
+    await recreate(slug, { build: opts.build });
+  });
+
+// ── fixtures ───────────────────────────────────────────────────────────
+const fixturesCmd = program
+  .command("fixtures")
+  .description("Fixture file management");
+
+fixturesCmd
+  .command("validate")
+  .description("Check fixture JSON files for structural errors")
+  .action(() => {
+    const report = fixturesValidate();
+    console.log(formatReport(report));
+    if (report.errors.length > 0) {
+      process.exit(1);
+    }
+  });
+
+// ── doctor ─────────────────────────────────────────────────────────────
+program
+  .command("doctor")
+  .description("Diagnose common local stack issues")
+  .action(async () => {
+    const output = await doctor();
+    console.log(output);
+  });
+
+// ── aimock-rebuild ─────────────────────────────────────────────────────
+program
+  .command("aimock-rebuild")
+  .description("Rebuild aimock from local source and redeploy container")
+  .option("--from <path>", "path to aimock source directory")
+  .action(async (opts: { from?: string }) => {
+    await aimockRebuild({ from: opts.from });
+  });
+
+// ── diff-logs ──────────────────────────────────────────────────────────
+program
+  .command("diff-logs <slug>")
+  .description("Show log output for a specific time window")
+  .option(
+    "--since <duration>",
+    'time window (e.g. "5m", "30s", "last-test")',
+    "5m",
+  )
+  .option("--grep <pattern>", "filter log lines by pattern")
+  .action(async (slug: string, opts: { since?: string; grep?: string }) => {
+    loadConfig();
+    await diffLogs(slug, { since: opts.since, grep: opts.grep });
   });
 
 // ── status ──────────────────────────────────────────────────────────────

--- a/showcase/harness/src/cli/aimock-rebuild.ts
+++ b/showcase/harness/src/cli/aimock-rebuild.ts
@@ -1,0 +1,148 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../logger.js";
+import { healthCheck } from "./lifecycle.js";
+
+const log = createLogger({ component: "aimock-rebuild" });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHOWCASE_DIR = path.resolve(__dirname, "../../..");
+const COMPOSE_FILE = path.join(SHOWCASE_DIR, "docker-compose.local.yml");
+
+// ---------------------------------------------------------------------------
+// Default aimock source locations (relative to showcase dir)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_AIMOCK_PATHS = [
+  path.resolve(SHOWCASE_DIR, "../../aimock"),
+  path.resolve(SHOWCASE_DIR, "../aimock"),
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findAimockSource(fromPath?: string): string {
+  if (fromPath) {
+    const resolved = path.resolve(fromPath);
+    if (!fs.existsSync(resolved)) {
+      throw new Error(`Aimock source not found at: ${resolved}`);
+    }
+    if (!fs.existsSync(path.join(resolved, "package.json"))) {
+      throw new Error(`No package.json found at: ${resolved} — not an aimock checkout`);
+    }
+    return resolved;
+  }
+
+  for (const candidate of DEFAULT_AIMOCK_PATHS) {
+    if (
+      fs.existsSync(candidate) &&
+      fs.existsSync(path.join(candidate, "package.json"))
+    ) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Aimock source not found at default locations: ${DEFAULT_AIMOCK_PATHS.join(", ")}. Use --from <path> to specify.`,
+  );
+}
+
+function compose(...args: string[]): string {
+  const fullArgs = ["compose", "-f", COMPOSE_FILE, ...args];
+  log.debug("exec", { cmd: ["docker", ...fullArgs].join(" ") });
+  return execFileSync("docker", fullArgs, {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd: SHOWCASE_DIR,
+  }).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export interface AimockRebuildOptions {
+  from?: string;
+}
+
+/**
+ * Rebuild aimock from a local source checkout and redeploy the container.
+ *
+ * Steps:
+ *   1. npm run build in aimock source dir
+ *   2. DEPOT_DISABLE=1 docker buildx build --builder desktop-linux --load -t aimock:local
+ *   3. docker compose up -d --force-recreate aimock
+ *   4. Health check
+ */
+export async function aimockRebuild(
+  opts?: AimockRebuildOptions,
+): Promise<void> {
+  const srcDir = findAimockSource(opts?.from);
+  log.info("rebuilding aimock from source", { srcDir });
+
+  // Step 1: npm run build
+  console.log(`\n  \x1b[36mBuilding aimock...\x1b[0m (${srcDir})`);
+  try {
+    execFileSync("npm", ["run", "build"], {
+      cwd: srcDir,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 120_000,
+    });
+    log.info("aimock build succeeded");
+  } catch (err) {
+    const e = err as { stderr?: string };
+    const stderr = typeof e.stderr === "string" ? e.stderr.trim() : "";
+    throw new Error(`aimock build failed:\n${stderr}`);
+  }
+
+  // Step 2: Docker buildx build
+  console.log("  \x1b[36mBuilding Docker image...\x1b[0m");
+  try {
+    execFileSync(
+      "docker",
+      [
+        "buildx",
+        "build",
+        "--builder",
+        "desktop-linux",
+        "--load",
+        "-t",
+        "aimock:local",
+        ".",
+      ],
+      {
+        cwd: srcDir,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, DEPOT_DISABLE: "1" },
+        timeout: 300_000,
+      },
+    );
+    log.info("docker image build succeeded");
+  } catch (err) {
+    const e = err as { stderr?: string };
+    const stderr = typeof e.stderr === "string" ? e.stderr.trim() : "";
+    throw new Error(`Docker image build failed:\n${stderr}`);
+  }
+
+  // Step 3: Force-recreate aimock container
+  console.log("  \x1b[36mRecreating aimock container...\x1b[0m");
+  compose("--profile", "infra", "up", "-d", "--force-recreate", "aimock");
+
+  // Step 4: Health check
+  console.log("  \x1b[36mWaiting for health...\x1b[0m");
+  const results = await healthCheck(["aimock"]);
+  const healthy = results.get("aimock");
+
+  if (!healthy) {
+    throw new Error(
+      "aimock failed health check after rebuild. Check logs with: showcase logs aimock",
+    );
+  }
+
+  console.log("  \x1b[32maimock rebuilt and healthy\x1b[0m\n");
+}

--- a/showcase/harness/src/cli/doctor.ts
+++ b/showcase/harness/src/cli/doctor.ts
@@ -1,0 +1,297 @@
+import { execFileSync, execSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "doctor" });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHOWCASE_DIR = path.resolve(__dirname, "../../..");
+const COMPOSE_FILE = path.join(SHOWCASE_DIR, "docker-compose.local.yml");
+const PORTS_FILE = path.join(SHOWCASE_DIR, "shared/local-ports.json");
+
+/** Well-known infra service ports. */
+const INFRA_PORTS: Record<string, number> = {
+  aimock: 4010,
+  pocketbase: 8090,
+  dashboard: 3200,
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Check {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+function checkDockerEngine(): Check {
+  try {
+    execFileSync("docker", ["info"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    return { name: "Docker engine", status: "ok", detail: "running" };
+  } catch (err) {
+    return {
+      name: "Docker engine",
+      status: "fail",
+      detail: `not reachable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function checkDepotInterception(): Check {
+  try {
+    const depotPath = execSync("which depot 2>/dev/null", {
+      encoding: "utf-8",
+      timeout: 5_000,
+    }).trim();
+
+    // Check if docker is shimmed by depot
+    try {
+      const dockerPath = execSync("which docker 2>/dev/null", {
+        encoding: "utf-8",
+        timeout: 5_000,
+      }).trim();
+
+      if (dockerPath.includes("depot")) {
+        return {
+          name: "Depot interception",
+          status: "warn",
+          detail: `depot found at ${depotPath}; docker appears shimmed (${dockerPath}). Set DEPOT_DISABLE=1 for local builds.`,
+        };
+      }
+    } catch {
+      // docker not found — already caught by Docker engine check
+    }
+
+    return {
+      name: "Depot interception",
+      status: "ok",
+      detail: `depot at ${depotPath}, docker not shimmed`,
+    };
+  } catch {
+    return {
+      name: "Depot interception",
+      status: "ok",
+      detail: "depot not installed (fine for local dev)",
+    };
+  }
+}
+
+function checkComposeFile(): Check {
+  if (fs.existsSync(COMPOSE_FILE)) {
+    return {
+      name: "Compose file",
+      status: "ok",
+      detail: COMPOSE_FILE,
+    };
+  }
+  return {
+    name: "Compose file",
+    status: "fail",
+    detail: `not found at ${COMPOSE_FILE}`,
+  };
+}
+
+function checkEnvFile(): Check {
+  const envPath = path.join(SHOWCASE_DIR, ".env");
+  if (fs.existsSync(envPath)) {
+    return { name: ".env file", status: "ok", detail: envPath };
+  }
+  return {
+    name: ".env file",
+    status: "warn",
+    detail: `not found at ${envPath}. Some services may need environment variables.`,
+  };
+}
+
+function checkStaleImages(): Check {
+  try {
+    const output = execFileSync(
+      "docker",
+      [
+        "compose",
+        "-f",
+        COMPOSE_FILE,
+        "--profile",
+        "all",
+        "images",
+        "--format",
+        "json",
+      ],
+      {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        cwd: SHOWCASE_DIR,
+        timeout: 15_000,
+      },
+    );
+
+    // Each line is a JSON object
+    const lines = output
+      .trim()
+      .split("\n")
+      .filter((l) => l.trim().length > 0);
+    const stale: string[] = [];
+    const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
+
+    for (const line of lines) {
+      try {
+        const img = JSON.parse(line) as {
+          Repository?: string;
+          Tag?: string;
+          CreatedAt?: string;
+        };
+        if (img.CreatedAt) {
+          const created = new Date(img.CreatedAt).getTime();
+          if (created < oneDayAgo) {
+            stale.push(`${img.Repository ?? "?"}:${img.Tag ?? "?"}`);
+          }
+        }
+      } catch {
+        // Skip unparseable lines
+      }
+    }
+
+    if (stale.length > 0) {
+      return {
+        name: "Stale images",
+        status: "warn",
+        detail: `${stale.length} image(s) older than 24h: ${stale.slice(0, 5).join(", ")}${stale.length > 5 ? "..." : ""}`,
+      };
+    }
+    return { name: "Stale images", status: "ok", detail: "all images recent" };
+  } catch {
+    return {
+      name: "Stale images",
+      status: "warn",
+      detail: "could not check image ages (compose images failed)",
+    };
+  }
+}
+
+/**
+ * Try to connect to a port. Returns true if something is listening.
+ */
+async function isPortListening(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+
+    socket.setTimeout(1_000);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+
+    socket.connect(port, "127.0.0.1");
+  });
+}
+
+async function checkPorts(): Promise<Check> {
+  const allPorts: Record<string, number> = { ...INFRA_PORTS };
+
+  try {
+    const raw = fs.readFileSync(PORTS_FILE, "utf-8");
+    const integrationPorts = JSON.parse(raw) as Record<string, number>;
+    Object.assign(allPorts, integrationPorts);
+  } catch {
+    // If we can't read ports file, just check infra
+  }
+
+  // Check which ports have something listening
+  const listening: string[] = [];
+  const portChecks = Object.entries(allPorts).map(async ([name, port]) => {
+    const inUse = await isPortListening(port);
+    if (inUse) {
+      listening.push(`${name}:${port}`);
+    }
+  });
+
+  await Promise.all(portChecks);
+
+  if (listening.length > 0) {
+    return {
+      name: "Port usage",
+      status: "ok",
+      detail: `${listening.length} port(s) in use: ${listening.slice(0, 8).join(", ")}${listening.length > 8 ? "..." : ""}`,
+    };
+  }
+
+  return {
+    name: "Port usage",
+    status: "ok",
+    detail: "no ports in use (stack appears down)",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all diagnostic checks and return a formatted report string.
+ */
+export async function doctor(): Promise<string> {
+  log.info("running diagnostics");
+
+  const checks: Check[] = [];
+
+  // Synchronous checks
+  checks.push(checkDockerEngine());
+  checks.push(checkDepotInterception());
+  checks.push(checkComposeFile());
+  checks.push(checkEnvFile());
+  checks.push(checkStaleImages());
+
+  // Async checks
+  checks.push(await checkPorts());
+
+  // Format report
+  const lines: string[] = ["\n  Showcase Doctor\n"];
+
+  for (const check of checks) {
+    const icon =
+      check.status === "ok"
+        ? "\x1b[32m✓\x1b[0m"
+        : check.status === "warn"
+          ? "\x1b[33m!\x1b[0m"
+          : "\x1b[31m✗\x1b[0m";
+
+    lines.push(`  ${icon} ${check.name}: ${check.detail}`);
+  }
+
+  const failCount = checks.filter((c) => c.status === "fail").length;
+  const warnCount = checks.filter((c) => c.status === "warn").length;
+
+  lines.push("");
+  if (failCount > 0) {
+    lines.push(
+      `  \x1b[31m${failCount} issue(s) need attention\x1b[0m${warnCount > 0 ? `, ${warnCount} warning(s)` : ""}`,
+    );
+  } else if (warnCount > 0) {
+    lines.push(`  \x1b[33m${warnCount} warning(s)\x1b[0m, no blockers`);
+  } else {
+    lines.push("  \x1b[32mAll checks passed\x1b[0m");
+  }
+
+  return lines.join("\n");
+}

--- a/showcase/harness/src/cli/fixtures.ts
+++ b/showcase/harness/src/cli/fixtures.ts
@@ -1,0 +1,174 @@
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createLogger } from "../logger.js";
+
+const log = createLogger({ component: "fixtures" });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SHOWCASE_DIR = path.resolve(__dirname, "../../..");
+const AIMOCK_DIR = path.join(SHOWCASE_DIR, "aimock");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FixtureEntry {
+  match?: Record<string, unknown>;
+  response?: Record<string, unknown>;
+}
+
+interface FixtureFile {
+  fixtures?: FixtureEntry[];
+}
+
+interface ValidationError {
+  file: string;
+  message: string;
+}
+
+export interface ValidationReport {
+  ok: number;
+  errors: ValidationError[];
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate all fixture JSON files under showcase/aimock/.
+ *
+ * Checks:
+ *   - Valid JSON parsing
+ *   - Required top-level `fixtures` array
+ *   - Each entry has `match` and `response` fields
+ *   - No duplicate sequence keys (userMessage + turnIndex combos)
+ */
+export function fixturesValidate(): ValidationReport {
+  const report: ValidationReport = { ok: 0, errors: [] };
+
+  if (!fs.existsSync(AIMOCK_DIR)) {
+    report.errors.push({
+      file: AIMOCK_DIR,
+      message: "aimock directory not found",
+    });
+    return report;
+  }
+
+  const jsonFiles = fs
+    .readdirSync(AIMOCK_DIR)
+    .filter((f) => f.endsWith(".json"));
+
+  if (jsonFiles.length === 0) {
+    log.warn("no JSON fixture files found", { dir: AIMOCK_DIR });
+    return report;
+  }
+
+  for (const file of jsonFiles) {
+    const filePath = path.join(AIMOCK_DIR, file);
+
+    // 1. Valid JSON?
+    let parsed: FixtureFile;
+    try {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      parsed = JSON.parse(raw) as FixtureFile;
+    } catch (err) {
+      report.errors.push({
+        file,
+        message: `Invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    // 2. Has fixtures array?
+    if (!Array.isArray(parsed.fixtures)) {
+      report.errors.push({
+        file,
+        message: 'Missing or non-array "fixtures" field',
+      });
+      continue;
+    }
+
+    // 3. Validate each entry and track sequence keys for duplicates
+    const seenKeys = new Set<string>();
+    let fileOk = true;
+
+    for (let i = 0; i < parsed.fixtures.length; i++) {
+      const entry = parsed.fixtures[i];
+
+      if (!entry.match || typeof entry.match !== "object") {
+        report.errors.push({
+          file,
+          message: `fixtures[${i}]: missing or invalid "match" field`,
+        });
+        fileOk = false;
+        continue;
+      }
+
+      if (!entry.response || typeof entry.response !== "object") {
+        report.errors.push({
+          file,
+          message: `fixtures[${i}]: missing or invalid "response" field`,
+        });
+        fileOk = false;
+        continue;
+      }
+
+      // 4. Check for duplicate sequence keys (userMessage + turnIndex)
+      const userMessage = entry.match.userMessage;
+      const turnIndex = entry.match.turnIndex;
+      const toolCallId = entry.match.toolCallId;
+
+      let seqKey: string | null = null;
+      if (typeof userMessage === "string") {
+        seqKey =
+          turnIndex !== undefined
+            ? `msg:${userMessage}@turn:${turnIndex}`
+            : `msg:${userMessage}`;
+      } else if (typeof toolCallId === "string") {
+        seqKey = `toolCallId:${toolCallId}`;
+      }
+
+      if (seqKey !== null) {
+        if (seenKeys.has(seqKey)) {
+          report.errors.push({
+            file,
+            message: `fixtures[${i}]: duplicate sequence key "${seqKey}"`,
+          });
+          fileOk = false;
+        } else {
+          seenKeys.add(seqKey);
+        }
+      }
+    }
+
+    if (fileOk) {
+      report.ok++;
+    }
+  }
+
+  return report;
+}
+
+/**
+ * Format a validation report as a human-readable string.
+ */
+export function formatReport(report: ValidationReport): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `\n  Fixture validation: ${report.ok} OK, ${report.errors.length} error(s)`,
+  );
+
+  if (report.errors.length > 0) {
+    lines.push("");
+    for (const err of report.errors) {
+      lines.push(`  \x1b[31m✗\x1b[0m ${err.file}: ${err.message}`);
+    }
+  } else {
+    lines.push("  \x1b[32m✓ All fixture files valid\x1b[0m");
+  }
+
+  return lines.join("\n");
+}

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -201,6 +201,32 @@ export function restoreSymlinks(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Timestamp file for diff-logs --since last-test
+// ---------------------------------------------------------------------------
+
+const LAST_TEST_TS_FILE = path.join(SHOWCASE_DIR, ".last-test-ts");
+
+/**
+ * Write the current timestamp to `.last-test-ts` so `diff-logs --since last-test`
+ * can reference when the last test run started.
+ */
+export function writeLastTestTimestamp(): void {
+  fs.writeFileSync(LAST_TEST_TS_FILE, new Date().toISOString(), "utf-8");
+  log.debug("wrote last-test timestamp", { path: LAST_TEST_TS_FILE });
+}
+
+/**
+ * Read the last-test timestamp. Returns null if the file doesn't exist.
+ */
+function readLastTestTimestamp(): string | null {
+  try {
+    return fs.readFileSync(LAST_TEST_TS_FILE, "utf-8").trim();
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Lifecycle functions
 // ---------------------------------------------------------------------------
 
@@ -353,6 +379,195 @@ export async function logs(
         resolve();
       } else {
         reject(new Error(`Log streaming for ${slug} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+/**
+ * Build Docker images without starting containers.
+ *
+ * - If `slugs` is empty, builds all images.
+ * - If `slugs` are provided, builds only those service images.
+ */
+export async function build(
+  slugs: string[],
+  _opts?: LifecycleOptions,
+): Promise<void> {
+  try {
+    stageSharedModules();
+
+    log.info("building images", {
+      slugs: slugs.length ? slugs : ["all"],
+    });
+
+    if (slugs.length > 0) {
+      const profileArgs = slugs.flatMap((s) => ["--profile", s]);
+      compose(...profileArgs, "build", ...slugs);
+    } else {
+      compose("--profile", "all", "build");
+    }
+
+    log.info("build complete");
+  } finally {
+    restoreSymlinks();
+  }
+}
+
+/**
+ * Force-recreate a service container, optionally rebuilding the image first.
+ * Runs a health check after recreating.
+ */
+export async function recreate(
+  slug: string,
+  opts?: { build?: boolean },
+): Promise<void> {
+  log.info("recreating service", { slug, build: opts?.build ?? false });
+
+  const args = [
+    "--profile",
+    slug,
+    "up",
+    "-d",
+    "--force-recreate",
+    ...(opts?.build ? ["--build"] : []),
+    slug,
+  ];
+
+  if (opts?.build) {
+    try {
+      stageSharedModules();
+      compose(...args);
+    } finally {
+      restoreSymlinks();
+    }
+  } else {
+    compose(...args);
+  }
+
+  // Health check
+  const results = await healthCheck([slug]);
+  const healthy = results.get(slug);
+
+  if (!healthy) {
+    throw new Error(
+      `Health check failed for ${slug} after recreate. Check logs with: showcase logs ${slug}`,
+    );
+  }
+
+  log.info("recreate complete, service healthy", { slug });
+}
+
+/**
+ * Return a formatted slug-to-port mapping table.
+ */
+export function ports(): string {
+  const integrationPorts = loadPortsFile();
+
+  const lines: string[] = ["\n  Slug                        Port"];
+  lines.push("  " + "-".repeat(40));
+
+  // Print infra ports first, then integration ports alphabetically
+  const infraEntries = Object.entries(INFRA_PORTS).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  const integrationEntries = Object.entries(integrationPorts).sort(
+    ([a], [b]) => a.localeCompare(b),
+  );
+
+  for (const [slug, port] of infraEntries) {
+    lines.push(`  ${slug.padEnd(28)} ${port}  (infra)`);
+  }
+
+  if (integrationEntries.length > 0) {
+    lines.push("  " + "-".repeat(40));
+    for (const [slug, port] of integrationEntries) {
+      lines.push(`  ${slug.padEnd(28)} ${port}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Show filtered logs for a service within a time window.
+ *
+ * @param slug - Service name
+ * @param opts.since - Duration string (e.g. "5m", "30s") or "last-test"
+ * @param opts.grep - Optional pattern filter
+ */
+export async function diffLogs(
+  slug: string,
+  opts?: { since?: string; grep?: string },
+): Promise<void> {
+  let sinceArg = opts?.since ?? "5m";
+
+  // Resolve "last-test" to a duration
+  if (sinceArg === "last-test") {
+    const ts = readLastTestTimestamp();
+    if (!ts) {
+      throw new Error(
+        "No last-test timestamp found. Run a test first: showcase test <target>",
+      );
+    }
+    // Calculate seconds since last test
+    const elapsed = Math.max(
+      1,
+      Math.ceil((Date.now() - new Date(ts).getTime()) / 1000),
+    );
+    sinceArg = `${elapsed}s`;
+    log.info("resolved last-test to duration", { ts, sinceArg });
+  }
+
+  const args: string[] = [
+    "compose",
+    "-f",
+    COMPOSE_FILE,
+    "logs",
+    "--since",
+    sinceArg,
+  ];
+
+  if (opts?.grep) {
+    // docker compose logs doesn't have --grep, so we filter with a pipe
+    // Instead, use the native --no-log-prefix and filter ourselves
+  }
+
+  args.push(slug);
+
+  log.debug("exec", { cmd: ["docker", ...args].join(" ") });
+
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn("docker", args, {
+      cwd: SHOWCASE_DIR,
+      stdio: opts?.grep ? ["pipe", "pipe", "inherit"] : "inherit",
+    } satisfies SpawnOptions);
+
+    if (opts?.grep && child.stdout) {
+      const pattern = new RegExp(opts.grep, "i");
+      child.stdout.on("data", (chunk: Buffer) => {
+        const lines = chunk.toString().split("\n");
+        for (const line of lines) {
+          if (pattern.test(line)) {
+            process.stdout.write(line + "\n");
+          }
+        }
+      });
+    }
+
+    child.on("error", (err) => {
+      reject(
+        new Error(`Failed to get logs for ${slug}: ${err.message}`),
+      );
+    });
+
+    child.on("close", (code) => {
+      if (code === 0 || code === null) {
+        resolve();
+      } else {
+        reject(
+          new Error(`Log retrieval for ${slug} exited with code ${code}`),
+        );
       }
     });
   });

--- a/showcase/harness/src/cli/targets.ts
+++ b/showcase/harness/src/cli/targets.ts
@@ -67,13 +67,14 @@ export interface ChatToolsInput {
  * e2e-deep (D5) driver input — mirrors the `inputSchema` in
  * `src/probes/drivers/e2e-deep.ts`. `backendUrl` or `publicUrl` is
  * required. The CLI sets `backendUrl` from local-ports and populates
- * `features` from the manifest's top-level `features` array.
+ * `demos` from the manifest's top-level `features` array (registry IDs
+ * that the driver maps to D5 feature types via `demosToFeatureTypes()`).
  */
 export interface DeepInput {
   key: string;
   backendUrl: string;
   name: string;
-  features: string[];
+  demos: string[];
   shape: "package";
 }
 
@@ -267,11 +268,11 @@ export function buildDeepInputs(
         key: `e2e-deep:${slug}`,
         backendUrl: getPackageUrl(slug, config),
         name: manifest.name,
-        features,
+        demos: features,
         shape: "package" as const,
       };
     })
-    .filter((input) => input.features.length > 0);
+    .filter((input) => input.demos.length > 0);
 }
 
 /**

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -97,6 +97,46 @@ export function keyFor(
     : `${dimension}:${slug}`;
 }
 
+/**
+ * Catalog feature ID → D5 PB row key suffix. The harness writes D5 rows
+ * keyed by `d5:<slug>/<d5FeatureType>`, but the dashboard resolves cells
+ * by catalog `featureId`. This map bridges the two namespaces.
+ *
+ * Mirrors `REGISTRY_TO_D5` in `harness/src/probes/helpers/d5-feature-mapping.ts`.
+ */
+const CATALOG_TO_D5_KEY: Readonly<Record<string, readonly string[]>> = {
+  "agentic-chat": ["agentic-chat"],
+  "tool-rendering": ["tool-rendering"],
+  "tool-rendering-default-catchall": ["tool-rendering"],
+  "tool-rendering-custom-catchall": ["tool-rendering"],
+  "headless-simple": ["gen-ui-headless"],
+  "headless-complete": ["gen-ui-headless"],
+  "gen-ui-tool-based": ["gen-ui-custom"],
+  "hitl-in-chat": ["hitl-text-input"],
+  "hitl-in-chat-booking": ["hitl-text-input"],
+  hitl: ["hitl-steps"],
+  "hitl-in-app": ["hitl-approve-deny"],
+  "shared-state-read-write": ["shared-state-read", "shared-state-write"],
+  "mcp-apps": ["mcp-apps"],
+  subagents: ["subagents"],
+};
+
+function resolveD5Row(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+): StatusRow | null {
+  const d5Keys = CATALOG_TO_D5_KEY[featureId];
+  if (!d5Keys) return null;
+  let worst: StatusRow | null = null;
+  for (const d5Key of d5Keys) {
+    const row = live.get(keyFor("d5", slug, d5Key)) ?? null;
+    if (!row) continue;
+    if (!worst || row.state === "red") worst = row;
+  }
+  return worst;
+}
+
 function rowTone(row: StatusRow | null): BadgeTone {
   if (!row) return "gray";
   switch (row.state) {
@@ -281,7 +321,7 @@ export function resolveCell(
   // (alert engine routes them independently, same model as smoke). A
   // missing row resolves to a gray "?" badge, which is the expected
   // resting state for D6 cells outside their weekly-rotation slot.
-  const d5Row = live.get(keyFor("d5", slug, featureId)) ?? null;
+  const d5Row = resolveD5Row(live, slug, featureId);
   const d6Row = live.get(keyFor("d6", slug, featureId)) ?? null;
 
   // Rollup contributors: health + e2e (Decision #7: smokeRow dropped).


### PR DESCRIPTION
## Summary

- **D5 dashboard chip fix**: `resolveCell()` looked up D5 PocketBase rows by catalog feature ID (e.g. `d5:slug/hitl-in-chat`) but the harness writes them keyed by D5 feature type (e.g. `d5:slug/hitl-text-input`). Added `CATALOG_TO_D5_KEY` mapping so the dashboard resolves the correct PB row for each cell — this is why D5 chips showed gray "?" instead of green/red.

- **CLI deep-input fix**: `buildDeepInputs()` passed manifest registry IDs as `features` but the D5 driver only maps through `demosToFeatureTypes()` when they arrive as `demos`. Changed to pass `demos` so `showcase test <slug> --d5` exercises all D5 feature types, not just the ~5 whose registry ID happens to match a D5 feature type.

- **7 new CLI debugging commands**: `build`, `ports`, `recreate`, `fixtures validate`, `doctor`, `aimock-rebuild`, `diff-logs` — all referenced by DEBUGGING.md but previously unimplemented.

## Test plan

- [ ] Dashboard shows D5 chips (green/red) after next harness tick
- [ ] `showcase test langgraph-python --d5` runs all 11 D5 feature types locally
- [ ] New CLI commands execute without errors