### PR TITLE
fix(showcase): increase probe cadence for aimock-backed integrations

### DIFF
--- a/showcase/harness/config/probes/e2e-deep.yml
+++ b/showcase/harness/config/probes/e2e-deep.yml
@@ -26,19 +26,14 @@
 #                                   featureType yet — coverage gap, not
 #                                   regression.
 #
-# ── Cadence: */60 (every 60 minutes) ────────────────────────────────────
+# ── Cadence: */15 (every 15 minutes) ────────────────────────────────────
 #
-# D5 is the slowest probe in the fleet — multi-turn conversations against
-# real Playwright + real (mocked) LLM. A single conversation can span 1-3
-# turns × ~5-10s/turn × ~10 feature types × 17 services. Even with
-# `max_concurrency: 4` capping parallel chromium and the per-feature
-# timeout budget, one tick is several minutes of wall time. Hourly
-# strikes the right balance: catches regressions within a half-deploy
-# window without flooding the scheduler. Speed up only after observing
-# headroom in production for a full cycle.
+# All showcase integrations are aimock-backed — zero LLM cost per tick.
+# D5 ticks take ~3.5 min with max_concurrency=4; every-15-min gives
+# continuous regression coverage within a single deploy window.
 #
-# Cron string: `5 * * * *` (every hour at :05). Offset from :00 to avoid
-# Chromium EAGAIN when co-firing with e2e-smoke's browser pool at :00.
+# Cron string: `5,20,35,50 * * * *` (every 15 min, offset from :00 to
+# avoid Chromium EAGAIN when co-firing with e2e-smoke's browser pool).
 #
 # ── timeout_ms: 180_000 (3 min) ─────────────────────────────────────────
 #
@@ -66,7 +61,7 @@
 # Starters short-circuit green inside the driver (no /demos routing).
 kind: e2e_deep
 id: e2e-deep
-schedule: "5 * * * *"
+schedule: "5,20,35,50 * * * *"
 timeout_ms: 180000
 max_concurrency: 4
 discovery:

--- a/showcase/harness/config/probes/e2e-demos.yml
+++ b/showcase/harness/config/probes/e2e-demos.yml
@@ -28,47 +28,15 @@
 # row via `keyFor("e2e", slug, featureId)` which formats as
 # `e2e:<slug>/<featureId>` — the driver's side-emit keys match.
 #
-# ── Cadence: every 6 hours ────────────────────────────────────────────
+# ── Cadence: hourly ────────────────────────────────────────────────────
 #
-# Chromium cost scales as demos × services per tick. The 17 framework
-# packages each carry ~32 demos on average; the largest single service
-# carries ~38 demos and is the wall-clock-dominating service under
-# bounded concurrency. Aggregate page loads per tick are
-# 17 × ~32 ≈ 544 typical (~32 average per service, capped by the
-# ~38-demo largest).
+# All showcase integrations are aimock-backed — zero LLM cost per tick.
+# The driver's goto + selector check takes 2-3 min typical wall-clock
+# (worst case 19 min for the largest 38-demo service, bounded by the
+# 20-min outer cap below). Hourly gives continuous structural coverage.
 #
-# Wall-clock per tick is NOT aggregate-divided-by-concurrency: with
-# `max_concurrency: 6` the wall-clock floor is set by the SLOWEST
-# single service's serial per-demo fan-out (the driver visits each
-# demo sequentially within a single service invocation).
-#
-# Per-demo wall-clock is bounded by `pageTimeoutMs` (30s) — the
-# driver's runDemo() shares one 30s budget across goto + all 5
-# fallback selector waits, so a single demo cannot exceed 30s
-# regardless of how many selectors it tries (enforced via a single
-# wall-clock deadline in `drivers/e2e-readiness.ts`'s runDemo()). For
-# the largest 38-demo service the
-# absolute worst case is therefore ~38 × 30s ≈ ~19 min — bounded by
-# the 20-min outer cap below (which the driver's internal hard-cap is
-# now aligned to via the orchestrator's `E2E_DEMOS_TIMEOUT_MS`
-# threading; see the `timeout_ms` block).
-#
-# Typical pages finish in ~3-5s so the realistic wall-clock is ~2-3
-# minutes (the slowest single service). Smaller services interleave
-# in parallel slots and don't extend wall-clock past the slowest, so
-# the bound holds regardless of service count.
-# Every 6 hours gives us:
-#   - 4 ticks/day: catches regressions within a half-deploy window
-#     while leaving ~90% of the scheduler's wall time to sibling
-#     probes.
-#   - Bounded LLM and bandwidth cost: the driver's ready-selector
-#     check does NOT issue a chat turn (unlike e2e-smoke) so there is
-#     no per-demo LLM spend, but each goto still pulls the Next.js
-#     bundle and chromium heap grows with page count.
-#
-# Speed up (e.g. */2h, */1h) ONLY after observing the per-tick memory
-# headroom + any downstream cost (LLM, bandwidth, Railway compute) on
-# the production orchestrator for a full cycle.
+# Cron string: `10 * * * *` (hourly at :10, offset from D5's :05/:20
+# cadence to avoid Chromium contention).
 #
 # ── timeout_ms: 1_200_000 (20 min) ─────────────────────────────────────
 #
@@ -128,7 +96,7 @@
 # new infra service added there lands here too during review.
 kind: e2e_demos
 id: e2e-demos
-schedule: "10 */6 * * *"
+schedule: "10 * * * *"
 timeout_ms: 1200000
 max_concurrency: 6
 discovery:

--- a/showcase/harness/config/probes/e2e-smoke.yml
+++ b/showcase/harness/config/probes/e2e-smoke.yml
@@ -38,7 +38,7 @@
 #   - showcase-shell-dashboard / -docs / -dojo (auxiliary UI services)
 kind: e2e_smoke
 id: e2e-smoke
-schedule: "*/30 * * * *"
+schedule: "*/15 * * * *"
 timeout_ms: 180000
 max_concurrency: 2
 discovery:

--- a/showcase/harness/config/probes/smoke.yml
+++ b/showcase/harness/config/probes/smoke.yml
@@ -54,7 +54,7 @@
 # max_concurrency × 3 endpoints = 18 inflight.
 kind: smoke
 id: smoke
-schedule: "*/15 * * * *"
+schedule: "*/5 * * * *"
 timeout_ms: 30000
 max_concurrency: 6
 discovery:


### PR DESCRIPTION
## Summary

All 18 showcase integrations are aimock-backed — zero LLM cost per probe tick. Tightened schedules to catch regressions faster:

| Probe | Before | After | What it does |
|-------|--------|-------|-------------|
| smoke | every 15 min | every 5 min | L1/L2 HTTP health checks |
| e2e-smoke | every 30 min | every 15 min | L3/L4 Playwright chat round-trip |
| e2e-deep (D5) | hourly | every 15 min | Multi-turn conversation probes |
| e2e-demos (D4) | every 6 hours | hourly | Per-demo structural coverage |

Cron offsets preserved to avoid Chromium EAGAIN across concurrent browser pools.

## Test plan

- [ ] Harness picks up new schedules after deploy
- [ ] No OOM or Chromium contention under tighter cadence
- [ ] Dashboard shows more frequent probe updates