### PR TITLE
fix(showcase): bottom padding for fixed legend bar

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -181,7 +181,7 @@ export default function Page() {
             />
           </div>
           {/* Single scroll area — stats bar and title scroll away, table headers stick */}
-          <div className="flex-1 min-h-0 overflow-auto">
+          <div className="flex-1 min-h-0 overflow-auto pb-12">
             <div className="px-8 py-3 border-b border-[var(--border)]">
               <AdaptiveStatsBar
                 overlays={overlays}


### PR DESCRIPTION
## Summary
- Adds `pb-12` to the scroll container so the fixed-position legend bar at the bottom doesn't obscure the last rows of the feature matrix table.

## Test plan
- Scroll to the bottom of the matrix — last row should be fully visible above the legend bar.