### PR TITLE
fix(showcase): ref-depth column sticky offset

### DIFF
--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -289,7 +289,7 @@ function CategorySection({
                   />
                 ) : (
                   <td
-                    className="sticky left-[260px] z-10 px-1 py-1 border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] align-top"
+                    className="sticky left-[160px] z-10 px-1 py-1 border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] align-top"
                     style={{ backgroundColor: "#f5f0ff" }}
                   >
                     <span className="text-[var(--text-muted)] text-[10px]">

--- a/showcase/shell-dashboard/src/components/ref-depth-column.tsx
+++ b/showcase/shell-dashboard/src/components/ref-depth-column.tsx
@@ -12,7 +12,7 @@ import { DepthChip } from "@/components/depth-chip";
 export function RefDepthHeader() {
   return (
     <th
-      className="sticky left-[260px] top-0 z-30 px-1.5 py-1.5 text-left border-b border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] font-normal"
+      className="sticky left-[160px] top-0 z-30 px-1.5 py-1.5 text-left border-b border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] font-normal"
       style={{ backgroundColor: "#f5f0ff" }}
     >
       <div className="text-[9px] font-semibold uppercase tracking-wider text-[#7c3aed] leading-tight">
@@ -38,7 +38,7 @@ export interface RefDepthCellProps {
 export function RefDepthCell({ depth, status, regression }: RefDepthCellProps) {
   return (
     <td
-      className="sticky left-[260px] z-10 px-1.5 py-1 border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] align-top"
+      className="sticky left-[160px] z-10 px-1.5 py-1 border-r-2 border-r-[#c4b5fd] border-l border-[var(--border)] align-top"
       style={{ backgroundColor: "#f5f0ff" }}
     >
       <DepthChip depth={depth} status={status} regression={regression} />


### PR DESCRIPTION
## Summary
- Fixes the ref-depth (parity) column's sticky left offset from `260px` to `160px` to match the reduced FEATURE column min-width. The stale offset caused the parity column to float disconnected from the feature column when scrolling horizontally.

## Test plan
- Enable Parity Review preset, scroll right — REF DEPTH column should stay pinned flush against the FEATURE column.