### PR TITLE
fix(showcase): docs overlay renders independently of health

### DIFF
--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -189,7 +189,7 @@ export function ComposedCell({
       {hasLinks && <LinksLayer ctx={ctx} />}
       {hasDepth && <DepthLayer ctx={ctx} catalogCell={catalogCell} />}
       {hasHealth && !ctx.demo.command && <HealthLayer ctx={ctx} />}
-      {hasDocs && !hasHealth && <DocsLayer ctx={ctx} />}
+      {hasDocs && <DocsLayer ctx={ctx} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removes the `!hasHealth` gate on DocsLayer, so toggling the Docs overlay always shows/hides docs content in cells regardless of whether Health is also active.

## Test plan
- Toggle Docs on/off with Health also active — docs should appear/disappear independently.