### PR TITLE
fix(showcase-dashboard): replace 🚫 emoji with 'N/A' text on unsupported cells

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -68,16 +68,19 @@ describe("DepthChip", () => {
     expect(chip.getAttribute("data-status")).toBe("unshipped");
   });
 
-  it("renders prohibited glyph for unsupported with descriptive tooltip", () => {
+  it("renders 'N/A' label for unsupported with descriptive tooltip", () => {
     const { getByTestId } = render(
       <DepthChip depth={0} status="unsupported" />,
     );
     const chip = getByTestId("depth-chip");
-    expect(chip.textContent).toBe("🚫");
+    // We render plain "N/A" text rather than the 🚫 emoji so the glyph
+    // renders consistently on systems without color emoji support; a
+    // missing emoji font there falls back to a tofu/X-shaped box that
+    // viewers misread as the unshipped X marker.
+    expect(chip.textContent).toBe("N/A");
     // Distinct attribute lets the matrix and tests differentiate from unshipped.
     expect(chip.getAttribute("data-status")).toBe("unsupported");
     expect(chip.getAttribute("title")).toBe("Not supported by this framework");
-    expect(chip.className).toContain("border-dashed");
   });
 
   it("unsupported renders distinctly from unshipped (different glyph + status)", () => {

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -8,8 +8,10 @@
  *   D1-D2 = amber — basic health and agent checks
  *   D0    = gray — exists but no live probe data
  *   unshipped = transparent + dashed border, displays "--"
- *   unsupported = transparent + dashed gray border, displays "🚫"
- *                 (architectural limit — framework cannot support feature)
+ *   unsupported = slate border + slate fill, displays "N/A"
+ *                 (architectural limit — framework cannot support feature;
+ *                  text label avoids 🚫 emoji which falls back to tofu/X
+ *                  glyphs on systems without color emoji support)
  *   regression = red (danger)
  */
 
@@ -57,16 +59,19 @@ export function DepthChip({ depth, status, regression }: DepthChipProps) {
 
   if (status === "unsupported") {
     // Distinct from "unshipped": architectural limit, not undone work.
-    // A solid dashed border + dimmed prohibited glyph + descriptive
-    // tooltip signals "cannot be supported" rather than "to be done".
+    // A solid (not dashed) border in a slate hue + the explicit "N/A"
+    // text label signals "cannot be supported" rather than "to be done".
+    // We deliberately avoid the 🚫 emoji here because it falls back to a
+    // tofu/X-shaped glyph on systems without color emoji support, which
+    // makes the cell read like an unshipped X to viewers.
     return (
       <span
         data-testid="depth-chip"
         data-status="unsupported"
-        className="inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums border border-dashed border-[var(--text-muted)]/60 bg-[var(--text-muted)]/5 text-[var(--text-muted)]/70"
+        className="inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[9px] font-semibold uppercase tracking-wider border border-slate-500/40 bg-slate-500/10 text-slate-400"
         title="Not supported by this framework"
       >
-        🚫
+        N/A
       </span>
     );
   }


### PR DESCRIPTION
## Why

After #4419 merged, the dashboard's matrix renders the 29 `unsupported` cells using the 🚫 emoji. On systems without color-emoji support (notably Windows Chrome default fonts), 🚫 falls back to a tofu/X-shaped glyph — which viewers correctly identify as visually identical to the unshipped X marker. The result: 29 architecturally-unsupported cells look indistinguishable from unshipped ones, defeating the whole point of introducing the `unsupported` state.

User report: "I see X on spring ai state streaming and byoc json-renderer, almost whole row for In-Chat HITL (useInterrupt — low-level primitive) and Headless Interrupt … and a few only have not supported".

The data is correct (`unsupported: 29`, `unshipped: 0` in the deployed bundle). Only the rendering needs to be more robust against font fallback.

## What

- **DepthChip unsupported branch**: replace the 🚫 emoji with the text label `N/A`. Slate-colored border + slate fill + uppercase `N/A` reads consistently regardless of emoji font availability and remains distinct from unshipped's dashed-gray `--`.
- **Header doc + inline comment**: explain why we don't use the emoji.
- **Test fixture**: assert `textContent === "N/A"` (was `=== "🚫"`); the distinctness test (which only compares unshipped's textContent vs unsupported's) still passes since `N/A !== --`.

## Test plan

- [x] `pnpm --filter shell-dashboard test src/components/__tests__/depth-chip.test.tsx` passes
- [ ] Visual: spot-check the matrix on the Vercel preview — unsupported cells should now show a slate `N/A` pill that is clearly distinct from unshipped's `--`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)