### PR TITLE
fix(showcase-dashboard): unsupported cells in feature-grid + revert to 🚫 emoji

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -68,16 +68,12 @@ describe("DepthChip", () => {
     expect(chip.getAttribute("data-status")).toBe("unshipped");
   });
 
-  it("renders 'N/A' label for unsupported with descriptive tooltip", () => {
+  it("renders 🚫 emoji for unsupported with descriptive tooltip", () => {
     const { getByTestId } = render(
       <DepthChip depth={0} status="unsupported" />,
     );
     const chip = getByTestId("depth-chip");
-    // We render plain "N/A" text rather than the 🚫 emoji so the glyph
-    // renders consistently on systems without color emoji support; a
-    // missing emoji font there falls back to a tofu/X-shaped box that
-    // viewers misread as the unshipped X marker.
-    expect(chip.textContent).toBe("N/A");
+    expect(chip.textContent).toBe("🚫");
     // Distinct attribute lets the matrix and tests differentiate from unshipped.
     expect(chip.getAttribute("data-status")).toBe("unsupported");
     expect(chip.getAttribute("title")).toBe("Not supported by this framework");

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -8,10 +8,8 @@
  *   D1-D2 = amber — basic health and agent checks
  *   D0    = gray — exists but no live probe data
  *   unshipped = transparent + dashed border, displays "--"
- *   unsupported = slate border + slate fill, displays "N/A"
- *                 (architectural limit — framework cannot support feature;
- *                  text label avoids 🚫 emoji which falls back to tofu/X
- *                  glyphs on systems without color emoji support)
+ *   unsupported = slate border + slate fill, displays "🚫"
+ *                 (architectural limit — framework cannot support feature)
  *   regression = red (danger)
  */
 
@@ -59,19 +57,16 @@ export function DepthChip({ depth, status, regression }: DepthChipProps) {
 
   if (status === "unsupported") {
     // Distinct from "unshipped": architectural limit, not undone work.
-    // A solid (not dashed) border in a slate hue + the explicit "N/A"
-    // text label signals "cannot be supported" rather than "to be done".
-    // We deliberately avoid the 🚫 emoji here because it falls back to a
-    // tofu/X-shaped glyph on systems without color emoji support, which
-    // makes the cell read like an unshipped X to viewers.
+    // A slate border + slate fill + 🚫 emoji + descriptive tooltip
+    // signals "cannot be supported" rather than "to be done".
     return (
       <span
         data-testid="depth-chip"
         data-status="unsupported"
-        className="inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[9px] font-semibold uppercase tracking-wider border border-slate-500/40 bg-slate-500/10 text-slate-400"
+        className="inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums border border-slate-500/40 bg-slate-500/10 text-slate-400"
         title="Not supported by this framework"
       >
-        N/A
+        🚫
       </span>
     );
   }

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -466,7 +466,10 @@ export function FeatureGrid({
 
       {connection === "error" && <OfflineBanner />}
 
-      <div className="rounded-lg border border-[var(--border)] bg-[var(--bg-surface)]" style={{ width: 'fit-content', minWidth: '100%' }}>
+      <div
+        className="rounded-lg border border-[var(--border)] bg-[var(--bg-surface)]"
+        style={{ width: "fit-content", minWidth: "100%" }}
+      >
         <table className="border-collapse text-sm">
           <thead>
             <tr>

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -299,6 +299,9 @@ function CategorySection({
                 ))}
               {integrations.map((integration) => {
                 const demo = integration.demos.find((d) => d.id === feature.id);
+                const isNotSupported =
+                  integration.not_supported_features?.includes(feature.id) ??
+                  false;
                 return (
                   <td
                     key={integration.slug}
@@ -316,6 +319,16 @@ function CategorySection({
                         liveStatus,
                         connection,
                       })
+                    ) : isNotSupported ? (
+                      // Architectural limit — framework cannot support this
+                      // feature. Distinct from the unshipped "no demo" ✗ so
+                      // viewers can tell "won't be done" apart from "to do".
+                      <span
+                        className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider border border-slate-500/40 bg-slate-500/10 text-slate-400"
+                        title="Not supported by this framework"
+                      >
+                        N/A
+                      </span>
                     ) : (
                       <div
                         className="text-center text-base text-[var(--danger)]"

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -324,10 +324,10 @@ function CategorySection({
                       // feature. Distinct from the unshipped "no demo" ✗ so
                       // viewers can tell "won't be done" apart from "to do".
                       <span
-                        className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wider border border-slate-500/40 bg-slate-500/10 text-slate-400"
+                        className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-base border border-slate-500/40 bg-slate-500/10 text-slate-400"
                         title="Not supported by this framework"
                       >
-                        N/A
+                        🚫
                       </span>
                     ) : (
                       <div

--- a/showcase/shell-dashboard/src/lib/registry.ts
+++ b/showcase/shell-dashboard/src/lib/registry.ts
@@ -47,6 +47,13 @@ export interface Integration {
   features: string[];
   demos: Demo[];
   /**
+   * Feature IDs the integration's framework cannot architecturally support
+   * (e.g. lacks a graph-interrupt primitive or MCP tool runtime). Cells for
+   * these IDs render as "Not supported" rather than the unshipped "no demo"
+   * marker. Source: `not_supported_features:` in the integration's manifest.
+   */
+  not_supported_features?: string[];
+  /**
    * Per-column docs link overrides sourced from
    * `showcase/integrations/<slug>/docs-links.json`. The `shell_docs_path` is a
    * path relative to the shell root; callers combine it with the framework


### PR DESCRIPTION
## Why

Follow-up to #4423. Two issues with how the dashboard renders unsupported cells:

1. **The actual ✗ source — feature-grid.tsx, not DepthChip.** The user's report (`<div class="text-center text-base text-[var(--danger)]" title="No demo">✗</div>`) traced to `feature-grid.tsx` line 320, which had its own no-demo branch rendering a literal Unicode `✗` (U+2717) in danger red — completely independent of DepthChip. That branch fired for every unsupported cell because the manifest doesn't list demos for unsupported features. PR #4423's DepthChip fix didn't touch this path.

2. **Emoji preference.** #4423 swapped DepthChip from 🚫 emoji to "N/A" text under the (mistaken) theory that the user was seeing a 🚫 fallback. Since the actual culprit was the literal ✗ in feature-grid (not a 🚫 fallback), and the user prefers the emoji, this PR restores 🚫 in both places.

## What

- **`feature-grid.tsx`**: when a cell has no demo entry but the integration's `not_supported_features` lists the feature, render the slate-pill 🚫 marker instead of the danger ✗.
- **`registry.ts`**: add the `not_supported_features?: string[]` field to the `Integration` interface (the data was already present in `registry.json`; the type just didn't expose it).
- **`depth-chip.tsx`**: revert the unsupported branch from "N/A" text back to 🚫 emoji on a slate pill.
- **`__tests__/depth-chip.test.tsx`**: assert `textContent === "🚫"` again.

## Three states stay visually distinct

| State | Marker | Color |
|-------|--------|-------|
| unshipped (planned, not built) | `--` | dashed gray |
| **unsupported** (architectural limit) | **🚫** | **slate** |
| no demo entry (feature listed without demo) | `✗` | danger red |

🤖 Generated with [Claude Code](https://claude.com/claude-code)