### PR TITLE
fix(showcase): increase zebra stripe visibility

### DIFF
--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -263,11 +263,11 @@ function CategorySection({
             <tr
               key={feature.id}
               className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
-              style={stripe ? { backgroundColor: "color-mix(in srgb, var(--bg-surface) 94%, var(--bg-muted))" } : undefined}
+              style={stripe ? { backgroundColor: "color-mix(in srgb, var(--bg-surface) 50%, var(--bg-muted))" } : undefined}
             >
               <td
                 className="sticky left-0 z-10 px-1 py-1 border-r border-[var(--border)] align-top"
-                style={{ backgroundColor: stripe ? "color-mix(in srgb, var(--bg-surface) 94%, var(--bg-muted))" : "var(--bg-surface)" }}
+                style={{ backgroundColor: stripe ? "color-mix(in srgb, var(--bg-surface) 50%, var(--bg-muted))" : "var(--bg-surface)" }}
               >
                 <div
                   className={


### PR DESCRIPTION
## Summary
- Previous 94%/6% color-mix was invisible (white vs near-white). Changed to 50/50 mix between `--bg-surface` and `--bg-muted` for actually visible alternating rows.

## Test plan
- Alternating rows should have a subtle but visible tint difference.