### PR TITLE
fix: GHCR drift audit false positive for showcase-pocketbase

### DIFF
--- a/.github/workflows/ghcr_unlinked_packages.yml
+++ b/.github/workflows/ghcr_unlinked_packages.yml
@@ -13,6 +13,16 @@
 # the only way to prevent future surprises is detect drift early via a
 # scheduled audit + Slack alert.
 #
+# ALLOWLIST (VERIFIED_ACCESS)
+# ---------------------------
+# Some packages show `repository: null` on the API but have working
+# Actions access because the "Manage Actions access" setting was
+# configured manually in the GitHub UI. There is NO API to detect this
+# setting, so we maintain an explicit allowlist of package names that
+# have been verified to have Actions write access. These are excluded
+# from the unlinked-package alert to avoid false positives. See the
+# VERIFIED_ACCESS array in the audit step below.
+#
 # This workflow is the operationalization of the lesson captured in
 # `feedback_ghcr_new_package_403.md`.
 #
@@ -94,6 +104,30 @@ jobs:
           # JSON array of {name, visibility} objects for downstream use.
           unlinked_json="$(echo "$all_packages_json" \
             | jq -c '[.[] | select(.repository == null) | {name: .name, visibility: .visibility}]')"
+
+          # Packages with `repository: null` that have verified Actions access
+          # configured via the GitHub UI ("Manage Actions access" → CopilotKit →
+          # Write). These are not truly drifted — pushes work fine — but there
+          # is no API to detect this, so we maintain an explicit allowlist.
+          # To add a package here: verify in the package settings UI that
+          # "Manage Actions access" lists CopilotKit with Write role, then
+          # add the exact package name to this array.
+          VERIFIED_ACCESS=("showcase-pocketbase")
+
+          # Remove allowlisted packages from the unlinked set.
+          unlinked_json_before_filter="$unlinked_json"
+          if [ ${#VERIFIED_ACCESS[@]} -gt 0 ]; then
+            allowlist_filter=$(printf '"%s",' "${VERIFIED_ACCESS[@]}")
+            allowlist_filter="[${allowlist_filter%,}]"
+            unlinked_json="$(echo "$unlinked_json" \
+              | jq -c --argjson allow "$allowlist_filter" \
+                '[.[] | select(.name as $n | $allow | index($n) | not)]')"
+          fi
+
+          skipped=$(($(echo "$unlinked_json_before_filter" | jq 'length') - $(echo "$unlinked_json" | jq 'length')))
+          if [ "$skipped" -gt 0 ]; then
+            echo "Skipped $skipped package(s) with verified Actions access (allowlist)."
+          fi
 
           unlinked_count="$(echo "$unlinked_json" | jq 'length')"
           echo "Unlinked container packages: $unlinked_count"

--- a/showcase/pocketbase/Dockerfile
+++ b/showcase/pocketbase/Dockerfile
@@ -33,6 +33,8 @@ RUN set -eux; \
     /pb/pocketbase --version
 
 FROM alpine:3.19
+LABEL org.opencontainers.image.source="https://github.com/CopilotKit/CopilotKit"
+LABEL org.opencontainers.image.description="PocketBase for CopilotKit showcase platform"
 # `su-exec` is alpine's minimal privilege-drop helper (~30 KB static
 # binary). Used by entrypoint.sh to run PocketBase as `pocketbase` while
 # still being able to chown /pb_data at container start — see the


### PR DESCRIPTION
## Summary

- Add OCI source labels to `showcase/pocketbase/Dockerfile` so future GHCR pushes auto-link the package to the `CopilotKit/CopilotKit` repository (sets the `repository` field on the Packages API)
- Add a `VERIFIED_ACCESS` allowlist to the daily GHCR drift audit workflow to suppress false positives for packages that have manual Actions access configured via the UI

## Why

The daily GHCR drift audit (`ghcr_unlinked_packages.yml`) checks `repository == null` on the GitHub Packages API and alerts to Slack. `showcase-pocketbase` has "Manage Actions access" configured with CopilotKit/Write, so pushes work fine — but the API still returns `repository: null` because the package was never linked to a source repository via OCI labels. There is no GitHub API to check manual Actions access, so the alert was a false positive.

## Test plan

- [ ] Docker build passes locally (verified — Depot build succeeded)
- [ ] `actionlint` clean on the workflow YAML (verified)
- [ ] Next scheduled audit run (or manual `workflow_dispatch`) should report 0 unlinked packages
- [ ] After the next `showcase-pocketbase` image push to GHCR, verify the package's `repository` field becomes non-null via `gh api /orgs/CopilotKit/packages/container/showcase-pocketbase --jq .repository`