### PR TITLE
fix(showcase): result-aware probe icons + browser history navigation

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -57,7 +57,7 @@ export default function Page() {
   );
 
   // Overlay state management (handles URL hash + localStorage persistence)
-  const { overlays, activeTab, toggle, applyPreset, setTab, activePreset } =
+  const { overlays, activeTab, toggle, applyPreset, setTab, activePreset, selectedProbeId, selectProbe } =
     useOverlays();
 
   // Build a cell-lookup map: integration slug + feature id -> CatalogCell
@@ -207,7 +207,12 @@ export default function Page() {
 
       {activeTab === "ops" && (
         <div className="flex-1 min-h-0 overflow-auto">
-          <StatusTab entries={probeEntries} onTrigger={handleTrigger} />
+          <StatusTab
+            entries={probeEntries}
+            onTrigger={handleTrigger}
+            selectedProbeId={selectedProbeId}
+            onSelectProbe={selectProbe}
+          />
         </div>
       )}
     </div>

--- a/showcase/shell-dashboard/src/components/status-running-panel.tsx
+++ b/showcase/shell-dashboard/src/components/status-running-panel.tsx
@@ -23,6 +23,9 @@ export interface StatusRunningPanelProps {
 type ServiceState = NonNullable<
   ProbeScheduleEntry["inflight"]
 >["services"][number]["state"];
+type ServiceResult = NonNullable<
+  NonNullable<ProbeScheduleEntry["inflight"]>["services"][number]["result"]
+>;
 
 const STATE_ICON: Record<ServiceState, string> = {
   completed: "✅",
@@ -30,6 +33,29 @@ const STATE_ICON: Record<ServiceState, string> = {
   queued: "⏸",
   failed: "❌",
 };
+
+/**
+ * Result-aware icon for completed services. A completed service with
+ * result "red" or "yellow" should NOT show ✅ — that misleads the
+ * operator into thinking everything passed when it didn't. Only
+ * result "green" earns the checkmark; yellow gets a warning, red
+ * gets the same ❌ as a failed service.
+ */
+const RESULT_ICON: Record<ServiceResult, string> = {
+  green: "✅",
+  yellow: "⚠️",
+  red: "❌",
+};
+
+function serviceIcon(
+  state: ServiceState,
+  result?: ServiceResult,
+): string {
+  if (state === "completed" && result) {
+    return RESULT_ICON[result] ?? STATE_ICON[state];
+  }
+  return STATE_ICON[state];
+}
 
 function useNowTick(): number {
   const [now, setNow] = useState(() => Date.now());
@@ -148,7 +174,7 @@ export function StatusRunningPanel({ entries }: StatusRunningPanelProps) {
                     data-state={s.state}
                     className="flex items-center gap-1.5 px-2 py-1 rounded border border-[var(--border)]"
                   >
-                    <span aria-hidden="true">{STATE_ICON[s.state]}</span>
+                    <span aria-hidden="true">{serviceIcon(s.state, s.result)}</span>
                     <span className="font-mono truncate">{s.slug}</span>
                     {sElapsed && (
                       <span className="ml-auto text-[var(--text-muted)] tabular-nums">

--- a/showcase/shell-dashboard/src/components/status-runs-list.tsx
+++ b/showcase/shell-dashboard/src/components/status-runs-list.tsx
@@ -80,8 +80,26 @@ const SERVICE_ICON: Record<string, string> = {
   failed: "❌",
 };
 
+/**
+ * Result-aware icon for historical run service chips. Completed services
+ * with result "red" or "yellow" should not show ✅ — mirrors the fix
+ * in status-running-panel.tsx for inflight services.
+ */
+const RESULT_ICON: Record<string, string> = {
+  green: "✅",
+  yellow: "⚠️",
+  red: "❌",
+};
+
+function serviceChipIcon(svc: ProbeRunServiceResult): string {
+  if (svc.state === "completed" && svc.result) {
+    return RESULT_ICON[svc.result] ?? SERVICE_ICON[svc.state] ?? "—";
+  }
+  return SERVICE_ICON[svc.state] ?? "—";
+}
+
 function ServiceChip({ svc }: { svc: ProbeRunServiceResult }) {
-  const icon = SERVICE_ICON[svc.state] ?? "—";
+  const icon = serviceChipIcon(svc);
   return (
     <div
       data-testid={`run-service-${svc.slug}`}

--- a/showcase/shell-dashboard/src/components/status-tab.tsx
+++ b/showcase/shell-dashboard/src/components/status-tab.tsx
@@ -11,7 +11,6 @@
  * was a real problem (e.g. local lacked `error?` / `finishedAt?` on
  * service progress, and used `string` instead of the `ProbeKind` union).
  */
-import { useState } from "react";
 import { StatusTable } from "./status-table";
 import { StatusRunningPanel } from "./status-running-panel";
 import { StatusDetailPanel } from "./status-detail-panel";
@@ -24,23 +23,22 @@ import type { ProbeScheduleEntry } from "../lib/ops-api";
 export interface StatusTabProps {
   entries: ProbeScheduleEntry[];
   onTrigger: (probeId: string, slugs?: string[]) => Promise<void>;
+  selectedProbeId: string | null;
+  onSelectProbe: (probeId: string | null) => void;
 }
 
-export function StatusTab({ entries, onTrigger }: StatusTabProps) {
-  // Drilldown selection lives at the StatusTab level so the table and the
-  // detail panel can stay decoupled — table emits an id, panel consumes it.
-  const [selectedProbeId, setSelectedProbeId] = useState<string | null>(null);
+export function StatusTab({ entries, onTrigger, selectedProbeId, onSelectProbe }: StatusTabProps) {
   return (
     <div data-testid="status-tab" className="flex flex-col">
       <StatusTable
         entries={entries}
         onTrigger={onTrigger}
-        onSelect={setSelectedProbeId}
+        onSelect={(id) => onSelectProbe(id)}
       />
       <StatusRunningPanel entries={entries} />
       <StatusDetailPanel
         probeId={selectedProbeId}
-        onClose={() => setSelectedProbeId(null)}
+        onClose={() => onSelectProbe(null)}
       />
     </div>
   );

--- a/showcase/shell-dashboard/src/components/status-table.tsx
+++ b/showcase/shell-dashboard/src/components/status-table.tsx
@@ -191,7 +191,10 @@ export function StatusTable({
                 (s) => s.state === "completed" && s.result === "green",
               ).length;
               const failed = inflight.services.filter(
-                (s) => s.state === "failed" || (s.state === "completed" && s.result === "red"),
+                (s) =>
+                  s.state === "failed" ||
+                  (s.state === "completed" &&
+                    (s.result === "red" || s.result === "yellow")),
               ).length;
 
               if (failed > 0) tone = "red";

--- a/showcase/shell-dashboard/src/hooks/useOverlays.ts
+++ b/showcase/shell-dashboard/src/hooks/useOverlays.ts
@@ -14,23 +14,31 @@ import {
 
 const STORAGE_KEY = "dashboard:overlays";
 const HASH_PREFIX = "matrix:";
+const OPS_PROBE_PREFIX = "ops:probe=";
 
 // ---------------------------------------------------------------------------
 // URL hash helpers
 // ---------------------------------------------------------------------------
 
-/** Parse the current URL hash into a tab + overlay set, handling legacy redirects. */
+/** Parse the current URL hash into tab + overlay set + optional probe ID. */
 function parseHash(): {
   tab: "matrix" | "ops";
   overlays: OverlaySet | null;
+  probeId: string | null;
 } {
   const raw =
     typeof window !== "undefined" ? window.location.hash.slice(1) : "";
-  if (!raw) return { tab: "matrix", overlays: null };
+  if (!raw) return { tab: "matrix", overlays: null, probeId: null };
+
+  // #ops:probe=<id> — ops tab with probe detail drilldown
+  if (raw.startsWith(OPS_PROBE_PREFIX)) {
+    const probeId = decodeURIComponent(raw.slice(OPS_PROBE_PREFIX.length));
+    return { tab: "ops", overlays: null, probeId: probeId || null };
+  }
 
   // #ops — switch to ops tab
   if (raw === "ops") {
-    return { tab: "ops", overlays: null };
+    return { tab: "ops", overlays: null, probeId: null };
   }
 
   // Legacy redirect check
@@ -38,15 +46,15 @@ function parseHash(): {
     const mapped = LEGACY_REDIRECTS[raw];
     // "status" redirects to ops tab
     if (mapped.length === 0) {
-      return { tab: "ops", overlays: null };
+      return { tab: "ops", overlays: null, probeId: null };
     }
     const set = new Set(mapped) as OverlaySet;
-    return { tab: "matrix", overlays: set };
+    return { tab: "matrix", overlays: set, probeId: null };
   }
 
   // #matrix or #matrix:links,depth,...
   if (raw === "matrix") {
-    return { tab: "matrix", overlays: null };
+    return { tab: "matrix", overlays: null, probeId: null };
   }
 
   if (raw.startsWith(HASH_PREFIX)) {
@@ -55,28 +63,42 @@ function parseHash(): {
       ALL_OVERLAYS.includes(p as Overlay),
     );
     if (valid.length > 0) {
-      return { tab: "matrix", overlays: new Set(valid) as OverlaySet };
+      return { tab: "matrix", overlays: new Set(valid) as OverlaySet, probeId: null };
     }
-    return { tab: "matrix", overlays: null };
+    return { tab: "matrix", overlays: null, probeId: null };
   }
 
-  return { tab: "matrix", overlays: null };
+  return { tab: "matrix", overlays: null, probeId: null };
 }
 
-/** Replace hash via replaceState (no history entry, no navigation). */
-function writeHash(tab: "matrix" | "ops", overlays?: OverlaySet): void {
+/**
+ * Write the URL hash. When `push` is true, creates a new browser history
+ * entry (pushState) so back/forward navigation works. When false, uses
+ * replaceState (used for initial mount sync to avoid polluting history).
+ */
+function writeHash(
+  tab: "matrix" | "ops",
+  overlays?: OverlaySet,
+  probeId?: string | null,
+  push = false,
+): void {
   if (typeof window === "undefined") return;
+  const method = push ? "pushState" : "replaceState";
+
   if (tab === "ops") {
-    window.history.replaceState(null, "", "#ops");
+    const hash = probeId
+      ? `#${OPS_PROBE_PREFIX}${encodeURIComponent(probeId)}`
+      : "#ops";
+    window.history[method](null, "", hash);
     return;
   }
   if (overlays && overlays.size > 0) {
     const sorted = [...overlays].sort(
       (a, b) => ALL_OVERLAYS.indexOf(a) - ALL_OVERLAYS.indexOf(b),
     );
-    window.history.replaceState(null, "", `#${HASH_PREFIX}${sorted.join(",")}`);
+    window.history[method](null, "", `#${HASH_PREFIX}${sorted.join(",")}`);
   } else {
-    window.history.replaceState(null, "", "#matrix");
+    window.history[method](null, "", "#matrix");
   }
 }
 
@@ -121,6 +143,8 @@ export interface UseOverlaysReturn {
   activePreset: string | null;
   showFilters: boolean;
   has: (overlay: Overlay) => boolean;
+  selectedProbeId: string | null;
+  selectProbe: (probeId: string | null) => void;
 }
 
 export function useOverlays(): UseOverlaysReturn {
@@ -130,14 +154,16 @@ export function useOverlays(): UseOverlaysReturn {
     () => new Set(DEFAULT_OVERLAYS) as OverlaySet,
   );
   const [activeTab, setActiveTabRaw] = useState<"matrix" | "ops">("matrix");
+  const [selectedProbeId, setSelectedProbeIdRaw] = useState<string | null>(null);
 
   // Sync from URL hash / localStorage after hydration
   useEffect(() => {
-    const { tab, overlays: fromHash } = parseHash();
+    const { tab, overlays: fromHash, probeId } = parseHash();
     const resolved =
       fromHash ?? loadFromStorage() ?? (new Set(DEFAULT_OVERLAYS) as OverlaySet);
     setOverlays(resolved);
     setActiveTabRaw(tab);
+    setSelectedProbeIdRaw(probeId);
   }, []);
 
   // On mount, write hash to reflect actual state (handles legacy redirects
@@ -145,14 +171,28 @@ export function useOverlays(): UseOverlaysReturn {
   useEffect(() => {
     if (!initialized.current) {
       initialized.current = true;
-      writeHash(activeTab, overlays);
+      writeHash(activeTab, overlays, selectedProbeId, false);
     }
-  }, [activeTab, overlays]);
+  }, [activeTab, overlays, selectedProbeId]);
+
+  // Listen for browser back/forward navigation
+  useEffect(() => {
+    function onPopState() {
+      const { tab, overlays: fromHash, probeId } = parseHash();
+      const resolved =
+        fromHash ?? loadFromStorage() ?? (new Set(DEFAULT_OVERLAYS) as OverlaySet);
+      setOverlays(resolved);
+      setActiveTabRaw(tab);
+      setSelectedProbeIdRaw(probeId);
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
 
   // Sync hash + localStorage whenever overlays change after initialization.
   const updateOverlays = useCallback((next: OverlaySet) => {
     setOverlays(next);
-    writeHash("matrix", next);
+    writeHash("matrix", next, null, true);
     saveToStorage(next);
   }, []);
 
@@ -167,7 +207,7 @@ export function useOverlays(): UseOverlaysReturn {
       } else {
         next.add(overlay);
       }
-      writeHash("matrix", next);
+      writeHash("matrix", next, null, true);
       saveToStorage(next);
       return next;
     });
@@ -186,9 +226,18 @@ export function useOverlays(): UseOverlaysReturn {
   const setTab = useCallback(
     (tab: "matrix" | "ops") => {
       setActiveTabRaw(tab);
-      writeHash(tab, overlays);
+      setSelectedProbeIdRaw(null);
+      writeHash(tab, overlays, null, true);
     },
     [overlays],
+  );
+
+  const selectProbe = useCallback(
+    (probeId: string | null) => {
+      setSelectedProbeIdRaw(probeId);
+      writeHash("ops", undefined, probeId, true);
+    },
+    [],
   );
 
   const activePreset = useMemo(() => {
@@ -222,5 +271,7 @@ export function useOverlays(): UseOverlaysReturn {
     activePreset,
     showFilters,
     has,
+    selectedProbeId,
+    selectProbe,
   };
 }


### PR DESCRIPTION
## Summary

- **Inflight/historical icons now differentiate pass vs fail**: Running panel and historical run chips show result-specific icons (green=✅, yellow=⚠️, red=❌). Previously all completed services showed ✅ regardless of result, making failing tests look like passes.
- **Inflight tally counts yellow (degraded) as failure**: The summary table's inflight branch now counts `result === "yellow"` services as failures alongside red, fixing undercounted fail tallies.
- **Browser back/forward navigation works**: All tab switches, overlay toggles, preset changes, and probe drilldowns now create browser history entries via pushState. Added popstate listener to sync state. Probe detail encoded in URL hash (`#ops:probe=<id>`).

## Test plan

- [x] Trigger an e2e-deep probe run with mixed results; verify inflight panel shows ❌ for red services (not ✅)
- [x] Verify summary tally matches inflight panel counts
- [x] Switch tabs Matrix→Ops, press Back, verify returns to Matrix
- [x] Open probe detail, press Back, verify returns to Ops overview
- [x] Toggle overlays, press Back, verify previous overlay state restores
- [x] Direct URL navigation to `#ops:probe=<id>` opens detail panel