### PR TITLE
fix(showcase): unblock built-in-agent and claude-sdk-typescript deploys

### DIFF
--- a/showcase/integrations/built-in-agent/package-lock.json
+++ b/showcase/integrations/built-in-agent/package-lock.json
@@ -15,7 +15,7 @@
         "@hashbrownai/react": "0.5.0-beta.4",
         "@tanstack/ai": "latest",
         "@tanstack/ai-openai": "latest",
-        "next": "^15.0.0",
+        "next": "^15.5.15",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^2.15.0",

--- a/showcase/integrations/claude-sdk-typescript/Dockerfile
+++ b/showcase/integrations/claude-sdk-typescript/Dockerfile
@@ -10,8 +10,8 @@ RUN npm run build
 # instead of `npx tsx` (which does a fresh in-process TS compile on each
 # cold start).
 RUN npx tsc --outDir /app/dist --module commonjs --moduleResolution node \
-    --target es2020 --esModuleInterop true --skipLibCheck true \
-    src/agent_server.ts
+    --target es2020 --esModuleInterop true --resolveJsonModule true \
+    --skipLibCheck true src/agent_server.ts
 
 # Stage 2: Production image — runtime only (no build tools)
 FROM node:22-slim AS runner


### PR DESCRIPTION
## Summary

- **built-in-agent**: Regenerate stale `package-lock.json` — was missing `@copilotkit/voice`, `@json-render/*`, `zod@4`, `openai@5` and others. Every deploy attempt failed at `npm ci`.
- **claude-sdk-typescript**: Add `--resolveJsonModule` to Dockerfile's tsc invocation. `a2ui-fixed-prompt.ts` imports a JSON schema; tsconfig.json had the flag but Dockerfile passes all flags explicitly, overriding it.

## Test plan

- [x] `npm ci --legacy-peer-deps --dry-run` passes for built-in-agent
- [ ] CI deploy builds both images successfully