### PR TITLE
WIP spike: OSS-69 host-portal pattern for shared gen-ui in inspector

### DIFF
--- a/examples/v2/react/demo/src/app/sidebar/page.tsx
+++ b/examples/v2/react/demo/src/app/sidebar/page.tsx
@@ -6,6 +6,7 @@ import {
   defineToolCallRenderer,
   useConfigureSuggestions,
   useFrontendTool,
+  useRenderTool,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
@@ -91,5 +92,114 @@ function SidebarChat() {
     },
   });
 
+  // OSS-69 prototype: gen-ui tool that renders a real chart in chat AND in
+  // the inspector via the host-portal bridge.
+  useFrontendTool({
+    name: "showChart",
+    description:
+      "Render a small bar chart. Use when the user asks to visualize data.",
+    parameters: z.object({
+      title: z.string(),
+      bars: z
+        .array(z.object({ label: z.string(), value: z.number() }))
+        .min(1)
+        .max(8),
+    }),
+    handler: async ({ title }) => `Rendered chart: ${title}`,
+  });
+
+  useRenderTool(
+    {
+      name: "showChart",
+      parameters: z.object({
+        title: z.string(),
+        bars: z.array(z.object({ label: z.string(), value: z.number() })),
+      }),
+      render: ({ status, parameters }) => {
+        if (status === "inProgress") {
+          return (
+            <div className="text-xs text-slate-500">Building chart…</div>
+          );
+        }
+        return <BarChart title={parameters.title} bars={parameters.bars} />;
+      },
+    },
+    [],
+  );
+
   return <CopilotSidebar defaultOpen={true} width="50%" />;
+}
+
+function BarChart({
+  title,
+  bars,
+}: {
+  title: string;
+  bars: { label: string; value: number }[];
+}) {
+  const max = Math.max(1, ...bars.map((b) => b.value));
+  const width = 320;
+  const height = 160;
+  const barWidth = width / bars.length;
+  return (
+    <div
+      style={{
+        background: "white",
+        border: "1px solid #e2e8f0",
+        borderRadius: 8,
+        padding: 12,
+        boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+        fontFamily:
+          "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 500,
+          color: "#334155",
+          marginBottom: 8,
+        }}
+      >
+        {title}
+      </div>
+      <svg width={width} height={height} style={{ display: "block" }}>
+        {bars.map((bar, i) => {
+          const h = (bar.value / max) * (height - 24);
+          const x = i * barWidth + 4;
+          const y = height - h - 16;
+          return (
+            <g key={i}>
+              <rect
+                x={x}
+                y={y}
+                width={barWidth - 8}
+                height={h}
+                fill="#6366f1"
+                rx={3}
+              />
+              <text
+                x={x + (barWidth - 8) / 2}
+                y={height - 4}
+                fontSize={10}
+                fill="#475569"
+                textAnchor="middle"
+              >
+                {bar.label}
+              </text>
+              <text
+                x={x + (barWidth - 8) / 2}
+                y={y - 2}
+                fontSize={10}
+                fill="#1e293b"
+                textAnchor="middle"
+              >
+                {bar.value}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
 }

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -29,6 +29,11 @@ import { DebugConfig } from "@copilotkit/shared";
 import { StateManager } from "./state-manager";
 import { ThreadStoreRegistry } from "./thread-store-registry";
 import { type ɵThreadStore } from "../threads";
+import {
+  ToolRenderBridge,
+  ToolRenderRegistry,
+  ToolRenderRequest,
+} from "./tool-render-bridge";
 
 /** Configuration options for `CopilotKitCore`. */
 export interface CopilotKitCoreConfig {
@@ -335,6 +340,7 @@ export class CopilotKitCore {
   private runHandler: RunHandler;
   private stateManager: StateManager;
   private threadStoreRegistry: ThreadStoreRegistry;
+  private toolRenderRegistry: ToolRenderRegistry = new ToolRenderRegistry();
 
   constructor({
     runtimeUrl,
@@ -674,6 +680,31 @@ export class CopilotKitCore {
 
   getSuggestions(agentId: string): CopilotKitCoreGetSuggestionsResult {
     return this.suggestionEngine.getSuggestions(agentId);
+  }
+
+  /**
+   * Tool render bridges (host-portal pattern).
+   *
+   * Frameworks (React, Angular, vanilla) register a bridge that knows how to
+   * paint a tool call into a host DOM node. Surfaces like the inspector ask
+   * core to fill a slot; core dispatches to the first bridge that claims it.
+   * Lets the inspector show the customer's own gen-ui without taking a
+   * framework dependency.
+   */
+  addToolRenderBridge(bridge: ToolRenderBridge): () => void {
+    return this.toolRenderRegistry.addBridge(bridge);
+  }
+
+  canRenderTool(req: ToolRenderRequest): boolean {
+    return this.toolRenderRegistry.canRender(req);
+  }
+
+  attachToolRender(req: ToolRenderRequest, hostEl: HTMLElement): boolean {
+    return this.toolRenderRegistry.attach(req, hostEl);
+  }
+
+  detachToolRender(toolCallId: string): void {
+    this.toolRenderRegistry.detach(toolCallId);
   }
 
   /**

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -4,3 +4,4 @@ export * from "./context-store";
 export * from "./suggestion-engine";
 export * from "./run-handler";
 export * from "./state-manager";
+export * from "./tool-render-bridge";

--- a/packages/core/src/core/tool-render-bridge.ts
+++ b/packages/core/src/core/tool-render-bridge.ts
@@ -1,0 +1,60 @@
+import { ToolCallStatus } from "../types";
+
+export interface ToolRenderRequest {
+  toolCallId: string;
+  toolName: string;
+  agentId?: string;
+  status: ToolCallStatus;
+  args: unknown;
+  result?: unknown;
+}
+
+export interface ToolRenderBridge {
+  canRender(req: ToolRenderRequest): boolean;
+  attach(req: ToolRenderRequest, hostEl: HTMLElement): void;
+  detach(toolCallId: string): void;
+}
+
+export class ToolRenderRegistry {
+  private bridges: Set<ToolRenderBridge> = new Set();
+  private slotOwnership: Map<string, ToolRenderBridge> = new Map();
+
+  addBridge(bridge: ToolRenderBridge): () => void {
+    this.bridges.add(bridge);
+    return () => {
+      this.bridges.delete(bridge);
+      for (const [id, owner] of this.slotOwnership) {
+        if (owner === bridge) this.slotOwnership.delete(id);
+      }
+    };
+  }
+
+  canRender(req: ToolRenderRequest): boolean {
+    for (const b of this.bridges) {
+      if (b.canRender(req)) return true;
+    }
+    return false;
+  }
+
+  attach(req: ToolRenderRequest, hostEl: HTMLElement): boolean {
+    const existing = this.slotOwnership.get(req.toolCallId);
+    if (existing && this.bridges.has(existing)) {
+      existing.attach(req, hostEl);
+      return true;
+    }
+    for (const b of this.bridges) {
+      if (b.canRender(req)) {
+        b.attach(req, hostEl);
+        this.slotOwnership.set(req.toolCallId, b);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  detach(toolCallId: string): void {
+    const owner = this.slotOwnership.get(toolCallId);
+    this.slotOwnership.delete(toolCallId);
+    if (owner) owner.detach(toolCallId);
+  }
+}

--- a/packages/react-core/src/v2/lib/host-portal-bridge.tsx
+++ b/packages/react-core/src/v2/lib/host-portal-bridge.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  CopilotKitCore,
+  ToolCallStatus,
+  ToolRenderBridge,
+  ToolRenderRequest,
+} from "@copilotkit/core";
+import type { ReactToolCallRenderer } from "../types/react-tool-call-renderer";
+import { CopilotKitCoreReact } from "./react-core";
+
+interface ActiveSlot {
+  req: ToolRenderRequest;
+  hostEl: HTMLElement;
+}
+
+function pickRenderer(
+  renderers: Readonly<ReactToolCallRenderer<any>[]>,
+  req: ToolRenderRequest,
+): ReactToolCallRenderer<any> | undefined {
+  const exactSameAgent = renderers.find(
+    (r) => r.name === req.toolName && r.agentId === req.agentId,
+  );
+  if (exactSameAgent) return exactSameAgent;
+  const exactAnyAgent = renderers.find(
+    (r) => r.name === req.toolName && !r.agentId,
+  );
+  if (exactAnyAgent) return exactAnyAgent;
+  const wildcard = renderers.find((r) => r.name === "*");
+  return wildcard;
+}
+
+/**
+ * Mounts inside the CopilotKit React tree and registers a ToolRenderBridge
+ * with core. When a foreign surface (web inspector, etc.) asks core to fill
+ * a host DOM node for a tool call, this component portals the matching
+ * React renderer into that node so it shares context with the host tree.
+ */
+export function HostPortalBridge({
+  copilotkit,
+}: {
+  copilotkit: CopilotKitCore;
+}) {
+  const [slots, setSlots] = useState<Map<string, ActiveSlot>>(() => new Map());
+  const renderersRef = useRef<Readonly<ReactToolCallRenderer<any>[]>>([]);
+
+  if (copilotkit instanceof CopilotKitCoreReact) {
+    renderersRef.current = copilotkit.renderToolCalls;
+  }
+
+  useEffect(() => {
+    if (!(copilotkit instanceof CopilotKitCoreReact)) return;
+    const sub = copilotkit.subscribe({
+      onRenderToolCallsChanged: ({ renderToolCalls }) => {
+        renderersRef.current = renderToolCalls;
+        setSlots((prev) => new Map(prev));
+      },
+    });
+    return () => sub.unsubscribe();
+  }, [copilotkit]);
+
+  useEffect(() => {
+    const bridge: ToolRenderBridge = {
+      canRender: (req) =>
+        Boolean(pickRenderer(renderersRef.current, req)),
+      attach: (req, hostEl) => {
+        setSlots((prev) => {
+          const next = new Map(prev);
+          next.set(req.toolCallId, { req, hostEl });
+          return next;
+        });
+      },
+      detach: (toolCallId) => {
+        setSlots((prev) => {
+          if (!prev.has(toolCallId)) return prev;
+          const next = new Map(prev);
+          next.delete(toolCallId);
+          return next;
+        });
+      },
+    };
+    return copilotkit.addToolRenderBridge(bridge);
+  }, [copilotkit]);
+
+  return (
+    <>
+      {Array.from(slots.values()).map(({ req, hostEl }) => {
+        const renderer = pickRenderer(renderersRef.current, req);
+        if (!renderer) return null;
+        const Renderer = renderer.render;
+        const props =
+          req.status === ToolCallStatus.Complete
+            ? {
+                name: req.toolName,
+                toolCallId: req.toolCallId,
+                args: req.args as any,
+                status: ToolCallStatus.Complete as const,
+                result: String(req.result ?? ""),
+              }
+            : req.status === ToolCallStatus.Executing
+              ? {
+                  name: req.toolName,
+                  toolCallId: req.toolCallId,
+                  args: req.args as any,
+                  status: ToolCallStatus.Executing as const,
+                  result: undefined,
+                }
+              : {
+                  name: req.toolName,
+                  toolCallId: req.toolCallId,
+                  args: req.args as any,
+                  status: ToolCallStatus.InProgress as const,
+                  result: undefined,
+                };
+        return (
+          <PortalErrorBoundary key={req.toolCallId}>
+            {createPortal(<Renderer {...props} />, hostEl, req.toolCallId)}
+          </PortalErrorBoundary>
+        );
+      })}
+    </>
+  );
+}
+
+class PortalErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  componentDidCatch(error: Error) {
+    console.warn("[CopilotKit host-portal] renderer threw", error);
+  }
+  render() {
+    if (this.state.error) return null;
+    return this.props.children;
+  }
+}

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -42,6 +42,7 @@ import { A2UICatalogContext } from "../a2ui/A2UICatalogContext";
 import { viewerTheme } from "@copilotkit/a2ui-renderer";
 import type { Theme as A2UITheme } from "@copilotkit/a2ui-renderer";
 import { CopilotKitCoreReact } from "../lib/react-core";
+import { HostPortalBridge } from "../lib/host-portal-bridge";
 import type {
   ReactActivityMessageRenderer,
   ReactToolCallRenderer,
@@ -791,6 +792,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
             />
           )}
           {children}
+          <HostPortalBridge copilotkit={copilotkit} />
           {shouldRenderInspector ? (
             <CopilotKitInspector
               core={copilotkit}

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -1,5 +1,13 @@
 import { LitElement, css, html, nothing, unsafeCSS } from "lit";
 import { marked } from "marked";
+import "./tool-render-slot";
+import type { ToolRenderSlotData } from "./tool-render-slot";
+
+export {
+  TOOL_RENDER_SLOT_TAG,
+  CpkToolRenderSlot,
+  type ToolRenderSlotData,
+} from "./tool-render-slot";
 import { styleMap } from "lit/directives/style-map.js";
 import tailwindStyles from "./styles/generated.css";
 import inspectorLogoUrl from "./assets/inspector-logo.svg";
@@ -610,6 +618,7 @@ class CpkThreadDetails extends LitElement {
   static properties = {
     threadId: { attribute: false },
     thread: { attribute: false },
+    core: { attribute: false },
     runtimeUrl: { attribute: false },
     headers: { attribute: false },
     agentStateInput: { attribute: false },
@@ -635,6 +644,7 @@ class CpkThreadDetails extends LitElement {
 
   threadId: string | null = null;
   thread: ɵThread | null = null;
+  core: CopilotKitCore | null = null;
   runtimeUrl = "";
   headers: Record<string, string> = {};
   agentStateInput: Record<string, unknown> | null = null;
@@ -1714,6 +1724,23 @@ class CpkThreadDetails extends LitElement {
 
   private renderToolBlock(item: ConversationToolCall) {
     const expanded = this._expandedTools.has(item.id);
+    const slotData: ToolRenderSlotData = {
+      toolCallId: item.toolCallId,
+      toolName: item.toolName,
+      args: item.arguments,
+      result: item.result ?? undefined,
+    };
+    const hasHostRenderer = Boolean(
+      this.core &&
+        "canRenderTool" in this.core &&
+        (this.core as any).canRenderTool({
+          toolCallId: item.toolCallId,
+          toolName: item.toolName,
+          args: item.arguments,
+          result: item.result ?? undefined,
+          status: "complete",
+        }),
+    );
     return html`
       <div class="cpk-td__tool-block">
         <div
@@ -1745,6 +1772,21 @@ class CpkThreadDetails extends LitElement {
           expanded
             ? html`
               <div class="cpk-td__tool-body">
+                ${
+                  hasHostRenderer
+                    ? html`<div
+                        class="cpk-td__tool-section-label"
+                        style="margin-bottom:6px"
+                      >
+                        Generative UI
+                      </div>
+                      <cpk-tool-render-slot
+                        .core=${this.core}
+                        .toolCall=${slotData}
+                        style="display:block;margin-bottom:10px"
+                      ></cpk-tool-render-slot>`
+                    : nothing
+                }
                 <div class="cpk-td__tool-section-label">Arguments</div>
                 <pre class="cpk-td__tool-pre">
 ${unsafeHTML(highlightedJson(item.arguments))}</pre
@@ -2908,8 +2950,24 @@ export class WebInspectorElement extends LitElement {
             call.function?.name ?? call.toolName ?? "Unknown function";
           const callId =
             typeof call?.id === "string" ? call.id : `tool-call-${index + 1}`;
+          const args = this.parseToolCallArguments(call.function?.arguments);
           const argsString = this.formatToolCallArguments(
             call.function?.arguments,
+          );
+          const slotData: ToolRenderSlotData = {
+            toolCallId: callId,
+            toolName: functionName,
+            args,
+          };
+          const hasHostRenderer = Boolean(
+            this._core &&
+              "canRenderTool" in this._core &&
+              (this._core as any).canRenderTool({
+                toolCallId: callId,
+                toolName: functionName,
+                args,
+                status: "complete",
+              }),
           );
           return html`
             <div
@@ -2921,20 +2979,37 @@ export class WebInspectorElement extends LitElement {
                 <span>${functionName}</span>
                 <span class="text-[10px] text-gray-500">ID: ${callId}</span>
               </div>
-              ${
-                argsString
+              ${hasHostRenderer
+                ? html`<div class="mt-2">
+                    <cpk-tool-render-slot
+                      .core=${this._core}
+                      .toolCall=${slotData}
+                    ></cpk-tool-render-slot>
+                  </div>`
+                : argsString
                   ? html`<pre
-                    class="mt-2 overflow-auto rounded bg-white p-2 text-[11px] leading-relaxed text-gray-800"
-                  >
+                      class="mt-2 overflow-auto rounded bg-white p-2 text-[11px] leading-relaxed text-gray-800"
+                    >
 ${argsString}</pre
-                  >`
-                  : nothing
-              }
+                    >`
+                  : nothing}
             </div>
           `;
         })}
       </div>
     `;
+  }
+
+  private parseToolCallArguments(args: unknown): unknown {
+    if (args === undefined || args === null || args === "") return undefined;
+    if (typeof args === "string") {
+      try {
+        return JSON.parse(args);
+      } catch {
+        return args;
+      }
+    }
+    return args;
   }
 
   private formatToolCallArguments(args: unknown): string | null {
@@ -5654,6 +5729,7 @@ ${argsString}</pre
                   style="flex:1;min-width:0;"
                   .threadId=${this.selectedThreadId}
                   .thread=${selectedThread}
+                  .core=${this._core}
                   .runtimeUrl=${this._core?.runtimeUrl ?? ""}
                   .headers=${this._core?.headers ?? {}}
                   .agentStateInput=${

--- a/packages/web-inspector/src/tool-render-slot.ts
+++ b/packages/web-inspector/src/tool-render-slot.ts
@@ -1,0 +1,108 @@
+import {
+  CopilotKitCore,
+  ToolCallStatus,
+  type ToolRenderRequest,
+} from "@copilotkit/core";
+
+export const TOOL_RENDER_SLOT_TAG = "cpk-tool-render-slot" as const;
+
+export type ToolRenderSlotData = {
+  toolCallId: string;
+  toolName: string;
+  agentId?: string;
+  status?: ToolCallStatus;
+  args?: unknown;
+  result?: unknown;
+};
+
+export class CpkToolRenderSlot extends HTMLElement {
+  private _core: CopilotKitCore | null = null;
+  private _data: ToolRenderSlotData | null = null;
+  private _attached = false;
+  private _fallbackEl: HTMLElement | null = null;
+
+  set core(value: CopilotKitCore | null) {
+    if (this._core === value) return;
+    this.teardown();
+    this._core = value;
+    this.tryAttach();
+  }
+
+  set toolCall(value: ToolRenderSlotData | null) {
+    const prev = this._data;
+    this._data = value;
+    if (prev && value && prev.toolCallId !== value.toolCallId) this.teardown();
+    this.tryAttach();
+  }
+
+  connectedCallback(): void {
+    this.tryAttach();
+  }
+
+  disconnectedCallback(): void {
+    this.teardown();
+  }
+
+  private tryAttach(): void {
+    if (!this.isConnected || !this._core || !this._data) return;
+    const req: ToolRenderRequest = {
+      toolCallId: this._data.toolCallId,
+      toolName: this._data.toolName,
+      agentId: this._data.agentId,
+      status: this._data.status ?? ToolCallStatus.Complete,
+      args: this._data.args,
+      result: this._data.result,
+    };
+    this.clearFallback();
+    const ok = this._core.attachToolRender(req, this);
+    this._attached = ok;
+    if (!ok) this.renderFallback(req);
+  }
+
+  private teardown(): void {
+    if (this._attached && this._core && this._data) {
+      this._core.detachToolRender(this._data.toolCallId);
+    }
+    this._attached = false;
+    this.clearFallback();
+  }
+
+  private renderFallback(req: ToolRenderRequest): void {
+    const argsText = formatJson(req.args);
+    const el = document.createElement("pre");
+    el.className =
+      "cpk-tool-render-slot-fallback overflow-auto rounded bg-white p-2 text-[11px] leading-relaxed text-gray-800";
+    el.textContent = argsText;
+    this.appendChild(el);
+    this._fallbackEl = el;
+  }
+
+  private clearFallback(): void {
+    if (this._fallbackEl && this._fallbackEl.parentNode === this) {
+      this.removeChild(this._fallbackEl);
+    }
+    this._fallbackEl = null;
+  }
+}
+
+function formatJson(value: unknown): string {
+  if (value == null || value === "") return "";
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+if (typeof customElements !== "undefined") {
+  if (!customElements.get(TOOL_RENDER_SLOT_TAG)) {
+    customElements.define(TOOL_RENDER_SLOT_TAG, CpkToolRenderSlot);
+  }
+}


### PR DESCRIPTION
## What this is

Recon prototype for [OSS-69](https://linear.app/copilotkit/issue/OSS-69/recon-options-for-sharing-gen-ui-components-in-intelligence-inspector). Not feature-ready. Posted to make the pattern concrete for the team discussion. The full options analysis (with pros/cons of iframe, schema-driven DSL, snapshot capture, etc.) lives in the [Notion recon doc](https://app.notion.com/p/3513aa381852810890daecbf2ed4addf).

Recommendation in the recon: Option A, the host-portal pattern. This PR proves it works.

## How it works

The inspector renders the customer's own gen-ui without taking a React or Angular dependency.

1. **`@copilotkit/core`**: `ToolRenderBridge` interface + `ToolRenderRegistry` class, with `addToolRenderBridge` / `canRenderTool` / `attachToolRender` / `detachToolRender` on `CopilotKitCore`. Pure DOM contract: `(req, hostEl: HTMLElement) => mount/unmount`. No framework references anywhere in core.

2. **`@copilotkit/react-core`**: `HostPortalBridge` component mounted from `CopilotKitProvider`. On mount, registers a bridge with core. When asked to fill a host element, it `createPortal`s the matching `renderToolCalls` renderer into that element. Portal preserves React context, so the customer's hooks, providers, and theming all work. Subscribes to `onRenderToolCallsChanged` so live status flows through.

3. **`@copilotkit/web-inspector`**: `cpk-tool-render-slot` custom element. The inspector probes `core.canRenderTool` and emits the slot when a host renderer exists. Falls back to today's JSON view when none is registered. Wired into both rendering paths: the legacy "Current Messages" view and the threads-tab Conversation sub-tab from the threads PR.

4. **Demo**: `examples/v2/react/demo/src/app/sidebar` registers a `showChart` frontend tool plus a `useRenderTool` returning an inline-SVG bar chart, so the chart shows up in the chat AND in the inspector's tool-call view.

## Why this option

Option A uniquely satisfies all three constraints from the recon:
- Zero new render code in the inspector bundle (just a slot custom element + a `canRenderTool` probe).
- Zero drift with the live customer app, because it IS the customer's renderer.
- Works for in-memory runner (no Intelligence dependency).
- Graceful JSON fallback when the host has no renderer for a given tool name.

## Future framework support

The bridge contract is pure DOM, so Vue / Svelte / Solid / vanilla all map onto it without changes to core or inspector. Adding a new SDK is one bridge file in that SDK's package. See the [Notion doc's "Future framework support" section](https://app.notion.com/p/3513aa381852810890daecbf2ed4addf) for the per-framework mount-API mapping.

## What's intentionally out of scope

- Angular bridge. Same shape as the React bridge (`ViewContainerRef.createComponent`), not built here.
- Vue / Svelte / Solid bridges.
- Intelligence-runner demo. The pattern is runtime-agnostic by design (the bridge is client-side; tool-call data shape is the same), but this demo currently uses `InMemoryAgentRunner`. Proving the Intelligence path end-to-end depends on CPK-7453 anyway.
- Tests.
- Tool result threading. The slot currently passes args; tool result is plumbed through but conversation builder doesn't always populate it for frontend tools (see "Known issues" below).

## Demo-only changes that aren't part of the pattern

- `openGenerativeUI: false` in `examples/v2/react/demo/src/app/api/copilotkit/[[...slug]]/route.ts`. The built-in `generateSandboxedUI` tool out-ranks `showChart` for any chart request. Flipping it off lets the demo's tool fire so we can see the slot light up. Flip back to `true` to restore default runtime behavior.
- `BarChart` in the sidebar demo uses inline styles, not Tailwind classes. Tailwind class names from the host page do not penetrate into the inspector's shadow DOM (Lit). Inline styles render correctly across the boundary. This is a per-renderer concern customers will hit when their gen-ui shows up in the inspector; worth a docs note in the eventual feature PR.

## Known issues that reproduce without this spike

- Tool block shows "PENDING" badge even after a frontend tool's handler returns. Threads PR conversation-builder logic (`item.result` truthiness check). Not touched by the spike.
- Chat conversation appears to clear on run completion. Reproduces on the threads PR branch without the spike applied (`HostPortalBridge` is a sibling of `children`, not a wrapper, so its state changes do not cascade into the chat subtree).

## How to run the demo

```bash
cd examples/v2/react/demo
pnpm dev
```

Then open `http://localhost:3000/sidebar` and prompt:

> Use the showChart tool with title "Fruit Sales" and bars apples 12, bananas 8, cherries 15

You should see the chart in the sidebar chat AND in the inspector's tool block (auto-expanded since a host renderer is wired). Comment out the `useRenderTool({ name: "showChart", ... })` block in the sidebar page and the inspector falls back to today's JSON view.

## Diff stat

8 files, ~535 lines. Three new files (bridge contract, React portal, inspector slot), three small edits (`CopilotKitCore`, `CopilotKitProvider`, threads-tab `renderToolBlock`), two demo edits.

## Base branch

This PR targets `feat/CPK-7193-inspector-threads-clean` because the spike wires the slot into the threads-tab conversation view. Mergeable in sequence after the threads PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)