### PR TITLE
fix: default streamSubgraphs to true in LangGraph agent wrapper

### DIFF
--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -154,7 +154,14 @@ export class LangGraphAgent extends AGUILangGraphAgent {
 
   // @ts-ignore
   run(input: RunAgentInput): Observable<BaseEvent> {
-    return super.run(input).pipe(
+    const enrichedInput = {
+      ...input,
+      forwardedProps: {
+        ...input.forwardedProps,
+        streamSubgraphs: input.forwardedProps?.streamSubgraphs ?? true,
+      },
+    };
+    return super.run(enrichedInput).pipe(
       map((processedEvent) => {
         // Turn raw event into emit state snapshot from tool call event
         if (processedEvent.type === EventType.RAW) {


### PR DESCRIPTION
## Summary

- Explicitly defaults `streamSubgraphs: true` in `LangGraphAgent.run()` forwardedProps so subagent streaming works with `@ag-ui/langgraph` 0.0.31+, which changed the default from `true` to `undefined`
- Uses nullish coalescing (`??`) so explicit user overrides (including `false`) are preserved
- Fixes 6 showcase integrations failing E2E probes on the `subagents` feature

## Why

`@ag-ui/langgraph` 0.0.31 removed the `?? true` fallback on `streamSubgraphs` in `handleStreamEvents()`. The CopilotKit runtime never explicitly set this prop, so subgraph event forwarding became silently disabled. This caused all subagent-dependent demos to stop working.

A previous v1 fix (commit `21e12afca`) handled this in the now-deleted `agui-action.ts`, but the logic was lost during the v2 migration.

## Additional context

Investigation identified a second issue: `@ag-ui/langgraph` 0.0.34 includes state snapshot fixes needed for shared-state-read/write features, but 0.0.34 is not yet published on npm (0.0.31 is latest). The ag-ui team needs to cut a release. Full analysis: [Notion write-up](https://app.notion.com/p/3513aa381852812a9ecef5fbf1e71739)

## Test plan

- [x] Runtime tests pass (1412/1412)
- [x] 7-agent CR converged Round 1 (0 findings)
- [ ] Verify showcase E2E probes for subagent features turn green after merge