### PR TITLE
feat(showcase): per-PR evaluation system with tiered D5 matrix

### DIFF
--- a/.github/workflows/showcase_eval.yml
+++ b/.github/workflows/showcase_eval.yml
@@ -1,0 +1,494 @@
+name: "showcase / eval"
+
+# SECURITY — residual trust model (read before editing):
+#
+# This workflow executes `showcase/bin/showcase eval` against PR-HEAD code.
+# Hardening layers mirror test_e2e-showcase-on-demand.yml:
+#   - `getCollaboratorPermissionLevel` gate limits the trigger to users with
+#     write (or higher) access — third-party commenters cannot spawn runs.
+#   - workflow-level `permissions: contents: read` means the eval job's
+#     GITHUB_TOKEN cannot mutate the repo; the `post-result` job gets write
+#     perms scoped to just the final PR comment.
+#   - `persist-credentials: false` on `actions/checkout` prevents the token
+#     from leaking to PR-HEAD build hooks.
+#   - `env:`-based pattern for UNTRUSTED values (comment body) prevents shell
+#     injection.
+#   - Slug whitelist (`^[a-z0-9-]+$`) prevents path traversal.
+#
+# Known TOCTOU — comment-trigger vs resolved HEAD SHA:
+#   Same gap as test_e2e-showcase-on-demand.yml. The `pulls.get` call resolves
+#   whatever HEAD is current at job start, not at comment time. The permission
+#   gate + code-review social contract are the mitigations.
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: showcase-eval-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    if: >
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/eval')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    outputs:
+      pr_sha: ${{ steps.pr-ref.outputs.sha }}
+      pr_number: ${{ steps.pr-ref.outputs.pr_number }}
+      level: ${{ steps.parse.outputs.level }}
+      scope_flag: ${{ steps.parse.outputs.scope_flag }}
+      scope_display: ${{ steps.parse.outputs.scope_display }}
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Check commenter has write access
+        id: auth
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            const level = perm.permission;
+            if (!['admin', 'write'].includes(level)) {
+              core.setFailed(`User ${context.payload.comment.user.login} has '${level}' access — write access required to trigger /eval.`);
+              return;
+            }
+            core.info(`User ${context.payload.comment.user.login} has '${level}' access — authorized.`);
+
+      - name: Parse /eval command
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+
+          # Extract the first line of the comment to parse the command.
+          FIRST_LINE=$(printf '%s' "$COMMENT_BODY" | head -n1)
+
+          # Parse: /eval → d5 affected
+          #        /eval d5 → d5 affected
+          #        /eval d5 all → d5 all
+          #        /eval d5 mastra,agno → d5 specific slugs
+          ARGS=$(printf '%s' "$FIRST_LINE" | sed 's|^/eval[[:space:]]*||')
+
+          # Default level
+          LEVEL="d5"
+          SCOPE=""
+          SCOPE_FLAG=""
+          SCOPE_DISPLAY=""
+
+          if [ -z "$ARGS" ]; then
+            # Bare /eval — d5 affected
+            SCOPE_FLAG="--scope affected"
+            SCOPE_DISPLAY="affected integrations"
+          else
+            # First token is the level (only d5 supported for now)
+            LEVEL_TOKEN=$(printf '%s' "$ARGS" | awk '{print $1}')
+            REST=$(printf '%s' "$ARGS" | sed "s|^${LEVEL_TOKEN}[[:space:]]*||")
+
+            # Validate level
+            case "$LEVEL_TOKEN" in
+              d5) LEVEL="d5" ;;
+              *)
+                echo "::error::Unknown eval level '$LEVEL_TOKEN'. Supported: d5"
+                exit 1
+                ;;
+            esac
+
+            if [ -z "$REST" ]; then
+              # /eval d5 — affected
+              SCOPE_FLAG="--scope affected"
+              SCOPE_DISPLAY="affected integrations"
+            elif [ "$REST" = "all" ]; then
+              # /eval d5 all
+              SCOPE_FLAG="--scope all"
+              SCOPE_DISPLAY="all integrations"
+            else
+              # /eval d5 mastra,agno → specific slugs
+              # Validate each slug against ^[a-z0-9-]+$ to prevent injection
+              IFS=',' read -ra SLUGS <<< "$REST"
+              for s in "${SLUGS[@]}"; do
+                s=$(printf '%s' "$s" | xargs)  # trim whitespace
+                case "$s" in
+                  ''|*[!a-z0-9-]*)
+                    echo "::error::Invalid slug '$s' — must match ^[a-z0-9-]+$"
+                    exit 1
+                    ;;
+                esac
+              done
+              # Reassemble validated slugs into a clean comma-separated string
+              # (trims whitespace the user may have typed, e.g. "mastra, agno")
+              CLEAN_REST=$(printf '%s' "$REST" | tr -d ' ')
+              SCOPE_FLAG="--slug $CLEAN_REST"
+              SCOPE_DISPLAY="$CLEAN_REST"
+            fi
+          fi
+
+          echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
+          echo "scope_flag=$SCOPE_FLAG" >> "$GITHUB_OUTPUT"
+          echo "scope_display=$SCOPE_DISPLAY" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve PR HEAD ref
+        id: pr-ref
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            if (pr.state !== 'open') {
+              core.setFailed(`PR #${pr.number} is ${pr.state} (not open). Refusing to run eval on a non-open PR.`);
+              return;
+            }
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('pr_number', pr.number);
+
+      - name: React with rocket emoji
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Post running status comment
+        uses: actions/github-script@v7
+        env:
+          LEVEL: ${{ steps.parse.outputs.level }}
+          SCOPE_DISPLAY: ${{ steps.parse.outputs.scope_display }}
+        with:
+          script: |
+            const level = process.env.LEVEL;
+            const scope = process.env.SCOPE_DISPLAY;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                `<!-- showcase-eval-status -->`,
+                `### Showcase Eval`,
+                ``,
+                `| | |`,
+                `|---|---|`,
+                `| **Status** | Running... |`,
+                `| **Level** | \`${level}\` |`,
+                `| **Scope** | ${scope} |`,
+                `| **Run** | [View workflow](${runUrl}) |`,
+              ].join('\n'),
+            });
+
+  eval:
+    needs: gate
+    runs-on: depot-ubuntu-24.04-16
+    timeout-minutes: 45
+
+    permissions:
+      contents: read
+
+    outputs:
+      result_json: ${{ steps.run-eval.outputs.result_json }}
+      exit_code: ${{ steps.run-eval.outputs.exit_code }}
+      stderr_excerpt: ${{ steps.run-eval.outputs.stderr_excerpt }}
+
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.pr_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - uses: pnpm/action-setup@v4.4.0
+        with:
+          version: "10.13.1"
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+
+      - name: Install Playwright chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Run showcase eval
+        id: run-eval
+        env:
+          EVAL_LEVEL: ${{ needs.gate.outputs.level }}
+          EVAL_SCOPE_FLAG: ${{ needs.gate.outputs.scope_flag }}
+        run: |
+          set -o pipefail
+
+          # Build the command. EVAL_SCOPE_FLAG may contain spaces (e.g. "--slug mastra,agno")
+          # so we intentionally leave it unquoted for word splitting.
+          # shellcheck disable=SC2086
+          CMD="showcase/bin/showcase eval --${EVAL_LEVEL} ${EVAL_SCOPE_FLAG} --parallel 8 --json --baseline compare --timeout 60000"
+          echo "::group::Running: $CMD"
+
+          EXIT_CODE=0
+          # Capture both stdout (JSON results) and stderr separately.
+          # Tee stderr to a file for excerpt extraction on failure.
+          $CMD > eval-results.json 2> eval-stderr.log || EXIT_CODE=$?
+
+          echo "::endgroup::"
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          if [ -f eval-results.json ] && [ -s eval-results.json ]; then
+            # GitHub outputs have a 1MB limit; truncate if needed
+            RESULT_SIZE=$(wc -c < eval-results.json)
+            if [ "$RESULT_SIZE" -gt 900000 ]; then
+              echo "::warning::eval-results.json exceeds 900KB ($RESULT_SIZE bytes), truncating for output"
+              head -c 900000 eval-results.json > eval-results-truncated.json
+              echo "result_json<<GHEOF" >> "$GITHUB_OUTPUT"
+              cat eval-results-truncated.json >> "$GITHUB_OUTPUT"
+              echo "GHEOF" >> "$GITHUB_OUTPUT"
+            else
+              echo "result_json<<GHEOF" >> "$GITHUB_OUTPUT"
+              cat eval-results.json >> "$GITHUB_OUTPUT"
+              echo "GHEOF" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'result_json={}' >> "$GITHUB_OUTPUT"
+          fi
+
+          # Capture last 50 lines of stderr for failure reporting
+          if [ -f eval-stderr.log ] && [ -s eval-stderr.log ]; then
+            echo "stderr_excerpt<<GHEOF" >> "$GITHUB_OUTPUT"
+            tail -n 50 eval-stderr.log >> "$GITHUB_OUTPUT"
+            echo "GHEOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "stderr_excerpt=" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Propagate the exit code so the job status reflects eval outcome
+          exit $EXIT_CODE
+
+      - name: Upload eval artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: showcase-eval-results
+          path: |
+            eval-results.json
+            eval-stderr.log
+          retention-days: 14
+          if-no-files-found: ignore
+
+  post-result:
+    needs: [gate, eval]
+    if: always() && needs.gate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Post eval results to PR
+        uses: actions/github-script@v7
+        env:
+          EVAL_STATUS: ${{ needs.eval.result }}
+          RESULT_JSON: ${{ needs.eval.outputs.result_json }}
+          STDERR_EXCERPT: ${{ needs.eval.outputs.stderr_excerpt }}
+          EXIT_CODE: ${{ needs.eval.outputs.exit_code }}
+          LEVEL: ${{ needs.gate.outputs.level }}
+          SCOPE_DISPLAY: ${{ needs.gate.outputs.scope_display }}
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+        with:
+          script: |
+            const evalStatus = process.env.EVAL_STATUS;
+            const resultJson = process.env.RESULT_JSON || '{}';
+            const stderrExcerpt = process.env.STDERR_EXCERPT || '';
+            const exitCode = process.env.EXIT_CODE || 'unknown';
+            const level = process.env.LEVEL;
+            const scope = process.env.SCOPE_DISPLAY;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            let body = '';
+
+            if (evalStatus === 'success') {
+              // Parse JSON results and build markdown table
+              let results;
+              try {
+                results = JSON.parse(resultJson);
+              } catch (e) {
+                // JSON parse failed — report raw
+                body = [
+                  `<!-- showcase-eval-result -->`,
+                  `### Showcase Eval Results`,
+                  ``,
+                  `| | |`,
+                  `|---|---|`,
+                  `| **Verdict** | :warning: PARSE ERROR |`,
+                  `| **Level** | \`${level}\` |`,
+                  `| **Scope** | ${scope} |`,
+                  `| **Run** | [View workflow](${runUrl}) |`,
+                  ``,
+                  `Could not parse eval JSON output:`,
+                  '```',
+                  e.message,
+                  '```',
+                  ``,
+                  `<details><summary>Raw output</summary>`,
+                  ``,
+                  '```json',
+                  resultJson.substring(0, 50000),
+                  '```',
+                  ``,
+                  `</details>`,
+                ].join('\n');
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+                return;
+              }
+
+              // Build results table from the JSON.
+              // Expected shape: { summary: { total, pass, fail, skip, duration_ms },
+              //   results: { slug: { testName: { status, duration_ms, error? } } } }
+              const summary = results.summary || {};
+              const resultsMap = results.results || {};
+              const total = summary.total || 0;
+              const passed = summary.pass || 0;
+              const failed = summary.fail || 0;
+              const skipped = summary.skip || 0;
+
+              const verdict = failed === 0
+                ? ':white_check_mark: **SAFE TO MERGE**'
+                : `:x: **FAILURES DETECTED** (${failed}/${total} failed)`;
+
+              // Build per-integration results table from nested object
+              let tableRows = '';
+              const rows = [];
+              for (const [slug, tests] of Object.entries(resultsMap)) {
+                for (const [testName, r] of Object.entries(tests)) {
+                  const icon = r.status === 'pass' ? ':white_check_mark:'
+                    : r.status === 'fail' ? ':x:'
+                    : r.status === 'skip' ? ':fast_forward:'
+                    : r.status === 'error' ? ':boom:'
+                    : r.status === 'build_failed' ? ':hammer:'
+                    : r.status === 'unhealthy' ? ':warning:'
+                    : ':question:';
+                  const duration = r.duration_ms ? `${(r.duration_ms / 1000).toFixed(1)}s` : '-';
+                  const detail = r.error ? r.error.substring(0, 120) : '-';
+                  rows.push(`| ${icon} | \`${slug}\` | ${testName} | ${r.status || 'unknown'} | ${duration} | ${detail} |`);
+                }
+              }
+              if (rows.length > 0) {
+                tableRows = rows.join('\n');
+              }
+
+              body = [
+                `<!-- showcase-eval-result -->`,
+                `### Showcase Eval Results`,
+                ``,
+                `| | |`,
+                `|---|---|`,
+                `| **Verdict** | ${verdict} |`,
+                `| **Level** | \`${level}\` |`,
+                `| **Scope** | ${scope} |`,
+                `| **Total** | ${total} |`,
+                `| **Passed** | ${passed} |`,
+                `| **Failed** | ${failed} |`,
+                `| **Skipped** | ${skipped} |`,
+                `| **Run** | [View workflow](${runUrl}) |`,
+                ``,
+              ].join('\n');
+
+              if (tableRows) {
+                body += [
+                  `#### Per-Integration Results`,
+                  ``,
+                  `| | Integration | Test | Status | Duration | Details |`,
+                  `|---|---|---|---|---|---|`,
+                  tableRows,
+                  ``,
+                ].join('\n');
+              }
+
+              // Collapsible full JSON
+              body += [
+                `<details><summary>Full JSON details</summary>`,
+                ``,
+                '```json',
+                JSON.stringify(results, null, 2).substring(0, 60000),
+                '```',
+                ``,
+                `</details>`,
+              ].join('\n');
+
+            } else {
+              // Eval failed — post error with stderr excerpt
+              body = [
+                `<!-- showcase-eval-result -->`,
+                `### Showcase Eval Results`,
+                ``,
+                `| | |`,
+                `|---|---|`,
+                `| **Verdict** | :x: **EVAL FAILED** (exit code: ${exitCode}) |`,
+                `| **Level** | \`${level}\` |`,
+                `| **Scope** | ${scope} |`,
+                `| **Run** | [View workflow](${runUrl}) |`,
+                ``,
+              ].join('\n');
+
+              if (stderrExcerpt) {
+                body += [
+                  `<details><summary>Error output (last 50 lines)</summary>`,
+                  ``,
+                  '```',
+                  stderrExcerpt.substring(0, 30000),
+                  '```',
+                  ``,
+                  `</details>`,
+                  ``,
+                ].join('\n');
+              }
+
+              // If we got partial JSON, include it
+              if (resultJson && resultJson !== '{}') {
+                body += [
+                  `<details><summary>Partial JSON output</summary>`,
+                  ``,
+                  '```json',
+                  resultJson.substring(0, 30000),
+                  '```',
+                  ``,
+                  `</details>`,
+                ].join('\n');
+              }
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });

--- a/showcase/.gitignore
+++ b/showcase/.gitignore
@@ -19,3 +19,7 @@ shell/src/data/*.json
 shell-dojo/src/data/*.json
 shell-docs/src/data/*.json
 shell-dashboard/src/data/*.json
+
+# Eval results (local, not committed)
+.eval-results/
+.eval-baseline.json

--- a/showcase/bin/showcase
+++ b/showcase/bin/showcase
@@ -109,6 +109,9 @@ case "$subcmd" in
     [ -z "$subcmd" ] && exit 1
     exit 0
     ;;
+  eval)
+    exec npx tsx "$SHOWCASE_ROOT/harness/src/cli.ts" eval "$@"
+    ;;
   *)
     # Convert dashes to underscores for function lookup: foo-bar → cmd_foo_bar
     func_name="cmd_${subcmd//-/_}"

--- a/showcase/eval-tiers.json
+++ b/showcase/eval-tiers.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Tiered evaluation order. Tier 1 fail_fast stops eval early on gold-standard regression.",
+  "tiers": [
+    {
+      "name": "Gold Standard",
+      "slugs": ["langgraph-python"],
+      "fail_fast": true
+    },
+    {
+      "name": "Key Partners",
+      "slugs": ["mastra", "crewai-crews", "google-adk", "langgraph-typescript"],
+      "fail_fast": false
+    },
+    {
+      "name": "Full Matrix",
+      "slugs": "*",
+      "fail_fast": false
+    }
+  ]
+}

--- a/showcase/harness/src/cli.ts
+++ b/showcase/harness/src/cli.ts
@@ -18,6 +18,7 @@ import { fixturesValidate, formatReport } from "./cli/fixtures.js";
 import { doctor } from "./cli/doctor.js";
 import { aimockRebuild } from "./cli/aimock-rebuild.js";
 import type { TestLevel } from "./cli/targets.js";
+import { registerEvalCommand } from "./cli/eval/index.js";
 
 const program = new Command();
 
@@ -235,6 +236,9 @@ program
       `Visit the showcase dashboard at ${config.dashboardUrl} for test results and status.`,
     );
   });
+
+// ── eval ───────────────────────────────────────────────────────────────
+registerEvalCommand(program);
 
 // ── error handling & entry point ────────────────────────────────────────
 process.on("unhandledRejection", (err) => {

--- a/showcase/harness/src/cli/eval/baseline.test.ts
+++ b/showcase/harness/src/cli/eval/baseline.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  transformHarnessResponse,
+  loadBaseline,
+  saveBaseline,
+  captureBaseline,
+  type EvalBaseline,
+} from "./baseline.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "baseline-test-"));
+}
+
+// ---------------------------------------------------------------------------
+// transformHarnessResponse
+// ---------------------------------------------------------------------------
+
+describe("transformHarnessResponse", () => {
+  it("converts API probe list to eval baseline format", () => {
+    const response = {
+      probes: [
+        {
+          id: "e2e-deep",
+          kind: "e2e",
+          lastRun: {
+            startedAt: "2025-06-01T00:00:00.000Z",
+            finishedAt: "2025-06-01T00:05:00.000Z",
+            durationMs: 300_000,
+            state: "completed" as const,
+            summary: { total: 10, passed: 8, failed: 2 },
+          },
+        },
+        {
+          id: "smoke-quick",
+          kind: "smoke",
+          lastRun: {
+            startedAt: "2025-06-01T00:00:00.000Z",
+            finishedAt: "2025-06-01T00:01:00.000Z",
+            durationMs: 60_000,
+            state: "completed" as const,
+            summary: { total: 5, passed: 5, failed: 0 },
+          },
+        },
+      ],
+    };
+
+    const baseline = transformHarnessResponse(response);
+
+    expect(baseline.version).toBe(1);
+    expect(baseline.source).toBe("harness-prod");
+    expect(baseline.timestamp).toBeTruthy();
+    expect(baseline.results["e2e-deep"]).toBeDefined();
+    expect(baseline.results["e2e-deep"]["default"]).toEqual({
+      status: "fail",
+      total: 10,
+      passed: 8,
+      failed: 2,
+    });
+    expect(baseline.results["smoke-quick"]["default"]).toEqual({
+      status: "pass",
+      total: 5,
+      passed: 5,
+      failed: 0,
+    });
+    expect(baseline.summary).toEqual({
+      total: 2,
+      pass: 1,
+      fail: 1,
+      skip: 0,
+    });
+  });
+
+  it("skips probes with null lastRun", () => {
+    const response = {
+      probes: [
+        {
+          id: "never-ran",
+          kind: "e2e",
+          lastRun: null,
+        },
+        {
+          id: "did-run",
+          kind: "smoke",
+          lastRun: {
+            startedAt: "2025-06-01T00:00:00.000Z",
+            finishedAt: "2025-06-01T00:01:00.000Z",
+            durationMs: 60_000,
+            state: "completed" as const,
+            summary: { total: 3, passed: 3, failed: 0 },
+          },
+        },
+      ],
+    };
+
+    const baseline = transformHarnessResponse(response);
+
+    expect(baseline.results["never-ran"]).toBeUndefined();
+    expect(baseline.results["did-run"]).toBeDefined();
+    expect(baseline.summary.total).toBe(1);
+    expect(baseline.summary.skip).toBe(0);
+  });
+
+  it("skips probes with null summary", () => {
+    const response = {
+      probes: [
+        {
+          id: "no-summary",
+          kind: "e2e",
+          lastRun: {
+            startedAt: "2025-06-01T00:00:00.000Z",
+            finishedAt: "2025-06-01T00:01:00.000Z",
+            durationMs: 60_000,
+            state: "completed" as const,
+            summary: null,
+          },
+        },
+        {
+          id: "has-summary",
+          kind: "smoke",
+          lastRun: {
+            startedAt: "2025-06-01T00:00:00.000Z",
+            finishedAt: "2025-06-01T00:01:00.000Z",
+            durationMs: 60_000,
+            state: "completed" as const,
+            summary: { total: 2, passed: 2, failed: 0 },
+          },
+        },
+      ],
+    };
+
+    const baseline = transformHarnessResponse(response);
+
+    expect(baseline.results["no-summary"]).toBeUndefined();
+    expect(baseline.results["has-summary"]).toBeDefined();
+    expect(baseline.summary.total).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadBaseline
+// ---------------------------------------------------------------------------
+
+describe("loadBaseline", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when file does not exist", () => {
+    const result = loadBaseline(path.join(dir, "nonexistent.json"));
+    expect(result).toBeNull();
+  });
+
+  it("reads valid JSON from disk", () => {
+    const baseline: EvalBaseline = {
+      version: 1,
+      timestamp: "2025-06-01T00:00:00.000Z",
+      source: "harness-prod",
+      branch: "",
+      base: "",
+      level: "deep",
+      results: {
+        "e2e-deep": {
+          default: { status: "pass", total: 10, passed: 10, failed: 0 },
+        },
+      },
+      summary: { total: 1, pass: 1, fail: 0, skip: 0 },
+    };
+    const filePath = path.join(dir, "baseline.json");
+    fs.writeFileSync(filePath, JSON.stringify(baseline));
+
+    const loaded = loadBaseline(filePath);
+    expect(loaded).toEqual(baseline);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveBaseline
+// ---------------------------------------------------------------------------
+
+describe("saveBaseline", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes valid JSON to disk", () => {
+    const baseline: EvalBaseline = {
+      version: 1,
+      timestamp: "2025-06-01T00:00:00.000Z",
+      source: "local-capture",
+      branch: "main",
+      base: "",
+      level: "deep",
+      results: {
+        "smoke-quick": {
+          default: { status: "pass", total: 5, passed: 5, failed: 0 },
+        },
+      },
+      summary: { total: 1, pass: 1, fail: 0, skip: 0 },
+    };
+    const filePath = path.join(dir, "out.json");
+
+    saveBaseline(baseline, filePath);
+
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    expect(parsed).toEqual(baseline);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// captureBaseline
+// ---------------------------------------------------------------------------
+
+describe("captureBaseline", () => {
+  let dir: string;
+  let outDir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    outDir = tmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it("copies latest eval result as baseline with source: local-capture", () => {
+    // Write two fake eval results — captureBaseline should pick the most
+    // recently modified one.
+    const older: EvalBaseline = {
+      version: 1,
+      timestamp: "2025-05-01T00:00:00.000Z",
+      source: "harness-prod",
+      branch: "old",
+      base: "",
+      level: "deep",
+      results: {},
+      summary: { total: 0, pass: 0, fail: 0, skip: 0 },
+    };
+    const newer: EvalBaseline = {
+      version: 1,
+      timestamp: "2025-06-01T00:00:00.000Z",
+      source: "harness-prod",
+      branch: "new",
+      base: "",
+      level: "deep",
+      results: {
+        "e2e-deep": {
+          default: { status: "pass", total: 3, passed: 3, failed: 0 },
+        },
+      },
+      summary: { total: 1, pass: 1, fail: 0, skip: 0 },
+    };
+
+    const olderPath = path.join(dir, "eval-2025-05-01.json");
+    const newerPath = path.join(dir, "eval-2025-06-01.json");
+    fs.writeFileSync(olderPath, JSON.stringify(older));
+    // Ensure newer file has a later mtime
+    const futureTime = new Date(Date.now() + 2000);
+    fs.writeFileSync(newerPath, JSON.stringify(newer));
+    fs.utimesSync(newerPath, futureTime, futureTime);
+
+    const baselinePath = path.join(outDir, "baseline.json");
+    captureBaseline(dir, baselinePath);
+
+    const captured = JSON.parse(fs.readFileSync(baselinePath, "utf-8"));
+    expect(captured.source).toBe("local-capture");
+    expect(captured.branch).toBe("new");
+    expect(captured.results).toEqual(newer.results);
+  });
+});

--- a/showcase/harness/src/cli/eval/baseline.ts
+++ b/showcase/harness/src/cli/eval/baseline.ts
@@ -1,0 +1,196 @@
+/**
+ * Eval baseline management — pull from the production harness, capture from
+ * local eval runs, and persist/load from disk.
+ *
+ * The baseline is a snapshot of probe results that serves as the "expected"
+ * state for regression detection. Two sources:
+ *
+ *   1. **harness-prod** — pulled from the live showcase-harness /api/probes
+ *      endpoint via `pullBaseline`.
+ *   2. **local-capture** — copied from the most recent local eval result
+ *      file via `captureBaseline`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EvalBaseline {
+  version: number;
+  timestamp: string;
+  source: "harness-prod" | "local-capture";
+  branch: string;
+  base: string;
+  level: string;
+  results: Record<
+    string,
+    Record<
+      string,
+      { status: string; total?: number; passed?: number; failed?: number }
+    >
+  >;
+  summary: { total: number; pass: number; fail: number; skip: number };
+}
+
+interface HarnessProbeEntry {
+  id: string;
+  kind: string;
+  lastRun: {
+    startedAt: string;
+    finishedAt: string;
+    durationMs: number;
+    state: string;
+    summary: { total: number; passed: number; failed: number } | null;
+  } | null;
+}
+
+interface HarnessProbesResponse {
+  probes: HarnessProbeEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure transform
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a harness /api/probes response into an EvalBaseline.
+ *
+ * Probes with null `lastRun` or null `summary` are skipped — they haven't
+ * produced a usable result yet. For each valid probe the status is "pass"
+ * when `summary.failed === 0`, "fail" otherwise. Results are keyed by probe
+ * ID with a single "default" sub-key (future: per-service breakdown).
+ */
+export function transformHarnessResponse(
+  response: HarnessProbesResponse,
+): EvalBaseline {
+  const results: EvalBaseline["results"] = {};
+  let pass = 0;
+  let fail = 0;
+
+  for (const probe of response.probes) {
+    if (!probe.lastRun) continue;
+    if (!probe.lastRun.summary) continue;
+
+    const { total, passed, failed } = probe.lastRun.summary;
+    const status = failed === 0 ? "pass" : "fail";
+
+    results[probe.id] = {
+      default: { status, total, passed, failed },
+    };
+
+    if (status === "pass") pass++;
+    else fail++;
+  }
+
+  return {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    source: "harness-prod",
+    branch: "",
+    base: "",
+    level: "deep",
+    results,
+    summary: { total: pass + fail, pass, fail, skip: 0 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Network pull
+// ---------------------------------------------------------------------------
+
+const DEFAULT_HARNESS_URL =
+  process.env["SHOWCASE_HARNESS_URL"] ??
+  "https://showcase-harness-production.up.railway.app";
+
+/**
+ * Pull the current probe state from a live harness instance, transform it
+ * into an EvalBaseline, and save to disk.
+ */
+export async function pullBaseline(
+  harnessUrl: string = DEFAULT_HARNESS_URL,
+  outputPath: string,
+): Promise<EvalBaseline> {
+  const url = `${harnessUrl.replace(/\/+$/, "")}/api/probes`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) {
+    throw new Error(
+      `Harness fetch failed: ${res.status} ${res.statusText} (${url})`,
+    );
+  }
+  const body = (await res.json()) as HarnessProbesResponse;
+  const baseline = transformHarnessResponse(body);
+  saveBaseline(baseline, outputPath);
+  return baseline;
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a baseline from disk. Returns null when the file doesn't exist.
+ */
+export function loadBaseline(filePath: string): EvalBaseline | null {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as EvalBaseline;
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Write a baseline to disk as pretty-printed JSON.
+ */
+export function saveBaseline(baseline: EvalBaseline, filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, JSON.stringify(baseline, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Local capture
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the most recently modified .json file in `evalResultsDir`, read it
+ * as an EvalBaseline, override `source` to "local-capture", and write it
+ * to `baselinePath`.
+ */
+export function captureBaseline(
+  evalResultsDir: string,
+  baselinePath: string,
+): void {
+  const files = fs
+    .readdirSync(evalResultsDir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => {
+      const full = path.join(evalResultsDir, f);
+      return { path: full, mtime: fs.statSync(full).mtimeMs };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  if (files.length === 0) {
+    throw new Error(
+      `No .json files found in eval results dir: ${evalResultsDir}`,
+    );
+  }
+
+  const raw = fs.readFileSync(files[0].path, "utf-8");
+  const data = JSON.parse(raw) as EvalBaseline;
+  data.source = "local-capture";
+
+  saveBaseline(data, baselinePath);
+}

--- a/showcase/harness/src/cli/eval/index.ts
+++ b/showcase/harness/src/cli/eval/index.ts
@@ -1,0 +1,575 @@
+/**
+ * Eval orchestrator — registers the `eval` subcommand and implements the
+ * full evaluation pipeline: scope detection, baseline comparison, tiered
+ * test execution, result collection, and verdict formatting.
+ *
+ * Pipeline:
+ *   1. Parse CLI options (--d5/--d6, --pr, --scope, --parallel, etc.)
+ *   2. Optionally create git worktree for PR evaluation
+ *   3. Detect affected scope via git diff
+ *   4. Load/pull baseline for comparison
+ *   5. Start affected services + aimock via lifecycle
+ *   6. Wait for health
+ *   7. Run tiered tests
+ *   8. Collect & format results
+ *   9. Save results + optional baseline capture
+ *  10. Cleanup
+ */
+
+import { Command, Option } from "commander";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { loadConfig } from "../config.js";
+import { up, down, isRunning } from "../lifecycle.js";
+import { createLogger, reloadLogLevel } from "../../logger.js";
+
+// Sibling modules created by other blitz agents — imports written against
+// the agreed interfaces. These will not resolve until the sibling branches
+// are merged into the integration branch.
+import { classifyScope, type ScopeResult } from "./scope.js";
+import {
+  pullBaseline,
+  loadBaseline,
+  captureBaseline,
+  type EvalBaseline,
+} from "./baseline.js";
+import {
+  collectResults,
+  formatMatrix,
+  formatVerdict,
+  computeRegressions,
+  saveResults,
+  type EvalResults,
+} from "./matrix.js";
+import { runTiered, type TieredRunResult, type RunOptions } from "./runner.js";
+
+const log = createLogger({ component: "eval" });
+
+// ---------------------------------------------------------------------------
+// CLI options interface
+// ---------------------------------------------------------------------------
+
+interface EvalOptions {
+  level?: string;
+  d5?: boolean;
+  pr?: string;
+  branch?: string;
+  scope?: string;
+  parallel?: string;
+  baseline?: string;
+  keep?: boolean;
+  json?: boolean;
+  timeout?: string;
+  slug?: string;
+  tier?: string;
+  failFast?: boolean; // commander negates --no-fail-fast to failFast: false
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerEvalCommand(program: Command): void {
+  program
+    .command("eval")
+    .description("Run the D5 evaluation matrix against showcase integrations")
+    .addOption(
+      new Option("--level <level>", "probe depth")
+        .choices(["d5"])
+        .default("d5"),
+    )
+    .option("--d5", "shorthand for --level d5")
+    .option("--pr <number>", "fetch PR into worktree and eval")
+    .option("--branch <name>", "eval a specific branch in a worktree")
+    .option("--scope <mode>", "affected or all", "affected")
+    .option("--parallel <n>", "max concurrent test runners", "4")
+    .option("--baseline <action>", "capture or compare")
+    .option("--keep", "leave containers running after eval")
+    .option("--json", "JSON output for CI")
+    .option("--timeout <ms>", "per-test timeout", "45000")
+    .option("--slug <slugs>", "override scope (comma-separated)")
+    .option("--tier <n>", "run only tiers 1 through N")
+    .option("--no-fail-fast", "don't stop on Tier 1 failure")
+    .action(async (opts: EvalOptions) => {
+      await runEval(opts);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export async function runEval(opts: EvalOptions): Promise<void> {
+  // In --json mode, redirect all logger output to stderr so it doesn't
+  // corrupt the JSON payload on stdout.
+  if (opts.json) {
+    process.env["LOG_LEVEL"] = "warn";
+    reloadLogLevel();
+  }
+
+  const config = loadConfig();
+
+  // -- 1. Resolve level ------------------------------------------------------
+  const level = opts.d5 ? "d5" : (opts.level ?? "d5");
+
+  const parallel = parseInt(opts.parallel ?? "4", 10);
+  const timeout = parseInt(opts.timeout ?? "45000", 10);
+  const maxTier = opts.tier ? parseInt(opts.tier, 10) : undefined;
+  const failFast = opts.failFast !== false; // default true; --no-fail-fast sets to false
+
+  log.info("eval starting", {
+    level,
+    parallel,
+    timeout,
+    scope: opts.scope,
+    baseline: opts.baseline,
+    failFast,
+  });
+
+  // -- 2. PR worktree setup --------------------------------------------------
+  let worktreeDir: string | null = null;
+  let originalCwd: string | null = null;
+
+  if (opts.pr) {
+    log.info("setting up PR worktree", { pr: opts.pr });
+    const prNumber = opts.pr;
+    const worktreePath = path.join(
+      config.showcaseDir,
+      "..",
+      `.eval-pr-${prNumber}`,
+    );
+    worktreeDir = worktreePath;
+    originalCwd = process.cwd();
+
+    try {
+      execFileSync(
+        "git",
+        ["fetch", "origin", `pull/${prNumber}/head:eval-pr-${prNumber}`],
+        {
+          cwd: config.showcaseDir,
+          stdio: "pipe",
+          encoding: "utf-8",
+        },
+      );
+      execFileSync(
+        "git",
+        ["worktree", "add", worktreePath, `eval-pr-${prNumber}`],
+        {
+          cwd: config.showcaseDir,
+          stdio: "pipe",
+          encoding: "utf-8",
+        },
+      );
+      process.chdir(worktreePath);
+      log.info("worktree created", { path: worktreePath });
+    } catch (err) {
+      console.error(
+        `Failed to set up PR worktree: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+  } else if (opts.branch) {
+    log.info("setting up branch worktree", { branch: opts.branch });
+    const worktreePath = path.join(
+      config.showcaseDir,
+      "..",
+      `.eval-branch-${opts.branch.replace(/\//g, "-")}`,
+    );
+    worktreeDir = worktreePath;
+    originalCwd = process.cwd();
+
+    try {
+      execFileSync("git", ["worktree", "add", worktreePath, opts.branch], {
+        cwd: config.showcaseDir,
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+      process.chdir(worktreePath);
+      log.info("worktree created", { path: worktreePath });
+    } catch (err) {
+      console.error(
+        `Failed to set up branch worktree: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  // Save the original showcaseDir BEFORE any worktree override so that
+  // cleanup can run `git worktree remove` with cwd OUTSIDE the worktree.
+  const originalShowcaseDir = config.showcaseDir;
+
+  // After worktree setup, override config.showcaseDir to point to the
+  // worktree's showcase directory so tests run against the PR's code.
+  if (worktreeDir) {
+    const worktreeShowcase = path.join(worktreeDir, "showcase");
+    config.showcaseDir = worktreeShowcase;
+    config.composeFile = path.join(
+      worktreeShowcase,
+      "docker-compose.local.yml",
+    );
+    config.localPorts = JSON.parse(
+      fs.readFileSync(
+        path.join(worktreeShowcase, "shared/local-ports.json"),
+        "utf-8",
+      ),
+    );
+    log.info("config overridden for worktree", {
+      showcaseDir: worktreeShowcase,
+    });
+  }
+
+  // -- 3. Detect scope -------------------------------------------------------
+  const allSlugs = Object.keys(config.localPorts);
+  let scopeResult: ScopeResult;
+
+  if (opts.slug) {
+    const rawSlugs = opts.slug
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const unknown = rawSlugs.filter((s) => !allSlugs.includes(s));
+    if (unknown.length > 0) {
+      log.warn("unknown slugs in --slug override (skipping)", { unknown });
+    }
+    const slugs = rawSlugs.filter((s) => allSlugs.includes(s));
+    scopeResult = {
+      slugs,
+      mode: "all",
+      reason: `manual override: ${slugs.join(", ")}`,
+    };
+    log.info("manual scope override", { slugs });
+  } else if (opts.scope === "all") {
+    scopeResult = {
+      slugs: [...allSlugs],
+      mode: "all",
+      reason: "user specified --scope all",
+    };
+    log.info("scope: all", { count: allSlugs.length });
+  } else {
+    let diffOutput = "";
+    try {
+      diffOutput = execFileSync(
+        "git",
+        ["diff", "--name-only", "origin/main...HEAD"],
+        {
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      ).trim();
+    } catch {
+      diffOutput = execFileSync(
+        "git",
+        ["diff", "--name-only", "origin/main", "HEAD"],
+        {
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      ).trim();
+    }
+    const changedFiles = diffOutput
+      .split("\n")
+      .map((f) => f.trim())
+      .filter(Boolean);
+    scopeResult = classifyScope(changedFiles, allSlugs);
+    log.info("scope detected", {
+      mode: scopeResult.mode,
+      slugs: scopeResult.slugs,
+    });
+  }
+
+  if (scopeResult.slugs.length === 0) {
+    if (opts.json) {
+      console.log(
+        JSON.stringify(
+          {
+            version: 1,
+            timestamp: new Date().toISOString(),
+            branch: "",
+            base: "",
+            level,
+            scope: scopeResult,
+            results: {},
+            summary: { total: 0, pass: 0, fail: 0, skip: 0, duration_ms: 0 },
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.log("\n  No showcase integrations affected by this change.\n");
+    }
+    await cleanup(worktreeDir, originalCwd, originalShowcaseDir);
+    return;
+  }
+
+  if (!opts.json) {
+    console.log(
+      `\n  \x1b[36mEval scope:\x1b[0m ${scopeResult.slugs.join(", ")} (${scopeResult.mode})\n`,
+    );
+  }
+
+  // -- 4. Baseline -----------------------------------------------------------
+  const baselinePath = path.join(config.showcaseDir, ".eval-baseline.json");
+  let baseline: EvalBaseline | null = null;
+
+  if (opts.baseline === "compare") {
+    baseline = loadBaseline(baselinePath);
+    if (!baseline) {
+      log.info("no local baseline, pulling from harness");
+      try {
+        baseline = await pullBaseline(undefined, baselinePath);
+      } catch (err) {
+        log.warn("failed to pull baseline", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } else {
+      log.info("loaded local baseline", {
+        slugCount: Object.keys(baseline.results).length,
+      });
+    }
+
+    if (!baseline) {
+      console.warn(
+        "  \x1b[33mWarning: no baseline found for comparison, proceeding without\x1b[0m\n",
+      );
+    }
+  }
+
+  // -- 5. Build + start services ---------------------------------------------
+  const slugsToStart = [...scopeResult.slugs];
+  // Always ensure aimock is running
+  if (!slugsToStart.includes("aimock")) {
+    slugsToStart.push("aimock");
+  }
+
+  const autoStarted: string[] = [];
+  for (const slug of slugsToStart) {
+    const running = await isRunning(slug);
+    if (!running) {
+      autoStarted.push(slug);
+    }
+  }
+
+  if (autoStarted.length > 0) {
+    if (!opts.json) {
+      console.log(
+        `  \x1b[36mStarting services:\x1b[0m ${autoStarted.join(", ")}`,
+      );
+    }
+    // up() includes health checks internally
+    await up(autoStarted);
+    if (!opts.json) {
+      console.log("  \x1b[32mAll services healthy\x1b[0m\n");
+    }
+  }
+
+  // -- 6-7. Run tiered tests -------------------------------------------------
+  const healthySlugs = scopeResult.slugs.filter((s) => {
+    try {
+      const result = execFileSync(
+        "docker",
+        ["inspect", "--format={{.State.Health.Status}}", `showcase-${s}`],
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+      ).trim();
+      return result === "healthy";
+    } catch {
+      return false;
+    }
+  });
+
+  let tieredResult: TieredRunResult;
+
+  try {
+    const runOptions: RunOptions = {
+      level,
+      maxParallel: parallel,
+      timeout,
+      showcaseDir: config.showcaseDir,
+      maxTier,
+      noFailFast: !failFast,
+      onSlugStart: (slug, tier) => {
+        if (!opts.json)
+          console.log(`  \x1b[2m[${tier}] testing ${slug}...\x1b[0m`);
+      },
+      onSlugComplete: (result, tier) => {
+        const icon =
+          result.status === "pass" ? "\x1b[32m✓\x1b[0m" : "\x1b[31m✗\x1b[0m";
+        if (!opts.json)
+          console.log(
+            `  ${icon} [${tier}] ${result.slug} (${result.duration_ms}ms)`,
+          );
+      },
+    };
+
+    tieredResult = await runTiered(scopeResult.slugs, healthySlugs, runOptions);
+  } catch (err) {
+    console.error(
+      `\x1b[31mEval run failed:\x1b[0m ${err instanceof Error ? err.message : String(err)}`,
+    );
+    await teardown(
+      autoStarted,
+      opts.keep,
+      worktreeDir,
+      originalCwd,
+      originalShowcaseDir,
+    );
+    process.exit(1);
+  }
+
+  // -- 8. Collect results ----------------------------------------------------
+  const branchName = (() => {
+    try {
+      return execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+        encoding: "utf-8",
+      }).trim();
+    } catch {
+      return opts.pr ? `PR #${opts.pr}` : (opts.branch ?? "unknown");
+    }
+  })();
+
+  const evalResults: EvalResults = collectResults(
+    tieredResult.results,
+    {
+      branch: branchName,
+      base: "origin/main",
+      level,
+      scope: {
+        mode: scopeResult.mode,
+        reason: scopeResult.reason,
+        slugs: scopeResult.slugs,
+      },
+    },
+  );
+
+  // -- 9. Format + print -----------------------------------------------------
+  // Adapt EvalBaseline to EvalResults for comparison. Both share the
+  // `.results[slug][test].status` shape that computeRegressions/formatMatrix read.
+  const baselineAsResults: EvalResults | undefined = baseline
+    ? {
+        version: baseline.version,
+        timestamp: baseline.timestamp,
+        branch: baseline.branch,
+        base: baseline.base,
+        level: baseline.level,
+        scope: {
+          mode: "all",
+          reason: "baseline",
+          slugs: Object.keys(baseline.results),
+        },
+        results: Object.fromEntries(
+          Object.entries(baseline.results).map(([slug, tests]) => [
+            slug,
+            Object.fromEntries(
+              Object.entries(tests).map(([testName, entry]) => [
+                testName,
+                {
+                  status:
+                    entry.status as import("./matrix.js").TestResult["status"],
+                  duration_ms: 0,
+                },
+              ]),
+            ),
+          ]),
+        ),
+        summary: { ...baseline.summary, duration_ms: 0 },
+      }
+    : undefined;
+
+  if (opts.json) {
+    console.log(JSON.stringify(evalResults, null, 2));
+  } else {
+    const matrix = formatMatrix(evalResults, baselineAsResults ?? undefined);
+    console.log(matrix);
+
+    if (baseline && opts.baseline === "compare") {
+      const regressions = computeRegressions(evalResults, baselineAsResults);
+      if (regressions.count > 0) {
+        console.log(
+          `\n  \x1b[31mRegressions detected: ${regressions.count}\x1b[0m`,
+        );
+        for (const r of regressions.details) {
+          console.log(`    - ${r.slug}: ${r.test}`);
+        }
+      }
+    }
+
+    const verdict = formatVerdict(evalResults, baselineAsResults ?? undefined);
+    console.log(verdict);
+  }
+
+  // -- 10. Save results ------------------------------------------------------
+  const savedPath = saveResults(evalResults, config.showcaseDir);
+  log.info("results saved", { path: savedPath });
+
+  if (opts.baseline === "capture") {
+    const evalResultsDir = path.join(config.showcaseDir, ".eval-results");
+    captureBaseline(evalResultsDir, baselinePath);
+    log.info("baseline captured");
+  }
+
+  // -- 11. Cleanup -----------------------------------------------------------
+  await teardown(
+    autoStarted,
+    opts.keep,
+    worktreeDir,
+    originalCwd,
+    originalShowcaseDir,
+  );
+
+  // Exit with failure if any tests failed
+  const totalFailed = evalResults.summary?.fail ?? 0;
+  if (totalFailed > 0) {
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function teardown(
+  autoStarted: string[],
+  keep: boolean | undefined,
+  worktreeDir: string | null,
+  originalCwd: string | null,
+  showcaseDir: string,
+): Promise<void> {
+  if (!keep && autoStarted.length > 0) {
+    log.info("stopping auto-started services", { services: autoStarted });
+    try {
+      await down(autoStarted);
+    } catch (err) {
+      log.warn("failed to stop services during teardown", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  await cleanup(worktreeDir, originalCwd, showcaseDir);
+}
+
+async function cleanup(
+  worktreeDir: string | null,
+  originalCwd: string | null,
+  showcaseDir: string,
+): Promise<void> {
+  if (worktreeDir && originalCwd) {
+    process.chdir(originalCwd);
+    try {
+      execFileSync("git", ["worktree", "remove", "--force", worktreeDir], {
+        cwd: showcaseDir,
+        stdio: "pipe",
+        encoding: "utf-8",
+      });
+      log.info("worktree removed", { path: worktreeDir });
+    } catch (err) {
+      log.warn("failed to remove worktree", {
+        path: worktreeDir,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/showcase/harness/src/cli/eval/index.ts
+++ b/showcase/harness/src/cli/eval/index.ts
@@ -16,7 +16,8 @@
  *  10. Cleanup
  */
 
-import { Command, Option } from "commander";
+import type { Command } from "commander";
+import { Option } from "commander";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -28,22 +29,20 @@ import { createLogger, reloadLogLevel } from "../../logger.js";
 // Sibling modules created by other blitz agents — imports written against
 // the agreed interfaces. These will not resolve until the sibling branches
 // are merged into the integration branch.
-import { classifyScope, type ScopeResult } from "./scope.js";
-import {
-  pullBaseline,
-  loadBaseline,
-  captureBaseline,
-  type EvalBaseline,
-} from "./baseline.js";
+import { classifyScope } from "./scope.js";
+import type { ScopeResult } from "./scope.js";
+import { pullBaseline, loadBaseline, captureBaseline } from "./baseline.js";
+import type { EvalBaseline } from "./baseline.js";
 import {
   collectResults,
   formatMatrix,
   formatVerdict,
   computeRegressions,
   saveResults,
-  type EvalResults,
 } from "./matrix.js";
-import { runTiered, type TieredRunResult, type RunOptions } from "./runner.js";
+import type { EvalResults } from "./matrix.js";
+import { runTiered } from "./runner.js";
+import type { TieredRunResult, RunOptions } from "./runner.js";
 
 const log = createLogger({ component: "eval" });
 
@@ -430,19 +429,16 @@ export async function runEval(opts: EvalOptions): Promise<void> {
     }
   })();
 
-  const evalResults: EvalResults = collectResults(
-    tieredResult.results,
-    {
-      branch: branchName,
-      base: "origin/main",
-      level,
-      scope: {
-        mode: scopeResult.mode,
-        reason: scopeResult.reason,
-        slugs: scopeResult.slugs,
-      },
+  const evalResults: EvalResults = collectResults(tieredResult.results, {
+    branch: branchName,
+    base: "origin/main",
+    level,
+    scope: {
+      mode: scopeResult.mode,
+      reason: scopeResult.reason,
+      slugs: scopeResult.slugs,
     },
-  );
+  });
 
   // -- 9. Format + print -----------------------------------------------------
   // Adapt EvalBaseline to EvalResults for comparison. Both share the

--- a/showcase/harness/src/cli/eval/matrix.test.ts
+++ b/showcase/harness/src/cli/eval/matrix.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  collectResults,
+  computeRegressions,
+  formatMatrix,
+  formatVerdict,
+  saveResults,
+  type EvalResults,
+  type SlugResult,
+  type EvalMetadata,
+  type TestResult,
+} from "./matrix.js";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMetadata(overrides: Partial<EvalMetadata> = {}): EvalMetadata {
+  return {
+    branch: "feat/test",
+    base: "main",
+    level: "smoke",
+    scope: { mode: "full", reason: "ci", slugs: ["slug-a", "slug-b"] },
+    ...overrides,
+  };
+}
+
+function makeSlugResult(
+  slug: string,
+  status: SlugResult["status"],
+  tests: Record<string, TestResult> = {},
+  duration_ms = 1000,
+): SlugResult {
+  return { slug, status, tests, duration_ms };
+}
+
+function makeEvalResults(
+  results: Record<string, Record<string, TestResult>>,
+  summary?: Partial<EvalResults["summary"]>,
+): EvalResults {
+  const allTests = Object.values(results).flatMap((t) => Object.values(t));
+  return {
+    version: 1,
+    timestamp: "2026-04-29T12:00:00.000Z",
+    branch: "feat/test",
+    base: "main",
+    level: "smoke",
+    scope: { mode: "full", reason: "ci", slugs: Object.keys(results) },
+    results,
+    summary: {
+      total: allTests.length,
+      pass: allTests.filter((t) => t.status === "pass").length,
+      fail: allTests.filter((t) => t.status !== "pass" && t.status !== "skip")
+        .length,
+      skip: allTests.filter((t) => t.status === "skip").length,
+      duration_ms: 5000,
+      ...summary,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// collectResults
+// ---------------------------------------------------------------------------
+
+describe("collectResults", () => {
+  it("aggregates per-slug results into consolidated JSON", () => {
+    const slugs: SlugResult[] = [
+      makeSlugResult("slug-a", "pass", {
+        smoke: { status: "pass", duration_ms: 100 },
+        liveness: { status: "pass", duration_ms: 200 },
+      }),
+      makeSlugResult("slug-b", "fail", {
+        smoke: { status: "pass", duration_ms: 150 },
+        liveness: { status: "fail", duration_ms: 300, error: "timeout" },
+      }),
+    ];
+    const meta = makeMetadata();
+    const result = collectResults(slugs, meta);
+
+    expect(result.version).toBe(1);
+    expect(result.branch).toBe("feat/test");
+    expect(result.base).toBe("main");
+    expect(result.level).toBe("smoke");
+    expect(result.scope).toEqual(meta.scope);
+    expect(result.results["slug-a"]).toBeDefined();
+    expect(result.results["slug-b"]).toBeDefined();
+    expect(result.results["slug-a"]["smoke"].status).toBe("pass");
+    expect(result.results["slug-b"]["liveness"].status).toBe("fail");
+    expect(result.summary.total).toBe(4);
+    expect(result.summary.pass).toBe(3);
+    expect(result.summary.fail).toBe(1);
+    expect(result.summary.skip).toBe(0);
+    expect(result.summary.duration_ms).toBe(2000);
+    expect(result.timestamp).toBeTruthy();
+  });
+
+  it("handles slugs with build_failed status", () => {
+    const slugs: SlugResult[] = [
+      makeSlugResult("slug-a", "build_failed", {}, 500),
+    ];
+    const result = collectResults(slugs, makeMetadata());
+
+    expect(result.results["slug-a"]).toBeDefined();
+    // build_failed slug gets a synthetic test entry
+    const tests = Object.values(result.results["slug-a"]);
+    expect(tests.some((t) => t.status === "build_failed")).toBe(true);
+    expect(result.summary.fail).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles slugs with unhealthy status", () => {
+    const slugs: SlugResult[] = [
+      makeSlugResult("slug-a", "unhealthy", {}, 500),
+    ];
+    const result = collectResults(slugs, makeMetadata());
+
+    expect(result.results["slug-a"]).toBeDefined();
+    const tests = Object.values(result.results["slug-a"]);
+    expect(tests.some((t) => t.status === "unhealthy")).toBe(true);
+    expect(result.summary.fail).toBeGreaterThanOrEqual(1);
+  });
+
+  it("computes correct summary totals", () => {
+    const slugs: SlugResult[] = [
+      makeSlugResult("slug-a", "pass", {
+        smoke: { status: "pass", duration_ms: 100 },
+        liveness: { status: "pass", duration_ms: 200 },
+      }),
+      makeSlugResult("slug-b", "fail", {
+        smoke: { status: "fail", duration_ms: 150 },
+        liveness: { status: "skip" },
+      }),
+      makeSlugResult("slug-c", "pass", {
+        smoke: { status: "pass", duration_ms: 100 },
+      }),
+    ];
+    const result = collectResults(slugs, makeMetadata());
+
+    expect(result.summary.total).toBe(5);
+    expect(result.summary.pass).toBe(3);
+    expect(result.summary.fail).toBe(1);
+    expect(result.summary.skip).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatMatrix
+// ---------------------------------------------------------------------------
+
+describe("formatMatrix", () => {
+  // Strip ANSI codes for easier assertion
+  function stripAnsi(str: string): string {
+    return str.replace(/\x1b\[[0-9;]*m/g, "");
+  }
+
+  it("produces correct pass/fail counts in summary", () => {
+    const results = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "pass", duration_ms: 100 },
+        liveness: { status: "pass", duration_ms: 200 },
+      },
+      "slug-b": {
+        smoke: { status: "fail", duration_ms: 150, error: "timeout" },
+        liveness: { status: "pass", duration_ms: 300 },
+      },
+    });
+
+    const output = stripAnsi(formatMatrix(results));
+    expect(output).toContain("3 passed");
+    expect(output).toContain("1 failed");
+  });
+
+  it("shows FIXED markers when baseline has fail and current has pass", () => {
+    const baseline = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "fail", duration_ms: 100 },
+      },
+    });
+    const current = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "pass", duration_ms: 100 },
+      },
+    });
+
+    const output = stripAnsi(formatMatrix(current, baseline));
+    expect(output).toContain("FIXED");
+  });
+
+  it("shows NEW markers when baseline has pass and current has fail", () => {
+    const baseline = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "pass", duration_ms: 100 },
+      },
+    });
+    const current = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "fail", duration_ms: 100, error: "broke" },
+      },
+    });
+
+    const output = stripAnsi(formatMatrix(current, baseline));
+    expect(output).toContain("NEW");
+  });
+
+  it("handles missing baseline (no delta markers, just raw results)", () => {
+    const results = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "pass", duration_ms: 100 },
+      },
+    });
+
+    const output = stripAnsi(formatMatrix(results));
+    expect(output).not.toContain("FIXED");
+    expect(output).not.toContain("NEW");
+    expect(output).toContain("slug-a");
+  });
+
+  it("handles empty results gracefully", () => {
+    const results = makeEvalResults({});
+    const output = stripAnsi(formatMatrix(results));
+    expect(output).toContain("0 passed");
+    // Should not throw
+    expect(typeof output).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRegressions
+// ---------------------------------------------------------------------------
+
+describe("computeRegressions", () => {
+  it("returns 0 when no baseline", () => {
+    const results = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "fail", duration_ms: 100 },
+      },
+    });
+    const { count, details } = computeRegressions(results);
+    expect(count).toBe(0);
+    expect(details).toEqual([]);
+  });
+
+  it("returns 0 when all stable", () => {
+    const baseline = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "pass", duration_ms: 100 },
+      },
+    });
+    const current = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "pass", duration_ms: 100 },
+      },
+    });
+    const { count } = computeRegressions(current, baseline);
+    expect(count).toBe(0);
+  });
+
+  it("returns count of pass->fail transitions", () => {
+    const baseline = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "pass", duration_ms: 100 },
+        liveness: { status: "pass", duration_ms: 200 },
+      },
+    });
+    const current = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "fail", duration_ms: 100 },
+        liveness: { status: "fail", duration_ms: 200 },
+      },
+    });
+    const { count, details } = computeRegressions(current, baseline);
+    expect(count).toBe(2);
+    expect(details).toEqual([
+      { slug: "slug-a", test: "smoke" },
+      { slug: "slug-a", test: "liveness" },
+    ]);
+  });
+
+  it("does not count fail->fail as regression", () => {
+    const baseline = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "fail", duration_ms: 100 },
+      },
+    });
+    const current = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "fail", duration_ms: 100 },
+      },
+    });
+    const { count } = computeRegressions(current, baseline);
+    expect(count).toBe(0);
+  });
+
+  it("does not count skip->fail as regression", () => {
+    const baseline = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "skip" },
+      },
+    });
+    const current = makeEvalResults({
+      "slug-a": {
+        smoke: { status: "fail", duration_ms: 100 },
+      },
+    });
+    const { count } = computeRegressions(current, baseline);
+    expect(count).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVerdict
+// ---------------------------------------------------------------------------
+
+describe("formatVerdict", () => {
+  function stripAnsi(str: string): string {
+    return str.replace(/\x1b\[[0-9;]*m/g, "");
+  }
+
+  it("returns SAFE TO MERGE when zero regressions", () => {
+    const results = makeEvalResults({
+      "slug-a": { smoke: { status: "pass", duration_ms: 100 } },
+    });
+    const verdict = stripAnsi(formatVerdict(results));
+    expect(verdict).toContain("SAFE TO MERGE");
+  });
+
+  it("returns REGRESSIONS DETECTED when >0 regressions", () => {
+    const baseline = makeEvalResults({
+      "slug-a": { smoke: { status: "pass", duration_ms: 100 } },
+    });
+    const current = makeEvalResults({
+      "slug-a": { smoke: { status: "fail", duration_ms: 100 } },
+    });
+    const verdict = stripAnsi(formatVerdict(current, baseline));
+    expect(verdict).toContain("REGRESSIONS DETECTED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveResults
+// ---------------------------------------------------------------------------
+
+describe("saveResults", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "eval-matrix-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes results to .eval-results/<timestamp>.json and returns path", () => {
+    const results = makeEvalResults({
+      "slug-a": { smoke: { status: "pass", duration_ms: 100 } },
+    });
+
+    const filePath = saveResults(results, tmpDir);
+    expect(filePath).toContain(".eval-results");
+    expect(filePath).toMatch(/\.json$/);
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const written = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    expect(written.version).toBe(1);
+    expect(written.results["slug-a"]).toBeDefined();
+  });
+});

--- a/showcase/harness/src/cli/eval/matrix.ts
+++ b/showcase/harness/src/cli/eval/matrix.ts
@@ -1,0 +1,294 @@
+/**
+ * Eval matrix reporting module — aggregates per-slug eval results into a
+ * consolidated report, formats a coloured terminal matrix with delta markers
+ * (FIXED / NEW) against a baseline, and computes regression counts.
+ *
+ * Uses the same ANSI colour constants as ../results.ts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// ANSI helpers (mirrored from ../results.ts)
+// ---------------------------------------------------------------------------
+
+const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const DIM = "\x1b[2m";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EvalResults {
+  version: number;
+  timestamp: string;
+  branch: string;
+  base: string;
+  level: string;
+  scope: { mode: string; reason: string; slugs: string[] };
+  results: Record<string, Record<string, TestResult>>;
+  summary: {
+    total: number;
+    pass: number;
+    fail: number;
+    skip: number;
+    duration_ms: number;
+  };
+}
+
+export interface TestResult {
+  status: "pass" | "fail" | "skip" | "error" | "build_failed" | "unhealthy";
+  duration_ms?: number;
+  error?: string;
+}
+
+export interface SlugResult {
+  slug: string;
+  status: "pass" | "fail" | "error" | "build_failed" | "unhealthy" | "skipped";
+  tests: Record<string, TestResult>;
+  duration_ms: number;
+}
+
+export interface EvalMetadata {
+  branch: string;
+  base: string;
+  level: string;
+  scope: { mode: string; reason: string; slugs: string[] };
+}
+
+// ---------------------------------------------------------------------------
+// collectResults
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate per-slug results into consolidated EvalResults format.
+ * Slugs whose status is build_failed or unhealthy with no tests get a
+ * synthetic test entry so they still appear in the matrix.
+ */
+export function collectResults(
+  slugResults: SlugResult[],
+  metadata: EvalMetadata,
+): EvalResults {
+  const results: Record<string, Record<string, TestResult>> = {};
+  let totalDuration = 0;
+
+  for (const sr of slugResults) {
+    const tests = { ...sr.tests };
+
+    // Synthetic entry for slugs that never ran tests
+    if (Object.keys(tests).length === 0) {
+      const syntheticStatus = sr.status === "skipped" ? "skip" : sr.status;
+      tests["_status"] = {
+        status: syntheticStatus as TestResult["status"],
+        duration_ms: sr.duration_ms,
+      };
+    }
+
+    results[sr.slug] = tests;
+    totalDuration += sr.duration_ms;
+  }
+
+  // Compute summary from all test entries
+  const allTests = Object.values(results).flatMap((t) => Object.values(t));
+  const pass = allTests.filter((t) => t.status === "pass").length;
+  const skip = allTests.filter((t) => t.status === "skip").length;
+  const fail = allTests.length - pass - skip;
+
+  return {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    branch: metadata.branch,
+    base: metadata.base,
+    level: metadata.level,
+    scope: metadata.scope,
+    results,
+    summary: {
+      total: allTests.length,
+      pass,
+      fail,
+      skip,
+      duration_ms: totalDuration,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeRegressions
+// ---------------------------------------------------------------------------
+
+/**
+ * Count pass->fail transitions between baseline and current results.
+ * Only pass->fail in the baseline is counted as a regression. fail->fail,
+ * skip->fail, and new tests are not regressions.
+ */
+export function computeRegressions(
+  results: EvalResults,
+  baseline?: EvalResults,
+): { count: number; details: Array<{ slug: string; test: string }> } {
+  if (!baseline) {
+    return { count: 0, details: [] };
+  }
+
+  const details: Array<{ slug: string; test: string }> = [];
+
+  for (const [slug, tests] of Object.entries(results.results)) {
+    const baselineTests = baseline.results[slug];
+    if (!baselineTests) continue;
+
+    for (const [testName, testResult] of Object.entries(tests)) {
+      const baselineTest = baselineTests[testName];
+      if (!baselineTest) continue;
+
+      // Only pass->fail is a regression
+      if (baselineTest.status === "pass" && testResult.status !== "pass") {
+        details.push({ slug, test: testName });
+      }
+    }
+  }
+
+  return { count: details.length, details };
+}
+
+// ---------------------------------------------------------------------------
+// formatMatrix
+// ---------------------------------------------------------------------------
+
+function statusColor(status: TestResult["status"]): string {
+  if (status === "pass") return GREEN;
+  if (status === "skip") return YELLOW;
+  return RED;
+}
+
+function statusIcon(status: TestResult["status"]): string {
+  if (status === "pass") return "✓";
+  if (status === "skip") return "-";
+  return "✗";
+}
+
+/**
+ * Format a coloured terminal matrix showing per-slug results with optional
+ * delta markers against a baseline.
+ */
+export function formatMatrix(
+  results: EvalResults,
+  baseline?: EvalResults,
+): string {
+  const lines: string[] = [];
+
+  lines.push("");
+  lines.push(
+    `  ${DIM}Eval Matrix${RESET}  ${results.branch} vs ${results.base}  ${DIM}(${results.level})${RESET}`,
+  );
+  lines.push(`  ${DIM}${"─".repeat(60)}${RESET}`);
+
+  const slugs = Object.keys(results.results).sort();
+
+  for (const slug of slugs) {
+    const tests = results.results[slug];
+    const testNames = Object.keys(tests).sort();
+    const slugPass = Object.values(tests).filter(
+      (t) => t.status === "pass",
+    ).length;
+    const slugTotal = testNames.length;
+    const slugColor = slugPass === slugTotal ? GREEN : RED;
+
+    lines.push(
+      `  ${slugColor}${slug}${RESET}  ${DIM}(${slugPass}/${slugTotal})${RESET}`,
+    );
+
+    for (const testName of testNames) {
+      const test = tests[testName];
+      const icon = statusIcon(test.status);
+      const color = statusColor(test.status);
+
+      let delta = "";
+      if (baseline) {
+        const baselineTest = baseline.results[slug]?.[testName];
+        if (baselineTest) {
+          if (baselineTest.status !== "pass" && test.status === "pass") {
+            delta = ` ${GREEN}[FIXED]${RESET}`;
+          } else if (baselineTest.status === "pass" && test.status !== "pass") {
+            delta = ` ${RED}[NEW]${RESET}`;
+          }
+        }
+      }
+
+      const duration = test.duration_ms
+        ? ` ${DIM}(${(test.duration_ms / 1000).toFixed(1)}s)${RESET}`
+        : "";
+      const errorStr = test.error ? `  ${RED}${test.error}${RESET}` : "";
+
+      lines.push(
+        `    ${color}${icon}${RESET} ${testName} ${color}${test.status}${RESET}${duration}${delta}${errorStr}`,
+      );
+    }
+  }
+
+  // Summary
+  lines.push(`  ${DIM}${"─".repeat(60)}${RESET}`);
+  const { pass, fail, skip } = results.summary;
+  const parts: string[] = [];
+  parts.push(`${GREEN}${pass} passed${RESET}`);
+  if (fail > 0) parts.push(`${RED}${fail} failed${RESET}`);
+  if (skip > 0) parts.push(`${YELLOW}${skip} skipped${RESET}`);
+  const durationStr = `${DIM}(${(results.summary.duration_ms / 1000).toFixed(1)}s)${RESET}`;
+  lines.push(`  ${parts.join(", ")} ${durationStr}`);
+
+  // If no failures, still show "0 passed" for empty case
+  if (pass === 0 && fail === 0 && skip === 0) {
+    lines[lines.length - 1] = `  ${GREEN}0 passed${RESET} ${durationStr}`;
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// formatVerdict
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a coloured verdict line — SAFE TO MERGE or REGRESSIONS DETECTED.
+ */
+export function formatVerdict(
+  results: EvalResults,
+  baseline?: EvalResults,
+): string {
+  const { count, details } = computeRegressions(results, baseline);
+  if (count === 0) {
+    return `\n  ${GREEN}✓ SAFE TO MERGE${RESET}  ${DIM}(0 regressions)${RESET}\n`;
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `\n  ${RED}✗ REGRESSIONS DETECTED${RESET}  ${RED}(${count} regression${count > 1 ? "s" : ""})${RESET}`,
+  );
+  for (const d of details) {
+    lines.push(`    ${RED}✗${RESET} ${d.slug} / ${d.test}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// saveResults
+// ---------------------------------------------------------------------------
+
+/**
+ * Write eval results to .eval-results/<timestamp>.json under the given
+ * showcase directory. Returns the absolute path to the written file.
+ */
+export function saveResults(results: EvalResults, showcaseDir: string): string {
+  const dir = path.join(showcaseDir, ".eval-results");
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Timestamp-based filename, safe for filesystem
+  const ts = results.timestamp.replace(/[:.]/g, "-");
+  const filePath = path.join(dir, `${ts}.json`);
+
+  fs.writeFileSync(filePath, JSON.stringify(results, null, 2) + "\n", "utf-8");
+  return filePath;
+}

--- a/showcase/harness/src/cli/eval/runner.test.ts
+++ b/showcase/harness/src/cli/eval/runner.test.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Types under test (imported from runner.ts once it exists)
+// ---------------------------------------------------------------------------
+import type {
+  TierConfig,
+  TiersFile,
+  RunOptions,
+  TieredRunResult,
+} from "./runner.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.hoisted() runs before vi.mock factories, so these
+// variables are available inside the factory closures.
+// ---------------------------------------------------------------------------
+const { execFileMock, readFileSyncMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock("node:fs", () => ({
+  default: { readFileSync: (...args: unknown[]) => readFileSyncMock(...args) },
+  readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
+}));
+
+// Now import the module under test
+import { loadTiers, runSlug, runParallel, runTiered } from "./runner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fake execFile callback invocation for a successful slug run. */
+function fakeExecFileSuccess(
+  stdout: string,
+  { delay = 0 }: { delay?: number } = {},
+) {
+  execFileMock.mockImplementationOnce(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: Record<string, unknown>,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const timeout = delay
+        ? setTimeout(() => cb(null, stdout, ""), delay)
+        : (cb(null, stdout, ""), undefined);
+      return {
+        pid: 1234,
+        kill: () => {
+          if (timeout) clearTimeout(timeout);
+        },
+      };
+    },
+  );
+}
+
+/** Create a fake execFile that exits with a non-zero code. */
+function fakeExecFileFail(code: number, stderr = "") {
+  execFileMock.mockImplementationOnce(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: Record<string, unknown>,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const err = Object.assign(new Error(`exit code ${code}`), {
+        code,
+        killed: false,
+        signal: null,
+      });
+      cb(err, "", stderr);
+      return { pid: 1234, kill: () => {} };
+    },
+  );
+}
+
+/** Create a fake execFile that times out (never calls callback). */
+function fakeExecFileTimeout() {
+  execFileMock.mockImplementationOnce(
+    (
+      _cmd: string,
+      _args: string[],
+      opts: Record<string, unknown>,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      // The runner should set a timeout. We simulate timeout by calling back
+      // with a timeout-like error after maxBuffer / timeout.
+      const err = Object.assign(new Error("Command timed out"), {
+        killed: true,
+        signal: "SIGTERM",
+        code: null,
+      });
+      // Call back async to simulate timeout
+      setTimeout(() => cb(err, "", ""), 10);
+      return { pid: 1234, kill: () => {} };
+    },
+  );
+}
+
+/** Sample Playwright JSON reporter output for a passing test. */
+function playwrightJsonOutput(
+  slug: string,
+  tests: Array<{
+    title: string;
+    status: string;
+    duration: number;
+    error?: string;
+  }>,
+): string {
+  const suites = [
+    {
+      title: slug,
+      specs: tests.map((t) => ({
+        title: t.title,
+        tests: [
+          {
+            results: [
+              {
+                status: t.status,
+                duration: t.duration,
+                error: t.error ? { message: t.error } : undefined,
+              },
+            ],
+          },
+        ],
+      })),
+    },
+  ];
+  return JSON.stringify({ suites });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("loadTiers", () => {
+  beforeEach(() => {
+    readFileSyncMock.mockReset();
+  });
+
+  it("reads tier config and resolves '*' wildcard against slug list", () => {
+    const tiersFile: TiersFile = {
+      tiers: [
+        { name: "Gold Standard", slugs: ["langgraph-python"], fail_fast: true },
+        {
+          name: "Key Partners",
+          slugs: ["mastra", "crewai-crews"],
+          fail_fast: false,
+        },
+        { name: "Full Matrix", slugs: "*", fail_fast: false },
+      ],
+    };
+    readFileSyncMock.mockReturnValueOnce(JSON.stringify(tiersFile));
+
+    const allSlugs = [
+      "langgraph-python",
+      "mastra",
+      "crewai-crews",
+      "google-adk",
+      "langgraph-typescript",
+      "openai-swarm",
+    ];
+
+    const result = loadTiers("/path/to/eval-tiers.json", allSlugs);
+
+    expect(result).toHaveLength(3);
+
+    // Tier 1: exact slugs
+    expect(result[0].name).toBe("Gold Standard");
+    expect(result[0].slugs).toEqual(["langgraph-python"]);
+    expect(result[0].fail_fast).toBe(true);
+
+    // Tier 2: exact slugs
+    expect(result[1].name).toBe("Key Partners");
+    expect(result[1].slugs).toEqual(["mastra", "crewai-crews"]);
+
+    // Tier 3: wildcard resolved — excludes slugs already in tiers 1 and 2
+    expect(result[2].name).toBe("Full Matrix");
+    expect(result[2].slugs).toEqual(
+      expect.arrayContaining([
+        "google-adk",
+        "langgraph-typescript",
+        "openai-swarm",
+      ]),
+    );
+    expect(result[2].slugs).not.toContain("langgraph-python");
+    expect(result[2].slugs).not.toContain("mastra");
+    expect(result[2].slugs).not.toContain("crewai-crews");
+  });
+
+  it("handles missing file gracefully (returns single 'all' tier)", () => {
+    readFileSyncMock.mockImplementationOnce(() => {
+      const err = Object.assign(new Error("ENOENT"), {
+        code: "ENOENT",
+      });
+      throw err;
+    });
+
+    const allSlugs = ["langgraph-python", "mastra"];
+    const result = loadTiers("/nonexistent/eval-tiers.json", allSlugs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("all");
+    expect(result[0].slugs).toEqual(allSlugs);
+    expect(result[0].fail_fast).toBe(false);
+  });
+});
+
+describe("runSlug", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("parses Playwright JSON reporter output", async () => {
+    const jsonOut = playwrightJsonOutput("langgraph-python", [
+      { title: "sends chat message", status: "passed", duration: 1200 },
+      { title: "uses tool", status: "passed", duration: 800 },
+    ]);
+    fakeExecFileSuccess(jsonOut);
+
+    const result = await runSlug("langgraph-python", "d5", 30000, "/showcase");
+
+    expect(result.slug).toBe("langgraph-python");
+    expect(result.status).toBe("pass");
+    expect(result.tests["langgraph-python > sends chat message"]).toBeDefined();
+    expect(result.tests["langgraph-python > sends chat message"].status).toBe(
+      "pass",
+    );
+    expect(
+      result.tests["langgraph-python > sends chat message"].duration_ms,
+    ).toBe(1200);
+    expect(result.tests["langgraph-python > uses tool"].status).toBe("pass");
+  });
+
+  it("handles child process crash (non-zero exit, no JSON output)", async () => {
+    fakeExecFileFail(1, "Segmentation fault");
+
+    const result = await runSlug("crewai-crews", "d5", 30000, "/showcase");
+
+    expect(result.slug).toBe("crewai-crews");
+    expect(result.status).toBe("fail");
+    expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(Object.keys(result.tests)).toHaveLength(0);
+  });
+
+  it("handles child process timeout", async () => {
+    fakeExecFileTimeout();
+
+    const result = await runSlug("slow-integration", "d5", 100, "/showcase");
+
+    expect(result.slug).toBe("slow-integration");
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("runParallel", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("collects results from all slugs", async () => {
+    const slugs = ["slug-a", "slug-b", "slug-c"];
+
+    for (const slug of slugs) {
+      const jsonOut = playwrightJsonOutput(slug, [
+        { title: "basic test", status: "passed", duration: 500 },
+      ]);
+      fakeExecFileSuccess(jsonOut);
+    }
+
+    const opts: RunOptions = {
+      level: "d5",
+      maxParallel: 3,
+      timeout: 30000,
+      showcaseDir: "/showcase",
+    };
+
+    const results = await runParallel(slugs, opts);
+
+    expect(results).toHaveLength(3);
+    const resultSlugs = results.map((r) => r.slug).sort();
+    expect(resultSlugs).toEqual(["slug-a", "slug-b", "slug-c"]);
+    expect(results.every((r) => r.status === "pass")).toBe(true);
+  });
+
+  it("respects concurrency limit", async () => {
+    let concurrentCount = 0;
+    let maxConcurrent = 0;
+
+    // Override execFile to track concurrency
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        _opts: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        concurrentCount++;
+        if (concurrentCount > maxConcurrent) {
+          maxConcurrent = concurrentCount;
+        }
+
+        // Simulate async work
+        setTimeout(() => {
+          concurrentCount--;
+          const jsonOut = playwrightJsonOutput("test", [
+            { title: "t", status: "passed", duration: 100 },
+          ]);
+          cb(null, jsonOut, "");
+        }, 50);
+
+        return { pid: 1234, kill: () => {} };
+      },
+    );
+
+    const slugs = ["a", "b", "c", "d", "e", "f"];
+    const opts: RunOptions = {
+      level: "d5",
+      maxParallel: 2,
+      timeout: 30000,
+      showcaseDir: "/showcase",
+    };
+
+    const results = await runParallel(slugs, opts);
+
+    expect(results).toHaveLength(6);
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("runTiered", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    readFileSyncMock.mockReset();
+  });
+
+  it("executes tiers in order (tier 1 before tier 2)", async () => {
+    const tiersFile: TiersFile = {
+      tiers: [
+        { name: "Tier 1", slugs: ["slug-a"], fail_fast: true },
+        { name: "Tier 2", slugs: ["slug-b"], fail_fast: false },
+      ],
+    };
+    readFileSyncMock.mockReturnValue(JSON.stringify(tiersFile));
+
+    const executionOrder: string[] = [];
+
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        args: string[],
+        _opts: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        // Extract slug from args — it's the argument after "test"
+        const testIdx = args.indexOf("test");
+        const slug = testIdx >= 0 ? args[testIdx + 1] : "unknown";
+        executionOrder.push(slug);
+
+        const jsonOut = playwrightJsonOutput(slug, [
+          { title: "basic", status: "passed", duration: 100 },
+        ]);
+        cb(null, jsonOut, "");
+        return { pid: 1234, kill: () => {} };
+      },
+    );
+
+    const opts: RunOptions = {
+      level: "d5",
+      maxParallel: 2,
+      timeout: 30000,
+      showcaseDir: "/showcase",
+    };
+
+    const result = await runTiered(
+      ["slug-a", "slug-b"],
+      ["slug-a", "slug-b"],
+      opts,
+    );
+
+    // Tier 1 slug should execute before tier 2 slug
+    expect(executionOrder.indexOf("slug-a")).toBeLessThan(
+      executionOrder.indexOf("slug-b"),
+    );
+    expect(result.tierSummaries).toHaveLength(2);
+    expect(result.tierSummaries[0].name).toBe("Tier 1");
+    expect(result.tierSummaries[1].name).toBe("Tier 2");
+  });
+
+  it("stops on tier 1 fail-fast when regression detected", async () => {
+    const tiersFile: TiersFile = {
+      tiers: [
+        { name: "Gold Standard", slugs: ["slug-a"], fail_fast: true },
+        { name: "Rest", slugs: ["slug-b"], fail_fast: false },
+      ],
+    };
+    readFileSyncMock.mockReturnValue(JSON.stringify(tiersFile));
+
+    // slug-a fails
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        args: string[],
+        _opts: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        const testIdx = args.indexOf("test");
+        const slug = testIdx >= 0 ? args[testIdx + 1] : "unknown";
+
+        if (slug === "slug-a") {
+          const jsonOut = playwrightJsonOutput(slug, [
+            {
+              title: "basic",
+              status: "failed",
+              duration: 100,
+              error: "assertion failed",
+            },
+          ]);
+          cb(null, jsonOut, "");
+        } else {
+          const jsonOut = playwrightJsonOutput(slug, [
+            { title: "basic", status: "passed", duration: 100 },
+          ]);
+          cb(null, jsonOut, "");
+        }
+        return { pid: 1234, kill: () => {} };
+      },
+    );
+
+    const opts: RunOptions = {
+      level: "d5",
+      maxParallel: 2,
+      timeout: 30000,
+      showcaseDir: "/showcase",
+    };
+
+    const result = await runTiered(
+      ["slug-a", "slug-b"],
+      ["slug-a", "slug-b"],
+      opts,
+    );
+
+    // Should have stopped after tier 1
+    expect(result.abortedAtTier).toBe(0);
+    expect(result.tierSummaries).toHaveLength(1);
+    // slug-b should be skipped
+    const slugBResult = result.results.find((r) => r.slug === "slug-b");
+    expect(slugBResult).toBeUndefined();
+  });
+
+  it("continues through all tiers when noFailFast=true", async () => {
+    const tiersFile: TiersFile = {
+      tiers: [
+        { name: "Gold Standard", slugs: ["slug-a"], fail_fast: true },
+        { name: "Rest", slugs: ["slug-b"], fail_fast: false },
+      ],
+    };
+    readFileSyncMock.mockReturnValue(JSON.stringify(tiersFile));
+
+    // slug-a fails
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        args: string[],
+        _opts: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        const testIdx = args.indexOf("test");
+        const slug = testIdx >= 0 ? args[testIdx + 1] : "unknown";
+
+        if (slug === "slug-a") {
+          const jsonOut = playwrightJsonOutput(slug, [
+            {
+              title: "basic",
+              status: "failed",
+              duration: 100,
+              error: "assertion failed",
+            },
+          ]);
+          cb(null, jsonOut, "");
+        } else {
+          const jsonOut = playwrightJsonOutput(slug, [
+            { title: "basic", status: "passed", duration: 100 },
+          ]);
+          cb(null, jsonOut, "");
+        }
+        return { pid: 1234, kill: () => {} };
+      },
+    );
+
+    const opts: RunOptions = {
+      level: "d5",
+      maxParallel: 2,
+      timeout: 30000,
+      showcaseDir: "/showcase",
+      noFailFast: true,
+    };
+
+    const result = await runTiered(
+      ["slug-a", "slug-b"],
+      ["slug-a", "slug-b"],
+      opts,
+    );
+
+    // Should NOT have stopped — continued through both tiers
+    expect(result.abortedAtTier).toBeUndefined();
+    expect(result.tierSummaries).toHaveLength(2);
+    expect(result.results).toHaveLength(2);
+  });
+});

--- a/showcase/harness/src/cli/eval/runner.ts
+++ b/showcase/harness/src/cli/eval/runner.ts
@@ -1,0 +1,449 @@
+/**
+ * Eval parallel test runner with tier support.
+ *
+ * Unlike the existing CLI runner (which runs probe drivers in-process), this
+ * runner spawns EXTERNAL processes (`showcase test <slug> --d5`) because each
+ * integration's Playwright suite is separate. Results are collected from the
+ * Playwright JSON reporter output on stdout.
+ *
+ * Tiers allow prioritized execution: Gold Standard integrations run first
+ * with fail-fast semantics, then Key Partners, then the Full Matrix.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+
+import type { SlugResult, TestResult } from "./matrix.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type { SlugResult } from "./matrix.js";
+
+export interface TierConfig {
+  name: string;
+  slugs: string[] | "*";
+  fail_fast: boolean;
+}
+
+export interface TiersFile {
+  tiers: TierConfig[];
+}
+
+export interface RunOptions {
+  level: string;
+  maxParallel: number;
+  timeout: number;
+  showcaseDir: string;
+  maxTier?: number;
+  noFailFast?: boolean;
+  onSlugStart?: (slug: string, tier: string) => void;
+  onSlugComplete?: (result: SlugResult, tier: string) => void;
+}
+
+export interface TieredRunResult {
+  results: SlugResult[];
+  abortedAtTier?: number;
+  tierSummaries: Array<{
+    name: string;
+    total: number;
+    passed: number;
+    failed: number;
+    duration_ms: number;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved tier (slugs always string[] after resolution)
+// ---------------------------------------------------------------------------
+
+interface ResolvedTier {
+  name: string;
+  slugs: string[];
+  fail_fast: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// loadTiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Load tier configuration from a JSON file. Resolves the "*" wildcard by
+ * filtering out slugs already named in previous tiers.
+ *
+ * If the file doesn't exist, returns a single "all" tier containing every slug.
+ */
+export function loadTiers(
+  tiersPath: string,
+  allSlugs: string[],
+): ResolvedTier[] {
+  let tiersFile: TiersFile;
+
+  try {
+    const raw = fs.readFileSync(tiersPath, "utf-8");
+    tiersFile = JSON.parse(raw) as TiersFile;
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return [{ name: "all", slugs: [...allSlugs], fail_fast: false }];
+    }
+    throw err;
+  }
+
+  const claimedSlugs = new Set<string>();
+  const resolved: ResolvedTier[] = [];
+
+  for (const tier of tiersFile.tiers) {
+    let slugs: string[];
+
+    if (tier.slugs === "*") {
+      // Wildcard: all slugs not already claimed by previous tiers
+      slugs = allSlugs.filter((s) => !claimedSlugs.has(s));
+    } else {
+      slugs = tier.slugs.filter((s) => allSlugs.includes(s));
+    }
+
+    for (const s of slugs) {
+      claimedSlugs.add(s);
+    }
+
+    resolved.push({
+      name: tier.name,
+      slugs,
+      fail_fast: tier.fail_fast,
+    });
+  }
+
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// runSlug
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn `npx tsx showcase/harness/src/cli.ts test <slug> --level <level> --json`
+ * and parse the Playwright JSON reporter output from stdout.
+ */
+export async function runSlug(
+  slug: string,
+  level: string,
+  timeout: number,
+  showcaseDir: string,
+): Promise<SlugResult> {
+  const startMs = Date.now();
+
+  return new Promise<SlugResult>((resolve) => {
+    const args = ["tsx", "harness/src/cli.ts", "test", slug, "--level", level];
+
+    execFile(
+      "npx",
+      args,
+      {
+        cwd: showcaseDir,
+        timeout,
+        maxBuffer: 10 * 1024 * 1024, // 10 MB
+        encoding: "utf-8",
+      },
+      (err: Error | null, stdout: string, _stderr: string) => {
+        const durationMs = Date.now() - startMs;
+
+        if (err) {
+          // Try to parse stdout even on error — sometimes tests fail with
+          // non-zero exit but still produce JSON output.
+          const parsed = tryParsePlaywrightJson(stdout);
+          if (parsed) {
+            resolve({
+              slug,
+              status: parsed.hasFailures ? "fail" : "pass",
+              tests: parsed.tests,
+              duration_ms: durationMs,
+            });
+            return;
+          }
+
+          resolve({
+            slug,
+            status: "fail",
+            tests: {},
+            duration_ms: durationMs,
+          });
+          return;
+        }
+
+        const parsed = tryParsePlaywrightJson(stdout);
+        if (!parsed) {
+          // JSON parsing failed (test command outputs terminal text, not JSON).
+          // Fall back to exit-code-based status: process exited 0 = pass.
+          resolve({
+            slug,
+            status: "pass",
+            tests: {},
+            duration_ms: durationMs,
+          });
+          return;
+        }
+
+        resolve({
+          slug,
+          status: parsed.hasFailures ? "fail" : "pass",
+          tests: parsed.tests,
+          duration_ms: durationMs,
+        });
+      },
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Playwright JSON parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedPlaywright {
+  tests: Record<string, TestResult>;
+  hasFailures: boolean;
+}
+
+/**
+ * Normalize Playwright test statuses to the vocabulary expected by the
+ * matrix module ("pass", "fail", "error", "skip").
+ */
+function normalizeStatus(pwStatus: string): TestResult["status"] {
+  if (pwStatus === "passed") return "pass";
+  if (pwStatus === "failed") return "fail";
+  if (pwStatus === "timedOut") return "error";
+  if (pwStatus === "skipped") return "skip";
+  if (pwStatus === "interrupted") return "error";
+  return "error";
+}
+
+/**
+ * Try to parse Playwright JSON reporter output from stdout. Returns null
+ * if parsing fails. Handles the nested suites/specs/tests structure.
+ */
+function tryParsePlaywrightJson(stdout: string): ParsedPlaywright | null {
+  try {
+    const data = JSON.parse(stdout) as {
+      suites?: Array<{
+        title: string;
+        specs?: Array<{
+          title: string;
+          tests?: Array<{
+            results?: Array<{
+              status: string;
+              duration: number;
+              error?: { message?: string };
+            }>;
+          }>;
+        }>;
+        suites?: Array<unknown>;
+      }>;
+    };
+
+    if (!data.suites) return null;
+
+    const tests: Record<string, TestResult> = {};
+    let hasFailures = false;
+
+    function walkSuites(
+      suites: Array<{
+        title: string;
+        specs?: Array<{
+          title: string;
+          tests?: Array<{
+            results?: Array<{
+              status: string;
+              duration: number;
+              error?: { message?: string };
+            }>;
+          }>;
+        }>;
+        suites?: Array<unknown>;
+      }>,
+      parentTitle?: string,
+    ): void {
+      for (const suite of suites) {
+        const suiteTitle = parentTitle
+          ? `${parentTitle} > ${suite.title}`
+          : suite.title;
+
+        if (suite.specs) {
+          for (const spec of suite.specs) {
+            if (spec.tests) {
+              for (const test of spec.tests) {
+                if (test.results && test.results.length > 0) {
+                  const lastResult = test.results[test.results.length - 1];
+                  const normalized = normalizeStatus(lastResult.status);
+                  const entry: TestResult = {
+                    status: normalized,
+                    duration_ms: lastResult.duration,
+                  };
+
+                  if (lastResult.error?.message) {
+                    entry.error = lastResult.error.message;
+                  }
+
+                  if (normalized === "fail" || normalized === "error") {
+                    hasFailures = true;
+                  }
+
+                  tests[`${suiteTitle} > ${spec.title}`] = entry;
+                }
+              }
+            }
+          }
+        }
+
+        // Recurse into nested suites
+        if (suite.suites) {
+          walkSuites(
+            suite.suites as Array<{
+              title: string;
+              specs?: Array<{
+                title: string;
+                tests?: Array<{
+                  results?: Array<{
+                    status: string;
+                    duration: number;
+                    error?: { message?: string };
+                  }>;
+                }>;
+              }>;
+              suites?: Array<unknown>;
+            }>,
+            suiteTitle,
+          );
+        }
+      }
+    }
+
+    walkSuites(data.suites);
+    return { tests, hasFailures };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runParallel
+// ---------------------------------------------------------------------------
+
+/**
+ * Run slugs in parallel with bounded concurrency using a Promise-based
+ * semaphore pattern.
+ */
+export async function runParallel(
+  slugs: string[],
+  opts: RunOptions,
+): Promise<SlugResult[]> {
+  const results: SlugResult[] = [];
+  const executing = new Set<Promise<void>>();
+
+  for (const slug of slugs) {
+    opts.onSlugStart?.(slug, "");
+
+    const p = runSlug(slug, opts.level, opts.timeout, opts.showcaseDir)
+      .then((r) => {
+        results.push(r);
+        opts.onSlugComplete?.(r, "");
+      })
+      .finally(() => executing.delete(p));
+    executing.add(p);
+
+    if (executing.size >= opts.maxParallel) {
+      await Promise.race(executing);
+    }
+  }
+
+  await Promise.all(executing);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// runTiered
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute tiers in sequence. Tier 1 runs with maxParallel=1 for fast feedback.
+ * After each tier, checks fail_fast + failure count; if fail_fast and any
+ * failures, stops the run.
+ *
+ * `healthySlugs` filters the tier slugs — only healthy slugs are run, the
+ * rest are marked "unhealthy".
+ */
+export async function runTiered(
+  allSlugs: string[],
+  healthySlugs: string[],
+  opts: RunOptions,
+): Promise<TieredRunResult> {
+  const tiersPath = `${opts.showcaseDir}/eval-tiers.json`;
+  const tiers = loadTiers(tiersPath, allSlugs);
+
+  const healthySet = new Set(healthySlugs);
+  const allResults: SlugResult[] = [];
+  const tierSummaries: TieredRunResult["tierSummaries"] = [];
+  let abortedAtTier: number | undefined;
+
+  const maxTier = opts.maxTier ?? tiers.length;
+
+  for (let i = 0; i < Math.min(tiers.length, maxTier); i++) {
+    const tier = tiers[i];
+    const tierStart = Date.now();
+
+    // Filter to only healthy slugs for this tier
+    const runnableSlugs = tier.slugs.filter((s) => healthySet.has(s));
+    const unhealthySlugs = tier.slugs.filter((s) => !healthySet.has(s));
+
+    // Mark unhealthy slugs as such
+    for (const slug of unhealthySlugs) {
+      allResults.push({
+        slug,
+        status: "unhealthy",
+        tests: {},
+        duration_ms: 0,
+      });
+    }
+
+    // Tier 1 runs with maxParallel=1 for fast feedback
+    const tierParallel = i === 0 ? 1 : opts.maxParallel;
+
+    const tierOpts: RunOptions = {
+      ...opts,
+      maxParallel: tierParallel,
+      onSlugStart: (slug) => opts.onSlugStart?.(slug, tier.name),
+      onSlugComplete: (result) => opts.onSlugComplete?.(result, tier.name),
+    };
+
+    const tierResults = await runParallel(runnableSlugs, tierOpts);
+    allResults.push(...tierResults);
+
+    const passed = tierResults.filter((r) => r.status === "pass").length;
+    const failed = tierResults.filter(
+      (r) => r.status === "fail" || r.status === "error",
+    ).length;
+
+    tierSummaries.push({
+      name: tier.name,
+      total: tier.slugs.length,
+      passed,
+      failed,
+      duration_ms: Date.now() - tierStart,
+    });
+
+    // Check fail-fast: if this tier has fail_fast and there are failures, abort
+    if (tier.fail_fast && !opts.noFailFast && failed > 0) {
+      abortedAtTier = i;
+      break;
+    }
+  }
+
+  return {
+    results: allResults,
+    abortedAtTier,
+    tierSummaries,
+  };
+}

--- a/showcase/harness/src/cli/eval/scope.test.ts
+++ b/showcase/harness/src/cli/eval/scope.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { classifyScope, type ScopeResult } from "./scope.js";
+
+const ALL_SLUGS = [
+  "langgraph-python",
+  "langgraph-typescript",
+  "langgraph-fastapi",
+  "google-adk",
+  "mastra",
+  "crewai-crews",
+  "pydantic-ai",
+  "claude-sdk-python",
+  "claude-sdk-typescript",
+  "agno",
+  "ag2",
+  "llamaindex",
+  "strands",
+  "langroid",
+  "ms-agent-python",
+  "ms-agent-dotnet",
+  "spring-ai",
+];
+
+describe("classifyScope", () => {
+  // ---- Platform-wide patterns => mode: "all" ----
+
+  it('returns "all" for packages/runtime/** changes', () => {
+    const result = classifyScope(
+      ["packages/runtime/src/lib/foo.ts"],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+    expect(result.reason).toContain("packages/runtime");
+  });
+
+  it('returns "all" for packages/sdk-js/** changes', () => {
+    const result = classifyScope(["packages/sdk-js/src/index.ts"], ALL_SLUGS);
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+
+  it('returns "all" for packages/react-core/** changes', () => {
+    const result = classifyScope(
+      ["packages/react-core/src/hooks.ts"],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+
+  it('returns "all" for showcase/shared/** changes', () => {
+    const result = classifyScope(
+      ["showcase/shared/some-config.json"],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+
+  it('returns "all" for showcase/aimock/** changes', () => {
+    const result = classifyScope(
+      ["showcase/aimock/fixtures/foo.json"],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+
+  it('returns "all" for showcase/docker-compose.local.yml changes', () => {
+    const result = classifyScope(
+      ["showcase/docker-compose.local.yml"],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+
+  it('returns "all" for pnpm-lock.yaml changes', () => {
+    const result = classifyScope(["pnpm-lock.yaml"], ALL_SLUGS);
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+
+  it('returns "all" for showcase/tests/** changes', () => {
+    const result = classifyScope(
+      ["showcase/tests/e2e/smoke.spec.ts"],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+
+  // ---- Per-integration pattern => mode: "per-integration" ----
+
+  it('returns "per-integration" for showcase/integrations/mastra/** changes', () => {
+    const result = classifyScope(
+      ["showcase/integrations/mastra/src/app.ts"],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("per-integration");
+    expect(result.slugs).toEqual(["mastra"]);
+    expect(result.reason).toContain("mastra");
+  });
+
+  it('returns "per-integration" for multiple integration changes and deduplicates', () => {
+    const result = classifyScope(
+      [
+        "showcase/integrations/mastra/src/a.ts",
+        "showcase/integrations/mastra/src/b.ts",
+        "showcase/integrations/crewai-crews/Dockerfile",
+        "showcase/integrations/agno/package.json",
+      ],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("per-integration");
+    expect(result.slugs).toEqual(
+      expect.arrayContaining(["mastra", "crewai-crews", "agno"]),
+    );
+    expect(result.slugs).toHaveLength(3);
+  });
+
+  // ---- Unrelated ----
+
+  it('returns "unrelated" for docs/** changes', () => {
+    const result = classifyScope(["docs/pages/getting-started.mdx"], ALL_SLUGS);
+    expect(result.mode).toBe("unrelated");
+    expect(result.slugs).toEqual([]);
+  });
+
+  it('returns "unrelated" for empty file list', () => {
+    const result = classifyScope([], ALL_SLUGS);
+    expect(result.mode).toBe("unrelated");
+    expect(result.slugs).toEqual([]);
+  });
+
+  // ---- Precedence ----
+
+  it("platform-wide takes precedence over per-integration when both present", () => {
+    const result = classifyScope(
+      [
+        "showcase/integrations/mastra/src/app.ts",
+        "packages/runtime/src/lib/foo.ts",
+      ],
+      ALL_SLUGS,
+    );
+    expect(result.mode).toBe("all");
+    expect(result.slugs).toEqual(ALL_SLUGS);
+  });
+});

--- a/showcase/harness/src/cli/eval/scope.ts
+++ b/showcase/harness/src/cli/eval/scope.ts
@@ -1,0 +1,102 @@
+/**
+ * Scope detection for the eval system.
+ *
+ * Given a list of changed file paths (relative to repo root) and the
+ * canonical set of integration slugs, determines whether to run all
+ * integrations, a subset, or nothing.
+ *
+ * Pure function — no I/O.
+ */
+
+export interface ScopeResult {
+  mode: "all" | "per-integration" | "unrelated";
+  reason: string;
+  slugs: string[];
+}
+
+/**
+ * Patterns that affect the entire showcase platform. A match on any of
+ * these means every integration must be re-evaluated.
+ */
+const PLATFORM_WIDE_PATTERNS: Array<{ regex: RegExp; label: string }> = [
+  {
+    regex: /^packages\/(runtime|sdk-js|react-core|react-ui|react-textarea)\//,
+    label: "packages/{matched}",
+  },
+  { regex: /^showcase\/(shared|aimock)\//, label: "showcase/{matched}" },
+  {
+    regex: /^showcase\/docker-compose\.local\.yml$/,
+    label: "showcase/docker-compose.local.yml",
+  },
+  { regex: /^showcase\/tests\//, label: "showcase/tests" },
+  { regex: /^showcase\/scripts\/cli\//, label: "showcase/scripts/cli" },
+  { regex: /^pnpm-lock\.yaml$/, label: "pnpm-lock.yaml" },
+];
+
+/**
+ * Regex to extract an integration slug from a changed file path.
+ * Matches `showcase/integrations/<slug>/...`.
+ */
+const INTEGRATION_RE = /^showcase\/integrations\/([^/]+)\//;
+
+/**
+ * Classify the scope of a set of changed files.
+ *
+ * @param changedFiles - Repo-relative file paths (e.g. from `git diff --name-only`).
+ * @param allSlugs    - The canonical list of all integration slugs.
+ * @returns A ScopeResult describing what to evaluate.
+ */
+export function classifyScope(
+  changedFiles: string[],
+  allSlugs: string[],
+): ScopeResult {
+  if (changedFiles.length === 0) {
+    return { mode: "unrelated", reason: "no changed files", slugs: [] };
+  }
+
+  // Check platform-wide patterns first (takes precedence).
+  for (const file of changedFiles) {
+    for (const { regex, label } of PLATFORM_WIDE_PATTERNS) {
+      const match = file.match(regex);
+      if (match) {
+        // Build a human-readable reason with the matched segment.
+        const reason = label.includes("{matched}")
+          ? label.replace("{matched}", match[1])
+          : label;
+        return {
+          mode: "all",
+          reason: `platform-wide change: ${reason}`,
+          slugs: [...allSlugs],
+        };
+      }
+    }
+  }
+
+  // Collect per-integration slugs.
+  const slugSet = new Set<string>();
+  for (const file of changedFiles) {
+    const match = file.match(INTEGRATION_RE);
+    if (match) {
+      const slug = match[1];
+      // Only include slugs that are in the canonical list.
+      if (allSlugs.includes(slug)) {
+        slugSet.add(slug);
+      }
+    }
+  }
+
+  if (slugSet.size > 0) {
+    const slugs = [...slugSet].sort();
+    return {
+      mode: "per-integration",
+      reason: `integration changes: ${slugs.join(", ")}`,
+      slugs,
+    };
+  }
+
+  return {
+    mode: "unrelated",
+    reason: "no showcase-relevant changes",
+    slugs: [],
+  };
+}


### PR DESCRIPTION
## Summary

Adds `showcase eval` — a command to evaluate any PR against the full showcase D5 integration matrix before merging. Catches cross-integration regressions (like PR #4358 breaking 13/18 integrations) before they land on main.

- **`showcase eval --d5`** — auto-detects affected integrations from git diff, builds + starts them in Docker, runs D5 probes, outputs a colored matrix with SAFE TO MERGE / REGRESSIONS DETECTED verdict
- **Tiered fail-fast** — Tier 1 (langgraph-python gold standard) runs first; regressions stop the eval immediately. Tier 2 (key partners) and Tier 3 (full matrix) follow
- **Baseline comparison** — pulls live D5 results from showcase-harness API or uses locally captured baselines for regression detection (pass→fail)
- **`/eval` PR comment trigger** — GitHub Actions workflow on Depot 16-core for async full-matrix runs with results posted as a markdown table on the PR
- **1363 vitest tests** pass across the harness (47 new eval-specific tests across 4 modules)

## Architecture

```
showcase/harness/src/cli/eval/
  scope.ts      — pure: git diff paths → affected slugs
  baseline.ts   — harness API pull + local capture
  matrix.ts     — result collection, terminal formatting, verdict
                  (canonical SlugResult/TestResult types)
  runner.ts     — parallel execution with tier support
  index.ts      — commander subcommand + orchestrator pipeline
```

## What was fixed during CR (5 rounds, 35 agent reviews)

- ESM `require("node:fs")` replaced with proper import
- GHA scope_flag whitespace from user-typed comma-space slugs
- Tier resolution included out-of-scope slugs (inflated fail count)
- Teardown `console.log` corrupted `--json` stdout in CI
- Logger `LOG_LEVEL=warn` wasn't reloaded (cached at import time)
- Synthetic status mapping dropped "pass" to "fail" for empty-test slugs
- Zero-affected-slugs path wrote plain text in `--json` mode
- Duplicate SlugResult types unified (runner imports from matrix)
- Worktree cleanup cwd was inside the worktree being deleted
- `normalizeStatus` fallthrough returned raw string instead of "error"

## Known v1 limitations

- Per-test granularity is slug-level only (exit-code-based); Playwright JSON reporter integration is future work
- Harness-prod baselines key by probe ID, not slug — regression detection works with locally captured baselines only
- CI workflow Docker setup (building 17 integration images) is Phase 3 work

## Test plan

- [x] `npx nx run @copilotkit/showcase-harness:test` — 1363 tests pass (70 files)
- [x] `tsc --noEmit` — zero type errors
- [ ] `showcase eval --help` — displays all flags
- [ ] `showcase eval --d5 --scope all` — full matrix against local Docker stack
- [ ] `/eval` comment on a test PR — GHA workflow triggers and posts results