### PR TITLE
fix: auto-format 16 files with pre-existing oxfmt violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ CopilotKit is a best-in-class SDK for building full-stack agentic applications, 
 We are the company behind the **AG-UI Protocol**, adopted by Google, LangChain, AWS, Microsoft, Mastra, PydanticAI, and more!
 
 https://github.com/user-attachments/assets/6f06c63f-9bd1-4762-99ac-24898ee227bc
+
 <div align="center"> Add AI to your app in 1 minute</div>
 
 **Features:**

--- a/packages/runtime/src/v2/runtime/endpoints/express.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/express.ts
@@ -149,7 +149,10 @@ export function createCopilotExpressHandler({
   } else if (normalizedBase === "/") {
     router.all(/.*/, expressHandler);
   } else {
-    router.all(new RegExp(`^${escapeRegExp(normalizedBase)}(\\/.*)?$`), expressHandler);
+    router.all(
+      new RegExp(`^${escapeRegExp(normalizedBase)}(\\/.*)?$`),
+      expressHandler,
+    );
   }
 
   return router;

--- a/showcase/DEBUGGING.md
+++ b/showcase/DEBUGGING.md
@@ -20,25 +20,25 @@ The unified CLI is at `bin/showcase`. It wraps Docker Compose and adds debugging
 
 ### Core Commands
 
-| Command | Description |
-|---------|-------------|
-| `showcase up [slug...]` | Start containers (rebuilds if source changed). No args = infra only (aimock, pocketbase, dashboard) |
-| `showcase down [slug...]` | Stop containers. No args = stop everything |
-| `showcase build [slug...]` | Build Docker images without starting containers |
-| `showcase ps` | Show running containers and their status |
-| `showcase ports` | Print slug-to-host-port mapping (from `shared/local-ports.json`) |
-| `showcase logs <slug>` | Follow container logs (supports `--grep`, `--since`, `-n`, `--no-follow`) |
+| Command                    | Description                                                                                         |
+| -------------------------- | --------------------------------------------------------------------------------------------------- |
+| `showcase up [slug...]`    | Start containers (rebuilds if source changed). No args = infra only (aimock, pocketbase, dashboard) |
+| `showcase down [slug...]`  | Stop containers. No args = stop everything                                                          |
+| `showcase build [slug...]` | Build Docker images without starting containers                                                     |
+| `showcase ps`              | Show running containers and their status                                                            |
+| `showcase ports`           | Print slug-to-host-port mapping (from `shared/local-ports.json`)                                    |
+| `showcase logs <slug>`     | Follow container logs (supports `--grep`, `--since`, `-n`, `--no-follow`)                           |
 
 ### Debugging Commands
 
-| Command | Description |
-|---------|-------------|
-| `showcase aimock-rebuild` | Rebuild local aimock from a source checkout and redeploy the container |
-| `showcase recreate <slug>` | Force-recreate a service (picks up a newly built image) |
-| `showcase test <slug>` | Run probe tests against a running service |
-| `showcase fixtures validate` | Check fixture JSON files for structural errors, duplicates, and common mistakes |
-| `showcase doctor` | Diagnose common local stack issues (Docker engine, Depot interception, stale images, port conflicts) |
-| `showcase diff-logs <slug>` | Show log output for a specific time window, filtering out noise from before your change |
+| Command                      | Description                                                                                          |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `showcase aimock-rebuild`    | Rebuild local aimock from a source checkout and redeploy the container                               |
+| `showcase recreate <slug>`   | Force-recreate a service (picks up a newly built image)                                              |
+| `showcase test <slug>`       | Run probe tests against a running service                                                            |
+| `showcase fixtures validate` | Check fixture JSON files for structural errors, duplicates, and common mistakes                      |
+| `showcase doctor`            | Diagnose common local stack issues (Docker engine, Depot interception, stale images, port conflicts) |
+| `showcase diff-logs <slug>`  | Show log output for a specific time window, filtering out noise from before your change              |
 
 ## The Debugging Loop
 
@@ -278,13 +278,13 @@ This filters out all log output from before your test started, showing only what
 
 ## Environment Variables
 
-| Variable | Purpose | Default |
-|----------|---------|---------|
-| `AIMOCK_SRC` | Path to local aimock checkout for `aimock-rebuild` | `../../aimock` relative to `showcase/` (sibling of repo root), then `../aimock` |
-| `SHOWCASE_LOCAL` | Use localhost ports instead of Railway URLs in the shell app | unset |
-| `DEPOT_DISABLE` | Bypass Depot CLI for local Docker builds | unset (set to `1` to disable) |
-| `OPENAI_API_KEY` | Required for all integrations (even with aimock, some init code validates the key) | none |
-| `ANTHROPIC_API_KEY` | Required for Claude Agent SDK demos | none |
+| Variable            | Purpose                                                                            | Default                                                                         |
+| ------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `AIMOCK_SRC`        | Path to local aimock checkout for `aimock-rebuild`                                 | `../../aimock` relative to `showcase/` (sibling of repo root), then `../aimock` |
+| `SHOWCASE_LOCAL`    | Use localhost ports instead of Railway URLs in the shell app                       | unset                                                                           |
+| `DEPOT_DISABLE`     | Bypass Depot CLI for local Docker builds                                           | unset (set to `1` to disable)                                                   |
+| `OPENAI_API_KEY`    | Required for all integrations (even with aimock, some init code validates the key) | none                                                                            |
+| `ANTHROPIC_API_KEY` | Required for Claude Agent SDK demos                                                | none                                                                            |
 
 ## Quick Diagnostic Commands
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -115,35 +115,35 @@ The showcase harness includes a CLI that runs the same probe drivers (liveness, 
 
 ### Commands
 
-| Command              | Description                                                                     |
-| -------------------- | ------------------------------------------------------------------------------- |
-| `test <slug>`        | Run probes against a running service                                            |
-| `up [slugs...]`      | Start infra (aimock, pocketbase, dashboard) + named packages. No args = infra only |
-| `down [slugs...]`    | Stop services. No args = stop everything                                        |
-| `build [slugs...]`   | Build Docker images                                                             |
-| `ps`                 | Show running services                                                           |
-| `ports`              | Print slug to host port mapping                                                 |
-| `logs <slug>`        | Follow container logs (supports `--grep`, `--since`, `-n`, `--no-follow`)       |
+| Command            | Description                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| `test <slug>`      | Run probes against a running service                                               |
+| `up [slugs...]`    | Start infra (aimock, pocketbase, dashboard) + named packages. No args = infra only |
+| `down [slugs...]`  | Stop services. No args = stop everything                                           |
+| `build [slugs...]` | Build Docker images                                                                |
+| `ps`               | Show running services                                                              |
+| `ports`            | Print slug to host port mapping                                                    |
+| `logs <slug>`      | Follow container logs (supports `--grep`, `--since`, `-n`, `--no-follow`)          |
 
 **Debugging commands** (see [DEBUGGING.md](DEBUGGING.md) for full details):
 
-| Command                  | Description                                              |
-| ------------------------ | -------------------------------------------------------- |
-| `aimock-rebuild`         | Rebuild aimock from local source                         |
-| `recreate <slug>`       | Force-recreate a service (picks up new image)            |
-| `fixtures validate`      | Validate fixture JSON files for common errors            |
-| `doctor`                 | Check local environment and stack health                 |
-| `diff-logs <slug>`       | Show log delta for a time window                         |
+| Command             | Description                                   |
+| ------------------- | --------------------------------------------- |
+| `aimock-rebuild`    | Rebuild aimock from local source              |
+| `recreate <slug>`   | Force-recreate a service (picks up new image) |
+| `fixtures validate` | Validate fixture JSON files for common errors |
+| `doctor`            | Check local environment and stack health      |
+| `diff-logs <slug>`  | Show log delta for a time window              |
 
 ### Test options
 
-| Option           | Description                                                          |
-| ---------------- | -------------------------------------------------------------------- |
-| `--d5`           | Run D5 (subagents/tool-rendering/agentic-chat) probes only           |
-| `--d6`           | Run D6 probes only                                                   |
-| `--verbose`      | Verbose test output                                                  |
-| `--cycle`        | On failure, auto-dump aimock logs from the test window                |
-| `--timeout <ms>` | Test timeout in milliseconds (default: 30000)                        |
+| Option           | Description                                                |
+| ---------------- | ---------------------------------------------------------- |
+| `--d5`           | Run D5 (subagents/tool-rendering/agentic-chat) probes only |
+| `--d6`           | Run D6 probes only                                         |
+| `--verbose`      | Verbose test output                                        |
+| `--cycle`        | On failure, auto-dump aimock logs from the test window     |
+| `--timeout <ms>` | Test timeout in milliseconds (default: 30000)              |
 
 `--d5` and `--d6` are mutually exclusive. When neither is given, all tests run.
 
@@ -235,6 +235,7 @@ Column ordering lives in `shell-dashboard/src/lib/sort-order.ts` — internal to
 For the full debugging playbook — including aimock rebuild cycles, fixture validation, probe testing, container diagnostics, and common gotchas — see [DEBUGGING.md](DEBUGGING.md).
 
 Quick start:
+
 ```sh
 showcase/bin/showcase doctor              # check your stack
 showcase/bin/showcase test mastra --d5    # run D5 probes

--- a/showcase/harness/src/alerts/render-red-tick.test.ts
+++ b/showcase/harness/src/alerts/render-red-tick.test.ts
@@ -165,5 +165,4 @@ describe("red-tick YAML rendering — Items 2 & 3", () => {
       expect(rendered).toContain("/runs/run-abc|Run");
     });
   });
-
 });

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -352,7 +352,8 @@ export async function fillAndVerifySend(
   },
 ): Promise<void> {
   const maxAttempts = overrides?.maxAttempts ?? SEND_VERIFY_MAX_ATTEMPTS;
-  const initialDelay = overrides?.initialDelayMs ?? SEND_VERIFY_INITIAL_DELAY_MS;
+  const initialDelay =
+    overrides?.initialDelayMs ?? SEND_VERIFY_INITIAL_DELAY_MS;
   const timeout = overrides?.timeoutMs ?? SEND_VERIFY_TIMEOUT_MS;
 
   const baseline = await readUserMessageCount(page);

--- a/showcase/harness/src/probes/scripts/d5-mcp-subagents.ts
+++ b/showcase/harness/src/probes/scripts/d5-mcp-subagents.ts
@@ -51,10 +51,7 @@ import {
  * a coherent reply" — not "are these exact phrases present." Per-word
  * fidelity is a D3 concern.
  */
-const EXPECTED_REPLY_FRAGMENTS = [
-  "remote work",
-  "talent pool",
-] as const;
+const EXPECTED_REPLY_FRAGMENTS = ["remote work", "talent pool"] as const;
 
 /**
  * Single user prompt that triggers the chain. Verbatim match against the

--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -57,8 +57,16 @@ export default function Page() {
   );
 
   // Overlay state management (handles URL hash + localStorage persistence)
-  const { overlays, activeTab, toggle, applyPreset, setTab, activePreset, selectedProbeId, selectProbe } =
-    useOverlays();
+  const {
+    overlays,
+    activeTab,
+    toggle,
+    applyPreset,
+    setTab,
+    activePreset,
+    selectedProbeId,
+    selectProbe,
+  } = useOverlays();
 
   // Build a cell-lookup map: integration slug + feature id -> CatalogCell
   const cellLookup = useMemo(() => {

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -178,7 +178,10 @@ export function AdaptiveLegend({ overlays }: AdaptiveLegendProps) {
           onClick={() => setOpen((v) => !v)}
           className="flex items-center gap-1 text-[10px] uppercase tracking-wider font-medium text-[var(--text-muted)] hover:text-[var(--text)] cursor-pointer bg-transparent border-none p-0"
         >
-          <span className="inline-block transition-transform" style={{ transform: open ? "rotate(90deg)" : "rotate(0deg)" }}>
+          <span
+            className="inline-block transition-transform"
+            style={{ transform: open ? "rotate(90deg)" : "rotate(0deg)" }}
+          >
             ▶
           </span>
           Legend

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -263,11 +263,22 @@ function CategorySection({
             <tr
               key={feature.id}
               className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
-              style={stripe ? { backgroundColor: "color-mix(in srgb, var(--bg-surface) 50%, var(--bg-muted))" } : undefined}
+              style={
+                stripe
+                  ? {
+                      backgroundColor:
+                        "color-mix(in srgb, var(--bg-surface) 50%, var(--bg-muted))",
+                    }
+                  : undefined
+              }
             >
               <td
                 className="sticky left-0 z-10 px-1 py-1 border-r border-[var(--border)] align-top"
-                style={{ backgroundColor: stripe ? "color-mix(in srgb, var(--bg-surface) 50%, var(--bg-muted))" : "var(--bg-surface)" }}
+                style={{
+                  backgroundColor: stripe
+                    ? "color-mix(in srgb, var(--bg-surface) 50%, var(--bg-muted))"
+                    : "var(--bg-surface)",
+                }}
               >
                 <div
                   className={

--- a/showcase/shell-dashboard/src/components/status-running-panel.tsx
+++ b/showcase/shell-dashboard/src/components/status-running-panel.tsx
@@ -47,10 +47,7 @@ const RESULT_ICON: Record<ServiceResult, string> = {
   red: "❌",
 };
 
-function serviceIcon(
-  state: ServiceState,
-  result?: ServiceResult,
-): string {
+function serviceIcon(state: ServiceState, result?: ServiceResult): string {
   if (state === "completed" && result) {
     return RESULT_ICON[result] ?? STATE_ICON[state];
   }
@@ -174,7 +171,9 @@ export function StatusRunningPanel({ entries }: StatusRunningPanelProps) {
                     data-state={s.state}
                     className="flex items-center gap-1.5 px-2 py-1 rounded border border-[var(--border)]"
                   >
-                    <span aria-hidden="true">{serviceIcon(s.state, s.result)}</span>
+                    <span aria-hidden="true">
+                      {serviceIcon(s.state, s.result)}
+                    </span>
                     <span className="font-mono truncate">{s.slug}</span>
                     {sElapsed && (
                       <span className="ml-auto text-[var(--text-muted)] tabular-nums">

--- a/showcase/shell-dashboard/src/components/status-runs-list.tsx
+++ b/showcase/shell-dashboard/src/components/status-runs-list.tsx
@@ -175,7 +175,11 @@ export function StatusRunsList({ runs }: StatusRunsListProps) {
                     {hasServices && (
                       <span
                         className="inline-block mr-1.5 text-[10px] text-[var(--text-muted)] transition-transform"
-                        style={{ transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)" }}
+                        style={{
+                          transform: isExpanded
+                            ? "rotate(90deg)"
+                            : "rotate(0deg)",
+                        }}
                       >
                         ▶
                       </span>
@@ -208,7 +212,10 @@ export function StatusRunsList({ runs }: StatusRunsListProps) {
                   </td>
                 </tr>
                 {isExpanded && hasServices && (
-                  <tr key={`${r.id}-detail`} className="border-b border-[var(--border)]">
+                  <tr
+                    key={`${r.id}-detail`}
+                    className="border-b border-[var(--border)]"
+                  >
                     <td colSpan={5} className="py-2 px-4">
                       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-1.5 text-[11px]">
                         {services.map((svc) => (

--- a/showcase/shell-dashboard/src/components/status-tab.tsx
+++ b/showcase/shell-dashboard/src/components/status-tab.tsx
@@ -27,7 +27,12 @@ export interface StatusTabProps {
   onSelectProbe: (probeId: string | null) => void;
 }
 
-export function StatusTab({ entries, onTrigger, selectedProbeId, onSelectProbe }: StatusTabProps) {
+export function StatusTab({
+  entries,
+  onTrigger,
+  selectedProbeId,
+  onSelectProbe,
+}: StatusTabProps) {
   return (
     <div data-testid="status-tab" className="flex flex-col">
       <StatusTable

--- a/showcase/shell-dashboard/src/components/status-table.tsx
+++ b/showcase/shell-dashboard/src/components/status-table.tsx
@@ -209,9 +209,7 @@ export function StatusTable({
               durationText = formatDuration(inflight.elapsedMs);
             } else {
               tone = lastRunTone(e.lastRun);
-              lastStartMs = e.lastRun
-                ? Date.parse(e.lastRun.startedAt)
-                : null;
+              lastStartMs = e.lastRun ? Date.parse(e.lastRun.startedAt) : null;
               durationText = e.lastRun
                 ? formatDuration(e.lastRun.durationMs)
                 : "—";

--- a/showcase/shell-dashboard/src/hooks/useOverlays.ts
+++ b/showcase/shell-dashboard/src/hooks/useOverlays.ts
@@ -63,7 +63,11 @@ function parseHash(): {
       ALL_OVERLAYS.includes(p as Overlay),
     );
     if (valid.length > 0) {
-      return { tab: "matrix", overlays: new Set(valid) as OverlaySet, probeId: null };
+      return {
+        tab: "matrix",
+        overlays: new Set(valid) as OverlaySet,
+        probeId: null,
+      };
     }
     return { tab: "matrix", overlays: null, probeId: null };
   }
@@ -154,13 +158,17 @@ export function useOverlays(): UseOverlaysReturn {
     () => new Set(DEFAULT_OVERLAYS) as OverlaySet,
   );
   const [activeTab, setActiveTabRaw] = useState<"matrix" | "ops">("matrix");
-  const [selectedProbeId, setSelectedProbeIdRaw] = useState<string | null>(null);
+  const [selectedProbeId, setSelectedProbeIdRaw] = useState<string | null>(
+    null,
+  );
 
   // Sync from URL hash / localStorage after hydration
   useEffect(() => {
     const { tab, overlays: fromHash, probeId } = parseHash();
     const resolved =
-      fromHash ?? loadFromStorage() ?? (new Set(DEFAULT_OVERLAYS) as OverlaySet);
+      fromHash ??
+      loadFromStorage() ??
+      (new Set(DEFAULT_OVERLAYS) as OverlaySet);
     setOverlays(resolved);
     setActiveTabRaw(tab);
     setSelectedProbeIdRaw(probeId);
@@ -180,7 +188,9 @@ export function useOverlays(): UseOverlaysReturn {
     function onPopState() {
       const { tab, overlays: fromHash, probeId } = parseHash();
       const resolved =
-        fromHash ?? loadFromStorage() ?? (new Set(DEFAULT_OVERLAYS) as OverlaySet);
+        fromHash ??
+        loadFromStorage() ??
+        (new Set(DEFAULT_OVERLAYS) as OverlaySet);
       setOverlays(resolved);
       setActiveTabRaw(tab);
       setSelectedProbeIdRaw(probeId);
@@ -232,13 +242,10 @@ export function useOverlays(): UseOverlaysReturn {
     [overlays],
   );
 
-  const selectProbe = useCallback(
-    (probeId: string | null) => {
-      setSelectedProbeIdRaw(probeId);
-      writeHash("ops", undefined, probeId, true);
-    },
-    [],
-  );
+  const selectProbe = useCallback((probeId: string | null) => {
+    setSelectedProbeIdRaw(probeId);
+    writeHash("ops", undefined, probeId, true);
+  }, []);
 
   const activePreset = useMemo(() => {
     for (const preset of PRESETS) {

--- a/showcase/shell-dashboard/tsconfig.json
+++ b/showcase/shell-dashboard/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- Auto-formats 16 files that accumulated formatting drift across recent PRs
- Fixes the `format` CI check that's been failing on main

## Files

README.md, express.ts, DEBUGGING.md, showcase README, render-red-tick test, conversation-runner, d5-mcp-subagents, and 9 shell-dashboard components/config files.

## Test plan

- [x] `pnpm run check-format` passes locally
- [ ] CI format check goes green