### PR TITLE
style(showcase/langroid): auto-format tool-rendering page

### DIFF
--- a/showcase/integrations/langroid/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/tool-rendering/page.tsx
@@ -44,7 +44,9 @@ function Chat() {
         feelsLike: parsed?.feels_like || parsed?.temperature || 0,
       };
 
-      const themeColor = loading ? "#667eea" : getThemeColor(weatherResult.conditions);
+      const themeColor = loading
+        ? "#667eea"
+        : getThemeColor(weatherResult.conditions);
 
       return (
         <WeatherCard
@@ -166,11 +168,15 @@ function WeatherCard({
                 </div>
                 <div data-testid="weather-wind">
                   <p className="text-white text-xs">Wind</p>
-                  <p className="text-white font-medium">{result.windSpeed} mph</p>
+                  <p className="text-white font-medium">
+                    {result.windSpeed} mph
+                  </p>
                 </div>
                 <div data-testid="weather-feels-like">
                   <p className="text-white text-xs">Feels Like</p>
-                  <p className="text-white font-medium">{result.feelsLike}&deg;</p>
+                  <p className="text-white font-medium">
+                    {result.feelsLike}&deg;
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Auto-format langroid tool-rendering page.tsx that was missed in PR #4449

## Test plan
- [x] `npx oxfmt --check` passes on the file