### PR TITLE
fix(showcase): add missing @copilotkit/voice dep to mastra and google-adk

### DIFF
--- a/showcase/integrations/google-adk/package.json
+++ b/showcase/integrations/google-adk/package.json
@@ -14,6 +14,7 @@
     "@copilotkit/a2ui-renderer": "next",
     "@copilotkit/react-core": "next",
     "@copilotkit/runtime": "next",
+    "@copilotkit/voice": "next",
     "@hashbrownai/core": "0.5.0-beta.4",
     "@hashbrownai/react": "0.5.0-beta.4",
     "@json-render/core": "0.18.0",

--- a/showcase/integrations/mastra/package.json
+++ b/showcase/integrations/mastra/package.json
@@ -17,6 +17,7 @@
     "@copilotkit/a2ui-renderer": "next",
     "@copilotkit/react-core": "next",
     "@copilotkit/runtime": "next",
+    "@copilotkit/voice": "next",
     "@hashbrownai/core": "0.5.0-beta.4",
     "@hashbrownai/react": "0.5.0-beta.4",
     "@json-render/core": "0.18.0",


### PR DESCRIPTION
## Summary
- Add `@copilotkit/voice` to mastra and google-adk package.json
- Mastra build was failing in CI; google-adk resolved via hoisting but adding explicitly

## Test plan
- [x] Audit confirmed these are the only two packages missing this dep