### PR TITLE
fix(showcase/ag2): remove __future__ annotations causing deploy crash

### DIFF
--- a/showcase/integrations/ag2/src/agents/agent_config_agent.py
+++ b/showcase/integrations/ag2/src/agents/agent_config_agent.py
@@ -19,8 +19,6 @@ References:
 - src/agents/shared_state_read_write.py — same ContextVariables pattern.
 """
 
-from __future__ import annotations
-
 import logging
 
 from autogen import ConversableAgent, LLMConfig


### PR DESCRIPTION
## Summary

- Remove `from __future__ import annotations` from `agent_config_agent.py` which causes the AG2 agent server to crash on startup with `PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.CallableSchema`
- The import turns `ContextVariables` type hints into string ForwardRefs that AG2's pydantic TypeAdapter can't resolve at tool registration time
- This fix was previously applied (cb2ef941) but reverted as part of the broader D2 revert (5a28b778)

## Test plan

- [x] Built Docker image locally and confirmed crash reproduction on current main
- [x] Applied fix, rebuilt, confirmed agent starts successfully (`Agent started (PID: 8)` vs previous `ERROR: Agent failed to start`)
- [x] Verified the current deployed GHCR image also crashes (pre-existing since the D2 revert)