### PR TITLE
fix: add showcase-aimock to CI build & deploy pipeline

### DIFF
--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -37,6 +37,7 @@ on:
           - shell-dashboard
           - shell-docs
           - showcase-harness
+          - showcase-aimock
 
 concurrency:
   # Key on `event_name + ref` so push events and manual workflow_dispatch
@@ -134,6 +135,8 @@ jobs:
               - 'showcase/shared/**'
               - 'showcase/scripts/**'
               - 'showcase/integrations/*/manifest.yaml'
+            showcase_aimock:
+              - 'showcase/aimock/**'
 
       - name: Build service matrix
         id: build-matrix
@@ -168,7 +171,8 @@ jobs:
             {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
             {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
             {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
-            {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"}
+            {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
+            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"}
           ]'
 
           DISPATCH="${{ github.event.inputs.service }}"

--- a/showcase/RUNBOOK.md
+++ b/showcase/RUNBOOK.md
@@ -94,6 +94,22 @@ Earned by bugs. Do not repeat.
 - **NEVER** assume "agent says done" means "D5 is green." Always run the actual test.
 - **NEVER** add a backend tool for something that should be a frontend HITL tool.
 
+## Aimock Fixture Deployment
+
+When adding or modifying fixture files in `showcase/aimock/`, the `showcase-aimock` image must be rebuilt so production picks up the changes. CI handles this automatically -- any push to `main` that touches `showcase/aimock/**` triggers the Build & Deploy workflow to rebuild and redeploy the image.
+
+For manual iteration (e.g. testing a fixture change before merging), build and push directly:
+
+```
+docker build --platform linux/amd64 -f showcase/aimock/Dockerfile -t ghcr.io/copilotkit/showcase-aimock:latest showcase/aimock/ --push
+```
+
+After pushing, redeploy the Railway service so it pulls the new image (the CI workflow does this automatically via `serviceInstanceRedeploy`).
+
+When adding a **new** fixture file, update both:
+1. `showcase/docker-compose.local.yml` -- add a volume mount for the new file
+2. `showcase/aimock/Dockerfile` -- add a `COPY` line for the new file
+
 ## Dev Iteration Speed
 
 Each integration service bind-mounts its host `src/` directory into the container via the `volumes` entry in `docker-compose.local.yml`:

--- a/showcase/aimock/Dockerfile
+++ b/showcase/aimock/Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/copilotkit/aimock:latest
+COPY d5-all.json /fixtures/d5-all.json
+COPY smoke.json /fixtures/smoke.json
+COPY feature-parity.json /fixtures/feature-parity.json

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -29,6 +29,12 @@ services:
     # Local aimock so the 17 integration containers can hit a stable LLM mock
     # on the compose network at http://aimock:4010 instead of the prod Railway
     # aimock (which can OOM) or direct-to-OpenAI (which costs).
+    #
+    # Local vs. production parity: local uses volume mounts (below) so fixture
+    # edits take effect on container restart without rebuilding. Production
+    # bakes fixtures into the image via showcase/aimock/Dockerfile. When adding
+    # a new fixture file, add it to BOTH the volumes list here AND the COPY
+    # lines in showcase/aimock/Dockerfile.
     image: ghcr.io/copilotkit/aimock:latest
     container_name: showcase-aimock
     env_file: .env


### PR DESCRIPTION
## Summary

- Add `showcase-aimock` to the Build & Deploy workflow matrix so fixture file changes in `showcase/aimock/` auto-deploy on merge to main
- Create `showcase/aimock/Dockerfile` -- thin overlay on `ghcr.io/copilotkit/aimock:latest` that bakes fixture files into the image
- Add local-vs-production parity comment in `docker-compose.local.yml` explaining that new fixture files must be added to both the volume mounts and the Dockerfile
- Add "Aimock Fixture Deployment" section to `showcase/RUNBOOK.md` with manual build command and new-fixture checklist

## Why

Production showcase-aimock was running a week-old image with no D5 fixtures because fixture file changes did not trigger a CI rebuild. This caused D5 probe failures that required manual intervention to resolve.

## Test plan

- [ ] CI workflow parses correctly (no YAML syntax errors)
- [ ] `workflow_dispatch` with `service=showcase-aimock` triggers the aimock build
- [ ] Push to `main` touching `showcase/aimock/**` triggers the aimock matrix leg