### PR TITLE
fix(react): render image attachments as compact thumbnails

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatAttachmentQueue.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAttachmentQueue.tsx
@@ -1,13 +1,13 @@
-import React, { useCallback, useEffect, useId, useRef, useState } from "react";
-import { createPortal, flushSync } from "react-dom";
+import React, { useEffect, useState } from "react";
 import type { Attachment } from "@copilotkit/shared";
 import {
   formatFileSize,
   getSourceUrl,
   getDocumentIcon,
 } from "@copilotkit/shared";
-import { Play, X } from "lucide-react";
+import { Play } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { Lightbox, useLightbox } from "./Lightbox";
 
 interface CopilotChatAttachmentQueueProps {
   attachments: Attachment[];
@@ -86,116 +86,6 @@ function AttachmentPreview({ attachment }: { attachment: Attachment }) {
     case "document":
       return <DocumentPreview attachment={attachment} />;
   }
-}
-
-// ---------------------------------------------------------------------------
-// Lightbox – fullscreen overlay for images and videos (portal to body)
-// Uses the View Transition API when available for a smooth thumbnail-to-
-// fullscreen morph; falls back to a simple opacity fade.
-// ---------------------------------------------------------------------------
-
-interface LightboxProps {
-  onClose: () => void;
-  children: React.ReactNode;
-}
-
-function Lightbox({ onClose, children }: LightboxProps) {
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [onClose]);
-
-  if (typeof document === "undefined") return null;
-
-  return createPortal(
-    <div
-      className="cpk:fixed cpk:inset-0 cpk:z-[9999] cpk:flex cpk:items-center cpk:justify-center cpk:bg-black/80 cpk:animate-fade-in"
-      onClick={onClose}
-    >
-      <button
-        onClick={onClose}
-        className="cpk:absolute cpk:top-4 cpk:right-4 cpk:text-white cpk:bg-white/10 cpk:hover:bg-white/20 cpk:rounded-full cpk:w-10 cpk:h-10 cpk:flex cpk:items-center cpk:justify-center cpk:cursor-pointer cpk:border-none cpk:z-10"
-        aria-label="Close preview"
-      >
-        <X className="cpk:w-5 cpk:h-5" />
-      </button>
-
-      <div onClick={(e) => e.stopPropagation()}>{children}</div>
-    </div>,
-    document.body,
-  );
-}
-
-type DocWithVT = Document & {
-  startViewTransition?: (cb: () => void) => { finished: Promise<void> };
-};
-
-/**
- * Hook that manages lightbox open/close and uses the View Transition API to
- * morph the thumbnail into fullscreen content.
- *
- * The trick: `view-transition-name` must live on exactly ONE element at a time.
- * - Old state (thumbnail visible): name is on the thumbnail.
- * - New state (lightbox visible): name moves to the lightbox content.
- * `flushSync` ensures React commits the DOM change synchronously inside the
- * `startViewTransition` callback so the API can snapshot old → new correctly.
- */
-function useLightbox() {
-  const thumbnailRef = useRef<HTMLElement>(null);
-  const [open, setOpen] = useState(false);
-  const vtName = useId();
-
-  const openLightbox = useCallback(() => {
-    const thumb = thumbnailRef.current;
-    const doc = document as DocWithVT;
-
-    if (doc.startViewTransition && thumb) {
-      // Old snapshot: name on the thumbnail
-      thumb.style.viewTransitionName = vtName;
-
-      doc.startViewTransition(() => {
-        // New snapshot: remove from thumb (lightbox content will have it)
-        thumb.style.viewTransitionName = "";
-        flushSync(() => setOpen(true));
-      });
-    } else {
-      setOpen(true);
-    }
-  }, []);
-
-  const closeLightbox = useCallback(() => {
-    const thumb = thumbnailRef.current;
-    const doc = document as DocWithVT;
-
-    if (doc.startViewTransition && thumb) {
-      const transition = doc.startViewTransition(() => {
-        // New snapshot: name back on thumbnail
-        flushSync(() => setOpen(false));
-        thumb.style.viewTransitionName = vtName;
-      });
-      // Clean up the name after animation finishes (or fails)
-      transition.finished
-        .then(() => {
-          thumb.style.viewTransitionName = "";
-        })
-        .catch(() => {
-          thumb.style.viewTransitionName = "";
-        });
-    } else {
-      setOpen(false);
-    }
-  }, []);
-
-  return {
-    thumbnailRef,
-    vtName,
-    open,
-    openLightbox,
-    closeLightbox,
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
@@ -36,7 +36,10 @@ const ImageAttachment = memo(function ImageAttachment({
     <img
       src={src}
       alt="Image attachment"
-      className={cn("cpk:max-w-full cpk:h-auto cpk:rounded-lg", className)}
+      className={cn(
+        "cpk:max-w-[300px] cpk:max-h-[300px] cpk:w-auto cpk:h-auto cpk:rounded-xl cpk:object-cover",
+        className,
+      )}
       onError={() => setError(true)}
     />
   );

--- a/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
@@ -2,6 +2,7 @@ import React, { memo, useState } from "react";
 import type { InputContentSource } from "@copilotkit/shared";
 import { getSourceUrl, getDocumentIcon } from "@copilotkit/shared";
 import { cn } from "../../lib/utils";
+import { Lightbox, useLightbox } from "./Lightbox";
 
 interface CopilotChatAttachmentRendererProps {
   type: "image" | "audio" | "video" | "document";
@@ -18,6 +19,8 @@ const ImageAttachment = memo(function ImageAttachment({
   className?: string;
 }) {
   const [error, setError] = useState(false);
+  const { thumbnailRef, vtName, open, openLightbox, closeLightbox } =
+    useLightbox();
 
   if (error) {
     return (
@@ -33,15 +36,29 @@ const ImageAttachment = memo(function ImageAttachment({
   }
 
   return (
-    <img
-      src={src}
-      alt="Image attachment"
-      className={cn(
-        "cpk:max-w-[300px] cpk:max-h-[300px] cpk:w-auto cpk:h-auto cpk:rounded-xl cpk:object-cover",
-        className,
+    <>
+      <img
+        ref={thumbnailRef as React.Ref<HTMLImageElement>}
+        src={src}
+        alt="Image attachment"
+        className={cn(
+          "cpk:max-w-[80px] cpk:max-h-[80px] cpk:w-auto cpk:h-auto cpk:rounded-xl cpk:object-cover cpk:cursor-pointer cpk:bg-muted",
+          className,
+        )}
+        onClick={openLightbox}
+        onError={() => setError(true)}
+      />
+      {open && (
+        <Lightbox onClose={closeLightbox}>
+          <img
+            style={{ viewTransitionName: vtName }}
+            src={src}
+            alt="Image attachment"
+            className="cpk:max-w-[90vw] cpk:max-h-[90vh] cpk:object-contain cpk:rounded-lg"
+          />
+        </Lightbox>
       )}
-      onError={() => setError(true)}
-    />
+    </>
   );
 });
 

--- a/packages/react-core/src/v2/components/chat/CopilotChatUserMessage.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatUserMessage.tsx
@@ -217,9 +217,8 @@ export function CopilotChatUserMessage({
       data-message-id={message.id}
       {...props}
     >
-      {BoundMessageRenderer}
       {mediaParts.length > 0 && (
-        <div className="cpk:flex cpk:flex-col cpk:items-end cpk:gap-2 cpk:mt-2">
+        <div className="cpk:flex cpk:flex-row cpk:flex-wrap cpk:justify-end cpk:gap-2 cpk:mb-2">
           {mediaParts.map((part, index) => (
             <CopilotChatAttachmentRenderer
               key={index}
@@ -230,6 +229,7 @@ export function CopilotChatUserMessage({
           ))}
         </div>
       )}
+      {BoundMessageRenderer}
       {BoundToolbar}
     </div>
   );

--- a/packages/react-core/src/v2/components/chat/Lightbox.tsx
+++ b/packages/react-core/src/v2/components/chat/Lightbox.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal, flushSync } from "react-dom";
 import { X } from "lucide-react";
 

--- a/packages/react-core/src/v2/components/chat/Lightbox.tsx
+++ b/packages/react-core/src/v2/components/chat/Lightbox.tsx
@@ -1,0 +1,109 @@
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { createPortal, flushSync } from "react-dom";
+import { X } from "lucide-react";
+
+interface LightboxProps {
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function Lightbox({ onClose, children }: LightboxProps) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="cpk:fixed cpk:inset-0 cpk:z-[9999] cpk:flex cpk:items-center cpk:justify-center cpk:bg-black/80 cpk:animate-fade-in"
+      onClick={onClose}
+    >
+      <button
+        onClick={onClose}
+        className="cpk:absolute cpk:top-4 cpk:right-4 cpk:text-white cpk:bg-white/10 cpk:hover:bg-white/20 cpk:rounded-full cpk:w-10 cpk:h-10 cpk:flex cpk:items-center cpk:justify-center cpk:cursor-pointer cpk:border-none cpk:z-10"
+        aria-label="Close preview"
+      >
+        <X className="cpk:w-5 cpk:h-5" />
+      </button>
+
+      <div onClick={(e) => e.stopPropagation()}>{children}</div>
+    </div>,
+    document.body,
+  );
+}
+
+type DocWithVT = Document & {
+  startViewTransition?: (cb: () => void) => { finished: Promise<void> };
+};
+
+/**
+ * Hook that manages lightbox open/close and uses the View Transition API to
+ * morph the thumbnail into fullscreen content.
+ *
+ * The trick: `view-transition-name` must live on exactly ONE element at a time.
+ * - Old state (thumbnail visible): name is on the thumbnail.
+ * - New state (lightbox visible): name moves to the lightbox content.
+ * `flushSync` ensures React commits the DOM change synchronously inside the
+ * `startViewTransition` callback so the API can snapshot old → new correctly.
+ */
+export function useLightbox() {
+  const thumbnailRef = useRef<HTMLElement>(null);
+  const [open, setOpen] = useState(false);
+  const vtName = useId();
+
+  const openLightbox = useCallback(() => {
+    const thumb = thumbnailRef.current;
+    const doc = document as DocWithVT;
+
+    if (doc.startViewTransition && thumb) {
+      thumb.style.viewTransitionName = vtName;
+
+      doc.startViewTransition(() => {
+        thumb.style.viewTransitionName = "";
+        flushSync(() => setOpen(true));
+      });
+    } else {
+      setOpen(true);
+    }
+  }, [vtName]);
+
+  const closeLightbox = useCallback(() => {
+    const thumb = thumbnailRef.current;
+    const doc = document as DocWithVT;
+
+    if (doc.startViewTransition && thumb) {
+      const transition = doc.startViewTransition(() => {
+        flushSync(() => setOpen(false));
+        thumb.style.viewTransitionName = vtName;
+      });
+      transition.finished
+        .then(() => {
+          thumb.style.viewTransitionName = "";
+        })
+        .catch(() => {
+          thumb.style.viewTransitionName = "";
+        });
+    } else {
+      setOpen(false);
+    }
+  }, [vtName]);
+
+  return {
+    thumbnailRef,
+    vtName,
+    open,
+    openLightbox,
+    closeLightbox,
+  };
+}

--- a/packages/react-ui/src/css/messages.css
+++ b/packages/react-ui/src/css/messages.css
@@ -208,9 +208,12 @@
 }
 
 .copilotKitImageRenderingImage {
-  max-width: 100%;
+  max-width: 300px;
+  max-height: 300px;
+  width: auto;
   height: auto;
-  border-radius: 8px;
+  object-fit: cover;
+  border-radius: 12px;
   box-shadow: var(--copilot-kit-shadow-sm);
 }
 

--- a/packages/react-ui/src/css/messages.css
+++ b/packages/react-ui/src/css/messages.css
@@ -208,13 +208,15 @@
 }
 
 .copilotKitImageRenderingImage {
-  max-width: 300px;
-  max-height: 300px;
+  max-width: 80px;
+  max-height: 80px;
   width: auto;
   height: auto;
   object-fit: cover;
   border-radius: 12px;
+  background-color: var(--copilot-kit-input-background-color);
   box-shadow: var(--copilot-kit-shadow-sm);
+  cursor: pointer;
 }
 
 .copilotKitImageRenderingContent {


### PR DESCRIPTION
## What does this PR do?

Polish image attachments in chat. Previously they rendered at the full message
width, taking up most of the screen. After this PR they render as compact 80x80
thumbnails — closer to how Claude shows attached images.

**Layout & sizing**
- Image attachments render as 80x80 thumbnails with `object-cover`, 12px
  rounded corners, and a muted background so transparent PNGs stay readable.
- Multiple attachments lay out in a horizontal row (`flex-row` + `flex-wrap` +
  `justify-end`) instead of stacking vertically.
- Attachments render *above* the message text instead of below.

**Click-to-zoom**
- Clicking a thumbnail opens it in a fullscreen lightbox with a smooth
  view-transition morph (same UX as the attachment queue preview).
- The `Lightbox` + `useLightbox` previously private to
  `CopilotChatAttachmentQueue` got extracted into a shared module
  (`packages/react-core/src/v2/components/chat/Lightbox.tsx`) so the queue and
  the rendered message attachment share one modal implementation.

**Both renderers updated**
- v2 (Tailwind): `CopilotChatAttachmentRenderer.tsx` + `CopilotChatUserMessage.tsx`
- legacy (CSS): `packages/react-ui/src/css/messages.css`

## Related PRs and Issues

- N/A

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked