### PR TITLE
fix(showcase): release pooled browsers on abort to prevent D5 pool starvation

### DIFF
--- a/showcase/harness/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   createE2eDeepDriver,
+  createPooledE2eDeepLauncher,
   D5_SCRIPT_FILE_MATCHER,
   e2eDeepDriver,
   FEATURE_CONCURRENCY,
@@ -1080,5 +1081,249 @@ describe("e2e-deep graceful degradation (FEATURE_CONCURRENCY=1 equivalent)", () 
     expect(state.contextsOpened).toBe(2);
     expect(state.contextsClosed).toBe(2);
     expect(state.closed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Pool starvation fix — verifies that createPooledE2eDeepLauncher
+// releases browsers back to the pool when the abort signal fires,
+// preventing cascading starvation when Promise.race abandons the
+// driver promise on timeout.
+// ---------------------------------------------------------------------
+describe("createPooledE2eDeepLauncher abort release", () => {
+  /**
+   * Minimal fake pool that tracks acquire/release calls. Uses a simple
+   * array of fake browsers with an available/in-use split. The fake
+   * browsers satisfy the Playwright Browser interface just enough for
+   * the pooled launcher to call newContext() on them.
+   */
+  function makeFakePool(size: number) {
+    interface FakeBrowser {
+      id: number;
+      newContext(): Promise<{
+        newPage(): Promise<{
+          on: (event: string, handler: (...args: unknown[]) => void) => void;
+          waitForSelector: () => Promise<void>;
+          fill: () => Promise<void>;
+          press: () => Promise<void>;
+          evaluate: () => Promise<unknown>;
+          goto: () => Promise<void>;
+          close: () => Promise<void>;
+          click: () => Promise<void>;
+          waitForFunction: () => Promise<void>;
+        }>;
+        close(): Promise<void>;
+      }>;
+      close(): Promise<void>;
+    }
+
+    const browsers: FakeBrowser[] = [];
+    for (let i = 0; i < size; i++) {
+      let contextsClosed = 0;
+      browsers.push({
+        id: i,
+        async newContext() {
+          return {
+            async newPage() {
+              return {
+                on: () => {},
+                waitForSelector: async () => {},
+                fill: async () => {},
+                press: async () => {},
+                evaluate: async () => 0,
+                goto: async () => {},
+                close: async () => {},
+                click: async () => {},
+                waitForFunction: async () => {},
+              };
+            },
+            async close() {
+              contextsClosed++;
+            },
+          };
+        },
+        async close() {},
+      });
+    }
+
+    const available = [...browsers];
+    const releaseLog: number[] = [];
+    const acquireLog: number[] = [];
+
+    const pool = {
+      async acquire(): Promise<unknown> {
+        const browser = available.shift();
+        if (!browser) throw new Error("FakePool: no browsers available");
+        acquireLog.push(browser.id);
+        return browser;
+      },
+      release(browser: unknown): void {
+        const fb = browser as FakeBrowser;
+        releaseLog.push(fb.id);
+        available.push(fb);
+      },
+      stats() {
+        return {
+          size,
+          available: available.length,
+          inUse: size - available.length,
+          totalRecycles: 0,
+        };
+      },
+      // Expose internals for assertions.
+      get _available() {
+        return available;
+      },
+      get _releaseLog() {
+        return releaseLog;
+      },
+      get _acquireLog() {
+        return acquireLog;
+      },
+    };
+
+    return pool;
+  }
+
+  it("releases browser back to pool when abort signal fires (prevents starvation)", async () => {
+    const pool = makeFakePool(2);
+    // Cast: the fake pool satisfies BrowserPool structurally for the
+    // subset of methods createPooledE2eDeepLauncher uses.
+    const launcher = createPooledE2eDeepLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    // Acquire both browsers through the launcher.
+    const abortCtrl1 = new AbortController();
+    const abortCtrl2 = new AbortController();
+    const browser1 = await launcher(abortCtrl1.signal);
+    const browser2 = await launcher(abortCtrl2.signal);
+
+    // Both browsers are now in use — pool should have 0 available.
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBe(2);
+
+    // Simulate timeout: abort signal fires for browser1.
+    abortCtrl1.abort();
+
+    // Give the abort handler's async context-close + release a tick.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Browser1 should be released back to the pool.
+    expect(pool._releaseLog).toContain(0);
+    expect(pool.stats().available).toBe(1);
+
+    // The driver's finally block eventually calls browser.close() —
+    // verify it's a no-op (doesn't double-release).
+    await browser1.close();
+    // Still only 1 release for browser 0.
+    expect(pool._releaseLog.filter((id) => id === 0)).toHaveLength(1);
+
+    // Browser2 is still held — normal close releases it.
+    await browser2.close();
+    expect(pool._releaseLog).toContain(1);
+    expect(pool.stats().available).toBe(2);
+  });
+
+  it("closes open contexts before releasing on abort", async () => {
+    const pool = makeFakePool(1);
+    const launcher = createPooledE2eDeepLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    const abortCtrl = new AbortController();
+    const browser = await launcher(abortCtrl.signal);
+
+    // Open a context (simulates the driver opening a page).
+    const ctx = await browser.newContext();
+    const _page = await ctx.newPage();
+
+    // Abort fires — should close context then release.
+    abortCtrl.abort();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Browser released back to pool.
+    expect(pool._releaseLog).toHaveLength(1);
+    expect(pool.stats().available).toBe(1);
+  });
+
+  it("handles already-aborted signal (releases immediately)", async () => {
+    const pool = makeFakePool(1);
+    const launcher = createPooledE2eDeepLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    // Pre-aborted signal.
+    const abortCtrl = new AbortController();
+    abortCtrl.abort();
+
+    const browser = await launcher(abortCtrl.signal);
+
+    // Should be released immediately (synchronously after acquire).
+    expect(pool._releaseLog).toHaveLength(1);
+    expect(pool.stats().available).toBe(1);
+
+    // Driver's close is a no-op.
+    await browser.close();
+    expect(pool._releaseLog).toHaveLength(1);
+  });
+
+  it("full pool starvation scenario: all slots acquired, timeout releases them for next run", async () => {
+    const POOL_SIZE = 4;
+    const pool = makeFakePool(POOL_SIZE);
+    const launcher = createPooledE2eDeepLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    // Simulate a probe run that acquires all 4 pool slots.
+    const abortCtrls = Array.from({ length: POOL_SIZE }, () => new AbortController());
+    const browsers = await Promise.all(
+      abortCtrls.map((ac) => launcher(ac.signal)),
+    );
+
+    // Pool is fully exhausted.
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBe(POOL_SIZE);
+
+    // Simulate timeout: abort all signals (as the invoker would).
+    for (const ac of abortCtrls) ac.abort();
+    await new Promise((r) => setTimeout(r, 20));
+
+    // All browsers should be released back to the pool.
+    expect(pool.stats().available).toBe(POOL_SIZE);
+    expect(pool._releaseLog).toHaveLength(POOL_SIZE);
+
+    // Next probe run can now acquire all 4 browsers.
+    const nextAbortCtrls = Array.from({ length: POOL_SIZE }, () => new AbortController());
+    const nextBrowsers = await Promise.all(
+      nextAbortCtrls.map((ac) => launcher(ac.signal)),
+    );
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBe(POOL_SIZE);
+
+    // Clean up: normal close for the second run.
+    for (const b of nextBrowsers) await b.close();
+    expect(pool.stats().available).toBe(POOL_SIZE);
+
+    // Driver's finally block for the first run — all no-ops.
+    for (const b of browsers) await b.close();
+    // No extra releases — still POOL_SIZE total from the abort +
+    // POOL_SIZE from the second run's normal close.
+    expect(pool._releaseLog).toHaveLength(POOL_SIZE * 2);
+  });
+
+  it("no-abort path: browser released normally via close()", async () => {
+    const pool = makeFakePool(1);
+    const launcher = createPooledE2eDeepLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    // No abort signal at all (backwards compat with defaultLauncher).
+    const browser = await launcher();
+    expect(pool.stats().available).toBe(0);
+
+    await browser.close();
+    expect(pool._releaseLog).toHaveLength(1);
+    expect(pool.stats().available).toBe(1);
   });
 });

--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -202,7 +202,9 @@ export interface E2eDeepBrowser {
   close(): Promise<void>;
 }
 
-export type E2eDeepBrowserLauncher = () => Promise<E2eDeepBrowser>;
+export type E2eDeepBrowserLauncher = (
+  abortSignal?: AbortSignal,
+) => Promise<E2eDeepBrowser>;
 
 /**
  * Script loader — invoked once per driver invocation (the registry is
@@ -362,11 +364,56 @@ const defaultLauncher: E2eDeepBrowserLauncher =
 export function createPooledE2eDeepLauncher(
   pool: BrowserPool,
 ): E2eDeepBrowserLauncher {
-  return async (): Promise<E2eDeepBrowser> => {
+  return async (abortSignal?: AbortSignal): Promise<E2eDeepBrowser> => {
     const browser = await pool.acquire();
+
+    // Track whether the browser was force-released by an abort so the
+    // driver's normal `browser.close()` in the finally block doesn't
+    // double-release (BrowserPool.release is a no-op for unknown refs
+    // after the browserToSlot entry is removed, but the close() would
+    // fail on an already-closed browser without the guard).
+    let forceReleased = false;
+
+    // Track open browser contexts so abort can close them before
+    // releasing the browser back to the pool. Without this, orphaned
+    // contexts keep the browser busy and the pool slot is effectively
+    // dead until the contexts are GC'd or the browser process crashes.
+    const openContexts = new Set<{ close(): Promise<void> }>();
+
+    // Abort listener: when the invoker's timeout fires, the abort
+    // signal triggers. Force-close all open contexts and release the
+    // browser back to the pool immediately so the next probe run can
+    // acquire it. This prevents pool starvation when Promise.race
+    // abandons the driver promise but the driver keeps running with
+    // the pooled browser held.
+    if (abortSignal) {
+      const onAbort = (): void => {
+        if (forceReleased) return;
+        forceReleased = true;
+        // Close contexts first (best-effort), then release. The
+        // close calls may throw if the context is already torn down
+        // -- that's fine, the pool release is what matters.
+        const contextClosePromises = Array.from(openContexts).map((ctx) =>
+          ctx.close().catch(() => {}),
+        );
+        void Promise.allSettled(contextClosePromises).then(() => {
+          pool.release(browser);
+        });
+      };
+      if (abortSignal.aborted) {
+        // Already aborted before we even acquired -- release immediately.
+        forceReleased = true;
+        pool.release(browser);
+      } else {
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
     return {
       async newContext(): Promise<E2eDeepBrowserContext> {
         const ctx = await browser.newContext();
+        const ctxHandle = { close: () => ctx.close() };
+        openContexts.add(ctxHandle);
         return {
           async newPage(): Promise<E2eDeepPage> {
             const page = await ctx.newPage();
@@ -411,10 +458,14 @@ export function createPooledE2eDeepLauncher(
             };
             return wrapped;
           },
-          close: () => ctx.close(),
+          close: async () => {
+            openContexts.delete(ctxHandle);
+            await ctx.close();
+          },
         };
       },
       close: async () => {
+        if (forceReleased) return;
         pool.release(browser);
       },
     };
@@ -678,7 +729,7 @@ export function createE2eDeepDriver(
       let browser: E2eDeepBrowser | undefined;
       try {
         try {
-          browser = await launcher();
+          browser = await launcher(abort.signal);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.warn("probe.e2e-deep.launcher-error", { slug, err: msg });


### PR DESCRIPTION
## Summary

- Wire abort signal through to `createPooledE2eDeepLauncher` so pooled browsers are force-released when the invoker's timeout fires
- Track open browser contexts and close them before releasing on abort to prevent orphaned contexts
- Guard against double-release with a `forceReleased` flag so the driver's finally block is a no-op after abort

## Root cause

When `executeOne`'s `Promise.race` timeout fires, it returns the timeout result but the driver promise continues running with a pooled browser acquired. The browser is not released back to the pool until the driver eventually finishes (up to 5 minutes later). Since pool size (4) equals `max_concurrency` (4), one orphaned browser means the next probe run (15 minutes later) can only acquire 3 browsers. Orphans accumulate across ticks, causing cascading starvation that manifests as D5 probe flapping in production.

## Changes

- `E2eDeepBrowserLauncher` type now accepts an optional `AbortSignal`
- `createPooledE2eDeepLauncher` registers an abort listener that closes open contexts and releases the browser back to the pool immediately
- Driver's `run()` passes its abort signal to the launcher
- 5 new tests covering: abort release, context cleanup on abort, pre-aborted signal, full starvation scenario with pool recovery, and backwards-compat no-signal path

## Test plan

- [x] 5 new unit tests for the pooled launcher abort behavior (all pass)
- [x] Full harness test suite: 1372 tests pass, 0 failures
- [x] TypeScript typecheck clean