### PR TITLE
fix(showcase): add logging to pool abort-release path

### DIFF
--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -894,7 +894,9 @@ export function registerAllProbeDrivers(
       createE2eDemosDriver({ launcher: createPooledE2eDemosLauncher(pool) }),
     );
     probeRegistry.register(
-      createE2eDeepDriver({ launcher: createPooledE2eDeepLauncher(pool) }),
+      createE2eDeepDriver({
+        launcher: createPooledE2eDeepLauncher(pool, logger),
+      }),
     );
     probeRegistry.register(
       createE2eParityDriver({ launcher: createPooledE2eParityLauncher(pool) }),

--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -363,6 +363,7 @@ const defaultLauncher: E2eDeepBrowserLauncher =
 
 export function createPooledE2eDeepLauncher(
   pool: BrowserPool,
+  logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eDeepBrowserLauncher {
   return async (abortSignal?: AbortSignal): Promise<E2eDeepBrowser> => {
     const browser = await pool.acquire();
@@ -390,19 +391,28 @@ export function createPooledE2eDeepLauncher(
       const onAbort = (): void => {
         if (forceReleased) return;
         forceReleased = true;
-        // Close contexts first (best-effort), then release. The
-        // close calls may throw if the context is already torn down
-        // -- that's fine, the pool release is what matters.
+        const ctxCount = openContexts.size;
+        const stats = pool.stats();
+        logger?.warn("probe.e2e-deep.pool-abort-release", {
+          openContexts: ctxCount,
+          poolAvailable: stats.available,
+          poolInUse: stats.inUse,
+          poolSize: stats.size,
+        });
         const contextClosePromises = Array.from(openContexts).map((ctx) =>
           ctx.close().catch(() => {}),
         );
         void Promise.allSettled(contextClosePromises).then(() => {
           pool.release(browser);
+          logger?.warn("probe.e2e-deep.pool-abort-released", {
+            closedContexts: ctxCount,
+            poolAvailable: pool.stats().available,
+          });
         });
       };
       if (abortSignal.aborted) {
-        // Already aborted before we even acquired -- release immediately.
         forceReleased = true;
+        logger?.warn("probe.e2e-deep.pool-pre-aborted-release");
         pool.release(browser);
       } else {
         abortSignal.addEventListener("abort", onAbort, { once: true });


### PR DESCRIPTION
## Summary
- Log pool stats when abort signal force-releases a browser back to the pool
- Provides visibility into starvation events for diagnosis in Railway logs

Follow-up to PR #4460 which added the abort-release mechanism but no telemetry.

## Test plan
- [x] 1372 harness tests pass