### PR TITLE
fix(suggestions): show available:"always" pills on welcome screen with runtimeUrl

### DIFF
--- a/packages/core/src/core/suggestion-engine.ts
+++ b/packages/core/src/core/suggestion-engine.ts
@@ -67,14 +67,15 @@ export class SuggestionEngine {
 
     // Use the provided agent instance when available; fall back to the registry agent.
     // Per-thread clones hold the actual conversation messages; the registry agent does not.
+    // The agent may legitimately be missing here (e.g. runtime info still loading,
+    // or the consumer agent is configured but not yet registered) — static suggestions
+    // don't need it, only dynamic generation does. Treat that case as "no messages yet"
+    // and process static configs anyway.
     const agent =
       consumerAgent ??
       (this.core as unknown as CopilotKitCoreFriendsAccess).getAgent(agentId);
-    if (!agent) {
-      return;
-    }
 
-    const messageCount = agent.messages?.length ?? 0;
+    const messageCount = agent?.messages?.length ?? 0;
     let hasAnySuggestions = false;
 
     for (const config of Object.values(this._suggestionsConfig)) {
@@ -95,6 +96,12 @@ export class SuggestionEngine {
       const suggestionId = randomUUID();
 
       if (isDynamicSuggestionsConfig(config)) {
+        // Dynamic suggestions need a real agent (provider + consumer messages).
+        // Skip when the agent isn't ready yet — `reloadSuggestions` will be
+        // called again once it is.
+        if (!agent) {
+          continue;
+        }
         if (!hasAnySuggestions) {
           hasAnySuggestions = true;
           void this.notifySuggestionsStartedLoading(agentId);

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.suggestionsAlways.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.suggestionsAlways.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, vi } from "vitest";
+import { useConfigureSuggestions } from "../../../hooks/use-configure-suggestions";
+import { CopilotChat } from "../CopilotChat";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import {
+  MockStepwiseAgent,
+  runStartedEvent,
+  runFinishedEvent,
+  textChunkEvent,
+  testId,
+} from "../../../__tests__/utils/test-helpers";
+import type { AutoScrollMode } from "../normalize-auto-scroll";
+
+// jsdom doesn't implement scrollTo; pin-to-send mode calls it from a rAF
+// callback, so without this stub the cleanup throws an unhandled error.
+beforeEach(() => {
+  HTMLElement.prototype.scrollTo = vi.fn();
+});
+
+const STATIC_SUGGESTIONS = [
+  { title: "Say hello", message: "Hello there!" },
+  { title: "Get help", message: "Can you help me?" },
+];
+
+const ChatWithStaticAlwaysSuggestions: React.FC<{
+  autoScroll?: AutoScrollMode | boolean;
+  consumerAgentId?: string;
+}> = ({ autoScroll, consumerAgentId }) => {
+  useConfigureSuggestions({
+    suggestions: STATIC_SUGGESTIONS,
+    available: "always",
+    ...(consumerAgentId ? { consumerAgentId } : {}),
+  });
+
+  return <CopilotChat autoScroll={autoScroll} />;
+};
+
+function renderChat({
+  agent,
+  autoScroll,
+  consumerAgentId,
+}: {
+  agent: MockStepwiseAgent;
+  autoScroll?: AutoScrollMode | boolean;
+  consumerAgentId?: string;
+}) {
+  return render(
+    <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+      <div style={{ height: 400 }}>
+        <ChatWithStaticAlwaysSuggestions
+          autoScroll={autoScroll}
+          consumerAgentId={consumerAgentId}
+        />
+      </div>
+    </CopilotKitProvider>,
+  );
+}
+
+describe("CopilotChat - static suggestions with available:'always'", () => {
+  it("should show suggestions on the welcome screen", async () => {
+    const agent = new MockStepwiseAgent();
+    renderChat({ agent, consumerAgentId: "default" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Say hello")).toBeDefined();
+      expect(screen.getByText("Get help")).toBeDefined();
+    });
+  });
+
+  it("should show suggestions on the welcome screen with global config (no consumerAgentId)", async () => {
+    const agent = new MockStepwiseAgent();
+    renderChat({ agent });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Say hello")).toBeDefined();
+      expect(screen.getByText("Get help")).toBeDefined();
+    });
+  });
+
+  it("should hide suggestions during a run and restore them after", async () => {
+    const agent = new MockStepwiseAgent();
+    renderChat({ agent, consumerAgentId: "default" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Say hello")).toBeDefined();
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Hi!" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hi!")).toBeDefined();
+    });
+
+    const messageId = testId("msg");
+    agent.emit(runStartedEvent());
+    agent.emit(textChunkEvent(messageId, "Hello! How can I help?"));
+
+    // While the run is in flight, suggestions should be hidden — every run
+    // changes the conversation context, so we wait for the end-of-run reload
+    // before showing them again.
+    await waitFor(() => {
+      expect(screen.queryByText("Say hello")).toBeNull();
+      expect(screen.queryByText("Get help")).toBeNull();
+    });
+
+    agent.emit(runFinishedEvent());
+    agent.complete();
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello! How can I help?")).toBeDefined();
+    });
+
+    // After the run, the static "always" config repopulates them.
+    await waitFor(
+      () => {
+        expect(screen.getByText("Say hello")).toBeDefined();
+        expect(screen.getByText("Get help")).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("should hide suggestions during a run in pin-to-send mode", async () => {
+    const agent = new MockStepwiseAgent();
+    renderChat({ agent, autoScroll: "pin-to-send" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Say hello")).toBeDefined();
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Hi!" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hi!")).toBeDefined();
+    });
+
+    const messageId = testId("msg");
+    agent.emit(runStartedEvent());
+    agent.emit(textChunkEvent(messageId, "Hello! How can I help?"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Say hello")).toBeNull();
+      expect(screen.queryByText("Get help")).toBeNull();
+    });
+
+    agent.emit(runFinishedEvent());
+    agent.complete();
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello! How can I help?")).toBeDefined();
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Say hello")).toBeDefined();
+        expect(screen.getByText("Get help")).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+  });
+});

--- a/packages/react-core/src/v2/hooks/use-configure-suggestions.tsx
+++ b/packages/react-core/src/v2/hooks/use-configure-suggestions.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useCopilotKit } from "../providers/CopilotKitProvider";
 import { useCopilotChatConfiguration } from "../providers/CopilotChatConfigurationProvider";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
-import {
+import type {
   DynamicSuggestionsConfig,
   StaticSuggestionsConfig,
   SuggestionsConfig,
@@ -211,7 +211,13 @@ export function useConfigureSuggestions(
     return () => {
       subscription.unsubscribe();
     };
-  }, [copilotkit, normalizedConfig, isDynamicConfigType, targetAgentId, requestReload]);
+  }, [
+    copilotkit,
+    normalizedConfig,
+    isDynamicConfigType,
+    targetAgentId,
+    requestReload,
+  ]);
 }
 
 function isDynamicConfig(

--- a/packages/react-core/src/v2/hooks/use-configure-suggestions.tsx
+++ b/packages/react-core/src/v2/hooks/use-configure-suggestions.tsx
@@ -106,21 +106,36 @@ export function useConfigureSuggestions(
   const isGlobalConfig =
     rawConsumerAgentId === undefined || rawConsumerAgentId === "*";
 
+  const isDynamicConfigType = useMemo(
+    () => !!normalizedConfig && "instructions" in normalizedConfig,
+    [normalizedConfig],
+  );
+
   const requestReload = useCallback(() => {
     if (!normalizedConfig) {
       return;
     }
 
     if (isGlobalConfig) {
+      const seen = new Set<string>();
       const agents = Object.values(copilotkit.agents ?? {});
       for (const entry of agents) {
         const agentId = entry.agentId;
         if (!agentId) {
           continue;
         }
+        seen.add(agentId);
         if (!entry.isRunning) {
           copilotkit.reloadSuggestions(agentId);
         }
+      }
+      // Also reload for the chat's resolved consumer agent. The registry can
+      // be empty at this point (e.g. runtime info still loading), in which
+      // case the loop above wouldn't have fired for the agent the user is
+      // actually chatting with — and the welcome screen would render with
+      // no suggestions until they navigate away and back.
+      if (targetAgentId && !seen.has(targetAgentId)) {
+        copilotkit.reloadSuggestions(targetAgentId);
       }
       return;
     }
@@ -169,6 +184,34 @@ export function useConfigureSuggestions(
     }
     requestReload();
   }, [extraDeps.length, normalizedConfig, requestReload, ...extraDeps]);
+
+  // When agents arrive after the initial render (runtime info just landed),
+  // re-request a reload so dynamic configs that need a real agent can finally
+  // generate.  Skip for static configs — they don't need an agent and the
+  // initial mount reload already handled them.  Skip when the target agent
+  // is already in the registry — the initial reload already covered it, and
+  // re-firing on every subsequent `onAgentsChanged` (e.g. dev-mode hot
+  // reloads, sibling chat configs mounting) would stack overlapping
+  // generations.
+  useEffect(() => {
+    if (!normalizedConfig || !isDynamicConfigType) return;
+    if (!targetAgentId) return;
+
+    const initiallyPresent = !!copilotkit.getAgent(targetAgentId);
+    if (initiallyPresent) return;
+
+    const subscription = copilotkit.subscribe({
+      onAgentsChanged: () => {
+        if (copilotkit.getAgent(targetAgentId)) {
+          requestReload();
+          subscription.unsubscribe();
+        }
+      },
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [copilotkit, normalizedConfig, isDynamicConfigType, targetAgentId, requestReload]);
 }
 
 function isDynamicConfig(


### PR DESCRIPTION
## Summary

`available: "always"` suggestion configs (static and dynamic) didn't render on the welcome screen when the chat used `runtimeUrl` to fetch agents instead of registering them locally with `agents__unsafe_dev_only`.

The bug has been latent since v2 first landed (Dec 2025); a per-thread cloning change masked it for some flows from Mar 31 → Apr 23, and the Apr 23 revert (#3525 backout) re-exposed it.

This PR is welcome-screen only — the `!isConnecting && !isRunning` UI gate is unchanged, so suggestions still hide during connect/replay and during runs as before.

## What was broken

With `runtimeUrl`, the agents registry is empty during the initial `/info` fetch. Two compounding issues meant `available: "always"` configs never got off the ground:

1. **`SuggestionEngine.reloadSuggestions`** bailed early when the consumer agent wasn't in the registry yet. The first reload fires from `useConfigureSuggestions` on mount — at that moment the registry is empty, so every config got skipped. Static pills never appeared, and dynamic pills never even started generating.
2. **`useConfigureSuggestions`'s global-config path** (no `consumerAgentId` or `"*"`) only iterated the current agents map. Empty map → zero reload calls → suggestions stuck empty until something else triggered a reload.

## Fix

Three small changes, scoped to the welcome screen path:

1. `SuggestionEngine.reloadSuggestions` no longer bails when the agent's missing — defaults `messageCount` to 0 and processes static configs anyway. Dynamic configs still skip until a real agent arrives.
2. `useConfigureSuggestions`'s global path also calls `reloadSuggestions(targetAgentId)` directly (covers the empty-map case where the agent the chat is bound to isn't yet in the registry).
3. `useConfigureSuggestions` subscribes to `onAgentsChanged` *only* for dynamic configs, *only* when the target agent isn't yet present, and *unsubscribes after firing once*. Dynamic pills catch up after the runtime fetch completes, without piling up overlapping generations as multiple hooks mount.

## What's preserved

- `hasSuggestions` keeps `!isConnecting && !isRunning` — bootstrap replay and run-in-flight both still hide pills (no mid-replay layout jump, no stale-context flash mid-run).
- `available: "always"` is the *eligibility window* (welcome screen vs after first message), not a "render through transitions" override.
- Threading behavior (thread switch, explicit `threadId`, multi-chat) is unchanged. None of the new code paths fire on thread connects.

## Test plan

- [x] `packages/core` — engine unit tests for `reloadSuggestions` when no agent is present + when only static "always" config exists. All 59 core-suggestions tests pass.
- [x] `packages/react-core` — 4 integration tests in `CopilotChat.suggestionsAlways.test.tsx`:
  - shows on welcome screen with explicit `consumerAgentId`
  - shows on welcome screen with global config
  - hides during a run, reappears after (default scroll)
  - hides during a run, reappears after (pin-to-send)
- [x] All 1157 react-core tests pass.
- [ ] Manual smoke in `examples/v2/react/demo` with both static and dynamic `available: "always"` configs — welcome screen pills, hide during run, regenerate after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)