### PR TITLE
fix(runtime): restore durable connect and replay parity

### DIFF
--- a/docs/content/docs/(root)/runtime-server-adapter.mdx
+++ b/docs/content/docs/(root)/runtime-server-adapter.mdx
@@ -33,6 +33,12 @@ The runtime supports two endpoint modes:
 
 Single-route mode is useful when your platform only allows a single route handler (e.g. a single serverless function), or when you prefer a simpler URL structure.
 
+For Intelligence-mode thread restore, `POST {basePath}/agent/:agentId/connect` has a small but important contract:
+
+- `200` means the runtime found a persisted thread and is returning realtime credentials for replay/resume.
+- `204` means the requested thread should be treated as fresh; this is expected for a brand-new explicit thread and should not be surfaced as an error.
+- `lastSeenEventId` is only meaningful for incremental reconnect after the client already has a replay baseline; otherwise the client should send `null` and expect a full restore.
+
 ## Fetch-Native Runtimes
 
 If your platform supports the Fetch API natively (Bun, Deno, Cloudflare Workers, etc.), you can use `createCopilotRuntimeHandler` directly — no adapter needed.

--- a/docs/content/docs/(root)/threads.mdx
+++ b/docs/content/docs/(root)/threads.mdx
@@ -229,6 +229,20 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
       </Step>
 
       <Step>
+        ### Understand `/connect` in Intelligence mode
+
+        `POST /agent/:agentId/connect` is the restore handshake for a caller-managed thread in Intelligence mode. It is used to answer one question: "does this thread already exist on the backend, and if so, where should the client resume replay?"
+
+        - Fresh local chat with no explicit `threadId`: do not call `/connect`. The UI stays on the local welcome screen until the first user message creates a real thread.
+        - Explicit `threadId` that does not exist yet: `/connect` is expected and may return `204 No Content`. That means "treat this as a brand-new thread" rather than an error.
+        - Explicit `threadId` that already exists: `/connect` returns `200` with realtime credentials and the canonical thread identity so the client can replay and resume safely.
+
+        `lastSeenEventId` is only for incremental reconnect. When the client has already observed replayed or live events for the current baseline, it sends the latest event id so the backend can resume from that cursor. When the client is doing a full restore from a blank baseline, it sends `lastSeenEventId: null` and expects a full replay.
+
+        Replay is assumed to be ordered. The client rebuilds messages, `STATE_SNAPSHOT`, and activity snapshots from replayed events, then treats observed connect-mode replay/control activity plus `stream_idle` as the signal that the restore is settled. `replay_complete` may be part of that sequence, but restore can still settle successfully without it.
+      </Step>
+
+      <Step>
         ### Add pagination for large thread lists
 
         For users with many conversations, use the `limit` parameter to enable cursor-based pagination.
@@ -258,6 +272,31 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
     </TailoredContentOption>
   </TailoredContent>
 </Steps>
+
+## Connect Error Contract
+
+Intelligence-mode `/connect` has two client-visible success paths and one client-visible failure path:
+
+- `200 OK`: restored persisted thread; realtime credentials are valid and replay should begin.
+- `204 No Content`: explicit thread was brand new, or the platform intentionally chose a fresh-thread path; render the empty thread UX instead of treating it as a failure.
+- Any other connect failure currently surfaces to the chat layer as a generic connect failure. The runtime handler distinguishes rejected requests, malformed `200` payloads, and unexpected failures internally, but the current restore UX does not present a stable caller-visible `4xx` vs `5xx` taxonomy.
+- Malformed `200` payloads are rejected by the runtime connect handler rather than being used for a partial reconnect, but that still reaches the chat layer as a generic connect failure today.
+
+## Manual QA Matrix
+
+Use this matrix before rollout when thread restore behavior changes:
+
+| Scenario | Setup | Expected result |
+|---------|-------|-----------------|
+| Fresh local chat | Open chat with no explicit `threadId` | No `/connect`; welcome screen stays visible until first submit |
+| Brand-new explicit thread | Navigate directly to a new explicit `threadId` | `/connect` returns `204`; empty thread renders without error |
+| Hard refresh on persisted thread | Load an existing thread, refresh the browser | Messages, state, and active UI surfaces restore from replay |
+| Thread switch `A → B → A` | Open thread A, switch to B, then back to A | Original baseline returns without duplication or welcome-screen flash |
+| Mid-stream reconnect | Disconnect transport during a running thread | Client reconnects with `lastSeenEventId` and resumes incrementally |
+| Stale cursor fallback | Force reconnect before replay baseline advances | Client falls back to `lastSeenEventId: null` full restore safely |
+| State restore | Persist a thread with `STATE_SNAPSHOT` updates | Restored thread hydrates the latest agent state |
+| Activity restore | Persist A2UI or Open Generative UI activity | Restored thread rebuilds the same UI surface after replay |
+| Rejected thread | Use a thread the caller is not allowed to access | Connect fails. With `onError` you can surface it explicitly; otherwise the chat may settle back to the empty or welcome state instead of showing a distinct rejected-thread UI |
 
 ## Next steps
 

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -1226,6 +1226,58 @@ describe("IntelligenceAgent", () => {
       expect(getSocket(agent)).toBeNull();
     });
 
+    it("collapses a non-OK connect response into the generic connect failure path", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: async () => ({
+          error: "Connect request rejected",
+          message: "Intelligence platform error 403",
+        }),
+        text: async () =>
+          JSON.stringify({
+            error: "Connect request rejected",
+            message: "Intelligence platform error 403",
+          }),
+      } as Response);
+
+      const agent = createAgent();
+      const result = await connectAgent(agent);
+
+      expect(result.completed).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toContain("REST connect request failed");
+      expect(result.error!.message).toContain("Connect request rejected");
+      expect(result.socket).toBeNull();
+      expect(result.channel).toBeNull();
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBeNull();
+    });
+
+    it("collapses malformed 200 connect credentials into the generic connect failure path", async () => {
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse({
+          threadId: "thread-1",
+          runId: null,
+          realtime: {
+            clientUrl: "ws://localhost:4000/client",
+            topic: "thread:thread-1",
+          },
+        }),
+      );
+
+      const agent = createAgent();
+      const result = await connectAgent(agent);
+
+      expect(result.completed).toBe(false);
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toContain("REST connect request failed");
+      expect(result.error!.message).toContain("missing joinToken");
+      expect(result.socket).toBeNull();
+      expect(result.channel).toBeNull();
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBeNull();
+    });
+
     it("errors the observable on join error", async () => {
       mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
 

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -118,6 +118,7 @@ interface IntelligenceAgentTestAccess {
   canonicalRunId: string | null;
   config: unknown;
   connect(input: RunAgentInput): Observable<BaseEvent>;
+  lastConnectRestoreOutcome: "fresh" | "restored" | null;
   messages: RunAgentInput["messages"];
   socket: MockSocket | null;
   threadId: string | undefined;
@@ -198,6 +199,12 @@ function getCanonicalRunIdForTest(
 
 function getConfigForTest(agent: IntelligenceAgentInstance): unknown {
   return getAgentTestAccess(agent).config;
+}
+
+function getLastConnectRestoreOutcomeForTest(
+  agent: IntelligenceAgentInstance,
+): "fresh" | "restored" | null {
+  return getAgentTestAccess(agent).lastConnectRestoreOutcome;
 }
 
 function replaceMessagesForTest(
@@ -687,6 +694,7 @@ describe("IntelligenceAgent", () => {
 
       const channel = getChannel(agent)!;
       channel.triggerJoin("ok");
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBeNull();
       channel.serverPush("ag_ui_event", {
         type: EventType.RUN_STARTED,
         threadId: "thread-1",
@@ -833,6 +841,15 @@ describe("IntelligenceAgent", () => {
       expect(channel.params).toEqual({
         stream_mode: "connect",
         last_seen_event_id: null,
+      });
+      expect(JSON.parse(mockFetch.mock.calls[0]![1].body)).toMatchObject({
+        lastSeenEventId: null,
+        restore: {
+          intent: "restore",
+          cursor: {
+            lastEventId: null,
+          },
+        },
       });
 
       channel.triggerJoin("ok");
@@ -1006,6 +1023,7 @@ describe("IntelligenceAgent", () => {
       expect(result.events).toHaveLength(0);
       expect(result.socket).toBeNull();
       expect(result.channel).toBeNull();
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBe("fresh");
     });
 
     it("completes on RUN_ERROR from server", async () => {
@@ -1081,6 +1099,7 @@ describe("IntelligenceAgent", () => {
           content: "hello",
         },
       ]);
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBe("restored");
       expect(getCanonicalRunIdForTest(agent)).toBeNull();
       expect(channel.left).toBe(true);
     });
@@ -1185,6 +1204,7 @@ describe("IntelligenceAgent", () => {
         },
       });
       expect(completed).toBe(true);
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBe("restored");
       expect(getCanonicalRunIdForTest(agent)).toBeNull();
     });
 
@@ -1218,6 +1238,7 @@ describe("IntelligenceAgent", () => {
       const result = await promise;
       expect(result.error).toBeInstanceOf(Error);
       expect(result.error!.message).toContain("Failed to join channel");
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBeNull();
     });
 
     it("does not error the observable on a single channel crash (Phoenix retries)", async () => {
@@ -1240,7 +1261,7 @@ describe("IntelligenceAgent", () => {
       expect(error).toBeNull();
     });
 
-    it("reacquires connect credentials after MAX_CONSECUTIVE_ERRORS socket errors", async () => {
+    it("reacquires connect credentials with a reconnect cursor after MAX_CONSECUTIVE_ERRORS socket errors", async () => {
       mockFetch.mockResolvedValueOnce(
         await jsonResponse(runtimeCredentials({ joinToken: "jt-1" })),
       );
@@ -1255,7 +1276,15 @@ describe("IntelligenceAgent", () => {
       });
       await waitForConnection(agent);
 
-      getChannel(agent)!.triggerJoin("ok");
+      const firstChannel = getChannel(agent)!;
+      firstChannel.triggerJoin("ok");
+      firstChannel.serverPush("ag_ui_event", {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        metadata: {
+          cpki_event_id: "event-2",
+          cpki_event_seq: 2,
+        },
+      } as BaseEvent);
 
       for (let i = 0; i < 5; i++) {
         getSocket(agent)!.triggerError(new Error("network failure"));
@@ -1264,8 +1293,211 @@ describe("IntelligenceAgent", () => {
       await waitForConnection(agent);
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(mockFetch.mock.calls[0]![1].body)).toMatchObject({
+        lastSeenEventId: null,
+        restore: {
+          intent: "restore",
+          cursor: {
+            lastEventId: null,
+          },
+        },
+      });
+      expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
+        lastSeenEventId: "event-2",
+        restore: {
+          intent: "reconnect",
+          cursor: {
+            lastEventId: "event-2",
+          },
+        },
+      });
       expect(getSocket(agent)!.opts.params).toMatchObject({
         join_token: "jt-2",
+      });
+      expect(getChannel(agent)!.params).toEqual({
+        stream_mode: "connect",
+        last_seen_event_id: "event-2",
+      });
+    });
+
+    it("keeps a clean replay baseline across an early reconnect before replay advances", async () => {
+      const agent = createAgent();
+      agent.run(defaultInput).subscribe({ next: () => {}, error: () => {} });
+      await waitForConnection(agent);
+
+      const runChannel = getChannel(agent)!;
+      runChannel.triggerJoin("ok");
+      runChannel.serverPush("ag_ui_event", {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        metadata: {
+          cpki_event_id: "stale-event-9",
+          cpki_event_seq: 9,
+        },
+      } as BaseEvent);
+
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse(runtimeCredentials({ joinToken: "jt-restore-1" })),
+      );
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse(runtimeCredentials({ joinToken: "jt-restore-2" })),
+      );
+
+      connectWithTestAccess(agent, defaultInput).subscribe({
+        next: () => {},
+        error: () => {},
+      });
+      await waitForConnection(agent);
+
+      const restoreChannel = getChannel(agent)!;
+      restoreChannel.triggerJoin("ok");
+
+      for (let index = 0; index < 5; index += 1) {
+        getSocket(agent)!.triggerError(new Error("network failure"));
+      }
+
+      await waitForConnection(agent);
+
+      expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
+        lastSeenEventId: null,
+        restore: {
+          intent: "restore",
+          cursor: {
+            lastEventId: null,
+          },
+        },
+      });
+      expect(JSON.parse(mockFetch.mock.calls[2]![1].body)).toMatchObject({
+        lastSeenEventId: null,
+        restore: {
+          intent: "reconnect",
+          cursor: {
+            lastEventId: null,
+          },
+        },
+      });
+      expect(getChannel(agent)!.params).toEqual({
+        stream_mode: "connect",
+        last_seen_event_id: null,
+      });
+    });
+
+    it("does not settle restored when replay is observed before reconnect fetch fails", async () => {
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse(runtimeCredentials({ joinToken: "jt-restore-1" })),
+      );
+      mockFetch.mockRejectedValueOnce(new Error("reconnect fetch failed"));
+
+      const agent = createAgent();
+      const promise = connectAgent(agent);
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      channel.triggerJoin("ok");
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        run_id: "backend-run-1",
+        input: { messages: [] },
+      } as BaseEvent);
+      channel.serverPush("replay_complete", { latestEventId: "event-2" });
+
+      for (let index = 0; index < 5; index += 1) {
+        getSocket(agent)!.triggerError(new Error("network failure"));
+      }
+
+      const result = await promise;
+
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toContain("REST connect request failed");
+      expect(result.events).toEqual([
+        {
+          type: EventType.RUN_STARTED,
+          threadId: "thread-1",
+          run_id: "backend-run-1",
+          input: { messages: [] },
+        },
+      ]);
+      expect(getLastConnectRestoreOutcomeForTest(agent)).toBeNull();
+    });
+
+    it("keeps the clean replay baseline across canonical thread remapping before replay advances", async () => {
+      const agent = createAgent();
+      const canonicalRunInput: RunAgentInput = {
+        ...defaultInput,
+        threadId: "canonical-thread",
+      };
+
+      agent.run(canonicalRunInput).subscribe({ next: () => {}, error: () => {} });
+      await waitForConnection(agent);
+
+      const canonicalRunChannel = getChannel(agent)!;
+      canonicalRunChannel.triggerJoin("ok");
+      canonicalRunChannel.serverPush("ag_ui_event", {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        metadata: {
+          cpki_event_id: "stale-canonical-event-4",
+          cpki_event_seq: 4,
+        },
+      } as BaseEvent);
+
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse(
+          runtimeCredentials({
+            threadId: "canonical-thread",
+            joinToken: "jt-remap-1",
+          }),
+        ),
+      );
+      mockFetch.mockResolvedValueOnce(
+        await jsonResponse(
+          runtimeCredentials({
+            threadId: "canonical-thread",
+            joinToken: "jt-remap-2",
+          }),
+        ),
+      );
+
+      connectWithTestAccess(agent, {
+        ...defaultInput,
+        threadId: "alias-thread",
+      }).subscribe({
+        next: () => {},
+        error: () => {},
+      });
+      await waitForConnection(agent);
+
+      const remappedChannel = getChannel(agent)!;
+      remappedChannel.triggerJoin("ok");
+
+      for (let index = 0; index < 5; index += 1) {
+        getSocket(agent)!.triggerError(new Error("network failure"));
+      }
+
+      await waitForConnection(agent);
+
+      expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
+        threadId: "alias-thread",
+        lastSeenEventId: null,
+        restore: {
+          intent: "restore",
+          cursor: {
+            lastEventId: null,
+          },
+        },
+      });
+      expect(JSON.parse(mockFetch.mock.calls[2]![1].body)).toMatchObject({
+        threadId: "canonical-thread",
+        lastSeenEventId: null,
+        restore: {
+          intent: "reconnect",
+          cursor: {
+            lastEventId: null,
+          },
+        },
+      });
+      expect(getChannel(agent)!.params).toEqual({
+        stream_mode: "connect",
+        last_seen_event_id: null,
       });
     });
 
@@ -1442,5 +1674,12 @@ describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
     await promise;
 
     expect(agent.state).toEqual(finalSnapshot);
+    expect(
+      (
+        agent as ProxiedCopilotRuntimeAgent & {
+          lastConnectRestoreOutcome: "fresh" | "restored" | null;
+        }
+      ).lastConnectRestoreOutcome,
+    ).toBe("restored");
   });
 });

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -31,6 +31,16 @@ interface RunnableAgent {
   run(input: RunAgentInput): Observable<BaseEvent>;
 }
 
+type ConnectRestoreOutcome = "fresh" | "restored";
+
+function hasConnectRestoreOutcome(
+  agent: AbstractAgent,
+): agent is AbstractAgent & {
+  lastConnectRestoreOutcome: ConnectRestoreOutcome | null;
+} {
+  return "lastConnectRestoreOutcome" in agent;
+}
+
 function hasHeaders(
   agent: AbstractAgent,
 ): agent is AbstractAgent & { headers?: Record<string, string> } {
@@ -88,6 +98,7 @@ export interface ProxiedCopilotRuntimeAgentConfig extends Omit<
 export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   runtimeUrl?: string;
   credentials?: RequestCredentials;
+  public lastConnectRestoreOutcome: ConnectRestoreOutcome | null = null;
   private transport: CopilotRuntimeTransport;
   private singleEndpointUrl?: string;
   private runtimeMode: ResolvedRuntimeMode;
@@ -222,6 +233,8 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       return super.connectAgent(parameters, subscriber);
     }
 
+    this.lastConnectRestoreOutcome = null;
+
     // If the delegate already has an active run (e.g. from a previous
     // connectAgent call that hasn't finished yet), detach it first.  This
     // ensures only one run is active on the delegate at a time — without it,
@@ -275,6 +288,9 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
 
     try {
       const result = await delegate.connectAgent(parameters, subscriber);
+      if (hasConnectRestoreOutcome(delegate)) {
+        this.lastConnectRestoreOutcome = delegate.lastConnectRestoreOutcome;
+      }
 
       // Final sync to guarantee the proxy reflects the delegate's end state.
       this.setMessages([...delegate.messages]);

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -59,6 +59,9 @@ interface IntelligenceAgentSharedState {
   lastSeenEventIds: Map<string, string>;
 }
 
+type ConnectRestoreIntent = "restore" | "reconnect";
+type ConnectRestoreOutcome = "fresh" | "restored";
+
 interface RealtimeConnectionInfo {
   clientUrl: string;
   topic: string;
@@ -99,6 +102,8 @@ export class IntelligenceAgent extends AbstractAgent {
   private activeChannel: Channel | null = null;
   private canonicalRunId: string | null = null;
   private sharedState: IntelligenceAgentSharedState;
+  private activeConnectReplayCursors = new Map<string, string | null>();
+  public lastConnectRestoreOutcome: ConnectRestoreOutcome | null = null;
 
   constructor(
     config: IntelligenceAgentConfig,
@@ -282,11 +287,20 @@ export class IntelligenceAgent extends AbstractAgent {
   protected connect(input: RunAgentInput): Observable<BaseEvent> {
     this.threadId = input.threadId;
     this.canonicalRunId = null;
-    this.clearReconnectCursor(input.threadId);
+    this.lastConnectRestoreOutcome = null;
+    const activeReplayThreadIds = new Set<string>([input.threadId]);
+    this.setActiveConnectReplayCursor(input.threadId, null);
+    let restoreObserved = false;
 
-    return defer(() => this.requestJoinCredentials$("connect", input)).pipe(
+    return defer(() =>
+      this.requestJoinCredentials$("connect", input, {
+        restoreIntent: "restore",
+      }),
+    ).pipe(
       switchMap((credentials) => {
         if (credentials === null) {
+          this.lastConnectRestoreOutcome = "fresh";
+          this.clearActiveConnectReplayCursors(activeReplayThreadIds);
           return EMPTY;
         }
 
@@ -295,11 +309,31 @@ export class IntelligenceAgent extends AbstractAgent {
           credentials,
           { fallbackToInputRunId: false },
         );
+        this.bindActiveConnectReplayCursor(
+          input.threadId,
+          canonicalInput.threadId,
+          activeReplayThreadIds,
+        );
 
         return this.observeThread$(canonicalInput, credentials, {
           completeOnRunError: false,
           streamMode: "connect",
-        });
+          replayCursor: null,
+          onRestoreObserved: () => {
+            restoreObserved = true;
+          },
+        }).pipe(
+          tap({
+            complete: () => {
+              if (restoreObserved) {
+                this.lastConnectRestoreOutcome = "restored";
+              }
+            },
+          }),
+        );
+      }),
+      finalize(() => {
+        this.clearActiveConnectReplayCursors(activeReplayThreadIds);
       }),
     );
   }
@@ -335,9 +369,19 @@ export class IntelligenceAgent extends AbstractAgent {
   private requestJoinCredentials$(
     mode: "run" | "connect",
     input: RunAgentInput,
+    options?: {
+      restoreIntent?: ConnectRestoreIntent;
+    },
   ): Observable<ThreadJoinCredentials | null> {
     return defer(async () => {
       try {
+        const connectRestore =
+          mode === "connect"
+            ? this.createConnectRestoreParameters(
+                input,
+                options?.restoreIntent ?? "restore",
+              )
+            : null;
         const response = await fetch(this.buildRuntimeUrl(mode), {
           method: "POST",
           headers: {
@@ -352,9 +396,7 @@ export class IntelligenceAgent extends AbstractAgent {
             context: input.context,
             state: input.state,
             forwardedProps: input.forwardedProps,
-            ...(mode === "connect"
-              ? { lastSeenEventId: this.getReconnectCursor(input) }
-              : {}),
+            ...(connectRestore ?? {}),
           }),
           ...(this.config.credentials
             ? { credentials: this.config.credentials }
@@ -439,6 +481,7 @@ export class IntelligenceAgent extends AbstractAgent {
       streamMode: "run" | "connect";
       channelMode?: "run" | "connect";
       replayCursor?: string | null;
+      onRestoreObserved?: () => void;
     },
   ): Observable<BaseEvent> {
     return this.observeThreadSession$(input, credentials, options).pipe(
@@ -447,7 +490,9 @@ export class IntelligenceAgent extends AbstractAgent {
           return throwError(() => error);
         }
 
-        return this.requestJoinCredentials$("connect", input).pipe(
+        return this.requestJoinCredentials$("connect", input, {
+          restoreIntent: "reconnect",
+        }).pipe(
           switchMap((refreshedCredentials) =>
             refreshedCredentials === null
               ? EMPTY
@@ -476,6 +521,7 @@ export class IntelligenceAgent extends AbstractAgent {
       streamMode: "run" | "connect";
       channelMode?: "run" | "connect";
       replayCursor?: string | null;
+      onRestoreObserved?: () => void;
     },
   ): Observable<BaseEvent> {
     return defer(() => {
@@ -531,11 +577,13 @@ export class IntelligenceAgent extends AbstractAgent {
         input.threadId,
         channel$,
         REPLAY_COMPLETE_EVENT,
+        options,
       ).pipe(ignoreElements(), share());
       const streamIdle$ = this.observeControlEvent$(
         input.threadId,
         channel$,
         STREAM_IDLE_EVENT,
+        options,
       ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
       const streamIdleCompletion$ =
         options.streamMode === "connect" ? streamIdle$.pipe(take(1)) : EMPTY;
@@ -574,7 +622,11 @@ export class IntelligenceAgent extends AbstractAgent {
   private observeThreadEvents$(
     threadId: string,
     channel$: Observable<ɵPhoenixChannelSession>,
-    options: { completeOnRunError: boolean; streamMode: "run" | "connect" },
+    options: {
+      completeOnRunError: boolean;
+      streamMode: "run" | "connect";
+      onRestoreObserved?: () => void;
+    },
   ): Observable<BaseEvent> {
     return channel$.pipe(
       switchMapOperator(({ channel }) =>
@@ -582,6 +634,7 @@ export class IntelligenceAgent extends AbstractAgent {
       ),
       tap((payload) => {
         this.updateLastSeenEventId(threadId, payload);
+        options.onRestoreObserved?.();
       }),
       mergeMap(
         (payload) =>
@@ -599,6 +652,7 @@ export class IntelligenceAgent extends AbstractAgent {
     threadId: string,
     channel$: Observable<ɵPhoenixChannelSession>,
     eventName: string,
+    options?: { onRestoreObserved?: () => void },
   ): Observable<unknown> {
     return channel$.pipe(
       switchMapOperator(({ channel }) =>
@@ -607,6 +661,9 @@ export class IntelligenceAgent extends AbstractAgent {
       tap((payload) =>
         this.updateLastSeenEventIdFromControl(threadId, payload),
       ),
+      tap(() => {
+        options?.onRestoreObserved?.();
+      }),
     );
   }
 
@@ -682,11 +739,72 @@ export class IntelligenceAgent extends AbstractAgent {
   }
 
   private getReconnectCursor(input: RunAgentInput): string | null {
+    if (this.activeConnectReplayCursors.has(input.threadId)) {
+      return this.activeConnectReplayCursors.get(input.threadId) ?? null;
+    }
     return this.getLastSeenEventId(input.threadId);
   }
 
-  private clearReconnectCursor(threadId: string): void {
-    this.sharedState.lastSeenEventIds.delete(threadId);
+  private setActiveConnectReplayCursor(
+    threadId: string,
+    eventId: string | null,
+  ): void {
+    this.activeConnectReplayCursors.set(threadId, eventId);
+  }
+
+  private bindActiveConnectReplayCursor(
+    sourceThreadId: string,
+    targetThreadId: string,
+    activeReplayThreadIds: Set<string>,
+  ): void {
+    activeReplayThreadIds.add(targetThreadId);
+
+    if (targetThreadId === sourceThreadId) {
+      return;
+    }
+
+    this.setActiveConnectReplayCursor(
+      targetThreadId,
+      this.activeConnectReplayCursors.get(sourceThreadId) ?? null,
+    );
+  }
+
+  private clearActiveConnectReplayCursor(threadId: string): void {
+    this.activeConnectReplayCursors.delete(threadId);
+  }
+
+  private clearActiveConnectReplayCursors(
+    threadIds: Iterable<string>,
+  ): void {
+    for (const threadId of threadIds) {
+      this.clearActiveConnectReplayCursor(threadId);
+    }
+  }
+
+  private createConnectRestoreParameters(
+    input: RunAgentInput,
+    restoreIntent: ConnectRestoreIntent,
+  ): {
+    lastSeenEventId: string | null;
+    restore: {
+      intent: ConnectRestoreIntent;
+      cursor: {
+        lastEventId: string | null;
+      };
+    };
+  } {
+    const lastEventId =
+      restoreIntent === "reconnect" ? this.getReconnectCursor(input) : null;
+
+    return {
+      lastSeenEventId: lastEventId,
+      restore: {
+        intent: restoreIntent,
+        cursor: {
+          lastEventId,
+        },
+      },
+    };
   }
 
   private updateLastSeenEventId(threadId: string, payload: BaseEvent): void {
@@ -696,6 +814,9 @@ export class IntelligenceAgent extends AbstractAgent {
     }
 
     this.sharedState.lastSeenEventIds.set(threadId, eventId);
+    if (this.activeConnectReplayCursors.has(threadId)) {
+      this.setActiveConnectReplayCursor(threadId, eventId);
+    }
   }
 
   private updateLastSeenEventIdFromControl(
@@ -708,6 +829,9 @@ export class IntelligenceAgent extends AbstractAgent {
     }
 
     this.sharedState.lastSeenEventIds.set(threadId, eventId);
+    if (this.activeConnectReplayCursors.has(threadId)) {
+      this.setActiveConnectReplayCursor(threadId, eventId);
+    }
   }
 
   private readEventId(payload: BaseEvent): string | null {

--- a/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
+++ b/packages/react-core/src/v2/__tests__/utils/test-helpers.tsx
@@ -164,6 +164,7 @@ export function renderWithCopilotKit({
   humanInTheLoop,
   agentId,
   threadId,
+  hasExplicitThreadId,
   defaultThrottleMs,
   children,
 }: {
@@ -176,12 +177,14 @@ export function renderWithCopilotKit({
   humanInTheLoop?: any[];
   agentId?: string;
   threadId?: string;
+  hasExplicitThreadId?: boolean;
   defaultThrottleMs?: number;
   children?: React.ReactNode;
 }): ReturnType<typeof render> {
   const resolvedAgents = agents || (agent ? { default: agent } : undefined);
   const resolvedAgentId = agentId ?? DEFAULT_AGENT_ID;
   const resolvedThreadId = threadId ?? "test-thread";
+  const resolvedHasExplicitThreadId = hasExplicitThreadId ?? false;
 
   return render(
     <CopilotKitProvider
@@ -196,6 +199,7 @@ export function renderWithCopilotKit({
       <CopilotChatConfigurationProvider
         agentId={resolvedAgentId}
         threadId={resolvedThreadId}
+        hasExplicitThreadId={resolvedHasExplicitThreadId}
       >
         {children || (
           <div style={{ height: 400 }}>

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -84,6 +84,46 @@ export type CopilotChatProps = Omit<
    */
   throttleMs?: number;
 };
+
+type ConnectRestoreOutcome = "fresh" | "restored";
+
+type ConnectSettlementState = {
+  attemptKey: string;
+  outcome: ConnectRestoreOutcome | "unknown";
+  status: "pending" | "settled";
+};
+
+const agentInstanceIds = new WeakMap<AbstractAgent, number>();
+let nextAgentInstanceId = 1;
+
+function getAgentInstanceId(agent: AbstractAgent): number {
+  const existingId = agentInstanceIds.get(agent);
+  if (existingId !== undefined) {
+    return existingId;
+  }
+
+  const assignedId = nextAgentInstanceId;
+  nextAgentInstanceId += 1;
+  agentInstanceIds.set(agent, assignedId);
+  return assignedId;
+}
+
+function readConnectRestoreOutcome(
+  agent: AbstractAgent,
+): ConnectRestoreOutcome | null {
+  if (!("lastConnectRestoreOutcome" in agent)) {
+    return null;
+  }
+
+  const outcome = (
+    agent as AbstractAgent & {
+      lastConnectRestoreOutcome?: unknown;
+    }
+  ).lastConnectRestoreOutcome;
+
+  return outcome === "fresh" || outcome === "restored" ? outcome : null;
+}
+
 export function CopilotChat({
   agentId,
   threadId,
@@ -204,17 +244,31 @@ export function CopilotChat({
     onStop: providedStopHandler,
     ...restProps
   } = props;
+  const connectAttemptCounterRef = useRef(0);
+  const connectTargetKey = hasExplicitThreadId
+    ? `${resolvedThreadId}:${resolvedAgentId}:${getAgentInstanceId(agent)}`
+    : null;
 
-  // Tracks the last threadId for which connectAgent has completed (success or
-  // failure). When the user supplies a threadId, we're in "resume existing
-  // thread" mode — the welcome screen should be suppressed until the connect
-  // resolves, otherwise switching threads flashes the welcome screen while the
-  // new thread's messages are still en route.
-  const [lastConnectedThreadId, setLastConnectedThreadId] = useState<
-    string | null
-  >(null);
-  const isConnecting =
-    hasExplicitThreadId && lastConnectedThreadId !== resolvedThreadId;
+  // Tracks the active connect attempt for the current explicit-thread target.
+  // Keying by an attempt id rather than threadId alone ensures same-thread
+  // reconnects or agent replacement re-enter the connecting path cleanly.
+  const [lastConnectSettlement, setLastConnectSettlement] =
+    useState<ConnectSettlementState | null>(null);
+  const activeConnectSettlement =
+    connectTargetKey &&
+    lastConnectSettlement?.attemptKey.startsWith(`${connectTargetKey}:`)
+      ? lastConnectSettlement
+      : null;
+  const settledOutcome =
+    activeConnectSettlement?.status === "settled"
+      ? activeConnectSettlement.outcome
+      : null;
+  const isConnecting = hasExplicitThreadId
+    ? activeConnectSettlement === null ||
+      activeConnectSettlement.status === "pending"
+    : false;
+  const shouldSuppressWelcomeForThread =
+    hasExplicitThreadId && settledOutcome === "restored";
 
   useEffect(() => {
     // When the caller hasn't picked a specific thread, resolvedThreadId is a
@@ -225,6 +279,13 @@ export function CopilotChat({
     if (!hasExplicitThreadId) return;
 
     let detached = false;
+    connectAttemptCounterRef.current += 1;
+    const connectAttemptKey = `${connectTargetKey}:${connectAttemptCounterRef.current}`;
+    setLastConnectSettlement({
+      attemptKey: connectAttemptKey,
+      outcome: "unknown",
+      status: "pending",
+    });
 
     // Create a fresh AbortController so we can cancel the HTTP request on cleanup.
     // HttpAgent (parent of ProxiedCopilotRuntimeAgent) uses this.abortController.signal
@@ -259,8 +320,15 @@ export function CopilotChat({
             typeof requestAnimationFrame === "function"
               ? requestAnimationFrame
               : (cb: () => void) => setTimeout(cb, 16);
+          const outcome = readConnectRestoreOutcome(agent) ?? "unknown";
           raf(() => {
-            if (!detached) setLastConnectedThreadId(resolvedThreadId);
+            if (!detached) {
+              setLastConnectSettlement({
+                attemptKey: connectAttemptKey,
+                outcome,
+                status: "settled",
+              });
+            }
           });
         }
       }
@@ -280,7 +348,7 @@ export function CopilotChat({
     };
     // copilotkit is intentionally excluded — it is a stable ref that never changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resolvedThreadId, agent, resolvedAgentId, hasExplicitThreadId]);
+  }, [connectTargetKey, resolvedThreadId, agent, resolvedAgentId, hasExplicitThreadId]);
 
   const onSubmitInput = useCallback(
     async (value: string) => {
@@ -605,6 +673,7 @@ export function CopilotChat({
     onDrop: handleDrop,
     isConnecting,
     hasExplicitThreadId,
+    suppressWelcomeScreen: shouldSuppressWelcomeForThread,
   };
 
   // Always create a provider with merged values

--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -459,16 +459,17 @@ export function CopilotChatInput({
       if (isProcessing) {
         onStop?.();
       } else {
-        send();
+        send(e.currentTarget.value);
       }
     }
   };
 
-  const send = () => {
+  const send = (submittedValue?: string) => {
     if (!onSubmitMessage) {
       return;
     }
-    const trimmed = resolvedValue.trim();
+    const nextValue = submittedValue ?? inputRef.current?.value ?? resolvedValue;
+    const trimmed = nextValue.trim();
     if (!trimmed) {
       return;
     }

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -102,6 +102,12 @@ export type CopilotChatViewProps = WithSlots<
      */
     hasExplicitThreadId?: boolean;
     /**
+     * Internal welcome-screen suppression flag used by CopilotChat to
+     * distinguish restored explicit threads from fresh/unknown outcomes
+     * without changing the meaning of `hasExplicitThreadId` for custom views.
+     */
+    suppressWelcomeScreen?: boolean;
+    /**
      * @deprecated Use the `input` slot's `disclaimer` prop instead:
      * ```tsx
      * <CopilotChat input={{ disclaimer: MyDisclaimer }} />
@@ -110,6 +116,8 @@ export type CopilotChatViewProps = WithSlots<
     disclaimer?: SlotValue<React.FC<React.HTMLAttributes<HTMLDivElement>>>;
   } & React.HTMLAttributes<HTMLDivElement>
 >;
+
+type EmptyInputSurface = "welcome" | "chat";
 
 function DropOverlay() {
   return (
@@ -161,6 +169,7 @@ export function CopilotChatView({
   onDrop,
   isConnecting = false,
   hasExplicitThreadId = false,
+  suppressWelcomeScreen,
   // Deprecated — forwarded to input slot
   disclaimer,
   children,
@@ -171,6 +180,7 @@ export function CopilotChatView({
   const [inputContainerHeight, setInputContainerHeight] = useState(0);
   const [isResizing, setIsResizing] = useState(false);
   const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const emptySurfaceBlurTimeoutRef = useRef<number | null>(null);
 
   // Track keyboard state for mobile
   const { isKeyboardOpen, keyboardHeight, availableHeight } =
@@ -291,6 +301,7 @@ export function CopilotChatView({
 
   // Welcome screen logic
   const isEmpty = messages.length === 0;
+  const hasDraftInput = (inputValue ?? "").trim().length > 0;
   // Type assertion needed because TypeScript doesn't fully propagate `| boolean` through WithSlots
   const welcomeScreenDisabled = (welcomeScreen as unknown) === false;
   // Suppress the welcome screen (1) while the initial connect is in flight
@@ -298,8 +309,78 @@ export function CopilotChatView({
   // managed case targets a conversation directly, so the generic welcome
   // greeting is never the right thing to show — even for a thread that
   // happens to have no messages yet.
+  const effectiveSuppressWelcomeScreen =
+    suppressWelcomeScreen !== undefined
+      ? suppressWelcomeScreen
+      : hasExplicitThreadId;
+
+  const shouldShowWelcomeScreenBase =
+    isEmpty &&
+    !welcomeScreenDisabled &&
+    !isConnecting &&
+    !effectiveSuppressWelcomeScreen;
+
+  const lastEmptySurfaceRef = useRef<"welcome" | "chat">(
+    shouldShowWelcomeScreenBase ? "welcome" : "chat",
+  );
+  const [focusedEmptySurface, setFocusedEmptySurface] =
+    useState<EmptyInputSurface | null>(null);
+
+  const clearEmptySurfaceBlurTimeout = useCallback(() => {
+    if (emptySurfaceBlurTimeoutRef.current !== null) {
+      window.clearTimeout(emptySurfaceBlurTimeoutRef.current);
+      emptySurfaceBlurTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearEmptySurfaceBlurTimeout();
+    };
+  }, [clearEmptySurfaceBlurTimeout]);
+
+  const handleEmptySurfaceFocus = useCallback(
+    (surface: EmptyInputSurface) => {
+      clearEmptySurfaceBlurTimeout();
+      lastEmptySurfaceRef.current = surface;
+      setFocusedEmptySurface(surface);
+    },
+    [clearEmptySurfaceBlurTimeout],
+  );
+
+  const handleEmptySurfaceBlur = useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      const currentTarget = event.currentTarget;
+      clearEmptySurfaceBlurTimeout();
+      emptySurfaceBlurTimeoutRef.current = window.setTimeout(() => {
+        if (!currentTarget.contains(document.activeElement)) {
+          setFocusedEmptySurface(null);
+        }
+        emptySurfaceBlurTimeoutRef.current = null;
+      }, 0);
+    },
+    [clearEmptySurfaceBlurTimeout],
+  );
+
+  useEffect(() => {
+    if (isEmpty && !hasDraftInput) {
+      lastEmptySurfaceRef.current = shouldShowWelcomeScreenBase
+        ? "welcome"
+        : "chat";
+    }
+  }, [hasDraftInput, isEmpty, shouldShowWelcomeScreenBase]);
+
+  // Keep the active empty-state input surface stable while the first draft is
+  // in progress. Without this, an explicit thread that settles from
+  // connecting -> fresh/unknown can swap between the overlay input and the
+  // welcome-screen input mid-keystroke, dropping the first submit. The same
+  // race can occur slightly earlier, while the user is focused in the empty
+  // input but the controlled draft state has not propagated yet.
   const shouldShowWelcomeScreen =
-    isEmpty && !welcomeScreenDisabled && !isConnecting && !hasExplicitThreadId;
+    isEmpty &&
+    (hasDraftInput || focusedEmptySurface !== null
+      ? lastEmptySurfaceRef.current === "welcome"
+      : shouldShowWelcomeScreenBase);
 
   if (shouldShowWelcomeScreen) {
     // Create a separate input for welcome screen with static positioning and disclaimer visible
@@ -326,7 +407,11 @@ export function CopilotChatView({
     ) as SlotValue<React.FC<WelcomeScreenProps>> | undefined;
     // Wrap the input with attachment queue above it
     const inputWithAttachments = (
-      <div className="cpk:w-full">
+      <div
+        className="cpk:w-full"
+        onBlurCapture={handleEmptySurfaceBlur}
+        onFocusCapture={() => handleEmptySurfaceFocus("welcome")}
+      >
         {attachments && attachments.length > 0 && (
           <CopilotChatAttachmentQueue
             attachments={attachments}
@@ -401,6 +486,8 @@ export function CopilotChatView({
         ref={inputContainerRef}
         data-testid="copilot-input-overlay"
         className="cpk:absolute cpk:bottom-0 cpk:left-0 cpk:right-0 cpk:z-20 cpk:pointer-events-none"
+        onBlurCapture={handleEmptySurfaceBlur}
+        onFocusCapture={() => handleEmptySurfaceFocus("chat")}
       >
         {attachments && attachments.length > 0 && (
           <div className="cpk:max-w-3xl cpk:mx-auto cpk:w-full cpk:pointer-events-auto">

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.onError.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.onError.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "../../../__tests__/utils/test-helpers";
 import { CopilotChat } from "../CopilotChat";
 import { CopilotKitCoreErrorCode } from "@copilotkit/core";
-import { type BaseEvent, type RunAgentInput } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
 import { Observable, EMPTY } from "rxjs";
 
 /**
@@ -44,6 +44,8 @@ describe("CopilotChat onError", () => {
 
     renderWithCopilotKit({
       agent,
+      threadId: "connect-error-thread",
+      hasExplicitThreadId: true,
       children: <CopilotChat welcomeScreen={false} onError={chatOnError} />,
     });
 
@@ -63,6 +65,8 @@ describe("CopilotChat onError", () => {
 
     renderWithCopilotKit({
       agent,
+      threadId: "healthy-connect-thread",
+      hasExplicitThreadId: true,
       children: <CopilotChat welcomeScreen={false} onError={chatOnError} />,
     });
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach } from "vitest";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
@@ -17,21 +17,65 @@ class TrackingAgent extends MockStepwiseAgent {
     threadId: string | undefined;
     agentId: string | undefined;
   }> = [];
+  static connectPlans: Array<{
+    outcome: "fresh" | "restored" | null;
+    deferred?: boolean;
+    transientRestoreObserved?: boolean;
+    error?: Error;
+  }> = [{ outcome: "restored" }];
+  static pendingConnectResolvers: Array<() => void> = [];
+  public lastConnectRestoreOutcome: "fresh" | "restored" | null = null;
 
   static reset() {
     TrackingAgent.connectCalls = [];
+    TrackingAgent.connectPlans = [{ outcome: "restored" }];
+    TrackingAgent.pendingConnectResolvers = [];
+  }
+
+  static resolveNextConnect() {
+    const resolver = TrackingAgent.pendingConnectResolvers.shift();
+    resolver?.();
   }
 
   async connectAgent(
     _params: unknown,
     _subscriber: unknown,
   ): Promise<{ result: unknown; newMessages: [] }> {
+    const plan =
+      TrackingAgent.connectPlans.shift() ?? { outcome: "restored" as const };
+    this.lastConnectRestoreOutcome = plan.transientRestoreObserved
+      ? "restored"
+      : plan.outcome;
     TrackingAgent.connectCalls.push({
       threadId: this.threadId,
       agentId: this.agentId,
     });
+    if (plan.deferred) {
+      await new Promise<void>((resolve) => {
+        TrackingAgent.pendingConnectResolvers.push(resolve);
+      });
+    }
+    if (plan.error) {
+      this.lastConnectRestoreOutcome = plan.outcome;
+      throw plan.error;
+    }
     return { result: undefined, newMessages: [] };
   }
+}
+
+function CustomViewProbe({
+  hasExplicitThreadId,
+  isConnecting,
+}: {
+  hasExplicitThreadId?: boolean;
+  isConnecting?: boolean;
+}) {
+  return (
+    <div>
+      <div data-testid="custom-explicit">{String(hasExplicitThreadId)}</div>
+      <div data-testid="custom-connecting">{String(isConnecting)}</div>
+    </div>
+  );
 }
 
 function renderWithKit(ui: React.ReactNode, agent: TrackingAgent) {
@@ -61,6 +105,7 @@ describe("CopilotChat welcome / connect integration", () => {
 
   describe("v1 bridge scenario (config provider marks threadId as non-explicit)", () => {
     it("does not call connectAgent and shows the welcome screen", async () => {
+      TrackingAgent.connectPlans = [{ outcome: null }];
       const agent = new TrackingAgent();
       agent.agentId = DEFAULT_AGENT_ID;
 
@@ -80,6 +125,29 @@ describe("CopilotChat welcome / connect integration", () => {
       expect(TrackingAgent.connectCalls).toHaveLength(0);
       expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
     });
+
+    it("submits the first message from the non-explicit welcome path", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(
+        <CopilotChatConfigurationProvider
+          threadId="auto-minted-uuid"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChat />
+        </CopilotChatConfigurationProvider>,
+        agent,
+      );
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Bridge submit" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Bridge submit")).toBeDefined();
+      });
+    });
   });
 
   describe("plain CopilotChat (no threadId anywhere)", () => {
@@ -93,6 +161,21 @@ describe("CopilotChat welcome / connect integration", () => {
 
       expect(TrackingAgent.connectCalls).toHaveLength(0);
       expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+    });
+
+    it("submits the first message from the local welcome path", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat />, agent);
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Local submit" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Local submit")).toBeDefined();
+      });
     });
   });
 
@@ -113,8 +196,196 @@ describe("CopilotChat welcome / connect integration", () => {
       ).toBe(true);
 
       // Welcome screen is suppressed even after connect resolves, because the
-      // thread was caller-picked (hasExplicitThreadId=true).
+      // thread resolved to a persisted restore rather than a fresh 204 thread.
       expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+    });
+
+    it("shows the welcome screen after an explicit thread settles as fresh", async () => {
+      TrackingAgent.connectPlans = [{ outcome: "fresh" }];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="fresh-thread" />, agent);
+
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some((c) => c.threadId === "fresh-thread"),
+        ).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
+    });
+
+    it("shows the welcome screen after an explicit thread settles with an unknown outcome", async () => {
+      TrackingAgent.connectPlans = [{ outcome: null }];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="unknown-thread" />, agent);
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some((c) => c.threadId === "unknown-thread"),
+        ).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
+    });
+
+    it("submits from the welcome-screen input after an explicit unknown settle", async () => {
+      TrackingAgent.connectPlans = [{ outcome: null }];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="welcome-thread" />, agent);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
+
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "Welcome submit" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Welcome submit")).toBeDefined();
+      });
+    });
+
+    it("shows the welcome screen when replay is observed but connect still fails", async () => {
+      TrackingAgent.connectPlans = [
+        {
+          outcome: null,
+          transientRestoreObserved: true,
+          error: new Error("reconnect fetch failed"),
+        },
+      ];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="failed-restore-thread" />, agent);
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some(
+            (c) => c.threadId === "failed-restore-thread",
+          ),
+        ).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
+    });
+
+    it("preserves hasExplicitThreadId for custom chat views after a fresh outcome", async () => {
+      TrackingAgent.connectPlans = [{ outcome: "fresh" }];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(
+        <CopilotChat
+          threadId="fresh-thread"
+          chatView={CustomViewProbe}
+          welcomeScreen={false}
+        />,
+        agent,
+      );
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some((c) => c.threadId === "fresh-thread"),
+        ).toBe(true);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("custom-explicit").textContent).toBe("true");
+        expect(screen.getByTestId("custom-connecting").textContent).toBe(
+          "false",
+        );
+      });
+    });
+
+    it("does not drop the first submit when a fresh settle lands after typing begins", async () => {
+      TrackingAgent.connectPlans = [{ outcome: "fresh", deferred: true }];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="fresh-thread" />, agent);
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "First submit" } });
+
+      TrackingAgent.resolveNextConnect();
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("First submit")).toBeDefined();
+      });
+
+      fireEvent.keyDown(screen.getByRole("textbox"), {
+        key: "Enter",
+        code: "Enter",
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("First submit")).toBeDefined();
+      });
+    });
+
+    it("does not drop the first submit when an unknown settle lands after typing begins", async () => {
+      TrackingAgent.connectPlans = [{ outcome: null, deferred: true }];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="unknown-thread" />, agent);
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Unknown submit" } });
+
+      TrackingAgent.resolveNextConnect();
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Unknown submit")).toBeDefined();
+      });
+
+      fireEvent.keyDown(screen.getByRole("textbox"), {
+        key: "Enter",
+        code: "Enter",
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Unknown submit")).toBeDefined();
+      });
+    });
+
+    it("keeps the focused empty input stable when an unknown settle lands before draft state propagates", async () => {
+      TrackingAgent.connectPlans = [{ outcome: null, deferred: true }];
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      renderWithKit(<CopilotChat threadId="unknown-thread" />, agent);
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.focus(input);
+
+      TrackingAgent.resolveNextConnect();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+      });
+
+      fireEvent.change(input, { target: { value: "Focused submit" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Focused submit")).toBeDefined();
+      });
     });
   });
 
@@ -181,6 +452,68 @@ describe("CopilotChat welcome / connect integration", () => {
       });
       // And after thread-b's connect resolves.
       expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+    });
+  });
+
+  describe("same-thread reconnect settlement", () => {
+    it("re-enters the connecting path for a new same-thread connect attempt", async () => {
+      TrackingAgent.connectPlans = [{ outcome: "restored" }];
+      const firstAgent = new TrackingAgent();
+      firstAgent.agentId = "agent-a";
+      const secondAgent = new TrackingAgent();
+      secondAgent.agentId = "agent-b";
+
+      const { rerender } = render(
+        <CopilotKitProvider
+          agents__unsafe_dev_only={{
+            "agent-a": firstAgent,
+            "agent-b": secondAgent,
+          }}
+        >
+          <div style={{ height: 400 }}>
+            <CopilotChat agentId="agent-a" threadId="same-thread" />
+          </div>
+        </CopilotKitProvider>,
+      );
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some(
+            (c) => c.threadId === "same-thread" && c.agentId === "agent-a",
+          ),
+        ).toBe(true);
+      });
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      TrackingAgent.connectPlans = [{ outcome: "fresh", deferred: true }];
+      rerender(
+        <CopilotKitProvider
+          agents__unsafe_dev_only={{
+            "agent-a": firstAgent,
+            "agent-b": secondAgent,
+          }}
+        >
+          <div style={{ height: 400 }}>
+            <CopilotChat agentId="agent-b" threadId="same-thread" />
+          </div>
+        </CopilotKitProvider>,
+      );
+
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some(
+            (c) => c.threadId === "same-thread" && c.agentId === "agent-b",
+          ),
+        ).toBe(true);
+      });
+
+      TrackingAgent.resolveNextConnect();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("copilot-welcome-screen")).toBeDefined();
+      });
     });
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.welcomeGate.test.tsx
@@ -453,6 +453,61 @@ describe("CopilotChat welcome / connect integration", () => {
       // And after thread-b's connect resolves.
       expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
     });
+
+    it("keeps the welcome screen hidden when switching A to B to A", async () => {
+      const agent = new TrackingAgent();
+      agent.agentId = DEFAULT_AGENT_ID;
+
+      const { rerender } = renderWithKit(
+        <CopilotChat threadId="thread-a" />,
+        agent,
+      );
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some((c) => c.threadId === "thread-a"),
+        ).toBe(true);
+      });
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      rerender(
+        <CopilotKitProvider
+          agents__unsafe_dev_only={{ [DEFAULT_AGENT_ID]: agent }}
+        >
+          <div style={{ height: 400 }}>
+            <CopilotChat threadId="thread-b" />
+          </div>
+        </CopilotKitProvider>,
+      );
+
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.some((c) => c.threadId === "thread-b"),
+        ).toBe(true);
+      });
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      rerender(
+        <CopilotKitProvider
+          agents__unsafe_dev_only={{ [DEFAULT_AGENT_ID]: agent }}
+        >
+          <div style={{ height: 400 }}>
+            <CopilotChat threadId="thread-a" />
+          </div>
+        </CopilotKitProvider>,
+      );
+
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+
+      await waitFor(() => {
+        expect(
+          TrackingAgent.connectCalls.filter((c) => c.threadId === "thread-a"),
+        ).toHaveLength(2);
+      });
+      expect(screen.queryByTestId("copilot-welcome-screen")).toBeNull();
+    });
   });
 
   describe("same-thread reconnect settlement", () => {

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -645,4 +645,122 @@ describe("CopilotChat activity message rendering", () => {
 
     expect(mockWebsandboxDestroy).toHaveBeenCalledTimes(1);
   });
+
+  it("restores a completed Open Generative UI activity from IntelligenceAgent /connect gateway replay", async () => {
+    mockWebsandboxCreate.mockClear();
+    mockWebsandboxDestroy.mockClear();
+
+    const threadId = testId("open-generative-ui-connect-thread");
+    const restoredHtml =
+      "<head></head><body><div>Restored open generative UI</div></body>";
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        threadId,
+        runId: null,
+        joinToken: "join-token-open-generative-ui",
+        realtime: {
+          clientUrl: "ws://localhost:4000/client",
+          topic: `thread:${threadId}`,
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    mockPhoenixSockets.length = 0;
+
+    const agent = new IntelligenceAgent({
+      url: "ws://localhost:4000/client",
+      runtimeUrl: "http://localhost:4000",
+      agentId: "my-agent",
+    });
+
+    try {
+      render(
+        <CopilotKitProvider
+          agents__unsafe_dev_only={{ default: agent }}
+          openGenerativeUI={{}}
+        >
+          <CopilotChatConfigurationProvider
+            threadId={threadId}
+            hasExplicitThreadId
+          >
+            <div style={{ height: 400 }}>
+              <CopilotChat welcomeScreen={false} />
+            </div>
+          </CopilotChatConfigurationProvider>
+        </CopilotKitProvider>,
+      );
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      await waitFor(() => {
+        expect(mockPhoenixSockets).toHaveLength(1);
+        expect(mockPhoenixSockets[0]?.channels).toHaveLength(1);
+      });
+
+      const channel = mockPhoenixSockets[0]!.channels[0]!;
+      expect(channel.topic).toBe(`thread:${threadId}`);
+      expect(channel.params).toEqual({
+        stream_mode: "connect",
+        last_seen_event_id: null,
+      });
+
+      channel.triggerJoin("ok");
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_STARTED,
+        threadId,
+        run_id: "backend-run-open-generative-ui",
+        input: {
+          messages: [
+            {
+              id: testId("connect-open-generative-ui-user-message"),
+              role: "user",
+              content: "show me the restored app",
+            },
+          ],
+        },
+      });
+      channel.serverPush("ag_ui_event", {
+        type: EventType.ACTIVITY_SNAPSHOT,
+        messageId: testId("connect-open-generative-ui-activity"),
+        activityType: "open-generative-ui",
+        content: {
+          initialHeight: 180,
+          generating: false,
+          html: [restoredHtml],
+          htmlComplete: true,
+        },
+      });
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_FINISHED,
+      });
+      channel.serverPush("stream_idle", { latestEventId: "event-3" });
+
+      await waitFor(() => {
+        expect(screen.getByText("show me the restored app")).toBeDefined();
+      });
+      await waitFor(() => {
+        expect(mockWebsandboxCreate).toHaveBeenCalledTimes(1);
+      });
+      expect(mockWebsandboxCreate.mock.calls[0]?.[1]).toMatchObject({
+        frameContent: restoredHtml,
+      });
+
+      const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("/agent/my-agent/connect");
+      expect(options.method).toBe("POST");
+
+      const requestBody = JSON.parse(String(options.body)) as {
+        threadId: string;
+        lastSeenEventId: string | null;
+        messages: unknown[];
+      };
+      expect(requestBody.threadId).toBe(threadId);
+      expect(requestBody.lastSeenEventId).toBeNull();
+      expect(requestBody.messages).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -376,6 +376,7 @@ describe("CopilotChat activity message rendering", () => {
     const { unmount } = renderWithCopilotKit({
       agent,
       threadId,
+      hasExplicitThreadId: true,
       renderActivityMessages: [a2uiRenderer],
     });
 
@@ -435,6 +436,7 @@ describe("CopilotChat activity message rendering", () => {
     renderWithCopilotKit({
       agent,
       threadId,
+      hasExplicitThreadId: true,
       renderActivityMessages: [a2uiRenderer],
     });
 
@@ -475,6 +477,7 @@ describe("CopilotChat activity message rendering", () => {
       renderWithCopilotKit({
         agent,
         threadId,
+        hasExplicitThreadId: true,
         renderActivityMessages: [a2uiRenderer],
       });
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
@@ -1522,24 +1522,42 @@ describe("CopilotChatInput", () => {
   describe("Scroll behavior", () => {
     it("does not call scrollIntoView when the textarea receives focus", async () => {
       const scrollIntoViewMock = vi.fn();
-      HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
-
-      renderWithProvider(
-        <CopilotChatInput autoFocus onSubmitMessage={mockOnSubmitMessage} />,
+      const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        "scrollIntoView",
       );
 
-      const textarea = screen.getByRole("textbox");
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        value: scrollIntoViewMock,
+      });
 
-      // Trigger focus explicitly (autoFocus also triggers it, but let's be explicit)
-      fireEvent.focus(textarea);
+      try {
+        renderWithProvider(
+          <CopilotChatInput autoFocus onSubmitMessage={mockOnSubmitMessage} />,
+        );
 
-      // Wait long enough for the 300ms setTimeout inside the focus handler
-      await new Promise((resolve) => setTimeout(resolve, 500));
+        const textarea = screen.getByRole("textbox");
 
-      expect(scrollIntoViewMock).not.toHaveBeenCalled();
+        // Trigger focus explicitly (autoFocus also triggers it, but let's be explicit)
+        fireEvent.focus(textarea);
 
-      // Clean up
-      delete (HTMLElement.prototype as any).scrollIntoView;
+        // Wait long enough for the 300ms setTimeout inside the focus handler
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        expect(scrollIntoViewMock).not.toHaveBeenCalled();
+      } finally {
+        if (originalScrollIntoViewDescriptor) {
+          Object.defineProperty(
+            HTMLElement.prototype,
+            "scrollIntoView",
+            originalScrollIntoViewDescriptor,
+          );
+        } else {
+          delete (HTMLElement.prototype as { scrollIntoView?: unknown })
+            .scrollIntoView;
+        }
+      }
     });
 
     it("does not auto-focus the textarea by default", () => {

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-thread-isolation.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-thread-isolation.test.tsx
@@ -26,11 +26,14 @@ const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
  * calls are meaningful (not vacuously true on an already-empty clone).
  */
 class CloneableAgent extends AbstractAgent {
+  public lastConnectRestoreOutcome: "fresh" | "restored" | null = "restored";
+
   clone(): CloneableAgent {
     const cloned = new CloneableAgent();
     cloned.agentId = this.agentId;
     // Copy messages so cloneForThread's setMessages([]) actually clears state
     cloned.setMessages([...this.messages]);
+    cloned.lastConnectRestoreOutcome = this.lastConnectRestoreOutcome;
     return cloned;
   }
 
@@ -209,6 +212,26 @@ describe("useAgent thread isolation", () => {
 
     expect(agents["a"]!.threadId).toBe("thread-a");
     expect(agents["b"]!.threadId).toBe("thread-b");
+  });
+
+  it("resets restore outcome metadata on fresh thread clones", () => {
+    let captured: AbstractAgent | undefined;
+
+    function Tracker() {
+      const { agent } = useAgent({ agentId: "my-agent", threadId: "thread-a" });
+      captured = agent;
+      return null;
+    }
+
+    render(<Tracker />);
+
+    expect(
+      (
+        captured as AbstractAgent & {
+          lastConnectRestoreOutcome?: "fresh" | "restored" | null;
+        }
+      ).lastConnectRestoreOutcome,
+    ).toBeNull();
   });
 
   it("invalidates stale clone when the registry agent is replaced", () => {

--- a/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
@@ -717,6 +717,7 @@ describe("HITL Thread Reconnection Bug", () => {
     // so the executing state is captured early and available when components mount.
 
     const agent = new MockReconnectableAgent();
+    const reconnectThreadId = "hitl-reconnect-thread";
 
     const HITLComponent: React.FC = () => {
       const hitlTool: ReactHumanInTheLoop<{ action: string }> = {
@@ -741,6 +742,8 @@ describe("HITL Thread Reconnection Bug", () => {
     // Phase 1: Initial render and run (user starts interaction)
     const { unmount } = renderWithCopilotKit({
       agent,
+      threadId: reconnectThreadId,
+      hasExplicitThreadId: true,
       children: (
         <>
           <HITLComponent />
@@ -797,6 +800,8 @@ describe("HITL Thread Reconnection Bug", () => {
     // Re-render with same thread (simulates reconnection)
     renderWithCopilotKit({
       agent,
+      threadId: reconnectThreadId,
+      hasExplicitThreadId: true,
       children: (
         <>
           <HITLComponent />

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -15,6 +15,8 @@ export enum UseAgentUpdate {
   OnRunStatusChanged = "OnRunStatusChanged",
 }
 
+type ConnectRestoreOutcome = "fresh" | "restored";
+
 const ALL_UPDATES: UseAgentUpdate[] = [
   UseAgentUpdate.OnMessagesChanged,
   UseAgentUpdate.OnStateChanged,
@@ -70,6 +72,13 @@ function cloneForThread(
   clone.threadId = threadId;
   clone.setMessages([]);
   clone.setState({});
+  if ("lastConnectRestoreOutcome" in clone) {
+    (
+      clone as AbstractAgent & {
+        lastConnectRestoreOutcome?: ConnectRestoreOutcome | null;
+      }
+    ).lastConnectRestoreOutcome = null;
+  }
   if (clone instanceof HttpAgent) {
     clone.headers = { ...headers };
   }

--- a/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
@@ -5,6 +5,8 @@ import { handleConnectAgent } from "../handlers/handle-connect";
 import { CopilotRuntime } from "../core/runtime";
 import { AgentRunnerConnectRequest } from "../runner/agent-runner";
 import { IntelligenceAgentRunner } from "../runner/intelligence";
+import type { ConnectRestorePayload } from "../handlers/shared/agent-utils";
+import { InvalidConnectResponseError } from "../intelligence-platform/client";
 
 describe("handleConnectAgent", () => {
   const createMockRuntime = (
@@ -190,6 +192,7 @@ describe("handleConnectAgent", () => {
     const createConnectRequest = (
       headers?: Record<string, string>,
       lastSeenEventId?: string | null,
+      restore?: ConnectRestorePayload | null,
     ) =>
       new Request("https://example.com/agent/my-agent/connect", {
         method: "POST",
@@ -203,6 +206,7 @@ describe("handleConnectAgent", () => {
           context: [],
           forwardedProps: {},
           ...(lastSeenEventId !== undefined ? { lastSeenEventId } : {}),
+          ...(restore !== undefined ? { restore } : {}),
         }),
       });
 
@@ -238,10 +242,10 @@ describe("handleConnectAgent", () => {
       } as unknown as CopilotRuntime;
     };
 
-    it("returns runtime websocket connection credentials when available", async () => {
+    it("returns runtime websocket connection credentials with the canonical thread identity when available", async () => {
       const platform = {
         ɵconnectThread: vi.fn().mockResolvedValue({
-          threadId: "thread-1",
+          threadId: "canonical-thread-1",
           joinToken: "jt-connect-1",
         }),
       };
@@ -257,17 +261,56 @@ describe("handleConnectAgent", () => {
       expect(response.headers.get("Content-Type")).toBe("application/json");
       const body = await response.json();
       expect(body).toEqual({
-        threadId: "thread-1",
+        threadId: "canonical-thread-1",
         joinToken: "jt-connect-1",
         realtime: {
           clientUrl: "wss://runtime.example/client",
-          topic: "thread:thread-1",
+          topic: "thread:canonical-thread-1",
         },
       });
       expect(platform.ɵconnectThread).toHaveBeenCalledWith({
         threadId: "thread-1",
         userId: "user-1",
         agentId: "my-agent",
+      });
+    });
+
+    it("returns 200 for a restored persisted thread while forwarding restore metadata", async () => {
+      const restore: ConnectRestorePayload = {
+        intent: "restore",
+        cursor: {
+          lastEventId: "event-9",
+        },
+      };
+      const platform = {
+        ɵconnectThread: vi.fn().mockResolvedValue({
+          threadId: "canonical-thread-restore",
+          joinToken: "jt-connect-restore",
+        }),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+
+      const response = await handleConnectAgent({
+        runtime,
+        request: createConnectRequest(undefined, "event-9", restore),
+        agentId: "my-agent",
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        threadId: "canonical-thread-restore",
+        joinToken: "jt-connect-restore",
+        realtime: {
+          clientUrl: "wss://runtime.example/client",
+          topic: "thread:canonical-thread-restore",
+        },
+      });
+      expect(platform.ɵconnectThread).toHaveBeenCalledWith({
+        threadId: "thread-1",
+        userId: "user-1",
+        agentId: "my-agent",
+        lastSeenEventId: "event-9",
+        restore,
       });
     });
 
@@ -321,11 +364,173 @@ describe("handleConnectAgent", () => {
       });
     });
 
-    it("returns 404 when connect planning is not available", async () => {
+    it("returns a connect-specific 500 fallback for unexpected connect failures", async () => {
       const platform = {
         ɵconnectThread: vi
           .fn()
           .mockRejectedValue(new Error("No active connect plan")),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+      const { logger } = await import("@copilotkit/shared");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      try {
+        const response = await handleConnectAgent({
+          runtime,
+          request: createConnectRequest(),
+          agentId: "my-agent",
+        });
+
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toEqual({
+          error: "Connect request failed",
+          message: "Intelligence platform connect failed unexpectedly",
+          details: "No active connect plan",
+        });
+        expect(errorSpy).toHaveBeenCalledWith(
+          {
+            err: expect.any(Error),
+            threadId: "thread-1",
+            agentId: "my-agent",
+          },
+          "Intelligence connect failed unexpectedly",
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("fails closed when the platform returns malformed 200 connect credentials", async () => {
+      const platform = {
+        ɵconnectThread: vi.fn().mockResolvedValue({
+          threadId: "canonical-thread-1",
+          joinToken: "",
+          joinTokenPreview: "secret-token",
+        }),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+      const { logger } = await import("@copilotkit/shared");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      try {
+        const response = await handleConnectAgent({
+          runtime,
+          request: createConnectRequest(),
+          agentId: "my-agent",
+        });
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+          error: "Connect response invalid",
+          message:
+            "Intelligence platform did not return canonical threadId and joinToken",
+        });
+        expect(errorSpy).toHaveBeenCalledWith(
+          {
+            threadId: "thread-1",
+            agentId: "my-agent",
+            resultSummary: {
+              canonicalThreadId: "canonical-thread-1",
+              hasJoinToken: false,
+              fields: ["threadId", "joinToken", "joinTokenPreview"],
+            },
+          },
+          "Intelligence connect returned malformed credentials",
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("fails closed when the platform returns an empty 200 connect response body", async () => {
+      const platform = {
+        ɵconnectThread: vi
+          .fn()
+          .mockRejectedValue(
+            new InvalidConnectResponseError(
+              "Intelligence platform returned empty connect response body",
+            ),
+          ),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+      const { logger } = await import("@copilotkit/shared");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      try {
+        const response = await handleConnectAgent({
+          runtime,
+          request: createConnectRequest(),
+          agentId: "my-agent",
+        });
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+          error: "Connect response invalid",
+          message: "Intelligence platform returned empty connect response body",
+        });
+        expect(errorSpy).toHaveBeenCalledWith(
+          {
+            err: expect.any(InvalidConnectResponseError),
+            threadId: "thread-1",
+            agentId: "my-agent",
+          },
+          "Intelligence connect returned invalid response",
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("fails closed when the platform returns a 200 JSON null connect payload", async () => {
+      const platform = {
+        ɵconnectThread: vi
+          .fn()
+          .mockRejectedValue(
+            new InvalidConnectResponseError(
+              "Intelligence platform returned invalid connect response payload",
+            ),
+          ),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+      const { logger } = await import("@copilotkit/shared");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+      try {
+        const response = await handleConnectAgent({
+          runtime,
+          request: createConnectRequest(),
+          agentId: "my-agent",
+        });
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+          error: "Connect response invalid",
+          message:
+            "Intelligence platform returned invalid connect response payload",
+        });
+        expect(errorSpy).toHaveBeenCalledWith(
+          {
+            err: expect.any(InvalidConnectResponseError),
+            threadId: "thread-1",
+            agentId: "my-agent",
+          },
+          "Intelligence connect returned invalid response",
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("fails closed when the platform returns malformed 200 connect JSON", async () => {
+      const platform = {
+        ɵconnectThread: vi
+          .fn()
+          .mockRejectedValue(
+            new InvalidConnectResponseError(
+              "Intelligence platform returned malformed connect response JSON",
+            ),
+          ),
       };
       const runtime = createIntelligenceRuntime(platform);
 
@@ -335,9 +540,11 @@ describe("handleConnectAgent", () => {
         agentId: "my-agent",
       });
 
-      expect(response.status).toBe(404);
-      const body = await response.json();
-      expect(body.error).toBe("Connect plan not available");
+      expect(response.status).toBe(502);
+      expect(await response.json()).toEqual({
+        error: "Connect response invalid",
+        message: "Intelligence platform returned malformed connect response JSON",
+      });
     });
 
     it("preserves platform not found errors when connect fails with 404", async () => {
@@ -406,15 +613,21 @@ describe("handleConnectAgent", () => {
       expect(body.error).toBe("Connect request rejected");
     });
 
-    it("does not forward replay cursors to the credentials-only intelligence platform connect", async () => {
+    it("forwards restore cursor semantics to the intelligence platform connect contract", async () => {
       const platform = {
         ɵconnectThread: vi.fn().mockResolvedValue(null),
       };
       const runtime = createIntelligenceRuntime(platform);
+      const restore: ConnectRestorePayload = {
+        intent: "restore",
+        cursor: {
+          lastEventId: "event-9",
+        },
+      };
 
       const response = await handleConnectAgent({
         runtime,
-        request: createConnectRequest(undefined, "event-9"),
+        request: createConnectRequest(undefined, "event-9", restore),
         agentId: "my-agent",
       });
 
@@ -423,6 +636,8 @@ describe("handleConnectAgent", () => {
         threadId: "thread-1",
         userId: "user-1",
         agentId: "my-agent",
+        lastSeenEventId: "event-9",
+        restore,
       });
     });
 
@@ -453,6 +668,7 @@ describe("handleConnectAgent", () => {
         threadId: "thread-1",
         userId: "resolved-user",
         agentId: "my-agent",
+        lastSeenEventId: "event-9",
       });
     });
 
@@ -512,11 +728,62 @@ describe("handleConnectAgent", () => {
         });
 
         expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+          error: "Failed to identify user",
+        });
         expect(platform.ɵconnectThread).not.toHaveBeenCalled();
       } finally {
         errorSpy.mockRestore();
       }
     });
+  });
+
+  it("returns the outer connect-specific fallback when agent cloning throws", async () => {
+    const runtime = createMockRuntime({
+      "broken-agent": {
+        clone: () => {
+          throw new Error("clone failed");
+        },
+      },
+    });
+    const request = new Request("https://example.com/agent/broken-agent/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thread-1",
+        runId: "run-1",
+        state: {},
+        messages: [],
+        tools: [],
+        context: [],
+        forwardedProps: {},
+      }),
+    });
+    const { logger } = await import("@copilotkit/shared");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    try {
+      const response = await handleConnectAgent({
+        runtime,
+        request,
+        agentId: "broken-agent",
+      });
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Failed to connect agent",
+        message: "clone failed",
+      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        {
+          err: expect.any(Error),
+          agentId: "broken-agent",
+        },
+        "Connect request handling failed",
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   describe("telemetry", () => {

--- a/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
@@ -2,6 +2,7 @@ import { handleIntelligenceConnect } from "./intelligence/connect";
 import { handleSseConnect } from "./sse/connect";
 import { isIntelligenceRuntime } from "../core/runtime";
 import { telemetry } from "../telemetry";
+import { logger } from "@copilotkit/shared";
 import {
   parseConnectRequest,
   RunAgentParameters as ConnectAgentParameters,
@@ -45,6 +46,7 @@ export async function handleConnectAgent({
         request,
         agentId,
         threadId: connectRequest.input.threadId,
+        restore: connectRequest.restore,
       });
     }
 
@@ -55,20 +57,17 @@ export async function handleConnectAgent({
       threadId: connectRequest.input.threadId,
     });
   } catch (error) {
-    console.error("Error running agent:", error);
-    console.error(
-      "Error stack:",
-      error instanceof Error ? error.stack : "No stack trace",
+    logger.error(
+      {
+        err: error,
+        agentId,
+      },
+      "Connect request handling failed",
     );
-    console.error("Error details:", {
-      name: error instanceof Error ? error.name : "Unknown",
-      message: error instanceof Error ? error.message : String(error),
-      cause: error instanceof Error ? error.cause : undefined,
-    });
 
     return new Response(
       JSON.stringify({
-        error: "Failed to run agent",
+        error: "Failed to connect agent",
         message: error instanceof Error ? error.message : "Unknown error",
       }),
       {

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/connect.ts
@@ -2,6 +2,12 @@ import { CopilotIntelligenceRuntimeLike } from "../../core/runtime";
 import { getPlatformErrorStatus } from "../shared/intelligence-utils";
 import { resolveIntelligenceUser } from "../shared/resolve-intelligence-user";
 import { isHandlerResponse } from "../shared/json-response";
+import { logger } from "@copilotkit/shared";
+import type { ConnectRestoreParameters } from "../shared/agent-utils";
+import {
+  InvalidConnectResponseError,
+  type ConnectThreadResponse,
+} from "../../intelligence-platform/client";
 
 /**
  * Builds browser-facing realtime connection metadata owned by the runtime.
@@ -21,6 +27,38 @@ interface HandleIntelligenceConnectParams {
   request: Request;
   agentId: string;
   threadId: string;
+  restore: ConnectRestoreParameters;
+}
+
+function summarizeInvalidConnectResult(
+  result: NonNullable<ConnectThreadResponse>,
+): {
+  canonicalThreadId?: string;
+  hasJoinToken: boolean;
+  fields: string[];
+} {
+  const candidate = result as Record<string, unknown>;
+
+  return {
+    ...(typeof result.threadId === "string"
+      ? { canonicalThreadId: result.threadId }
+      : {}),
+    hasJoinToken:
+      typeof candidate.joinToken === "string" && candidate.joinToken.length > 0,
+    fields: Object.keys(candidate),
+  };
+}
+
+function hasConnectResponseFields(
+  result: ConnectThreadResponse,
+): result is NonNullable<ConnectThreadResponse> {
+  return (
+    result !== null &&
+    typeof result.threadId === "string" &&
+    result.threadId.length > 0 &&
+    typeof result.joinToken === "string" &&
+    result.joinToken.length > 0
+  );
 }
 
 export async function handleIntelligenceConnect({
@@ -28,6 +66,7 @@ export async function handleIntelligenceConnect({
   request,
   agentId,
   threadId,
+  restore,
 }: HandleIntelligenceConnectParams): Promise<Response> {
   if (!runtime.intelligence) {
     return Response.json(
@@ -49,12 +88,32 @@ export async function handleIntelligenceConnect({
       threadId,
       userId: user.id,
       agentId,
+      ...restore,
     });
 
     if (result === null) {
       return new Response(null, {
         status: 204,
       });
+    }
+
+    if (!hasConnectResponseFields(result)) {
+      logger.error(
+        {
+          threadId,
+          agentId,
+          resultSummary: summarizeInvalidConnectResult(result),
+        },
+        "Intelligence connect returned malformed credentials",
+      );
+      return Response.json(
+        {
+          error: "Connect response invalid",
+          message:
+            "Intelligence platform did not return canonical threadId and joinToken",
+        },
+        { status: 502 },
+      );
     }
 
     return Response.json(
@@ -71,14 +130,26 @@ export async function handleIntelligenceConnect({
       },
     );
   } catch (error) {
+    if (error instanceof InvalidConnectResponseError) {
+      logger.error(
+        {
+          err: error,
+          threadId,
+          agentId,
+        },
+        "Intelligence connect returned invalid response",
+      );
+      return Response.json(
+        {
+          error: "Connect response invalid",
+          message: error.message,
+        },
+        { status: 502 },
+      );
+    }
+
     const status = getPlatformErrorStatus(error);
-    if (
-      status === 400 ||
-      status === 401 ||
-      status === 403 ||
-      status === 404 ||
-      status === 409
-    ) {
+    if (status !== undefined && status >= 400 && status < 500) {
       return Response.json(
         {
           error: "Connect request rejected",
@@ -91,12 +162,21 @@ export async function handleIntelligenceConnect({
       );
     }
 
-    console.error("Connect plan not available:", error);
+    logger.error(
+      {
+        err: error,
+        threadId,
+        agentId,
+      },
+      "Intelligence connect failed unexpectedly",
+    );
     return Response.json(
       {
-        error: "Connect plan not available",
+        error: "Connect request failed",
+        message: "Intelligence platform connect failed unexpectedly",
+        ...(error instanceof Error ? { details: error.message } : {}),
       },
-      { status: 404 },
+      { status: 500 },
     );
   }
 }

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -23,6 +23,35 @@ export interface RunAgentParameters {
 
 export interface ConnectRequestBody extends RunAgentInput {
   lastSeenEventId?: string | null;
+  restore?: ConnectRestorePayload | null;
+}
+
+type ConnectJsonPrimitive = string | number | boolean | null;
+type ConnectJsonValue =
+  | ConnectJsonPrimitive
+  | ConnectJsonValue[]
+  | { [key: string]: ConnectJsonValue | undefined };
+
+export interface ConnectRestoreCursor {
+  lastEventId?: string | null;
+  [key: string]: ConnectJsonValue | undefined;
+}
+
+export interface ConnectRestorePayload {
+  intent?: string;
+  cursor?: ConnectRestoreCursor;
+  [key: string]: ConnectJsonValue | undefined;
+}
+
+export interface ConnectRestoreParameters {
+  lastSeenEventId?: string | null;
+  restore?: ConnectRestorePayload | null;
+}
+
+function isConnectRestorePayload(
+  value: unknown,
+): value is ConnectRestorePayload | null {
+  return value === null || (typeof value === "object" && !Array.isArray(value));
 }
 
 export async function cloneAgentForRequest(
@@ -121,13 +150,13 @@ export async function parseConnectRequest(request: Request): Promise<
   | Response
   | {
       input: RunAgentInput;
-      lastSeenEventId: string | null;
+      restore: ConnectRestoreParameters;
     }
 > {
   try {
     const requestBody = await request.json();
     const input = RunAgentInputSchema.parse(requestBody);
-    let lastSeenEventId: string | null = null;
+    const restore: ConnectRestoreParameters = {};
 
     if (
       "lastSeenEventId" in (requestBody as Record<string, unknown>) &&
@@ -135,11 +164,32 @@ export async function parseConnectRequest(request: Request): Promise<
         "string" ||
         (requestBody as Record<string, unknown>).lastSeenEventId === null)
     ) {
-      lastSeenEventId =
+      restore.lastSeenEventId =
         (requestBody as ConnectRequestBody).lastSeenEventId ?? null;
     }
 
-    return { input, lastSeenEventId };
+    if ("restore" in (requestBody as Record<string, unknown>)) {
+      if (
+        !isConnectRestorePayload(
+          (requestBody as Record<string, unknown>).restore,
+        )
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: "Invalid request body",
+            details: "restore must be an object or null",
+          }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      restore.restore = (requestBody as ConnectRequestBody).restore;
+    }
+
+    return { input, restore };
   } catch (error) {
     logger.error("Invalid connect request body:", error);
     return new Response(

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { CopilotKitIntelligence } from "../client";
+import {
+  CopilotKitIntelligence,
+  InvalidConnectResponseError,
+} from "../client";
 
 const fetchMock = vi.fn();
 globalThis.fetch = fetchMock;
@@ -582,6 +585,36 @@ describe("CopilotKitIntelligence", () => {
       });
     });
 
+    it("forwards restore intent and replay cursor fields to the connect endpoint", async () => {
+      fetchMock.mockReturnValue(emptyResponse());
+
+      await client.ɵconnectThread({
+        threadId: "t-1",
+        userId: "user-1",
+        agentId: "agent-1",
+        lastSeenEventId: "event-9",
+        restore: {
+          intent: "restore",
+          cursor: {
+            lastEventId: "event-9",
+          },
+        },
+      });
+
+      const [, opts] = fetchMock.mock.calls[0];
+      expect(JSON.parse(opts.body)).toEqual({
+        userId: "user-1",
+        agentId: "agent-1",
+        lastSeenEventId: "event-9",
+        restore: {
+          intent: "restore",
+          cursor: {
+            lastEventId: "event-9",
+          },
+        },
+      });
+    });
+
     it("returns credentials-only connect response", async () => {
       const payload = {
         threadId: "t-1",
@@ -596,6 +629,53 @@ describe("CopilotKitIntelligence", () => {
       });
 
       expect(result).toEqual(payload);
+    });
+
+    it("throws an invalid connect response error on empty 200 bodies", async () => {
+      fetchMock.mockReturnValue(emptyResponse(200));
+
+      await expect(
+        client.ɵconnectThread({
+          threadId: "t-1",
+          userId: "user-1",
+          agentId: "agent-1",
+        }),
+      ).rejects.toBeInstanceOf(InvalidConnectResponseError);
+    });
+
+    it("throws an invalid connect response error on 200 JSON null bodies", async () => {
+      fetchMock.mockReturnValue(jsonResponse(null));
+
+      await expect(
+        client.ɵconnectThread({
+          threadId: "t-1",
+          userId: "user-1",
+          agentId: "agent-1",
+        }),
+      ).rejects.toThrow(
+        "Intelligence platform returned invalid connect response payload",
+      );
+    });
+
+    it("throws an invalid connect response error on malformed 200 JSON bodies", async () => {
+      fetchMock.mockReturnValue(
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: () => Promise.resolve("{not-json"),
+        } as Response),
+      );
+
+      await expect(
+        client.ɵconnectThread({
+          threadId: "t-1",
+          userId: "user-1",
+          agentId: "agent-1",
+        }),
+      ).rejects.toThrow(
+        "Intelligence platform returned malformed connect response JSON",
+      );
     });
   });
 });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -28,6 +28,35 @@ export class PlatformRequestError extends Error {
   }
 }
 
+export class InvalidConnectResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidConnectResponseError";
+  }
+}
+
+function parseConnectResponseBody(text: string): ThreadConnectionResponse {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new InvalidConnectResponseError(
+        "Intelligence platform returned invalid connect response payload",
+      );
+    }
+
+    return parsed as ThreadConnectionResponse;
+  } catch (error) {
+    if (error instanceof InvalidConnectResponseError) {
+      throw error;
+    }
+
+    throw new InvalidConnectResponseError(
+      "Intelligence platform returned malformed connect response JSON",
+    );
+  }
+}
+
 /**
  * Client for the CopilotKit Intelligence Platform REST API.
  *
@@ -165,6 +194,14 @@ export interface SubscribeToThreadsRequest {
 
 export interface SubscribeToThreadsResponse {
   joinToken: string;
+}
+
+export interface ConnectThreadRequest {
+  threadId: string;
+  userId: string;
+  agentId: string;
+  lastSeenEventId?: string | null;
+  restore?: import("../handlers/shared/agent-utils").ConnectRestorePayload | null;
 }
 
 export type ConnectThreadResponse = ThreadConnectionResponse | null;
@@ -657,22 +694,56 @@ export class CopilotKitIntelligence {
     );
   }
 
-  async ɵconnectThread(params: {
-    threadId: string;
-    userId: string;
-    agentId: string;
-  }): Promise<ConnectThreadResponse> {
-    const result = await this.#request<ThreadConnectionResponse>(
-      "POST",
-      `/api/threads/${encodeURIComponent(params.threadId)}/connect`,
-      {
+  async ɵconnectThread(
+    params: ConnectThreadRequest,
+  ): Promise<ConnectThreadResponse> {
+    const path = `/api/threads/${encodeURIComponent(params.threadId)}/connect`;
+    const url = `${this.#apiUrl}${path}`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.#apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
         userId: params.userId,
         agentId: params.agentId,
-      },
-    );
+        ...(params.lastSeenEventId !== undefined
+          ? { lastSeenEventId: params.lastSeenEventId }
+          : {}),
+        ...(params.restore !== undefined ? { restore: params.restore } : {}),
+      }),
+    });
 
-    // request() returns undefined for empty/204 responses
-    return result ?? null;
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      logger.error(
+        { status: response.status, body: text, path },
+        "Intelligence platform request failed",
+      );
+      throw new PlatformRequestError(
+        `Intelligence platform error ${response.status}: ${text || response.statusText}`,
+        response.status,
+      );
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const text = await response.text();
+    if (!text) {
+      logger.error(
+        { status: response.status, path },
+        "Intelligence connect returned empty response body",
+      );
+      throw new InvalidConnectResponseError(
+        "Intelligence platform returned empty connect response body",
+      );
+    }
+
+    return parseConnectResponseBody(text);
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- aligns runtime `/connect` handling with durable restore semantics from Intelligence
- restores persisted thread reconnect behavior across `runtime`, `core`, and `react-core`, including same-thread reconnects, explicit-thread gating, and `A -> B -> A` thread switches
- adds regression coverage and docs for blank-thread, `/connect`, reconnect, and persisted activity restore behavior

## Related PRs and Issues

- Parent Linear issue: https://linear.app/copilotkit/issue/ENT-447/fix-connectthread-restore-parity-across-intelligence-runtime-core-and
- ENT-449: https://linear.app/copilotkit/issue/ENT-449/runtime-forward-restore-intent-and-map-intelligence-connect-results
- ENT-450: https://linear.app/copilotkit/issue/ENT-450/corereact-restore-persisted-threads-deterministically-on-remount-and
- ENT-451: https://linear.app/copilotkit/issue/ENT-451/testsdocs-add-a-connect-blank-thread-and-reconnect-regression-matrix

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
