### PR TITLE
fix(showcase): add comprehensive logging to harness probe execution pipeline

### DIFF
--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -272,7 +272,7 @@ export async function boot(opts: BootOptions = {}): Promise<{
   const poolSize = process.env.BROWSER_POOL_SIZE
     ? parseInt(process.env.BROWSER_POOL_SIZE, 10) || 4
     : 4;
-  const browserPool = new BrowserPool(poolSize);
+  const browserPool = new BrowserPool(poolSize, undefined, logger);
   let browserPoolReady = false;
   try {
     await browserPool.init();

--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -636,6 +636,13 @@ export function createE2eDeepDriver(
         });
       }
 
+      const serviceStart = Date.now();
+      ctx.logger.info("probe.e2e-deep.service-start", {
+        slug,
+        featureCount: requestedFeatures.length,
+        backendUrl,
+      });
+
       // Partition features into "registered" (script available) vs
       // "skipped" (no script). The skipped set short-circuits before
       // chromium so we don't pay for a launch per slug when Wave 2b
@@ -799,6 +806,7 @@ export function createE2eDeepDriver(
           const url = `${backendUrl}${route}`;
 
           await sem.acquire();
+          const featureStart = Date.now();
           try {
             if (abort.signal.aborted) {
               await sideEmit(ctx, {
@@ -816,6 +824,15 @@ export function createE2eDeepDriver(
                     : "aborted",
                 },
                 observedAt: ctx.now().toISOString(),
+              });
+              ctx.logger.info("probe.e2e-deep.feature-complete", {
+                slug,
+                featureType: ft,
+                pass: false,
+                errorDesc: timedOut
+                  ? `timeout after ${timeoutMs}ms`
+                  : "aborted",
+                durationMs: Date.now() - featureStart,
               });
               return {
                 ft,
@@ -856,6 +873,12 @@ export function createE2eDeepDriver(
                 },
                 observedAt: ctx.now().toISOString(),
               });
+              ctx.logger.info("probe.e2e-deep.feature-complete", {
+                slug,
+                featureType: ft,
+                pass: true,
+                durationMs: Date.now() - featureStart,
+              });
               return { ft, ok: true as const };
             } else {
               await sideEmit(ctx, {
@@ -877,6 +900,13 @@ export function createE2eDeepDriver(
                   diagnostics: featureResult.diagnostics,
                 },
                 observedAt: ctx.now().toISOString(),
+              });
+              ctx.logger.info("probe.e2e-deep.feature-complete", {
+                slug,
+                featureType: ft,
+                pass: false,
+                errorDesc: featureResult.errorDesc,
+                durationMs: Date.now() - featureStart,
               });
               return {
                 ft,
@@ -944,6 +974,15 @@ export function createE2eDeepDriver(
         }
 
         const aggregateGreen = failed.length === 0;
+        ctx.logger.info("probe.e2e-deep.service-complete", {
+          slug,
+          passed,
+          failed: failed.length,
+          skipped: skipped.length,
+          total: requestedFeatures.length,
+          state: aggregateGreen ? "green" : "red",
+          durationMs: Date.now() - serviceStart,
+        });
         return {
           key: input.key,
           state: aggregateGreen ? "green" : "red",

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -17,6 +17,15 @@ export interface BrowserPoolStats {
   totalRecycles: number;
 }
 
+/**
+ * Minimal logger surface the pool uses for lifecycle events. Matches the
+ * harness-wide `Logger` interface but only the `info` method is required.
+ * Optional so existing callers (tests, legacy boot paths) don't break.
+ */
+interface PoolLogger {
+  info(msg: string, meta?: Record<string, unknown>): void;
+}
+
 export class BrowserPool {
   private readonly poolSize: number;
   private readonly recycleAfter: number;
@@ -26,13 +35,19 @@ export class BrowserPool {
   private totalRecycles = 0;
   private inFlightRecycles = new Set<Promise<void>>();
   private isShutdown = false;
+  private readonly logger?: PoolLogger;
 
   // Tracks which Browser instance maps to which Slot, so release() can find
   // the slot in O(1) even after the slot was removed from `available`.
   private browserToSlot = new Map<Browser, Slot>();
 
-  constructor(size = 4, recycleAfter?: number) {
+  constructor(
+    size = 4,
+    recycleAfter?: number,
+    logger?: PoolLogger,
+  ) {
     this.poolSize = size;
+    this.logger = logger;
     const envRecycle = process.env.BROWSER_POOL_RECYCLE_AFTER
       ? parseInt(process.env.BROWSER_POOL_RECYCLE_AFTER, 10)
       : undefined;
@@ -71,6 +86,10 @@ export class BrowserPool {
 
     const slot = this.available.shift();
     if (slot) {
+      this.logger?.info("browser-pool.acquire", {
+        available: this.available.length,
+        inUse: this.slots.length - this.available.length,
+      });
       return slot.browser;
     }
 
@@ -119,6 +138,11 @@ export class BrowserPool {
     } else {
       this.available.push(slot);
     }
+    const s = this.stats();
+    this.logger?.info("browser-pool.release", {
+      available: s.available,
+      inUse: s.inUse,
+    });
   }
 
   async shutdown(): Promise<void> {
@@ -158,6 +182,13 @@ export class BrowserPool {
 
   private recycleSlot(slot: Slot): void {
     this.totalRecycles++;
+    const slotIdx = this.slots.indexOf(slot);
+    this.logger?.info("browser-pool.recycle", {
+      slotIndex: slotIdx,
+      contextCount: slot.contextCount,
+      recycleAfter: this.recycleAfter,
+      totalRecycles: this.totalRecycles,
+    });
 
     // Remove the old browser from the lookup map immediately so a
     // double-release of the stale reference is a no-op.

--- a/showcase/harness/src/probes/loader/probe-invoker.ts
+++ b/showcase/harness/src/probes/loader/probe-invoker.ts
@@ -208,6 +208,7 @@ export function buildProbeInvoker(
     // produce zero workers and drop every input on the floor.
     const concurrency = Math.max(cfg.max_concurrency, 1);
     const timeoutMs = "timeout_ms" in cfg ? cfg.timeout_ms : undefined;
+    const tickStart = Date.now();
 
     // B7: tracker registration. Read the slot's `triggeredRun` flag — set
     // by scheduler.trigger() before the handler runs — so the snapshot the
@@ -289,6 +290,14 @@ export function buildProbeInvoker(
     // the synthetic-error tile is emitted below and there's nothing to
     // fan out across.
     const allInputs: ResolvedInput[] = resolved.ok ? resolved.inputs : [];
+
+    logger.info("probe.tick-start", {
+      probeId: cfg.id,
+      kind: cfg.kind,
+      discoveredTargets: allInputs.length,
+      discoveryOk: resolved.ok,
+      triggered,
+    });
 
     // CR-A1.1: thread the trigger's slug filter end-to-end. Discover the
     // FULL roster (so logs/diagnostics still see what the source returned)
@@ -516,6 +525,8 @@ export function buildProbeInvoker(
         // a dead defensive guard.
         const idx = cursor++;
         const { input, key, preError } = inputs[idx]!;
+        const targetStart = Date.now();
+        logger.info("probe.target-start", { probeId: cfg.id, key });
         // B7: mark running just before handing the input to the driver.
         tracker.start(key);
         // CR-A1.2: short-circuit on inputs the resolver pre-flagged as
@@ -562,6 +573,12 @@ export function buildProbeInvoker(
           tracker.complete(key, "red");
           failed++;
         }
+        logger.info("probe.target-complete", {
+          probeId: cfg.id,
+          key,
+          state: result.state,
+          durationMs: Date.now() - targetStart,
+        });
         try {
           await writer.write(result);
         } catch (err) {
@@ -688,6 +705,35 @@ export function buildProbeInvoker(
             err: err instanceof Error ? err.message : String(err),
           });
         }
+      }
+      logger.info("probe.tick-complete", {
+        probeId: cfg.id,
+        kind: cfg.kind,
+        total: summary.total,
+        passed: summary.passed,
+        failed: summary.failed,
+        durationMs: Date.now() - tickStart,
+        discoveryFailed: summary.discoveryFailed ?? false,
+      });
+      // Structured per-service run summary — a single log line carrying
+      // every target's outcome so Railway logs give a complete picture
+      // without needing PocketBase.
+      const summarySnap = tracker.snapshot();
+      if (summarySnap.services.length > 0) {
+        logger.info("probe.run-summary", {
+          probeId: cfg.id,
+          kind: cfg.kind,
+          total: summary.total,
+          passed: summary.passed,
+          failed: summary.failed,
+          durationMs: Date.now() - tickStart,
+          services: summarySnap.services.map((s) => ({
+            slug: s.slug,
+            state: s.state,
+            result: s.result,
+            ...(s.error ? { error: s.error } : {}),
+          })),
+        });
       }
       // B7: clear the tracker so the next snapshot reports no inflight run.
       // Done in `finally` so even an unexpected throw still leaves the


### PR DESCRIPTION
## Summary

- Add structured INFO-level logging to the probe execution pipeline so Railway logs give full visibility into probe runs without needing PocketBase
- Cover all four layers: invoker tick lifecycle, D5 driver per-service/per-feature results, and browser pool acquire/release/recycle stats
- Single `probe.run-summary` log line at tick completion carries every service's outcome in one structured payload

## Changes

**probe-invoker.ts** — tick lifecycle:
- `probe.tick-start`: probe ID, kind, discovered targets, trigger source
- `probe.target-start` / `probe.target-complete`: per-service key, state, duration
- `probe.tick-complete`: passed/failed counts, total duration
- `probe.run-summary`: all service results in one line

**e2e-deep.ts** — D5 driver:
- `probe.e2e-deep.service-start`: slug, feature count, backend URL
- `probe.e2e-deep.feature-complete`: slug, feature type, pass/fail, error, duration
- `probe.e2e-deep.service-complete`: slug, aggregate counts, duration

**browser-pool.ts** — pool stats:
- `browser-pool.acquire` / `browser-pool.release`: available/inUse counts
- `browser-pool.recycle`: slot index, context count, threshold

**orchestrator.ts** — thread logger into BrowserPool constructor

## Test plan

- [x] `cd showcase/harness && npx vitest run` — 70 test files, 1372 tests pass
- [x] New log lines visible in test output confirming correct event names and payloads
- [x] No verbose per-turn or per-page-operation logging added — lifecycle events only