### PR TITLE
fix(showcase): preserve langgraph-typescript agent node_modules in compose

### DIFF
--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -141,6 +141,12 @@ services:
     profiles: ["langgraph-typescript", "all"]
     volumes:
       - ./integrations/langgraph-typescript/src:/app/src
+      # Preserve the agent's node_modules from the Docker image.  The bind
+      # mount above overlays the host's src/ (no node_modules) on top of the
+      # container's /app/src, which clobbers src/agent/node_modules installed
+      # during the build.  This anonymous volume pins the image's copy so
+      # `node --import tsx` can resolve tsx at runtime.
+      - /app/src/agent/node_modules
 
   langgraph-fastapi:
     <<: *integration-defaults


### PR DESCRIPTION
## Summary

- Fixes `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'` crash in the
  local langgraph-typescript container
- Root cause: the host bind mount `src:/app/src` clobbers
  `src/agent/node_modules` that was installed during the Docker build
- Fix: anonymous volume `/app/src/agent/node_modules` preserves the
  image's copy through the bind mount overlay
- google-adk D5 intermittent failures are pool starvation (already
  addressed by #4460); no code change needed

## Test plan

- [x] Verified the compose container crash-loops before the fix
- [x] Verified the container starts healthy after the fix
- [x] Confirmed the production GHCR image works correctly (the issue
  is compose-local only)