### PR TITLE
fix(a2ui-renderer): remove redundant prepack causing canary publish ENOENT

### DIFF
--- a/packages/a2ui-renderer/package.json
+++ b/packages/a2ui-renderer/package.json
@@ -38,7 +38,6 @@
     "access": "public"
   },
   "scripts": {
-    "prepack": "pnpm run build",
     "build": "tsdown",
     "check-types": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",


### PR DESCRIPTION
## What does this PR do?

Removes the `prepack` script from `@copilotkit/a2ui-renderer/package.json`, which was causing the canary publish job to fail with `ENOENT` on the staging tarball.

### The failure

[Failed run](https://github.com/CopilotKit/CopilotKit/actions/runs/25148053109/job/73712052657):

\`\`\`
✔ Build complete in 3002ms
 ENOENT  ENOENT: no such file or directory, open '/tmp/.../copilotkit-a2ui-renderer-1.56.4-canary.tyler/romantic-spence-2261fe.tgz'
Error: Command failed: pnpm publish --no-git-checks --tag canary --access public
\`\`\`

### Root cause

The release scripts already build the workspace before publishing:
- `scripts/release/prerelease.ts:77` runs `pnpm run build` across the monorepo
- `scripts/release/publish-release.ts:145` does the same

`a2ui-renderer` was the **only** package in the monorepo with `"prepack": "pnpm run build"`. That script fired during `pnpm publish` and rebuilt the package a second time. Combined with tsdown's `exports: true` (which regenerates `package.json`'s exports field on every build), the second rewrite happened mid-publish and pnpm's pack step failed silently — leaving an empty staging directory and the ENOENT we see.

### Why removal is safe

- All 12 other monorepo-scope packages publish without `prepack` and work fine.
- Both release scripts (`prerelease.ts`, `publish-release.ts`) build the whole workspace before the publish loop, so dist is always ready.
- No CI workflow or script invokes `pnpm pack` directly.
- Consumer-side installs, workspace deps, and `pnpm link` don't run `prepack` anyway.

The only behavioral change: a developer manually running `pnpm publish` or `pnpm pack` from the package directory now needs to `pnpm build` first — matching the rest of the monorepo.

## Related PRs and Issues

- Failed CI run: https://github.com/CopilotKit/CopilotKit/actions/runs/25148053109/job/73712052657

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked