### PR TITLE
fix(showcase): replace SpringAIAgent with SyncAgent for spring-ai D5

### DIFF
--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
@@ -2,12 +2,12 @@ package com.copilotkit.showcase.springai;
 
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
-import com.agui.spring.ai.SpringAIAgent;
 import com.copilotkit.showcase.springai.tools.DisplayFlightTool;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
 
 /**
  * A2UI Fixed Schema demo — dedicated controller at /a2ui-fixed-schema/run.
@@ -39,39 +41,35 @@ public class A2uiFixedSchemaController {
 
     @PostMapping("/a2ui-fixed-schema/run")
     public ResponseEntity<SseEmitter> run(@RequestBody AgUiParameters params) {
-        SpringAIAgent agent = buildAgent();
+        SyncAgent agent = buildAgent();
         SseEmitter emitter = agUiService.runAgent(agent, params);
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noCache())
                 .body(emitter);
     }
 
-    private SpringAIAgent buildAgent() {
+    private SyncAgent buildAgent() {
         ChatMemory memory = MessageWindowChatMemory.builder()
                 .chatMemoryRepository(new InMemoryChatMemoryRepository())
                 .maxMessages(10)
                 .build();
-        try {
-            return SpringAIAgent.builder()
-                    .agentId("a2ui-fixed-schema")
-                    .chatModel(chatModel)
-                    .chatMemory(memory)
-                    .systemMessage("""
-                            You are a flight-search assistant. When the user asks about a flight,
-                            call the display_flight tool with the origin airport code, destination
-                            airport code, airline, and price string (e.g. "$289"). Use 3-letter
-                            airport codes. After calling the tool, reply with a brief confirmation
-                            in plain text.
-                            """)
-                    .toolCallback(
-                            FunctionToolCallback.builder("display_flight", new DisplayFlightTool())
-                                    .description("Display a flight card for the given trip")
-                                    .inputType(DisplayFlightTool.Request.class)
-                                    .build()
-                    )
-                    .build();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to build a2ui-fixed-schema agent", e);
-        }
+        ToolCallback displayFlightCallback = FunctionToolCallback
+                .builder("display_flight", new DisplayFlightTool())
+                .description("Display a flight card for the given trip")
+                .inputType(DisplayFlightTool.Request.class)
+                .build();
+        return new SyncAgent(
+                "a2ui-fixed-schema",
+                chatModel,
+                memory,
+                """
+                You are a flight-search assistant. When the user asks about a flight,
+                call the display_flight tool with the origin airport code, destination
+                airport code, airline, and price string (e.g. "$289"). Use 3-letter
+                airport codes. After calling the tool, reply with a brief confirmation
+                in plain text.
+                """,
+                List.of(displayFlightCallback)
+        );
     }
 }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
@@ -1,6 +1,5 @@
 package com.copilotkit.showcase.springai;
 
-import com.agui.spring.ai.SpringAIAgent;
 import com.copilotkit.showcase.springai.model.SalesTodo;
 import com.copilotkit.showcase.springai.tools.WeatherRequest;
 import com.copilotkit.showcase.springai.tools.WeatherTool;
@@ -14,6 +13,7 @@ import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,81 +33,82 @@ public class AgentConfig {
     }
 
     @Bean
-    public SpringAIAgent agent(ChatModel chatModel, ChatMemory chatMemory) {
+    public SyncAgent agent(ChatModel chatModel, ChatMemory chatMemory) {
         // Shared mutable todos list between get/manage tools
         var salesTodosTool = new GetSalesTodosTool();
         List<SalesTodo> sharedTodos = salesTodosTool.getTodos();
         var manageSalesTodosTool = new ManageSalesTodosTool(sharedTodos);
 
-        try {
-            return SpringAIAgent.builder()
-                    .agentId("agentic_chat")
-                    .chatModel(chatModel)
-                    .chatMemory(chatMemory)
-                    .systemMessage("""
-                        You are a helpful assistant for the CopilotKit showcase.
-                        You can check the weather using the get_weather tool.
-                        You can query financial/business data using the query_data tool.
-                        You can schedule meetings using the schedule_meeting tool.
-                        You can manage the sales pipeline using get_sales_todos and manage_sales_todos tools.
-                        You can search for flights using the search_flights tool.
-                        You can generate dynamic UI using the generate_a2ui tool.
-                        For other tools (change_background, generate_haiku, generate_task_steps,
-                        pieChart, barChart, scheduleTime, toggleTheme),
-                        these are provided by the frontend — use them when relevant to the user's request.
-                        When asked to plan or create steps, use the generate_task_steps tool.
-                        When asked about weather, use the get_weather tool.
-                        When asked about data, charts, or analytics, use the query_data tool.
-                        When asked to schedule a meeting, use the schedule_meeting tool.
-                        When asked about the sales pipeline or deals, use get_sales_todos first.
-                        When asked to search for flights, use the search_flights tool.
-                        Keep responses concise and helpful.
-                        """)
-                    .toolCallback(
-                        FunctionToolCallback.builder("get_weather", new WeatherTool())
-                            .description("Get current weather for a location")
-                            .inputType(WeatherRequest.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("query_data", new QueryDataTool())
-                            .description("Query financial data for charts and analytics")
-                            .inputType(QueryDataTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("schedule_meeting", new ScheduleMeetingTool())
-                            .description("Schedule a meeting with a given reason and duration")
-                            .inputType(ScheduleMeetingTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("get_sales_todos", salesTodosTool)
-                            .description("Get the current sales pipeline todos")
-                            .inputType(GetSalesTodosTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("manage_sales_todos", manageSalesTodosTool)
-                            .description("Update the sales pipeline with a new set of todos")
-                            .inputType(ManageSalesTodosTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("search_flights", new SearchFlightsTool())
-                            .description("Search for available flights between two cities")
-                            .inputType(SearchFlightsTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("generate_a2ui", new GenerateA2uiTool(chatModel))
-                            .description("Generate dynamic A2UI components using a secondary LLM call")
-                            .inputType(GenerateA2uiTool.Request.class)
-                            .build()
-                    )
-                    .build();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to build SpringAIAgent", e);
-        }
+        List<ToolCallback> toolCallbacks = new ArrayList<>();
+        toolCallbacks.add(
+            FunctionToolCallback.builder("get_weather", new WeatherTool())
+                .description("Get current weather for a location")
+                .inputType(WeatherRequest.class)
+                .build()
+        );
+        toolCallbacks.add(
+            FunctionToolCallback.builder("query_data", new QueryDataTool())
+                .description("Query financial data for charts and analytics")
+                .inputType(QueryDataTool.Request.class)
+                .build()
+        );
+        toolCallbacks.add(
+            FunctionToolCallback.builder("schedule_meeting", new ScheduleMeetingTool())
+                .description("Schedule a meeting with a given reason and duration")
+                .inputType(ScheduleMeetingTool.Request.class)
+                .build()
+        );
+        toolCallbacks.add(
+            FunctionToolCallback.builder("get_sales_todos", salesTodosTool)
+                .description("Get the current sales pipeline todos")
+                .inputType(GetSalesTodosTool.Request.class)
+                .build()
+        );
+        toolCallbacks.add(
+            FunctionToolCallback.builder("manage_sales_todos", manageSalesTodosTool)
+                .description("Update the sales pipeline with a new set of todos")
+                .inputType(ManageSalesTodosTool.Request.class)
+                .build()
+        );
+        toolCallbacks.add(
+            FunctionToolCallback.builder("search_flights", new SearchFlightsTool())
+                .description("Search for available flights between two cities")
+                .inputType(SearchFlightsTool.Request.class)
+                .build()
+        );
+        toolCallbacks.add(
+            FunctionToolCallback.builder("generate_a2ui", new GenerateA2uiTool(chatModel))
+                .description("Generate dynamic A2UI components using a secondary LLM call")
+                .inputType(GenerateA2uiTool.Request.class)
+                .build()
+        );
+
+        String systemMessage = """
+            You are a helpful assistant for the CopilotKit showcase.
+            You can check the weather using the get_weather tool.
+            You can query financial/business data using the query_data tool.
+            You can schedule meetings using the schedule_meeting tool.
+            You can manage the sales pipeline using get_sales_todos and manage_sales_todos tools.
+            You can search for flights using the search_flights tool.
+            You can generate dynamic UI using the generate_a2ui tool.
+            For other tools (change_background, generate_haiku, generate_task_steps,
+            pieChart, barChart, scheduleTime, toggleTheme),
+            these are provided by the frontend — use them when relevant to the user's request.
+            When asked to plan or create steps, use the generate_task_steps tool.
+            When asked about weather, use the get_weather tool.
+            When asked about data, charts, or analytics, use the query_data tool.
+            When asked to schedule a meeting, use the schedule_meeting tool.
+            When asked about the sales pipeline or deals, use get_sales_todos first.
+            When asked to search for flights, use the search_flights tool.
+            Keep responses concise and helpful.
+            """;
+
+        return new SyncAgent(
+                "agentic_chat",
+                chatModel,
+                chatMemory,
+                systemMessage,
+                toolCallbacks
+        );
     }
 }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
@@ -2,7 +2,6 @@ package com.copilotkit.showcase.springai;
 
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
-import com.agui.spring.ai.SpringAIAgent;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.ArrayList;
 import java.util.Set;
 
 /**
@@ -24,7 +24,7 @@ import java.util.Set;
  *
  * Reads three forwarded properties from the AG-UI request envelope
  * (`forwardedProps.tone`, `forwardedProps.expertise`,
- * `forwardedProps.responseLength`) and builds a per-request SpringAIAgent
+ * `forwardedProps.responseLength`) and builds a per-request SyncAgent
  * with a system prompt composed from those three axes. Mirrors the
  * LangGraph variant (src/agents/agent_config_agent.py).
  *
@@ -72,7 +72,7 @@ public class AgentConfigController {
         String systemPrompt = buildSystemPrompt(tone, expertise, length);
 
         AgUiParameters params = objectMapper.readValue(rawBody, AgUiParameters.class);
-        SpringAIAgent perRequestAgent = buildAgent(systemPrompt);
+        SyncAgent perRequestAgent = buildAgent(systemPrompt);
 
         SseEmitter emitter = agUiService.runAgent(perRequestAgent, params);
         return ResponseEntity.ok()
@@ -84,21 +84,18 @@ public class AgentConfigController {
         return value != null && allowed.contains(value) ? value : fallback;
     }
 
-    private SpringAIAgent buildAgent(String systemPrompt) {
+    private SyncAgent buildAgent(String systemPrompt) {
         ChatMemory memory = MessageWindowChatMemory.builder()
                 .chatMemoryRepository(new InMemoryChatMemoryRepository())
                 .maxMessages(10)
                 .build();
-        try {
-            return SpringAIAgent.builder()
-                    .agentId("agent-config-demo")
-                    .chatModel(chatModel)
-                    .chatMemory(memory)
-                    .systemMessage(systemPrompt)
-                    .build();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to build agent-config agent", e);
-        }
+        return new SyncAgent(
+                "agent-config-demo",
+                chatModel,
+                memory,
+                systemPrompt,
+                new ArrayList<>()
+        );
     }
 
     private static String buildSystemPrompt(String tone, String expertise, String length) {

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentController.java
@@ -2,7 +2,6 @@ package com.copilotkit.showcase.springai;
 
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
-import com.agui.spring.ai.SpringAIAgent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +14,10 @@ import java.util.Map;
 public class AgentController {
 
     private final AgUiService agUiService;
-    private final SpringAIAgent agent;
+    private final SyncAgent agent;
 
     @Autowired
-    public AgentController(AgUiService agUiService, SpringAIAgent agent) {
+    public AgentController(AgUiService agUiService, SyncAgent agent) {
         this.agUiService = agUiService;
         this.agent = agent;
     }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
@@ -1,0 +1,87 @@
+package com.copilotkit.showcase.springai;
+
+import com.agui.core.message.AssistantMessage;
+import com.agui.core.message.BaseMessage;
+import com.agui.core.message.DeveloperMessage;
+import com.agui.core.message.SystemMessage;
+import com.agui.core.message.ToolMessage;
+import com.agui.core.message.UserMessage;
+import com.agui.core.message.Role;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Custom Jackson configuration for the showcase spring-ai backend.
+ *
+ * The AG-UI Java SDK's {@code MessageMixin} only registers five message
+ * roles: assistant, developer, user, system, tool. The CopilotKit runtime
+ * can forward messages with additional roles (activity, reasoning) that
+ * the Java SDK does not model. Without this configuration, Jackson throws
+ * {@code InvalidTypeIdException} when encountering an unknown role,
+ * causing the entire request deserialization to fail.
+ *
+ * This configuration replaces the SDK's mixin AFTER {@code AgUiAutoConfiguration}
+ * has registered the original one. The replacement adds
+ * {@code defaultImpl = UnknownMessage.class} so messages with unrecognized
+ * roles deserialize into a harmless object instead of throwing.
+ */
+@Configuration
+public class JacksonConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(JacksonConfig.class);
+
+    /**
+     * Catch-all message type for roles the Java SDK does not support.
+     * Instances of this class appear in the messages list when the
+     * CopilotKit runtime forwards messages with roles like "activity"
+     * or "reasoning". They are harmless: getLatestUserMessage() only
+     * matches Role.user, and combineMessages() only checks the id.
+     */
+    public static class UnknownMessage extends BaseMessage {
+        @Override
+        public Role getRole() {
+            // Return a role that will never match Role.user so
+            // getLatestUserMessage() skips these.
+            return Role.developer;
+        }
+    }
+
+    /**
+     * Mixin that extends the AG-UI SDK's MessageMixin with defaultImpl
+     * so that unrecognized role values deserialize to UnknownMessage
+     * instead of throwing InvalidTypeIdException.
+     */
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "role",
+        defaultImpl = UnknownMessage.class
+    )
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = AssistantMessage.class, name = "assistant"),
+        @JsonSubTypes.Type(value = DeveloperMessage.class, name = "developer"),
+        @JsonSubTypes.Type(value = UserMessage.class, name = "user"),
+        @JsonSubTypes.Type(value = SystemMessage.class, name = "system"),
+        @JsonSubTypes.Type(value = ToolMessage.class, name = "tool")
+    })
+    interface LenientMessageMixin {}
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * Override the AG-UI SDK's MessageMixin with our lenient version.
+     * This runs after all auto-configuration (including AgUiAutoConfiguration)
+     * has completed, ensuring our mixin wins.
+     */
+    @PostConstruct
+    public void overrideMessageMixin() {
+        objectMapper.addMixIn(BaseMessage.class, LenientMessageMixin.class);
+        log.info("[JacksonConfig] Replaced AG-UI MessageMixin with lenient version (unknown roles -> UnknownMessage)");
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SyncAgent.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SyncAgent.java
@@ -1,0 +1,301 @@
+package com.copilotkit.showcase.springai;
+
+import com.agui.core.agent.AgentSubscriber;
+import com.agui.core.agent.AgentSubscriberParams;
+import com.agui.core.agent.RunAgentInput;
+import com.agui.core.event.BaseEvent;
+import com.agui.core.exception.AGUIException;
+import com.agui.core.function.FunctionCall;
+import com.agui.core.message.AssistantMessage;
+import com.agui.core.message.Role;
+import com.agui.core.state.State;
+import com.agui.core.tool.ToolCall;
+import com.agui.server.LocalAgent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.agui.server.EventFactory.runErrorEvent;
+import static com.agui.server.EventFactory.runFinishedEvent;
+import static com.agui.server.EventFactory.runStartedEvent;
+import static com.agui.server.EventFactory.textMessageContentEvent;
+import static com.agui.server.EventFactory.textMessageEndEvent;
+import static com.agui.server.EventFactory.textMessageStartEvent;
+import static com.agui.server.EventFactory.toolCallArgsEvent;
+import static com.agui.server.EventFactory.toolCallEndEvent;
+import static com.agui.server.EventFactory.toolCallResultEvent;
+import static com.agui.server.EventFactory.toolCallStartEvent;
+
+/**
+ * Synchronous LocalAgent that uses {@link ChatClient#call()} instead of
+ * {@code .stream()}. This is necessary because Spring AI's streaming mode
+ * does NOT auto-execute tool callbacks — the model returns tool_calls but
+ * they are never invoked, causing the CopilotKit runtime to re-invoke the
+ * agent in an infinite loop.
+ *
+ * By using {@code .call()}, Spring AI's internal tool-execution loop runs
+ * tools automatically, and we emit the full AG-UI event envelope
+ * (TOOL_CALL_START/ARGS/END/RESULT) so the CopilotKit runtime sees a
+ * complete tool cycle and does not re-invoke.
+ *
+ * This replaces the upstream {@code SpringAIAgent} for all showcase
+ * endpoints that register backend tools (agentic_chat, a2ui-fixed-schema,
+ * agent-config, etc.). Controllers that need custom state management
+ * (SubagentsController, SharedStateReadWriteController) already extend
+ * LocalAgent directly with their own .call()-based run() implementations.
+ */
+public class SyncAgent extends LocalAgent {
+
+    private static final Logger log = LoggerFactory.getLogger(SyncAgent.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ChatClient chatClient;
+    private final String systemMessage;
+    private final List<ToolCallback> toolCallbacks;
+    private final ChatMemory chatMemory;
+
+    public SyncAgent(
+            String agentId,
+            ChatModel chatModel,
+            ChatMemory chatMemory,
+            String systemMessage,
+            List<ToolCallback> toolCallbacks
+    ) {
+        super(agentId, new State(), new ArrayList<>());
+        this.chatClient = ChatClient.builder(chatModel).build();
+        this.chatMemory = chatMemory;
+        this.systemMessage = systemMessage;
+        this.toolCallbacks = toolCallbacks;
+    }
+
+    @Override
+    protected void run(RunAgentInput input, AgentSubscriber subscriber) {
+        this.combineMessages(input);
+
+        String messageId = UUID.randomUUID().toString();
+        String threadId = input.threadId();
+        String runId = input.runId();
+
+        State runState = input.state() != null ? input.state() : new State();
+        this.state = runState;
+
+        String userContent;
+        try {
+            userContent = this.getLatestUserMessage(messages).getContent();
+        } catch (AGUIException e) {
+            log.error("Failed to read latest user message from {} messages", messages.size(), e);
+            this.emitEvent(runErrorEvent(String.format(
+                    "agent run failed: %s (see server logs)",
+                    e.getClass().getSimpleName())), subscriber);
+            return;
+        }
+
+        this.emitEvent(runStartedEvent(threadId, runId), subscriber);
+
+        List<BaseEvent> deferredEvents = new ArrayList<>();
+        List<ToolCall> capturedToolCalls = new ArrayList<>();
+
+        // Wrap backend tool callbacks to capture AG-UI events during
+        // Spring AI's auto-invocation inside .call().
+        List<ToolCallback> allCallbacks = new ArrayList<>();
+        for (ToolCallback cb : toolCallbacks) {
+            allCallbacks.add(new EventCapturingToolCallback(
+                    cb, deferredEvents, capturedToolCalls, messageId));
+        }
+
+        // Map frontend tools (from CopilotKit runtime) to pass-through callbacks.
+        if (input.tools() != null && !input.tools().isEmpty()) {
+            for (var tool : input.tools()) {
+                String toolName = tool.name();
+                String description = tool.description() != null ? tool.description() : "";
+                String inputSchema;
+                try {
+                    inputSchema = MAPPER.writeValueAsString(tool.parameters());
+                } catch (Exception e) {
+                    inputSchema = "{}";
+                }
+                allCallbacks.add(new FrontendToolPassthrough(
+                        toolName, description, inputSchema,
+                        deferredEvents, capturedToolCalls, messageId));
+            }
+        }
+
+        AssistantMessage assistantMessage = new AssistantMessage();
+        assistantMessage.setId(messageId);
+        assistantMessage.setName(this.agentId);
+        assistantMessage.setContent("");
+
+        this.emitEvent(textMessageStartEvent(messageId, "assistant"), subscriber);
+
+        try {
+            ChatClient.ChatClientRequestSpec chatRequest = chatClient.prompt(
+                        Prompt.builder().content(userContent).build())
+                    .system(systemMessage);
+
+            if (!allCallbacks.isEmpty()) {
+                chatRequest = chatRequest.toolCallbacks(allCallbacks.toArray(new ToolCallback[0]));
+            }
+
+            ChatResponse response = chatRequest.call().chatResponse();
+
+            // Surface captured tool calls on the assistant message
+            for (ToolCall call : capturedToolCalls) {
+                if (assistantMessage.getToolCalls() == null) {
+                    assistantMessage.setToolCalls(new ArrayList<>());
+                }
+                assistantMessage.getToolCalls().add(call);
+                subscriber.onNewToolCall(call);
+            }
+
+            String text = response != null
+                    ? response.getResult().getOutput().getText()
+                    : null;
+            if (StringUtils.hasText(text)) {
+                this.emitEvent(textMessageContentEvent(messageId, text), subscriber);
+                assistantMessage.setContent(text);
+            }
+        } catch (Exception e) {
+            log.error("ChatClient call failed", e);
+            this.emitEvent(runErrorEvent(String.format(
+                    "agent run failed: %s (see server logs)",
+                    e.getClass().getSimpleName())), subscriber);
+            return;
+        }
+
+        this.emitEvent(textMessageEndEvent(messageId), subscriber);
+        for (BaseEvent ev : deferredEvents) {
+            this.emitEvent(ev, subscriber);
+        }
+        subscriber.onNewMessage(assistantMessage);
+        this.emitEvent(runFinishedEvent(threadId, runId), subscriber);
+        subscriber.onRunFinalized(
+                new AgentSubscriberParams(input.messages(), runState, this, input));
+    }
+
+    /**
+     * Wraps a backend ToolCallback to capture AG-UI events during Spring AI's
+     * auto-invocation inside .call(). Delegates the tool definition and call
+     * to the original callback, then records the result as AG-UI events.
+     */
+    static class EventCapturingToolCallback implements ToolCallback {
+
+        private final ToolCallback delegate;
+        private final List<BaseEvent> deferredEvents;
+        private final List<ToolCall> capturedToolCalls;
+        private final String parentMessageId;
+
+        EventCapturingToolCallback(
+                ToolCallback delegate,
+                List<BaseEvent> deferredEvents,
+                List<ToolCall> capturedToolCalls,
+                String parentMessageId) {
+            this.delegate = delegate;
+            this.deferredEvents = deferredEvents;
+            this.capturedToolCalls = capturedToolCalls;
+            this.parentMessageId = parentMessageId;
+        }
+
+        @Override
+        public ToolDefinition getToolDefinition() {
+            return delegate.getToolDefinition();
+        }
+
+        @Override
+        public String call(String toolInput) {
+            return call(toolInput, null);
+        }
+
+        @Override
+        public String call(String toolInput, @Nullable ToolContext toolContext) {
+            String result = delegate.call(toolInput, toolContext);
+
+            String toolCallId = UUID.randomUUID().toString();
+            String toolName = delegate.getToolDefinition().name();
+
+            FunctionCall fc = new FunctionCall(toolName, toolInput);
+            capturedToolCalls.add(new ToolCall(toolCallId, "function", fc));
+
+            deferredEvents.add(toolCallStartEvent(parentMessageId, toolName, toolCallId));
+            deferredEvents.add(toolCallArgsEvent(toolInput, toolCallId));
+            deferredEvents.add(toolCallEndEvent(toolCallId));
+            deferredEvents.add(toolCallResultEvent(
+                    toolCallId, result, parentMessageId, Role.tool));
+
+            return result;
+        }
+    }
+
+    /**
+     * Pass-through callback for frontend tools. When Spring AI auto-invokes
+     * this during .call(), it returns an empty string (the frontend will
+     * handle actual execution). We capture AG-UI events (start/args/end)
+     * WITHOUT a result so the CopilotKit runtime knows to execute them on
+     * the frontend.
+     */
+    static class FrontendToolPassthrough implements ToolCallback {
+
+        private final String toolName;
+        private final String description;
+        private final String inputSchema;
+        private final List<BaseEvent> deferredEvents;
+        private final List<ToolCall> capturedToolCalls;
+        private final String parentMessageId;
+
+        FrontendToolPassthrough(
+                String toolName,
+                String description,
+                String inputSchema,
+                List<BaseEvent> deferredEvents,
+                List<ToolCall> capturedToolCalls,
+                String parentMessageId) {
+            this.toolName = toolName;
+            this.description = description;
+            this.inputSchema = inputSchema;
+            this.deferredEvents = deferredEvents;
+            this.capturedToolCalls = capturedToolCalls;
+            this.parentMessageId = parentMessageId;
+        }
+
+        @Override
+        public ToolDefinition getToolDefinition() {
+            return new ToolDefinition() {
+                @Override
+                public String name() { return toolName; }
+
+                @Override
+                public String description() { return description; }
+
+                @Override
+                public String inputSchema() { return inputSchema; }
+            };
+        }
+
+        @Override
+        public String call(String toolInput) {
+            String toolCallId = UUID.randomUUID().toString();
+
+            FunctionCall fc = new FunctionCall(toolName, toolInput);
+            capturedToolCalls.add(new ToolCall(toolCallId, "function", fc));
+
+            deferredEvents.add(toolCallStartEvent(parentMessageId, toolName, toolCallId));
+            deferredEvents.add(toolCallArgsEvent(toolInput, toolCallId));
+            deferredEvents.add(toolCallEndEvent(toolCallId));
+
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `SpringAIAgent` (streaming `.stream()`) with custom `SyncAgent` (synchronous `.call()`) for all spring-ai showcase controllers
- Add `JacksonConfig` to handle unknown AG-UI message roles (activity, reasoning) gracefully
- Fix the root cause of spring-ai D5 timeouts on tool-rendering, hitl-steps, gen-ui, mcp-apps, and shared-state features

## Why

Spring AI's streaming mode does NOT auto-execute tool callbacks. The model returns `tool_calls` in the SSE stream but the tools are never invoked. The AG-UI event stream emits `TOOL_CALL_START/ARGS/END` without `TOOL_CALL_RESULT`, causing the CopilotKit runtime to re-invoke the agent in an infinite loop (and eventual timeout).

By using `ChatClient.call()`, Spring AI's internal tool-execution loop runs tools automatically. `SyncAgent` wraps each backend tool callback to capture AG-UI events during auto-invocation, and registers frontend tools as pass-through callbacks.

The `JacksonConfig` addresses a secondary issue: the AG-UI Java SDK's `MessageMixin` only maps 5 roles (assistant, developer, user, system, tool). Messages with roles like "reasoning" cause `InvalidTypeIdException` during deserialization. The config overrides the mixin with `defaultImpl = UnknownMessage.class` so unknown roles deserialize harmlessly.

## Test plan

- [ ] Docker build succeeds (verified locally)
- [ ] D5 tool-rendering passes
- [ ] D5 subagents passes
- [ ] D5 hitl-steps passes
- [ ] D5 mcp-apps passes
- [ ] D5 shared-state passes