### PR TITLE
fix(ci): decouple showcase build and deploy workflows

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -1,0 +1,360 @@
+name: "Showcase: Build & Push"
+
+# Decoupled from the old "Build & Deploy" workflow. This workflow ONLY builds
+# Docker images and pushes them to GHCR. Railway auto-update
+# (environmentPatchCommit) picks up the new :latest tag and deploys
+# automatically. The separate "Showcase: Verify Deploy" workflow
+# (showcase_deploy.yml) handles health verification.
+#
+# Critical design property: NO concurrency group with cancel-in-progress.
+# Every push to main runs to completion so that rapid-fire PR merges never
+# cancel in-flight builds. This was the #1 operational pain point with the
+# old combined workflow.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "showcase/**"
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Service to build"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - shell
+          - langgraph-python
+          - mastra
+          - crewai-crews
+          - pydantic-ai
+          - google-adk
+          - ag2
+          - agno
+          - llamaindex
+          - langgraph-fastapi
+          - langgraph-typescript
+          - langroid
+          - spring-ai
+          - strands
+          - ms-agent-python
+          - claude-sdk-typescript
+          - ms-agent-dotnet
+          - claude-sdk-python
+          - built-in-agent
+          - shell-dojo
+          - shell-dashboard
+          - shell-docs
+          - showcase-harness
+          - showcase-aimock
+
+# No top-level concurrency group. Every build run completes. This is the
+# whole point of the decoupling: rapid pushes to main no longer cancel
+# in-flight builds.
+
+env:
+  RAILWAY_ENV_ID: "b14919f4-6417-429f-848d-c6ae2201e04f"
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has_changes: ${{ steps.build-matrix.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # All filter values use list form for consistency. `shell`
+          # genuinely needs multiple paths; the others could collapse to
+          # single-line strings, but mixing styles (list vs. string)
+          # in the same filters block is easy to misread during review.
+          filters: |
+            shell:
+              - 'showcase/shell/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            langgraph_python:
+              - 'showcase/integrations/langgraph-python/**'
+            mastra:
+              - 'showcase/integrations/mastra/**'
+            crewai_crews:
+              - 'showcase/integrations/crewai-crews/**'
+            pydantic_ai:
+              - 'showcase/integrations/pydantic-ai/**'
+            google_adk:
+              - 'showcase/integrations/google-adk/**'
+            ag2:
+              - 'showcase/integrations/ag2/**'
+            agno:
+              - 'showcase/integrations/agno/**'
+            llamaindex:
+              - 'showcase/integrations/llamaindex/**'
+            langgraph_fastapi:
+              - 'showcase/integrations/langgraph-fastapi/**'
+            langgraph_typescript:
+              - 'showcase/integrations/langgraph-typescript/**'
+            langroid:
+              - 'showcase/integrations/langroid/**'
+            spring_ai:
+              - 'showcase/integrations/spring-ai/**'
+            strands:
+              - 'showcase/integrations/strands/**'
+            ms_agent_python:
+              - 'showcase/integrations/ms-agent-python/**'
+            claude_sdk_typescript:
+              - 'showcase/integrations/claude-sdk-typescript/**'
+            ms_agent_dotnet:
+              - 'showcase/integrations/ms-agent-dotnet/**'
+            claude_sdk_python:
+              - 'showcase/integrations/claude-sdk-python/**'
+            built_in_agent:
+              - 'showcase/integrations/built-in-agent/**'
+            shell_dojo:
+              - 'showcase/shell-dojo/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            shell_dashboard:
+              - 'showcase/shell-dashboard/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            shell_docs:
+              - 'showcase/shell-docs/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            showcase_harness:
+              - 'showcase/harness/**'
+              - 'showcase/shared/**'
+              - 'showcase/scripts/**'
+              - 'showcase/integrations/*/manifest.yaml'
+            showcase_aimock:
+              - 'showcase/aimock/**'
+
+      - name: Build service matrix
+        id: build-matrix
+        run: |
+          # Full service config as JSON
+          # Fields: dispatch_name, filter_key, context, image, railway_id, timeout, lfs, build_args, build_args_sha, build_args_branch, dockerfile, health_path
+          # health_path: explicit endpoint the verify step probes. Required
+          # for every service — no fallback. An unscoped fallback could mask
+          # a broken endpoint when an unrelated catch-all/CDN/actuator happens
+          # to 200 at the other path. Misconfigured paths are a config bug to
+          # fix in the matrix, not runtime behavior to hide.
+          ALL_SERVICES='[
+            {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell/Dockerfile","health_path":"/"},
+            {"dispatch_name":"langgraph-python","filter_key":"langgraph_python","context":"showcase/integrations/langgraph-python","image":"showcase-langgraph-python","railway_id":"90d03214-4569-41b0-b4c1-6438a8a7b203","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"mastra","filter_key":"mastra","context":"showcase/integrations/mastra","image":"showcase-mastra","railway_id":"d7979eb7-2405-4aab-ad21-438f4a1b08af","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"crewai-crews","filter_key":"crewai_crews","context":"showcase/integrations/crewai-crews","image":"showcase-crewai-crews","railway_id":"0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"pydantic-ai","filter_key":"pydantic_ai","context":"showcase/integrations/pydantic-ai","image":"showcase-pydantic-ai","railway_id":"0a106173-2282-4887-a994-0ca276a99d69","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"google-adk","filter_key":"google_adk","context":"showcase/integrations/google-adk","image":"showcase-google-adk","railway_id":"87f60507-5a3d-4b8a-9e23-2b1de85d939c","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"ag2","filter_key":"ag2","context":"showcase/integrations/ag2","image":"showcase-ag2","railway_id":"4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"agno","filter_key":"agno","context":"showcase/integrations/agno","image":"showcase-agno","railway_id":"32cab80b-e329-45bd-9c73-c4e1ddc94305","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"llamaindex","filter_key":"llamaindex","context":"showcase/integrations/llamaindex","image":"showcase-llamaindex","railway_id":"285386e8-492d-4cb8-b632-0a7d4607378f","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"langgraph-fastapi","filter_key":"langgraph_fastapi","context":"showcase/integrations/langgraph-fastapi","image":"showcase-langgraph-fastapi","railway_id":"06cccb5c-59f4-46b5-8adc-7113e77011a4","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"langgraph-typescript","filter_key":"langgraph_typescript","context":"showcase/integrations/langgraph-typescript","image":"showcase-langgraph-typescript","railway_id":"66246d3b-a18e-46f0-be51-5f3ff7a36e5a","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"langroid","filter_key":"langroid","context":"showcase/integrations/langroid","image":"showcase-langroid","railway_id":"6dd9cb0a-66cc-46f1-972e-7cd74756157d","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"spring-ai","filter_key":"spring_ai","context":"showcase/integrations/spring-ai","image":"showcase-spring-ai","railway_id":"eed5d041-91be-4282-b414-beea00843401","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"strands","filter_key":"strands","context":"showcase/integrations/strands","image":"showcase-strands","railway_id":"92e1cfad-ad53-403f-ab2b-5ab380832232","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"ms-agent-python","filter_key":"ms_agent_python","context":"showcase/integrations/ms-agent-python","image":"showcase-ms-agent-python","railway_id":"655db75a-af8d-427d-a4f9-441570ae5003","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"claude-sdk-typescript","filter_key":"claude_sdk_typescript","context":"showcase/integrations/claude-sdk-typescript","image":"showcase-claude-sdk-typescript","railway_id":"18a98727-5700-44aa-b497-b60795dbbd6a","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"ms-agent-dotnet","filter_key":"ms_agent_dotnet","context":"showcase/integrations/ms-agent-dotnet","image":"showcase-ms-agent-dotnet","railway_id":"beeb2dd6-87a4-4599-aa07-0578f7bd6519","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
+            {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
+            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
+            {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
+            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"}
+          ]'
+
+          DISPATCH="${{ github.event.inputs.service }}"
+          CHANGES='${{ steps.filter.outputs.changes }}'
+          CHANGES="${CHANGES:-[]}"
+
+          # Filter services based on three dispatch modes:
+          #   dispatch == "all": manual "deploy all" — include every service unconditionally.
+          #     This re-pulls :latest for every matrix slot (~38 services); intentional for
+          #     drift-rebuild runs and full-fleet restarts. Do NOT try to short-circuit
+          #     unchanged services here — operators invoke "all" precisely when they want
+          #     the fleet re-deployed regardless of git state (cache poisoning, base-image CVE).
+          #     (paths-filter is unreliable on workflow_dispatch because there is no 'before' SHA,
+          #      so we must NOT consult $changes here — doing so silently produces an empty matrix).
+          #   dispatch == <specific service>: narrow to that service only (skips paths-filter so
+          #     drift-rebuild and manual single-service dispatches work regardless of $changes).
+          #   dispatch == "": push event — include services whose filter_key appears in paths-filter CHANGES.
+          MATRIX=$(echo "$ALL_SERVICES" | jq -c --arg dispatch "$DISPATCH" --argjson changes "$CHANGES" '
+            [.[] | (.filter_key as $fk | select(
+              $dispatch == "all" or
+              ($dispatch != "" and $dispatch != "all" and $dispatch == .dispatch_name) or
+              ($dispatch == "" and ($changes | index($fk) != null))
+            ))]
+          ')
+
+          # Fail loudly on typo'd workflow_dispatch inputs. If a user types a
+          # service name that doesn't exist in ALL_SERVICES, the jq filter
+          # silently produces [] and the run shows green with zero work
+          # done — a common "did my dispatch deploy?" footgun. The `all` and
+          # empty (push-event) modes legitimately produce [] when there are
+          # no changes and must still succeed.
+          if [ "$MATRIX" = "[]" ] && [ -n "$DISPATCH" ] && [ "$DISPATCH" != "all" ]; then
+            echo "::error::workflow_dispatch service='$DISPATCH' did not match any entry in ALL_SERVICES — check the dispatch_name spelling"
+            exit 1
+          fi
+
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          if [ "$MATRIX" = "[]" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+  check-lockfile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      # Omit `version:` so pnpm/action-setup inherits from the repo's
+      # `packageManager` field in package.json (enforced via corepack).
+      # Earlier revisions hard-pinned `version: 10.13.1` which silently
+      # drifted from package.json whenever the repo bumped pnpm —
+      # resulting in lockfile-vs-engine mismatches that only surfaced on
+      # the slow `--frozen-lockfile` path.
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+
+  verify-image-refs:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Verify Railway image refs
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: npx tsx showcase/scripts/verify-railway-image-refs.ts
+
+  build:
+    needs: [detect-changes, check-lockfile, verify-image-refs]
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: ${{ fromJSON(matrix.service.timeout) }}
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: ${{ matrix.service.lfs }}
+
+      - name: Setup Depot
+        uses: depot/setup-action@v1
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare build args
+        id: build-args
+        run: |
+          ARGS=""
+          if [ -n "${{ matrix.service.build_args_sha }}" ]; then
+            ARGS="COMMIT_SHA=${{ matrix.service.build_args_sha }}"
+            ARGS="${ARGS}"$'\n'"BRANCH=${{ matrix.service.build_args_branch }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_pb_url }}" ]; then
+            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POCKETBASE_URL=${{ matrix.service.build_args_pb_url }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_shell_url }}" ]; then
+            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SHELL_URL=${{ matrix.service.build_args_shell_url }}"
+          fi
+          if [ -n "${{ matrix.service.build_args_ops_url }}" ]; then
+            # OPS_BASE_URL is required at build time by shell-dashboard's
+            # next.config.ts rewrites() — without it `next build` aborts.
+            ARGS="${ARGS:+${ARGS}$'\n'}OPS_BASE_URL=${{ matrix.service.build_args_ops_url }}"
+          fi
+          # Use delimiter to safely pass multiline value
+          echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT
+          echo "$ARGS" >> $GITHUB_OUTPUT
+          echo "BUILDARGS_EOF" >> $GITHUB_OUTPUT
+
+      - name: Copy shared modules into build context
+        run: |
+          set -euo pipefail
+          CONTEXT="${{ matrix.service.context }}"
+          # Idempotent copy: if a stale `shared_python`/`shared_typescript`
+          # already exists (previous failed run on the same runner, or a
+          # checkout artifact), remove it first. `cp -r src dst` into an
+          # existing directory nests source-inside-destination, which
+          # would silently produce a broken build context.
+          if [ -d "showcase/shared/python" ] && [ -d "$CONTEXT" ]; then
+            rm -rf "$CONTEXT/shared_python"
+            cp -r showcase/shared/python "$CONTEXT/shared_python"
+          fi
+          if [ -d "showcase/shared/typescript/tools" ] && [ -d "$CONTEXT" ]; then
+            rm -rf "$CONTEXT/shared_typescript"
+            mkdir -p "$CONTEXT/shared_typescript"
+            cp -r showcase/shared/typescript/tools "$CONTEXT/shared_typescript/tools"
+          fi
+
+          # Dereference tools/ and shared-tools/ symlinks for Docker
+          # context. Integration directories use symlinks pointing to
+          # ../../shared/python/tools etc. Docker cannot follow symlinks
+          # outside the build context, so we replace each symlink with a
+          # real copy of its target.
+          for link_name in tools shared-tools; do
+            link_path="$CONTEXT/$link_name"
+            if [ -L "$link_path" ]; then
+              target="$(readlink -f "$link_path")"
+              if [ -d "$target" ]; then
+                rm "$link_path"
+                cp -r "$target" "$link_path"
+              fi
+            fi
+          done
+
+      - name: Build and push
+        uses: depot/build-push-action@v1
+        with:
+          project: m2kw2wmmcp
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile != '' && matrix.service.dockerfile || format('{0}/Dockerfile', matrix.service.context) }}
+          # Pin amd64: Railway and GHCR serve x86 hosts. An arm64-only
+          # image crashes on pull with "does not have a linux/amd64
+          # variant available".
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/copilotkit/${{ matrix.service.image }}:latest
+            ghcr.io/copilotkit/${{ matrix.service.image }}:${{ github.sha }}
+          build-args: ${{ steps.build-args.outputs.args }}
+
+      # No Railway deploy step. Railway auto-update (environmentPatchCommit)
+      # picks up the new :latest GHCR tag and deploys automatically.
+      # The "Showcase: Verify Deploy" workflow handles health verification.

--- a/.github/workflows/showcase_capture-previews.yml
+++ b/.github/workflows/showcase_capture-previews.yml
@@ -2,7 +2,7 @@ name: "Showcase: Capture Previews"
 
 on:
   workflow_run:
-    workflows: ["Showcase: Build & Deploy"]
+    workflows: ["Showcase: Build & Push"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -1,14 +1,24 @@
-name: "Showcase: Build & Deploy"
+name: "Showcase: Verify Deploy"
+
+# Triggered after "Showcase: Build & Push" completes. This workflow verifies
+# that Railway picked up the new images (via environmentPatchCommit auto-update)
+# and that each service is healthy. It does NOT do the actual deploy — Railway
+# auto-update handles that.
+#
+# This workflow CAN use cancel-in-progress: true because verification is
+# idempotent. If a newer build completes while we're still verifying an
+# older one, the newer verification supersedes — the older images are
+# already stale.
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Showcase: Build & Push"]
+    types: [completed]
     branches: [main]
-    paths:
-      - "showcase/**"
   workflow_dispatch:
     inputs:
       service:
-        description: "Service to deploy"
+        description: "Service to verify"
         required: false
         default: "all"
         type: choice
@@ -40,397 +50,118 @@ on:
           - showcase-aimock
 
 concurrency:
-  # Key on `event_name + ref` so push events and manual workflow_dispatch
-  # runs queue INDEPENDENTLY. A previous revision keyed on ref alone and
-  # let a push-to-main (cancel-in-progress: true) kill a 38-service
-  # `service=all` manual dispatch mid-run — operator intent was lost.
-  # Splitting the group means:
-  #   - push → push:     cancel-in-progress true (latest main wins)
-  #   - dispatch → push: coexist (different groups)
-  #   - dispatch → dispatch: queue (cancel-in-progress false — let the
-  #     prior fleet rebuild finish before the next one starts)
-  group: showcase-deploy-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  group: showcase-verify-deploy
+  cancel-in-progress: true
 
 env:
   RAILWAY_ENV_ID: "b14919f4-6417-429f-848d-c6ae2201e04f"
 
 jobs:
-  detect-changes:
+  resolve-matrix:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 3
+    # Only run verification when the build workflow succeeded.
+    # On workflow_dispatch, always run (workflow_run context is absent).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-      has_changes: ${{ steps.build-matrix.outputs.has_changes }}
+      has_services: ${{ steps.build-matrix.outputs.has_services }}
+      build_run_id: ${{ steps.build-matrix.outputs.build_run_id }}
+      build_run_url: ${{ steps.build-matrix.outputs.build_run_url }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect changed paths
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          # All filter values use list form for consistency. `shell`
-          # genuinely needs multiple paths; the others could collapse to
-          # single-line strings, but mixing styles (list vs. string)
-          # in the same filters block is easy to misread during review.
-          filters: |
-            shell:
-              - 'showcase/shell/**'
-              - 'showcase/shared/**'
-              - 'showcase/scripts/**'
-              - 'showcase/integrations/*/manifest.yaml'
-            langgraph_python:
-              - 'showcase/integrations/langgraph-python/**'
-            mastra:
-              - 'showcase/integrations/mastra/**'
-            crewai_crews:
-              - 'showcase/integrations/crewai-crews/**'
-            pydantic_ai:
-              - 'showcase/integrations/pydantic-ai/**'
-            google_adk:
-              - 'showcase/integrations/google-adk/**'
-            ag2:
-              - 'showcase/integrations/ag2/**'
-            agno:
-              - 'showcase/integrations/agno/**'
-            llamaindex:
-              - 'showcase/integrations/llamaindex/**'
-            langgraph_fastapi:
-              - 'showcase/integrations/langgraph-fastapi/**'
-            langgraph_typescript:
-              - 'showcase/integrations/langgraph-typescript/**'
-            langroid:
-              - 'showcase/integrations/langroid/**'
-            spring_ai:
-              - 'showcase/integrations/spring-ai/**'
-            strands:
-              - 'showcase/integrations/strands/**'
-            ms_agent_python:
-              - 'showcase/integrations/ms-agent-python/**'
-            claude_sdk_typescript:
-              - 'showcase/integrations/claude-sdk-typescript/**'
-            ms_agent_dotnet:
-              - 'showcase/integrations/ms-agent-dotnet/**'
-            claude_sdk_python:
-              - 'showcase/integrations/claude-sdk-python/**'
-            built_in_agent:
-              - 'showcase/integrations/built-in-agent/**'
-            shell_dojo:
-              - 'showcase/shell-dojo/**'
-              - 'showcase/shared/**'
-              - 'showcase/scripts/**'
-              - 'showcase/integrations/*/manifest.yaml'
-            shell_dashboard:
-              - 'showcase/shell-dashboard/**'
-              - 'showcase/shared/**'
-              - 'showcase/scripts/**'
-              - 'showcase/integrations/*/manifest.yaml'
-            shell_docs:
-              - 'showcase/shell-docs/**'
-              - 'showcase/shared/**'
-              - 'showcase/scripts/**'
-              - 'showcase/integrations/*/manifest.yaml'
-            showcase_harness:
-              - 'showcase/harness/**'
-              - 'showcase/shared/**'
-              - 'showcase/scripts/**'
-              - 'showcase/integrations/*/manifest.yaml'
-            showcase_aimock:
-              - 'showcase/aimock/**'
-
-      - name: Build service matrix
+      - name: Build verification matrix
         id: build-matrix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Full service config as JSON
-          # Fields: dispatch_name, filter_key, context, image, railway_id, timeout, lfs, build_args, build_args_sha, build_args_branch, dockerfile, health_path
-          # health_path: explicit endpoint the verify step probes. Required
-          # for every service — no fallback. An unscoped fallback could mask
-          # a broken endpoint when an unrelated catch-all/CDN/actuator happens
-          # to 200 at the other path. Misconfigured paths are a config bug to
-          # fix in the matrix, not runtime behavior to hide.
+          # Service registry: same as showcase_build.yml but only the fields
+          # needed for verification (dispatch_name, railway_id, health_path).
           ALL_SERVICES='[
-            {"dispatch_name":"shell","filter_key":"shell","context":".","image":"showcase-shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell/Dockerfile","health_path":"/"},
-            {"dispatch_name":"langgraph-python","filter_key":"langgraph_python","context":"showcase/integrations/langgraph-python","image":"showcase-langgraph-python","railway_id":"90d03214-4569-41b0-b4c1-6438a8a7b203","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"mastra","filter_key":"mastra","context":"showcase/integrations/mastra","image":"showcase-mastra","railway_id":"d7979eb7-2405-4aab-ad21-438f4a1b08af","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"crewai-crews","filter_key":"crewai_crews","context":"showcase/integrations/crewai-crews","image":"showcase-crewai-crews","railway_id":"0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"pydantic-ai","filter_key":"pydantic_ai","context":"showcase/integrations/pydantic-ai","image":"showcase-pydantic-ai","railway_id":"0a106173-2282-4887-a994-0ca276a99d69","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"google-adk","filter_key":"google_adk","context":"showcase/integrations/google-adk","image":"showcase-google-adk","railway_id":"87f60507-5a3d-4b8a-9e23-2b1de85d939c","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"ag2","filter_key":"ag2","context":"showcase/integrations/ag2","image":"showcase-ag2","railway_id":"4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"agno","filter_key":"agno","context":"showcase/integrations/agno","image":"showcase-agno","railway_id":"32cab80b-e329-45bd-9c73-c4e1ddc94305","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"llamaindex","filter_key":"llamaindex","context":"showcase/integrations/llamaindex","image":"showcase-llamaindex","railway_id":"285386e8-492d-4cb8-b632-0a7d4607378f","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"langgraph-fastapi","filter_key":"langgraph_fastapi","context":"showcase/integrations/langgraph-fastapi","image":"showcase-langgraph-fastapi","railway_id":"06cccb5c-59f4-46b5-8adc-7113e77011a4","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"langgraph-typescript","filter_key":"langgraph_typescript","context":"showcase/integrations/langgraph-typescript","image":"showcase-langgraph-typescript","railway_id":"66246d3b-a18e-46f0-be51-5f3ff7a36e5a","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"langroid","filter_key":"langroid","context":"showcase/integrations/langroid","image":"showcase-langroid","railway_id":"6dd9cb0a-66cc-46f1-972e-7cd74756157d","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"spring-ai","filter_key":"spring_ai","context":"showcase/integrations/spring-ai","image":"showcase-spring-ai","railway_id":"eed5d041-91be-4282-b414-beea00843401","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"strands","filter_key":"strands","context":"showcase/integrations/strands","image":"showcase-strands","railway_id":"92e1cfad-ad53-403f-ab2b-5ab380832232","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"ms-agent-python","filter_key":"ms_agent_python","context":"showcase/integrations/ms-agent-python","image":"showcase-ms-agent-python","railway_id":"655db75a-af8d-427d-a4f9-441570ae5003","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"claude-sdk-typescript","filter_key":"claude_sdk_typescript","context":"showcase/integrations/claude-sdk-typescript","image":"showcase-claude-sdk-typescript","railway_id":"18a98727-5700-44aa-b497-b60795dbbd6a","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"ms-agent-dotnet","filter_key":"ms_agent_dotnet","context":"showcase/integrations/ms-agent-dotnet","image":"showcase-ms-agent-dotnet","railway_id":"beeb2dd6-87a4-4599-aa07-0578f7bd6519","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"claude-sdk-python","filter_key":"claude_sdk_python","context":"showcase/integrations/claude-sdk-python","image":"showcase-claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"built-in-agent","filter_key":"built_in_agent","context":"showcase/integrations/built-in-agent","image":"showcase-built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","timeout":15,"lfs":false,"build_args":"","dockerfile":"","health_path":"/api/health"},
-            {"dispatch_name":"shell-dojo","filter_key":"shell_dojo","context":".","image":"showcase-shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","timeout":10,"lfs":false,"build_args":"","dockerfile":"showcase/shell-dojo/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-dashboard","filter_key":"shell_dashboard","context":".","image":"showcase-shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","build_args_pb_url":"https://showcase-pocketbase-production.up.railway.app","build_args_shell_url":"https://showcase.copilotkit.ai","build_args_ops_url":"https://showcase-harness-production.up.railway.app","dockerfile":"showcase/shell-dashboard/Dockerfile","health_path":"/"},
-            {"dispatch_name":"shell-docs","filter_key":"shell_docs","context":".","image":"showcase-shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","timeout":10,"lfs":true,"build_args_sha":"${{ github.sha }}","build_args_branch":"${{ github.ref_name }}","dockerfile":"showcase/shell-docs/Dockerfile","health_path":"/"},
-            {"dispatch_name":"showcase-harness","filter_key":"showcase_harness","context":".","image":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","timeout":20,"lfs":false,"build_args":"","dockerfile":"showcase/harness/Dockerfile","health_path":"/health"},
-            {"dispatch_name":"showcase-aimock","filter_key":"showcase_aimock","context":"showcase/aimock","image":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","timeout":5,"lfs":false,"build_args":"","dockerfile":"showcase/aimock/Dockerfile","health_path":"/health"}
+            {"dispatch_name":"shell","railway_id":"40eea0da-6071-4ea8-bdb9-39afb19225ec","health_path":"/"},
+            {"dispatch_name":"langgraph-python","railway_id":"90d03214-4569-41b0-b4c1-6438a8a7b203","health_path":"/api/health"},
+            {"dispatch_name":"mastra","railway_id":"d7979eb7-2405-4aab-ad21-438f4a1b08af","health_path":"/api/health"},
+            {"dispatch_name":"crewai-crews","railway_id":"0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4","health_path":"/api/health"},
+            {"dispatch_name":"pydantic-ai","railway_id":"0a106173-2282-4887-a994-0ca276a99d69","health_path":"/api/health"},
+            {"dispatch_name":"google-adk","railway_id":"87f60507-5a3d-4b8a-9e23-2b1de85d939c","health_path":"/api/health"},
+            {"dispatch_name":"ag2","railway_id":"4a37481b-f264-4eb7-a9cd-0a9ebb9ac05c","health_path":"/api/health"},
+            {"dispatch_name":"agno","railway_id":"32cab80b-e329-45bd-9c73-c4e1ddc94305","health_path":"/api/health"},
+            {"dispatch_name":"llamaindex","railway_id":"285386e8-492d-4cb8-b632-0a7d4607378f","health_path":"/api/health"},
+            {"dispatch_name":"langgraph-fastapi","railway_id":"06cccb5c-59f4-46b5-8adc-7113e77011a4","health_path":"/api/health"},
+            {"dispatch_name":"langgraph-typescript","railway_id":"66246d3b-a18e-46f0-be51-5f3ff7a36e5a","health_path":"/api/health"},
+            {"dispatch_name":"langroid","railway_id":"6dd9cb0a-66cc-46f1-972e-7cd74756157d","health_path":"/api/health"},
+            {"dispatch_name":"spring-ai","railway_id":"eed5d041-91be-4282-b414-beea00843401","health_path":"/api/health"},
+            {"dispatch_name":"strands","railway_id":"92e1cfad-ad53-403f-ab2b-5ab380832232","health_path":"/api/health"},
+            {"dispatch_name":"ms-agent-python","railway_id":"655db75a-af8d-427d-a4f9-441570ae5003","health_path":"/api/health"},
+            {"dispatch_name":"claude-sdk-typescript","railway_id":"18a98727-5700-44aa-b497-b60795dbbd6a","health_path":"/api/health"},
+            {"dispatch_name":"ms-agent-dotnet","railway_id":"beeb2dd6-87a4-4599-aa07-0578f7bd6519","health_path":"/api/health"},
+            {"dispatch_name":"claude-sdk-python","railway_id":"b122ab65-9854-4cb2-a68e-b50ff13f7481","health_path":"/api/health"},
+            {"dispatch_name":"built-in-agent","railway_id":"f4f8371a-bc46-45b2-b6d4-9c9af608bdbf","health_path":"/api/health"},
+            {"dispatch_name":"shell-dojo","railway_id":"7ad1ece7-2228-49cd-8a78-bddf30322907","health_path":"/"},
+            {"dispatch_name":"shell-dashboard","railway_id":"4d5dfd74-be61-40b2-8564-b53b7dd4c15b","health_path":"/"},
+            {"dispatch_name":"shell-docs","railway_id":"7badfb8d-4228-414c-9145-b4026803714f","health_path":"/"},
+            {"dispatch_name":"showcase-harness","railway_id":"3a14bfed-0537-4d71-897b-7c593dca161d","health_path":"/health"},
+            {"dispatch_name":"showcase-aimock","railway_id":"0fa0435d-8a66-46f0-84fd-e4250b580013","health_path":"/health"}
           ]'
 
           DISPATCH="${{ github.event.inputs.service }}"
-          CHANGES='${{ steps.filter.outputs.changes }}'
-          CHANGES="${CHANGES:-[]}"
+          BUILD_RUN_ID="${{ github.event.workflow_run.id }}"
+          BUILD_RUN_URL="${{ github.event.workflow_run.html_url }}"
 
-          # Filter services based on three dispatch modes:
-          #   dispatch == "all": manual "deploy all" — include every service unconditionally.
-          #     This re-pulls :latest for every matrix slot (~38 services); intentional for
-          #     drift-rebuild runs and full-fleet restarts. Do NOT try to short-circuit
-          #     unchanged services here — operators invoke "all" precisely when they want
-          #     the fleet re-deployed regardless of git state (cache poisoning, base-image CVE).
-          #     (paths-filter is unreliable on workflow_dispatch because there is no 'before' SHA,
-          #      so we must NOT consult $changes here — doing so silently produces an empty matrix).
-          #   dispatch == <specific service>: narrow to that service only (skips paths-filter so
-          #     drift-rebuild and manual single-service dispatches work regardless of $changes).
-          #   dispatch == "": push event — include services whose filter_key appears in paths-filter CHANGES.
-          MATRIX=$(echo "$ALL_SERVICES" | jq -c --arg dispatch "$DISPATCH" --argjson changes "$CHANGES" '
-            [.[] | (.filter_key as $fk | select(
-              $dispatch == "all" or
-              ($dispatch != "" and $dispatch != "all" and $dispatch == .dispatch_name) or
-              ($dispatch == "" and ($changes | index($fk) != null))
-            ))]
-          ')
-
-          # Fail loudly on typo'd workflow_dispatch inputs. If a user types a
-          # service name that doesn't exist in ALL_SERVICES, the jq filter
-          # silently produces [] and the run shows green with zero work
-          # done — a common "did my dispatch deploy?" footgun. The `all` and
-          # empty (push-event) modes legitimately produce [] when there are
-          # no changes and must still succeed.
-          if [ "$MATRIX" = "[]" ] && [ -n "$DISPATCH" ] && [ "$DISPATCH" != "all" ]; then
-            echo "::error::workflow_dispatch service='$DISPATCH' did not match any entry in ALL_SERVICES — check the dispatch_name spelling"
-            exit 1
-          fi
-
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
-          if [ "$MATRIX" = "[]" ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+          if [ "$DISPATCH" = "all" ] || [ -z "$DISPATCH" ]; then
+            if [ -n "$BUILD_RUN_ID" ]; then
+              # workflow_run trigger: discover which services the build
+              # workflow actually built by inspecting its matrix job names.
+              # Job names follow "build (<dispatch_name>, ...)" pattern.
+              JOBS_JSON=$(gh api "repos/${{ github.repository }}/actions/runs/${BUILD_RUN_ID}/jobs" --paginate 2>/dev/null \
+                | jq -cs '[.[].jobs[]?]' 2>/dev/null || echo '[]')
+              BUILD_JOBS=$(echo "$JOBS_JSON" | jq -c '[.[] | select((.name // "") | startswith("build"))]')
+              # Extract dispatch_names from successful build job names
+              BUILT_SERVICES=$(echo "$BUILD_JOBS" | jq -c '[.[] | select(.conclusion == "success") | .name | capture("^build \\((?<svc>[^,)]+)") | .svc]')
+              # Filter ALL_SERVICES to only those that were actually built
+              MATRIX=$(echo "$ALL_SERVICES" | jq -c --argjson built "$BUILT_SERVICES" '
+                [.[] | select(.dispatch_name as $dn | $built | index($dn) != null)]
+              ')
+            else
+              # workflow_dispatch with "all": verify every service
+              MATRIX=$(echo "$ALL_SERVICES" | jq -c '.')
+            fi
           else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            # Specific service dispatch
+            MATRIX=$(echo "$ALL_SERVICES" | jq -c --arg svc "$DISPATCH" '[.[] | select(.dispatch_name == $svc)]')
           fi
 
-  check-lockfile:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      # Omit `version:` so pnpm/action-setup inherits from the repo's
-      # `packageManager` field in package.json (enforced via corepack).
-      # Earlier revisions hard-pinned `version: 10.13.1` which silently
-      # drifted from package.json whenever the repo bumped pnpm —
-      # resulting in lockfile-vs-engine mismatches that only surfaced on
-      # the slow `--frozen-lockfile` path.
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-      - run: pnpm install --frozen-lockfile --ignore-scripts
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          if [ "$MATRIX" = "[]" ]; then
+            echo "has_services=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_services=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "build_run_id=${BUILD_RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "build_run_url=${BUILD_RUN_URL}" >> "$GITHUB_OUTPUT"
 
-  verify-image-refs:
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.has_changes == 'true'
+  verify:
+    needs: [resolve-matrix]
+    if: needs.resolve-matrix.outputs.has_services == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 3
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-      - name: Verify Railway image refs
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: npx tsx showcase/scripts/verify-railway-image-refs.ts
-
-  build:
-    needs: [detect-changes, check-lockfile, verify-image-refs]
-    if: needs.detect-changes.outputs.has_changes == 'true'
-    runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: ${{ fromJSON(matrix.service.timeout) }}
+    timeout-minutes: 15
     permissions:
-      id-token: write
       contents: read
-      packages: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
-        service: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
+        service: ${{ fromJSON(needs.resolve-matrix.outputs.matrix) }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          lfs: ${{ matrix.service.lfs }}
-
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare build args
-        id: build-args
-        run: |
-          ARGS=""
-          if [ -n "${{ matrix.service.build_args_sha }}" ]; then
-            ARGS="COMMIT_SHA=${{ matrix.service.build_args_sha }}"
-            ARGS="${ARGS}"$'\n'"BRANCH=${{ matrix.service.build_args_branch }}"
-          fi
-          if [ -n "${{ matrix.service.build_args_pb_url }}" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_POCKETBASE_URL=${{ matrix.service.build_args_pb_url }}"
-          fi
-          if [ -n "${{ matrix.service.build_args_shell_url }}" ]; then
-            ARGS="${ARGS:+${ARGS}$'\n'}NEXT_PUBLIC_SHELL_URL=${{ matrix.service.build_args_shell_url }}"
-          fi
-          if [ -n "${{ matrix.service.build_args_ops_url }}" ]; then
-            # OPS_BASE_URL is required at build time by shell-dashboard's
-            # next.config.ts rewrites() — without it `next build` aborts.
-            ARGS="${ARGS:+${ARGS}$'\n'}OPS_BASE_URL=${{ matrix.service.build_args_ops_url }}"
-          fi
-          # Use delimiter to safely pass multiline value
-          echo "args<<BUILDARGS_EOF" >> $GITHUB_OUTPUT
-          echo "$ARGS" >> $GITHUB_OUTPUT
-          echo "BUILDARGS_EOF" >> $GITHUB_OUTPUT
-
-      - name: Copy shared modules into build context
-        run: |
-          set -euo pipefail
-          CONTEXT="${{ matrix.service.context }}"
-          # Idempotent copy: if a stale `shared_python`/`shared_typescript`
-          # already exists (previous failed run on the same runner, or a
-          # checkout artifact), remove it first. `cp -r src dst` into an
-          # existing directory nests source-inside-destination, which
-          # would silently produce a broken build context.
-          if [ -d "showcase/shared/python" ] && [ -d "$CONTEXT" ]; then
-            rm -rf "$CONTEXT/shared_python"
-            cp -r showcase/shared/python "$CONTEXT/shared_python"
-          fi
-          if [ -d "showcase/shared/typescript/tools" ] && [ -d "$CONTEXT" ]; then
-            rm -rf "$CONTEXT/shared_typescript"
-            mkdir -p "$CONTEXT/shared_typescript"
-            cp -r showcase/shared/typescript/tools "$CONTEXT/shared_typescript/tools"
-          fi
-
-          # Dereference tools/ and shared-tools/ symlinks for Docker
-          # context. Integration directories use symlinks pointing to
-          # ../../shared/python/tools etc. Docker cannot follow symlinks
-          # outside the build context, so we replace each symlink with a
-          # real copy of its target.
-          for link_name in tools shared-tools; do
-            link_path="$CONTEXT/$link_name"
-            if [ -L "$link_path" ]; then
-              target="$(readlink -f "$link_path")"
-              if [ -d "$target" ]; then
-                rm "$link_path"
-                cp -r "$target" "$link_path"
-              fi
-            fi
-          done
-
-      - name: Build and push
-        uses: depot/build-push-action@v1
-        with:
-          project: m2kw2wmmcp
-          context: ${{ matrix.service.context }}
-          file: ${{ matrix.service.dockerfile != '' && matrix.service.dockerfile || format('{0}/Dockerfile', matrix.service.context) }}
-          # Pin amd64: Railway and GHCR serve x86 hosts. An arm64-only
-          # image crashes on pull with "does not have a linux/amd64
-          # variant available".
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/copilotkit/${{ matrix.service.image }}:latest
-            ghcr.io/copilotkit/${{ matrix.service.image }}:${{ github.sha }}
-          build-args: ${{ steps.build-args.outputs.args }}
-
-      - name: Deploy to Railway
-        id: deploy
-        if: matrix.service.railway_id != ''
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          SERVICE_ID: ${{ matrix.service.railway_id }}
-          ENV_ID: ${{ env.RAILWAY_ENV_ID }}
-        run: |
-          # Capture the current deployment ID BEFORE redeploying so the verify
-          # step can distinguish the fresh deployment from the prior one.
-          # `--retry 2 --retry-all-errors --retry-delay 1` tolerates the
-          # occasional transient 5xx from Railway GraphQL without failing
-          # the deploy; `--fail-with-body` prints the HTML error body on
-          # hard failure so a reviewer can diagnose without re-running.
-          PRIOR_RESULT=$(curl -s --retry 2 --retry-all-errors --retry-delay 1 \
-            --fail-with-body \
-            -H "Authorization: Bearer $RAILWAY_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"query\":\"query { deployments(first: 1, input: { serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\" }) { edges { node { id } } } }\"}" \
-            https://backboard.railway.com/graphql/v2 2>/dev/null)
-          # Fail fast on GraphQL errors — silent failure here would bypass the
-          # stale-deployment guard in the verify step.
-          PRIOR_ERRORS=$(echo "$PRIOR_RESULT" | jq -r '.errors[]?.message // empty')
-          if [ -n "$PRIOR_ERRORS" ]; then
-            echo "::error::Railway prior-deploy query failed: $PRIOR_ERRORS"
-            exit 1
-          fi
-          PRIOR_DEPLOY_ID=$(echo "$PRIOR_RESULT" | jq -r '.data.deployments.edges[0].node.id // empty')
-          echo "Prior deployment ID: ${PRIOR_DEPLOY_ID:-<none>}"
-          echo "prior_deploy_id=$PRIOR_DEPLOY_ID" >> "$GITHUB_OUTPUT"
-
-          # Record a cutoff AT the mutation time (no -5s subtraction).
-          # An earlier revision subtracted 5 seconds "for clock skew" — but
-          # that opened a 5s window where an externally-triggered concurrent
-          # redeploy could be mis-attributed as ours (its createdAt would
-          # legitimately exceed cutoff-5). Computing the cutoff immediately
-          # before the mutation (and after the mutation lands it's the
-          # NEW deploy's timestamp that matters) is tighter; Railway's
-          # createdAt monotonicity + serialized GraphQL ordering guarantees
-          # our fresh deployment's createdAt is >= this cutoff. Normalize
-          # to ms precision so the lex-compare in Verify handles Railway's
-          # ISO8601-with-ms format correctly.
-          REDEPLOY_CUTOFF_EPOCH=$(date -u +%s)
-          REDEPLOY_CUTOFF_ISO=$(date -u -d "@${REDEPLOY_CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z" 2>/dev/null || date -u -r "${REDEPLOY_CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z")
-          echo "Redeploy cutoff (ISO): $REDEPLOY_CUTOFF_ISO"
-          echo "redeploy_cutoff_iso=$REDEPLOY_CUTOFF_ISO" >> "$GITHUB_OUTPUT"
-          echo "redeploy_cutoff_epoch=$REDEPLOY_CUTOFF_EPOCH" >> "$GITHUB_OUTPUT"
-
-          # All Railway services are configured to pull :latest from GHCR.
-          # serviceInstanceRedeploy triggers a fresh pull of the configured image.
-          # Check response body for GraphQL errors (HTTP 200 + errors is valid).
-          REDEPLOY_RESULT=$(curl -s --retry 2 --retry-all-errors --retry-delay 1 \
-            --fail-with-body \
-            -X POST "https://backboard.railway.com/graphql/v2" \
-            -H "Authorization: Bearer $RAILWAY_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"query\":\"mutation { serviceInstanceRedeploy(serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\") }\"}")
-          REDEPLOY_ERRORS=$(echo "$REDEPLOY_RESULT" | jq -r '.errors[]?.message // empty')
-          if [ -n "$REDEPLOY_ERRORS" ]; then
-            echo "::error::Railway redeploy failed: $REDEPLOY_ERRORS"
-            exit 1
-          fi
-          REDEPLOY_OK=$(echo "$REDEPLOY_RESULT" | jq -r '.data.serviceInstanceRedeploy // false')
-          if [ "$REDEPLOY_OK" != "true" ]; then
-            echo "::error::Railway redeploy did not confirm success: $REDEPLOY_RESULT"
-            exit 1
-          fi
-          echo "Deploy triggered for ${{ matrix.service.dispatch_name }}"
-
       - name: Verify deploy health
-        if: matrix.service.railway_id != ''
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           SERVICE_ID: ${{ matrix.service.railway_id }}
           ENV_ID: ${{ env.RAILWAY_ENV_ID }}
-          PRIOR_DEPLOY_ID: ${{ steps.deploy.outputs.prior_deploy_id }}
-          REDEPLOY_CUTOFF_ISO: ${{ steps.deploy.outputs.redeploy_cutoff_iso }}
-          REDEPLOY_CUTOFF_EPOCH: ${{ steps.deploy.outputs.redeploy_cutoff_epoch }}
         run: |
           # Fail fast if RAILWAY_TOKEN is not set
           if [ -z "$RAILWAY_TOKEN" ]; then
@@ -438,19 +169,12 @@ jobs:
             exit 1
           fi
 
-          echo "Verifying fresh deploy (prior ID: ${PRIOR_DEPLOY_ID:-<none>}, cutoff: ${REDEPLOY_CUTOFF_ISO:-<none>})..."
-          # Enforce a 600s wall-clock budget rather than a fixed iteration
-          # count. Previous revision counted 40 attempts * 15s sleep and
-          # *assumed* total ≈ 600s — but each iteration also spent up to
-          # 15s on the curl (--max-time 15) plus health probes, so the
-          # actual budget could stretch past 900s in practice.
-          # Tracking START and checking elapsed per-loop makes the budget
-          # real. Previous 360s was tight for JVM services (spring-ai's
-          # lazy bean init + first HTTP serve can exceed 5 min on a cold
-          # Railway container). 600s is still bounded.
-          # Require 2 consecutive healthy polls before declaring success —
-          # catches SUCCESS-then-crash (JVM lazy init failure, Python OOM
-          # on first request).
+          echo "Verifying Railway auto-deploy for ${{ matrix.service.dispatch_name }}..."
+
+          # Railway auto-update (environmentPatchCommit) picks up the new
+          # :latest tag and triggers a redeploy. We poll until the service
+          # is healthy. 600s budget accommodates JVM/slow-boot services.
+          # Require 2 consecutive healthy polls before declaring success.
           HEALTHY_STREAK=0
           REQUIRED_STREAK=2
           START=$(date +%s)
@@ -462,7 +186,7 @@ jobs:
               --fail-with-body \
               -H "Authorization: Bearer $RAILWAY_TOKEN" \
               -H "Content-Type: application/json" \
-              -d "{\"query\":\"query { deployments(first: 1, input: { serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\" }) { edges { node { id status staticUrl createdAt } } } }\"}" \
+              -d "{\"query\":\"query { deployments(first: 1, input: { serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\" }) { edges { node { id status staticUrl } } } }\"}" \
               https://backboard.railway.com/graphql/v2 2>/dev/null)
 
             # Surface GraphQL errors and fail fast
@@ -472,54 +196,12 @@ jobs:
               exit 1
             fi
 
-            # `// empty` so a missing edge yields "" instead of the literal
-            # string "null". Matches the PRIOR_DEPLOY_ID extraction above —
-            # without it, the `$DEPLOY_ID = $PRIOR_DEPLOY_ID` comparison and
-            # the `$DOMAIN != "null"` guard break in inconsistent ways when
-            # Railway's edges array is transiently empty.
             DEPLOY_ID=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.id // empty')
             STATUS=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.status // empty')
             DOMAIN=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.staticUrl // empty')
-            CREATED_AT=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.createdAt // empty')
-            echo "Attempt $i: deploy=$DEPLOY_ID status=$STATUS domain=$DOMAIN createdAt=$CREATED_AT streak=$HEALTHY_STREAK"
+            echo "Attempt $i: deploy=$DEPLOY_ID status=$STATUS domain=$DOMAIN streak=$HEALTHY_STREAK"
 
-            # Skip stale deployments: if we see the prior deployment, the fresh
-            # one hasn't appeared yet — wait without declaring success or failure.
-            if [ -n "$PRIOR_DEPLOY_ID" ] && [ "$DEPLOY_ID" = "$PRIOR_DEPLOY_ID" ]; then
-              echo "  (prior deployment still latest — waiting for fresh one)"
-              HEALTHY_STREAK=0
-              sleep 15
-              continue
-            fi
-
-            # Secondary guard: close the race window between the prior-ID read
-            # and serviceInstanceRedeploy. If a concurrent external deploy
-            # landed a different new ID (neither PRIOR nor ours), its
-            # createdAt may predate the redeploy cutoff. Reject those so we
-            # don't mis-attribute someone else's deploy as our fresh one.
-            #
-            # Epoch-number compare (instead of lex string compare) sidesteps
-            # Railway's mixed-precision createdAt format: the API returns
-            # `2006-01-02T15:04:05.123Z` (ms precision) while a lex cutoff
-            # in `2006-01-02T15:04:05Z` (second precision) sorted the fresh
-            # deploy as OLDER because ASCII `.` < `Z`. Converting both
-            # sides to epoch seconds eliminates the format-sensitivity.
-            if [ -n "${REDEPLOY_CUTOFF_EPOCH:-}" ] && [ -n "$CREATED_AT" ]; then
-              # Strip fractional seconds + Z for cross-platform `date -d`.
-              CREATED_AT_SANE=$(printf '%s' "$CREATED_AT" | sed -E 's/\.[0-9]+Z$/Z/')
-              CREATED_EPOCH=$(date -u -d "$CREATED_AT_SANE" +%s 2>/dev/null \
-                || date -u -jf "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT_SANE" +%s 2>/dev/null \
-                || echo 0)
-              if [ "$CREATED_EPOCH" -gt 0 ] && [ "$CREATED_EPOCH" -lt "$REDEPLOY_CUTOFF_EPOCH" ]; then
-                echo "  (latest deploy createdAt $CREATED_AT predates cutoff $REDEPLOY_CUTOFF_ISO — waiting for our deploy)"
-                HEALTHY_STREAK=0
-                sleep 15
-                continue
-              fi
-            fi
-
-            # Fail on any terminal failure status. Railway's DeploymentStatus enum
-            # has no CANCELLED value; the real terminal failures are below.
+            # Fail on any terminal failure status
             case "$STATUS" in
               CRASHED|FAILED|REMOVED|SKIPPED)
                 echo "::error::Service ${{ matrix.service.dispatch_name }} deploy status: $STATUS"
@@ -527,99 +209,31 @@ jobs:
                 ;;
             esac
 
-            # `DOMAIN` is empty string on missing edge (jq `// empty`), so a
-            # `-n` check is sufficient. The prior `!= "null"` guard was dead
-            # — jq `// empty` already resolves JSON null to "", never to the
-            # literal string "null".
             if [ "$STATUS" = "SUCCESS" ] && [ -n "$DOMAIN" ]; then
-              # Probe the service-specific health_path. Hit a real endpoint
-              # rather than root: many services are API-only backends that 404
-              # at /, so a 404 at root can't distinguish "dead" from
-              # "alive-but-no-index-route".
-              # No fallback — an unscoped fallback could mask a broken endpoint
-              # when an unrelated catch-all/CDN/actuator happens to 200 at the
-              # other path. Misconfigured paths are a config bug to fix in the
-              # matrix, not runtime behavior to hide.
               HEALTH_PATH="${{ matrix.service.health_path }}"
               if [ -z "$HEALTH_PATH" ]; then
-                echo "::error::health_path not configured for service ${{ matrix.service.dispatch_name }} in ALL_SERVICES"
+                echo "::error::health_path not configured for service ${{ matrix.service.dispatch_name }}"
                 exit 1
               fi
               HEALTH_URL="https://${DOMAIN}${HEALTH_PATH}"
-              # Services like `shell` and `shell-dojo` probe `/` (a Next.js
-              # homepage), which can transiently 5xx or bounce through a 301
-              # chain during cold starts — a single bad response would reset
-              # HEALTHY_STREAK and throw away progress. Retry the probe up to
-              # 3 times within this iteration before treating it as a genuine
-              # non-200; legitimate failures still fail because all 3 tries
-              # must return non-200.
+              # Retry probe up to 3 times within this iteration before
+              # treating it as a genuine non-200
               HTTP_CODE="000"
-              RETRY_AFTER=""
               for probe_try in 1 2 3; do
-                RESP_HEADERS=$(mktemp)
-                HTTP_CODE=$(curl -s -o /dev/null -D "$RESP_HEADERS" -w "%{http_code}" --max-time 15 "$HEALTH_URL" 2>/dev/null || echo "000")
-                # Capture Retry-After so 429/503 waits respect the server hint
-                # instead of hammering every 2s. Header case-insensitive grep.
-                RETRY_AFTER=$(awk 'BEGIN{IGNORECASE=1} /^Retry-After:/ {sub(/\r$/,""); print $2; exit}' "$RESP_HEADERS" 2>/dev/null || echo "")
-                rm -f "$RESP_HEADERS"
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$HEALTH_URL" 2>/dev/null || echo "000")
                 if [ "$HTTP_CODE" = "200" ]; then
                   break
                 fi
                 if [ "$probe_try" -lt 3 ]; then
-                  echo "HTTP check: $HEALTH_URL → $HTTP_CODE (retry $probe_try/3)"
-                  # Honor Retry-After. RFC 7231 allows either a
-                  # delta-seconds integer OR an HTTP-date. Railway's
-                  # upstreams have been observed emitting both, so we
-                  # parse both forms; unknown/unparseable falls through
-                  # to the 2s default.
-                  RETRY_SECONDS=""
-                  if [ -n "$RETRY_AFTER" ]; then
-                    if printf '%s' "$RETRY_AFTER" | grep -Eq '^[0-9]+$'; then
-                      RETRY_SECONDS="$RETRY_AFTER"
-                    else
-                      # HTTP-date form: `Wed, 21 Oct 2015 07:28:00 GMT`.
-                      # GNU date on the runner parses this directly; BSD
-                      # date (macOS CI fallback) has a different flag set
-                      # — `|| true` ensures neither path aborts the probe
-                      # loop if the header is garbled.
-                      HD_EPOCH=$(date -u -d "$RETRY_AFTER" +%s 2>/dev/null || echo "")
-                      if [ -n "$HD_EPOCH" ]; then
-                        NOW_EPOCH=$(date -u +%s)
-                        DELTA=$((HD_EPOCH - NOW_EPOCH))
-                        if [ "$DELTA" -gt 0 ]; then
-                          RETRY_SECONDS="$DELTA"
-                        fi
-                      fi
-                    fi
-                    # If the header was present but neither decimal-seconds
-                    # nor HTTP-date parsed, surface a warning so operators
-                    # can spot misformatted Retry-After headers instead of
-                    # silently burning retry budget at 2s/try.
-                    if [ -z "$RETRY_SECONDS" ]; then
-                      echo "::warning::Unparseable Retry-After header '$RETRY_AFTER' from $HEALTH_URL — falling back to 2s"
-                    fi
-                  fi
-                  # Clamp to [1, 30]: upper cap keeps a broken Retry-After from
-                  # blowing the 600s budget; lower clamp ensures `Retry-After: 0`
-                  # still yields at least one tick of backoff rather than a busy
-                  # loop of same-second retries.
-                  if [ -n "$RETRY_SECONDS" ]; then
-                    if [ "$RETRY_SECONDS" -lt 1 ]; then RETRY_SECONDS=1; fi
-                    if [ "$RETRY_SECONDS" -gt 30 ]; then RETRY_SECONDS=30; fi
-                    sleep "$RETRY_SECONDS"
-                  else
-                    sleep 2
-                  fi
+                  echo "HTTP check: $HEALTH_URL -> $HTTP_CODE (retry $probe_try/3)"
+                  sleep 2
                 fi
               done
-              echo "HTTP check: $HEALTH_URL → $HTTP_CODE"
-              # Fail fast on permanent client errors. 404 (wrong health_path),
-              # 410 (endpoint decommissioned), 501 (method not implemented)
-              # will never recover — retrying for 10 min wastes the job budget
-              # and hides misconfiguration behind "did not become healthy".
+              echo "HTTP check: $HEALTH_URL -> $HTTP_CODE"
+              # Fail fast on permanent client errors
               case "$HTTP_CODE" in
                 404|410|501)
-                  echo "::error::Service ${{ matrix.service.dispatch_name }} health endpoint returned $HTTP_CODE at $HEALTH_URL — check health_path in ALL_SERVICES or confirm the service still serves that route"
+                  echo "::error::Service ${{ matrix.service.dispatch_name }} health endpoint returned $HTTP_CODE at $HEALTH_URL"
                   exit 1
                   ;;
               esac
@@ -630,10 +244,8 @@ jobs:
                   exit 0
                 fi
               else
-                # Reset streak if we had a partial streak and then a non-200
                 HEALTHY_STREAK=0
               fi
-              # SUCCESS but not yet responding — app process still booting
             else
               HEALTHY_STREAK=0
             fi
@@ -641,177 +253,78 @@ jobs:
             sleep 15
           done
           echo "::error::Service ${{ matrix.service.dispatch_name }} did not become healthy within 600s"
-          # Fail the job so Slack alerts fire — silent deploy failures
-          # should never report green. Railway is on the Pro tier and does
-          # not sleep on idle, so a persistent timeout is a real failure.
           exit 1
 
   notify-harness:
-    needs: [detect-changes, check-lockfile, verify-image-refs, build]
-    if: always()
+    needs: [resolve-matrix, verify]
+    if: always() && needs.resolve-matrix.outputs.has_services == 'true'
     permissions:
       contents: read
       actions: read
     runs-on: ubuntu-latest
-    # 3 attempts * (30s curl + up to 10s backoff) is ~130s in the worst case,
-    # plus payload assembly. 2 minutes leaves no headroom and truncated the
-    # final retry under load; bumping to 3 gives a clean budget.
     timeout-minutes: 3
     steps:
       - name: Compute deploy-result payload
         id: payload
         env:
-          BUILD_RESULT: ${{ needs.build.result }}
-          LOCKFILE_RESULT: ${{ needs.check-lockfile.result }}
-          VERIFY_RESULT: ${{ needs.verify-image-refs.result }}
-          DETECT_RESULT: ${{ needs.detect-changes.result }}
-          DETECT_HAS_CHANGES: ${{ needs.detect-changes.outputs.has_changes }}
-          DETECT_MATRIX: ${{ needs.detect-changes.outputs.matrix }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          MATRIX: ${{ needs.resolve-matrix.outputs.matrix }}
+          BUILD_RUN_ID: ${{ needs.resolve-matrix.outputs.build_run_id }}
+          BUILD_RUN_URL: ${{ needs.resolve-matrix.outputs.build_run_url }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Only short-circuit on the genuine "nothing to deploy" case: detect
-          # ran successfully AND reported no changed services. A detect-changes
-          # failure must fall through so the GATE_REASON="detect-changes-<result>"
-          # branch below can fire an alert — previously this was the explicit
-          # intent (see the comment on "upstream gate, also not our fault") but
-          # the compound guard swallowed the failure path entirely, making the
-          # detect-changes-failure branch unreachable dead code.
-          if [ "${DETECT_RESULT}" = "success" ] && [ "${DETECT_HAS_CHANGES}" != "true" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # DETECT_MATRIX is empty or malformed when detect-changes failed or
-          # was cancelled. Fall back to an empty array so `jq` doesn't error
-          # out and kill the whole notify-harness step — the gate-reason branch
-          # below still fires the alert with an empty services list.
-          SERVICES=$(echo "$DETECT_MATRIX" | jq -c '[.[].dispatch_name]' 2>/dev/null || echo '[]')
+
+          SERVICES=$(echo "$MATRIX" | jq -c '[.[].dispatch_name]' 2>/dev/null || echo '[]')
           SERVICES=${SERVICES:-'[]'}
-          # Disambiguate skipped-because-gated from ran-and-failed-everything.
-          # `needs.build.result == "skipped"` can arise from THREE distinct
-          # causes — reporting every service as failed in any of them is a
-          # false positive and spams #oss-alerts with bogus "all services
-          # failed" messages. The previous single-condition check
-          # (LOCKFILE_RESULT != success) conflated:
-          #   - lockfile actually failed (gated intentionally)
-          #   - lockfile cancelled (external cancel, not our concern)
-          #   - detect-changes failed (upstream gate, also not our fault)
-          # Split into explicit branches so each case is identifiable.
-          GATE_SKIPPED=false
-          GATE_REASON=""
-          if [ "${BUILD_RESULT}" = "skipped" ]; then
-            if [ "${LOCKFILE_RESULT}" = "failure" ]; then
-              GATE_SKIPPED=true
-              GATE_REASON="lockfile-failed"
-            elif [ "${LOCKFILE_RESULT}" = "cancelled" ]; then
-              GATE_SKIPPED=true
-              GATE_REASON="lockfile-cancelled"
-            elif [ "${VERIFY_RESULT}" = "failure" ]; then
-              # Pre-build drift assertion fired — Railway image refs don't
-              # match expected shape. showcase-harness renders a distinct alert
-              # rather than a generic deploy failure. Check the run log for
-              # the per-service violation list.
-              GATE_SKIPPED=true
-              GATE_REASON="verify-image-refs-failed"
-            elif [ "${VERIFY_RESULT}" = "cancelled" ]; then
-              GATE_SKIPPED=true
-              GATE_REASON="verify-image-refs-cancelled"
-            elif [ "${DETECT_RESULT}" != "success" ]; then
-              GATE_SKIPPED=true
-              GATE_REASON="detect-changes-${DETECT_RESULT}"
-            fi
-          fi
-          # HF13-E3: per-matrix-leg partition via `gh api`.
-          #
-          # The aggregate `needs.build.result` CANNOT be used to partition
-          # failed-vs-succeeded services when the build matrix has
-          # `fail-fast: false`. `needs.build.result == "failure"` means "at
-          # least one leg failed" — it does NOT mean "all legs failed".
-          # Previously we set `FAILED="$SERVICES"` on aggregate-failure,
-          # marking every successful leg as failed and rendering the
-          # signal.partial branch in deploy-result.yml unreachable. Query
-          # the per-job conclusions directly and partition by matching job
-          # name against each service's dispatch_name.
-          if [ "${BUILD_RESULT}" = "cancelled" ]; then
+
+          if [ "${VERIFY_RESULT}" = "cancelled" ]; then
             FAILED='[]'
             SUCCEEDED='[]'
             CANCELLED=true
-          elif [ "$GATE_SKIPPED" = "true" ]; then
-            # Build matrix never ran. Send an empty failed/succeeded pair plus
-            # a `gateSkipped: true` discriminator so showcase-harness can render
-            # a "blocked by lockfile gate" alert instead of a deploy failure.
-            FAILED='[]'
-            SUCCEEDED='[]'
-            CANCELLED=false
-          elif [ "${BUILD_RESULT}" = "success" ]; then
-            # Fast-path: aggregate success means every leg succeeded — no
-            # need to round-trip through the API just to re-derive the same
-            # answer. Keeps notify-harness within its retry budget on the happy
-            # path where most runs land.
+          elif [ "${VERIFY_RESULT}" = "success" ]; then
             FAILED='[]'
             SUCCEEDED="$SERVICES"
             CANCELLED=false
           else
-            # Partial / all-failed / unknown aggregate: ask the Actions API
-            # for per-leg conclusions. `--paginate` handles large matrices
-            # (>30 jobs per page); filter to build-matrix legs by name
-            # prefix. GitHub renders matrix job names as
-            # "build (<dispatch_name>, <context>, <image>, ...)" — the
-            # dispatch_name is the first serialized matrix-object field.
-            # We match with a token-bounded prefix ("build (<svc>,") rather
-            # than substring contains() to avoid partial-name collisions
-            # (e.g. a slug that is a prefix of another slug).
-            JOBS_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs" --paginate 2>/dev/null \
+            # Partial failure: query per-job conclusions from the verify matrix
+            JOBS_JSON=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" --paginate 2>/dev/null \
               | jq -cs '[.[].jobs[]?]' 2>/dev/null || echo '[]')
-            BUILD_JOBS=$(echo "$JOBS_JSON" | jq -c '[.[] | select((.name // "") | startswith("build"))]' 2>/dev/null || echo '[]')
-            FAILED=$(echo "$SERVICES" | jq -c --argjson jobs "$BUILD_JOBS" '
+            VERIFY_JOBS=$(echo "$JOBS_JSON" | jq -c '[.[] | select((.name // "") | startswith("verify"))]' 2>/dev/null || echo '[]')
+            FAILED=$(echo "$SERVICES" | jq -c --argjson jobs "$VERIFY_JOBS" '
               [
                 .[] as $svc
                 | $jobs[]
-                | select((.name // "") as $n | ($n | startswith("build (" + $svc + ",")) or $n == ("build (" + $svc + ")"))
+                | select((.name // "") as $n | ($n | contains($svc)))
                 | select(.conclusion == "failure")
                 | $svc
               ] | unique
             ' 2>/dev/null || echo "$SERVICES")
-            # SUCCEEDED = services with at least one job whose conclusion
-            # is "success". Matrix legs that were cancelled/skipped by the
-            # platform land in neither bucket — surfaced implicitly as
-            # `totalCount - failedCount - succeededCount` on the receiver.
-            SUCCEEDED=$(echo "$SERVICES" | jq -c --argjson jobs "$BUILD_JOBS" '
+            SUCCEEDED=$(echo "$SERVICES" | jq -c --argjson jobs "$VERIFY_JOBS" '
               [
                 .[] as $svc
                 | $jobs[]
-                | select((.name // "") as $n | ($n | startswith("build (" + $svc + ",")) or $n == ("build (" + $svc + ")"))
+                | select((.name // "") as $n | ($n | contains($svc)))
                 | select(.conclusion == "success")
                 | $svc
               ] | unique
             ' 2>/dev/null || echo '[]')
-            # Defensive fallback: if the API query failed and FAILED is an
-            # empty array while the aggregate says failure, fall back to
-            # marking all services failed rather than silently reporting
-            # "everything green on a failed run".
-            FAILED_LEN=$(echo "$FAILED" | jq 'length' 2>/dev/null || echo 0)
-            SUCCEEDED_LEN=$(echo "$SUCCEEDED" | jq 'length' 2>/dev/null || echo 0)
-            if [ "$FAILED_LEN" = "0" ] && [ "$SUCCEEDED_LEN" = "0" ]; then
-              echo "::warning::gh api job-partition query returned no matches; falling back to aggregate-failure"
-              FAILED="$SERVICES"
-              SUCCEEDED='[]'
-            fi
             CANCELLED=false
           fi
           PAYLOAD=$(jq -cn \
             --arg runId "$RUN_ID" \
             --arg runUrl "$RUN_URL" \
-            --arg gateReason "$GATE_REASON" \
+            --arg buildRunId "${BUILD_RUN_ID:-}" \
+            --arg buildRunUrl "${BUILD_RUN_URL:-}" \
+            --arg gateReason "" \
             --argjson services "$SERVICES" \
             --argjson failed "$FAILED" \
             --argjson succeeded "$SUCCEEDED" \
             --argjson cancelled "$CANCELLED" \
-            --argjson gateSkipped "$GATE_SKIPPED" \
-            '{runId:$runId,runUrl:$runUrl,services:$services,failed:$failed,succeeded:$succeeded,cancelled:$cancelled,gateSkipped:$gateSkipped,gateReason:$gateReason}')
-          echo "skip=false" >> "$GITHUB_OUTPUT"
+            --argjson gateSkipped false \
+            '{runId:$runId,runUrl:$runUrl,buildRunId:$buildRunId,buildRunUrl:$buildRunUrl,services:$services,failed:$failed,succeeded:$succeeded,cancelled:$cancelled,gateSkipped:$gateSkipped,gateReason:$gateReason}')
           {
             echo "payload<<EOF_PAYLOAD"
             echo "$PAYLOAD"
@@ -819,7 +332,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: POST deploy result to showcase-harness
-        if: steps.payload.outputs.skip != 'true'
         env:
           SHOWCASE_HARNESS_URL: ${{ secrets.SHOWCASE_HARNESS_URL }}
           SHARED_SECRET: ${{ secrets.SHOWCASE_HARNESS_SHARED_SECRET }}
@@ -836,21 +348,11 @@ jobs:
           BODY_SHA=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hex | awk '{print $2}')
           CANONICAL="${METHOD}|${WEBHOOK_PATH}|${TS}|${BODY_SHA}"
           SIG=$(printf '%s' "$CANONICAL" | openssl dgst -sha256 -hmac "$SHARED_SECRET" -hex | awk '{print $2}')
-          # Bounded retry loop. curl's `--retry` alone is insufficient here:
-          # it only retries on transient transport failures, not on the 502/503/
-          # 504 responses Railway occasionally emits while a new showcase-harness
-          # deploy is coming up. We want retry on both transport + 5xx, with
-          # backoff, and a hard fail if the service is really down.
           HTTP_CODE="000"
           ATTEMPT=0
           MAX_ATTEMPTS=3
           while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
             ATTEMPT=$((ATTEMPT + 1))
-            # `--retry-all-errors` covers DNS/TLS/connect-reset failures that
-            # plain `--retry` skips (`--retry` only retries on 5xx + transient
-            # transport). 2 in-curl retries give us a short fast-path against
-            # a flapping resolver without blowing the 30s per-attempt budget;
-            # the outer loop still handles persistent 5xx.
             HTTP_CODE=$(curl -sS -o /tmp/body -w '%{http_code}' \
               --connect-timeout 10 --max-time 30 \
               --retry 2 --retry-all-errors --retry-delay 1 \


### PR DESCRIPTION
## Summary

The old "Showcase: Build & Deploy" workflow used a single concurrency group
with cancel-in-progress. Every push to main cancelled in-flight builds,
which meant rapid-fire PR merges routinely killed deploys mid-run. The
harness logging PR (#4465) never deployed because a subsequent merge
cancelled it.

This splits the workflow into two independent files:

- **showcase_build.yml** ("Showcase: Build & Push") -- triggered on push to
  main, builds Docker images and pushes to GHCR. Has NO concurrency group
  so every run completes. Railway auto-update picks up the new :latest tag.

- **showcase_deploy.yml** ("Showcase: Verify Deploy") -- triggered by
  workflow_run from the build workflow. Polls Railway to verify each service
  picked up the new image and is healthy. Uses cancel-in-progress since
  verification is idempotent.

Also updates showcase_capture-previews.yml to reference the renamed build
workflow.

## Test plan

- Workflow YAML validates (checked locally)
- Build workflow: no concurrency group, every push-to-main build completes
- Verify workflow: triggered by workflow_run, cancel-in-progress is safe
- showcase-aimock included in both workflows (from #4458)