### PR TITLE
fix(sdk-python/lg-middleware): strip orphan function_call content blocks (OpenAI Responses)

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -223,23 +223,34 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
 
             tool_calls = getattr(msg, 'tool_calls', None) or []
 
-            # 1. Sync content with tool_calls: remove tool_use content blocks
-            #    that aren't in msg.tool_calls (e.g. stripped by after_model
-            #    but content blocks left behind in checkpoint).
+            # 1. Sync content with tool_calls: remove tool_use (Anthropic) and
+            #    function_call (OpenAI Responses) content blocks that aren't in
+            #    msg.tool_calls (e.g. stripped by after_model but content blocks
+            #    left behind in checkpoint). Anthropic tool_use blocks key on
+            #    block["id"]; OpenAI function_call blocks key on block["call_id"]
+            #    (block["id"] on those is the item id, not the call id).
+            def _orphan_tool_block(block, tc_ids):
+                if not isinstance(block, dict):
+                    return False
+                btype = block.get('type')
+                if btype == 'tool_use':
+                    return block.get('id') not in tc_ids
+                if btype == 'function_call':
+                    return block.get('call_id') not in tc_ids
+                return False
+
             if tool_calls and isinstance(msg.content, list):
                 tc_ids = {tc.get('id') for tc in tool_calls}
                 msg.content = [
                     block for block in msg.content
-                    if not (isinstance(block, dict)
-                            and block.get('type') == 'tool_use'
-                            and block.get('id') not in tc_ids)
+                    if not _orphan_tool_block(block, tc_ids)
                 ]
             elif not tool_calls and isinstance(msg.content, list):
-                # No tool_calls at all — strip ALL tool_use content blocks
+                # No tool_calls at all — strip ALL tool_use / function_call blocks
                 msg.content = [
                     block for block in msg.content
                     if not (isinstance(block, dict)
-                            and block.get('type') == 'tool_use')
+                            and block.get('type') in ('tool_use', 'function_call'))
                 ]
 
             if not tool_calls:
@@ -263,13 +274,16 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
                 unanswered_ids = {tc['id'] for tc in unanswered}
                 msg.tool_calls = [tc for tc in tool_calls if tc.get('id') in adjacent_tc_ids]
 
-                # Also strip matching content blocks
+                # Also strip matching content blocks (tool_use + function_call)
                 if isinstance(msg.content, list):
                     msg.content = [
                         block for block in msg.content
-                        if not (isinstance(block, dict)
-                                and block.get('type') == 'tool_use'
-                                and block.get('id') in unanswered_ids)
+                        if not (isinstance(block, dict) and (
+                            (block.get('type') == 'tool_use'
+                             and block.get('id') in unanswered_ids)
+                            or (block.get('type') == 'function_call'
+                                and block.get('call_id') in unanswered_ids)
+                        ))
                     ]
 
             # 3. Fix string args in tool_calls

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -563,3 +563,67 @@ def test_bedrock_fix_repairs_string_args_to_dicts():
 
     repaired = next(m for m in messages if isinstance(m, AIMessage))
     assert repaired.tool_calls[0]["args"] == {"q": "hello"}
+
+
+def test_bedrock_fix_strips_orphan_function_call_content_blocks_no_tool_calls():
+    """When tool_calls is empty (e.g. after_model intercepted the frontend tool),
+    any leftover OpenAI Responses 'function_call' content block must be stripped
+    so langchain-openai doesn't re-emit it as an unanswered Responses input
+    item ("No tool output found for function call call_..." 400 from OpenAI).
+    """
+    ai = AIMessage(
+        content=[
+            {"type": "text", "text": "calling tool"},
+            {
+                "type": "function_call",
+                "call_id": "call_orphan",
+                "name": "frontend_action",
+                "arguments": "{}",
+                "id": "fc_item_1",
+            },
+        ],
+        id="ai-1",
+    )
+    messages: list[Any] = [HumanMessage("hi"), ai]
+
+    CopilotKitMiddleware._fix_messages_for_bedrock(messages)
+
+    repaired = next(m for m in messages if isinstance(m, AIMessage))
+    assert isinstance(repaired.content, list)
+    types_left = [b.get("type") for b in repaired.content if isinstance(b, dict)]
+    assert "function_call" not in types_left
+    assert "text" in types_left
+
+
+def test_bedrock_fix_strips_orphan_function_call_blocks_when_tool_calls_partial():
+    """function_call content blocks whose call_id isn't in tool_calls must
+    be removed alongside their tool_calls peers."""
+    ai = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "call_id": "call_kept",
+                "name": "search",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_orphan",
+                "name": "frontend_action",
+                "arguments": "{}",
+            },
+        ],
+        tool_calls=[{"id": "call_kept", "name": "search", "args": {}}],
+        id="ai-1",
+    )
+    answered = ToolMessage(content="ok", tool_call_id="call_kept")
+    messages: list[Any] = [HumanMessage("hi"), ai, answered]
+
+    CopilotKitMiddleware._fix_messages_for_bedrock(messages)
+
+    repaired = next(m for m in messages if isinstance(m, AIMessage))
+    call_ids = [
+        b.get("call_id") for b in repaired.content
+        if isinstance(b, dict) and b.get("type") == "function_call"
+    ]
+    assert call_ids == ["call_kept"]


### PR DESCRIPTION
## Summary

`CopilotKitMiddleware._fix_messages_for_bedrock` (mis-named — it runs for every provider) already strips orphan **`tool_use`** content blocks (Anthropic shape) but not **`function_call`** blocks (OpenAI Responses API shape, used by `langchain-openai` 1.x with default `output_version="responses/v1"`).

When a frontend tool call is intercepted by `after_model`:

1. \`tool_calls\` is cleared from the \`AIMessage\`,
2. but the equivalent \`{type: "function_call", call_id, ...}\` **content block** is left behind.

On the next request, \`langchain-openai\` serializes that orphan content block into the Responses API \`input\`, and OpenAI rejects with:

\`\`\`
400 - "No tool output found for function call call_..."
\`\`\`

This PR extends the existing tool-block stripping to handle both Anthropic (\`tool_use\`) and OpenAI (\`function_call\`) shapes, in both code paths:

1. **No \`tool_calls\` left** → strip all matching content blocks.
2. **Partial \`tool_calls\` left** (some answered, some not) → strip only the orphan content blocks whose call id isn't in the remaining \`tool_calls\`.

**Keying differs** between the two shapes:

- Anthropic \`tool_use\`: call id lives at \`block["id"]\` (existing behavior preserved).
- OpenAI \`function_call\`: call id lives at \`block["call_id"]\`. \`block["id"]\` is the response item id (e.g. \`fc_...\`), **not** the call id (\`call_...\`) — they're different things and \`tool_calls[i].id\` matches \`call_id\`.

## Changes

- \`sdk-python/copilotkit/copilotkit_lg_middleware.py\` — extracted a small \`_orphan_tool_block(block, tc_ids)\` helper that handles both shapes; re-used in both stripping paths.
- \`sdk-python/tests/test_copilotkit_lg_middleware.py\` — two new cases:
  - Orphan \`function_call\` block stripped when \`tool_calls\` is empty.
  - Mixed: \`function_call\` with valid \`call_id\` kept, orphan \`function_call\` removed.

## Linked

ag-ui PR with the matching role-converter fix (without it, the request dies one step earlier on \"message role is not supported\"): https://github.com/ag-ui-protocol/ag-ui/pull/1621

## Test plan

- [x] New unit tests pass.
- [x] Existing Anthropic \`tool_use\` regression still passes (verified locally).
- [x] End-to-end repro in \`examples/integrations/langgraph-python\` with LangGraph Python + OpenAI \`gpt-5.5\` Responses API + frontend A2UI tools: before this patch, second turn 400s with \"No tool output found for function call call_...\"; with this patch (+ ag-ui PR), multi-turn flow works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)