### PR TITLE
fix(ci): restore Railway deploy trigger in showcase build workflow

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -1,10 +1,9 @@
 name: "Showcase: Build & Push"
 
-# Decoupled from the old "Build & Deploy" workflow. This workflow ONLY builds
-# Docker images and pushes them to GHCR. Railway auto-update
-# (environmentPatchCommit) picks up the new :latest tag and deploys
-# automatically. The separate "Showcase: Verify Deploy" workflow
-# (showcase_deploy.yml) handles health verification.
+# Decoupled from the old "Build & Deploy" workflow. This workflow builds
+# Docker images, pushes them to GHCR, and triggers Railway to redeploy.
+# The separate "Showcase: Verify Deploy" workflow (showcase_deploy.yml)
+# handles health verification.
 #
 # Critical design property: NO concurrency group with cancel-in-progress.
 # Every push to main runs to completion so that rapid-fire PR merges never
@@ -355,6 +354,30 @@ jobs:
             ghcr.io/copilotkit/${{ matrix.service.image }}:${{ github.sha }}
           build-args: ${{ steps.build-args.outputs.args }}
 
-      # No Railway deploy step. Railway auto-update (environmentPatchCommit)
-      # picks up the new :latest GHCR tag and deploys automatically.
-      # The "Showcase: Verify Deploy" workflow handles health verification.
+      - name: Trigger Railway redeploy
+        if: matrix.service.railway_id != ''
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          SERVICE_ID: ${{ matrix.service.railway_id }}
+          ENV_ID: ${{ env.RAILWAY_ENV_ID }}
+        run: |
+          # Trigger Railway to pull the freshly-pushed :latest image.
+          # Not all services have environmentPatchCommit auto-update
+          # configured, so an explicit redeploy is the reliable path.
+          RESULT=$(curl -s --retry 2 --retry-all-errors --retry-delay 1 \
+            --fail-with-body \
+            -X POST "https://backboard.railway.com/graphql/v2" \
+            -H "Authorization: Bearer $RAILWAY_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\":\"mutation { serviceInstanceRedeploy(serviceId: \\\"$SERVICE_ID\\\", environmentId: \\\"$ENV_ID\\\") }\"}")
+          ERRORS=$(echo "$RESULT" | jq -r '.errors[]?.message // empty')
+          if [ -n "$ERRORS" ]; then
+            echo "::error::Railway redeploy failed for ${{ matrix.service.dispatch_name }}: $ERRORS"
+            exit 1
+          fi
+          OK=$(echo "$RESULT" | jq -r '.data.serviceInstanceRedeploy // false')
+          if [ "$OK" != "true" ]; then
+            echo "::error::Railway redeploy did not confirm success for ${{ matrix.service.dispatch_name }}: $RESULT"
+            exit 1
+          fi
+          echo "Railway redeploy triggered for ${{ matrix.service.dispatch_name }}"

--- a/.github/workflows/showcase_deploy.yml
+++ b/.github/workflows/showcase_deploy.yml
@@ -1,9 +1,9 @@
 name: "Showcase: Verify Deploy"
 
 # Triggered after "Showcase: Build & Push" completes. This workflow verifies
-# that Railway picked up the new images (via environmentPatchCommit auto-update)
-# and that each service is healthy. It does NOT do the actual deploy — Railway
-# auto-update handles that.
+# that Railway deployed the new images and that each service is healthy.
+# The build workflow triggers Railway redeploys after pushing GHCR images;
+# this workflow only verifies the result.
 #
 # This workflow CAN use cancel-in-progress: true because verification is
 # idempotent. If a newer build completes while we're still verifying an
@@ -169,11 +169,11 @@ jobs:
             exit 1
           fi
 
-          echo "Verifying Railway auto-deploy for ${{ matrix.service.dispatch_name }}..."
+          echo "Verifying Railway deploy for ${{ matrix.service.dispatch_name }}..."
 
-          # Railway auto-update (environmentPatchCommit) picks up the new
-          # :latest tag and triggers a redeploy. We poll until the service
-          # is healthy. 600s budget accommodates JVM/slow-boot services.
+          # The build workflow triggers Railway redeploys after pushing
+          # GHCR images. We poll until the service is healthy. 600s
+          # budget accommodates JVM/slow-boot services.
           # Require 2 consecutive healthy polls before declaring success.
           HEALTHY_STREAK=0
           REQUIRED_STREAK=2


### PR DESCRIPTION
## Summary

- Restores the Railway `serviceInstanceRedeploy` call after each GHCR image push in the build workflow
- PR #4471 removed this trigger assuming Railway `environmentPatchCommit` auto-update would handle deploys, but not all services have auto-update configured
- Without the explicit trigger, GHCR images get pushed and nothing tells Railway to pull them

## Changes

- `showcase_build.yml`: Replace the "no deploy step" comment with the actual Railway redeploy step (matching the old `showcase_deploy.yml` behavior)
- `showcase_deploy.yml`: Update comments to reflect that the build workflow triggers deploys (verify workflow only checks health)

## Test plan

- [ ] Merge and observe that the next showcase push to main triggers Railway redeploys
- [ ] Verify the "Showcase: Verify Deploy" workflow confirms services are healthy after build completes