### PR TITLE
fix(showcase): streaming tool execution for spring-ai D5

### DIFF
--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
@@ -2,7 +2,6 @@ package com.copilotkit.showcase.springai;
 
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
-import com.agui.spring.ai.SpringAIAgent;
 import com.copilotkit.showcase.springai.tools.DisplayFlightTool;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
@@ -39,39 +38,36 @@ public class A2uiFixedSchemaController {
 
     @PostMapping("/a2ui-fixed-schema/run")
     public ResponseEntity<SseEmitter> run(@RequestBody AgUiParameters params) {
-        SpringAIAgent agent = buildAgent();
+        MessageListFilter.filterNulls(params);
+        StreamingToolAgent agent = buildAgent();
         SseEmitter emitter = agUiService.runAgent(agent, params);
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noCache())
                 .body(emitter);
     }
 
-    private SpringAIAgent buildAgent() {
+    private StreamingToolAgent buildAgent() {
         ChatMemory memory = MessageWindowChatMemory.builder()
                 .chatMemoryRepository(new InMemoryChatMemoryRepository())
                 .maxMessages(10)
                 .build();
-        try {
-            return SpringAIAgent.builder()
-                    .agentId("a2ui-fixed-schema")
-                    .chatModel(chatModel)
-                    .chatMemory(memory)
-                    .systemMessage("""
-                            You are a flight-search assistant. When the user asks about a flight,
-                            call the display_flight tool with the origin airport code, destination
-                            airport code, airline, and price string (e.g. "$289"). Use 3-letter
-                            airport codes. After calling the tool, reply with a brief confirmation
-                            in plain text.
-                            """)
-                    .toolCallback(
-                            FunctionToolCallback.builder("display_flight", new DisplayFlightTool())
-                                    .description("Display a flight card for the given trip")
-                                    .inputType(DisplayFlightTool.Request.class)
-                                    .build()
-                    )
-                    .build();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to build a2ui-fixed-schema agent", e);
-        }
+        return StreamingToolAgent.builder()
+                .agentId("a2ui-fixed-schema")
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .systemMessage("""
+                        You are a flight-search assistant. When the user asks about a flight,
+                        call the display_flight tool with the origin airport code, destination
+                        airport code, airline, and price string (e.g. "$289"). Use 3-letter
+                        airport codes. After calling the tool, reply with a brief confirmation
+                        in plain text.
+                        """)
+                .toolCallback(
+                        FunctionToolCallback.builder("display_flight", new DisplayFlightTool())
+                                .description("Display a flight card for the given trip")
+                                .inputType(DisplayFlightTool.Request.class)
+                                .build()
+                )
+                .build();
     }
 }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
@@ -1,6 +1,5 @@
 package com.copilotkit.showcase.springai;
 
-import com.agui.spring.ai.SpringAIAgent;
 import com.copilotkit.showcase.springai.model.SalesTodo;
 import com.copilotkit.showcase.springai.tools.WeatherRequest;
 import com.copilotkit.showcase.springai.tools.WeatherTool;
@@ -18,7 +17,6 @@ import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
@@ -32,82 +30,86 @@ public class AgentConfig {
                 .build();
     }
 
+    /**
+     * Main agentic chat agent. Uses {@link StreamingToolAgent} which streams
+     * text via {@code .stream()} for real-time delivery and falls back to
+     * {@code .call()} when tool execution is needed. This replaces the stock
+     * AG-UI {@code SpringAIAgent} which used {@code .stream()} exclusively
+     * and never executed tool callbacks (Spring AI streaming does not
+     * auto-execute tools).
+     */
     @Bean
-    public SpringAIAgent agent(ChatModel chatModel, ChatMemory chatMemory) {
+    public StreamingToolAgent agent(ChatModel chatModel, ChatMemory chatMemory) {
         // Shared mutable todos list between get/manage tools
         var salesTodosTool = new GetSalesTodosTool();
         List<SalesTodo> sharedTodos = salesTodosTool.getTodos();
         var manageSalesTodosTool = new ManageSalesTodosTool(sharedTodos);
 
-        try {
-            return SpringAIAgent.builder()
-                    .agentId("agentic_chat")
-                    .chatModel(chatModel)
-                    .chatMemory(chatMemory)
-                    .systemMessage("""
-                        You are a helpful assistant for the CopilotKit showcase.
-                        You can check the weather using the get_weather tool.
-                        You can query financial/business data using the query_data tool.
-                        You can schedule meetings using the schedule_meeting tool.
-                        You can manage the sales pipeline using get_sales_todos and manage_sales_todos tools.
-                        You can search for flights using the search_flights tool.
-                        You can generate dynamic UI using the generate_a2ui tool.
-                        For other tools (change_background, generate_haiku, generate_task_steps,
-                        pieChart, barChart, scheduleTime, toggleTheme),
-                        these are provided by the frontend — use them when relevant to the user's request.
-                        When asked to plan or create steps, use the generate_task_steps tool.
-                        When asked about weather, use the get_weather tool.
-                        When asked about data, charts, or analytics, use the query_data tool.
-                        When asked to schedule a meeting, use the schedule_meeting tool.
-                        When asked about the sales pipeline or deals, use get_sales_todos first.
-                        When asked to search for flights, use the search_flights tool.
-                        Keep responses concise and helpful.
-                        """)
-                    .toolCallback(
-                        FunctionToolCallback.builder("get_weather", new WeatherTool())
-                            .description("Get current weather for a location")
-                            .inputType(WeatherRequest.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("query_data", new QueryDataTool())
-                            .description("Query financial data for charts and analytics")
-                            .inputType(QueryDataTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("schedule_meeting", new ScheduleMeetingTool())
-                            .description("Schedule a meeting with a given reason and duration")
-                            .inputType(ScheduleMeetingTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("get_sales_todos", salesTodosTool)
-                            .description("Get the current sales pipeline todos")
-                            .inputType(GetSalesTodosTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("manage_sales_todos", manageSalesTodosTool)
-                            .description("Update the sales pipeline with a new set of todos")
-                            .inputType(ManageSalesTodosTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("search_flights", new SearchFlightsTool())
-                            .description("Search for available flights between two cities")
-                            .inputType(SearchFlightsTool.Request.class)
-                            .build()
-                    )
-                    .toolCallback(
-                        FunctionToolCallback.builder("generate_a2ui", new GenerateA2uiTool(chatModel))
-                            .description("Generate dynamic A2UI components using a secondary LLM call")
-                            .inputType(GenerateA2uiTool.Request.class)
-                            .build()
-                    )
-                    .build();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to build SpringAIAgent", e);
-        }
+        return StreamingToolAgent.builder()
+                .agentId("agentic_chat")
+                .chatModel(chatModel)
+                .chatMemory(chatMemory)
+                .systemMessage("""
+                    You are a helpful assistant for the CopilotKit showcase.
+                    You can check the weather using the get_weather tool.
+                    You can query financial/business data using the query_data tool.
+                    You can schedule meetings using the schedule_meeting tool.
+                    You can manage the sales pipeline using get_sales_todos and manage_sales_todos tools.
+                    You can search for flights using the search_flights tool.
+                    You can generate dynamic UI using the generate_a2ui tool.
+                    For other tools (change_background, generate_haiku, generate_task_steps,
+                    pieChart, barChart, scheduleTime, toggleTheme),
+                    these are provided by the frontend — use them when relevant to the user's request.
+                    When asked to plan or create steps, use the generate_task_steps tool.
+                    When asked about weather, use the get_weather tool.
+                    When asked about data, charts, or analytics, use the query_data tool.
+                    When asked to schedule a meeting, use the schedule_meeting tool.
+                    When asked about the sales pipeline or deals, use get_sales_todos first.
+                    When asked to search for flights, use the search_flights tool.
+                    Keep responses concise and helpful.
+                    """)
+                .toolCallback(
+                    FunctionToolCallback.builder("get_weather", new WeatherTool())
+                        .description("Get current weather for a location")
+                        .inputType(WeatherRequest.class)
+                        .build()
+                )
+                .toolCallback(
+                    FunctionToolCallback.builder("query_data", new QueryDataTool())
+                        .description("Query financial data for charts and analytics")
+                        .inputType(QueryDataTool.Request.class)
+                        .build()
+                )
+                .toolCallback(
+                    FunctionToolCallback.builder("schedule_meeting", new ScheduleMeetingTool())
+                        .description("Schedule a meeting with a given reason and duration")
+                        .inputType(ScheduleMeetingTool.Request.class)
+                        .build()
+                )
+                .toolCallback(
+                    FunctionToolCallback.builder("get_sales_todos", salesTodosTool)
+                        .description("Get the current sales pipeline todos")
+                        .inputType(GetSalesTodosTool.Request.class)
+                        .build()
+                )
+                .toolCallback(
+                    FunctionToolCallback.builder("manage_sales_todos", manageSalesTodosTool)
+                        .description("Update the sales pipeline with a new set of todos")
+                        .inputType(ManageSalesTodosTool.Request.class)
+                        .build()
+                )
+                .toolCallback(
+                    FunctionToolCallback.builder("search_flights", new SearchFlightsTool())
+                        .description("Search for available flights between two cities")
+                        .inputType(SearchFlightsTool.Request.class)
+                        .build()
+                )
+                .toolCallback(
+                    FunctionToolCallback.builder("generate_a2ui", new GenerateA2uiTool(chatModel))
+                        .description("Generate dynamic A2UI components using a secondary LLM call")
+                        .inputType(GenerateA2uiTool.Request.class)
+                        .build()
+                )
+                .build();
     }
 }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
@@ -2,7 +2,6 @@ package com.copilotkit.showcase.springai;
 
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
-import com.agui.spring.ai.SpringAIAgent;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -72,7 +71,8 @@ public class AgentConfigController {
         String systemPrompt = buildSystemPrompt(tone, expertise, length);
 
         AgUiParameters params = objectMapper.readValue(rawBody, AgUiParameters.class);
-        SpringAIAgent perRequestAgent = buildAgent(systemPrompt);
+        MessageListFilter.filterNulls(params);
+        StreamingToolAgent perRequestAgent = buildAgent(systemPrompt);
 
         SseEmitter emitter = agUiService.runAgent(perRequestAgent, params);
         return ResponseEntity.ok()
@@ -84,21 +84,17 @@ public class AgentConfigController {
         return value != null && allowed.contains(value) ? value : fallback;
     }
 
-    private SpringAIAgent buildAgent(String systemPrompt) {
+    private StreamingToolAgent buildAgent(String systemPrompt) {
         ChatMemory memory = MessageWindowChatMemory.builder()
                 .chatMemoryRepository(new InMemoryChatMemoryRepository())
                 .maxMessages(10)
                 .build();
-        try {
-            return SpringAIAgent.builder()
-                    .agentId("agent-config-demo")
-                    .chatModel(chatModel)
-                    .chatMemory(memory)
-                    .systemMessage(systemPrompt)
-                    .build();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to build agent-config agent", e);
-        }
+        return StreamingToolAgent.builder()
+                .agentId("agent-config-demo")
+                .chatModel(chatModel)
+                .chatMemory(memory)
+                .systemMessage(systemPrompt)
+                .build();
     }
 
     private static String buildSystemPrompt(String tone, String expertise, String length) {

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentController.java
@@ -2,7 +2,6 @@ package com.copilotkit.showcase.springai;
 
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
-import com.agui.spring.ai.SpringAIAgent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
@@ -15,16 +14,17 @@ import java.util.Map;
 public class AgentController {
 
     private final AgUiService agUiService;
-    private final SpringAIAgent agent;
+    private final StreamingToolAgent agent;
 
     @Autowired
-    public AgentController(AgUiService agUiService, SpringAIAgent agent) {
+    public AgentController(AgUiService agUiService, StreamingToolAgent agent) {
         this.agUiService = agUiService;
         this.agent = agent;
     }
 
     @PostMapping("/")
     public ResponseEntity<SseEmitter> run(@RequestBody AgUiParameters params) {
+        MessageListFilter.filterNulls(params);
         SseEmitter emitter = agUiService.runAgent(agent, params);
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noCache())

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
@@ -1,0 +1,40 @@
+package com.copilotkit.showcase.springai;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Jackson configuration for tolerant deserialization of AG-UI messages.
+ *
+ * <p>The CopilotKit runtime forwards the full conversation history to the
+ * agent, including messages with roles that the AG-UI Java SDK does not
+ * recognise (e.g. "activity", "reasoning"). The AG-UI {@code MessageMixin}
+ * uses {@code @JsonTypeInfo(property = "role")} with a closed set of
+ * {@code @JsonSubTypes}; an unrecognised role causes
+ * {@code InvalidTypeIdException} during deserialization, crashing the
+ * request before the agent code even runs.
+ *
+ * <p>We disable two features:
+ * <ul>
+ *   <li>{@code FAIL_ON_UNKNOWN_PROPERTIES} — tolerates extra JSON fields
+ *       that don't map to a Java field.</li>
+ *   <li>{@code FAIL_ON_INVALID_SUBTYPE} — when the {@code role} type-id
+ *       doesn't match any registered {@code @JsonSubTypes} name, Jackson
+ *       returns {@code null} for that list element instead of throwing.
+ *       Downstream code must null-check message lists (see
+ *       {@link MessageListFilter}).</li>
+ * </ul>
+ */
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer tolerantObjectMapperCustomizer() {
+        return builder -> builder.featuresToDisable(
+                DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                DeserializationFeature.FAIL_ON_INVALID_SUBTYPE
+        );
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/MessageListFilter.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/MessageListFilter.java
@@ -1,0 +1,47 @@
+package com.copilotkit.showcase.springai;
+
+import com.agui.core.message.BaseMessage;
+import com.agui.server.spring.AgUiParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Strips null entries from AG-UI message lists.
+ *
+ * <p>When Jackson's {@code FAIL_ON_INVALID_SUBTYPE} is disabled (see
+ * {@link JacksonConfig}), messages with unrecognised {@code role} values
+ * (e.g. "activity", "reasoning" sent by the CopilotKit runtime) deserialize
+ * as {@code null} inside the {@code List<BaseMessage>}. If those nulls
+ * reach {@code LocalAgent.combineMessages()}, the {@code message.getId()}
+ * call NPEs and crashes the request.
+ *
+ * <p>This utility filters nulls at the controller boundary — before the
+ * {@code AgUiParameters} object is handed to any agent.
+ */
+public final class MessageListFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(MessageListFilter.class);
+
+    private MessageListFilter() {}
+
+    /**
+     * Removes null entries from the parameters' message list in place.
+     * Returns the same parameters object for convenience chaining.
+     */
+    public static AgUiParameters filterNulls(AgUiParameters params) {
+        if (params == null || params.getMessages() == null) {
+            return params;
+        }
+        List<BaseMessage> messages = params.getMessages();
+        int before = messages.size();
+        messages.removeIf(m -> m == null);
+        int removed = before - messages.size();
+        if (removed > 0) {
+            log.debug("Filtered {} null message(s) from AG-UI parameters "
+                    + "(unrecognised role values)", removed);
+        }
+        return params;
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateReadWriteController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateReadWriteController.java
@@ -99,6 +99,7 @@ public class SharedStateReadWriteController {
 
     @PostMapping("/shared-state-read-write/run")
     public ResponseEntity<SseEmitter> run(@RequestBody AgUiParameters params) throws Exception {
+        MessageListFilter.filterNulls(params);
         SharedStateAgent agent = new SharedStateAgent(chatModel);
         SseEmitter emitter = agUiService.runAgent(agent, params);
         return ResponseEntity.ok()

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
@@ -1,0 +1,355 @@
+package com.copilotkit.showcase.springai;
+
+import com.agui.core.agent.AgentSubscriber;
+import com.agui.core.agent.AgentSubscriberParams;
+import com.agui.core.agent.RunAgentInput;
+import com.agui.core.event.BaseEvent;
+import com.agui.core.exception.AGUIException;
+import com.agui.core.message.AssistantMessage;
+import com.agui.core.message.Role;
+import com.agui.core.state.State;
+import com.agui.server.LocalAgent;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.agui.server.EventFactory.runErrorEvent;
+import static com.agui.server.EventFactory.runFinishedEvent;
+import static com.agui.server.EventFactory.runStartedEvent;
+import static com.agui.server.EventFactory.textMessageContentEvent;
+import static com.agui.server.EventFactory.textMessageEndEvent;
+import static com.agui.server.EventFactory.textMessageStartEvent;
+import static com.agui.server.EventFactory.toolCallArgsEvent;
+import static com.agui.server.EventFactory.toolCallEndEvent;
+import static com.agui.server.EventFactory.toolCallResultEvent;
+import static com.agui.server.EventFactory.toolCallStartEvent;
+
+/**
+ * Streaming agent that supports tool execution.
+ *
+ * <p>Spring AI's {@code ChatClient.stream()} does NOT auto-execute tool callbacks
+ * (unlike {@code .call()} which has a built-in tool execution loop). The stock
+ * AG-UI {@code SpringAIAgent} uses {@code .stream()} and therefore tools are
+ * never invoked — the model returns {@code tool_calls} in the stream but the
+ * tool functions are never called, leaving the CopilotKit runtime stuck in an
+ * infinite re-invocation loop.
+ *
+ * <p>This agent implements a two-phase approach:
+ * <ol>
+ *   <li><b>Phase 1 — stream:</b> Use {@code .stream()} WITHOUT tool callbacks
+ *       to get real-time text delivery. If the model wants to call tools,
+ *       the stream will contain tool_calls but since no callbacks are registered
+ *       on this path, it just completes with the tool call indication.</li>
+ *   <li><b>Phase 2 — call with tools:</b> If tool calls were detected, re-invoke
+ *       the model via {@code .call()} WITH tool callbacks attached. Spring AI's
+ *       built-in tool execution loop handles all tool iterations automatically.
+ *       The final text response is emitted as AG-UI events.</li>
+ * </ol>
+ *
+ * <p>When no tools are needed, the agent behaves as a pure streaming agent.
+ * When tools are needed, the first streamed response is discarded (it's just
+ * the tool call request) and the {@code .call()} path produces the complete
+ * response including tool execution.
+ */
+public class StreamingToolAgent extends LocalAgent {
+
+    private static final Logger log = LoggerFactory.getLogger(StreamingToolAgent.class);
+
+    private final ChatClient chatClient;
+    private final ChatMemory chatMemory;
+    private final List<ToolCallback> toolCallbacks;
+    private final String systemMessage;
+
+    private StreamingToolAgent(Builder builder) {
+        super(builder.agentId, new State(), new ArrayList<>());
+        this.chatClient = ChatClient.builder(builder.chatModel).build();
+        this.chatMemory = builder.chatMemory;
+        this.toolCallbacks = builder.toolCallbacks;
+        this.systemMessage = builder.systemMessage;
+    }
+
+    @Override
+    protected void run(RunAgentInput input, AgentSubscriber subscriber) {
+        this.combineMessages(input);
+
+        String messageId = UUID.randomUUID().toString();
+        String threadId = input.threadId();
+        String runId = input.runId();
+
+        String userContent;
+        try {
+            var userMessage = this.getLatestUserMessage(messages);
+            userContent = userMessage.getContent();
+        } catch (AGUIException e) {
+            log.error("Failed to read latest user message", e);
+            this.emitEvent(runErrorEvent(String.format(
+                    "agent run failed: %s (see server logs)",
+                    e.getClass().getSimpleName())), subscriber);
+            return;
+        }
+
+        this.emitEvent(runStartedEvent(threadId, runId), subscriber);
+        this.emitEvent(textMessageStartEvent(messageId, "assistant"), subscriber);
+
+        var assistantMessage = new AssistantMessage();
+        assistantMessage.setId(messageId);
+        assistantMessage.setName(this.agentId);
+        assistantMessage.setContent("");
+
+        List<BaseEvent> deferredEvents = new ArrayList<>();
+
+        try {
+            // Phase 1: Stream WITHOUT tool callbacks to detect whether tools
+            // are needed. Text chunks are emitted in real time.
+            boolean toolCallsDetected = streamFirstTurn(
+                    input, userContent, messageId, assistantMessage, subscriber);
+
+            if (toolCallsDetected) {
+                // Phase 2: Tools needed. Discard the streamed text (it was
+                // just the model's tool-call request, not a final answer).
+                // Re-invoke with .call() + tool callbacks so Spring AI's
+                // internal loop handles execution.
+                assistantMessage.setContent("");
+                callWithTools(input, userContent, messageId,
+                        assistantMessage, deferredEvents, subscriber);
+            }
+        } catch (Exception e) {
+            log.error("Agent run failed", e);
+            this.emitEvent(runErrorEvent(String.format(
+                    "agent run failed: %s (see server logs)",
+                    e.getClass().getSimpleName())), subscriber);
+            return;
+        }
+
+        this.emitEvent(textMessageEndEvent(messageId), subscriber);
+        for (BaseEvent ev : deferredEvents) {
+            this.emitEvent(ev, subscriber);
+        }
+        subscriber.onNewMessage(assistantMessage);
+        this.emitEvent(runFinishedEvent(threadId, runId), subscriber);
+        subscriber.onRunFinalized(
+                new AgentSubscriberParams(input.messages(), state, this, input));
+    }
+
+    /**
+     * Streams the first model turn WITHOUT tool callbacks. Text chunks are
+     * emitted as AG-UI events in real time. Returns true if the model
+     * requested tool calls (meaning we need a follow-up .call()).
+     */
+    private boolean streamFirstTurn(
+            RunAgentInput input, String userContent, String messageId,
+            AssistantMessage assistantMessage, AgentSubscriber subscriber)
+            throws InterruptedException {
+
+        StringBuilder textAccumulator = new StringBuilder();
+        AtomicBoolean sawToolCalls = new AtomicBoolean(false);
+        AtomicReference<Throwable> streamError = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Build request WITHOUT tool callbacks — we just want to stream text
+        // and detect whether tools are needed.
+        ChatClient.ChatClientRequestSpec request = buildBaseRequest(input, userContent);
+
+        request.stream()
+                .chatResponse()
+                .subscribe(
+                        evt -> {
+                            if (evt.hasToolCalls()) {
+                                sawToolCalls.set(true);
+                            }
+                            String content = evt.getResult().getOutput().getText();
+                            if (StringUtils.hasText(content)) {
+                                this.emitEvent(
+                                        textMessageContentEvent(messageId, content),
+                                        subscriber);
+                                textAccumulator.append(content);
+                            }
+                        },
+                        err -> {
+                            streamError.set(err);
+                            latch.countDown();
+                        },
+                        latch::countDown
+                );
+
+        if (!latch.await(120, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Streaming timed out after 120 seconds");
+        }
+
+        Throwable err = streamError.get();
+        if (err != null) {
+            throw new RuntimeException("Streaming failed", err);
+        }
+
+        assistantMessage.setContent(textAccumulator.toString());
+        return sawToolCalls.get();
+    }
+
+    /**
+     * Re-invokes the model via .call() WITH tool callbacks. Spring AI's
+     * built-in tool execution loop handles all iterations. Tool AG-UI events
+     * are emitted via the wrapper callbacks.
+     */
+    private void callWithTools(
+            RunAgentInput input, String userContent, String messageId,
+            AssistantMessage assistantMessage, List<BaseEvent> deferredEvents,
+            AgentSubscriber subscriber) {
+
+        ChatClient.ChatClientRequestSpec request = buildBaseRequest(input, userContent);
+
+        // Wrap each tool callback to emit AG-UI events when invoked
+        if (!toolCallbacks.isEmpty()) {
+            List<ToolCallback> wrapped = new ArrayList<>();
+            for (ToolCallback cb : toolCallbacks) {
+                wrapped.add(new AgUiToolCallbackWrapper(
+                        cb, messageId, deferredEvents));
+            }
+            request = request.toolCallbacks(wrapped);
+        }
+
+        ChatResponse response = request.call().chatResponse();
+
+        String text = response != null
+                ? response.getResult().getOutput().getText()
+                : null;
+        if (StringUtils.hasText(text)) {
+            this.emitEvent(textMessageContentEvent(messageId, text), subscriber);
+            assistantMessage.setContent(text);
+        }
+    }
+
+    /**
+     * Builds a base ChatClient request with system prompt and memory
+     * but WITHOUT tool callbacks.
+     */
+    private ChatClient.ChatClientRequestSpec buildBaseRequest(
+            RunAgentInput input, String userContent) {
+        ChatClient.ChatClientRequestSpec request = chatClient.prompt(
+                Prompt.builder().content(userContent).build())
+                .system(systemMessage);
+
+        if (chatMemory != null) {
+            request.advisors(PromptChatMemoryAdvisor.builder(chatMemory).build());
+            request.advisors(a -> a.param(
+                    ChatMemory.CONVERSATION_ID, input.threadId()));
+        }
+
+        return request;
+    }
+
+    /**
+     * Wraps a Spring AI ToolCallback to emit AG-UI tool call events when
+     * the tool is invoked during .call()'s internal tool execution loop.
+     */
+    static class AgUiToolCallbackWrapper implements ToolCallback {
+        private final ToolCallback delegate;
+        private final String parentMessageId;
+        private final List<BaseEvent> deferredEvents;
+
+        AgUiToolCallbackWrapper(ToolCallback delegate, String parentMessageId,
+                                List<BaseEvent> deferredEvents) {
+            this.delegate = delegate;
+            this.parentMessageId = parentMessageId;
+            this.deferredEvents = deferredEvents;
+        }
+
+        @Override
+        public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+            return delegate.getToolDefinition();
+        }
+
+        @Override
+        public String call(String toolInput) {
+            return call(toolInput, null);
+        }
+
+        @Override
+        public String call(String toolInput,
+                           org.springframework.ai.chat.model.ToolContext toolContext) {
+            String result = delegate.call(toolInput, toolContext);
+
+            String toolCallId = UUID.randomUUID().toString();
+            String toolName = delegate.getToolDefinition().name();
+
+            deferredEvents.add(toolCallStartEvent(parentMessageId, toolName, toolCallId));
+            deferredEvents.add(toolCallArgsEvent(toolInput, toolCallId));
+            deferredEvents.add(toolCallEndEvent(toolCallId));
+            deferredEvents.add(toolCallResultEvent(
+                    toolCallId, result, parentMessageId, Role.tool));
+
+            return result;
+        }
+    }
+
+    // -- Builder --
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String agentId;
+        private ChatModel chatModel;
+        private ChatMemory chatMemory;
+        private String systemMessage;
+        private final List<ToolCallback> toolCallbacks = new ArrayList<>();
+
+        public Builder agentId(String agentId) {
+            this.agentId = agentId;
+            return this;
+        }
+
+        public Builder chatModel(ChatModel chatModel) {
+            this.chatModel = chatModel;
+            return this;
+        }
+
+        public Builder chatMemory(ChatMemory chatMemory) {
+            this.chatMemory = chatMemory;
+            return this;
+        }
+
+        public Builder systemMessage(String systemMessage) {
+            this.systemMessage = systemMessage;
+            return this;
+        }
+
+        public Builder toolCallback(ToolCallback toolCallback) {
+            this.toolCallbacks.add(toolCallback);
+            return this;
+        }
+
+        public Builder toolCallbacks(List<ToolCallback> toolCallbacks) {
+            this.toolCallbacks.addAll(toolCallbacks);
+            return this;
+        }
+
+        public StreamingToolAgent build() {
+            if (agentId == null) {
+                throw new IllegalArgumentException("agentId is required");
+            }
+            if (chatModel == null) {
+                throw new IllegalArgumentException("chatModel is required");
+            }
+            if (systemMessage == null) {
+                throw new IllegalArgumentException("systemMessage is required");
+            }
+            return new StreamingToolAgent(this);
+        }
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
@@ -131,6 +131,7 @@ public class SubagentsController {
 
     @PostMapping("/subagents/run")
     public ResponseEntity<SseEmitter> run(@RequestBody AgUiParameters params) throws Exception {
+        MessageListFilter.filterNulls(params);
         SubagentsAgent agent = new SubagentsAgent(chatModel);
         SseEmitter emitter = agUiService.runAgent(agent, params);
         return ResponseEntity.ok()


### PR DESCRIPTION
## Summary

- Replace `SpringAIAgent` (AG-UI SDK) with custom `StreamingToolAgent` that uses `.stream()` for real-time text delivery and `.call()` with tool callbacks when tools are needed
- Spring AI's `ChatClient.stream()` fundamentally does NOT auto-execute tool callbacks; only `.call()` has the built-in tool execution loop. The stock `SpringAIAgent` used `.stream()` exclusively, so tools were never invoked and the CopilotKit runtime re-invoked the agent infinitely
- Fix Jackson `InvalidTypeIdException` crashes from CopilotKit runtime messages with unrecognized roles (`activity`, `reasoning`) by disabling `FAIL_ON_INVALID_SUBTYPE`, with null-filtering at controller boundaries

## Root cause

The AG-UI Java SDK's `SpringAIAgent` calls `chatClient.prompt().stream().chatResponse().subscribe()`. In Spring AI 1.0.1, the `.stream()` path does not execute tool callbacks — it only streams text chunks. When the model returns `tool_calls` in the stream, they're captured as AG-UI events but the actual Java tool functions are never invoked. The CopilotKit runtime sees incomplete tool cycles and re-invokes the agent infinitely.

## Approach

`StreamingToolAgent` implements a two-phase approach:
1. **Phase 1 (stream)**: Uses `.stream()` WITHOUT tool callbacks for real-time text delivery. Detects whether the model wants to call tools.
2. **Phase 2 (call with tools)**: If tools are needed, re-invokes via `.call()` WITH tool callbacks. Spring AI's built-in tool execution loop handles all iterations automatically. AG-UI tool events are emitted via `AgUiToolCallbackWrapper`.

When no tools are needed, the agent behaves as a pure streaming agent (no regression from the previous `SpringAIAgent` behavior for tool-free conversations).

## Why not the previous fix (PR #4469)?

PR #4469 replaced `SpringAIAgent` with `SyncAgent` which used `.call()` only — this fixed tools but broke streaming entirely. This PR preserves streaming for the happy path (no tools) and only falls back to `.call()` when tool execution is actually needed.

## Files changed

- **New**: `StreamingToolAgent.java` — custom `LocalAgent` with stream+call hybrid
- **New**: `JacksonConfig.java` — tolerant deserialization for unknown message roles
- **New**: `MessageListFilter.java` — strips null messages from deserialized lists
- **Modified**: `AgentConfig.java`, `AgentController.java`, `AgentConfigController.java`, `A2uiFixedSchemaController.java` — use `StreamingToolAgent` instead of `SpringAIAgent`
- **Modified**: `SubagentsController.java`, `SharedStateReadWriteController.java` — add `MessageListFilter.filterNulls()` at controller boundary

## Test plan

- [x] Docker build passes (`depot build --platform linux/amd64`)
- [ ] D5 agentic_chat features with tool calls (weather, flights, etc.) complete without infinite loop
- [ ] D5 agentic_chat features without tools stream text correctly
- [ ] D5 subagents feature works (already used `.call()`, just added null filtering)
- [ ] D5 shared-state-read-write feature works
- [ ] D5 a2ui-fixed-schema feature works
- [ ] D5 agent-config feature works