### PR TITLE
fix(runtime): stop converting TanStack stream after RUN_FINISHED

### DIFF
--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -266,11 +266,29 @@ export async function* convertTanStackStream(
     }
   }
 
+  // TanStack's chat() engine runs a multi-turn agent loop: after the model
+  // returns tool calls, the engine tries to execute them and re-prompt. This
+  // produces a second round of TOOL_CALL_START / TOOL_CALL_END events that
+  // duplicate the ones from the first streaming pass. The CopilotKit runtime
+  // handles tool execution externally (via the frontend SDK), so we must stop
+  // converting events once the TanStack adapter signals the first turn is
+  // complete with RUN_FINISHED.
+  let runFinished = false;
+
   for await (const chunk of stream) {
     if (abortSignal.aborted) break;
 
     const raw = chunk as Record<string, unknown>;
     const type = raw.type as string;
+
+    // Stop converting after the first RUN_FINISHED — any subsequent events
+    // come from TanStack's internal tool-execution loop and would produce
+    // duplicate TOOL_CALL_END events that violate the ag-ui verify middleware.
+    if (type === "RUN_FINISHED") {
+      runFinished = true;
+      continue;
+    }
+    if (runFinished) continue;
 
     if (type === "TEXT_MESSAGE_CONTENT" && raw.delta != null) {
       yield* closeReasoningIfOpen();

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -313,5 +313,16 @@ services:
     volumes:
       - ./integrations/spring-ai/src:/app/src
 
+  built-in-agent:
+    <<: *integration-defaults
+    build: ./integrations/built-in-agent
+    image: showcase-built-in-agent:local
+    container_name: showcase-built-in-agent
+    ports:
+      - "3117:10000"
+    profiles: ["built-in-agent", "all"]
+    volumes:
+      - ./integrations/built-in-agent/src:/app/src
+
 volumes:
   showcase-pb-data:

--- a/showcase/shared/local-ports.json
+++ b/showcase/shared/local-ports.json
@@ -15,5 +15,6 @@
   "langroid": 3113,
   "ms-agent-python": 3114,
   "ms-agent-dotnet": 3115,
-  "spring-ai": 3116
+  "spring-ai": 3116,
+  "built-in-agent": 3117
 }


### PR DESCRIPTION
## Summary

- Fixes built-in-agent D5 failures caused by duplicate `TOOL_CALL_END` events from TanStack's internal tool execution loop
- TanStack's `chat()` engine runs a multi-turn agent loop that re-emits `TOOL_CALL_END` for frontend-only tools (like `render_pie_chart`) without a preceding `TOOL_CALL_START`, violating the ag-ui verify middleware
- Adds `runFinished` flag to `convertTanStackStream` to discard all events after the first `RUN_FINISHED`
- Adds built-in-agent to `docker-compose.local.yml` and `local-ports.json`

## Test plan

- [x] Runtime test suite passes (1412/1412 tests, 101 files)
- [x] Container hotpatch verified: no more duplicate TOOL_CALL_END errors in logs
- [x] D5 hitl-approve-deny now passes (was failing due to this bug)
- [x] aimock v1.16.3 released with complementary item_id fix