### PR TITLE
fix: add debug logging to D5 probe execution pipeline

### DIFF
--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -1064,6 +1064,13 @@ async function runFeature(opts: {
     context = await browser.newContext();
     page = await context.newPage();
 
+    console.debug("[e2e-deep] runFeature — navigating", {
+      url,
+      pageTimeoutMs,
+      featureType: buildCtx.featureType,
+      slug: buildCtx.integrationSlug,
+    });
+
     // Navigate. The conversation-runner's first action is a
     // chat-input selector probe with its own short timeout, so we
     // don't need to waitForSelector again here — a clean goto is
@@ -1073,8 +1080,13 @@ async function runFeature(opts: {
         waitUntil: "load",
         timeout: pageTimeoutMs,
       });
+      console.debug("[e2e-deep] runFeature — navigation complete", { url });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      console.debug("[e2e-deep] runFeature — navigation FAILED", {
+        url,
+        error: msg,
+      });
       return {
         ok: false,
         errorClass: "goto-error",
@@ -1087,6 +1099,10 @@ async function runFeature(opts: {
     // Without this, the SSR'd textarea is visible but Enter has no
     // handler, so the first turn's keypress is a no-op and the probe
     // times out waiting for an assistant response that never comes.
+    console.debug("[e2e-deep] runFeature — waiting for React hydration", {
+      url,
+      timeout: 15_000,
+    });
     try {
       await page.waitForFunction(
         () => {
@@ -1108,16 +1124,37 @@ async function runFeature(opts: {
         },
         { timeout: 15_000 },
       );
+      console.debug("[e2e-deep] runFeature — React hydration detected", { url });
     } catch {
       // Non-fatal — proceed anyway; worst case is a downstream timeout
       // error that's more diagnosable than "assistant did not respond".
+      console.debug("[e2e-deep] runFeature — React hydration wait timed out (proceeding anyway)", {
+        url,
+      });
     }
 
     const turns = script.buildTurns(buildCtx);
+    console.debug("[e2e-deep] runFeature — built conversation turns", {
+      turnCount: turns.length,
+      featureType: buildCtx.featureType,
+      slug: buildCtx.integrationSlug,
+    });
     const conversation = await runConversation(page, turns);
 
     if (conversation.failure_turn !== undefined) {
+      console.debug("[e2e-deep] runFeature — conversation FAILED", {
+        featureType: buildCtx.featureType,
+        slug: buildCtx.integrationSlug,
+        failureTurn: conversation.failure_turn,
+        turnsCompleted: conversation.turns_completed,
+        totalTurns: conversation.total_turns,
+        error: conversation.error,
+      });
       const diagnostics = await captureDiagnostics(page);
+      console.debug("[e2e-deep] runFeature — failure diagnostics captured", {
+        featureType: buildCtx.featureType,
+        diagnosticKeys: diagnostics ? Object.keys(diagnostics) : [],
+      });
       return {
         ok: false,
         errorClass: "conversation-error",
@@ -1130,6 +1167,12 @@ async function runFeature(opts: {
       };
     }
 
+    console.debug("[e2e-deep] runFeature — conversation succeeded", {
+      featureType: buildCtx.featureType,
+      slug: buildCtx.integrationSlug,
+      turnsCompleted: conversation.turns_completed,
+      turnDurations: conversation.turn_durations_ms,
+    });
     return { ok: true, conversation };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -207,8 +207,15 @@ export async function runConversation(
   const settleMs = opts.assistantSettleMs ?? DEFAULT_SETTLE_MS;
   const durations: number[] = [];
 
+  console.debug("[conversation-runner] starting conversation", {
+    totalTurns: total,
+    settleMs,
+    chatInputSelector: opts.chatInputSelector ?? "(cascade)",
+  });
+
   // Empty turns array: return zeroes immediately, no page interaction.
   if (total === 0) {
+    console.debug("[conversation-runner] empty turns array — returning immediately");
     return {
       turns_completed: 0,
       total_turns: 0,
@@ -226,7 +233,13 @@ export async function runConversation(
       page,
       opts.chatInputSelector,
     );
+    console.debug("[conversation-runner] resolved chat input selector", {
+      selector: chatInputSelector,
+    });
   } catch (err) {
+    console.debug("[conversation-runner] chat input selector cascade FAILED", {
+      error: errorMessage(err),
+    });
     return {
       turns_completed: 0,
       total_turns: total,
@@ -242,6 +255,9 @@ export async function runConversation(
   // count, and we need to wait for growth from that baseline rather
   // than from 0.
   let baselineCount = await readMessageCount(page);
+  console.debug("[conversation-runner] initial baseline assistant message count", {
+    baselineCount,
+  });
 
   for (let idx = 0; idx < total; idx++) {
     const turn = turns[idx]!;
@@ -249,8 +265,21 @@ export async function runConversation(
     const turnTimeoutMs = turn.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
     const startedAt = Date.now();
 
+    console.debug(`[conversation-runner] turn ${turnNum}/${total} — sending message`, {
+      input: turn.input,
+      timeoutMs: turnTimeoutMs,
+      baselineCount,
+    });
+
     try {
       await fillAndVerifySend(page, chatInputSelector, turn.input);
+
+      console.debug(`[conversation-runner] turn ${turnNum}/${total} — waiting for assistant settle`, {
+        selector: chatInputSelector,
+        baselineCount,
+        settleMs,
+        timeoutMs: turnTimeoutMs,
+      });
 
       // Wait for the assistant-message count to grow past the baseline
       // and then stay stable for `settleMs`. If the deadline passes
@@ -262,8 +291,16 @@ export async function runConversation(
         timeoutMs: turnTimeoutMs,
       });
 
+      console.debug(`[conversation-runner] turn ${turnNum}/${total} — assistant settled`, {
+        newCount,
+        previousBaseline: baselineCount,
+        hasAssertions: !!turn.assertions,
+      });
+
       if (turn.assertions) {
+        console.debug(`[conversation-runner] turn ${turnNum}/${total} — running assertions`);
         await turn.assertions(page);
+        console.debug(`[conversation-runner] turn ${turnNum}/${total} — assertions passed`);
       }
 
       durations.push(Date.now() - startedAt);
@@ -276,6 +313,11 @@ export async function runConversation(
       // failed turn is still recoverable from `observedAt` deltas if
       // operators need it.
       void startedAt;
+      console.debug(`[conversation-runner] turn ${turnNum}/${total} — FAILED`, {
+        error: errorMessage(err),
+        turnsCompleted: idx,
+        elapsedMs: Date.now() - startedAt,
+      });
       return {
         turns_completed: idx,
         total_turns: total,
@@ -285,6 +327,11 @@ export async function runConversation(
       };
     }
   }
+
+  console.debug("[conversation-runner] conversation completed successfully", {
+    turnsCompleted: total,
+    totalDurationMs: durations.reduce((a, b) => a + b, 0),
+  });
 
   return {
     turns_completed: total,
@@ -357,10 +404,17 @@ export async function fillAndVerifySend(
   const timeout = overrides?.timeoutMs ?? SEND_VERIFY_TIMEOUT_MS;
 
   const baseline = await readUserMessageCount(page);
+  console.debug("[conversation-runner] fillAndVerifySend — start", {
+    input: input.slice(0, 100),
+    selector: chatInputSelector,
+    userMessageBaseline: baseline,
+    maxAttempts,
+  });
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     await page.fill(chatInputSelector, input);
     await page.press(chatInputSelector, "Enter");
+    console.debug(`[conversation-runner] fillAndVerifySend — attempt ${attempt}/${maxAttempts} fill+Enter done`);
 
     // Wait briefly for React to process the event and render the
     // user message bubble.
@@ -374,17 +428,22 @@ export async function fillAndVerifySend(
       const current = await readUserMessageCount(page);
       if (current > baseline) {
         // User message appeared — send succeeded.
+        console.debug(`[conversation-runner] fillAndVerifySend — user message appeared on attempt ${attempt}`, {
+          userMessageCount: current,
+          baseline,
+        });
         return;
       }
       await sleep(POLL_INTERVAL_MS);
     }
 
     // If this wasn't the last attempt, we'll retry the fill+press.
-    // No log needed — the retry is silent.
+    console.debug(`[conversation-runner] fillAndVerifySend — attempt ${attempt} timed out (no user message growth from baseline=${baseline})`);
   }
 
   // All attempts exhausted. Proceed anyway — the downstream timeout
   // will produce a clear failure message.
+  console.debug("[conversation-runner] fillAndVerifySend — all attempts exhausted, proceeding anyway");
 }
 
 /**
@@ -399,6 +458,10 @@ async function resolveChatInputSelector(
   override: string | undefined,
 ): Promise<string> {
   const candidates = override ? [override] : CHAT_INPUT_SELECTORS;
+  console.debug("[conversation-runner] resolving chat input selector", {
+    candidateCount: candidates.length,
+    override: override ?? "(none — using cascade)",
+  });
   let lastError: unknown;
   for (const selector of candidates) {
     try {
@@ -406,8 +469,15 @@ async function resolveChatInputSelector(
         state: "visible",
         timeout: SELECTOR_PROBE_TIMEOUT_MS,
       });
+      console.debug("[conversation-runner] chat input selector resolved", {
+        selector,
+      });
       return selector;
     } catch (err) {
+      console.debug("[conversation-runner] chat input selector miss", {
+        selector,
+        error: err instanceof Error ? err.message : String(err),
+      });
       lastError = err;
     }
   }
@@ -493,12 +563,30 @@ async function waitForAssistantSettled(opts: {
   const deadline = Date.now() + timeoutMs;
   let lastCount = await readMessageCount(page);
   let lastChangeAt = Date.now();
+  let pollCount = 0;
+  let lastLoggedCount = lastCount;
+
+  console.debug("[conversation-runner] waitForAssistantSettled — start", {
+    baselineCount,
+    initialCount: lastCount,
+    settleMs,
+    timeoutMs,
+  });
 
   while (Date.now() < deadline) {
     await sleep(POLL_INTERVAL_MS);
     const current = await readMessageCount(page);
+    pollCount++;
     if (current !== lastCount) {
+      console.debug("[conversation-runner] waitForAssistantSettled — message count changed", {
+        previous: lastCount,
+        current,
+        baselineCount,
+        pollCount,
+        elapsedMs: Date.now() - (deadline - timeoutMs),
+      });
       lastCount = current;
+      lastLoggedCount = current;
       lastChangeAt = Date.now();
       continue;
     }
@@ -506,9 +594,32 @@ async function waitForAssistantSettled(opts: {
     // quiet window has elapsed. "Stable at baseline" means no response
     // arrived yet — keep polling.
     if (current > baselineCount && Date.now() - lastChangeAt >= settleMs) {
+      console.debug("[conversation-runner] waitForAssistantSettled — settled", {
+        count: current,
+        baselineCount,
+        quietWindowMs: Date.now() - lastChangeAt,
+        totalPollCount: pollCount,
+        totalElapsedMs: Date.now() - (deadline - timeoutMs),
+      });
       return current;
     }
+    // Log a periodic status when still waiting at baseline (every ~5s)
+    if (current === lastLoggedCount && pollCount % 50 === 0) {
+      console.debug("[conversation-runner] waitForAssistantSettled — still polling", {
+        current,
+        baselineCount,
+        pollCount,
+        elapsedMs: Date.now() - (deadline - timeoutMs),
+        remainingMs: deadline - Date.now(),
+      });
+    }
   }
+  console.debug("[conversation-runner] waitForAssistantSettled — TIMEOUT", {
+    baselineCount,
+    lastCount,
+    timeoutMs,
+    totalPollCount: pollCount,
+  });
   throw new Error(
     `timeout: assistant did not respond within ${timeoutMs}ms (baseline=${baselineCount}, current=${lastCount})`,
   );

--- a/showcase/harness/src/probes/scripts/d5-agentic-chat.ts
+++ b/showcase/harness/src/probes/scripts/d5-agentic-chat.ts
@@ -112,6 +112,11 @@ function expectAssistantContains(opts: {
 }): (page: Page) => Promise<void> {
   return async (page: Page) => {
     const transcript = (await readAssistantTranscript(page)) ?? "";
+    console.debug(`[d5-agentic-chat] ${opts.label} — checking assistant contains`, {
+      expectedFragments: opts.fragments,
+      transcriptLength: transcript.length,
+      transcriptSnippet: transcript.slice(0, 300),
+    });
     if (transcript.trim().length === 0) {
       throw new Error(`${opts.label}: assistant response was empty`);
     }
@@ -126,6 +131,7 @@ function expectAssistantContains(opts: {
           .join(", ")}]`,
       );
     }
+    console.debug(`[d5-agentic-chat] ${opts.label} — assertion passed`);
   };
 }
 
@@ -137,9 +143,14 @@ function expectAssistantContains(opts: {
 function expectAssistantNonEmpty(label: string): (page: Page) => Promise<void> {
   return async (page: Page) => {
     const transcript = (await readAssistantTranscript(page)) ?? "";
+    console.debug(`[d5-agentic-chat] ${label} — checking non-empty`, {
+      transcriptLength: transcript.length,
+      transcriptSnippet: transcript.slice(0, 300),
+    });
     if (transcript.trim().length === 0) {
       throw new Error(`${label}: assistant response was empty`);
     }
+    console.debug(`[d5-agentic-chat] ${label} — non-empty assertion passed`);
   };
 }
 

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
@@ -78,6 +78,11 @@ function isChartIntegration(slug: string): boolean {
 
 export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
   const usePieChart = isChartIntegration(ctx.integrationSlug);
+  console.debug("[d5-gen-ui-custom] buildTurns", {
+    slug: ctx.integrationSlug,
+    usePieChart,
+    userMessage: usePieChart ? PIE_CHART_USER_MESSAGE : HAIKU_USER_MESSAGE,
+  });
 
   return [
     {
@@ -86,16 +91,25 @@ export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
         // 1. Cascade-find the rendered component. Gen-UI components
         //    surface through the same selector hooks regardless of which
         //    tool fired.
+        console.debug("[d5-gen-ui-custom] waiting for gen-UI component");
         const matchedSelector = await waitForGenUiComponent(page);
+        console.debug("[d5-gen-ui-custom] gen-UI component found", {
+          matchedSelector,
+        });
 
         if (usePieChart) {
           // --- Pie chart path (chart integrations) ---
+          console.debug("[d5-gen-ui-custom] asserting pie chart shape");
           await assertPieChartShape(page, matchedSelector);
 
           // Narration check: the second-leg LLM response must
           // mention the chart. Token-level so wording drift doesn't
           // fail the probe.
           const text = (await readLastAssistantText(page)).toLowerCase();
+          console.debug("[d5-gen-ui-custom] pie chart follow-up text check", {
+            expectedTokens: [...PIE_CHART_FOLLOWUP_TOKENS],
+            assistantText: text.slice(0, 300),
+          });
           const missing = PIE_CHART_FOLLOWUP_TOKENS.filter(
             (tok) => !text.includes(tok),
           );
@@ -112,7 +126,9 @@ export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
           // `followUp: false`, so there is no second-leg narration.
           // The structural check alone (card rendered with children
           // + text) is sufficient for the custom tier.
+          console.debug("[d5-gen-ui-custom] asserting haiku card shape");
           await assertHaikuCardShape(page, matchedSelector);
+          console.debug("[d5-gen-ui-custom] haiku card assertion passed");
         }
       },
     },

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-headless.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-headless.ts
@@ -70,7 +70,11 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         // 1. Cascade-find the rendered component. Throws on timeout
         //    with a descriptive error so the conversation-runner
         //    surfaces it as the turn's failure_turn.
+        console.debug("[d5-gen-ui-headless] waiting for gen-UI component");
         const matchedSelector = await waitForGenUiComponent(page);
+        console.debug("[d5-gen-ui-headless] gen-UI component found", {
+          matchedSelector,
+        });
 
         // 2. Read the matched node's child count via page.evaluate.
         //    Ensures the component is structurally non-trivial. The
@@ -80,6 +84,11 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
           page,
           matchedSelector,
         );
+        console.debug("[d5-gen-ui-headless] child count check", {
+          matchedSelector,
+          childCount,
+          minRequired: MIN_CHILDREN,
+        });
         if (childCount < MIN_CHILDREN) {
           throw new Error(
             `gen-ui-headless: matched component ${matchedSelector} has ${childCount} children (expected >= ${MIN_CHILDREN})`,
@@ -92,6 +101,11 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         //    integrations doesn't fail the probe. We require at
         //    least one primary token OR one secondary token.
         const text = (await readLastAssistantText(page)).toLowerCase();
+        console.debug("[d5-gen-ui-headless] follow-up text check", {
+          primaryTokens: [...FOLLOWUP_TOKENS_PRIMARY],
+          secondaryTokens: [...FOLLOWUP_TOKENS_SECONDARY],
+          assistantText: text.slice(0, 300),
+        });
         const primaryMissing = FOLLOWUP_TOKENS_PRIMARY.filter(
           (tok) => !text.includes(tok),
         );
@@ -103,6 +117,7 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
             `gen-ui-headless: assistant follow-up missing tokens (need at least one of [${[...FOLLOWUP_TOKENS_PRIMARY, ...FOLLOWUP_TOKENS_SECONDARY].join(", ")}]); last assistant text: ${text.slice(0, 200)}`,
           );
         }
+        console.debug("[d5-gen-ui-headless] all assertions passed");
       },
     },
   ];

--- a/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.ts
+++ b/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.ts
@@ -82,11 +82,21 @@ const script: D5Script = {
         // click triggers the second LLM leg, which lands a NEW
         // assistant message. We poll for growth past this baseline.
         const baselineCount = await readAssistantCount(hitlPage);
+        console.debug("[d5-hitl-approve-deny] clicking approve", {
+          baselineCount,
+        });
         await approveOrDeny(hitlPage, "approve");
+        console.debug("[d5-hitl-approve-deny] waiting for follow-up assistant message", {
+          baselineCount,
+        });
         const followup = await waitForNextAssistantMessage(
           hitlPage,
           baselineCount,
         );
+        console.debug("[d5-hitl-approve-deny] checking follow-up tokens", {
+          expectedTokens: [...REFERENCE_TOKENS],
+          followupSnippet: followup.slice(0, 300),
+        });
         for (const token of REFERENCE_TOKENS) {
           if (!followup.includes(token)) {
             throw new Error(
@@ -94,6 +104,7 @@ const script: D5Script = {
             );
           }
         }
+        console.debug("[d5-hitl-approve-deny] all token assertions passed");
       },
     },
   ],

--- a/showcase/harness/src/probes/scripts/d5-hitl-steps.ts
+++ b/showcase/harness/src/probes/scripts/d5-hitl-steps.ts
@@ -77,23 +77,37 @@ const script: D5Script = {
           );
         }
         const baselineCount = await readAssistantCount(hitlPage);
+        console.debug("[d5-hitl-steps] waiting for steps card", {
+          baselineCount,
+        });
         await selectorCascade(
           hitlPage,
           STEPS_CARD_SELECTORS,
           "steps card",
           HITL_CARD_TIMEOUT_MS,
         );
+        console.debug("[d5-hitl-steps] steps card found — waiting for confirm button");
         const confirmSelector = await selectorCascade(
           hitlPage,
           CONFIRM_BUTTON_SELECTORS,
           "confirm button",
           HITL_CARD_TIMEOUT_MS,
         );
+        console.debug("[d5-hitl-steps] clicking confirm button", {
+          confirmSelector,
+        });
         await hitlPage.click(confirmSelector);
+        console.debug("[d5-hitl-steps] waiting for follow-up assistant message", {
+          baselineCount,
+        });
         const followup = await waitForNextAssistantMessage(
           hitlPage,
           baselineCount,
         );
+        console.debug("[d5-hitl-steps] checking follow-up tokens", {
+          expectedTokens: [...REFERENCE_TOKENS],
+          followupSnippet: followup.slice(0, 300),
+        });
         for (const token of REFERENCE_TOKENS) {
           if (!followup.toLowerCase().includes(token.toLowerCase())) {
             throw new Error(
@@ -101,6 +115,7 @@ const script: D5Script = {
             );
           }
         }
+        console.debug("[d5-hitl-steps] all token assertions passed");
       },
     },
   ],

--- a/showcase/harness/src/probes/scripts/d5-hitl-text-input.ts
+++ b/showcase/harness/src/probes/scripts/d5-hitl-text-input.ts
@@ -140,11 +140,21 @@ const script: D5Script = {
           );
         }
         const baselineCount = await readAssistantCount(hitlPage);
+        console.debug("[d5-hitl-text-input] picking time slot", {
+          baselineCount,
+        });
         await pickTimeSlot(hitlPage);
+        console.debug("[d5-hitl-text-input] waiting for follow-up assistant message", {
+          baselineCount,
+        });
         const followup = await waitForNextAssistantMessage(
           hitlPage,
           baselineCount,
         );
+        console.debug("[d5-hitl-text-input] checking follow-up tokens", {
+          expectedTokens: [...REFERENCE_TOKENS],
+          followupSnippet: followup.slice(0, 300),
+        });
         for (const token of REFERENCE_TOKENS) {
           if (!followup.includes(token)) {
             throw new Error(
@@ -152,6 +162,7 @@ const script: D5Script = {
             );
           }
         }
+        console.debug("[d5-hitl-text-input] all token assertions passed");
       },
     },
   ],

--- a/showcase/harness/src/probes/scripts/d5-mcp-subagents.ts
+++ b/showcase/harness/src/probes/scripts/d5-mcp-subagents.ts
@@ -159,11 +159,18 @@ export async function assertChainedReply(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   let lastMissing: string[] = [...EXPECTED_REPLY_FRAGMENTS];
+  let pollCount = 0;
+
+  console.debug("[d5-mcp-subagents] polling for chained reply fragments", {
+    expectedFragments: [...EXPECTED_REPLY_FRAGMENTS],
+    timeoutMs,
+  });
 
   while (Date.now() < deadline) {
     // Try assistant-message elements first; fall back to full page text.
     let text = await readAssistantTranscript(page);
-    if (text.trim().length === 0) {
+    const usedFallback = text.trim().length === 0;
+    if (usedFallback) {
       text = await readFullPageText(page);
     }
 
@@ -171,14 +178,31 @@ export async function assertChainedReply(
     lastMissing = EXPECTED_REPLY_FRAGMENTS.filter(
       (fragment) => !lower.includes(fragment.toLowerCase()),
     );
+    pollCount++;
+
+    if (pollCount === 1 || pollCount % 10 === 0) {
+      console.debug("[d5-mcp-subagents] chained reply poll", {
+        pollCount,
+        usedFallback,
+        textLength: text.length,
+        textSnippet: text.slice(0, 300),
+        missingFragments: lastMissing,
+        elapsedMs: Date.now() - (deadline - timeoutMs),
+      });
+    }
 
     if (lastMissing.length === 0) {
+      console.debug("[d5-mcp-subagents] all fragments found", { pollCount });
       return; // All fragments found.
     }
 
     await sleep(CHAIN_POLL_INTERVAL_MS);
   }
 
+  console.debug("[d5-mcp-subagents] chained reply TIMEOUT", {
+    pollCount,
+    missingFragments: lastMissing,
+  });
   throw new Error(
     `mcp-subagents: chained reply missing fragments after ${timeoutMs}ms: ${lastMissing.join(", ")}`,
   );

--- a/showcase/harness/src/probes/scripts/d5-shared-state.ts
+++ b/showcase/harness/src/probes/scripts/d5-shared-state.ts
@@ -196,7 +196,13 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         // conversation runner may settle on the tool-call message before
         // the text leg arrives — use waitForNonEmptyAssistantText to
         // bridge the gap when the initial message has no visible text.
+        console.debug("[d5-shared-state] turn 1 — reading assistant text");
         const text = await waitForNonEmptyAssistantText(page);
+        console.debug("[d5-shared-state] turn 1 — assistant text", {
+          textLength: text.length,
+          textSnippet: text.slice(0, 300),
+          expectedTokens: ["color", "blue"],
+        });
         if (text.length === 0) {
           throw new Error(
             "turn 1: no assistant message text found after settle",
@@ -211,6 +217,7 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
             `turn 1: assistant response did not mention color/blue (got: ${truncate(text, 200)})`,
           );
         }
+        console.debug("[d5-shared-state] turn 1 — assertion passed");
       },
     },
     {
@@ -219,7 +226,13 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         // Turn 2 is a plain text response (no tool call), but poll
         // defensively in case the DOM snapshot is briefly empty while
         // streaming starts.
+        console.debug("[d5-shared-state] turn 2 — reading assistant text");
         const text = await waitForNonEmptyAssistantText(page);
+        console.debug("[d5-shared-state] turn 2 — assistant text", {
+          textLength: text.length,
+          textSnippet: text.slice(0, 300),
+          expectedToken: "blue",
+        });
         if (text.length === 0) {
           throw new Error(
             "turn 2: no assistant message text found after settle",
@@ -230,6 +243,7 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
             `turn 2: assistant did not recall "blue" — shared state did not persist between turns (got: ${truncate(text, 200)})`,
           );
         }
+        console.debug("[d5-shared-state] turn 2 — assertion passed");
       },
     },
   ];

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering.ts
@@ -226,6 +226,10 @@ export function buildToolRenderingAssertion(opts?: {
 }): (page: Page) => Promise<void> {
   const pollTimeout = opts?.pollTimeoutMs ?? PROBE_POLL_TIMEOUT_MS;
   return async (page: Page): Promise<void> => {
+    console.debug("[d5-tool-rendering] waiting for tool card", {
+      canonicalSelector: TOOL_CARD_SELECTORS[0],
+      pollTimeoutMs: pollTimeout,
+    });
     // Best-effort wait for the canonical selector. We don't fail here
     // if it times out — the cascade probe below covers integrations
     // that use a different selector. This wait exists so that, on the
@@ -236,28 +240,53 @@ export function buildToolRenderingAssertion(opts?: {
         state: "visible",
         timeout: SELECTOR_PROBE_TIMEOUT_MS,
       });
+      console.debug("[d5-tool-rendering] canonical selector matched", {
+        selector: TOOL_CARD_SELECTORS[0],
+      });
     } catch {
       // Canonical selector didn't appear — let the cascade probe try
       // the fallbacks. A genuine "no card at all" outcome surfaces
       // through the probe result below.
+      console.debug("[d5-tool-rendering] canonical selector miss — trying cascade probe");
     }
 
     // Poll probeToolCard until the card is structurally complete or
     // the deadline passes. First probe is immediate (no initial sleep).
     const deadline = Date.now() + pollTimeout;
     let lastError: string | null = null;
+    let probeCount = 0;
 
     while (Date.now() < deadline) {
       const probe = await probeToolCard(page);
+      probeCount++;
       lastError = validateProbe(probe);
       if (lastError === null) {
         // All checks passed — card is structurally complete.
+        console.debug("[d5-tool-rendering] tool card structurally complete", {
+          selector: probe.selector,
+          text: probe.text.slice(0, 200),
+          childCount: probe.childCount,
+          probeAttempts: probeCount,
+        });
         return;
+      }
+      if (probeCount === 1 || probeCount % 10 === 0) {
+        console.debug("[d5-tool-rendering] tool card probe — not ready yet", {
+          probeCount,
+          selector: probe.selector,
+          text: probe.text.slice(0, 100),
+          childCount: probe.childCount,
+          validationError: lastError,
+        });
       }
       // Card not ready yet — sleep briefly and retry.
       await new Promise<void>((r) => setTimeout(r, PROBE_POLL_INTERVAL_MS));
     }
 
+    console.debug("[d5-tool-rendering] tool card probe TIMEOUT", {
+      probeCount,
+      lastError,
+    });
     // Deadline elapsed — throw the last validation error.
     throw new Error(lastError!);
   };


### PR DESCRIPTION
## Summary

Adds comprehensive `console.debug` logging to the D5 probe execution pipeline so production probe failures are diagnosable from logs alone, without requiring reproduction.

**conversation-runner.ts** (the core multi-turn conversation engine):
- Logs conversation start/end with turn count and settle configuration
- Logs chat input selector cascade resolution -- each selector miss and the final hit
- Logs per-turn lifecycle: message send, assistant settle wait, message count changes, assertion execution, and failures with elapsed times
- Logs the fillAndVerifySend retry loop with attempt counts and user message baseline vs current counts
- Logs waitForAssistantSettled polling with count changes, periodic status during long waits (~every 5s), and timeout details

**e2e-deep.ts** (the driver that orchestrates per-feature runs):
- Logs page navigation URL and result
- Logs React hydration wait start, success, and timeout
- Logs conversation turn count after buildTurns
- Logs conversation success/failure with diagnostic capture summary

**All 9 D5 scripts** (agentic-chat, gen-ui-custom, gen-ui-headless, hitl-approve-deny, hitl-steps, hitl-text-input, mcp-subagents, shared-state, tool-rendering):
- Logs expected tokens/fragments and actual assistant text at each assertion checkpoint
- Logs DOM element discovery (matched selectors, child counts, card structure)
- Logs polling progress for long-running assertions (tool card probe, chained reply fragments)

All logging uses `console.debug(...)` which is suppressed at INFO level in production but available when operators set `LOG_LEVEL=debug` for investigation.

## Test plan

- [x] All 1372 existing tests pass (`cd showcase/harness && npx vitest run` -- 70 test files, 0 failures)
- [x] Debug output is visible in test stdout (vitest captures it per-test)
- [x] No functional changes -- all logging is additive `console.debug` calls