### PR TITLE
fix(showcase): replace ? with strikethrough for unavailable probe depths

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -177,7 +177,7 @@ describe("CellDrilldown", () => {
     expect(closed).toBe(true);
   });
 
-  it("renders gray '?' for dimensions with no data", () => {
+  it("renders strikethrough 'n/a' for dimensions with no data (not '?')", () => {
     const { getByTestId } = render(
       <CellDrilldown
         slug="lgp"
@@ -189,6 +189,9 @@ describe("CellDrilldown", () => {
       />,
     );
     const healthBadge = getByTestId("drilldown-badge-health");
-    expect(healthBadge.textContent).toContain("?");
+    expect(healthBadge.textContent).toContain("n/a");
+    // Verify strikethrough styling is applied
+    const strikethroughEl = healthBadge.querySelector(".line-through");
+    expect(strikethroughEl).not.toBeNull();
   });
 });

--- a/showcase/shell-dashboard/src/components/badges.tsx
+++ b/showcase/shell-dashboard/src/components/badges.tsx
@@ -40,6 +40,11 @@ export function Badge({
     openedRef.current = true;
     onTooltipOpen?.();
   };
+  // When the label is "?" (no probe data), render the dimension name with
+  // strikethrough instead of appending a question mark. This communicates
+  // "this depth doesn't exist / hasn't run" more clearly than "D5 ?".
+  const isUnavailable = state.label === "?";
+
   const inner = (
     <span
       className="whitespace-nowrap"
@@ -47,10 +52,18 @@ export function Badge({
       onMouseEnter={handleOpen}
       onFocus={handleOpen}
     >
-      <span className="text-[var(--text-muted)]">{name}</span>{" "}
-      <span className={`tabular-nums ${TONE_CLASS[state.tone]}`}>
-        {state.label}
-      </span>
+      {isUnavailable ? (
+        <span className="text-[var(--text-muted)] line-through">
+          {name}
+        </span>
+      ) : (
+        <>
+          <span className="text-[var(--text-muted)]">{name}</span>{" "}
+          <span className={`tabular-nums ${TONE_CLASS[state.tone]}`}>
+            {state.label}
+          </span>
+        </>
+      )}
     </span>
   );
   return href ? (

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -78,11 +78,17 @@ function BadgeRow({ badge, label }: { badge: BadgeRender; label: string }) {
             {label}
           </span>
         </div>
-        <span
-          className={`text-xs font-semibold tabular-nums ${TONE_CLASS[badge.tone]}`}
-        >
-          {badge.label}
-        </span>
+        {badge.label === "?" ? (
+          <span className="text-xs text-[var(--text-muted)] line-through">
+            n/a
+          </span>
+        ) : (
+          <span
+            className={`text-xs font-semibold tabular-nums ${TONE_CLASS[badge.tone]}`}
+          >
+            {badge.label}
+          </span>
+        )}
       </div>
       <p className="mt-0.5 text-[10px] text-[var(--text-muted)] leading-tight">
         {badge.tooltip}


### PR DESCRIPTION
## Summary

- When a dashboard cell has no probe data for a depth (D5, D6), the badge now renders the dimension name with CSS `line-through` instead of appending a `?` label
- Strikethrough communicates "this depth hasn't run" more clearly than `D5 ?`
- Same treatment applied to the CellDrilldown panel (renders strikethrough `n/a` instead of `?`)

## Test plan

- [x] cell-drilldown tests updated and passing
- [x] live-status tests passing (formatLabel still returns `?` internally; rendering layer handles display)
- [x] depth-chip, depth-utils, chips-explainer tests all green