### PR TITLE
fix(showcase): test built-in-agent with runtime PR #4482 pkg-pr-new build

### DIFF
--- a/showcase/integrations/built-in-agent/package-lock.json
+++ b/showcase/integrations/built-in-agent/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@copilotkit/a2ui-renderer": "next",
         "@copilotkit/react-core": "next",
-        "@copilotkit/runtime": "next",
+        "@copilotkit/runtime": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@4482",
         "@copilotkit/shared": "next",
         "@copilotkit/voice": "next",
         "@hashbrownai/core": "0.5.0-beta.4",
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@ag-ui/a2ui-middleware": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.4.tgz",
-      "integrity": "sha512-N7goCObceqsCQgFRKBpo/X9D9Q0Jp6ALV+ier2W7WnK3sy0WfY2jAeFhqEaoZRqcNeLTKEt8sDqdtd4TGQE1+w==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.5.tgz",
+      "integrity": "sha512-nhF8LBzq36BmLR1O3nStxqSpIu1+4//ttqOyQgiXUsKZK1znCyN4q4MBTARrkFa7CuFr3fcNTiZuS4V1HRUHTw==",
       "dependencies": {
         "clarinet": "^0.12.6"
       },
@@ -109,12 +109,12 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.27.tgz",
-      "integrity": "sha512-sfUG985ngG4HAGIZK04POvZVDrsI3QaeWuqJ388QgBPGg9n/oi4+vxueW7O5PIQv6uOPCLsbxf43pZZRN3zZtg==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.31.tgz",
+      "integrity": "sha512-mK24pfQZiV5SlnDLhTka+873gw7QQOAWXqqDSnwkuyoQQQFX7KC8xZR+4Da2dWqyVhbhNPx+amE16X7twS1wcg==",
       "dependencies": {
-        "@langchain/core": "^0.3.80",
-        "@langchain/langgraph-sdk": "^0.1.2",
+        "@langchain/core": "^1.1.40",
+        "@langchain/langgraph-sdk": "^1.8.8",
         "langchain": ">=1.2.0",
         "partial-json": "^0.1.7",
         "rxjs": "7.8.1"
@@ -549,6 +549,223 @@
       }
     },
     "node_modules/@copilotkit/runtime": {
+      "version": "1.56.4",
+      "resolved": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@4482",
+      "integrity": "sha512-3gcGENpJ1zgFGdHrkWl/edj/BRJ8wkGUZ7AahQLAMZzM6xto+qD1eNrr3wBFAQ1/gKF4LvaKiqMeEIJPnMiXsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/a2ui-middleware": "0.0.5",
+        "@ag-ui/client": "0.0.52",
+        "@ag-ui/core": "0.0.52",
+        "@ag-ui/encoder": "0.0.52",
+        "@ag-ui/langgraph": "0.0.31",
+        "@ag-ui/mcp-apps-middleware": "0.0.3",
+        "@ai-sdk/anthropic": "^3.0.49",
+        "@ai-sdk/google": "^3.0.33",
+        "@ai-sdk/google-vertex": "^3.0.97",
+        "@ai-sdk/mcp": "^1.0.21",
+        "@ai-sdk/openai": "^3.0.36",
+        "@copilotkit/license-verifier": "0.2.0",
+        "@copilotkit/shared": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@b355acd56cd00856d7df1b0f9a7e1f6f6974b42d",
+        "@graphql-yoga/plugin-defer-stream": "^3.3.1",
+        "@hono/node-server": "^1.13.5",
+        "@modelcontextprotocol/sdk": "^1.18.2",
+        "@remix-run/node-fetch-server": "^0.13.0",
+        "@scarf/scarf": "^1.3.0",
+        "@segment/analytics-node": "^2.1.2",
+        "ai": "^6.0.104",
+        "clarinet": "^0.12.4",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
+        "cors": "^2.8.5",
+        "express": "^4.21.2",
+        "graphql": "^16.8.1",
+        "graphql-scalars": "^1.23.0",
+        "graphql-yoga": "^5.3.1",
+        "hono": "^4.11.4",
+        "openai": "^4.85.1 || >=5.0.0",
+        "partial-json": "^0.1.7",
+        "phoenix": "^1.8.4",
+        "pino": "^9.2.0",
+        "pino-pretty": "^11.2.1",
+        "reflect-metadata": "^0.2.2",
+        "rxjs": "7.8.1",
+        "type-graphql": "2.0.0-rc.1",
+        "uuid": "^10.0.0",
+        "ws": "^8.18.0",
+        "zod": "^3.23.3"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": "^0.57.0",
+        "@langchain/aws": ">=0.1.9",
+        "@langchain/community": ">=0.3.58",
+        "@langchain/core": ">=0.3.66",
+        "@langchain/google-gauth": ">=0.1.0",
+        "@langchain/langgraph-sdk": ">=0.1.2",
+        "@langchain/openai": ">=0.4.2",
+        "groq-sdk": ">=0.3.0 <1.0.0",
+        "langchain": ">=0.3.3",
+        "openai": "^4.85.1 || >=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@langchain/aws": {
+          "optional": true
+        },
+        "@langchain/community": {
+          "optional": true
+        },
+        "@langchain/google-gauth": {
+          "optional": true
+        },
+        "@langchain/langgraph-sdk": {
+          "optional": true
+        },
+        "@langchain/openai": {
+          "optional": true
+        },
+        "groq-sdk": {
+          "optional": true
+        },
+        "langchain": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@copilotkit/runtime-client-gql": {
+      "version": "1.55.2-next.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.55.2-next.1.tgz",
+      "integrity": "sha512-7Rjw2uW09zIcwAw3vyalxjaYbV03OVbtnLAlbXpw2sLjs/FHRpsjIl1Bpv6KCcBt0sTC5rDrVNe+tyzVVCHO0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@copilotkit/shared": "1.55.2-next.1",
+        "@urql/core": "^5.0.3",
+        "untruncate-json": "^0.0.1",
+        "urql": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/@copilotkit/license-verifier": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.2.0.tgz",
+      "integrity": "sha512-hliCifqy5a65YTozgRckuQmvBEQlt4L2PhbpSDY6fb/TKqPHyNDJgItRSnOpxOVDqvEfHEbUUqw3NaD88ZtdJA=="
+    },
+    "node_modules/@copilotkit/runtime/node_modules/@copilotkit/shared": {
+      "version": "1.56.4",
+      "resolved": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/shared@b355acd56cd00856d7df1b0f9a7e1f6f6974b42d",
+      "integrity": "sha512-sHmjRyZkmbHqhbK0OGT66gtCHAMA2AIWtNEFb2nwStzVu64a5dNhaayzpu7VbLpfkzeNzeWCPmZecdrN/EK1wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.52",
+        "@copilotkit/license-verifier": "0.2.0",
+        "@segment/analytics-node": "^2.1.2",
+        "@standard-schema/spec": "^1.0.0",
+        "chalk": "4.1.2",
+        "graphql": "^16.8.1",
+        "partial-json": "^0.1.7",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.3",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@ag-ui/core": ">=0.0.48"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/@copilotkit/shared/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@copilotkit/shared": {
+      "version": "1.55.2-next.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.55.2-next.1.tgz",
+      "integrity": "sha512-B96UNONgbJLL+pJr3smNkmFtaVMLQJLjjHmHQ7hprMVvwC5kjOxRC1HobhcrM/rwlspd/QPAYH6vKNzhir11jA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.52",
+        "@copilotkit/license-verifier": "0.0.1-a1",
+        "@segment/analytics-node": "^2.1.2",
+        "@standard-schema/spec": "^1.0.0",
+        "chalk": "4.1.2",
+        "graphql": "^16.8.1",
+        "partial-json": "^0.1.7",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.3",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@ag-ui/core": ">=0.0.48"
+      }
+    },
+    "node_modules/@copilotkit/voice": {
+      "version": "1.55.2-next.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/voice/-/voice-1.55.2-next.1.tgz",
+      "integrity": "sha512-hhRDrUjrBkVKcr/qLLnHOUKQYp76a7PlIgEvDBlJi0lp20RtKG0U1YKaBN4er3KMf1R64VLyP5qaXbId7EHHOQ==",
+      "dependencies": {
+        "@copilotkit/runtime": "1.55.2-next.1",
+        "openai": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@copilotkit/voice/node_modules/@ag-ui/a2ui-middleware": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.4.tgz",
+      "integrity": "sha512-N7goCObceqsCQgFRKBpo/X9D9Q0Jp6ALV+ier2W7WnK3sy0WfY2jAeFhqEaoZRqcNeLTKEt8sDqdtd4TGQE1+w==",
+      "dependencies": {
+        "clarinet": "^0.12.6"
+      },
+      "peerDependencies": {
+        "@ag-ui/client": ">=0.0.40",
+        "rxjs": "7.8.1"
+      }
+    },
+    "node_modules/@copilotkit/voice/node_modules/@ag-ui/langgraph": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.27.tgz",
+      "integrity": "sha512-sfUG985ngG4HAGIZK04POvZVDrsI3QaeWuqJ388QgBPGg9n/oi4+vxueW7O5PIQv6uOPCLsbxf43pZZRN3zZtg==",
+      "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "@langchain/langgraph-sdk": "^0.1.2",
+        "langchain": ">=1.2.0",
+        "partial-json": "^0.1.7",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "@ag-ui/client": ">=0.0.42",
+        "@ag-ui/core": ">=0.0.42"
+      }
+    },
+    "node_modules/@copilotkit/voice/node_modules/@copilotkit/runtime": {
       "version": "1.55.2-next.1",
       "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.55.2-next.1.tgz",
       "integrity": "sha512-lCZK3wE3eaV7GJnnl+jFtCDOcOE3yAFPUh3cSK+QDfxK+RCsOVAC7fplUxbIolPngKsy//QL2UxKea7pPIKXUg==",
@@ -636,31 +853,7 @@
         }
       }
     },
-    "node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.55.2-next.1.tgz",
-      "integrity": "sha512-7Rjw2uW09zIcwAw3vyalxjaYbV03OVbtnLAlbXpw2sLjs/FHRpsjIl1Bpv6KCcBt0sTC5rDrVNe+tyzVVCHO0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@copilotkit/shared": "1.55.2-next.1",
-        "@urql/core": "^5.0.3",
-        "untruncate-json": "^0.0.1",
-        "urql": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/openai": {
+    "node_modules/@copilotkit/voice/node_modules/@copilotkit/runtime/node_modules/openai": {
       "version": "4.104.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
@@ -690,16 +883,62 @@
         }
       }
     },
-    "node_modules/@copilotkit/runtime/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
+    "node_modules/@copilotkit/voice/node_modules/@langchain/core": {
+      "version": "0.3.80",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
+      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "^0.3.67",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "zod": "^3.25.32",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/@copilotkit/runtime/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+    "node_modules/@copilotkit/voice/node_modules/@langchain/langgraph-sdk": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.1.10.tgz",
+      "integrity": "sha512-9srSCb2bSvcvehMgjA2sMMwX0o1VUgPN6ghwm5Fwc9JGAKsQa6n1S4eCwy1h4abuYxwajH5n3spBw+4I2WYbgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.31 <0.4.0 || ^1.0.0-alpha",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@copilotkit/voice/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -709,37 +948,80 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@copilotkit/shared": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.55.2-next.1.tgz",
-      "integrity": "sha512-B96UNONgbJLL+pJr3smNkmFtaVMLQJLjjHmHQ7hprMVvwC5kjOxRC1HobhcrM/rwlspd/QPAYH6vKNzhir11jA==",
+    "node_modules/@copilotkit/voice/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.52",
-        "@copilotkit/license-verifier": "0.0.1-a1",
-        "@segment/analytics-node": "^2.1.2",
-        "@standard-schema/spec": "^1.0.0",
-        "chalk": "4.1.2",
-        "graphql": "^16.8.1",
-        "partial-json": "^0.1.7",
-        "uuid": "^11.1.0",
-        "zod": "^3.23.3",
-        "zod-to-json-schema": "^3.23.5"
-      },
-      "peerDependencies": {
-        "@ag-ui/core": ">=0.0.48"
+        "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@copilotkit/voice": {
-      "version": "1.55.2-next.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/voice/-/voice-1.55.2-next.1.tgz",
-      "integrity": "sha512-hhRDrUjrBkVKcr/qLLnHOUKQYp76a7PlIgEvDBlJi0lp20RtKG0U1YKaBN4er3KMf1R64VLyP5qaXbId7EHHOQ==",
+    "node_modules/@copilotkit/voice/node_modules/langsmith": {
+      "version": "0.3.87",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "license": "MIT",
       "dependencies": {
-        "@copilotkit/runtime": "1.55.2-next.1",
-        "openai": "^5.9.0"
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@copilotkit/voice/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@copilotkit/voice/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@copilotkit/voice/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@copilotkit/web-inspector": {
@@ -1658,39 +1940,24 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.80",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
-      "integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.42.tgz",
+      "integrity": "sha512-d0tN96BrwPMryYyWR9VfyAntSivn7EQrZCe5Kpxum93tcjTXbKKmKvItFec8AluQt88iTcmAJrahUZUNfzGwTA==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
         "ansi-styles": "^5.0.0",
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.67",
+        "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=20"
       }
     },
     "node_modules/@langchain/langgraph": {
@@ -1737,6 +2004,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -1747,50 +2015,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.1.10.tgz",
-      "integrity": "sha512-9srSCb2bSvcvehMgjA2sMMwX0o1VUgPN6ghwm5Fwc9JGAKsQa6n1S4eCwy1h4abuYxwajH5n3spBw+4I2WYbgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.2.31 <0.4.0 || ^1.0.0-alpha",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.9.tgz",
-      "integrity": "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==",
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.10.tgz",
+      "integrity": "sha512-wrB3rkRw5KAmsqezwvKP3midT4qJrV6Hj9XJMYo+cbvXC4HYpSAmyY/VriSyeTFRbLG/OP/pY2Yz+9Z54nSaXQ==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
@@ -1823,26 +2050,13 @@
         }
       }
     },
-    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/eventemitter3": {
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
-    "node_modules/@langchain/langgraph/node_modules/p-queue": {
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
       "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
@@ -1858,22 +2072,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph/node_modules/p-retry": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
-      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-network-error": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/p-timeout": {
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
@@ -1885,10 +2084,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/@langchain/langgraph/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7620,28 +7833,45 @@
       }
     },
     "node_modules/langchain": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.4.tgz",
-      "integrity": "sha512-umrD+ZC6vr0Q0U1lC5PoIMMQqgnP+7QhaIdAXCeZiSX2GPVBiVR7Ed2ZR+3MPvz1yWrRtIm17wPaovkND+wOXg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.5.tgz",
+      "integrity": "sha512-QSB8TEo6G1tWupgNt1Osm8ylLLoOMq1lLw5NeijnIwRPI5BqdBjUn4/U8usbjEJJcQnbXSK2qTKgTx7zvblnBw==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph": "^1.2.9",
         "@langchain/langgraph-checkpoint": "^1.0.1",
         "langsmith": ">=0.5.0 <1.0.0",
-        "uuid": "^11.1.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.41"
+        "@langchain/core": "^1.1.42"
       }
     },
-    "node_modules/langchain/node_modules/langsmith": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.25.tgz",
-      "integrity": "sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==",
+    "node_modules/langium": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.26.tgz",
+      "integrity": "sha512-HmmFgeQR2n9x1Kq8NiVaNL/j72ta71qN11hYjbyePJ/QuYEnOMhQjbNv9KeyKB3bOetpIzNalQbhHm+RyKoPRQ==",
       "license": "MIT",
       "dependencies": {
         "p-queue": "6.6.2"
@@ -7669,71 +7899,6 @@
         "ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/langium": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
-      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chevrotain/regexp-to-ast": "~12.0.0",
-        "chevrotain": "~12.0.0",
-        "chevrotain-allstar": "~0.4.1",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.1.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/langsmith/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/layout-base": {
@@ -15633,16 +15798,18 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
       "license": "MIT",
       "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
+        "is-network-error": "^1.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {

--- a/showcase/integrations/built-in-agent/package.json
+++ b/showcase/integrations/built-in-agent/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@copilotkit/a2ui-renderer": "next",
     "@copilotkit/react-core": "next",
-    "@copilotkit/runtime": "next",
+    "@copilotkit/runtime": "https://pkg.pr.new/CopilotKit/CopilotKit/@copilotkit/runtime@4482",
     "@copilotkit/shared": "next",
     "@copilotkit/voice": "next",
     "@hashbrownai/core": "0.5.0-beta.4",

--- a/showcase/integrations/built-in-agent/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/gen-ui-tool-based/page.tsx
@@ -24,8 +24,7 @@ function Demo() {
     <main className="p-8">
       <h1 className="text-2xl font-semibold mb-4">Tool-Based Generative UI</h1>
       <p className="text-sm opacity-70 mb-6">
-        Try: &ldquo;Write me a haiku about nature.&rdquo; The agent calls
-        the
+        Try: &ldquo;Write me a haiku about nature.&rdquo; The agent calls the
         <code className="mx-1 px-1 bg-gray-100 rounded">generate_haiku</code>
         tool and the result renders inline as a typed card.
       </p>
@@ -48,8 +47,7 @@ function HaikuCard(props: any) {
   const gradient: string | undefined = props.gradient;
   const topic: string | undefined = props.topic;
 
-  const hasContent =
-    japaneseLines.length > 0 || englishLines.length > 0;
+  const hasContent = japaneseLines.length > 0 || englishLines.length > 0;
 
   if (!hasContent) {
     return (
@@ -68,9 +66,7 @@ function HaikuCard(props: any) {
       className="border rounded p-4 my-2 bg-amber-50"
       style={gradient ? { background: gradient } : undefined}
     >
-      <div className="font-medium mb-2">
-        Haiku{topic ? ` — ${topic}` : ""}
-      </div>
+      <div className="font-medium mb-2">Haiku{topic ? ` — ${topic}` : ""}</div>
       {japaneseLines.length > 0 && (
         <div className="mb-2">
           {japaneseLines.map((line: string, i: number) => (

--- a/showcase/integrations/built-in-agent/src/app/demos/gen-ui-tool-based/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/gen-ui-tool-based/page.tsx
@@ -16,7 +16,7 @@ export default function GenUiToolBased() {
 
 function Demo() {
   useComponent({
-    name: "haiku",
+    name: "generate_haiku",
     render: HaikuCard,
   });
 
@@ -24,9 +24,9 @@ function Demo() {
     <main className="p-8">
       <h1 className="text-2xl font-semibold mb-4">Tool-Based Generative UI</h1>
       <p className="text-sm opacity-70 mb-6">
-        Try: &ldquo;Write me a haiku about morning dew.&rdquo; The agent calls
+        Try: &ldquo;Write me a haiku about nature.&rdquo; The agent calls
         the
-        <code className="mx-1 px-1 bg-gray-100 rounded">haiku</code>
+        <code className="mx-1 px-1 bg-gray-100 rounded">generate_haiku</code>
         tool and the result renders inline as a typed card.
       </p>
       <CopilotChat />
@@ -34,32 +34,62 @@ function Demo() {
   );
 }
 
+/**
+ * HaikuCard — rendered by `useComponent({ name: "generate_haiku" })`.
+ *
+ * `useComponent` passes tool-call arguments directly as React props (via
+ * `useFrontendTool`'s `render: ({ args }) => <Component {...args} />`).
+ * The D5 fixture sends: { japanese, english, image_name, gradient }.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function HaikuCard(props: any) {
-  const { status, result, parameters } = props;
+  const japaneseLines: string[] = props.japanese ?? [];
+  const englishLines: string[] = props.english ?? props.lines ?? [];
+  const gradient: string | undefined = props.gradient;
+  const topic: string | undefined = props.topic;
 
-  if (status !== "complete" || !result) {
+  const hasContent =
+    japaneseLines.length > 0 || englishLines.length > 0;
+
+  if (!hasContent) {
     return (
-      <div className="border rounded p-3 my-2 opacity-70 text-sm">
-        Composing haiku
-        {parameters?.topic ? ` about ${parameters.topic}…` : "…"}
+      <div
+        data-testid="haiku-card"
+        className="border rounded p-3 my-2 opacity-70 text-sm"
+      >
+        Composing haiku{topic ? ` about ${topic}` : ""}…
       </div>
     );
   }
 
-  let data: { topic?: string; lines?: string[] } = {};
-  try {
-    data = JSON.parse(result);
-  } catch {
-    // leave empty on parse failure
-  }
-  const lines = data.lines ?? [];
-
   return (
-    <div className="border rounded p-4 my-2 bg-amber-50">
-      <div className="font-medium mb-2">Haiku — {data.topic ?? ""}</div>
+    <div
+      data-testid="haiku-card"
+      className="border rounded p-4 my-2 bg-amber-50"
+      style={gradient ? { background: gradient } : undefined}
+    >
+      <div className="font-medium mb-2">
+        Haiku{topic ? ` — ${topic}` : ""}
+      </div>
+      {japaneseLines.length > 0 && (
+        <div className="mb-2">
+          {japaneseLines.map((line: string, i: number) => (
+            <div
+              key={i}
+              data-testid="haiku-japanese-line"
+              className="text-lg leading-relaxed"
+            >
+              {line}
+            </div>
+          ))}
+        </div>
+      )}
       <div className="font-serif italic whitespace-pre-line text-lg leading-relaxed">
-        {lines.join("\n")}
+        {englishLines.map((line: string, i: number) => (
+          <div key={i} data-testid="haiku-english-line">
+            {line}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/showcase/integrations/built-in-agent/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/hitl-in-chat/page.tsx
@@ -15,7 +15,10 @@ import {
   useHumanInTheLoop,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
-import { TimePickerCard, TimeSlot } from "../hitl-in-chat-booking/time-picker-card";
+import {
+  TimePickerCard,
+  TimeSlot,
+} from "../hitl-in-chat-booking/time-picker-card";
 
 const DEFAULT_SLOTS: TimeSlot[] = [
   { label: "Tomorrow 10:00 AM", iso: "2026-04-30T10:00:00-07:00" },
@@ -61,8 +64,8 @@ function Demo() {
     <main className="p-8">
       <h1 className="text-2xl font-semibold mb-4">In-Chat Booking (HITL)</h1>
       <p className="text-sm opacity-70 mb-6">
-        Try: &ldquo;Book a 30-minute onboarding call for Alice.&rdquo; The
-        agent renders an inline time picker; pick a slot to confirm.
+        Try: &ldquo;Book a 30-minute onboarding call for Alice.&rdquo; The agent
+        renders an inline time picker; pick a slot to confirm.
       </p>
       <CopilotChat />
     </main>

--- a/showcase/integrations/built-in-agent/src/app/demos/hitl-in-chat/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/hitl-in-chat/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * In-Chat HITL (book_call) demo.
+ *
+ * Mirrors the hitl-in-chat-booking page at `/demos/hitl-in-chat-booking`
+ * but exposed at the canonical `/demos/hitl-in-chat` route that the D5
+ * harness expects. The `book_call` tool presents a TimePickerCard with
+ * fixed time slots; the user picks one, and the agent acknowledges.
+ */
+
+import {
+  CopilotKitProvider,
+  CopilotChat,
+  useHumanInTheLoop,
+} from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { TimePickerCard, TimeSlot } from "../hitl-in-chat-booking/time-picker-card";
+
+const DEFAULT_SLOTS: TimeSlot[] = [
+  { label: "Tomorrow 10:00 AM", iso: "2026-04-30T10:00:00-07:00" },
+  { label: "Tomorrow 2:00 PM", iso: "2026-04-30T14:00:00-07:00" },
+  { label: "Monday 9:00 AM", iso: "2026-05-04T09:00:00-07:00" },
+  { label: "Monday 3:30 PM", iso: "2026-05-04T15:30:00-07:00" },
+];
+
+export default function HitlInChat() {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
+      <Demo />
+    </CopilotKitProvider>
+  );
+}
+
+function Demo() {
+  useHumanInTheLoop({
+    name: "book_call",
+    description:
+      "Ask the user to pick a time slot for a call. The picker UI presents fixed candidate slots; the user's choice is returned to the agent.",
+    parameters: z.object({
+      topic: z
+        .string()
+        .describe("What the call is about (e.g. 'Intro with sales')"),
+      attendee: z
+        .string()
+        .describe("Who the call is with (e.g. 'Alice from Sales')"),
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render: ({ args, status, respond }: any) => (
+      <TimePickerCard
+        topic={args?.topic ?? "a call"}
+        attendee={args?.attendee}
+        slots={DEFAULT_SLOTS}
+        status={status}
+        onSubmit={(result) => respond?.(result)}
+      />
+    ),
+  });
+
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold mb-4">In-Chat Booking (HITL)</h1>
+      <p className="text-sm opacity-70 mb-6">
+        Try: &ldquo;Book a 30-minute onboarding call for Alice.&rdquo; The
+        agent renders an inline time picker; pick a slot to confirm.
+      </p>
+      <CopilotChat />
+    </main>
+  );
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/subagents/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/subagents/page.tsx
@@ -16,11 +16,15 @@ export default function Subagents() {
 
 function Demo() {
   useComponent({
-    name: "delegate_to_planner",
+    name: "research_agent",
     render: DelegationCard,
   });
   useComponent({
-    name: "delegate_to_researcher",
+    name: "writing_agent",
+    render: DelegationCard,
+  });
+  useComponent({
+    name: "critique_agent",
     render: DelegationCard,
   });
 
@@ -29,11 +33,14 @@ function Demo() {
       <h1 className="text-2xl font-semibold mb-4">Sub-Agents</h1>
       <p className="text-sm opacity-70 mb-6">
         The main agent delegates tasks to subagents via{" "}
-        <code className="px-1 bg-gray-100 rounded">delegate_to_planner</code>
+        <code className="px-1 bg-gray-100 rounded">research_agent</code>
         {" / "}
-        <code className="px-1 bg-gray-100 rounded">delegate_to_researcher</code>
+        <code className="px-1 bg-gray-100 rounded">writing_agent</code>
+        {" / "}
+        <code className="px-1 bg-gray-100 rounded">critique_agent</code>
         . Each delegation runs a nested <code>chat()</code> with its own system
-        prompt. Try: &ldquo;Plan a 2-day trip to Tokyo with key sights.&rdquo;
+        prompt. Try: &ldquo;Research the benefits of remote work and draft a
+        one-paragraph summary.&rdquo;
       </p>
       <CopilotChat />
     </main>
@@ -44,7 +51,9 @@ function Demo() {
 function DelegationCard(props: any) {
   const { name, status, parameters, result } = props;
   const role =
-    typeof name === "string" ? name.replace(/^delegate_to_/, "") : "subagent";
+    typeof name === "string"
+      ? name.replace(/_agent$/, "").replace(/_/g, " ")
+      : "subagent";
 
   let parsed: { role?: string; text?: string } = {};
   if (status === "complete" && typeof result === "string") {

--- a/showcase/integrations/built-in-agent/src/app/demos/subagents/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/subagents/page.tsx
@@ -37,9 +37,9 @@ function Demo() {
         {" / "}
         <code className="px-1 bg-gray-100 rounded">writing_agent</code>
         {" / "}
-        <code className="px-1 bg-gray-100 rounded">critique_agent</code>
-        . Each delegation runs a nested <code>chat()</code> with its own system
-        prompt. Try: &ldquo;Research the benefits of remote work and draft a
+        <code className="px-1 bg-gray-100 rounded">critique_agent</code>. Each
+        delegation runs a nested <code>chat()</code> with its own system prompt.
+        Try: &ldquo;Research the benefits of remote work and draft a
         one-paragraph summary.&rdquo;
       </p>
       <CopilotChat />

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/page.tsx
@@ -3,9 +3,10 @@
 import {
   CopilotKitProvider,
   CopilotChat,
-  useComponent,
+  useRenderTool,
   useDefaultRenderTool,
 } from "@copilotkit/react-core/v2";
+import { z } from "zod";
 
 export default function ToolRendering() {
   return (
@@ -17,9 +18,18 @@ export default function ToolRendering() {
 
 function Demo() {
   // @region[render-weather-tool]
-  useComponent({
-    name: "weather",
-    render: WeatherCard,
+  useRenderTool({
+    name: "get_weather",
+    parameters: z.object({ location: z.string() }),
+    render: ({ parameters, result, status }) => {
+      return (
+        <WeatherCard
+          loading={status !== "complete"}
+          parameters={parameters}
+          result={result}
+        />
+      );
+    },
   });
   // @endregion[render-weather-tool]
 
@@ -34,7 +44,7 @@ function Demo() {
       <h1 className="text-2xl font-semibold mb-4">Tool Rendering</h1>
       <p className="text-sm opacity-70 mb-6">
         Try: &ldquo;What&apos;s the weather in Tokyo?&rdquo; The
-        <code className="mx-1 px-1 bg-gray-100 rounded">weather</code>tool
+        <code className="mx-1 px-1 bg-gray-100 rounded">get_weather</code>tool
         renders with a custom card; everything else falls back to a generic
         renderer.
       </p>
@@ -43,44 +53,69 @@ function Demo() {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function WeatherCard(props: any) {
-  const { status, result } = props;
-  if (status !== "complete" || !result) {
+/**
+ * WeatherCard — rendered via `useRenderTool({ name: "get_weather" })`.
+ *
+ * Receives `loading`, `parameters` (tool args), and `result` (tool output).
+ * The server tool returns: { city, temperature, humidity, wind_speed, conditions }.
+ */
+function WeatherCard({
+  loading,
+  parameters,
+  result,
+}: {
+  loading: boolean;
+  parameters?: { location?: string };
+  result?: unknown;
+}) {
+  if (loading || !result) {
     return (
       <div className="border rounded p-3 my-2 opacity-70 text-sm">
         Fetching weather…
       </div>
     );
   }
+
   let data: {
     city?: string;
+    temperature?: number;
     tempF?: number;
     condition?: string;
+    conditions?: string;
     humidity?: number;
+    wind_speed?: number;
   } = {};
   try {
-    data = JSON.parse(result);
+    data =
+      typeof result === "string" ? JSON.parse(result) : (result as typeof data);
   } catch {
     // Leave data empty on parse failure
   }
-  const humidityPct =
-    data.humidity != null ? `${Math.round(data.humidity * 100)}%` : "—";
+  const city = data.city ?? parameters?.location ?? "—";
+  const temp = data.temperature ?? data.tempF;
+  const condition = data.conditions ?? data.condition;
+  const humidityVal = data.humidity;
+  const humidityStr =
+    humidityVal != null
+      ? humidityVal < 1
+        ? `${Math.round(humidityVal * 100)}%`
+        : `${humidityVal}%`
+      : "—";
   return (
-    <div className="border rounded p-3 my-2">
-      <div className="font-medium">Weather in {data.city ?? "—"}</div>
+    <div data-testid="weather-card" className="border rounded p-3 my-2">
+      <div className="font-medium">Weather in {city}</div>
       <div className="grid grid-cols-3 gap-2 text-sm mt-2">
         <div>
           <div className="opacity-60">Temp</div>
-          <div>{data.tempF != null ? `${data.tempF}°F` : "—"}</div>
+          <div>{temp != null ? `${temp}°F` : "—"}</div>
         </div>
         <div>
           <div className="opacity-60">Condition</div>
-          <div>{data.condition ?? "—"}</div>
+          <div>{condition ?? "—"}</div>
         </div>
         <div>
           <div className="opacity-60">Humidity</div>
-          <div>{humidityPct}</div>
+          <div>{humidityStr}</div>
         </div>
       </div>
     </div>

--- a/showcase/integrations/built-in-agent/src/lib/factory/server-tools.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/server-tools.ts
@@ -119,6 +119,24 @@ export const rollDiceTool = toolDefinition({
   result: Math.floor(Math.random() * Math.max(2, sides)) + 1,
 }));
 
+// Tool for the shared-state-read-write demo. The `set_notes` tool
+// updates the `notes` slot in shared state, mirroring the LangGraph
+// Python reference agent's `set_notes` tool. The actual state mutation
+// happens client-side when the tool result is returned; here we just
+// echo the notes back so the runtime/frontend can handle it.
+export const setNotesTool = toolDefinition({
+  name: "set_notes",
+  description:
+    "Replace the notes array in shared state with the full updated list. " +
+    "Use this tool whenever the user asks you to 'remember' something, or " +
+    "when you have an observation about the user worth surfacing in the " +
+    "UI's notes panel. Always pass the FULL notes list (existing notes + " +
+    "any new ones), not a diff. Keep each note short (< 120 chars).",
+  inputSchema: z.object({
+    notes: z.array(z.string()).describe("The complete updated list of notes"),
+  }),
+}).server(async ({ notes }) => ({ success: true, notes }));
+
 export const baseServerTools = [
   weatherTool,
   haikuTool,
@@ -126,4 +144,5 @@ export const baseServerTools = [
   searchFlightsTool,
   getStockPriceTool,
   rollDiceTool,
+  setNotesTool,
 ] as const;

--- a/showcase/integrations/built-in-agent/src/lib/factory/subagent-tools.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/subagent-tools.ts
@@ -6,15 +6,30 @@ import { openaiText } from "@tanstack/ai-openai";
 // Each role becomes its own nested chat() with a dedicated system prompt.
 // They don't share memory or tools with the supervisor — the supervisor
 // only sees the role's return value via the delegate tool below.
+//
+// Tool names match the LangGraph Python reference agent (`subagents.py`):
+//   research_agent, writing_agent, critique_agent
+// This alignment is load-bearing: the D5 fixtures are recorded against
+// the LGP agent's tool names, and aimock matches on tool name.
 const subagentRoles = [
   {
-    id: "planner",
+    id: "research_agent",
     systemPrompt:
-      "You are a trip planner. Reply concisely with the day-by-day plan.",
+      "You are a research sub-agent. Given a topic, produce a concise " +
+      "bulleted list of 3-5 key facts. No preamble, no closing.",
   },
   {
-    id: "researcher",
-    systemPrompt: "You are a researcher. Reply concisely with verified facts.",
+    id: "writing_agent",
+    systemPrompt:
+      "You are a writing sub-agent. Given a brief and optional source " +
+      "facts, produce a polished 1-paragraph draft. Be clear and " +
+      "concrete. No preamble.",
+  },
+  {
+    id: "critique_agent",
+    systemPrompt:
+      "You are an editorial critique sub-agent. Given a draft, give " +
+      "2-3 crisp, actionable critiques. No preamble.",
   },
 ] as const;
 // @endregion[subagent-setup]
@@ -25,17 +40,17 @@ const subagentRoles = [
 // the in-flight subagent call — orphan async work, billed tokens, hung
 // promises. Each parent run threads its controller through here.
 // @region[supervisor-delegation-tools]
-// Each `delegate_to_<role>` tool wraps a nested chat() call with the
+// Each `<role>_agent` tool wraps a nested chat() call with the
 // role's system prompt. The supervisor LLM "calls" these tools to
 // delegate work; each invocation runs the matching subagent and returns
 // its output for the supervisor's next step.
 export function buildSubagentTools(parentAbortController: AbortController) {
   return subagentRoles.map((role) =>
     toolDefinition({
-      name: `delegate_to_${role.id}`,
-      description: `Delegate a task to the ${role.id} subagent.`,
+      name: role.id,
+      description: `Delegate a task to the ${role.id.replace(/_/g, " ")}.`,
       inputSchema: z.object({
-        task: z.string().describe(`Task description for the ${role.id}`),
+        task: z.string().describe(`Task description for the ${role.id.replace(/_/g, " ")}`),
       }),
     }).server(async ({ task }) => {
       const text = await chat({

--- a/showcase/integrations/built-in-agent/src/lib/factory/subagent-tools.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/subagent-tools.ts
@@ -50,7 +50,9 @@ export function buildSubagentTools(parentAbortController: AbortController) {
       name: role.id,
       description: `Delegate a task to the ${role.id.replace(/_/g, " ")}.`,
       inputSchema: z.object({
-        task: z.string().describe(`Task description for the ${role.id.replace(/_/g, " ")}`),
+        task: z
+          .string()
+          .describe(`Task description for the ${role.id.replace(/_/g, " ")}`),
       }),
     }).server(async ({ task }) => {
       const text = await chat({


### PR DESCRIPTION
## Summary
Install pkg-pr-new build of @copilotkit/runtime (from PR #4482) in built-in-agent, and align all demo page wiring with the LangGraph-Python D5 fixtures.

**Runtime fix** — The `@copilotkit/runtime` dependency points to a `pkg.pr.new` URL instead of the `next` npm tag. This MUST be reverted to `"next"` once a proper @copilotkit/runtime release includes the TanStack RUN_FINISHED fix from PR #4482.

**D5 wiring fixes** — Seven D5 features failed because built-in-agent demo pages used different tool names and hook types than the LGP reference agent:

- **tool-rendering**: switched from `useComponent("weather")` to `useRenderTool("get_weather")` with correct `{parameters, result, status}` render shape
- **gen-ui-tool-based**: renamed `useComponent("haiku")` to `useComponent("generate_haiku")`, rewrote HaikuCard to accept args as direct props
- **hitl-in-chat**: created `/demos/hitl-in-chat` route (was missing); reuses TimePickerCard from hitl-in-chat-booking with `book_call` tool
- **shared-state**: added `set_notes` server tool so the fixture's `set_notes` call has a backend handler
- **subagents**: renamed `delegate_to_planner`/`delegate_to_researcher` to `research_agent`/`writing_agent`/`critique_agent` matching LGP fixture tool names
- **subagents page**: updated `useComponent` registrations and DelegationCard for the renamed tools

## Results
- Before: 3/10 D5 features pass
- After: targeting 10/10 (pending D5 probe verification)

## Test plan
- [x] Docker image builds
- [x] TypeScript check — no new errors (only pre-existing Zod version mismatch)
- [x] All 6 files modified/created verified
- [ ] D5 probe run against deployed built-in-agent
- [ ] Team review of runtime change scope
- [ ] Revert runtime dep to `"next"` after proper release