### PR TITLE
fix(showcase): remove trailing slash from ms-agent-python hitl-in-app agent URL

### DIFF
--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit/route.ts
@@ -52,10 +52,10 @@ for (const name of agentNames) {
   agents[name] = createAgent();
 }
 // In-App HITL -- async frontend-tool + app-level modal (outside chat).
-// Points at the dedicated hitl-in-app agent mounted at /hitl-in-app on the
-// FastAPI backend; the agent has tools=[] and a system prompt tailored to
-// the frontend-provided `request_user_approval` tool.
-agents["hitl-in-app"] = new HttpAgent({ url: `${AGENT_URL}/hitl-in-app/` });
+// Dedicated hitl-in-app agent mounted at /hitl-in-app on the FastAPI
+// backend; agent has tools=[] and relies on the frontend-provided
+// `request_user_approval` tool injected by CopilotKit at request time.
+agents["hitl-in-app"] = createAgent("/hitl-in-app");
 
 // In-Chat HITL -- frontend-defined `book_call` tool rendered inline in the
 // chat via `useHumanInTheLoop`. Backend agent has tools=[] and routes to


### PR DESCRIPTION
## Summary

- Remove trailing slash from the `hitl-in-app` agent URL in ms-agent-python's CopilotKit route handler

## Why

The `hitl-in-app` agent was the **only** agent registered with a trailing slash in the URL (`/hitl-in-app/`). The FastAPI backend mounts the endpoint at `/hitl-in-app` (no slash). FastAPI's default `redirect_slashes=True` returns a **307 redirect** for POST requests to the trailing-slash variant, and the AG-UI `HttpAgent` does not follow POST redirects during streaming. This caused the agent to appear completely unresponsive — the D5 `hitl-approve-deny` probe timed out at 60s with `baseline=0, current=0` (zero assistant messages).

Verified via container: `POST /hitl-in-app/` returns 307 → `POST /hitl-in-app` returns 422 (correct routing, body validation).

The fix uses the shared `createAgent("/hitl-in-app")` helper (which does not append a trailing slash) for consistency with every other agent registration in the file.

## Test plan

- [ ] D5 `hitl-approve-deny` passes for ms-agent-python (`showcase test ms-agent-python --d5`)
- [ ] No regression in other ms-agent-python D5 features (10/11 → 11/11)