### PR TITLE
fix(showcase/spring-ai): prevent streaming crash on frontend tool calls

### DIFF
--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/BoundedToolCallingManagerConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/BoundedToolCallingManagerConfig.java
@@ -12,6 +12,7 @@ import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.DefaultToolExecutionExceptionProcessor;
 import org.springframework.ai.tool.resolution.StaticToolCallbackResolver;
+import org.springframework.ai.tool.resolution.ToolCallbackResolver;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
@@ -107,14 +108,96 @@ public class BoundedToolCallingManagerConfig {
         ObservationRegistry observationRegistry =
                 observationRegistryProvider.getIfUnique(() -> ObservationRegistry.NOOP);
 
+        // Use a lenient resolver that returns a placeholder callback for
+        // unknown tools instead of throwing IllegalStateException. In the
+        // CopilotKit architecture, the model sees both backend tools
+        // (registered here or via ChatClient.toolCallbacks()) and frontend
+        // tools (injected by the CopilotKit runtime). Frontend tools are
+        // handled client-side; the Java agent should not crash when the
+        // model tries to call one. The placeholder callback returns an
+        // informational message that the tool is externally managed, which
+        // allows Spring AI's tool execution loop to continue normally.
+        ToolCallbackResolver lenientResolver = new LenientToolCallbackResolver(
+                new StaticToolCallbackResolver(toolCallbacks));
+
         ToolCallingManager delegate = ToolCallingManager.builder()
                 .observationRegistry(observationRegistry)
-                .toolCallbackResolver(new StaticToolCallbackResolver(toolCallbacks))
+                .toolCallbackResolver(lenientResolver)
                 .toolExecutionExceptionProcessor(
                         DefaultToolExecutionExceptionProcessor.builder().build())
                 .build();
 
         return new BoundedToolCallingManager(delegate, toolIterationCapInclusive);
+    }
+
+    /**
+     * Wraps a delegate {@link ToolCallbackResolver} and catches resolution
+     * failures for unknown tools (typically frontend tools injected by the
+     * CopilotKit runtime). Instead of propagating the
+     * {@code IllegalStateException}, returns a no-op {@link ToolCallback}
+     * that yields an informational message. This allows Spring AI's tool
+     * execution loop to continue without crashing.
+     */
+    static final class LenientToolCallbackResolver implements ToolCallbackResolver {
+
+        private final ToolCallbackResolver delegate;
+
+        LenientToolCallbackResolver(ToolCallbackResolver delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ToolCallback resolve(String toolName) {
+            ToolCallback resolved;
+            try {
+                resolved = delegate.resolve(toolName);
+            } catch (Exception e) {
+                // Some resolvers throw (e.g. future Spring AI versions);
+                // treat the same as null.
+                resolved = null;
+            }
+            if (resolved != null) {
+                return resolved;
+            }
+            log.debug("[LenientResolver] Tool '{}' not registered locally; "
+                    + "returning placeholder (likely a frontend tool "
+                    + "handled by the CopilotKit runtime)", toolName);
+            return new FrontendToolPlaceholder(toolName);
+        }
+    }
+
+    /**
+     * Placeholder callback for tools not registered on the Java backend.
+     * Returns a message indicating the tool is handled externally, allowing
+     * Spring AI's tool execution loop to continue instead of crashing.
+     */
+    static final class FrontendToolPlaceholder implements ToolCallback {
+
+        private final String toolName;
+
+        FrontendToolPlaceholder(String toolName) {
+            this.toolName = toolName;
+        }
+
+        @Override
+        public ToolDefinition getToolDefinition() {
+            return ToolDefinition.builder()
+                    .name(toolName)
+                    .description("Frontend tool handled by CopilotKit runtime")
+                    .inputSchema("{}")
+                    .build();
+        }
+
+        @Override
+        public String call(String toolInput) {
+            return "Tool '" + toolName + "' is handled by the frontend runtime.";
+        }
+
+        @Override
+        public String call(String toolInput,
+                           org.springframework.ai.chat.model.ToolContext toolContext) {
+            return call(toolInput);
+        }
     }
 
     /**

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
@@ -15,6 +15,7 @@ import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.util.StringUtils;
 import org.slf4j.Logger;
@@ -51,10 +52,14 @@ import static com.agui.server.EventFactory.toolCallStartEvent;
  *
  * <p>This agent implements a two-phase approach:
  * <ol>
- *   <li><b>Phase 1 — stream:</b> Use {@code .stream()} WITHOUT tool callbacks
- *       to get real-time text delivery. If the model wants to call tools,
- *       the stream will contain tool_calls but since no callbacks are registered
- *       on this path, it just completes with the tool call indication.</li>
+ *   <li><b>Phase 1 — stream:</b> Use {@code .stream()} with
+ *       {@code internalToolExecutionEnabled=false} for real-time text delivery.
+ *       This prevents Spring AI's model layer from auto-executing tool calls
+ *       through the global {@code ToolCallingManager} (which only knows about
+ *       backend tools and would throw on frontend-provided tools like
+ *       {@code generate_task_steps}, {@code show_card}, etc.). If the model
+ *       wants to call tools, the stream will contain tool_calls metadata but
+ *       they are detected without execution.</li>
  *   <li><b>Phase 2 — call with tools:</b> If tool calls were detected, re-invoke
  *       the model via {@code .call()} WITH tool callbacks attached. Spring AI's
  *       built-in tool execution loop handles all tool iterations automatically.
@@ -136,10 +141,13 @@ public class StreamingToolAgent extends LocalAgent {
             return;
         }
 
-        this.emitEvent(textMessageEndEvent(messageId), subscriber);
+        // Emit tool call events BEFORE textMessageEnd so the frontend's
+        // useRenderTool sees them while the message is still "open". Events
+        // emitted after textMessageEnd may be missed by renderers.
         for (BaseEvent ev : deferredEvents) {
             this.emitEvent(ev, subscriber);
         }
+        this.emitEvent(textMessageEndEvent(messageId), subscriber);
         subscriber.onNewMessage(assistantMessage);
         this.emitEvent(runFinishedEvent(threadId, runId), subscriber);
         subscriber.onRunFinalized(
@@ -161,9 +169,12 @@ public class StreamingToolAgent extends LocalAgent {
         AtomicReference<Throwable> streamError = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
 
-        // Build request WITHOUT tool callbacks — we just want to stream text
-        // and detect whether tools are needed.
-        ChatClient.ChatClientRequestSpec request = buildBaseRequest(input, userContent);
+        // Build request WITHOUT tool callbacks and with internal tool
+        // execution disabled — we just want to stream text and detect
+        // whether tools are needed without Spring AI's model layer
+        // attempting to execute them through the global ToolCallingManager.
+        ChatClient.ChatClientRequestSpec request = buildBaseRequest(
+                input, userContent, true);
 
         request.stream()
                 .chatResponse()
@@ -204,13 +215,21 @@ public class StreamingToolAgent extends LocalAgent {
      * Re-invokes the model via .call() WITH tool callbacks. Spring AI's
      * built-in tool execution loop handles all iterations. Tool AG-UI events
      * are emitted via the wrapper callbacks.
+     *
+     * <p>Internal tool execution is left ENABLED here (unlike Phase 1) so
+     * Spring AI's loop can execute backend tools. Frontend tools (injected
+     * by the CopilotKit runtime but unknown to this agent) are handled by
+     * the {@code LenientToolCallbackResolver} in
+     * {@link BoundedToolCallingManagerConfig}, which returns a placeholder
+     * callback instead of crashing.
      */
     private void callWithTools(
             RunAgentInput input, String userContent, String messageId,
             AssistantMessage assistantMessage, List<BaseEvent> deferredEvents,
             AgentSubscriber subscriber) {
 
-        ChatClient.ChatClientRequestSpec request = buildBaseRequest(input, userContent);
+        ChatClient.ChatClientRequestSpec request = buildBaseRequest(
+                input, userContent, false);
 
         // Wrap each tool callback to emit AG-UI events when invoked
         if (!toolCallbacks.isEmpty()) {
@@ -236,12 +255,29 @@ public class StreamingToolAgent extends LocalAgent {
     /**
      * Builds a base ChatClient request with system prompt and memory
      * but WITHOUT tool callbacks.
+     *
+     * @param disableInternalToolExecution when {@code true}, sets
+     *        {@code internalToolExecutionEnabled=false} on the request
+     *        options. This prevents Spring AI's model layer from
+     *        auto-executing tool calls through the global
+     *        {@link org.springframework.ai.model.tool.ToolCallingManager}.
+     *        Used by the streaming path (Phase 1) so that tool_calls in
+     *        the stream are detected but not executed — execution happens
+     *        in Phase 2 via {@code .call()} with explicit tool callbacks.
      */
     private ChatClient.ChatClientRequestSpec buildBaseRequest(
-            RunAgentInput input, String userContent) {
+            RunAgentInput input, String userContent,
+            boolean disableInternalToolExecution) {
         ChatClient.ChatClientRequestSpec request = chatClient.prompt(
                 Prompt.builder().content(userContent).build())
                 .system(systemMessage);
+
+        if (disableInternalToolExecution) {
+            request = request.options(
+                    OpenAiChatOptions.builder()
+                            .internalToolExecutionEnabled(false)
+                            .build());
+        }
 
         if (chatMemory != null) {
             request.advisors(PromptChatMemoryAdvisor.builder(chatMemory).build());


### PR DESCRIPTION
## Summary

- **StreamingToolAgent Phase 1 (streaming)**: Set `internalToolExecutionEnabled=false` via `OpenAiChatOptions` so Spring AI detects `tool_calls` in the stream without attempting execution through the global `ToolCallingManager`. Previously, `OpenAiChatModel.internalStream()` would auto-execute tool calls, and when the model called frontend tools (like `generate_task_steps`, `show_card`) that aren't registered on the Java backend, `StaticToolCallbackResolver` returned null causing `DefaultToolCallingManager` to throw `IllegalStateException`.
- **BoundedToolCallingManagerConfig**: Wrap `StaticToolCallbackResolver` with `LenientToolCallbackResolver` that returns a `FrontendToolPlaceholder` for unknown tools instead of letting the resolver return null. This prevents crashes during Phase 2 (`.call()`) when the model calls frontend tools injected by the CopilotKit runtime.
- **AG-UI event ordering**: Reorder event emission so tool call events are emitted BEFORE `textMessageEnd`, which is required for the frontend's `useRenderTool` to see them while the message is still open.

## Why

PR #4475 introduced `StreamingToolAgent` which uses Spring AI's `.stream()` for real-time text delivery. However, Spring AI's `OpenAiChatModel.internalStream()` auto-executes tool calls through the global `ToolCallingManager`, which only knows about backend tools. Frontend tools injected by the CopilotKit runtime caused `IllegalStateException` crashes, breaking all D5 tests (0/11).

This fix recovers agentic-chat, gen-ui-custom, and gen-ui-headless D5 tests (3/11). The remaining 8 failures are pre-existing issues in other controllers (subagents, shared-state, hitl) unrelated to the streaming regression.

## Test plan

- [ ] `showcase test spring-ai --d5 --verbose` passes agentic-chat, gen-ui-custom, gen-ui-headless
- [ ] Docker build succeeds locally
- [ ] No `IllegalStateException` in Spring AI container logs during D5 runs
- [ ] Frontend tool calls (generate_task_steps, show_card) handled gracefully via placeholder