### PR TITLE
refactor(showcase): migrate multimodal demos from legacy binary to modern AG-UI content shape

### DIFF
--- a/showcase/integrations/claude-sdk-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/multimodal_agent.py
@@ -25,11 +25,19 @@ each attachment in-process:
   PDF beta access.
 - Anything else falls through as-is.
 
+The legacy ``binary`` shape is *not* handled here. The runtime route at
+``src/app/api/copilotkit-multimodal/route.ts`` does not install an
+``onRunInitialized`` shim that rewrites modern parts into ``binary``,
+and ``HttpAgent`` forwards parts through unchanged — so this backend
+only ever sees the modern AG-UI shape. If a future page somewhere in
+the chain ever needs to downgrade to ``binary``, fix it there rather
+than re-introducing a dead branch here.
+
 References:
 - packages/runtime/src/agent/converters/tanstack.ts (modern AG-UI parts)
-- langgraph-python multimodal_agent.py (baseline pattern; the legacy
-  ``binary`` shim is not needed here because HttpAgent forwards modern
-  parts through without rewriting them).
+- langgraph-python multimodal_agent.py (baseline pattern; that demo
+  needs a ``binary`` shim because the published ``@ag-ui/langgraph``
+  converter drops modern parts — Claude's HttpAgent path doesn't).
 """
 
 from __future__ import annotations
@@ -165,30 +173,6 @@ def convert_part_for_claude(part: Any) -> Any:
             "type": "text",
             "text": f"[Attached document: unsupported type {mime or 'unknown'}.]",
         }
-
-    # Legacy ``binary`` shape (defensive: if any adapter in the chain
-    # still rewrites to it, handle it here instead of dropping).
-    if part_type == "binary":
-        mime = (part.get("mimeType") or "").lower()
-        data = part.get("data")
-        if isinstance(data, str) and mime.startswith("image/"):
-            return {
-                "type": "image",
-                "source": {
-                    "type": "base64",
-                    "media_type": mime,
-                    "data": data,
-                },
-            }
-        if isinstance(data, str) and "pdf" in mime:
-            text = _extract_pdf_text(data)
-            if text:
-                return {"type": "text", "text": f"[Attached document]\n{text}"}
-            return {
-                "type": "text",
-                "text": "[Attached document: PDF could not be read.]",
-            }
-        return part
 
     return part
 

--- a/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
@@ -81,28 +81,42 @@ console.log(
 // ---------------------------------------------------------------------------
 
 /**
- * Convert an AG-UI `binary` content part into an Anthropic ContentBlock.
- * Returns `null` if the part cannot be mapped (unsupported mime/no payload).
+ * Convert a modern AG-UI multimodal content part into an Anthropic
+ * ContentBlock. Returns `null` if the part cannot be mapped (unsupported
+ * mime / missing payload).
+ *
+ * Modern AG-UI shape (>= @ag-ui/core 0.0.48) splits each attachment by
+ * media type and wraps the payload in a tagged `source`:
+ *   { type: "image"   | "audio" | "video" | "document",
+ *     source: { type: "data", value: <base64>,  mimeType }
+ *           | { type: "url",  value: <url>,     mimeType } }
  *
  * Claude's Messages API accepts `image` and `document` blocks natively;
  * images use `source: { type: "base64", media_type, data }` and PDFs use
- * `type: "document"` with the same source shape. URL-backed parts are
- * mapped to `source: { type: "url", url }`.
+ * `type: "document"` with the same source shape. URL-backed parts map to
+ * `source: { type: "url", url }`.
+ *
+ * Audio and video parts are dropped — Anthropic Messages doesn't accept
+ * those block types — but we don't crash the run. The frontend's
+ * `accept` attribute restricts uploads to image + PDF, so this is purely
+ * a defensive guard against future demo changes.
  */
-function binaryPartToAnthropic(part: {
-  type: "binary";
-  mimeType: string;
-  data?: string;
-  url?: string;
+function modernPartToAnthropic(part: {
+  type: "image" | "audio" | "video" | "document";
+  source?: { type?: string; value?: string; mimeType?: string };
 }): Anthropic.ContentBlockParam | null {
-  const mime = part.mimeType || "";
-  const isImage = mime.startsWith("image/");
+  const source = part.source;
+  if (!source || typeof source.value !== "string") return null;
+
+  const mime = source.mimeType || "";
+  const isImage = part.type === "image" || mime.startsWith("image/");
   const isPdf =
-    mime === "application/pdf" || mime.toLowerCase().includes("pdf");
+    part.type === "document" &&
+    (mime === "application/pdf" || mime.toLowerCase().includes("pdf"));
 
   if (!isImage && !isPdf) return null;
 
-  if (part.data) {
+  if (source.type === "data") {
     if (isImage) {
       return {
         type: "image",
@@ -113,7 +127,7 @@ function binaryPartToAnthropic(part: {
             | "image/png"
             | "image/gif"
             | "image/webp",
-          data: part.data,
+          data: source.value,
         },
       };
     }
@@ -122,21 +136,21 @@ function binaryPartToAnthropic(part: {
       source: {
         type: "base64",
         media_type: "application/pdf",
-        data: part.data,
+        data: source.value,
       },
     };
   }
 
-  if (part.url) {
+  if (source.type === "url") {
     if (isImage) {
       return {
         type: "image",
-        source: { type: "url", url: part.url },
+        source: { type: "url", url: source.value },
       };
     }
     return {
       type: "document",
-      source: { type: "url", url: part.url },
+      source: { type: "url", url: source.value },
     };
   }
 
@@ -150,14 +164,23 @@ function buildAnthropicMessages(messages: Message[]): Anthropic.MessageParam[] {
     if (msg.role === "user") {
       const raw = (msg as any).content;
       if (Array.isArray(raw)) {
-        // AG-UI content parts — map text + binary to Anthropic blocks.
+        // AG-UI content parts — map text + modern multimodal parts
+        // (image/document/audio/video, source-tagged) to Anthropic blocks.
+        // The AG-UI client's BackwardCompatibility_0_0_47 middleware
+        // upgrades any legacy `binary` parts to this modern shape before
+        // they reach this server, so there's no separate `binary` branch.
         const blocks: Anthropic.ContentBlockParam[] = [];
         for (const part of raw) {
           if (!part || typeof part !== "object") continue;
           if (part.type === "text" && typeof part.text === "string") {
             blocks.push({ type: "text", text: part.text });
-          } else if (part.type === "binary") {
-            const mapped = binaryPartToAnthropic(part);
+          } else if (
+            part.type === "image" ||
+            part.type === "document" ||
+            part.type === "audio" ||
+            part.type === "video"
+          ) {
+            const mapped = modernPartToAnthropic(part);
             if (mapped) blocks.push(mapped);
           }
         }
@@ -274,8 +297,10 @@ function buildTools(tools: RunAgentInput["tools"]): Anthropic.Tool[] {
 }
 
 /**
- * Does the user messages contain any binary parts? Used to route the run
- * to the vision-capable Sonnet model instead of the default Haiku.
+ * Does the user messages contain any modern multimodal parts? Used to
+ * route the run to the vision-capable Sonnet model instead of the default
+ * Haiku. Matches the same set of part types that `modernPartToAnthropic`
+ * accepts so the model selection and the body translation stay in sync.
  */
 function messagesHaveAttachments(messages: Message[]): boolean {
   for (const msg of messages) {
@@ -283,7 +308,13 @@ function messagesHaveAttachments(messages: Message[]): boolean {
     const content = (msg as any).content;
     if (!Array.isArray(content)) continue;
     for (const part of content) {
-      if (part && typeof part === "object" && part.type === "binary") {
+      if (!part || typeof part !== "object") continue;
+      if (
+        part.type === "image" ||
+        part.type === "document" ||
+        part.type === "audio" ||
+        part.type === "video"
+      ) {
         return true;
       }
     }

--- a/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
@@ -94,7 +94,9 @@ const ANTHROPIC_SUPPORTED_IMAGE_MIMES = [
 
 type AnthropicImageMime = (typeof ANTHROPIC_SUPPORTED_IMAGE_MIMES)[number];
 
-function isSupportedAnthropicImageMime(mime: string): mime is AnthropicImageMime {
+function isSupportedAnthropicImageMime(
+  mime: string,
+): mime is AnthropicImageMime {
   return (ANTHROPIC_SUPPORTED_IMAGE_MIMES as readonly string[]).includes(mime);
 }
 

--- a/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
@@ -80,6 +80,26 @@ console.log(
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Anthropic Messages API only accepts these image mime types for base64
+// image blocks. The frontend's `accept="image/*"` is broader (svg, heic,
+// avif, bmp, ...), so we whitelist here and drop anything else with a
+// warning rather than forwarding an unsupported type and getting an
+// opaque 400 from the API.
+const ANTHROPIC_SUPPORTED_IMAGE_MIMES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+type AnthropicImageMime = (typeof ANTHROPIC_SUPPORTED_IMAGE_MIMES)[number];
+
+function isSupportedAnthropicImageMime(mime: string): mime is AnthropicImageMime {
+  return (ANTHROPIC_SUPPORTED_IMAGE_MIMES as readonly string[]).includes(mime);
+}
+
+const warnedUnsupportedImageMimes = new Set<string>();
+
 /**
  * Convert a modern AG-UI multimodal content part into an Anthropic
  * ContentBlock. Returns `null` if the part cannot be mapped (unsupported
@@ -110,11 +130,23 @@ function modernPartToAnthropic(part: {
 
   const mime = source.mimeType || "";
   const isImage = part.type === "image" || mime.startsWith("image/");
-  const isPdf =
-    part.type === "document" &&
-    (mime === "application/pdf" || mime.toLowerCase().includes("pdf"));
+  // Strict equality only — loose substring matching ("includes('pdf')")
+  // would match unrelated mimes like `text/pdf-spec` or
+  // `application/x-pdfanything`, which Anthropic then rejects when we
+  // forward them as `application/pdf`.
+  const isPdf = part.type === "document" && mime === "application/pdf";
 
   if (!isImage && !isPdf) return null;
+
+  if (isImage && !isSupportedAnthropicImageMime(mime)) {
+    if (!warnedUnsupportedImageMimes.has(mime)) {
+      warnedUnsupportedImageMimes.add(mime);
+      console.warn(
+        `[agent_server] dropping image attachment with unsupported mime type "${mime}"; Anthropic Messages only accepts ${ANTHROPIC_SUPPORTED_IMAGE_MIMES.join(", ")}.`,
+      );
+    }
+    return null;
+  }
 
   if (source.type === "data") {
     if (isImage) {
@@ -122,11 +154,7 @@ function modernPartToAnthropic(part: {
         type: "image",
         source: {
           type: "base64",
-          media_type: mime as
-            | "image/jpeg"
-            | "image/png"
-            | "image/gif"
-            | "image/webp",
+          media_type: mime as AnthropicImageMime,
           data: source.value,
         },
       };
@@ -297,6 +325,38 @@ function buildTools(tools: RunAgentInput["tools"]): Anthropic.Tool[] {
 }
 
 /**
+ * Returns true iff `modernPartToAnthropic(part)` would produce a
+ * non-null Anthropic ContentBlock. Centralizing the check keeps
+ * `messagesHaveAttachments` (model routing) and the body translation
+ * in sync — otherwise a user uploading e.g. a `.docx` document part
+ * would route to the more expensive vision model and then have its
+ * attachment silently dropped at conversion time.
+ */
+function isAnthropicSupportedPart(part: unknown): boolean {
+  if (!part || typeof part !== "object") return false;
+  const p = part as {
+    type?: unknown;
+    source?: { type?: string; value?: string; mimeType?: string };
+  };
+  if (
+    p.type !== "image" &&
+    p.type !== "document" &&
+    p.type !== "audio" &&
+    p.type !== "video"
+  ) {
+    return false;
+  }
+  return (
+    modernPartToAnthropic(
+      p as {
+        type: "image" | "audio" | "video" | "document";
+        source?: { type?: string; value?: string; mimeType?: string };
+      },
+    ) !== null
+  );
+}
+
+/**
  * Does the user messages contain any modern multimodal parts? Used to
  * route the run to the vision-capable Sonnet model instead of the default
  * Haiku. Matches the same set of part types that `modernPartToAnthropic`
@@ -308,13 +368,7 @@ function messagesHaveAttachments(messages: Message[]): boolean {
     const content = (msg as any).content;
     if (!Array.isArray(content)) continue;
     for (const part of content) {
-      if (!part || typeof part !== "object") continue;
-      if (
-        part.type === "image" ||
-        part.type === "document" ||
-        part.type === "audio" ||
-        part.type === "video"
-      ) {
+      if (isAnthropicSupportedPart(part)) {
         return true;
       }
     }

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/multimodal/page.tsx
@@ -8,27 +8,20 @@
  * same pipeline the paperclip button uses.
  *
  * Claude handles image and PDF attachments natively through the Messages
- * API — no pypdf-style flattening is required on the backend. We still
- * rewrite CopilotChat's modern multimodal parts
- * (`{ type: "image" | "document", source: { type: "data", value, mimeType } }`)
- * to the AG-UI legacy `binary` shape before submission so they survive the
- * AG-UI protocol schema (which, at the currently pinned version, only
- * validates `text` and `binary` user-content parts). The Claude
- * `agent_server.ts` maps those `binary` parts back into Anthropic
- * `image` / `document` blocks server-side.
+ * API — no pypdf-style flattening is required on the backend. The chat
+ * forwards CopilotChat's modern multimodal parts directly through the
+ * AG-UI protocol:
+ *   `{ type: "image" | "document", source: { type: "data", value, mimeType } }`
+ * The AG-UI runtime is pinned at `@ag-ui/core ^0.0.48`, which validates
+ * those shapes natively, and `agent_server.ts` maps them straight into
+ * Anthropic `image` / `document` blocks server-side.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 type DataUploadResult = Extract<AttachmentUploadResult, { type: "data" }>;
 
@@ -63,107 +56,11 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/crewai-crews/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/multimodal/page.tsx
@@ -11,57 +11,62 @@
  * - Dedicated runtime route at `/api/copilotkit-multimodal` (see
  *   ../api/copilotkit-multimodal/route.ts). The AG-UI attachment pipeline is
  *   scoped to just this demo so other cells' runtimes stay lean.
- * - Backend: shared CrewAI crew. CAVEAT — the shared crew's chat LLM is
- *   `gpt-4o`, which accepts image content blocks, but crew agents themselves
- *   use their configured model. Attachments reach the chat-LLM layer
- *   (ChatWithCrewFlow's `acompletion`) which forwards them natively for
- *   vision. PDFs are flattened to text by the runtime before the agent sees
- *   them. This is NOT a bespoke vision crew — a dedicated per-demo crew with
- *   vision-tuned agent prompts is tracked as follow-up work.
+ * - Backend: shared CrewAI crew over `HttpAgent`. CAVEAT — the shared crew's
+ *   chat LLM is `gpt-4o`, which accepts image content blocks, but crew
+ *   agents themselves use their configured model. Attachments reach the
+ *   chat-LLM layer (`ChatWithCrewFlow`'s `acompletion`) which forwards them
+ *   natively for vision. PDFs are flattened to text by the runtime before
+ *   the agent sees them. This is NOT a bespoke vision crew — a dedicated
+ *   per-demo crew with vision-tuned agent prompts is tracked as follow-up
+ *   work.
  * - Sample files live at `/demo-files/sample.png` and `/demo-files/sample.pdf`.
  *   The sample-buttons component fetches them client-side, wraps the blob in
  *   a File, and drives the same hidden `<input type="file">` the paperclip
  *   path uses.
  *
- * Legacy-shape rewrite:
- * - The AG-UI → downstream agent converters that some agent adapters ship
- *   today (notably the published `@ag-ui/langgraph` 0.0.x converter) only
- *   understand the legacy `{ type: "binary", mimeType, data | url }`
- *   content-part shape when forwarding AG-UI messages. The modern
- *   `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
- *   parts that CopilotChat emits may be silently dropped depending on the
- *   adapter version. To make this demo robust across runtime versions, we
- *   rewrite outgoing user-message image/document/audio/video parts to the
- *   legacy `binary` shape in `onRunInitialized`. If the downstream converter
- *   already handles modern parts the rewrite is a no-op (idempotent when
- *   applied on already-legacy parts).
+ * Modern AG-UI shape:
+ * - User-message attachments are emitted in the modern multimodal shape
+ *   (`{ type: "image" | "document", source: { type: "data" | "url", ... } }`)
+ *   that CopilotChat produces by default. The CrewAI Python adapter is
+ *   content-shape-agnostic: it forwards user messages straight into
+ *   litellm's `acompletion()` without rewriting content parts. No
+ *   downstream AG-UI converter (e.g. the legacy `@ag-ui/langgraph` 0.0.x
+ *   path) sits between this demo and the agent, so no legacy `binary`
+ *   rewrite is needed.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
 
 /**
- * Minimal structural shape of an AG-UI message. `@ag-ui/client`'s exported
- * `Message` is a tagged union by role, but for the rewrite we only care
- * about the `user` branch and treat every other role as pass-through.
- * Keeping the type local avoids pulling `@ag-ui/client` into this package's
- * direct dependencies.
+ * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
+ * always return the `data` variant — the demo inlines base64 instead of
+ * uploading to external storage.
  */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
-
 type DataUploadResult = Extract<AttachmentUploadResult, { type: "data" }>;
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 const ACCEPT_MIME = "image/*,application/pdf";
+/**
+ * Selector used by <SampleAttachmentButtons /> to locate CopilotChat's
+ * hidden file input. Kept as a constant so the wrapper element and the
+ * sample buttons cannot drift.
+ */
 const CHAT_ROOT_SELECTOR = "[data-multimodal-demo-chat-root]";
 
+/**
+ * Convert a File into the `AttachmentsConfig.onUpload` result shape —
+ * inline base64 with the browser-provided mime type. We do this in the
+ * browser rather than uploading to external storage because this is a
+ * self-contained demo; `maxSize: 10 MB` (set below) caps bloat.
+ *
+ * `FileReader` produces a `data:<mime>;base64,<payload>` URL; we strip the
+ * prefix so the runtime forwards the raw base64 value (what the agent
+ * expects in `source.value`).
+ */
 function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -73,6 +78,7 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
         reject(new Error(`Unexpected FileReader result type for ${file.name}`));
         return;
       }
+      // result looks like "data:image/png;base64,iVBORw0K..." — strip the prefix.
       const commaIdx = result.indexOf(",");
       const base64 = commaIdx >= 0 ? result.slice(commaIdx + 1) : result;
       resolve({
@@ -89,138 +95,16 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
- *
- * Some AG-UI → downstream-agent converters only recognize legacy `binary`
- * parts; modern parts are silently filtered out in those adapters. Returning
- * the legacy shape keeps the attachment visible to the agent while leaving
- * everything else (CopilotChat UI, upload pipeline, etc.) untouched. Text
- * parts and already-legacy parts pass through unchanged (idempotent).
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
- *
- * Returns the same array reference if nothing changed so the subscriber in
- * `onRunInitialized` can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent. Scoped to
- * a small inner component so it can use the `useAgent` hook the
- * <CopilotChat> parent already relies on — subscribing there means we
- * rewrite messages on the *same* agent instance CopilotChat dispatches
- * through, even when threads are cloned or swapped.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
-    // structural message shape and returns only partial mutations, so cast
-    // at the subscribe boundary. The cast is safe: our onRunInitialized
-    // only ever returns a messages-mutation or void.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
+  // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
+  // paperclip button and the sample-injection path route files through
+  // this same function (sample buttons drive CopilotChat's hidden file
+  // input, which calls this internally via `useAttachments`). No
+  // duplicated upload code lives in the sample-button component.
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"
@@ -249,6 +133,8 @@ export default function MultimodalDemoPage() {
               maxSize: MAX_FILE_SIZE_BYTES,
               onUpload,
               onUploadFailed: (err) => {
+                // Log without disrupting the default UI — CopilotChat already
+                // shows a toast-style indicator on validation failure.
                 console.warn("[multimodal-demo] attachment rejected", err);
               },
             }}

--- a/showcase/integrations/langgraph-fastapi/src/agents/src/multimodal_agent.py
+++ b/showcase/integrations/langgraph-fastapi/src/agents/src/multimodal_agent.py
@@ -13,14 +13,12 @@ Attachments arrive here after travelling through:
                                                    (ag-ui → LangChain converter)
               →  this agent (LangChain HumanMessage content parts)
 
-The ag-ui-langgraph converter only understands the legacy
-``{ type: "binary", mimeType, data | url }`` AG-UI part shape — the page
-at ``src/app/demos/multimodal/page.tsx`` installs an
-``onRunInitialized`` shim that rewrites the modern
-``{ type: "image" | "document", source: {...} }`` shape CopilotChat emits
-to the legacy shape before it hits the runtime. Once the converter has
-run, every attachment shows up in this agent as a LangChain
-``image_url`` content part::
+CopilotChat emits the modern AG-UI multimodal shape
+(``{ "type": "image" | "document", "source": { "type": "data", "value",
+"mimeType" } }``). The ``@ag-ui/langgraph`` converter (>= 0.0.28) routes
+every media type through LangChain's ``image_url`` block — that is the
+only multimodal block shape LangChain natively supports — so by the time
+a message reaches this agent each attachment looks like::
 
     {"type": "image_url", "image_url": {"url": "data:<mime>;base64,<payload>"}}
 
@@ -33,9 +31,9 @@ the model can read them without needing file-part support.
 
 References:
 - src/agents/main.py, src/agents/agentic_chat.py (baseline pattern)
-- packages/runtime/src/agent/converters/tanstack.ts (the modern content-
-  part shape — useful context when the runtime gets upgraded and this
-  agent can drop the pypdf flatten)
+- F:/projects/cpk/ag-ui/integrations/langgraph/python/ag_ui_langgraph/utils.py
+  (the upstream AG-UI → LangChain converter that produces the
+  ``image_url`` shape this agent consumes)
 """
 
 from __future__ import annotations
@@ -118,55 +116,36 @@ def _classify_attachment_part(part: Any) -> tuple[str, str, str] | None:
     ``None`` if the part is not an attachment we recognise (plain text,
     unrelated dict, string, etc.).
 
-    Handles the shapes we actually see in practice:
+    The shape we see in practice is what the ``@ag-ui/langgraph``
+    converter emits for every modern AG-UI multimodal part:
 
     - ``{"type": "image_url", "image_url": {"url": "data:..."}}``
-      (what the ag-ui-langgraph converter emits for every attachment
-      after the page rewrites to legacy ``binary``).
     - ``{"type": "image_url", "image_url": "data:..."}``
-      (older LangChain/OpenAI shape where ``image_url`` is a raw string).
-    - ``{"type": "document", "source": {"type": "data",
-      "value": "<base64>", "mimeType": "application/pdf"}}``
-      (modern AG-UI shape — preserved for forward-compat if the runtime
-      ever starts forwarding modern parts directly).
+      (older LangChain/OpenAI shape where ``image_url`` is a raw string)
     """
     if not isinstance(part, dict):
         return None
-    part_type = part.get("type")
+    if part.get("type") != "image_url":
+        return None
 
-    if part_type == "image_url":
-        image_url = part.get("image_url")
-        url: str | None = None
-        if isinstance(image_url, str):
-            url = image_url
-        elif isinstance(image_url, dict):
-            raw_url = image_url.get("url")
-            if isinstance(raw_url, str):
-                url = raw_url
-        if not url:
-            return None
-        mime, payload = _extract_data_url_parts(url)
-        if not payload or not mime:
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, payload)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, payload)
-        return ("other", mime, payload)
-
-    if part_type == "document":
-        source = part.get("source")
-        if not isinstance(source, dict) or source.get("type") != "data":
-            return None
-        value = source.get("value")
-        mime = source.get("mimeType", "")
-        if not isinstance(value, str) or not isinstance(mime, str):
-            return None
-        if "pdf" in mime.lower():
-            return ("pdf", mime, value)
-        return ("other", mime, value)
-
-    return None
+    image_url = part.get("image_url")
+    url: str | None = None
+    if isinstance(image_url, str):
+        url = image_url
+    elif isinstance(image_url, dict):
+        raw_url = image_url.get("url")
+        if isinstance(raw_url, str):
+            url = raw_url
+    if not url:
+        return None
+    mime, payload = _extract_data_url_parts(url)
+    if not payload or not mime:
+        return None
+    if mime.startswith("image/"):
+        return ("image", mime, payload)
+    if "pdf" in mime.lower():
+        return ("pdf", mime, payload)
+    return ("other", mime, payload)
 
 
 def _preprocess_part(part: Any) -> Any:

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/multimodal/page.tsx
@@ -24,35 +24,20 @@
  *   `change`). This keeps the sample and real-upload paths on a single
  *   code path — whatever works for one works for both.
  *
- * Legacy-shape rewrite:
- * - The published `@ag-ui/langgraph` converter (0.0.x) only understands
- *   the legacy `{ type: "binary", mimeType, data | url }` content-part
- *   shape when forwarding AG-UI messages to LangChain. The modern
- *   `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
- *   parts that CopilotChat emits are silently dropped. Until the runtime
- *   ships an updated converter, we rewrite the outgoing user message in
- *   `onRunInitialized` so image/document/audio/video parts round-trip
- *   through the legacy shape the converter preserves.
+ * Wire format
+ * ===========
+ * CopilotChat emits the modern AG-UI multimodal shape
+ * (`{ type: "image" | "document", source: { type: "data", value, mimeType } }`),
+ * which the `@ag-ui/langgraph` converter (>= 0.0.28) routes to LangChain's
+ * `image_url` content blocks before the agent receives them. No client-side
+ * rewrite is needed.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. `@ag-ui/client`'s
- * exported `Message` is a tagged union by role, but for the rewrite
- * we only care about the `user` branch and treat every other role as
- * pass-through. Keeping the type local avoids pulling `@ag-ui/client`
- * into this package's direct dependencies.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -108,133 +93,6 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
- *
- * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
- * in that package) only recognizes legacy `binary` parts — modern parts
- * are silently filtered out, so the LangGraph agent never sees them.
- * Returning the legacy shape keeps the attachment visible to the agent
- * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
- * untouched. Text parts and already-legacy parts pass through unchanged.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
- *
- * Returns the same array reference if nothing changed so the subscriber
- * in `onRunInitialized` can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent. Scoped
- * to a small inner component so it can use the `useAgent` hook the
- * <CopilotChat> parent already relies on — subscribing there means we
- * rewrite messages on the *same* agent instance CopilotChat dispatches
- * through, even when threads are cloned or swapped.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
-    // structural message shape and returns only partial mutations, so
-    // cast at the subscribe boundary. The cast is safe: our
-    // onRunInitialized only ever returns a messages-mutation or void.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
   // paperclip button and the sample-injection path route files through
@@ -245,7 +103,6 @@ export default function MultimodalDemoPage() {
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
@@ -13,14 +13,12 @@ Attachments arrive here after travelling through:
                                                    (ag-ui → LangChain converter)
               →  this agent (LangChain HumanMessage content parts)
 
-The ag-ui-langgraph converter only understands the legacy
-``{ type: "binary", mimeType, data | url }`` AG-UI part shape — the page
-at ``src/app/demos/multimodal/page.tsx`` installs an
-``onRunInitialized`` shim that rewrites the modern
-``{ type: "image" | "document", source: {...} }`` shape CopilotChat emits
-to the legacy shape before it hits the runtime. Once the converter has
-run, every attachment shows up in this agent as a LangChain
-``image_url`` content part::
+CopilotChat emits the modern AG-UI multimodal shape
+``{ type: "image" | "document", source: { type: "data" | "url",
+value, mimeType } }``. The ``@ag-ui/langgraph`` converter
+(``convertAguiMultimodalToLangchain``) consumes this shape natively and
+routes every media kind through LangChain's ``image_url`` content block
+before it hits this agent::
 
     {"type": "image_url", "image_url": {"url": "data:<mime>;base64,<payload>"}}
 
@@ -29,13 +27,15 @@ regardless of whether the upstream modality was ``image`` or ``document``.
 We therefore route on ``mimeType``, not the part ``type``:
 ``image/*`` parts are forwarded to GPT-4o unchanged (vision-native);
 ``application/pdf`` parts are flattened to inline text via ``pypdf`` so
-the model can read them without needing file-part support.
+the model can read them without needing file-part support. The modern
+``document`` branch in ``_classify_attachment_part`` is kept as a
+forward-compat path in case a future converter forwards document parts
+through unchanged instead of flattening them to ``image_url``.
 
 References:
 - src/agents/main.py, src/agents/agentic_chat.py (baseline pattern)
 - packages/runtime/src/agent/converters/tanstack.ts (the modern content-
-  part shape — useful context when the runtime gets upgraded and this
-  agent can drop the pypdf flatten)
+  part shape on the JS side)
 """
 
 from __future__ import annotations
@@ -121,14 +121,16 @@ def _classify_attachment_part(part: Any) -> tuple[str, str, str] | None:
     Handles the shapes we actually see in practice:
 
     - ``{"type": "image_url", "image_url": {"url": "data:..."}}``
-      (what the ag-ui-langgraph converter emits for every attachment
-      after the page rewrites to legacy ``binary``).
+      (what the ag-ui-langgraph converter emits for every attachment —
+      both ``image`` and ``document`` modern AG-UI parts are mapped to
+      LangChain's ``image_url`` block by ``convertAguiMultimodalToLangchain``).
     - ``{"type": "image_url", "image_url": "data:..."}``
       (older LangChain/OpenAI shape where ``image_url`` is a raw string).
     - ``{"type": "document", "source": {"type": "data",
       "value": "<base64>", "mimeType": "application/pdf"}}``
-      (modern AG-UI shape — preserved for forward-compat if the runtime
-      ever starts forwarding modern parts directly).
+      (modern AG-UI shape — preserved for forward-compat if a future
+      converter forwards document parts through unchanged instead of
+      flattening them to ``image_url``).
     """
     if not isinstance(part, dict):
         return None

--- a/showcase/integrations/langgraph-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/multimodal/page.tsx
@@ -24,35 +24,21 @@
  *   `change`). This keeps the sample and real-upload paths on a single
  *   code path — whatever works for one works for both.
  *
- * Legacy-shape rewrite:
- * - The published `@ag-ui/langgraph` converter (0.0.x) only understands
- *   the legacy `{ type: "binary", mimeType, data | url }` content-part
- *   shape when forwarding AG-UI messages to LangChain. The modern
- *   `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
- *   parts that CopilotChat emits are silently dropped. Until the runtime
- *   ships an updated converter, we rewrite the outgoing user message in
- *   `onRunInitialized` so image/document/audio/video parts round-trip
- *   through the legacy shape the converter preserves.
+ * Multimodal content shape:
+ * - CopilotChat emits the modern AG-UI multimodal content-part shape
+ *   `{ type: "image" | "document" | "audio" | "video",
+ *      source: { type: "data" | "url", value, mimeType } }`.
+ *   `@ag-ui/langgraph`'s `aguiMessagesToLangChain` converter consumes this
+ *   shape natively (see `convertAguiMultimodalToLangchain` in that package),
+ *   routing every media kind through LangChain's `image_url` content block
+ *   for the agent to receive. No client-side rewrite is required.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. `@ag-ui/client`'s
- * exported `Message` is a tagged union by role, but for the rewrite
- * we only care about the `user` branch and treat every other role as
- * pass-through. Keeping the type local avoids pulling `@ag-ui/client`
- * into this package's direct dependencies.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -108,133 +94,6 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
- *
- * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
- * in that package) only recognizes legacy `binary` parts — modern parts
- * are silently filtered out, so the LangGraph agent never sees them.
- * Returning the legacy shape keeps the attachment visible to the agent
- * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
- * untouched. Text parts and already-legacy parts pass through unchanged.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
- *
- * Returns the same array reference if nothing changed so the subscriber
- * in `onRunInitialized` can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent. Scoped
- * to a small inner component so it can use the `useAgent` hook the
- * <CopilotChat> parent already relies on — subscribing there means we
- * rewrite messages on the *same* agent instance CopilotChat dispatches
- * through, even when threads are cloned or swapped.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
-    // structural message shape and returns only partial mutations, so
-    // cast at the subscribe boundary. The cast is safe: our
-    // onRunInitialized only ever returns a messages-mutation or void.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
   // paperclip button and the sample-injection path route files through
@@ -245,7 +104,6 @@ export default function MultimodalDemoPage() {
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/langgraph-typescript/src/agent/multimodal.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/multimodal.ts
@@ -41,7 +41,8 @@ import {
 } from "@langchain/langgraph";
 import { ChatOpenAI } from "@langchain/openai";
 import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
-import pdfParse from "pdf-parse";
+// Deep import bypasses pdf-parse's debug entrypoint, which reads a test fixture at import time.
+import pdfParse from "pdf-parse/lib/pdf-parse.js";
 
 const SYSTEM_PROMPT =
   "You are a helpful assistant. The user may attach images or documents " +

--- a/showcase/integrations/langgraph-typescript/src/agent/multimodal.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/multimodal.ts
@@ -3,17 +3,27 @@
  * attachments scoped to the `/demos/multimodal` cell.
  *
  * Uses a *dedicated* vision-capable graph (gpt-4o) so other demos continue
- * to use cheaper, text-only models. Inputs forwarded by the runtime:
- *   - `{"type": "text", "text": "..."}`
- *   - `{"type": "image", "source": {"type": "data", "value": "<base64>",
- *      "mimeType": "image/png"}}`
- *   - `{"type": "document", "source": {"type": "data", "value": "<base64>",
- *      "mimeType": "application/pdf"}}`
+ * to use cheaper, text-only models.
  *
- * gpt-4o consumes `image` parts natively. For `document` parts (PDFs) we
- * extract text server-side via `pdf-parse` and inline it as a text part
- * with a clear delimiter — matching the Python reference's `pypdf`-backed
- * extraction so the TS multimodal demo reaches feature parity.
+ * Content-part shapes the agent has to handle
+ * --------------------------------------------
+ * Modern AG-UI shape (primary, what CopilotChat emits):
+ *   - `{ "type": "text", "text": "..." }`
+ *   - `{ "type": "image",    "source": { "type": "data", "value": "<base64>", "mimeType": "image/png" } }`
+ *   - `{ "type": "document", "source": { "type": "data", "value": "<base64>", "mimeType": "application/pdf" } }`
+ *
+ * Post-converter LangChain shape (what actually reaches the LangGraph
+ * deployment after `@ag-ui/langgraph`'s `aguiMessagesToLangChain`
+ * collapses every modern media type into LangChain's only multimodal
+ * primitive):
+ *   - `{ "type": "image_url", "image_url": { "url": "data:<mime>;base64,<payload>" } }`
+ *
+ * gpt-4o consumes `image_url` parts whose data URL has an `image/*` mime
+ * type natively. PDFs cannot be ingested as images, so we detect the
+ * `application/pdf` data URL and extract the text server-side via
+ * `pdf-parse`, replacing the part with an inline text part. The modern
+ * `document` shape is preserved as a fallback for any flow that
+ * forwards AG-UI parts directly without going through the converter.
  */
 
 import { RunnableConfig } from "@langchain/core/runnables";
@@ -48,19 +58,97 @@ type AgentState = typeof AgentStateAnnotation.State;
 interface ContentPart {
   type?: string;
   text?: string;
+  image_url?: string | { url?: string };
   source?: { type?: string; value?: string; mimeType?: string };
   [k: string]: unknown;
 }
 
+/** Parse a `data:<mime>;base64,<payload>` URL into its parts. */
+function parseDataUrl(url: string): { mime: string; payload: string } | null {
+  if (!url.startsWith("data:")) return null;
+  const commaIdx = url.indexOf(",");
+  if (commaIdx < 0) return null;
+  const header = url.slice(5, commaIdx); // strip "data:"
+  const payload = url.slice(commaIdx + 1);
+  // header is "<mime>;base64" (we only ever emit base64 data URLs here).
+  const mime = header.split(";", 1)[0] ?? "";
+  if (!mime || !payload) return null;
+  return { mime, payload };
+}
+
+/** Extract text from a base64-encoded PDF payload. Returns "" on failure. */
+async function extractPdfText(base64Payload: string): Promise<{
+  text: string;
+  pages: number;
+} | null> {
+  try {
+    const buffer = Buffer.from(base64Payload, "base64");
+    const parsed = await pdfParse(buffer);
+    return { text: parsed.text.trim(), pages: parsed.numpages };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[multimodal_agent] pdf-parse failed: ${message}`);
+    return null;
+  }
+}
+
+/** Build a `[Attached PDF]` text part from extracted PDF text. */
+function buildPdfTextPart(extracted: { text: string; pages: number } | null): {
+  type: "text";
+  text: string;
+} {
+  if (!extracted || !extracted.text) {
+    return {
+      type: "text",
+      text: "[Attached document: PDF could not be read.]",
+    };
+  }
+  const { text, pages } = extracted;
+  return {
+    type: "text",
+    text:
+      `[Attached PDF (${pages} page${pages === 1 ? "" : "s"}) — extracted text follows]\n\n` +
+      text,
+  };
+}
+
 /**
  * Rewrite a multimodal content part into a shape the OpenAI chat API
- * understands. Images are converted to OpenAI's `image_url` data-URL parts.
- * PDF `document` parts have their text extracted server-side via `pdf-parse`
- * and inlined. Plain text passes through unchanged.
+ * understands.
+ *
+ * - Post-converter `image_url` parts whose data URL is an image pass
+ *   through unchanged (gpt-4o consumes them natively).
+ * - Post-converter `image_url` parts whose data URL is a PDF have their
+ *   text extracted server-side and are replaced with a text part.
+ * - Modern AG-UI `image` parts are normalized to `image_url`.
+ * - Modern AG-UI `document` parts (PDFs) have their text extracted
+ *   server-side and are replaced with a text part.
+ * - Plain text and unrecognized parts pass through unchanged.
  */
 async function rewritePart(part: unknown): Promise<unknown> {
   if (!part || typeof part !== "object") return part;
   const p = part as ContentPart;
+
+  // Post-converter LangChain shape (what `@ag-ui/langgraph` emits today).
+  if (p.type === "image_url") {
+    const url =
+      typeof p.image_url === "string"
+        ? p.image_url
+        : (p.image_url?.url ?? "");
+    const parsed = parseDataUrl(url);
+    if (!parsed) return part;
+    if (parsed.mime.startsWith("image/")) {
+      return part;
+    }
+    if (parsed.mime.toLowerCase().includes("pdf")) {
+      const extracted = await extractPdfText(parsed.payload);
+      return buildPdfTextPart(extracted);
+    }
+    return part;
+  }
+
+  // Modern AG-UI shape — preserved for forward-compat / direct AG-UI flows
+  // that bypass the LangChain converter.
   if (p.type === "image" && p.source?.type === "data") {
     const mime = p.source.mimeType ?? "image/png";
     const value = p.source.value ?? "";
@@ -75,37 +163,20 @@ async function rewritePart(part: unknown): Promise<unknown> {
   if (p.type === "document" && p.source?.type === "data") {
     const mime = p.source.mimeType ?? "";
     const value = p.source.value ?? "";
-    if (mime === "application/pdf" && value) {
-      try {
-        // Strip data: prefix if present, then base64-decode.
-        const base64 = value.startsWith("data:")
-          ? value.slice(value.indexOf(",") + 1)
-          : value;
-        const buffer = Buffer.from(base64, "base64");
-        const parsed = await pdfParse(buffer);
-        const text = parsed.text.trim();
-        if (text) {
-          return {
-            type: "text",
-            text:
-              `[Attached PDF (${parsed.numpages} page${parsed.numpages === 1 ? "" : "s"}) — extracted text follows]\n\n` +
-              text,
-          };
-        }
-      } catch (err) {
-        // Fall through to the generic marker below on extraction failure.
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          type: "text",
-          text: `[Attached PDF — server-side extraction failed: ${message}]`,
-        };
-      }
+    if (mime.toLowerCase().includes("pdf") && value) {
+      // Strip data: prefix if present, then base64-decode.
+      const base64 = value.startsWith("data:")
+        ? value.slice(value.indexOf(",") + 1)
+        : value;
+      const extracted = await extractPdfText(base64);
+      return buildPdfTextPart(extracted);
     }
     return {
       type: "text",
       text: `[Attached document${mime ? ` (${mime})` : ""}: contents not extracted server-side; describe what you can infer from the filename/type if asked.]`,
     };
   }
+
   return part;
 }
 

--- a/showcase/integrations/langgraph-typescript/src/agent/multimodal.ts
+++ b/showcase/integrations/langgraph-typescript/src/agent/multimodal.ts
@@ -133,9 +133,7 @@ async function rewritePart(part: unknown): Promise<unknown> {
   // Post-converter LangChain shape (what `@ag-ui/langgraph` emits today).
   if (p.type === "image_url") {
     const url =
-      typeof p.image_url === "string"
-        ? p.image_url
-        : (p.image_url?.url ?? "");
+      typeof p.image_url === "string" ? p.image_url : (p.image_url?.url ?? "");
     const parsed = parseDataUrl(url);
     if (!parsed) return part;
     if (parsed.mime.startsWith("image/")) {

--- a/showcase/integrations/langgraph-typescript/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/multimodal/page.tsx
@@ -12,10 +12,10 @@
  *   ../api/copilotkit-multimodal/route.ts). The vision-capable model
  *   (gpt-4o) is scoped to just this demo, so other cells keep their
  *   cheaper text-only models.
- * - Dedicated LangGraph agent at `src/agents/multimodal_agent.py` under
- *   the slug `multimodal-demo`. The agent is registered in langgraph.json
- *   under the graph id `multimodal`. Images are forwarded to the model
- *   natively; PDFs are flattened to text on the Python side via `pypdf`
+ * - Dedicated LangGraph agent at `src/agent/multimodal.ts` under the slug
+ *   `multimodal-demo`. The agent is registered in langgraph.json under
+ *   the graph id `multimodal`. Images are forwarded to the model
+ *   natively; PDFs are flattened to text on the Node side via `pdf-parse`
  *   for provider-agnostic behavior.
  * - Sample files live at `/demo-files/sample.png` and `/demo-files/sample.pdf`
  *   (see `public/demo-files/`). The sample-buttons component fetches them
@@ -23,36 +23,13 @@
  *   `<input type="file">` the paperclip path uses (DataTransfer + dispatch
  *   `change`). This keeps the sample and real-upload paths on a single
  *   code path — whatever works for one works for both.
- *
- * Legacy-shape rewrite:
- * - The published `@ag-ui/langgraph` converter (0.0.x) only understands
- *   the legacy `{ type: "binary", mimeType, data | url }` content-part
- *   shape when forwarding AG-UI messages to LangChain. The modern
- *   `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
- *   parts that CopilotChat emits are silently dropped. Until the runtime
- *   ships an updated converter, we rewrite the outgoing user message in
- *   `onRunInitialized` so image/document/audio/video parts round-trip
- *   through the legacy shape the converter preserves.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. `@ag-ui/client`'s
- * exported `Message` is a tagged union by role, but for the rewrite
- * we only care about the `user` branch and treat every other role as
- * pass-through. Keeping the type local avoids pulling `@ag-ui/client`
- * into this package's direct dependencies.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -108,133 +85,6 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
- *
- * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
- * in that package) only recognizes legacy `binary` parts — modern parts
- * are silently filtered out, so the LangGraph agent never sees them.
- * Returning the legacy shape keeps the attachment visible to the agent
- * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
- * untouched. Text parts and already-legacy parts pass through unchanged.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
- *
- * Returns the same array reference if nothing changed so the subscriber
- * in `onRunInitialized` can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent. Scoped
- * to a small inner component so it can use the `useAgent` hook the
- * <CopilotChat> parent already relies on — subscribing there means we
- * rewrite messages on the *same* agent instance CopilotChat dispatches
- * through, even when threads are cloned or swapped.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
-    // structural message shape and returns only partial mutations, so
-    // cast at the subscribe boundary. The cast is safe: our
-    // onRunInitialized only ever returns a messages-mutation or void.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
   // paperclip button and the sample-injection path route files through
@@ -245,7 +95,6 @@ export default function MultimodalDemoPage() {
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/langroid/src/agents/multimodal_agent.py
+++ b/showcase/integrations/langroid/src/agents/multimodal_agent.py
@@ -8,15 +8,16 @@ so the two demos exercise comparable behavior.
 
 Wire format
 ===========
-Attachments arrive in user-message content as either:
+Attachments arrive in user-message content as the modern AG-UI shape::
 
-1. ``{"type": "image", "source": {"type": "data", "value": "<b64>",
-   "mimeType": "image/png"}}`` — modern AG-UI shape that CopilotChat
-   emits natively.
-2. ``{"type": "binary", "mimeType": "application/pdf", "data": "<b64>"}``
-   — legacy AG-UI binary part the langgraph-python integration's
-   ``onRunInitialized`` shim normalizes to. Kept for interop in case a
-   future runtime path forwards through that converter.
+    {"type": "image" | "document",
+     "source": {"type": "data", "value": "<b64>", "mimeType": "..."}}
+
+Unlike the langgraph-python sibling, the Langroid path has no
+``@ag-ui/langgraph`` converter sitting between the runtime and the agent
+— ``HttpAgent`` forwards the AG-UI body unchanged to this FastAPI
+handler, so the modern shape arrives intact and no legacy ``binary``
+rewrite shim is needed on the page.
 
 Image parts are forwarded to OpenAI as ``image_url`` content parts with
 inline ``data:<mime>;base64,...`` URLs; gpt-4o reads them natively. PDF
@@ -113,7 +114,6 @@ def _normalize_part(part: Any) -> dict[str, Any] | None:
     - ``{"type": "text", "text": "..."}`` — passthrough.
     - ``{"type": "image", "source": {"type": "data", "value": "<b64>", "mimeType": "..."}}``
     - ``{"type": "document", "source": {"type": "data", "value": "<b64>", "mimeType": "..."}}``
-    - ``{"type": "binary", "mimeType": "...", "data": "<b64>"}`` (legacy)
     - ``{"type": "image_url", "image_url": {"url": "data:..."}}`` (already OpenAI shape)
     - bare strings (treated as text).
     """
@@ -161,26 +161,6 @@ def _normalize_part(part: Any) -> dict[str, Any] | None:
             }
         if "pdf" in mime.lower():
             text = _extract_pdf_text(value)
-            if not text:
-                return {
-                    "type": "text",
-                    "text": "[Attached document: PDF could not be read.]",
-                }
-            return {"type": "text", "text": f"[Attached document]\n{text}"}
-        return None
-
-    if ptype == "binary":
-        mime = part.get("mimeType") or ""
-        data = part.get("data")
-        if not isinstance(mime, str) or not isinstance(data, str):
-            return None
-        if mime.startswith("image/"):
-            return {
-                "type": "image_url",
-                "image_url": {"url": f"data:{mime};base64,{data}"},
-            }
-        if "pdf" in mime.lower():
-            text = _extract_pdf_text(data)
             if not text:
                 return {
                     "type": "text",

--- a/showcase/integrations/mastra/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/mastra/src/app/demos/multimodal/page.tsx
@@ -12,47 +12,26 @@
  *   ../api/copilotkit-multimodal/route.ts). The vision-capable model
  *   (gpt-4o) is scoped to just this demo, so other cells keep their
  *   cheaper text-only models.
- * - Dedicated LangGraph agent at `src/agents/multimodal_agent.py` under
- *   the slug `multimodal-demo`. The agent is registered in langgraph.json
- *   under the graph id `multimodal`. Images are forwarded to the model
- *   natively; PDFs are flattened to text on the Python side via `pypdf`
- *   for provider-agnostic behavior.
+ * - Dedicated Mastra agent at `src/mastra/agents/index.ts` exposed under
+ *   the slug `multimodal-demo`. The AG-UI Mastra adapter forwards modern
+ *   AG-UI multimodal content parts (`image` / `audio` / `video` /
+ *   `document` with `source.{type,value,mimeType}`) directly to Mastra's
+ *   structured `CoreMessage` content shape — see
+ *   `convertAGUIMessagesToMastra` in `@ag-ui/mastra`. No legacy `binary`
+ *   rewrite is required: the adapter consumes the modern shape natively.
  * - Sample files live at `/demo-files/sample.png` and `/demo-files/sample.pdf`
  *   (see `public/demo-files/`). The sample-buttons component fetches them
  *   client-side, wraps the blob in a File, and drives the same hidden
  *   `<input type="file">` the paperclip path uses (DataTransfer + dispatch
  *   `change`). This keeps the sample and real-upload paths on a single
  *   code path — whatever works for one works for both.
- *
- * Legacy-shape rewrite:
- * - The published `@ag-ui/langgraph` converter (0.0.x) only understands
- *   the legacy `{ type: "binary", mimeType, data | url }` content-part
- *   shape when forwarding AG-UI messages to LangChain. The modern
- *   `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
- *   parts that CopilotChat emits are silently dropped. Until the runtime
- *   ships an updated converter, we rewrite the outgoing user message in
- *   `onRunInitialized` so image/document/audio/video parts round-trip
- *   through the legacy shape the converter preserves.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. `@ag-ui/client`'s
- * exported `Message` is a tagged union by role, but for the rewrite
- * we only care about the `user` branch and treat every other role as
- * pass-through. Keeping the type local avoids pulling `@ag-ui/client`
- * into this package's direct dependencies.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -108,133 +87,6 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
- *
- * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
- * in that package) only recognizes legacy `binary` parts — modern parts
- * are silently filtered out, so the LangGraph agent never sees them.
- * Returning the legacy shape keeps the attachment visible to the agent
- * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
- * untouched. Text parts and already-legacy parts pass through unchanged.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
- *
- * Returns the same array reference if nothing changed so the subscriber
- * in `onRunInitialized` can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent. Scoped
- * to a small inner component so it can use the `useAgent` hook the
- * <CopilotChat> parent already relies on — subscribing there means we
- * rewrite messages on the *same* agent instance CopilotChat dispatches
- * through, even when threads are cloned or swapped.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
-    // structural message shape and returns only partial mutations, so
-    // cast at the subscribe boundary. The cast is safe: our
-    // onRunInitialized only ever returns a messages-mutation or void.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
   // paperclip button and the sample-injection path route files through
@@ -245,7 +97,6 @@ export default function MultimodalDemoPage() {
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/mastra/src/mastra/agents/index.ts
+++ b/showcase/integrations/mastra/src/mastra/agents/index.ts
@@ -316,10 +316,13 @@ Do NOT call \`read_me\`, do NOT iterate, do NOT make multiple calls. Ship on the
  * Vision-capable Mastra agent backing the Multimodal Attachments demo.
  *
  * gpt-4o supports image and PDF attachments in the messages array. The
- * AG-UI Mastra adapter forwards user-message `content` parts (image_url /
- * file) verbatim to the model. Kept on a dedicated agent (and dedicated
- * route) so the vision-tier cost is scoped to exactly the cell that
- * exercises it.
+ * AG-UI Mastra adapter (`convertAGUIMessagesToMastra` in `@ag-ui/mastra`)
+ * forwards modern AG-UI multimodal content parts — `image` to Mastra's
+ * `{ type: "image", image }` shape, and `audio` / `video` / `document`
+ * to Mastra's `{ type: "file", data, mimeType }` shape — directly to the
+ * model. No legacy `binary` rewrite is required. Kept on a dedicated
+ * agent (and dedicated route) so the vision-tier cost is scoped to
+ * exactly the cell that exercises it.
  */
 export const multimodalAgent = new Agent({
   id: "multimodal-demo",

--- a/showcase/integrations/ms-agent-python/requirements.txt
+++ b/showcase/integrations/ms-agent-python/requirements.txt
@@ -1,4 +1,4 @@
-agent-framework-ag-ui>=1.0.0b251117
+agent-framework-ag-ui>=1.0.0b260225
 agent-framework-openai>=1.0.0rc6
 httpx>=0.28.0
 langchain-openai>=1.1.0

--- a/showcase/integrations/ms-agent-python/src/agents/multimodal_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/multimodal_agent.py
@@ -15,16 +15,22 @@ Attachments arrive here after travelling through:
                                                        (AG-UI -> AF adapter)
                 ->  this agent
 
-The deployed AG-UI adapter recognizes the legacy
-``{ type: "binary", mimeType, data | url }`` AG-UI part shape. The page at
-``src/app/demos/multimodal/page.tsx`` installs an ``onRunInitialized`` shim
-that rewrites the modern ``{ type: "image" | "document", source: {...} }``
-shape CopilotChat emits to the legacy ``binary`` shape before it hits the
-runtime. We therefore route on ``mimeType``, not the part ``type``:
+CopilotChat emits the modern AG-UI multimodal content-part shape:
 
-- ``image/*`` parts are forwarded to GPT-4o-mini unchanged (vision-native).
-- ``application/pdf`` parts are flattened to inline text via ``pypdf`` so
-  the model can read them without needing file-part support.
+    {"type": "image", "source": {"type": "data", "value": "<base64>",
+                                 "mimeType": "image/png"}}
+    {"type": "document", "source": {"type": "data", "value": "<base64>",
+                                    "mimeType": "application/pdf"}}
+
+The MS-AF AG-UI adapter (>=1.0.0b260225) recognizes this shape directly
+in ``_parse_multimodal_media_part`` and converts it to Agent Framework
+``Content.from_uri`` / ``Content.from_data`` for the underlying chat
+client. We pre-process the AG-UI dicts on the way in so PDFs are flattened
+to text via ``pypdf`` (gpt-4o vision does not natively read PDFs).
+Images pass through untouched and are forwarded to the model natively.
+
+We also accept the legacy ``image_url`` shape some chat clients post-process
+into, purely as a defensive fallback -- modern shape is canonical.
 
 Reference:
 - showcase/integrations/langgraph-python/src/agents/multimodal_agent.py
@@ -35,7 +41,7 @@ from __future__ import annotations
 import base64
 import io
 from textwrap import dedent
-from typing import Any
+from typing import Any, AsyncGenerator
 
 from agent_framework import Agent, BaseChatClient
 from agent_framework_ag_ui import AgentFrameworkAgent
@@ -107,21 +113,39 @@ def _classify_attachment_part(part: Any) -> tuple[str, str, str] | None:
     ``kind`` is one of ``"image"``, ``"pdf"``, ``"other"``. Returns ``None``
     if the part is not an attachment we recognize.
 
-    Handles the shapes the MS-AF AG-UI adapter may surface:
+    Modern AG-UI shape (canonical, what CopilotChat emits):
+
+    - ``{"type": "image", "source": {"type": "data",
+      "value": "<base64>", "mimeType": "image/png"}}``
+    - ``{"type": "document", "source": {"type": "data",
+      "value": "<base64>", "mimeType": "application/pdf"}}``
+
+    Legacy fallback (some chat clients post-process modern parts into a
+    classic OpenAI-style ``image_url`` shape; we accept it defensively):
 
     - ``{"type": "image_url", "image_url": {"url": "data:..."}}``
-      (post-adapter, from the legacy-binary rewrite on the page).
-    - ``{"type": "image_url", "image_url": "data:..."}`` (older shape).
-    - ``{"type": "binary", "mimeType": "...", "data": "<base64>"}``
-      (direct legacy binary).
-    - ``{"type": "document", "source": {"type": "data",
-      "value": "<base64>", "mimeType": "application/pdf"}}`` (modern AG-UI).
-    - ``{"type": "image", "source": {...}}`` (modern AG-UI, for completeness).
+    - ``{"type": "image_url", "image_url": "data:..."}``
     """
     if not isinstance(part, dict):
         return None
     part_type = part.get("type")
 
+    # Modern AG-UI shape (canonical).
+    if part_type in ("image", "document"):
+        source = part.get("source")
+        if not isinstance(source, dict) or source.get("type") != "data":
+            return None
+        value = source.get("value")
+        mime = source.get("mimeType", "")
+        if not isinstance(value, str) or not isinstance(mime, str):
+            return None
+        if mime.startswith("image/"):
+            return ("image", mime, value)
+        if "pdf" in mime.lower():
+            return ("pdf", mime, value)
+        return ("other", mime, value)
+
+    # Defensive fallback: classic OpenAI-style image_url shape.
     if part_type == "image_url":
         image_url = part.get("image_url")
         url: str | None = None
@@ -141,31 +165,6 @@ def _classify_attachment_part(part: Any) -> tuple[str, str, str] | None:
         if "pdf" in mime.lower():
             return ("pdf", mime, payload)
         return ("other", mime, payload)
-
-    if part_type == "binary":
-        mime = part.get("mimeType", "")
-        data = part.get("data")
-        if not isinstance(mime, str) or not isinstance(data, str):
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, data)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, data)
-        return ("other", mime, data)
-
-    if part_type in ("document", "image"):
-        source = part.get("source")
-        if not isinstance(source, dict) or source.get("type") != "data":
-            return None
-        value = source.get("value")
-        mime = source.get("mimeType", "")
-        if not isinstance(value, str) or not isinstance(mime, str):
-            return None
-        if mime.startswith("image/"):
-            return ("image", mime, value)
-        if "pdf" in mime.lower():
-            return ("pdf", mime, value)
-        return ("other", mime, value)
 
     return None
 
@@ -193,38 +192,45 @@ def _preprocess_part(part: Any) -> Any:
     return {"type": "text", "text": f"[Attached document]\n{text}"}
 
 
-class _MultimodalAgent(AgentFrameworkAgent):
-    """Thin wrapper that pre-processes inbound messages before each run.
+def _flatten_messages(messages: Any) -> Any:
+    """Walk an AG-UI input ``messages`` list and rewrite PDF parts to text.
 
-    We flatten `document` (PDF) content parts to text so the model can reason
-    about them even when the underlying chat client does not accept the
-    `document` content-part shape. Images are untouched.
+    Operates on the raw AG-UI dict representation (before the adapter
+    converts to Agent Framework ``Message`` objects). Non-list / non-dict
+    structures pass through unchanged.
+    """
+    if not isinstance(messages, list):
+        return messages
+    rewritten: list[Any] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            rewritten.append(message)
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            rewritten.append(message)
+            continue
+        new_parts = [_preprocess_part(part) for part in content]
+        rewritten.append({**message, "content": new_parts})
+    return rewritten
+
+
+class _MultimodalAgent(AgentFrameworkAgent):
+    """Pre-processes inbound AG-UI messages before each run.
+
+    PDF (``document``) content parts are flattened to text so the model can
+    reason about them even when the underlying chat client does not accept
+    document content natively (gpt-4o vision reads images but not PDFs).
+    Image parts are untouched and forwarded to the model via the MS-AF
+    adapter's modern multimodal pipeline.
     """
 
-    def _flatten_messages(self, messages: Any) -> Any:
-        if not isinstance(messages, list):
-            return messages
-        rewritten: list[Any] = []
-        for message in messages:
-            if not isinstance(message, dict):
-                rewritten.append(message)
-                continue
-            content = message.get("content")
-            if not isinstance(content, list):
-                rewritten.append(message)
-                continue
-            new_parts = [_preprocess_part(part) for part in content]
-            rewritten.append({**message, "content": new_parts})
-        return rewritten
-
-    async def run(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
-        # AG-UI may hand us messages via a positional or keyword argument;
-        # normalize both shapes before delegating to the base implementation.
-        if "messages" in kwargs:
-            kwargs["messages"] = self._flatten_messages(kwargs["messages"])
-        elif args and isinstance(args[0], list):
-            args = (self._flatten_messages(args[0]), *args[1:])
-        return await super().run(*args, **kwargs)
+    async def run(self, input_data: dict[str, Any]) -> AsyncGenerator[Any, None]:  # type: ignore[override]
+        rewritten_messages = _flatten_messages(input_data.get("messages"))
+        if rewritten_messages is not input_data.get("messages"):
+            input_data = {**input_data, "messages": rewritten_messages}
+        async for event in super().run(input_data):
+            yield event
 
 
 def create_multimodal_agent(chat_client: BaseChatClient) -> AgentFrameworkAgent:

--- a/showcase/integrations/ms-agent-python/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/multimodal/page.tsx
@@ -22,23 +22,22 @@
  *   `<input type="file">` the paperclip path uses (DataTransfer + dispatch
  *   `change`). This keeps the sample and real-upload paths on a single
  *   code path -- whatever works for one works for both.
+ *
+ * Wire format
+ * -----------
+ * CopilotChat emits the modern AG-UI multimodal content-part shape
+ * (`type: "image" | "document"`, `source: { type, value, mimeType }`)
+ * end-to-end. The MS Agent Framework AG-UI adapter (>=1.0.0b260225)
+ * recognizes this shape natively in `_parse_multimodal_media_part` and
+ * converts it to `Content.from_uri` / `Content.from_data` for the
+ * underlying chat client. No client-side legacy rewrite is required.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. We care only about the
- * `user` branch; every other role passes through.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -88,125 +87,11 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites modern multimodal content parts (`type: "image" | "document" |
- * "audio" | "video"`, `source.{type,value,mimeType}`) to the legacy binary
- * shape (`type: "binary"`, `mimeType`, `data` | `url`). The deployed AG-UI
- * converter only recognizes legacy `binary` parts — modern parts are silently
- * filtered out, so without this rewrite the agent never sees the attachment.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Returns the same array reference when nothing
- * changes so the subscriber can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent so we
- * rewrite modern multimodal parts to the legacy shape the AG-UI converter
- * understands.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // Structural shim shape; cast at subscribe boundary.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/pydantic-ai/src/agents/multimodal_agent.py
+++ b/showcase/integrations/pydantic-ai/src/agents/multimodal_agent.py
@@ -1,8 +1,7 @@
 """Multimodal PydanticAI agent — accepts image + document (PDF) attachments.
 
-Ports showcase/integrations/langgraph-python/src/agents/multimodal_agent.py to
-PydanticAI. The vision-capable model (`gpt-4o`) is scoped to this agent
-only so other demos keep their cheaper text-only models.
+The vision-capable model (`gpt-4o`) is scoped to this agent only so
+other demos keep their cheaper text-only models.
 
 Wire format the agent sees
 ==========================
@@ -11,23 +10,23 @@ Attachments arrive here after travelling through:
   CopilotChat  →  AG-UI message content parts  →  PydanticAI AG-UI bridge
               →  this agent (PydanticAI messages)
 
-The frontend page at ``src/app/demos/multimodal/page.tsx`` installs the
-same ``onRunInitialized`` shim used in the langgraph-python reference:
-modern ``{ type: "image" | "document", source: {...} }`` parts get
-rewritten to the legacy ``{ type: "binary", mimeType, data | url }``
-shape before the request reaches the runtime. This keeps the on-wire
-format compatible with AG-UI bridges that only understand the legacy
-shape.
+CopilotChat emits modern multimodal parts of the form
+``{ type: "image" | "document", source: { type: "data" | "url",
+value, mimeType } }``. The PydanticAI AG-UI adapter forwards
+``UserMessage.content`` through unchanged, so the parts arrive at this
+agent as plain ``dict``s in the AG-UI shape (the AG-UI client's
+``BackwardCompatibility_0_0_47`` middleware also upgrades any legacy
+``binary`` parts to the modern shape on the way in, so we never see
+the legacy form here).
 
 On the Python side we use a ``history_processor`` to preprocess user
 messages before each model call:
 
-- ``image/*`` legacy-binary parts are converted to PydanticAI's
-  ``ImageUrl`` content (which ``OpenAIResponsesModel`` forwards as a
-  vision-native ``image_url`` part to GPT-4o).
-- ``application/pdf`` legacy-binary parts are flattened to inline text
-  via ``pypdf`` so the model can read them without needing file-part
-  support — matching the langgraph-python behaviour exactly.
+- ``image/*`` parts are rewritten to OpenAI-style ``image_url`` dicts
+  with a ``data:`` URL embedded. ``OpenAIResponsesModel`` forwards
+  these as vision-native ``image_url`` parts to GPT-4o.
+- ``application/pdf`` parts are flattened to inline text via ``pypdf``
+  so the model can read them without needing file-part support.
 - Any other part shape passes through unchanged.
 """
 
@@ -85,60 +84,54 @@ def _extract_pdf_text(b64: str) -> str:
         return ""
 
 
-def _classify_binary_part(part: Any) -> tuple[str, str, str] | None:
+def _classify_modern_part(part: Any) -> tuple[str, str, str] | None:
     """Inspect an AG-UI content part and return ``(kind, mime, payload)``.
 
     ``kind`` is one of ``"image"``, ``"pdf"``, ``"other"``. Returns
-    ``None`` if the part is not an attachment we recognise.
+    ``None`` if the part is not a modern multimodal attachment with an
+    inline ``data`` source.
 
-    Handles both shapes that can arrive at the agent:
-
-    - Legacy binary: ``{"type": "binary", "mimeType": "...",
-      "data": "<base64>"}`` or ``"url": "..."``.
-    - Modern source: ``{"type": "image" | "document",
+    Recognises modern AG-UI shape only:
+    ``{"type": "image" | "document",
       "source": {"type": "data", "value": "<base64>", "mimeType": "..."}}``.
+
+    Legacy ``binary`` parts are handled upstream by the AG-UI client's
+    ``BackwardCompatibility_0_0_47`` middleware, which upgrades them to
+    the modern shape before they reach the agent.
     """
     if not isinstance(part, dict):
         return None
     part_type = part.get("type")
+    if part_type not in ("image", "document"):
+        return None
 
-    if part_type == "binary":
-        mime = part.get("mimeType") or ""
-        data = part.get("data")
-        if isinstance(data, str) and mime:
-            if mime.startswith("image/"):
-                return ("image", mime, data)
-            if "pdf" in mime.lower():
-                return ("pdf", mime, data)
-            return ("other", mime, data)
+    source = part.get("source")
+    if not isinstance(source, dict) or source.get("type") != "data":
+        return None
+    value = source.get("value")
+    mime = source.get("mimeType", "")
+    if not isinstance(value, str) or not isinstance(mime, str) or not mime:
+        return None
 
-    if part_type in ("image", "document"):
-        source = part.get("source")
-        if isinstance(source, dict) and source.get("type") == "data":
-            value = source.get("value")
-            mime = source.get("mimeType", "")
-            if isinstance(value, str) and isinstance(mime, str) and mime:
-                if mime.startswith("image/"):
-                    return ("image", mime, value)
-                if "pdf" in mime.lower():
-                    return ("pdf", mime, value)
-                return ("other", mime, value)
-
-    return None
+    if mime.startswith("image/"):
+        return ("image", mime, value)
+    if "pdf" in mime.lower():
+        return ("pdf", mime, value)
+    return ("other", mime, value)
 
 
 def _rewrite_part_for_model(part: Any) -> Any:
     """Rewrite a single content part into a model-friendly shape.
 
-    - Image binary parts → OpenAI-style ``image_url`` dict with a
-      ``data:`` URL embedded. ``OpenAIResponsesModel`` passes this
-      through natively, matching GPT-4o's vision input format.
-    - PDF binary parts → text part prefixed with ``[Attached document]``
-      and the extracted body; falls back to a structured placeholder if
+    - Image parts → OpenAI-style ``image_url`` dict with a ``data:``
+      URL embedded. ``OpenAIResponsesModel`` passes this through
+      natively, matching GPT-4o's vision input format.
+    - PDF parts → text part prefixed with ``[Attached document]`` and
+      the extracted body; falls back to a structured placeholder if
       extraction failed.
     - Everything else → unchanged.
     """
-    classified = _classify_binary_part(part)
+    classified = _classify_modern_part(part)
     if classified is None:
         return part
     kind, mime, payload = classified
@@ -167,7 +160,7 @@ def _rewrite_message_content(content: Any) -> Any:
     """Rewrite the ``content`` field of a single message.
 
     User messages carry lists of content parts; we walk the list and
-    rewrite any binary/image/document parts in place. String-only
+    rewrite any modern image/document parts in place. String-only
     content (assistant replies, system prompts) passes through.
     """
     if not isinstance(content, list):

--- a/showcase/integrations/pydantic-ai/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/multimodal/page.tsx
@@ -12,11 +12,10 @@
  *   ../api/copilotkit-multimodal/route.ts). The vision-capable model
  *   (gpt-4o) is scoped to just this demo, so other cells keep their
  *   cheaper text-only models.
- * - Dedicated LangGraph agent at `src/agents/multimodal_agent.py` under
- *   the slug `multimodal-demo`. The agent is registered in langgraph.json
- *   under the graph id `multimodal`. Images are forwarded to the model
- *   natively; PDFs are flattened to text on the Python side via `pypdf`
- *   for provider-agnostic behavior.
+ * - Dedicated PydanticAI agent at `src/agents/multimodal_agent.py`,
+ *   mounted at `/multimodal/` on the backend (see `src/agent_server.py`).
+ *   Images are forwarded to the model natively; PDFs are flattened to
+ *   text on the Python side via `pypdf` for provider-agnostic behavior.
  * - Sample files live at `/demo-files/sample.png` and `/demo-files/sample.pdf`
  *   (see `public/demo-files/`). The sample-buttons component fetches them
  *   client-side, wraps the blob in a File, and drives the same hidden
@@ -24,35 +23,21 @@
  *   `change`). This keeps the sample and real-upload paths on a single
  *   code path — whatever works for one works for both.
  *
- * Legacy-shape rewrite:
- * - The published `@ag-ui/langgraph` converter (0.0.x) only understands
- *   the legacy `{ type: "binary", mimeType, data | url }` content-part
- *   shape when forwarding AG-UI messages to LangChain. The modern
- *   `{ type: "image" | "document", source: { type: "data" | "url", ... } }`
- *   parts that CopilotChat emits are silently dropped. Until the runtime
- *   ships an updated converter, we rewrite the outgoing user message in
- *   `onRunInitialized` so image/document/audio/video parts round-trip
- *   through the legacy shape the converter preserves.
+ * Wire format:
+ * - CopilotChat emits modern multimodal content parts of the form
+ *   `{ type: "image" | "document", source: { type: "data" | "url",
+ *   value, mimeType } }`. The PydanticAI AG-UI adapter forwards
+ *   `UserMessage.content` straight through, and the agent's
+ *   `history_processor` rewrites image/document parts into shapes
+ *   the GPT-4o vision API understands. No frontend rewrite shim is
+ *   required.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. `@ag-ui/client`'s
- * exported `Message` is a tagged union by role, but for the rewrite
- * we only care about the `user` branch and treat every other role as
- * pass-through. Keeping the type local avoids pulling `@ag-ui/client`
- * into this package's direct dependencies.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -108,133 +93,6 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites a single `InputContent` part from the modern multimodal shape
- * (`type: "image" | "document" | "audio" | "video"`, `source.{type,value,mimeType}`)
- * to the legacy binary shape (`type: "binary"`, `mimeType`, `data` | `url`).
- *
- * The published `@ag-ui/langgraph` converter (see `aguiMessagesToLangChain`
- * in that package) only recognizes legacy `binary` parts — modern parts
- * are silently filtered out, so the LangGraph agent never sees them.
- * Returning the legacy shape keeps the attachment visible to the agent
- * while leaving everything else (CopilotChat UI, upload pipeline, etc.)
- * untouched. Text parts and already-legacy parts pass through unchanged.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user messages and plain-string user
- * messages pass through untouched. Idempotent: already-legacy `binary`
- * parts are a no-op for `rewriteMultimodalPart`.
- *
- * Returns the same array reference if nothing changed so the subscriber
- * in `onRunInitialized` can skip an unnecessary state write.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent. Scoped
- * to a small inner component so it can use the `useAgent` hook the
- * <CopilotChat> parent already relies on — subscribing there means we
- * rewrite messages on the *same* agent instance CopilotChat dispatches
- * through, even when threads are cloned or swapped.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    // AG-UI's AgentSubscriber type is tagged by role; our shim uses a
-    // structural message shape and returns only partial mutations, so
-    // cast at the subscribe boundary. The cast is safe: our
-    // onRunInitialized only ever returns a messages-mutation or void.
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
   // paperclip button and the sample-injection path route files through
@@ -245,7 +103,6 @@ export default function MultimodalDemoPage() {
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"

--- a/showcase/integrations/strands/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/multimodal/page.tsx
@@ -18,31 +18,20 @@
  *   client-side, wraps the blob in a File, and drives the same hidden
  *   `<input type="file">` the paperclip path uses.
  *
- * Legacy-shape rewrite:
- * - Defensively rewrite outgoing user messages in `onRunInitialized` so
- *   image/document/audio/video modern parts round-trip through the legacy
- *   `{ type: "binary", mimeType, data | url }` shape most AG-UI adapters
- *   preserve. Idempotent: already-legacy parts are a no-op. This matches
- *   the shape historically consumed by ag_ui_strands / strands model
- *   adapters; plain-text parts and already-legacy binary parts pass
- *   through untouched.
+ * Modern AG-UI shape:
+ * - Attachments are forwarded as modern AG-UI multimodal parts
+ *   (`{ type: "image" | "document" | ..., source: { type, value, mimeType } }`).
+ *   The upstream `ag_ui_strands` Python adapter consumes these directly —
+ *   see `_resolve_source_bytes` and the per-type branches in
+ *   `ag_ui_strands/utils.py` — so no client-side legacy `binary` rewrite is
+ *   needed.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
-import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
+import { useCallback } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
-
-/**
- * Minimal structural shape of an AG-UI message. We only need the `user`
- * branch for the rewrite; every other role passes through untouched.
- */
-type AgentMessage = {
-  id?: string;
-  role: string;
-  content?: unknown;
-};
 
 /**
  * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
@@ -86,123 +75,11 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
-/**
- * Rewrites a single modern multimodal `InputContent` part (image/document/
- * audio/video with `source.{type,value,mimeType}`) to the legacy binary
- * shape (`type: "binary"`, `mimeType`, `data` | `url`). Idempotent for
- * already-legacy parts. Text parts pass through.
- */
-function rewriteMultimodalPart(part: unknown): unknown {
-  if (!part || typeof part !== "object") return part;
-  const candidate = part as {
-    type?: string;
-    text?: string;
-    source?: {
-      type?: string;
-      value?: string;
-      mimeType?: string;
-    };
-  };
-  const type = candidate.type;
-  if (
-    type !== "image" &&
-    type !== "document" &&
-    type !== "audio" &&
-    type !== "video"
-  ) {
-    return part;
-  }
-  const source = candidate.source;
-  if (!source || typeof source.value !== "string") {
-    return part;
-  }
-  const mimeType = source.mimeType ?? "application/octet-stream";
-  if (source.type === "data") {
-    return {
-      type: "binary",
-      mimeType,
-      data: source.value,
-    };
-  }
-  if (source.type === "url") {
-    return {
-      type: "binary",
-      mimeType,
-      url: source.value,
-    };
-  }
-  return part;
-}
-
-/**
- * Walks a message list and rewrites user-message multimodal content parts
- * to the legacy `binary` shape. Non-user and plain-string messages pass
- * through untouched. Returns the same reference if nothing changed so the
- * subscriber can skip unnecessary state writes.
- */
-function rewriteMessagesForLegacyConverter(
-  messages: ReadonlyArray<Readonly<AgentMessage>>,
-): AgentMessage[] | null {
-  let mutated = false;
-  const next = messages.map((message) => {
-    if (message.role !== "user") return message as AgentMessage;
-    const content = message.content;
-    if (!Array.isArray(content)) return message as AgentMessage;
-    let partMutated = false;
-    const rewrittenParts = content.map((part) => {
-      const rewritten = rewriteMultimodalPart(part);
-      if (rewritten !== part) partMutated = true;
-      return rewritten;
-    });
-    if (!partMutated) return message as AgentMessage;
-    mutated = true;
-    return {
-      ...(message as object),
-      content: rewrittenParts,
-    } as AgentMessage;
-  });
-  return mutated ? next : null;
-}
-
-/**
- * Installs the `onRunInitialized` subscriber on the active agent so the
- * rewrite runs on the same agent instance CopilotChat dispatches through.
- */
-function LegacyConverterShim() {
-  const { agent } = useAgent({ agentId: "multimodal-demo" });
-
-  const subscriber = useMemo(
-    () => ({
-      onRunInitialized: ({
-        messages,
-      }: {
-        messages: ReadonlyArray<Readonly<AgentMessage>>;
-      }) => {
-        const rewritten = rewriteMessagesForLegacyConverter(messages);
-        if (!rewritten) return;
-        return { messages: rewritten };
-      },
-    }),
-    [],
-  );
-
-  useEffect(() => {
-    if (!agent) return;
-    const handle = agent.subscribe(
-      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
-    );
-    return () => handle.unsubscribe();
-  }, [agent, subscriber]);
-
-  return null;
-}
-
 export default function MultimodalDemoPage() {
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
-      <LegacyConverterShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"


### PR DESCRIPTION
## Summary

Migrates 11 showcase multimodal demos from the deprecated AG-UI \`binary\` content-part shape to the modern \`image | document | audio | video\` + \`source\` shape. Largely subtractive (1620 lines deleted, 486 added; -1134 net) — removes the obsolete \`LegacyConverterShim\` from each demo's \`page.tsx\` and the dead \`binary\` branch from each agent.

The legacy shim was a workaround for older \`@ag-ui/*\` converter versions that only understood \`{ type: \"binary\", mimeType, data | url }\`. Current converters (\`@ag-ui/langgraph 0.0.31\`, \`@ag-ui/mastra\` upstream, \`agent-framework-ag-ui >= 1.0.0b260225\`, etc.) handle modern multimodal parts natively, and the \`@ag-ui/client\` \`BackwardCompatibility_0_0_47\` middleware upgrades any straggling legacy parts on entry. The shim was actively downgrading the modern shape CopilotChat emits.

## Per-integration outcome

| Integration | Outcome |
|---|---|
| langgraph-python | Migrated. Page shim removed, agent docstring + classifier updated. |
| langgraph-typescript | Migrated. Page shim + helpers removed; agent gained native modern \`image\`/\`document\` branches and post-converter \`image_url\` PDF text extraction. |
| langgraph-fastapi | Migrated. Page shim removed; agent simplified to \`image_url\` post-converter shape. |
| ms-agent-python | Migrated. Bumped \`agent-framework-ag-ui >= 1.0.0b260225\` (modern-shape support added in this beta), made modern shape the primary classifier branch, and fixed a previously-dead \`_MultimodalAgent.run()\` override (parent expects \`input_data: dict\`, not \`messages=…\`). |
| pydantic-ai | Migrated. Verified \`pydantic_ai.ag_ui\` forwards modern parts unchanged; renamed \`_classify_binary_part\` → \`_classify_modern_part\`. |
| crewai-crews | Migrated. Page shim removed; CrewAI uses \`HttpAgent\` so no agent-side shape concern. |
| mastra | Migrated. Verified upstream \`@ag-ui/mastra\` \`convertAGUIMessagesToMastra\` natively handles modern types; removed page shim. |
| strands | Migrated. Verified upstream \`ag_ui_strands\` adapter supports modern image/document/audio/video parts; removed page shim. |
| claude-sdk-typescript | Migrated. New \`modernPartToAnthropic\` and \`messagesHaveAttachments\` functions, with shared \`isAnthropicSupportedPart\` predicate; image-mime whitelist (jpeg/png/gif/webp); strict \`application/pdf\` equality. |
| claude-sdk-python | Audited. \`binary\` branch in \`convert_part_for_claude\` was dead (no shim to produce it; agent forwards \`HttpAgent\` parts unchanged). Dropped. |
| langroid | Audited. Same — dead \`binary\` branch dropped. |
| **ms-agent-dotnet** | **Skipped.** Upstream .NET adapter (\`Microsoft.Agents.AI.Hosting.AGUI.AspNetCore\` 1.0.0-preview.251110.1) only carries \`string\` content end-to-end — neither modern nor legacy shape works through the deserializer. Files left untouched; tracked as a future follow-up once upstream adds polymorphic content-part support. |

## CR loop

Ran the full \`cr-loop\` (7-agent unbiased review × Round 1 + confirmation round + Procedure 3 promotion audit).

**Round 1 → bucket (a) (3 fixed in this PR):**
- claude-sdk-typescript: tightened image \`media_type\` to a whitelist; previously cast \`mime\` blindly to Anthropic's 4-mime union (SVG/HEIC/AVIF/etc → opaque 400).
- claude-sdk-typescript: synced \`messagesHaveAttachments\` and \`modernPartToAnthropic\` via a shared \`isAnthropicSupportedPart\` predicate; previously the vision-routing trigger and the body translator could disagree, causing Sonnet pricing on attachments that were silently dropped at conversion.
- langgraph-typescript: imported \`pdf-parse\` via \`pdf-parse/lib/pdf-parse.js\` to bypass the package's known debug-fixture entry path that ENOENTs in serverless bundles.

**Confirmation round + Procedure 3 audit:** zero bucket (a) findings, zero promotions. Convergence achieved.

## Deferred (bucket c — pre-existing showcase quality, not introduced by this PR)

The CR loop surfaced ~80 pre-existing showcase quality concerns that exist independently of the multimodal-shape migration. Notable ones to track as future work:

- All Python agents use \`print()\` for warnings instead of \`logging\` (langroid does it correctly).
- All Python \`_extract_pdf_text\` use bare \`except Exception\` with a single placeholder — encrypted vs malformed vs missing-pypdf are indistinguishable to the user.
- pydantic-ai \`_rewrite_history\` has a bare \`except Exception: pass\` on \`part.content\` assignment (silent fallback if pydantic-ai ever switches to frozen parts).
- pydantic-ai uses \`OpenAIResponsesModel\` but emits Chat-Completions-style \`image_url\`. Whether this is correct depends on pydantic-ai's translation layer; verify empirically.
- claude-sdk-typescript \`runAgenticLoop\` has several pre-existing edge cases (frontend-tool branch leaving unmatched \`tool_use\`, silent \`MAX_TOOL_ITERATIONS\` cap, \`messagesHaveAttachments\` scanning whole history).
- mastra \`multimodalAgent\` uses the generic \`AgentState\` (proverbs) working-memory schema; large base64 attachments accumulate in the shared \`mastra-memory.db\`.
- langroid \`_build_messages\` drops assistant/system list-content and tool-role messages.

## Known deployment gap

\`@copilotkit/runtime@next\` currently transitively pins \`@ag-ui/langgraph 0.0.27\` (per existing showcase package-locks), which lacks modern multimodal support. The runtime source-of-truth in this repo is already at \`0.0.31\`. Until a new \`runtime@next\` is published and the showcase lockfiles are regenerated, deployed langgraph-* showcases will see modern parts dropped at the converter boundary. Source-level migration is correct; deployment requires the next runtime release.

## Test plan

- [x] Per-integration typecheck via \`tsc --noEmit\` (where the showcase has a usable tsconfig).
- [x] Python \`ast.parse\` clean on all modified \`.py\`.
- [x] CR-loop confirmation round + Procedure 3 audit (zero bucket-a, zero promotions).
- [ ] Manual smoke test of each \`/demos/multimodal\` cell with a sample image and PDF.
- [ ] Verify deployed showcase environments after the next \`@copilotkit/runtime\` publish.