### PR TITLE
fix(shell-docs): reference accuracy + observability V2 translation + contributor docs rewrite

### DIFF
--- a/showcase/shell-docs/src/content/docs/(other)/contributing/docs-contributions.mdx
+++ b/showcase/shell-docs/src/content/docs/(other)/contributing/docs-contributions.mdx
@@ -2,65 +2,80 @@
 title: Documentation Contributions
 ---
 
-We understand that as we move quickly, sometimes our documentation website can be a bit outdated. Therefore, we highly value contributions to our documentation.
+We move quickly and our docs sometimes lag the code, so contributions to the documentation site are very welcome.
+
+The documentation site lives in `showcase/shell-docs` inside the [CopilotKit](https://github.com/CopilotKit/CopilotKit) monorepo. It is a [Fumadocs](https://fumadocs.dev/) site; the legacy Nextra `docs/` tree is being phased out and is no longer the right place to author new content.
 
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/en/) 20.x or later
 - [pnpm](https://pnpm.io/) v9.x installed globally (`npm i -g pnpm@^9`)
+- [Nx](https://nx.dev/) — used to drive all tasks in the monorepo. You don't need to install it globally; the repo's `pnpm install` provides everything.
 
 ## How To Contribute
 
 <Steps>
   <Step>
-  ### Fork The Repository
+  ### Fork and clone the repository
 
-First, head over to the [CopilotKit GitHub repository](https://github.com/CopilotKit/CopilotKit) and create a fork.
-
-Then, clone the forked repository to your local machine:
+First, fork the [CopilotKit GitHub repository](https://github.com/CopilotKit/CopilotKit), then clone your fork:
 
 ```shell
 git clone https://github.com/<your-username>/CopilotKit
-cd CopilotKit/docs
+cd CopilotKit
+pnpm install
 ```
+
+`pnpm install` at the repo root installs every package in the workspace and wires up the lefthook pre-commit hook (lint, format, test) — running it once is required before your first commit.
 
   </Step>
   <Step>
-  ### Run the Documentation Site Locally
+  ### Run the documentation site locally
 
-To run the documentation site locally, install the dependencies and then start the docs in development mode:
+The shell-docs site is an Nx project (`@copilotkit/showcase-shell-docs`). Run it through Nx from the repo root:
 
 ```shell
-pnpm install
-pnpm run dev
+nx run shell-docs:dev
 ```
 
-The documentation site should be available at [http://localhost:3000](http://localhost:3000).
+The site is served at [http://localhost:3003](http://localhost:3003). If you prefer to run it from the package directory, `cd showcase/shell-docs && pnpm dev` works too — both go through the same script.
+
+<Callout type="info">
+Always prefer running tasks via Nx (`nx run`, `nx run-many`, `nx affected`) rather than the underlying tooling directly. This is the convention across the monorepo and ensures task dependencies are respected.
+</Callout>
 
   </Step>
   <Step>
-  ### Make Your Changes
+  ### Make your changes
 
-Now, you can make your changes to the documentation website.
+Documentation pages live under:
 
-- All documentation-related files are located in the docs repository
-- You may want to familiarize yourself with [Nextra](https://nextra.site/) to understand how the documentation website is structured.
+```
+showcase/shell-docs/src/content/docs/
+```
 
-        <Callout type="info">
+A few conventions to keep in mind:
 
-  Please ensure you review your changes for grammar, spelling and formatting errors. Also, ensure that links and images are working.
+- The site is built with **Fumadocs**. Content is authored in MDX. Frontmatter (`title`, `description`, `icon`, etc.) drives the sidebar and metadata.
+- For code samples, prefer the **`<Snippet>` region pattern** over hand-inlining code blocks. `<Snippet>` pulls real source from the showcase integrations under `showcase/integrations/<framework>/...` using region markers (e.g. `// region:my-region` … `// endregion:my-region`). This keeps every code sample tied to runnable demo code and lets us catch drift automatically. When in doubt, look at how an adjacent page references the same integration and follow that pattern.
+- Reference pages for hooks, components, and runtime APIs use a `<PropertyReference>` component to render the prop / parameter table. Match the style of an existing reference page in the same directory.
 
-    </Callout>
-</Step>
-<Step>
+<Callout type="info">
+Please review your changes for grammar, spelling, and formatting, and confirm that links, code blocks, and images render correctly in the local dev server before opening a PR.
+</Callout>
 
-### Review Changes & Submit Pull Request
+  </Step>
+  <Step>
 
-Once you are happy with your changes, you can commit and push them. Then, head over to the [Pull Requests page](https://github.com/CopilotKit/CopilotKit/pulls) and create a pull request. Thank you for your contribution!
+  ### Review changes and submit a pull request
+
+Before pushing, the lefthook pre-commit hook will run lint, format, and tests on the affected projects via Nx. If anything fails, fix the issue and commit again — don't bypass the hook.
+
+When you're happy with the result, push and open a PR against the [CopilotKit/CopilotKit](https://github.com/CopilotKit/CopilotKit/pulls) repo. Thank you for your contribution!
 
   </Step>
 </Steps>
 
 ## Need help?
 
-If you need help with anything, please don't hesitate to reach out to us on [Discord](https://discord.gg/6dffbvGU3D). We have a dedicated [#contributing](https://discord.com/channels/1122926057641742418/1183863183149117561) channel.
+If you need help with anything, please don't hesitate to reach out on [Discord](https://discord.gg/6dffbvGU3D). There's a dedicated [#contributing](https://discord.com/channels/1122926057641742418/1183863183149117561) channel.

--- a/showcase/shell-docs/src/content/docs/reference/v1/classes/llm-adapters/LangChainAdapter.mdx
+++ b/showcase/shell-docs/src/content/docs/reference/v1/classes/llm-adapters/LangChainAdapter.mdx
@@ -2,13 +2,6 @@
 title: "LangChainAdapter"
 description: "Copilot Runtime adapter for LangChain."
 ---
-{
- /*
-  * ATTENTION! DO NOT MODIFY THIS FILE!
-  * This page is auto-generated. If you want to make any changes to this page, changes must be made at:
-  * packages/runtime/src/service-adapters/langchain/langchain-adapter.ts
-  */
-}
 Copilot Runtime adapter for LangChain.
  
 ## Example
@@ -20,7 +13,7 @@ import { ChatOpenAI } from "@langchain/openai";
 const copilotKit = new CopilotRuntime();
  
 const model = new ChatOpenAI({
-  model: "gpt-5.4",
+  model: "gpt-4o",
   apiKey: "<your-api-key>",
 });
  

--- a/showcase/shell-docs/src/content/docs/reference/v2/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/docs/reference/v2/hooks/useAgent.mdx
@@ -25,6 +25,10 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent }
     ID of the agent to retrieve. Must match an agent configured in `CopilotKitProvider`.
   </PropertyReference>
 
+  <PropertyReference name="threadId" type="string">
+    Optional thread ID to scope the agent instance per conversation thread. When provided, `useAgent` returns a per-thread clone of the registered agent so that messages, state, and `threadId` are isolated to that thread. Falls back to the enclosing `CopilotChatConfigurationProvider`'s `threadId` if not provided.
+  </PropertyReference>
+
   <PropertyReference name="updates" type="UseAgentUpdate[]" default="[OnMessagesChanged, OnStateChanged, OnRunStatusChanged]">
     Controls which agent changes trigger component re-renders. Options:
     - `UseAgentUpdate.OnMessagesChanged` - Re-render when messages change
@@ -34,8 +38,10 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent }
     Pass an empty array `[]` to prevent automatic re-renders.
   </PropertyReference>
 
-  <PropertyReference name="throttleMs" type="number" default="0">
+  <PropertyReference name="throttleMs" type="number" default="provider.defaultThrottleMs ?? 0">
     Throttle interval (in milliseconds) for React re-renders triggered by `OnMessagesChanged` notifications. Useful to reduce re-render frequency during streaming, where new tokens can fire many updates per second.
+
+    The default is resolved as a cascade: `throttleMs ?? provider.defaultThrottleMs ?? 0`. When you omit `throttleMs`, the hook inherits `defaultThrottleMs` from the enclosing `CopilotKitProvider`; when neither is set, the floor is `0` (no throttling). Passing `throttleMs={0}` explicitly disables throttling even when the provider specifies a non-zero `defaultThrottleMs`.
 
     Uses a **leading+trailing** pattern:
     - First update fires immediately (no delay for the initial token)

--- a/showcase/shell-docs/src/content/docs/reference/v2/hooks/useThreads.mdx
+++ b/showcase/shell-docs/src/content/docs/reference/v2/hooks/useThreads.mdx
@@ -51,6 +51,7 @@ function useThreads(input: UseThreadsInput): UseThreadsResult
     - `archived: boolean` — whether the thread is archived
     - `createdAt: string` — ISO 8601 timestamp
     - `updatedAt: string` — ISO 8601 timestamp
+    - `lastRunAt?: string` — ISO 8601 timestamp of the most recent run on this thread. Only present when the thread has had at least one run. Useful for surfacing "last activity" timing distinct from `updatedAt` (which also bumps on metadata changes like rename/archive).
   </PropertyReference>
 
   <PropertyReference name="isLoading" type="boolean">

--- a/showcase/shell-docs/src/content/docs/troubleshooting/observability-connectors.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/observability-connectors.mdx
@@ -4,35 +4,35 @@ description: "Manage Error Monitoring, Logging and Alerts."
 icon: "lucide/TriangleAlert"
 ---
 
-CopilotKit Premium provides production-grade error observability with the observability solution of your choice via the `onError` hook. This feature requires a `publicLicenseKey` or `publicApiKey` and provides rich, structured error events you can forward to your monitoring and analytics systems.
+CopilotKit Premium provides production-grade error observability with the observability solution of your choice via the `onError` hook on `CopilotKitProvider`. This feature requires a `publicLicenseKey` or `publicApiKey` and provides structured error events you can forward to your monitoring and analytics systems.
 See [Observability](/premium/observability) for a complete description of all Observability features.
 
 ## Quick Setup
 
 ```tsx
-import { CopilotKit } from "@copilotkit/react-core";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 
 export default function App() {
   return (
-    <CopilotKit
+    <CopilotKitProvider
       runtimeUrl="<your-runtime-url>"
       publicApiKey="ck_pub_your_key" // [!code highlight] - Use publicApiKey for Copilot Cloud
       // OR
       publicLicenseKey="ck_pub_your_key" // [!code highlight] - Use publicLicenseKey for self-hosted
-      onError={(errorEvent) => {
+      onError={({ error, code, context }) => {
         // [!code highlight]
         // Send to your monitoring/analytics service
-        console.error("CopilotKit Error:", errorEvent);
+        console.error("CopilotKit Error:", { error, code, context });
         analytics.track("copilotkit_error", {
-          type: errorEvent.type,
-          source: errorEvent.context.source,
-          timestamp: errorEvent.timestamp,
+          code,
+          message: error.message,
+          context,
         });
       }} // [!code highlight]
       showDevConsole={false}
     >
       {/* Your app */}
-    </CopilotKit>
+    </CopilotKitProvider>
   );
 }
 ```
@@ -52,74 +52,49 @@ You can get either type of key from [cloud.copilotkit.ai](https://cloud.copilotk
 
 ## Error Event Structure
 
-The `onError` hook provides detailed, structured events:
+The V2 `onError` callback fires for any error surfaced by `CopilotKitCore` — including runtime `/info` failures, agent connect/run failures, tool argument parse/handler failures, transcription errors, and thread-locked conditions. Each event has the following shape:
+
+```ts
+import { CopilotKitCoreErrorCode } from "@copilotkit/core";
+
+type CopilotKitErrorEvent = {
+  error: Error;
+  code: CopilotKitCoreErrorCode;
+  context: Record<string, any>;
+};
+```
+
+- **`error`** — the underlying `Error` instance (with `message`, `stack`, etc.).
+- **`code`** — a stable string enum (`CopilotKitCoreErrorCode`) you can switch on. Values include `runtime_info_fetch_failed`, `agent_connect_failed`, `agent_run_failed`, `agent_run_failed_event`, `agent_run_error_event`, `tool_argument_parse_failed`, `tool_handler_failed`, `tool_not_found`, `agent_not_found`, `agent_thread_locked`, `transcription_failed`, `transcription_service_not_configured`, `transcription_invalid_audio`, and `subscriber_callback_failed`.
+- **`context`** — a free-form record carrying whatever extra metadata the error site provides (e.g. `agentId`, `runId`, `toolName`, request URL).
 
 ```tsx
-import { CopilotErrorEvent } from "@copilotkit/shared";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import { CopilotKitCoreErrorCode } from "@copilotkit/core";
 
-<CopilotKit
+<CopilotKitProvider
   publicApiKey="ck_pub_your_key" // or publicLicenseKey for self-hosted
-  onError={(errorEvent: CopilotErrorEvent) => {
-    switch (errorEvent.type) {
-      case "error":
-        logToService("Critical error", errorEvent);
+  onError={({ error, code, context }) => {
+    switch (code) {
+      case CopilotKitCoreErrorCode.AGENT_RUN_FAILED:
+      case CopilotKitCoreErrorCode.AGENT_RUN_ERROR_EVENT:
+        logToService("Agent run failed", { error, code, context });
         break;
-      case "request":
-        logToService("Request started", errorEvent);
+      case CopilotKitCoreErrorCode.RUNTIME_INFO_FETCH_FAILED:
+        logToService("Runtime unreachable", { error, code, context });
         break;
-      case "response":
-        logToService("Response received", errorEvent);
+      case CopilotKitCoreErrorCode.TOOL_HANDLER_FAILED:
+      case CopilotKitCoreErrorCode.TOOL_ARGUMENT_PARSE_FAILED:
+        logToService("Tool error", { error, code, context });
         break;
-      case "agent_state":
-        logToService("Agent state change", errorEvent);
+      case CopilotKitCoreErrorCode.AGENT_THREAD_LOCKED:
+        // Show "Agent is busy, retry?" UI
         break;
     }
   }}
 >
   {/* Your app */}
-</CopilotKit>;
-```
-
-### Error Event Interface
-
-```ts
-interface CopilotErrorEvent {
-  type:
-    | "error"
-    | "request"
-    | "response"
-    | "agent_state"
-    | "action"
-    | "message"
-    | "performance";
-  timestamp: number;
-  context: {
-    source: "ui" | "runtime" | "agent";
-    request?: {
-      operation: string;
-      method?: string;
-      url?: string;
-      startTime: number;
-    };
-    response?: {
-      endTime: number;
-      latency: number;
-    };
-    agent?: {
-      name: string;
-      nodeName?: string;
-    };
-    messages?: {
-      input: any[];
-      messageCount: number;
-    };
-    technical?: {
-      environment: string;
-      stackTrace?: string;
-    };
-  };
-  error?: any; // Present for error events
-}
+</CopilotKitProvider>;
 ```
 
 ## Common Integration Patterns
@@ -128,91 +103,120 @@ interface CopilotErrorEvent {
 
 ```tsx
 import * as Sentry from "@sentry/react";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 
-<CopilotKit
+<CopilotKitProvider
   publicApiKey="ck_pub_your_key" // or publicLicenseKey for self-hosted
-  onError={(errorEvent) => {
-    if (errorEvent.type === "error") {
-      Sentry.captureException(errorEvent.error, {
-        tags: {
-          source: errorEvent.context.source,
-          operation: errorEvent.context.request?.operation,
-        },
-        extra: {
-          context: errorEvent.context,
-          timestamp: errorEvent.timestamp,
-        },
-      });
-    }
+  onError={({ error, code, context }) => {
+    Sentry.captureException(error, {
+      tags: {
+        copilotkit_code: code,
+      },
+      extra: {
+        context,
+      },
+    });
   }}
 >
   {/* Your app */}
-</CopilotKit>;
+</CopilotKitProvider>;
 ```
 
 ### Custom Analytics
 
 ```tsx
-<CopilotKit
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+<CopilotKitProvider
   publicApiKey="ck_pub_your_key" // or publicLicenseKey for self-hosted
-  onError={(errorEvent) => {
+  onError={({ error, code, context }) => {
     analytics.track("copilotkit_event", {
-      event_type: errorEvent.type,
-      source: errorEvent.context.source,
-      agent_name: errorEvent.context.agent?.name,
-      latency: errorEvent.context.response?.latency,
-      error_message: errorEvent.error?.message,
-      timestamp: errorEvent.timestamp,
+      code,
+      error_message: error.message,
+      agent_id: context.agentId,
+      run_id: context.runId,
     });
   }}
 >
   {/* Your app */}
-</CopilotKit>
+</CopilotKitProvider>
 ```
+
+## Server-side Observability Hooks
+
+In addition to client-side `onError`, the runtime exposes server-side hooks for LLM request/response/error logging via `CopilotObservabilityConfig` (see `packages/runtime/src/lib/observability.ts`). This is the recommended place to wire up backend observability — token counts, latency, full request/response payloads — without depending on the browser.
+
+```ts
+import { CopilotRuntime } from "@copilotkit/runtime";
+
+const runtime = new CopilotRuntime({
+  observability_c: {
+    enabled: true,
+    progressive: true, // stream tokens/updates as they arrive (vs. buffered)
+    hooks: {
+      handleRequest: (data) => {
+        // data: { threadId?, runId?, model?, messages, actions?, forwardedParameters?, timestamp, provider? }
+        logger.info("llm.request", data);
+      },
+      handleResponse: (data) => {
+        // data: { threadId, runId?, model?, output, latency, timestamp, provider?, isProgressiveChunk?, isFinalResponse? }
+        logger.info("llm.response", data);
+      },
+      handleError: (data) => {
+        // data: { threadId?, runId?, model?, error, timestamp, provider? }
+        logger.error("llm.error", data);
+      },
+    },
+  },
+});
+```
+
+The three hooks correspond to the three phases of an LLM call. Custom observability hooks require a valid CopilotKit public API key.
 
 ## Environment-Specific Setup
 
 ### Development Environment
 
 ```tsx
-<CopilotKit
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+<CopilotKitProvider
   runtimeUrl="http://localhost:3000/api/copilotkit"
   publicApiKey={process.env.NEXT_PUBLIC_COPILOTKIT_API_KEY} // For observability
   showDevConsole={true} // Visual errors for fast iteration
-  onError={(errorEvent) => {
+  onError={({ error, code, context }) => {
     // Lightweight console logging in dev
-    console.log("CopilotKit Event:", errorEvent);
+    console.log("CopilotKit Event:", { error, code, context });
   }}
 >
   {/* Your app */}
-</CopilotKit>
+</CopilotKitProvider>
 ```
 
 ### Production Environment
 
 ```tsx
-<CopilotKit
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+<CopilotKitProvider
   runtimeUrl="https://your-app.com/api/copilotkit"
   publicApiKey={process.env.NEXT_PUBLIC_COPILOTKIT_API_KEY} // [!code highlight]
   showDevConsole={false} // Hide details from end-users
-  onError={(errorEvent) => {
-    if (errorEvent.type === "error") {
-      // Critical logging
-      logger.error("CopilotKit Error", {
-        error: errorEvent.error,
-        context: errorEvent.context,
-        timestamp: errorEvent.timestamp,
-      });
+  onError={({ error, code, context }) => {
+    logger.error("CopilotKit Error", {
+      error,
+      code,
+      context,
+    });
 
-      // Forward to monitoring
-      monitoring.captureError(errorEvent.error, {
-        extra: errorEvent.context,
-      });
-    }
+    // Forward to monitoring
+    monitoring.captureError(error, {
+      extra: { code, context },
+    });
   }}
 >
   {/* Your app */}
-</CopilotKit>
+</CopilotKitProvider>
 ```
 
 ## Environment Variables
@@ -240,7 +244,7 @@ NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY=ck_pub_your_key_here
 
 - **High-volume logging:**
   - Keep `onError` lightweight; batch or throttle before sending to external services
-  - Consider filtering events by type to reduce noise
+  - Consider filtering events by `code` to reduce noise
 
 ### Key Configuration Issues
 


### PR DESCRIPTION
## Summary

Updates incorrect/outdated documentation about real APIs. Reference pages aligned with current package source; observability page mechanically translated V1->V2; contributor onboarding rewritten to point at shell-docs/Fumadocs/Nx instead of the legacy Nextra tree.

**Items addressed (from [triage plan](https://app.notion.com/p/3523aa3818528128bcb0ee9e137cfff0)):**
- 9.3 — `LangChainAdapter.mdx`: `gpt-5.4` -> `gpt-4o`, drop the misleading "auto-generated" header comment
- 19.1 — V2 hook reference pages: add missing `threadId` on `useAgent`, fix `throttleMs` default cascade, add `lastRunAt` on `useThreads` Thread shape
- 5.1 — `observability-connectors.mdx`: mechanical V1->V2 translation (`<CopilotKit>` -> `<CopilotKitProvider>`, V2 import path, updated `onError` event shape, optional server-side `CopilotObservabilityConfig` section)
- 20.1 — `docs-contributions.mdx`: rewrite for shell-docs / Fumadocs / Nx with real dev commands and ports

## Visual inspection

1. Start the dev server:
   ```bash
   nx run shell-docs:dev
   ```
   Open http://localhost:3003.

2. **Reference pages — accuracy.** Visit each page and verify the documented shape matches the source:
   - `/reference/v1/classes/llm-adapters/LangChainAdapter` — `## Example` should show `model: "gpt-4o"`, not `gpt-5.4`. Page header should no longer claim it's auto-generated.
   - `/reference/v2/hooks/useAgent` — Parameters section should now list `threadId`. `throttleMs` description should mention the provider-cascade default.
   - `/reference/v2/hooks/useThreads` — `threads` Return Value's Thread shape should now list `lastRunAt`.

3. **Observability page — V2 translation.** Visit `/troubleshooting/observability-connectors`:
   - Code blocks should use `<CopilotKitProvider>`, not `<CopilotKit>`.
   - Imports should be from `@copilotkit/react-core/v2`.
   - The `onError` event shape should be `{ error, code, context }`, not the V1 `CopilotErrorEvent` fields.
   - `publicApiKey` and `publicLicenseKey` props should still appear (they carry over to V2).
   - A server-side section was added referencing `CopilotObservabilityConfig` from the runtime.

4. **Contributor docs — read-through.** Visit the rendered "Documentation Contributions" page (under the `(other)/contributing` group). Walk through as if you're a new contributor:
   - Clone instructions should point at `CopilotKit` root with Nx commands run from there.
   - Dev port should be 3003.
   - Should mention Fumadocs (not Nextra).
   - Should mention `<Snippet>`-region authoring at a high level.
   - Should mention the pre-commit hook expectation.

5. **Anti-checks (should NOT have changed):**
   - The actual JSDoc source in `packages/` is unchanged.
   - Other reference pages (e.g. `/reference/v2/hooks/useCapabilities`) are unchanged.
   - The legacy `docs/` tree (the Nextra one) is unchanged.