### PR TITLE
fix(shell-docs): IA, sidebar, and HITL cleanup

### DIFF
--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -354,6 +354,17 @@ const nextConfig: NextConfig = {
         destination: "/migrate",
         permanent: false,
       },
+
+      // ag-ui-middleware moved into the agentic-protocols group so it
+      // appears in the sidebar under AG-UI rather than as an orphan
+      // root page. 302 (not 301) since the new home is recent and we
+      // want flexibility to revisit placement without burning the
+      // permanent-redirect cache.
+      {
+        source: "/ag-ui-middleware",
+        destination: "/agentic-protocols/ag-ui-middleware",
+        permanent: false,
+      },
     ];
   },
 };

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -232,7 +232,8 @@ export async function DocsPageView({
                         <WhenFrameworkHas
                           {...(props as {
                             flag: "a2ui_pattern" | "interrupt_pattern";
-                            equals: string;
+                            equals?: string;
+                            absent?: boolean;
                             framework?: string;
                             children?: React.ReactNode;
                           })}

--- a/showcase/shell-docs/src/components/when-framework-has.tsx
+++ b/showcase/shell-docs/src/components/when-framework-has.tsx
@@ -44,9 +44,19 @@ interface WhenFrameworkHasProps {
   /**
    * Required value to match. Children render only when
    * `integration[flag] === equals`. Strict equality — null/undefined
-   * never matches.
+   * never matches. Mutually exclusive with `absent`.
    */
-  equals: string;
+  equals?: string;
+  /**
+   * Inverse mode: render children only when the flag is null/missing on
+   * the active framework's manifest. Lets MDX pages declare a single
+   * "fallback" branch for frameworks that don't implement a feature, so
+   * gated pages don't collapse to an empty middle.
+   *
+   * Mutually exclusive with `equals`. Exactly one of `equals` / `absent`
+   * must be provided.
+   */
+  absent?: boolean;
   /**
    * Integration slug (e.g. `langgraph-python`, `mastra`). Defaults to
    * `defaultFramework` injected by the page renderer.
@@ -63,6 +73,7 @@ interface WhenFrameworkHasProps {
 export function WhenFrameworkHas({
   flag,
   equals,
+  absent,
   framework,
   defaultFramework,
   children,
@@ -78,7 +89,18 @@ export function WhenFrameworkHas({
   // because TypeScript can't statically prove `flag` indexes a typed
   // field, but `SupportedFlag` keeps the lookup safe in practice.
   const value = (integration as unknown as Record<string, unknown>)[flag];
+
+  // `absent` mode: render the fallback when the flag is null/missing.
+  // Used by pages that gate per-framework variants and need a "doesn't
+  // apply here" branch so non-matching frameworks see useful prose
+  // instead of a collapsed page.
+  if (absent) {
+    if (value == null) return <>{children}</>;
+    return null;
+  }
+
   if (value == null) return null;
+  if (equals === undefined) return null;
   if (value !== equals) return null;
 
   return <>{children}</>;

--- a/showcase/shell-docs/src/content/docs/agent-config.mdx
+++ b/showcase/shell-docs/src/content/docs/agent-config.mdx
@@ -20,6 +20,8 @@ If the values are a *channel* the user occasionally tunes (a settings panel, a t
 
 <InlineDemo demo="agent-config" />
 
+How agent config flows from the UI into the agent's reasoning loop depends on your runtime architecture. Agents living behind a runtime read it from agent state on every run, while in-process agents receive the same object as forwarded properties on the provider — same UX, slightly different wiring on each side.
+
 <WhenFrameworkHas flag="agent_config_pattern" equals="shared-state">
 
 ## How it works

--- a/showcase/shell-docs/src/content/docs/agentic-protocols/ag-ui-middleware.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-protocols/ag-ui-middleware.mdx
@@ -4,6 +4,14 @@ icon: lucide/Layers
 description: Configure AG-UI middleware for your CopilotKit application.
 hideTOC: true
 ---
+
+> AG-UI middleware is fundamentally an [AG-UI protocol](./ag-ui)
+> concept defined upstream in `@ag-ui/client`. This page covers how to
+> wire it into a CopilotKit runtime; for the protocol-level reference
+> (lifecycle, `runNextWithState`, the `Middleware` base class), see the
+> upstream guide at
+> [docs.ag-ui.com/sdk/js/client/middleware](https://docs.ag-ui.com/sdk/js/client/middleware).
+
 AG-UI agents expose a middleware layer via `agent.use(middleware)`, a powerful hook for logging, guardrails, request transformation, and event rewriting. Because CopilotKit runs the middleware server-side inside the [Copilot Runtime](/backend/copilot-runtime), it executes in a trusted environment where the client cannot tamper with it.
 
 ## Defining a Middleware

--- a/showcase/shell-docs/src/content/docs/agentic-protocols/meta.json
+++ b/showcase/shell-docs/src/content/docs/agentic-protocols/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Agentic Protocols",
   "icon": "lucide/Zap",
-  "pages": ["index", "ag-ui", "mcp", "a2a"]
+  "pages": ["index", "ag-ui", "ag-ui-middleware", "mcp", "a2a"]
 }

--- a/showcase/shell-docs/src/content/docs/human-in-the-loop/headless.mdx
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop/headless.mdx
@@ -38,6 +38,19 @@ mechanism.
 
 </WhenFrameworkHas>
 
+<WhenFrameworkHas flag="interrupt_pattern" absent>
+
+> **Not available on this framework.** Headless interrupts are built on
+> top of `useInterrupt` / `useFrontendTool` patterns that require the
+> runtime to expose either a native `interrupt(...)` primitive
+> (LangGraph) or a Promise-resolving frontend-tool path (Microsoft Agent
+> Framework). For all other integrations, use
+> [`useHumanInTheLoop`](../human-in-the-loop) instead — it's the
+> standard hook for tool-call-based pause/resume flows and works on
+> every framework that supports tool calls.
+
+</WhenFrameworkHas>
+
 <InlineDemo demo="interrupt-headless" />
 
 ## When should I use this?
@@ -111,6 +124,8 @@ A few things this pattern is careful about:
 
 </WhenFrameworkHas>
 
+<WhenFrameworkHas flag="interrupt_pattern" equals="native">
+
 ## Driving it from plain UI
 
 Once `useHeadlessInterrupt` returns `{ pending, resolve }`, the rest is
@@ -145,6 +160,8 @@ function HeadlessInterruptPanel() {
   return <button onClick={() => kickOff("Book a call with sales.")}>Book call</button>;
 }
 ```
+
+</WhenFrameworkHas>
 
 ## Going further
 

--- a/showcase/shell-docs/src/content/docs/human-in-the-loop/useInterrupt.mdx
+++ b/showcase/shell-docs/src/content/docs/human-in-the-loop/useInterrupt.mdx
@@ -40,6 +40,18 @@ user answers, agent resumes — different mechanism underneath.
 
 </WhenFrameworkHas>
 
+<WhenFrameworkHas flag="interrupt_pattern" absent>
+
+> **Not available on this framework.** `useInterrupt` is only meaningful
+> when the underlying runtime exposes either a native `interrupt(...)`
+> primitive (LangGraph) or a Promise-resolving frontend tool path
+> (Microsoft Agent Framework). For all other integrations, use
+> [`useHumanInTheLoop`](../human-in-the-loop) instead — it's the
+> standard hook for tool-call-based pause/resume flows and works on
+> every framework that supports tool calls.
+
+</WhenFrameworkHas>
+
 <InlineDemo demo="gen-ui-interrupt" />
 
 ## When should I use this?

--- a/showcase/shell-docs/src/content/docs/multi-agent/meta.json
+++ b/showcase/shell-docs/src/content/docs/multi-agent/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Multi-Agent",
+  "icon": "lucide/Network",
+  "pages": ["subagents"]
+}


### PR DESCRIPTION
## Summary

Sidebar / IA / HITL cleanup from the shell-docs QA triage. Adds fallback callouts to HITL pages for non-native frameworks, fixes gate scoping bugs, wires orphan pages into nav, adds missing `meta.json`.

**Items addressed:**
- 3.1 — `useInterrupt` and `headless` fallback callout for the 13 frameworks without `interrupt_pattern` (via new `absent` mode on `<WhenFrameworkHas>`)
- 3.3 — `headless.mdx` `useHeadlessInterrupt` symbol scope fix (wrap "Driving it from plain UI" inside the native gate)
- 3.5 — `multi-agent/meta.json` added so breadcrumbs use the explicit "Multi-Agent" label
- 17.1 — `agent-config.mdx` shared lead-in between `<InlineDemo>` and the gated branches
- 18.1 — `ag-ui-middleware.mdx` moved under `agentic-protocols/`, registered in `meta.json`, links to upstream AG-UI guide, 302 from the old `/ag-ui-middleware` path

## Visual inspection

1. Start the dev server:
   ```bash
   nx run shell-docs:dev
   ```
   Open http://localhost:3003.

2. **HITL fallback callout.** Switch the framework picker to each of: `built-in-agent`, `mastra`, `crewai-crews`, `ag2`, `google-adk`, `pydantic-ai`, `agno`, `claude-sdk-python`, `claude-sdk-typescript`, `llamaindex`, `langroid`, `spring-ai`, `strands`. For each, navigate to:
   - `/human-in-the-loop/useInterrupt`
   - `/human-in-the-loop/headless`
   The page should render a callout pointing readers at `/human-in-the-loop` (`useHumanInTheLoop`), NOT collapse to an empty middle.

3. **HITL native framework check (no regression).** Switch to `langgraph-fastapi`, `langgraph-typescript`, `langgraph-python`, `ms-agent-dotnet`, `ms-agent-python`. Same two pages should still render their full native/promise-based content. Especially check `/human-in-the-loop/headless` for proper `useHeadlessInterrupt` usage now within its gate.

4. **Multi-agent sidebar.** With any framework selected, confirm "Multi-Agent" appears in the sidebar with `subagents` as a sub-entry.

5. **agent-config lead-in.** Visit `/agent-config`. Verify there's a smooth prose transition between the InlineDemo and the "How it works" section.

6. **AG-UI middleware sidebar.** Confirm `ag-ui-middleware` appears in the sidebar under the AG-UI / agentic-protocols section. Click through and verify the page renders correctly. Verify the 302 from the old `/ag-ui-middleware` URL works.

7. **Anti-checks (should NOT have changed):**
   - Per-framework HITL nav for the 5 native fws unchanged in shape.
   - Other sidebar sections unaffected.
   - Existing `<WhenFrameworkHas>` gates on other pages still work.