### PR TITLE
fix(shell-docs): critical-path content fixes — imports, links, model names, premium walkthrough

### DIFF
--- a/scripts/validate-doc-model-names.ts
+++ b/scripts/validate-doc-model-names.ts
@@ -22,6 +22,12 @@ interface Violation {
 
 const DOCS_DIR = path.resolve(__dirname, "../docs");
 const ALLOWLIST_PATH = path.join(DOCS_DIR, "model-allowlist.json");
+// Additional roots to scan. The main legacy Nextra tree under `docs/` is the
+// primary canonical home, but the new shell-docs surface (`showcase/shell-docs/`)
+// is now also authored content and must obey the same allowlist.
+const EXTRA_DOCS_DIRS = [
+  path.resolve(__dirname, "../showcase/shell-docs/src/content"),
+];
 
 // Provider prefixes stripped before matching (e.g. "openai/gpt-4o" -> "gpt-4o")
 const PROVIDER_PREFIXES = [
@@ -274,6 +280,10 @@ function main() {
   }
 
   const violations = validateFiles(DOCS_DIR, ALLOWLIST_PATH);
+  for (const extra of EXTRA_DOCS_DIRS) {
+    if (!fs.existsSync(extra)) continue;
+    violations.push(...validateFiles(extra, ALLOWLIST_PATH));
+  }
 
   if (violations.length === 0) {
     console.log("All model names in docs are valid.");

--- a/showcase/shell-docs/src/content/docs/agentic-protocols/index.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-protocols/index.mdx
@@ -75,7 +75,7 @@ Learn about these protocols and how to connect your app to agents which support 
           verticalAlign: "top",
         }}
       >
-        <a href="./ag-ui-protocol">
+        <a href="./ag-ui">
           <strong>AG-UI</strong>
         </a>
         <br />
@@ -103,7 +103,7 @@ Learn about these protocols and how to connect your app to agents which support 
           verticalAlign: "top",
         }}
       >
-        <a href="./connect-mcp-servers">
+        <a href="./mcp">
           <strong>MCP</strong>
         </a>
         <br />
@@ -131,7 +131,7 @@ Learn about these protocols and how to connect your app to agents which support 
           verticalAlign: "top",
         }}
       >
-        <a href="./a2a-protocol">
+        <a href="./a2a">
           <strong>A2A</strong>
         </a>
         <br />
@@ -147,16 +147,15 @@ Learn about these protocols and how to connect your app to agents which support 
         <strong>Agent ↔ Generative UI </strong>
       </td>
       <td style={{ padding: "12px", verticalAlign: "top" }}>
-        <strong>[A2UI](./generative-ui/specs/a2ui)</strong> (Google)
+        <strong>[A2UI](/generative-ui/a2ui)</strong> (Google)
         <br />
-        <strong>[MCP Apps](./generative-ui/specs/mcp-apps)</strong> (MCP
+        <strong>[MCP Apps](/generative-ui/mcp-apps)</strong> (MCP
         Ecosystem)
         <br />
-        <strong>[Open-JSON-UI](./generative-ui/specs/open-json-ui)</strong>{" "}
-        (OpenAI)
+        <strong>Open-JSON-UI</strong> (OpenAI)
       </td>
       <td style={{ padding: "12px" }}>
-        Declarative, LLM-friendly [generative UI specs](./generative-ui/specs)
+        Declarative, LLM-friendly [generative UI specs](/generative-ui)
         that define <em>what</em> to render and how to structure agent responses
         visually. CopilotKit fully supports all of these.
       </td>

--- a/showcase/shell-docs/src/content/docs/agentic-protocols/index.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-protocols/index.mdx
@@ -75,7 +75,7 @@ Learn about these protocols and how to connect your app to agents which support 
           verticalAlign: "top",
         }}
       >
-        <a href="./ag-ui">
+        <a href="/agentic-protocols/ag-ui">
           <strong>AG-UI</strong>
         </a>
         <br />
@@ -103,7 +103,7 @@ Learn about these protocols and how to connect your app to agents which support 
           verticalAlign: "top",
         }}
       >
-        <a href="./mcp">
+        <a href="/agentic-protocols/mcp">
           <strong>MCP</strong>
         </a>
         <br />
@@ -131,7 +131,7 @@ Learn about these protocols and how to connect your app to agents which support 
           verticalAlign: "top",
         }}
       >
-        <a href="./a2a">
+        <a href="/agentic-protocols/a2a">
           <strong>A2A</strong>
         </a>
         <br />

--- a/showcase/shell-docs/src/content/docs/agentic-protocols/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-protocols/mcp.mdx
@@ -102,6 +102,7 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
         ```tsx
         "use client";
 
+        import { CopilotKit } from "@copilotkit/react-core/v2";
 
         export default function App() {
           return (
@@ -120,6 +121,8 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
         ```tsx
         "use client";
 
+        import { useEffect } from "react";
+        import { useCopilotKit } from "@copilotkit/react-core/v2";
 
         function McpServerManager() {
           const { setMcpServers } = useCopilotKit();
@@ -148,6 +151,7 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
         ```tsx
         "use client";
 
+        import { CopilotChat } from "@copilotkit/react-core/v2";
 
         export default function ChatInterface() {
           return (
@@ -169,6 +173,7 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
         ```tsx
         "use client";
 
+        import {
           useFrontendTool,
           CatchAllActionRenderProps,
         } from "@copilotkit/react-core/v2";
@@ -195,6 +200,7 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
         ```tsx
         "use client";
 
+        import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
         export default function Page() {
           return (
@@ -331,10 +337,12 @@ For detailed implementation guidance, refer to the [official MCP SDK documentati
 Here's a basic example of configuring the runtime:
 
 ```tsx
+import {
   CopilotRuntime,
   OpenAIAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
 } from "@copilotkit/runtime";
+import { NextRequest } from "next/server";
 
 const serviceAdapter = new OpenAIAdapter();
 

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -25,6 +25,8 @@ If you don't need any of those, skip auth entirely. The agent runs anonymously a
 Pass your token via the `headers` prop on `<CopilotKit>`. CopilotKit forwards every request with that header attached.
 
 ```tsx title="frontend/src/app/page.tsx"
+import { CopilotKit } from "@copilotkit/react-core/v2";
+
 <CopilotKit
   runtimeUrl="/api/copilotkit"
   headers={{
@@ -82,6 +84,8 @@ export const GET = (req: NextRequest) => handler(req);
 Pass your token via the `properties` prop. CopilotKit forwards it to LangGraph as a Bearer token automatically.
 
 ```tsx title="frontend/src/app/page.tsx"
+import { CopilotKit } from "@copilotkit/react-core/v2";
+
 <CopilotKit
   runtimeUrl="/api/copilotkit"
   properties={{
@@ -185,6 +189,8 @@ async def my_agent_node(state: AgentState, config: RunnableConfig):
 Pass your token via the `properties` prop. CopilotKit forwards it to AG2's `/chat` endpoint as a request header.
 
 ```tsx title="frontend/src/app/page.tsx"
+import { CopilotKit } from "@copilotkit/react-core/v2";
+
 <CopilotKit
   runtimeUrl="/api/copilotkit"
   properties={{
@@ -210,7 +216,7 @@ from autogen.ag_ui import AGUIStream, RunAgentInput
 agent = ConversableAgent(
     name="assistant",
     system_message="You are a helpful assistant.",
-    llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+    llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
 )
 
 stream = AGUIStream(agent)
@@ -268,6 +274,8 @@ def get_account_data(
 Microsoft Agent Framework's AG-UI host expects authentication on a request header rather than the runtime properties channel. Pass the token via `<CopilotKit headers={...}>`:
 
 ```tsx title="frontend/src/app/page.tsx"
+import { CopilotKit } from "@copilotkit/react-core/v2";
+
 <CopilotKit
   runtimeUrl="/api/copilotkit"
   headers={{

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -40,6 +40,8 @@ export const POST = async (req: NextRequest) => {
 Then point your frontend at the endpoint:
 
 ```tsx
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
 <CopilotKitProvider runtimeUrl="/api/copilotkit">
   <YourApp />
 </CopilotKitProvider>
@@ -59,6 +61,8 @@ The runtime supports multiple agent types. `BuiltInAgent` is the primary agent c
 If you register an agent under the name `"default"`, CopilotKit's prebuilt UI components will use it automatically without any additional configuration on the frontend. This is useful when you have one primary agent and don't want to specify an `agentId` everywhere.
 
 ```ts title="app/api/copilotkit/route.ts"
+import { BuiltInAgent } from "@copilotkit/runtime/v2";
+
 const runtime = new CopilotRuntime({
   agents: {
     // This agent is used automatically by CopilotPopup, CopilotSidebar, etc.
@@ -111,6 +115,8 @@ a2ui: { agents: ["my-agent"] }
 On the frontend, the A2UI renderer activates automatically — no extra configuration needed. If you want to override the default theme, pass an `a2ui` prop to `<CopilotKitProvider>`:
 
 ```tsx
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
 <CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui={{ theme: myCustomTheme }}>
   {children}
 </CopilotKitProvider>
@@ -139,6 +145,7 @@ CopilotKit is built on the [AG-UI protocol](./ag-ui), which is an open standard.
 
 ```tsx
 import { HttpAgent } from "@ag-ui/client";
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 
 const myAgent = new HttpAgent({
   url: "https://my-agent.example.com",

--- a/showcase/shell-docs/src/content/docs/faq.mdx
+++ b/showcase/shell-docs/src/content/docs/faq.mdx
@@ -38,21 +38,21 @@ We've got answers to some common questions!
     Beautiful, powerful and customizable chat components just an import away.
     | | |
     |---------|-------------|
-    | [**Chat**](/reference/v1/components/chat/CopilotChat) | Simple and powerful chat interface |
-    | [**Pop-up**](/reference/v1/components/chat/CopilotPopup) | The Chat component in a pop-up format |
-    | [**Sidebar**](/reference/v1/components/chat/CopilotSidebar) | The Chat component in a sidebar format |
-    | [**Copilot Textarea**](/reference/v1/components/CopilotTextarea) | Powerful AI autocompletion as a drop-in replacement for any textarea |
+    | **Chat** | Simple and powerful chat interface |
+    | **Pop-up** | The Chat component in a pop-up format |
+    | **Sidebar** | The Chat component in a sidebar format |
+    | **Copilot Textarea** | Powerful AI autocompletion as a drop-in replacement for any textarea |
     | [**Headless**](/custom-look-and-feel/slots) | Full customization of the chat interfaces |
 
     ### Deeply integrated Copilots
     Give Copilots the ability to execute tools directly in your application.
     |  |  |
     |---------|-------------|
-    | [**Copilot Readable State**](/reference/v1/hooks/useCopilotReadable) | Enables Copilots to read and understand the application state |
-    | [**Frontend Tools**](/reference/v1/hooks/useFrontendTool) | Copilots can execute tools in the application |
+    | **Copilot Readable State** | Enables Copilots to read and understand the application state |
+    | **Frontend Tools** | Copilots can execute tools in the application |
     | [**Generative UI**](/generative-ui/your-components/display-only) | Render any component in the copilot chat interface |
-    | [**AI Autosuggestions**](/reference/v1/hooks/useCopilotChatSuggestions) | AI-powered autosuggestions in your AI chat interface |
-    | [**Copilot Tasks**](/reference/v1/classes/CopilotTask) | Let your copilots execute tools proactively based on application state |
+    | **AI Autosuggestions** | AI-powered autosuggestions in your AI chat interface |
+    | **Copilot Tasks** | Let your copilots execute tools proactively based on application state |
 
     ### Rich agentic experiences
     Integrate your LangChain agents into your product with ease.

--- a/showcase/shell-docs/src/content/docs/faq.mdx
+++ b/showcase/shell-docs/src/content/docs/faq.mdx
@@ -58,9 +58,9 @@ We've got answers to some common questions!
     Integrate your LangChain agents into your product with ease.
     | |  |
     |---------|-------------|
-    | [**Deep support for LangChain**](/langgraph/quickstart) | Bring your LangChain agents directly into your product |
-    | [**Human-in-the-loop**](/langgraph/human-in-the-loop) | Allow your users to work with your agents to solve complex problems |
-    | [**Shared state**](/langgraph/shared-state) | Render the state of your LangChain agents with less than 10 lines of code |
+    | **Deep support for LangChain** | Bring your LangChain agents directly into your product |
+    | **Human-in-the-loop** | Allow your users to work with your agents to solve complex problems |
+    | **Shared state** | Render the state of your LangChain agents with less than 10 lines of code |
 
   </Accordion>
   <Accordion title="How does it all work?">

--- a/showcase/shell-docs/src/content/docs/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/inspector.mdx
@@ -24,7 +24,7 @@ The **CopilotKit Inspector** is a built-in debugging overlay that sits on top of
 | **Available Agents** | Which agents CopilotKit has discovered via `/info` and which one is currently active. |
 | **Agent State** | The current `agent.state` tree, rerendered as it updates. Great for debugging [shared state](./shared-state) flows. |
 | **Frontend Tools** | Every tool registered via `useFrontendTool`, `useComponent`, `useHumanInTheLoop`, or `useRenderTool`, along with its parameter schema. |
-| **Context** | The [`useAgentContext`](/langgraph/agent-app-context) entries the agent currently receives, plus any document context you've attached. |
+| **Context** | The [`useAgentContext`](/langgraph-python/agent-app-context) entries the agent currently receives, plus any document context you've attached. |
 
 ## When should I use it?
 

--- a/showcase/shell-docs/src/content/docs/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/inspector.mdx
@@ -24,7 +24,7 @@ The **CopilotKit Inspector** is a built-in debugging overlay that sits on top of
 | **Available Agents** | Which agents CopilotKit has discovered via `/info` and which one is currently active. |
 | **Agent State** | The current `agent.state` tree, rerendered as it updates. Great for debugging [shared state](./shared-state) flows. |
 | **Frontend Tools** | Every tool registered via `useFrontendTool`, `useComponent`, `useHumanInTheLoop`, or `useRenderTool`, along with its parameter schema. |
-| **Context** | The [`useAgentContext`](./agent-app-context) entries the agent currently receives, plus any document context you've attached. |
+| **Context** | The [`useAgentContext`](/langgraph/agent-app-context) entries the agent currently receives, plus any document context you've attached. |
 
 ## When should I use it?
 

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -221,10 +221,13 @@ Before you begin, you'll need the following:
                 Create an API route to connect CopilotKit to your ADK agent:
 
                 ```tsx title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { HttpAgent } from "@ag-ui/client";
+                import { NextRequest } from "next/server";
 
                 const serviceAdapter = new ExperimentalEmptyAdapter();
 
@@ -251,6 +254,9 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import './globals.css';
 
                 // ...
 
@@ -274,6 +280,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
+              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/frontend-tools.mdx
@@ -103,7 +103,7 @@ Without frontend actions, agents are limited to just processing and returning da
                 agent = ConversableAgent(
                     name="assistant",
                     system_message="You are a helpful assistant.",
-                    llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+                    llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
                 )
 
                 stream = AGUIStream(agent)

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/generative-ui/state-rendering.mdx
@@ -71,7 +71,7 @@ is a situation where a user and an agent are working together to solve a problem
             "You are a helpful assistant for storing searches. "
             "Use `add_search` once per query, then call `run_searches`."
         ),
-        llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+        llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
     )
 
 

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/generative-ui/tool-rendering.mdx
@@ -46,7 +46,7 @@ Start your AG2 backend with a `/chat` endpoint and connect CopilotKit to that en
         agent = ConversableAgent(
             name="assistant",
             system_message="You are a helpful assistant.",
-            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
         )
 
         @agent.register_for_llm(

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/human-in-the-loop.mdx
@@ -122,7 +122,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
                 "When you need the user to choose, call the frontend tool `offerOptions`. "
                 "After it returns, call `store_user_choice` with the selected value."
             ),
-            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
         )
 
         @agent.register_for_llm(description="Store the latest user choice in shared state.")

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/readables.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/readables.mdx
@@ -116,7 +116,7 @@ This context can then be shared with your AG2 backend.
                                 "You are a helpful assistant that can help emailing colleagues. "
                                 "Call `get_colleagues` before suggesting recipients."
                             ),
-                            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+                            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
                         )
 
                         @agent.register_for_llm(description="Return the current user's colleagues from CopilotKit readables.")
@@ -199,7 +199,7 @@ This context can then be shared with your AG2 backend.
                         agent = ConversableAgent(
                             name="assistant",
                             system_message="You are a helpful assistant.",
-                            llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+                            llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
                         )
 
                         @agent.register_for_llm(description="Read colleagues from CopilotKit readable context.")

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/shared-state/read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/shared-state/read.mdx
@@ -70,7 +70,7 @@ state updates, you can reflect these updates natively in your application.
             "You are a helpful assistant for tracking language. "
             "Always respond in the current language."
         ),
-        llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+        llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
     )
 
     @agent.register_for_llm(description="Update the language in shared state.")

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/shared-state/write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/shared-state/write.mdx
@@ -69,7 +69,7 @@ You can use this when you want to keep your interface and backend agent state sy
             "You are a helpful assistant for tracking language. "
             "Always respond in the current language."
         ),
-        llm_config=LLMConfig({"model": "gpt-5.2-mini"}),
+        llm_config=LLMConfig({"model": "gpt-5.4-mini"}),
     )
 
     @agent.register_for_llm(description="Update the language in shared state.")

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/generative-ui/tool-rendering.mdx
@@ -72,7 +72,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
 
         llm = OpenAiCompatibleConfig(
             name="my_llm",
-            model_id="gpt-5.2-mini",
+            model_id="gpt-5.4-mini",
             url="https://api.openai.com/v1",
         )
         weather_tool = ServerTool( # ServerTool are backend tools in Agent Spec

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
@@ -334,7 +334,7 @@ hideTOC: true
           Wrap your application with the CopilotKit provider:
 
           ```tsx title="app/layout.tsx"
-          import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+          import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
           import "@copilotkit/react-ui/v2/styles.css";
           import './globals.css';
 

--- a/showcase/shell-docs/src/content/docs/integrations/agno/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/frontend-tools.mdx
@@ -98,7 +98,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
         from tools.frontend import sayHello
 
         agent = Agent(
-            model=OpenAIChat(id="gpt-5.2"),
+            model=OpenAIChat(id="gpt-5.4"),
             tools=[sayHello],
             description="A helpful assistant that can answer questions and provide information.",
             instructions="Be helpful and friendly. Format your responses using markdown where appropriate.",

--- a/showcase/shell-docs/src/content/docs/integrations/agno/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/generative-ui/tool-rendering.mdx
@@ -64,7 +64,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
         # ...
 
         agent = Agent(
-            model=OpenAIChat(id="gpt-5.2"),
+            model=OpenAIChat(id="gpt-5.4"),
             tools=[get_weather], # [!code highlight]
             description="A helpful assistant that can answer questions and provide information.",
             instructions="Be helpful and friendly. Format your responses using markdown where appropriate.",

--- a/showcase/shell-docs/src/content/docs/integrations/agno/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/human-in-the-loop.mdx
@@ -64,7 +64,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
         from tools.frontend import offerOptions
 
         agent = Agent(
-            model=OpenAIChat(id="gpt-5.2"),
+            model=OpenAIChat(id="gpt-5.4"),
             tools=[offerOptions],
             description="A helpful assistant that can answer questions and provide information.",
             instructions="Be helpful and friendly. Format your responses using markdown where appropriate.",

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -149,7 +149,7 @@ Before you begin, you'll need the following:
                 from agno.os.interfaces.agui import AGUI
 
                 agent = Agent(
-                    model=OpenAIChat(id="gpt-5.2"),
+                    model=OpenAIChat(id="gpt-5.4"),
                     description="A helpful assistant that can answer questions and provide information.",
                     instructions="Be helpful and friendly. Format your responses using markdown where appropriate.",
                 )
@@ -188,10 +188,13 @@ Before you begin, you'll need the following:
                 Create an API route to connect CopilotKit to your Agno agent:
 
                 ```tsx title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { AgnoAgent } from "@ag-ui/agno";
+                import { NextRequest } from "next/server";
 
                 const serviceAdapter = new ExperimentalEmptyAdapter();
 
@@ -218,6 +221,9 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import './globals.css';
 
                 // ...
 
@@ -241,6 +247,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
+              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/frontend-tools.mdx
@@ -73,7 +73,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
         api_key = os.getenv("OPENAI_API_KEY", "")
         model = OpenAIModel(
             client_args={"api_key": api_key},
-            model_id="gpt-5.2",
+            model_id="gpt-5.4",
         )
 
         agent = Agent(

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/generative-ui/tool-rendering.mdx
@@ -64,7 +64,7 @@ def get_weather(location: str) -> dict:
 api_key = os.getenv("OPENAI_API_KEY", "")
 model = OpenAIModel(
     client_args={"api_key": api_key},
-    model_id="gpt-5.2",
+    model_id="gpt-5.4",
 )
 
 agent = Agent(

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -152,7 +152,7 @@ Before you begin, you'll need the following:
                 api_key = os.getenv("OPENAI_API_KEY", "")
                 model = OpenAIModel(
                     client_args={"api_key": api_key},
-                    model_id="gpt-5.2",
+                    model_id="gpt-5.4",
                 )
 
                 agent = Agent(
@@ -202,10 +202,13 @@ Before you begin, you'll need the following:
                 Create an API route to connect CopilotKit to your Strands agent:
 
                 ```tsx title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { HttpAgent } from "@ag-ui/client";
+                import { NextRequest } from "next/server";
 
                 const serviceAdapter = new ExperimentalEmptyAdapter();
 
@@ -232,6 +235,9 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import './globals.css';
 
                 // ...
 
@@ -255,6 +261,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
+              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -92,7 +92,7 @@ Before you begin, you'll need the following:
         Wrap your application with the CopilotKit provider:
 
         ```tsx title="app/layout.tsx"
-        import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+        import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
         import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
         import './globals.css';
 

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/advanced/disabling-state-streaming.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/advanced/disabling-state-streaming.mdx
@@ -30,7 +30,7 @@ You can control whether to stream messages or tool calls by selectively wrapping
 
             # 1) Do not emit messages or tool calls, keeping the LLM call private.
             response = completion(
-                model="openai/gpt-5.2",
+                model="openai/gpt-5.4",
                 messages=[
                     {"role": "system", "content": "You are a helpful assistant"},
                     *self.state.messages
@@ -42,7 +42,7 @@ You can control whether to stream messages or tool calls by selectively wrapping
             #    Note that we pass `stream=True` to the inner `completion` call.
             response = await copilotkit_stream(
                 completion(
-                    model="openai/gpt-5.2",
+                    model="openai/gpt-5.4",
                     messages=[
                         {"role": "system", "content": "You are a helpful assistant"},
                         *self.state.messages

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/advanced/emit-messages.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/advanced/emit-messages.mdx
@@ -66,7 +66,7 @@ Manually emitted messages are great for **when you don't want to wait for the fu
 
                     response = copilotkit_stream(
                         completion(
-                            model="openai/gpt-5.2",
+                            model="openai/gpt-5.4",
                             messages=[
                                 {"role": "system", "content": "You are a helpful assistant."},
                                 *self.state["messages"]

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/generative-ui/state-rendering.mdx
@@ -99,7 +99,7 @@ is a situation where a user and an agent are working together to solve a problem
             # Run the model to generate a response
             response = await copilotkit_stream(
                 completion(
-                    model="openai/gpt-5.2",
+                    model="openai/gpt-5.4",
                     messages=[
                         {"role": "system", "content": "You are a helpful assistant."},
                         *self.state.get("messages", [])

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/human-in-the-loop/flow.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/human-in-the-loop/flow.mdx
@@ -177,7 +177,7 @@ of everything that has happened during a HITL interaction.
 
                 response = await copilotkit_stream(
                     completion(
-                        model="openai/gpt-5.2",
+                        model="openai/gpt-5.4",
                         messages=[system_message, *messages],
                         tools=self.state["copilotkit"]["actions"],
                         stream=True

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/shared-state/predictive-state-updates.mdx
@@ -163,7 +163,7 @@ included in the function's final returned state. Otherwise, they will be overwri
                                 # Provide the tool to the LLM and call the model
                                 response = await copilotkit_stream(
                                     completion(
-                                        model="openai/gpt-5.2",
+                                        model="openai/gpt-5.4",
                                         messages=[
                                             {
                                                 "role": "system",

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/advanced/disabling-state-streaming.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/advanced/disabling-state-streaming.mdx
@@ -36,7 +36,7 @@ You can disable all message streaming and tool call streaming by passing `emit_m
             )
 
             # 2) Provide the actions to the LLM
-            model = ChatOpenAI(model="gpt-5.2").bind_tools([
+            model = ChatOpenAI(model="gpt-5.4").bind_tools([
               *state["copilotkit"]["actions"],
               # ... any tools you want to make available to the model
             ])
@@ -73,7 +73,7 @@ You can disable all message streaming and tool call streaming by passing `emit_m
             });
 
             // 2) Provide the actions to the LLM
-            const model = new ChatOpenAI({ temperature: 0, model: "gpt-5.2" });
+            const model = new ChatOpenAI({ temperature: 0, model: "gpt-5.4" });
             const modelWithTools = model.bindTools!([
                 ...convertActionsToDynamicStructuredTools(state.copilotkit?.actions || []),
                 ...tools,

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/advanced/emit-messages.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/advanced/emit-messages.mdx
@@ -57,7 +57,7 @@ Manually emitted messages are great for **when you don't want to wait for the no
                 # ...
 
                 async def chat_node(state: AgentState, config: RunnableConfig):
-                    model = ChatOpenAI(model="gpt-5.2")
+                    model = ChatOpenAI(model="gpt-5.4")
 
                     # [!code highlight:2]
                     intermediate_message = "Thinking really hard..."
@@ -85,7 +85,7 @@ Manually emitted messages are great for **when you don't want to wait for the no
                 // ...
 
                 async function chat_node(state: AgentState, config: RunnableConfig) {
-                    const model = new ChatOpenAI({ model: "gpt-5.2" });
+                    const model = new ChatOpenAI({ model: "gpt-5.4" });
 
                     // [!code highlight:2]
                     const intermediateMessage = "Thinking really hard...";

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
@@ -12,7 +12,7 @@ This context can then be shared with your LangGraph agent.
 
 ## Implementation
 <Callout>
-    Check out the [Frontend Data documentation](/langgraph/agent-app-context) to understand what this is and how to use it.
+    Check out the [Frontend Data documentation](/langgraph-python/agent-app-context) to understand what this is and how to use it.
 </Callout>
 
 <TailoredContent

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
@@ -12,7 +12,7 @@ This context can then be shared with your LangGraph agent.
 
 ## Implementation
 <Callout>
-    Check out the [Frontend Data documentation](/built-in-agent/agent-app-context) to understand what this is and how to use it.
+    Check out the [Frontend Data documentation](/langgraph/agent-app-context) to understand what this is and how to use it.
 </Callout>
 
 <TailoredContent

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
@@ -266,7 +266,7 @@ persisted at the end of a node.
 
                 async def chat_node(state: AgentState, config: RunnableConfig):
                     # 1) Call the model with CopilotKit's modified config
-                    model = ChatOpenAI(model="gpt-5.2")
+                    model = ChatOpenAI(model="gpt-5.4")
                     response = await model.ainvoke(state["messages"], modifiedConfig)
 
                     # 2) Make sure to return the new messages
@@ -280,7 +280,7 @@ persisted at the end of a node.
 
                 async function chatNode(state: AgentState, config: RunnableConfig): Promise<AgentState> {
                     // 1) Call the model with CopilotKit's modified config
-                    const model = new ChatOpenAI({ temperature: 0, model: "gpt-5.2" });
+                    const model = new ChatOpenAI({ temperature: 0, model: "gpt-5.4" });
                     const response = await model.invoke(state.messages, modifiedConfig);
 
                     // 2) Make sure to return the new messages
@@ -309,7 +309,7 @@ persisted at the end of a node.
                     )
 
                     # 2) Call the model with CopilotKit's modified config
-                    model = ChatOpenAI(model="gpt-5.2")
+                    model = ChatOpenAI(model="gpt-5.4")
                     response = await model.ainvoke(state["messages"], modifiedConfig)
 
                     # 3) Don't return the new response to hide it from the user
@@ -326,7 +326,7 @@ persisted at the end of a node.
                     });
 
                     // 2) Call the model with CopilotKit's modified config
-                    const model = new ChatOpenAI({ temperature: 0, model: "gpt-5.2" });
+                    const model = new ChatOpenAI({ temperature: 0, model: "gpt-5.4" });
                     const response = await model.invoke(state.messages, modifiedConfig);
 
                     // 3) Don't return the new response to hide it from the user

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/mcp-apps.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/mcp-apps.mdx
@@ -32,10 +32,14 @@ Key benefits:
     ```
 
     ```typescript title="app/api/copilotkit/route.ts"
+    import {
       CopilotRuntime,
       ExperimentalEmptyAdapter,
       copilotRuntimeNextJSAppRouterEndpoint,
     } from "@copilotkit/runtime";
+    import { LangGraphAgent } from "@copilotkit/runtime";
+    import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
+    import { NextRequest } from "next/server";
 
     const agent = new LangGraphAgent({
       deploymentUrl: process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123",

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -302,10 +302,13 @@ Before you begin, you'll need the following:
               <Tabs groupId="deployment_method" items={['LangSmith', 'FastAPI']}>
                 <Tab value="LangSmith">
                   ```tsx title="app/api/copilotkit/route.ts"
+                  import {
                     CopilotRuntime,
                     ExperimentalEmptyAdapter,
                     copilotRuntimeNextJSAppRouterEndpoint,
                   } from "@copilotkit/runtime";
+                  import { LangGraphAgent } from "@copilotkit/runtime";
+                  import { NextRequest } from "next/server";
                   // [!code highlight]
 
                   const serviceAdapter = new ExperimentalEmptyAdapter();
@@ -334,10 +337,13 @@ Before you begin, you'll need the following:
               </Tab>
               <Tab value="FastAPI">
                 ```tsx title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { LangGraphHttpAgent } from "@copilotkit/runtime";
+                import { NextRequest } from "next/server";
                 // [!code highlight]
 
                 const serviceAdapter = new ExperimentalEmptyAdapter();
@@ -370,7 +376,9 @@ Before you begin, you'll need the following:
               Wrap your application with the CopilotKit provider:
 
               ```tsx title="app/layout.tsx"
-              // [!code highlight:2]
+              import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+              import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+              import './globals.css';
 
               // ...
 
@@ -394,6 +402,7 @@ Before you begin, you'll need the following:
             Add the CopilotSidebar component to your page:
 
             ```tsx title="app/page.tsx"
+            import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
             export default function Page() {
               return (

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/generative-ui/state-rendering.mdx
@@ -99,7 +99,7 @@ is a situation where a user and an agent are working together to solve a problem
         return "All searches completed!"
 
     # Initialize the LLM
-    llm = OpenAI(model="gpt-5.2")
+    llm = OpenAI(model="gpt-5.4")
 
     # Create the AG-UI workflow router
     agentic_chat_router = get_ag_ui_workflow_router(

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/generative-ui/tool-rendering.mdx
@@ -57,7 +57,7 @@ def getWeather(location: str) -> str:
     return f"The weather in {location} is sunny and 70 degrees."
 
 # Initialize the LLM
-llm = OpenAI(model="gpt-5.2")
+llm = OpenAI(model="gpt-5.4")
 
 # Create the AG-UI workflow router
 agentic_chat_router = get_ag_ui_workflow_router(

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/human-in-the-loop.mdx
@@ -55,7 +55,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
             return f"Presenting options: {option_1} or {option_2}"
 
         # Initialize the LLM
-        llm = OpenAI(model="gpt-5.2")
+        llm = OpenAI(model="gpt-5.4")
 
         # Create the AG-UI workflow router
         agentic_chat_router = get_ag_ui_workflow_router(

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -179,7 +179,7 @@ Before you begin, you'll need the following:
                 from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
 
                 # Initialize the LLM
-                llm = OpenAI(model="gpt-5.2")
+                llm = OpenAI(model="gpt-5.4")
 
                 # Create the AG-UI workflow router
                 agentic_chat_router = get_ag_ui_workflow_router(
@@ -229,10 +229,13 @@ Before you begin, you'll need the following:
                 Create an API route to connect CopilotKit to your LlamaIndex agent:
 
                 ```tsx title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { LlamaIndexAgent } from "@ag-ui/llamaindex";
+                import { NextRequest } from "next/server";
 
                 const serviceAdapter = new ExperimentalEmptyAdapter();
 
@@ -259,6 +262,9 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import './globals.css';
 
                 // ...
 
@@ -282,6 +288,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
+              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-read.mdx
@@ -45,7 +45,7 @@ state updates, you can reflect these updates natively in your application.
     from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
 
     # Initialize the LLM
-    llm = OpenAI(model="gpt-5.2")
+    llm = OpenAI(model="gpt-5.4")
 
     # Create the AG-UI workflow router
     agentic_chat_router = get_ag_ui_workflow_router(

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/in-app-agent-write.mdx
@@ -44,7 +44,7 @@ You can use this when you want to provide user input or control to your agent's 
     from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
 
     # Initialize the LLM
-    llm = OpenAI(model="gpt-5.2")
+    llm = OpenAI(model="gpt-5.4")
 
     # Create the AG-UI workflow router
     agentic_chat_router = get_ag_ui_workflow_router(

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/predictive-state-updates.mdx
@@ -150,7 +150,7 @@ When your agent finishes executing, **its final state becomes the single source 
 
 
             # Initialize the LLM
-            llm = OpenAI(model="gpt-5.2")
+            llm = OpenAI(model="gpt-5.4")
 
             # Create the AG-UI workflow router
             agentic_chat_router = get_ag_ui_workflow_router(

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/workflow-execution.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/shared-state/workflow-execution.mdx
@@ -105,7 +105,7 @@ In addition, some state properties contain a lot of information. Syncing them ba
         return f"Resource added: {resource}"
 
     # Initialize the LLM
-    llm = OpenAI(model="gpt-5.2")
+    llm = OpenAI(model="gpt-5.4")
 
     # Create the AG-UI workflow router
     agentic_chat_router = get_ag_ui_workflow_router(

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/generative-ui/state-rendering.mdx
@@ -64,7 +64,7 @@ is a situation where a user and an agent are working together to solve a problem
 
     export const searchAgent = new Agent({
       name: "Search Agent",
-      model: openai("gpt-5.2"),
+      model: openai("gpt-5.4"),
       instructions: `
         You are a helpful assistant for storing searches.
 

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/generative-ui/tool-rendering.mdx
@@ -57,7 +57,7 @@ export const weatherAgent = new Agent({
   name: "Weather Agent",
   instructions:
     "You are a helpful assistant that provides current weather information. When asked about the weather, use the weather information tool to fetch the data.",
-  model: openai("gpt-5.2-mini"),
+  model: openai("gpt-5.4-mini"),
   tools: {
     weatherInfo,
   },

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -126,7 +126,7 @@ Before you begin, you'll need the following:
                 export const myAgent = new Agent({
                   name: "My Agent",
                   instructions: "You are a helpful assistant!",
-                  model: openai("gpt-5.2"),
+                  model: openai("gpt-5.4"),
                 });
                 ```
 
@@ -175,10 +175,14 @@ Before you begin, you'll need the following:
                 Create an API route to connect CopilotKit to your Mastra agent:
 
                 ```ts title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { MastraAgent } from "@ag-ui/mastra";
+                import { mastra } from "@/mastra";
+                import { NextRequest } from "next/server";
 
                 const serviceAdapter = new ExperimentalEmptyAdapter();
 
@@ -203,6 +207,9 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import './globals.css';
 
                 // ...
 
@@ -226,6 +233,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
+              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-read.mdx
@@ -68,7 +68,7 @@ state updates, you can reflect these updates natively in your application.
     // 3. Create the agent
     export const languageAgent = new Agent({
       name: "Language Agent",
-      model: openai("gpt-5.2"),
+      model: openai("gpt-5.4"),
       instructions: "Always communicate in the preferred language of the user as defined in your working memory. Do not communicate in any other language.",
       memory: new Memory({
         storage: new LibSQLStore({ id: "mastra-storage", url: ":memory:" }),

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-write.mdx
@@ -67,7 +67,7 @@ You can use this when you want to provide user input or control to your agent's 
     // 3. Create the agent
     export const languageAgent = new Agent({
       name: "Language Agent",
-      model: openai("gpt-5.2"),
+      model: openai("gpt-5.4"),
       instructions: "Always communicate in the preferred language of the user as defined in your working memory. Do not communicate in any other language.",
       memory: new Memory({
         storage: new LibSQLStore({ id: "mastra-storage", url: ":memory:" }),

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -367,7 +367,7 @@ Before you begin, you'll need the following:
                 via the Microsoft Agent Framework agent.
 
                 ```tsx title="app/layout.tsx"
-                import { CopilotKit } from "@copilotkit/react-core"; // [!code highlight]
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
                 import "@copilotkit/react-ui/v2/styles.css";
                 import './globals.css';
 

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/generative-ui/state-rendering.mdx
@@ -52,7 +52,7 @@ is a situation where a user and an agent are working together to solve a problem
         searches: list[Search] = Field(default_factory=list)
 
 
-    agent = Agent("openai:gpt-5.2-mini", deps_type=StateDeps[AgentState])
+    agent = Agent("openai:gpt-5.4-mini", deps_type=StateDeps[AgentState])
 
 
     @agent.tool

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/generative-ui/tool-rendering.mdx
@@ -50,7 +50,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
         ```python title="agent.py"
         from pydantic_ai import Agent
 
-        agent = Agent("openai:gpt-5.2-mini")
+        agent = Agent("openai:gpt-5.4-mini")
 
 
         @agent.tool_plain

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop.mdx
@@ -95,7 +95,7 @@ Use frontend tools when you need your agent to interact with client-side primiti
         ```python title="agent.py"
         from pydantic_ai import Agent
 
-        agent = Agent('openai:gpt-5.2-mini')
+        agent = Agent('openai:gpt-5.4-mini')
         app = agent.to_ag_ui()
         ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop/agent.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop/agent.mdx
@@ -107,7 +107,7 @@ is the complete implementation of the agent with explanations.
         ```python title="agent/sample_agent/agent.py"
         from pydantic_ai import Agent
 
-        agent = Agent('openai:gpt-5.2-mini')
+        agent = Agent('openai:gpt-5.4-mini')
 
         @agent.tool_plain
         async def write_essay(topic: str) -> str:

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -179,10 +179,13 @@ Before you begin, you'll need the following:
                 Create an API route to connect CopilotKit to your Pydantic AI agent:
 
                 ```tsx title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { HttpAgent } from "@ag-ui/client";
+                import { NextRequest } from "next/server";
 
                 const serviceAdapter = new ExperimentalEmptyAdapter();
 
@@ -209,6 +212,9 @@ Before you begin, you'll need the following:
                 Wrap your application with the CopilotKit provider:
 
                 ```tsx title="app/layout.tsx"
+                import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
+                import "@copilotkit/react-ui/v2/styles.css"; // [!code highlight]
+                import './globals.css';
 
                 // ...
 
@@ -232,6 +238,7 @@ Before you begin, you'll need the following:
               Add the CopilotSidebar component to your page:
 
               ```tsx title="app/page.tsx"
+              import { CopilotSidebar } from "@copilotkit/react-core/v2"; // [!code highlight]
 
               export default function Page() {
                 return (

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
@@ -137,10 +137,13 @@ Before you begin, you'll need the following:
                 For now, let's start with a minimal setup.
 
                 ```tsx title="app/api/copilotkit/route.ts"
+                import {
                   CopilotRuntime,
                   ExperimentalEmptyAdapter,
                   copilotRuntimeNextJSAppRouterEndpoint,
                 } from "@copilotkit/runtime";
+                import { HttpAgent } from "@ag-ui/client";
+                import { NextRequest } from "next/server";
 
                 // 1. You can use any service adapter here for multi-agent support. We use
                 //    the empty adapter since we're only using one agent.

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-read.mdx
@@ -52,7 +52,7 @@ state updates, you can reflect these updates natively in your application.
         language: str = "english"
 
 
-    agent = Agent("openai:gpt-5.2-mini", deps_type=StateDeps[AgentState])
+    agent = Agent("openai:gpt-5.4-mini", deps_type=StateDeps[AgentState])
 
 
     @agent.instructions()

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/in-app-agent-write.mdx
@@ -52,7 +52,7 @@ when your agent is calling tools. CopilotKit allows you to fully customize how t
         language: str = "english"
 
 
-    agent = Agent("openai:gpt-5.2-mini", deps_type=StateDeps[AgentState])
+    agent = Agent("openai:gpt-5.4-mini", deps_type=StateDeps[AgentState])
 
 
     @agent.instructions()

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/shared-state/predictive-state-updates.mdx
@@ -60,7 +60,7 @@ included in the function's final returned state. Otherwise, they will be overwri
             observed_steps: list[str] = []
 
 
-        agent = Agent('openai:gpt-5.2-mini', deps_type=StateDeps[AgentState])
+        agent = Agent('openai:gpt-5.4-mini', deps_type=StateDeps[AgentState])
         app = agent.to_ag_ui(deps=StateDeps(AgentState()))
 
 

--- a/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
+++ b/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
@@ -173,7 +173,3 @@ When a user attaches files and sends a message, CopilotKit:
 4. The agent receives the multimodal content via the AG-UI protocol and forwards it to the model
 
 The attachments are part of the standard AG-UI `InputContent` schema, so any AG-UI-compatible agent (BuiltInAgent, LangGraph, custom) can receive them.
-
-<Callout type="info">
-  Migrating from the old `imageUploadsEnabled` prop? See the [migration guide](/migration-guides/migrate-attachments) for a step-by-step walkthrough.
-</Callout>

--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -56,7 +56,7 @@ Every meaningful configuration value that is sensitive — database URL, Redis U
 
 ### Install
 
-A `helm install` creates one namespace (by default `copilot-intelligence`), the Deployments above, their Services and ServiceAccounts, PodDisruptionBudgets, HorizontalPodAutoscalers, an Ingress resource, and any `ExternalSecret` resources you enabled. A pre-install `Job` runs schema migrations against your Postgres database; the chart blocks the rollout until migrations complete.
+A `helm install` creates one namespace (by default `copilot-intelligence`), the Deployments above, their Services and ServiceAccounts, PodDisruptionBudgets, HorizontalPodAutoscalers, an Ingress resource, and any `ExternalSecret` resources you enabled. If you set `migrations.enabled: true`, a pre-install `Job` runs schema migrations against your Postgres database; the chart blocks the rollout until migrations complete. The Job is opt-in (`migrations.enabled` defaults to `false`) — leave it disabled if you manage migrations out-of-band.
 
 ### Runtime lifecycle
 

--- a/showcase/shell-docs/src/content/docs/premium/self-hosting.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/self-hosting.mdx
@@ -192,6 +192,19 @@ Before starting, make sure the following are in place. The [How the Intelligence
   </Step>
 
   <Step>
+    ### (Optional) Enable schema migrations
+
+    The chart can run database schema migrations as a pre-install `Job`. This is **disabled by default** (`migrations.enabled: false`). If you want the chart to apply migrations for you on install, set the following in `my-values.yaml`:
+
+    ```yaml title="my-values.yaml"
+    migrations:
+      enabled: true
+    ```
+
+    With this enabled, `helm install` blocks the rollout until the migrations Job reports `Completed`. Leave it disabled if you manage schema migrations out-of-band (for example, via your existing CI/CD or DBA pipeline).
+  </Step>
+
+  <Step>
     ### Install the chart
 
     ```bash title="Terminal"
@@ -203,7 +216,7 @@ Before starting, make sure the following are in place. The [How the Intelligence
       --timeout 10m
     ```
 
-    `--wait` blocks until the `Deployments` report healthy replicas; `--timeout 10m` allows enough time for image pulls and the initial database migration job.
+    `--wait` blocks until the `Deployments` report healthy replicas; `--timeout 10m` allows enough time for image pulls and (if you enabled it in the previous step) the initial database migration job.
   </Step>
 
   <Step>
@@ -216,7 +229,7 @@ Before starting, make sure the following are in place. The [How the Intelligence
     kubectl get ingress -n copilot-intelligence
     ```
 
-    You should see `app-api`, `app-frontend`, and — if enabled — `realtime-gateway` pods running. The migrations `Job` will appear as `Completed`.
+    You should see `app-api`, `app-frontend`, and — if enabled — `realtime-gateway` pods running. If you opted into migrations (`migrations.enabled: true`, see the values step above), the migrations `Job` will also appear as `Completed`; if you left migrations disabled, no Job is created.
 
     Confirm the API health check reports `ok`:
 

--- a/showcase/shell-docs/src/content/docs/troubleshooting/common-issues.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/common-issues.mdx
@@ -71,7 +71,7 @@ If you're getting a *"CopilotKit's Remote Endpoint not found"* error, the `/info
 
 <Accordions>
 <Accordion title="Check your FastAPI / backend setup">
-Confirm the CopilotKit SDK is mounted. If you're using Python + FastAPI, follow the [Remote Python Endpoint](../copilot-runtime) guide.
+Confirm the CopilotKit SDK is mounted. If you're using Python + FastAPI, follow the [Remote Python Endpoint](/backend/copilot-runtime) guide.
 </Accordion>
 
 <Accordion title="Test the /info endpoint directly">
@@ -121,7 +121,8 @@ If any of these fail:
 
 Usually one of:
 
-- The LLM model string isn't a model the runtime's provider actually supports — double-check against [Model Selection](../model-selection).
+{/* TODO: retarget if model-selection is canonicalized at root */}
+- The LLM model string isn't a model the runtime's provider actually supports — double-check against [Model Selection](/built-in-agent/model-selection).
 - The Built-in Agent's `prompt` is empty and the user message is "do nothing" — give the agent a system prompt.
 - A frontend tool is throwing during its handler and the agent is treating the empty result as the turn output — see [Error Debugging](./error-debugging) for the `tool_handler_failed` code.
 

--- a/showcase/shell-docs/src/content/docs/whats-new/v1-50.mdx
+++ b/showcase/shell-docs/src/content/docs/whats-new/v1-50.mdx
@@ -187,7 +187,7 @@ Our direct to LLM integration now supports more models and implements shared sta
 const runtime = new CopilotRuntime({
   agents: {
     myBasicAgent: new BasicAgent({
-		  model: "openai/gpt-5.2", // much broader model support
+		  model: "openai/gpt-5.4", // much broader model support
 		  prompt: "You are a helpful AI assistant.",
 		  temperature: 0.7,
 		});

--- a/showcase/shell-docs/src/content/reference/hooks/useCopilotChatConfiguration.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useCopilotChatConfiguration.mdx
@@ -133,6 +133,7 @@ The `CopilotChatLabels` type defines all customizable text strings used by the c
 ### Basic Label Customization
 
 ```tsx
+import {
   CopilotChatConfigurationProvider,
   useCopilotChatConfiguration,
 } from "@copilotkit/react-core/v2";
@@ -189,6 +190,7 @@ function SupportChat() {
 ### Modal State Management
 
 ```tsx
+import {
   CopilotChatConfigurationProvider,
   useCopilotChatConfiguration,
 } from "@copilotkit/react-core/v2";

--- a/showcase/shell-docs/src/content/snippets/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/snippets/integrations/langgraph/frontend-tools.mdx
@@ -20,7 +20,7 @@ import {
                 # Access the tools from the copilotkit property
 
                 tools = state.get("copilotkit", {}).get("actions", []) # [!code highlight]
-                model = ChatOpenAI(model="gpt-5.2").bind_tools(tools)
+                model = ChatOpenAI(model="gpt-5.4").bind_tools(tools)
 
                 # ...
                 ```
@@ -31,7 +31,7 @@ import {
                 // Access the tools from the copilotkit property
 
                 const tools = state.copilotkit?.actions; // [!code highlight]
-                const model = ChatOpenAI({ model: 'gpt-5.2' }).bindTools(tools);
+                const model = ChatOpenAI({ model: 'gpt-5.4' }).bindTools(tools);
 
                 // ...
                 }
@@ -51,7 +51,7 @@ import {
                 from copilotkit import CopilotKitMiddleware, CopilotKitState # [!code highlight]
 
                 graph = create_agent( # Works the same for "create_react_agent" or similar options
-                    model="openai:gpt-5.2",
+                    model="openai:gpt-5.4",
                     tools=[],  # Backend tools go here
                     middleware=[CopilotKitMiddleware()], # [!code highlight]
                     system_prompt="You are a helpful assistant.",
@@ -65,7 +65,7 @@ import {
                 import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
 
                 export const agenticChatGraph = createAgent({ // Works the same for "create_react_agent" or similar options
-                    model: "openai:gpt-5.2",
+                    model: "openai:gpt-5.4",
                     tools: [],  // Backend tools go here
                     middleware: [copilotkitMiddleware], // [!code highlight]
                     systemPrompt: "You are a helpful assistant.",

--- a/showcase/shell-docs/src/content/snippets/shared/generative-ui/mcp-apps.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/generative-ui/mcp-apps.mdx
@@ -78,7 +78,7 @@ If you're looking to add an MCP App into an existing application, let's walk thr
 
     // 1. Create your agent
     const agent = new BuiltInAgent({
-      model: "openai/gpt-5.2",
+      model: "openai/gpt-5.4",
       prompt: "You are a helpful assistant.",
     });
 
@@ -124,7 +124,7 @@ If you're looking to add an MCP App into an existing application, let's walk thr
     import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 
     const agent = new BuiltInAgent({
-      model: "openai/gpt-5.2",
+      model: "openai/gpt-5.4",
       prompt: "You are a helpful assistant.",
     }).use(
       new MCPAppsMiddleware({


### PR DESCRIPTION
## Summary

Critical-path content fixes from the shell-docs QA triage. Fixes everything that breaks copy-paste or click-through on existing pages.

**Items addressed:**
- 2.2, 8.1, 13.1, 13.2 — code-block import hygiene
- 12.1, 14.1, 15.1, 15.2, 22.1 — cross-page link sweep
- 9.1, 9.2 — `gpt-5.2*` → `gpt-5.4*` sweep + extend model-name CI validator
- 7.1 — `migrations.enabled` premium walkthrough corrections

## Visual inspection

1. Start the dev server:
   ```bash
   nx run shell-docs:dev
   ```
   Open http://localhost:3003.

2. **Imports — copy-paste check.** Visit each page below; copy each `route.ts` / `app/layout.tsx` / `app/page.tsx` block into a scratch TypeScript file and verify it has all needed imports:
   - `/built-in-agent/quickstart` (BIA, default integration — should now import `CopilotKit` from `@copilotkit/react-core/v2`)
   - `/agent-spec/quickstart`
   - `/microsoft-agent-framework/quickstart`
   - Switch framework picker to each of: `langgraph`, `mastra`, `pydantic-ai`, `adk`, `agno`, `aws-strands`, `llamaindex`. Re-check the same blocks.
   - `/auth`, `/agentic-protocols/mcp`, `/backend/copilot-runtime`, `/multimodal-attachments` — verify code blocks now show import lines.

3. **Links — click-through check.** On each page below, click every external link in the prose:
   - `/agentic-protocols` (the index — 7 link rewrites; all should resolve)
   - `/multimodal-attachments` (the migration Callout should be GONE)
   - `/faq` ("What's available?" table — the rows should be plain bold labels, not links)
   - `/langgraph/agent-app-context` (mid-prose link should now point at langgraph fw page, not BIA)
   - `/inspector` (the agent-app-context relative link should resolve to langgraph fw page)
   - `/troubleshooting/common-issues` (the `copilot-runtime` and `model-selection` links should now resolve)

4. **Model names — search check.** In the dev server (or via grep), confirm `gpt-5.2` and `gpt-5.2-mini` no longer appear anywhere in `showcase/shell-docs/src/content/`. All references should now be `gpt-5.4` / `gpt-5.4-mini`.

5. **Premium walkthrough — read-through.** Walk `/premium/self-hosting` end to end as if installing fresh. The walkthrough should now tell you to set `migrations.enabled: true` BEFORE the install command. The "Job will appear as Completed" prose should only fire if migrations were enabled.

6. **Anti-checks (these should NOT have changed):**
   - The legitimate `gpt-4o`, `gpt-4.1`, `gpt-5.4` references in JSDoc / source code.
   - Code blocks where imports were intentionally omitted because a prior block on the same page established them.
   - Reference pages under `/reference/v1/` (those are owned by a separate PR).