### PR TITLE
fix(showcase): unblock dashboard D3 — pool zombie detection + e2e-demos abort release + deploy webhook schema

### DIFF
--- a/showcase/harness/src/events/event-bus.ts
+++ b/showcase/harness/src/events/event-bus.ts
@@ -25,6 +25,16 @@ export interface DeployResultEvent {
    * only need to guard one shape.
    */
   gateReason?: string;
+  /**
+   * Identifiers of the upstream build run that produced the images this
+   * deploy verified. Co-sent by the deploy workflow after PR #4471 split
+   * build and deploy into separate workflows so Slack alerts and
+   * dashboard tooltips can link "deploy red" back to "the build that
+   * produced these images". Both fields are optional because pre-split
+   * payloads (and manually-triggered redeploys) don't carry them.
+   */
+  buildRunId?: string;
+  buildRunUrl?: string;
 }
 
 /**

--- a/showcase/harness/src/http/webhooks/deploy.test.ts
+++ b/showcase/harness/src/http/webhooks/deploy.test.ts
@@ -525,6 +525,69 @@ describe("POST /webhooks/deploy — gateSkipped pass-through", () => {
   });
 });
 
+describe("POST /webhooks/deploy — buildRunId / buildRunUrl pass-through", () => {
+  // Regression coverage for PR #4471: the deploy workflow co-sends the
+  // upstream build run's identifiers so Slack/dashboard surfaces can link
+  // a red deploy back to the build that produced its images. The strict
+  // schema MUST accept these fields — pre-fix it returned 400 with
+  // "Unrecognized key(s) in object: 'buildRunId', 'buildRunUrl'", which
+  // broke every Showcase: Verify Deploy run.
+  it("accepts buildRunId and buildRunUrl and propagates them to the emitted event", async () => {
+    const { app, seen } = buildApp();
+    const payload = JSON.stringify({
+      runId: "deploy-1",
+      runUrl: "https://github.com/CopilotKit/CopilotKit/actions/runs/deploy-1",
+      services: ["mastra"],
+      failed: [],
+      succeeded: ["mastra"],
+      cancelled: false,
+      buildRunId: "build-99",
+      buildRunUrl:
+        "https://github.com/CopilotKit/CopilotKit/actions/runs/build-99",
+    });
+    const { headers, body } = signed(payload);
+    const res = await app.request(PATH, { method: "POST", headers, body });
+    expect(res.status).toBe(202);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.buildRunId).toBe("build-99");
+    expect(seen[0]!.buildRunUrl).toBe(
+      "https://github.com/CopilotKit/CopilotKit/actions/runs/build-99",
+    );
+  });
+
+  it("accepts payload without buildRunId/buildRunUrl (legacy senders / manual redeploys)", async () => {
+    const { app, seen } = buildApp();
+    const payload = JSON.stringify({
+      runId: "deploy-2",
+      services: ["mastra"],
+      failed: [],
+      succeeded: ["mastra"],
+      cancelled: false,
+    });
+    const { headers, body } = signed(payload);
+    const res = await app.request(PATH, { method: "POST", headers, body });
+    expect(res.status).toBe(202);
+    expect(seen[0]!.buildRunId).toBeUndefined();
+    expect(seen[0]!.buildRunUrl).toBeUndefined();
+  });
+
+  it("rejects buildRunUrl with a non-http(s) scheme (mirrors runUrl refinement)", async () => {
+    const { app } = buildApp();
+    const payload = JSON.stringify({
+      runId: "deploy-bad",
+      services: [],
+      failed: [],
+      succeeded: [],
+      cancelled: false,
+      buildRunId: "build-99",
+      buildRunUrl: "javascript:alert(1)",
+    });
+    const { headers, body } = signed(payload);
+    const res = await app.request(PATH, { method: "POST", headers, body });
+    expect(res.status).toBe(400);
+  });
+});
+
 describe("POST /webhooks/deploy — idempotency (composite runId+bodySha)", () => {
   it("returns 200 (not 202) on duplicate runId+body and does NOT re-emit", async () => {
     const { app, seen } = buildApp();

--- a/showcase/harness/src/http/webhooks/deploy.ts
+++ b/showcase/harness/src/http/webhooks/deploy.ts
@@ -67,6 +67,23 @@ const deployPayloadSchema = z
     // workflow can always pass the jq `--arg gateReason` shape without
     // branching on presence.
     gateReason: z.string().optional(),
+    // After PR #4471 split build and deploy into separate workflows, the
+    // deploy workflow co-sends the upstream build run's identifiers so
+    // Slack alerts and dashboard tooltips can link the deploy result back
+    // to the build that produced its images. Both fields are optional
+    // because the schema also accepts payloads from the legacy single-
+    // workflow shape and from manually-triggered redeploys.
+    buildRunId: z.string().optional(),
+    buildRunUrl: z
+      .string()
+      .url()
+      // Same http(s)-only refinement as `runUrl` — this field is also
+      // rendered as a link in Slack / dashboard UIs and a signed sender
+      // with a typo must not be able to plant a `javascript:` URL.
+      .refine((u) => /^https?:\/\//i.test(u), {
+        message: "buildRunUrl must be http(s)",
+      })
+      .optional(),
   })
   .strict();
 
@@ -273,6 +290,8 @@ export function registerDeployWebhook(
       cancelled: result.data.cancelled,
       gateSkipped: result.data.gateSkipped,
       gateReason,
+      buildRunId: result.data.buildRunId,
+      buildRunUrl: result.data.buildRunUrl,
     };
     deps.bus.emit("deploy.result", event);
     deps.logger.info("webhook.deploy.accepted", {

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -891,7 +891,9 @@ export function registerAllProbeDrivers(
       createE2eSmokeDriver({ launcher: createPooledE2eSmokeLauncher(pool) }),
     );
     probeRegistry.register(
-      createE2eDemosDriver({ launcher: createPooledE2eDemosLauncher(pool) }),
+      createE2eDemosDriver({
+        launcher: createPooledE2eDemosLauncher(pool, logger),
+      }),
     );
     probeRegistry.register(
       createE2eDeepDriver({

--- a/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import {
   e2eReadinessDriver,
   createE2eDemosDriver,
+  createPooledE2eDemosLauncher,
   type E2eDemosBrowser,
   type E2eDemosBrowserContext,
   type E2eDemosPage,
@@ -1674,5 +1675,190 @@ describe("shortest-service-first dispatch (integration)", () => {
     })();
 
     expect(dispatchOrder).toEqual(["tiny", "medium", "huge"]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Pool starvation parity with createPooledE2eDeepLauncher (ed0933e5c).
+// e2e-demos shares the same Promise.race-driven outer-timeout pattern
+// as e2e-deep, so it needs the same abort-driven release path or a hung
+// service holds its slot until the orphaned driver promise drains.
+// ---------------------------------------------------------------------
+describe("createPooledE2eDemosLauncher abort release", () => {
+  /**
+   * Minimal fake pool tracking acquire/release calls. Mirrors the shape
+   * used by createPooledE2eDeepLauncher's tests so the two pooled launchers
+   * exercise an analogous fixture.
+   */
+  function makeFakePool(size: number) {
+    interface FakeBrowser {
+      id: number;
+      newContext(): Promise<{
+        newPage(): Promise<{
+          goto(): Promise<void>;
+          waitForSelector(): Promise<void>;
+          close(): Promise<void>;
+        }>;
+        close(): Promise<void>;
+      }>;
+      close(): Promise<void>;
+    }
+
+    const browsers: FakeBrowser[] = [];
+    for (let i = 0; i < size; i++) {
+      browsers.push({
+        id: i,
+        async newContext() {
+          return {
+            async newPage() {
+              return {
+                async goto() {},
+                async waitForSelector() {},
+                async close() {},
+              };
+            },
+            async close() {},
+          };
+        },
+        async close() {},
+      });
+    }
+
+    const available = [...browsers];
+    const releaseLog: number[] = [];
+    const acquireLog: number[] = [];
+
+    return {
+      async acquire(): Promise<unknown> {
+        const browser = available.shift();
+        if (!browser) throw new Error("FakePool: no browsers available");
+        acquireLog.push(browser.id);
+        return browser;
+      },
+      release(browser: unknown): void {
+        const fb = browser as FakeBrowser;
+        releaseLog.push(fb.id);
+        available.push(fb);
+      },
+      stats() {
+        return {
+          size,
+          available: available.length,
+          inUse: size - available.length,
+          totalRecycles: 0,
+        };
+      },
+      get _releaseLog() {
+        return releaseLog;
+      },
+      get _acquireLog() {
+        return acquireLog;
+      },
+    };
+  }
+
+  it("releases the pooled browser when the abort signal fires (prevents starvation)", async () => {
+    const pool = makeFakePool(2);
+    const launcher = createPooledE2eDemosLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    const ac1 = new AbortController();
+    const ac2 = new AbortController();
+    const browser1 = await launcher(ac1.signal);
+    const browser2 = await launcher(ac2.signal);
+
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBe(2);
+
+    ac1.abort();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(pool._releaseLog).toContain(0);
+    expect(pool.stats().available).toBe(1);
+
+    // Driver's finally-block close is a no-op after force-release.
+    await browser1.close();
+    expect(pool._releaseLog.filter((id) => id === 0)).toHaveLength(1);
+
+    // Browser2 still held — normal close releases it.
+    await browser2.close();
+    expect(pool._releaseLog).toContain(1);
+    expect(pool.stats().available).toBe(2);
+  });
+
+  it("closes open contexts before releasing on abort", async () => {
+    const pool = makeFakePool(1);
+    const launcher = createPooledE2eDemosLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    const ac = new AbortController();
+    const browser = await launcher(ac.signal);
+
+    const ctx = await browser.newContext();
+    const _page = await ctx.newPage();
+
+    ac.abort();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(pool._releaseLog).toHaveLength(1);
+    expect(pool.stats().available).toBe(1);
+  });
+
+  it("handles already-aborted signal (releases immediately)", async () => {
+    const pool = makeFakePool(1);
+    const launcher = createPooledE2eDemosLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    const ac = new AbortController();
+    ac.abort();
+
+    const browser = await launcher(ac.signal);
+
+    // Released synchronously after acquire (no waiting on abort event).
+    expect(pool._releaseLog).toHaveLength(1);
+    expect(pool.stats().available).toBe(1);
+
+    await browser.close();
+    expect(pool._releaseLog).toHaveLength(1);
+  });
+
+  it("full pool starvation scenario: all slots acquired, abort releases them for the next run", async () => {
+    const POOL_SIZE = 4;
+    const pool = makeFakePool(POOL_SIZE);
+    const launcher = createPooledE2eDemosLauncher(
+      pool as unknown as import("../helpers/browser-pool.js").BrowserPool,
+    );
+
+    const acs = Array.from({ length: POOL_SIZE }, () => new AbortController());
+    const browsers = await Promise.all(acs.map((ac) => launcher(ac.signal)));
+
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBe(POOL_SIZE);
+
+    for (const ac of acs) ac.abort();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(pool.stats().available).toBe(POOL_SIZE);
+    expect(pool._releaseLog).toHaveLength(POOL_SIZE);
+
+    // Next run can acquire all slots immediately.
+    const nextAcs = Array.from(
+      { length: POOL_SIZE },
+      () => new AbortController(),
+    );
+    const nextBrowsers = await Promise.all(
+      nextAcs.map((ac) => launcher(ac.signal)),
+    );
+    expect(pool.stats().available).toBe(0);
+    expect(pool.stats().inUse).toBe(POOL_SIZE);
+
+    for (const b of nextBrowsers) await b.close();
+    for (const b of browsers) await b.close();
+    // POOL_SIZE releases from abort + POOL_SIZE from the second run's
+    // normal close. The first run's normal close is a no-op.
+    expect(pool._releaseLog).toHaveLength(POOL_SIZE * 2);
   });
 });

--- a/showcase/harness/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.ts
@@ -144,7 +144,9 @@ export interface E2eDemosBrowser {
   close(): Promise<void>;
 }
 
-export type E2eDemosBrowserLauncher = () => Promise<E2eDemosBrowser>;
+export type E2eDemosBrowserLauncher = (
+  abortSignal?: AbortSignal,
+) => Promise<E2eDemosBrowser>;
 
 /**
  * Per-demo metadata surfaced by the resolver. `route` is the path segment
@@ -247,40 +249,93 @@ const READY_SELECTORS = [
  *  budget, starving subsequent selectors of time). */
 const READY_SELECTOR_COMPOUND = READY_SELECTORS.join(", ");
 
-const defaultLauncher: E2eDemosBrowserLauncher =
-  async (): Promise<E2eDemosBrowser> => {
-    const mod = (await import("playwright")) as typeof import("playwright");
-    const browser = await mod.chromium.launch({
-      headless: true,
-      args: ["--no-sandbox", "--disable-dev-shm-usage"],
-    });
-    return {
-      async newContext(): Promise<E2eDemosBrowserContext> {
-        const ctx = await browser.newContext();
-        return {
-          async newPage(): Promise<E2eDemosPage> {
-            const page = await ctx.newPage();
-            return {
-              goto: (url, opts) => page.goto(url, opts),
-              waitForSelector: (sel, opts) => page.waitForSelector(sel, opts),
-              close: () => page.close(),
-            };
-          },
-          close: () => ctx.close(),
-        };
-      },
-      close: () => browser.close(),
-    };
+const defaultLauncher: E2eDemosBrowserLauncher = async (
+  _abortSignal?: AbortSignal,
+): Promise<E2eDemosBrowser> => {
+  // _abortSignal is ignored here: the default launcher dedicates a
+  // chromium per call and lets the driver's finally block close it. The
+  // pooled launcher (createPooledE2eDemosLauncher) is the path that
+  // actually needs prompt release on abort.
+  const mod = (await import("playwright")) as typeof import("playwright");
+  const browser = await mod.chromium.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  });
+  return {
+    async newContext(): Promise<E2eDemosBrowserContext> {
+      const ctx = await browser.newContext();
+      return {
+        async newPage(): Promise<E2eDemosPage> {
+          const page = await ctx.newPage();
+          return {
+            goto: (url, opts) => page.goto(url, opts),
+            waitForSelector: (sel, opts) => page.waitForSelector(sel, opts),
+            close: () => page.close(),
+          };
+        },
+        close: () => ctx.close(),
+      };
+    },
+    close: () => browser.close(),
   };
+};
 
 export function createPooledE2eDemosLauncher(
   pool: BrowserPool,
+  logger?: { warn(event: string, meta?: Record<string, unknown>): void },
 ): E2eDemosBrowserLauncher {
-  return async (): Promise<E2eDemosBrowser> => {
+  return async (abortSignal?: AbortSignal): Promise<E2eDemosBrowser> => {
     const browser = await pool.acquire();
+
+    // Track whether the browser was force-released by an abort so the
+    // driver's normal `browser.close()` in the finally block doesn't
+    // double-release the same slot. Mirrors createPooledE2eDeepLauncher's
+    // pattern (see e2e-deep.ts) — pool starvation under outer-timeout was
+    // the documented motivation there and the same race exists here:
+    // Promise.race in the invoker abandons the driver promise but the
+    // driver continues iterating demos with the pooled browser held until
+    // the loop drains. Without this listener the slot stays in-use across
+    // probe ticks and the next tick can't acquire it.
+    let forceReleased = false;
+    const openContexts = new Set<{ close(): Promise<void> }>();
+
+    if (abortSignal) {
+      const onAbort = (): void => {
+        if (forceReleased) return;
+        forceReleased = true;
+        const ctxCount = openContexts.size;
+        const stats = pool.stats();
+        logger?.warn("probe.e2e-demos.pool-abort-release", {
+          openContexts: ctxCount,
+          poolAvailable: stats.available,
+          poolInUse: stats.inUse,
+          poolSize: stats.size,
+        });
+        const contextClosePromises = Array.from(openContexts).map((ctx) =>
+          ctx.close().catch(() => {}),
+        );
+        void Promise.allSettled(contextClosePromises).then(() => {
+          pool.release(browser);
+          logger?.warn("probe.e2e-demos.pool-abort-released", {
+            closedContexts: ctxCount,
+            poolAvailable: pool.stats().available,
+          });
+        });
+      };
+      if (abortSignal.aborted) {
+        forceReleased = true;
+        logger?.warn("probe.e2e-demos.pool-pre-aborted-release");
+        pool.release(browser);
+      } else {
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
     return {
       async newContext(): Promise<E2eDemosBrowserContext> {
         const ctx = await browser.newContext();
+        const ctxHandle = { close: () => ctx.close() };
+        openContexts.add(ctxHandle);
         return {
           async newPage(): Promise<E2eDemosPage> {
             const page = await ctx.newPage();
@@ -290,10 +345,14 @@ export function createPooledE2eDemosLauncher(
               close: () => page.close(),
             };
           },
-          close: () => ctx.close(),
+          close: async () => {
+            openContexts.delete(ctxHandle);
+            await ctx.close();
+          },
         };
       },
       close: async () => {
+        if (forceReleased) return;
         pool.release(browser);
       },
     };
@@ -562,7 +621,12 @@ export function createE2eDemosDriver(
       let browser: E2eDemosBrowser | undefined;
       try {
         try {
-          browser = await launcher();
+          // Pass abort.signal so a pooled launcher can release the slot
+          // immediately when the outer-timeout (or external abort) fires,
+          // instead of holding the browser until this run() drains all
+          // remaining demos. The default (per-call chromium) launcher
+          // ignores the signal; only the pooled path needs this.
+          browser = await launcher(abort.signal);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.warn("probe.e2e-demos.launcher-error", { slug, err: msg });

--- a/showcase/harness/src/probes/helpers/browser-pool.test.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import type { Browser } from "playwright";
+import { BrowserPool, type LaunchBrowser } from "./browser-pool.js";
+
+/**
+ * Minimal `Browser` stand-in that exposes the surface BrowserPool actually
+ * uses (`isConnected`, `on`, `close`, `newContext`) plus test-only hooks
+ * for simulating chromium lifecycle events:
+ *
+ *   - `__crash()`           — fires the `disconnected` event AND flips
+ *                             `isConnected` false. Mirrors a real chromium
+ *                             that died and notified Playwright cleanly.
+ *   - `__silentlyDisconnect()` — flips `isConnected` false but does NOT
+ *                             fire `disconnected`. Mirrors a process that
+ *                             died without Playwright noticing in time
+ *                             (e.g. WebSocket hung), so the pool's only
+ *                             defense is the on-acquire health check.
+ */
+interface FakeBrowser {
+  readonly __id: number;
+  isConnected(): boolean;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  close(): Promise<void>;
+  newContext(): Promise<{ close(): Promise<void> }>;
+  __crash(): void;
+  __silentlyDisconnect(): void;
+  readonly __closeCount: number;
+}
+
+let nextBrowserId = 0;
+
+function makeFakeBrowser(): FakeBrowser {
+  const id = nextBrowserId++;
+  let connected = true;
+  let closeCount = 0;
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  const fire = (event: string): void => {
+    for (const h of handlers.get(event) ?? []) h();
+  };
+  return {
+    __id: id,
+    get __closeCount() {
+      return closeCount;
+    },
+    isConnected: () => connected,
+    on(event, handler) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    async close() {
+      closeCount++;
+      const wasConnected = connected;
+      connected = false;
+      if (wasConnected) fire("disconnected");
+    },
+    async newContext() {
+      return { close: async () => {} };
+    },
+    __crash() {
+      if (connected) {
+        connected = false;
+        fire("disconnected");
+      }
+    },
+    __silentlyDisconnect() {
+      connected = false;
+    },
+  };
+}
+
+interface FakeLauncher {
+  launchBrowser: LaunchBrowser;
+  launched: FakeBrowser[];
+}
+
+function makeFakeLauncher(opts?: { failAt?: number }): FakeLauncher {
+  const launched: FakeBrowser[] = [];
+  let callCount = 0;
+  const launchBrowser = async (): Promise<Browser> => {
+    callCount++;
+    if (opts?.failAt !== undefined && callCount === opts.failAt) {
+      throw new Error("simulated launch failure");
+    }
+    const b = makeFakeBrowser();
+    launched.push(b);
+    return b as unknown as Browser;
+  };
+  return { launchBrowser, launched };
+}
+
+interface CapturedLog {
+  event: string;
+  meta?: Record<string, unknown>;
+}
+
+function makeFakeLogger(): {
+  logger: { info: (msg: string, meta?: Record<string, unknown>) => void };
+  events: CapturedLog[];
+} {
+  const events: CapturedLog[] = [];
+  return {
+    logger: {
+      info(msg, meta) {
+        events.push({ event: msg, meta });
+      },
+    },
+    events,
+  };
+}
+
+/**
+ * `recycleSlot` kicks off an async relaunch via a fire-and-forget IIFE.
+ * Tests that observe post-recycle state need to await the in-flight
+ * promise to settle. `shutdown()` already awaits `inFlightRecycles`, so
+ * this helper is just `await pool.shutdown()` from the test side; here
+ * we use a small drain helper for tests that want to observe state
+ * without tearing the pool down.
+ */
+async function drainMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("BrowserPool dead-instance detection", () => {
+  it("registers a disconnected listener on each browser at init and recycles when one fires", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const { logger, events } = makeFakeLogger();
+    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    await pool.init();
+    expect(launched).toHaveLength(2);
+
+    // Crash slot 0's browser. The disconnected listener should fire and
+    // kick recycle, which launches a fresh browser (the 3rd one).
+    launched[0]!.__crash();
+    await drainMicrotasks();
+
+    const disconnected = events.find(
+      (e) => e.event === "browser-pool.disconnected",
+    );
+    expect(disconnected).toBeDefined();
+    expect(disconnected?.meta).toEqual({ slotIndex: 0 });
+
+    await pool.shutdown();
+    // After shutdown awaits the in-flight recycle, the fresh launch must
+    // have completed.
+    expect(launched.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("acquire() skips a silently-disconnected slot and returns the next live one", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const { logger, events } = makeFakeLogger();
+    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    await pool.init();
+
+    const slot0Browser = launched[0]!;
+    const slot1Browser = launched[1]!;
+
+    // Silent disconnect: `isConnected` flips false without firing the
+    // event. acquire() must still skip it.
+    slot0Browser.__silentlyDisconnect();
+
+    const acquired = await pool.acquire();
+    expect(acquired).toBe(slot1Browser as unknown as Browser);
+
+    expect(
+      events.some((e) => e.event === "browser-pool.skipped-dead-slot"),
+    ).toBe(true);
+
+    await pool.shutdown();
+  });
+
+  it("acquire() recycles every zombie slot and falls through to the waiter path when no live slots remain", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool(2, 100, undefined, launchBrowser);
+    await pool.init();
+
+    launched[0]!.__silentlyDisconnect();
+    launched[1]!.__silentlyDisconnect();
+
+    // Both available slots are zombies. acquire() should kick recycle on
+    // each and return a Promise that resolves once a recycled browser
+    // becomes available.
+    const acquirePromise = pool.acquire();
+
+    await drainMicrotasks(20);
+
+    const acquired = await acquirePromise;
+    // The fresh launch is browser #2 or #3 — either is fine.
+    const fresh = launched.slice(2);
+    expect(fresh).toContain(acquired as unknown as FakeBrowser);
+
+    await pool.shutdown();
+  });
+
+  it("disconnected event during in-use slot triggers a recycle that delivers a fresh browser to the next acquire", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool(1, 100, undefined, launchBrowser);
+    await pool.init();
+
+    const browser = await pool.acquire();
+    expect(browser).toBe(launched[0] as unknown as Browser);
+
+    // Simulate chromium dying while the probe still holds the browser.
+    launched[0]!.__crash();
+    await drainMicrotasks(20);
+
+    const next = await pool.acquire();
+    expect(next).not.toBe(browser);
+    expect(next).toBe(launched[launched.length - 1] as unknown as Browser);
+
+    await pool.shutdown();
+  });
+
+  it("does not double-recycle when both the disconnect event and the on-acquire zombie check fire for the same slot", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const pool = new BrowserPool(1, 100, undefined, launchBrowser);
+    await pool.init();
+
+    // Crash fires disconnect AND flips isConnected false.
+    launched[0]!.__crash();
+    // Acquire while the recycle is still in flight — sees nothing in
+    // available, falls through to waiter path. The disconnect-driven
+    // recycle delivers the fresh browser to the waiter.
+    const acquired = await pool.acquire();
+
+    // Exactly one fresh browser was launched (the recycle replacement).
+    expect(launched.length).toBe(2);
+    expect(acquired).toBe(launched[1] as unknown as Browser);
+
+    await pool.shutdown();
+  });
+
+  it("release() of a slot whose browser disconnected after acquire still recycles instead of returning a dead browser to available", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const { logger, events } = makeFakeLogger();
+    const pool = new BrowserPool(1, 100, logger, launchBrowser);
+    await pool.init();
+
+    const browser = await pool.acquire();
+    // Silent disconnect: no event fires. The pool only learns the slot
+    // is dead at the next isConnected check — which the patched
+    // release() now performs before re-queuing.
+    (browser as unknown as FakeBrowser).__silentlyDisconnect();
+    pool.release(browser);
+
+    await drainMicrotasks(20);
+
+    expect(
+      events.some((e) => e.event === "browser-pool.release-dead-slot"),
+    ).toBe(true);
+    // A fresh browser was launched; the dead one was not re-queued.
+    expect(launched.length).toBe(2);
+
+    const next = await pool.acquire();
+    expect(next).toBe(launched[1] as unknown as Browser);
+    expect((next as unknown as FakeBrowser).isConnected()).toBe(true);
+
+    await pool.shutdown();
+  });
+
+  it("shutdown() does not loop the disconnect handler when closing slot browsers", async () => {
+    const { launchBrowser, launched } = makeFakeLauncher();
+    const { logger, events } = makeFakeLogger();
+    const pool = new BrowserPool(2, 100, logger, launchBrowser);
+    await pool.init();
+
+    await pool.shutdown();
+
+    // shutdown closes both browsers, which fires disconnected on the fakes.
+    // The handler must early-return on isShutdown so no relaunches happen.
+    expect(launched.length).toBe(2);
+    expect(
+      events.filter((e) => e.event === "browser-pool.recycle"),
+    ).toHaveLength(0);
+    expect(launched[0]!.__closeCount).toBeGreaterThan(0);
+    expect(launched[1]!.__closeCount).toBeGreaterThan(0);
+  });
+});

--- a/showcase/harness/src/probes/helpers/browser-pool.ts
+++ b/showcase/harness/src/probes/helpers/browser-pool.ts
@@ -26,6 +26,14 @@ interface PoolLogger {
   info(msg: string, meta?: Record<string, unknown>): void;
 }
 
+/**
+ * Factory that produces a fresh `Browser` for the pool. The default
+ * implementation imports `playwright` and calls `chromium.launch`. Tests
+ * inject a fake so the pool's lifecycle logic is exercisable without
+ * spawning a real chromium process.
+ */
+export type LaunchBrowser = () => Promise<Browser>;
+
 export class BrowserPool {
   private readonly poolSize: number;
   private readonly recycleAfter: number;
@@ -34,8 +42,10 @@ export class BrowserPool {
   private waiters: Waiter[] = [];
   private totalRecycles = 0;
   private inFlightRecycles = new Set<Promise<void>>();
+  private recyclingSlots = new Set<Slot>();
   private isShutdown = false;
   private readonly logger?: PoolLogger;
+  private readonly injectedLaunchBrowser?: LaunchBrowser;
 
   // Tracks which Browser instance maps to which Slot, so release() can find
   // the slot in O(1) even after the slot was removed from `available`.
@@ -45,9 +55,11 @@ export class BrowserPool {
     size = 4,
     recycleAfter?: number,
     logger?: PoolLogger,
+    launchBrowser?: LaunchBrowser,
   ) {
     this.poolSize = size;
     this.logger = logger;
+    this.injectedLaunchBrowser = launchBrowser;
     const envRecycle = process.env.BROWSER_POOL_RECYCLE_AFTER
       ? parseInt(process.env.BROWSER_POOL_RECYCLE_AFTER, 10)
       : undefined;
@@ -59,13 +71,17 @@ export class BrowserPool {
   }
 
   async init(): Promise<void> {
-    const { chromium } =
-      (await import("playwright")) as typeof import("playwright");
-    this.launchBrowser = () =>
-      chromium.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-dev-shm-usage"],
-      });
+    if (this.injectedLaunchBrowser) {
+      this.launchBrowser = this.injectedLaunchBrowser;
+    } else {
+      const { chromium } =
+        (await import("playwright")) as typeof import("playwright");
+      this.launchBrowser = () =>
+        chromium.launch({
+          headless: true,
+          args: ["--no-sandbox", "--disable-dev-shm-usage"],
+        });
+    }
 
     for (let i = 0; i < this.poolSize; i++) {
       const browser = await this.launchBrowser();
@@ -73,24 +89,37 @@ export class BrowserPool {
       this.slots.push(slot);
       this.available.push(slot);
       this.browserToSlot.set(browser, slot);
+      this.attachDisconnectHandler(slot, browser);
     }
   }
 
   // Assigned during init() after the dynamic import resolves.
-  private launchBrowser!: () => Promise<Browser>;
+  private launchBrowser!: LaunchBrowser;
 
   async acquire(timeoutMs = 30_000): Promise<Browser> {
     if (this.isShutdown) {
       throw new Error("BrowserPool is shut down");
     }
 
-    const slot = this.available.shift();
-    if (slot) {
-      this.logger?.info("browser-pool.acquire", {
-        available: this.available.length,
-        inUse: this.slots.length - this.available.length,
+    // Skip zombie slots whose browser has disconnected but whose disconnect
+    // handler hasn't yet completed the recycle. Without this loop, a single
+    // dead chromium process locks every probe that draws its slot until
+    // either the harness restarts or 100 release-cycles trigger the
+    // contextCount-based recycle. Each zombie is kicked into recycle so the
+    // pool self-heals across ticks.
+    while (this.available.length > 0) {
+      const slot = this.available.shift()!;
+      if (slot.browser.isConnected()) {
+        this.logger?.info("browser-pool.acquire", {
+          available: this.available.length,
+          inUse: this.slots.length - this.available.length,
+        });
+        return slot.browser;
+      }
+      this.logger?.info("browser-pool.skipped-dead-slot", {
+        slotIndex: this.slots.indexOf(slot),
       });
-      return slot.browser;
+      this.recycleSlot(slot);
     }
 
     return new Promise<Browser>((resolve, reject) => {
@@ -128,6 +157,19 @@ export class BrowserPool {
     slot.contextCount++;
 
     if (slot.contextCount >= this.recycleAfter) {
+      this.recycleSlot(slot);
+      return;
+    }
+
+    // Defensive: a release-time isConnected check catches the race where
+    // the disconnect event hasn't fired yet (Playwright's events are
+    // asynchronous) but the underlying process is already dead. Without
+    // this, a dead browser would re-enter `available` and the next
+    // acquire would hand it out before the disconnect handler runs.
+    if (!slot.browser.isConnected()) {
+      this.logger?.info("browser-pool.release-dead-slot", {
+        slotIndex: this.slots.indexOf(slot),
+      });
       this.recycleSlot(slot);
       return;
     }
@@ -180,7 +222,42 @@ export class BrowserPool {
     };
   }
 
+  /**
+   * Register a `disconnected` listener on a browser so a chromium process
+   * that crashes mid-life proactively recycles its slot instead of waiting
+   * for the next release-driven check. Three guards keep stale fires
+   * harmless:
+   *
+   *   1. Pool shutdown: handler may fire as we close everything; ignore.
+   *   2. Slot reassignment: `slot.browser` may already point to a fresh
+   *      browser if recycle completed before the old browser's disconnect
+   *      event drained — the late fire is for the OLD instance, not the
+   *      slot's current one.
+   *   3. Slot eviction: launch failure during recycle removes the slot
+   *      from `this.slots`; a disconnect for a no-longer-tracked slot is
+   *      a no-op.
+   */
+  private attachDisconnectHandler(slot: Slot, browser: Browser): void {
+    browser.on("disconnected", () => {
+      if (this.isShutdown) return;
+      if (slot.browser !== browser) return;
+      if (!this.slots.includes(slot)) return;
+      this.logger?.info("browser-pool.disconnected", {
+        slotIndex: this.slots.indexOf(slot),
+      });
+      this.recycleSlot(slot);
+    });
+  }
+
   private recycleSlot(slot: Slot): void {
+    // Re-entry guard: a second call for the same slot (e.g. zombie-skip in
+    // acquire() racing the disconnect handler) is a no-op. Without this,
+    // both call sites would launch a fresh browser and the second would
+    // overwrite `slot.browser` while the first's relaunch was still in
+    // flight, leaking one browser process.
+    if (this.recyclingSlots.has(slot)) return;
+    this.recyclingSlots.add(slot);
+
     this.totalRecycles++;
     const slotIdx = this.slots.indexOf(slot);
     this.logger?.info("browser-pool.recycle", {
@@ -225,6 +302,7 @@ export class BrowserPool {
         slot.browser = fresh;
         slot.contextCount = 0;
         this.browserToSlot.set(fresh, slot);
+        this.attachDisconnectHandler(slot, fresh);
 
         const waiter = this.waiters.shift();
         if (waiter) {
@@ -259,6 +337,7 @@ export class BrowserPool {
 
     this.inFlightRecycles.add(recyclePromise);
     recyclePromise.finally(() => {
+      this.recyclingSlots.delete(slot);
       this.inFlightRecycles.delete(recyclePromise);
     });
   }


### PR DESCRIPTION
## Summary

Three coordinated fixes that together restore D3 (`e2e-readiness` per-cell) emission for the half of the dashboard that's been stuck at D2 since the #4442 revert removed the D5-as-D3/D4 bypass. Apps are healthy on Railway; the regression is harness-side (zombie pooled browsers) plus a separate-but-related webhook 400.

### 1. `BrowserPool` dead-instance detection — *primary fix for the dashboard regression*

Production logs showed every starved cell hitting:

```
errorClass: "driver-error"
errorDesc:  "browser.newContext: Target page, context or browser has been closed"
```

…all clustered at the `:10` cron-tick start across the same set of slugs every hour. The pool had no way to detect that a chromium process had died — once a slot's `Browser` instance went zombie, it stayed in `available[]` and every probe that drew it failed identically. The dead slot only ever recycled when 100 release-cycles tripped the existing `contextCount >= recycleAfter` path, i.e. days later.

`showcase/harness/src/probes/helpers/browser-pool.ts`:

- **`browser.on("disconnected", ...)`** registered per slot in `init()` and `recycleSlot()`. When chromium dies cleanly (Playwright fires `disconnected`), the listener proactively kicks `recycleSlot(slot)`. Three guards prevent stale fires from causing havoc: pool-shutdown, slot-reassignment (`slot.browser !== browser`), and slot-eviction (`!this.slots.includes(slot)`).
- **`isConnected()` skip-loop in `acquire()`.** For the case where chromium hung without a clean `disconnected` (WebSocket dropped, kill -9, etc.), `acquire()` now walks `available[]`, recycling each zombie via `recycleSlot()` and returning the first live browser. Logs `browser-pool.skipped-dead-slot { slotIndex }` so operators can see it happening.
- **`isConnected()` check at release time** catches the disconnect-event-pending race where `release()` runs between chromium dying and Playwright's async event firing — without it, the dead browser would re-enter `available` and the next acquire would hand it out before the disconnect handler runs.
- **`recyclingSlots` per-slot guard** added to `recycleSlot()` so the disconnect-handler path and the on-acquire-zombie-skip path can't both launch a fresh browser for the same slot. Without this, the second path would overwrite `slot.browser` while the first's relaunch was in flight, leaking one chromium process per double-fire.
- **Test-injectable `LaunchBrowser` factory** added to the constructor (4th positional, optional) so the pool's lifecycle is exercisable from unit tests without spawning real chromium. The dynamic `import("playwright")` path remains the production default.

7 new unit tests in `browser-pool.test.ts` cover: disconnect-listener registration + recycle, on-acquire zombie skip with logged skip event, fall-through-to-waiter when all slots are zombies, mid-use disconnect → fresh browser on next acquire, no-double-recycle when both detection paths fire, release-time zombie detection, and shutdown not looping the disconnect handler.

### 2. `createPooledE2eDemosLauncher` abort release

Direct port of the `createPooledE2eDeepLauncher` fix from `ed0933e5c`. Same `Promise.race`-driven outer-timeout pattern in `e2e-demos` had the same starvation hazard: when the invoker abandoned the driver promise on outer-timeout, the orphan kept the pooled browser held until it drained all remaining demos.

`showcase/harness/src/probes/drivers/e2e-readiness.ts`:

- `E2eDemosBrowserLauncher` signature now takes an optional `AbortSignal`.
- `createPooledE2eDemosLauncher` honours the abort signal: tracks open contexts in a `Set`, force-closes them and releases the browser back to the pool on abort, uses a `forceReleased` flag so the driver's normal `browser.close()` in the finally block doesn't double-release.
- Driver `run()` threads `abort.signal` into the launcher call.
- Orchestrator wires the logger into the pooled launcher registration (matches how `createPooledE2eDeepLauncher(pool, logger)` is wired).
- Default per-call chromium launcher accepts and ignores the signal — its lifecycle doesn't need it.

4 new unit tests (mirroring the existing `createPooledE2eDeepLauncher` suite): basic abort-release, context-close-before-release, pre-aborted signal, full-pool-starvation scenario.

### 3. `/webhooks/deploy` accepts `buildRunId` / `buildRunUrl`

PR #4471 ("Decouple showcase build and deploy into separate workflows") started co-sending `buildRunId` and `buildRunUrl` so Slack/dashboard surfaces can link a red deploy back to the build that produced its images. But `deployPayloadSchema` is `.strict()` and was rejecting them as unknown keys — every `Showcase: Verify Deploy` run since #4471 has 400'd:

```
{"ok":false,"reason":"invalid-payload",
 "errors":{"formErrors":["Unrecognized key(s) in object: 'buildRunId', 'buildRunUrl'"]}}
```

`showcase/harness/src/http/webhooks/deploy.ts`:

- Adds both fields as `.optional()` in the schema.
- `buildRunUrl` mirrors `runUrl`'s http(s)-only refinement so a signed sender with a typo can't plant a `javascript:` URL in a Slack-rendered link.
- Propagates both onto `DeployResultEvent` (and the type in `events/event-bus.ts`) so downstream alert templates and dashboard tooltips can surface them.

3 new test cases: pass-through with both fields, pass-through without (legacy senders / manual redeploys), refinement rejects non-http(s) `buildRunUrl`.

## Why one PR

The three changes share the same scope (showcase-harness probe pipeline), the same blast radius (rebuilding and redeploying `showcase-harness` on Railway), and the same beneficiary (the dashboard returns to D4-5 once the harness redeploys with these patches). Bundling avoids three separate harness rebuilds and three review cycles for what is functionally one ops-recovery patch.

## Test plan

- [x] `oxfmt --check` clean on all 8 touched files.
- [x] `tsc --noEmit` clean (`@copilotkit/showcase-harness:typecheck`).
- [x] Vitest pass on every test in the touched files: 7 new in `browser-pool.test.ts`, 4 new in `e2e-readiness.test.ts`, 3 new in `deploy.test.ts`. The 19 pre-existing Windows-only failures (path-separator hardcoded `/abs/...` strings + boot-wiring test timeouts) match the same shape on `origin/main` HEAD and are untouched by this change — count actually drops by 4 vs main baseline because some fixture-write tests cope better with the newer code paths.
- [x] `tsc -p tsconfig.build.json` clean (`@copilotkit/showcase-harness:build`).
- [ ] On deploy of this branch, watch one full `e2e-demos` cron tick at `:10`. Expected log signal: `browser-pool.disconnected { slotIndex }` and/or `browser-pool.skipped-dead-slot { slotIndex }` for any slot that was zombie at boot, followed by `browser-pool.recycle` and `browser-pool.acquire`. The previously-dead slugs flip back to green D3 and the dashboard returns to D4-5.
- [ ] After deploy, confirm the next deploy-result webhook from the workflow lands `202 Accepted` instead of `400 invalid-payload`, and that the harness logs `webhook.deploy.accepted` with both `buildRunId` and `buildRunUrl` populated.
- [ ] Spot-check that `Showcase: Verify Deploy` workflow runs are now exiting 0 instead of failing on the `notify-harness` step.