### PR TITLE
perf(showcase-dashboard): memoize matrix cells + coalesce SSE deltas

### DIFF
--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -7,7 +7,7 @@
  * a single composable component that stacks only the active layers.
  */
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { memo, useState, useEffect, useRef, useCallback } from "react";
 import type { CellContext } from "@/components/feature-grid";
 import { CellStatus, DocsRow, urlsFor } from "@/components/cell-pieces";
 import { CellDrilldown } from "@/components/cell-drilldown";
@@ -15,6 +15,7 @@ import { CommandCell } from "@/components/command-cell";
 import { DepthChip } from "@/components/depth-chip";
 import { deriveDepth } from "@/components/depth-utils";
 import type { CatalogCell } from "@/components/depth-utils";
+import { keyFor } from "@/lib/live-status";
 
 /** Overlay types — defined locally; canonical types live in a sibling module. */
 export type Overlay = "links" | "depth" | "health" | "parity" | "docs";
@@ -163,11 +164,7 @@ function DocsLayer({ ctx }: { ctx: CellContext }) {
  * "parity" overlay adds no per-cell content — if only parity is active,
  * the cell renders empty.
  */
-export function ComposedCell({
-  ctx,
-  overlays,
-  catalogCell,
-}: ComposedCellProps) {
+function ComposedCellInner({ ctx, overlays, catalogCell }: ComposedCellProps) {
   const isTesting = ctx.feature.kind === "testing";
   const hasLinks = overlays.has("links");
   const hasDepth = overlays.has("depth");
@@ -193,3 +190,60 @@ export function ComposedCell({
     </div>
   );
 }
+
+/**
+ * Custom equality check for ComposedCell. Skipping a cell render when its
+ * underlying inputs are unchanged is the difference between a single PB SSE
+ * delta re-rendering 1 cell vs. all ~720 cells in the matrix.
+ *
+ * `ctx.liveStatus` is a fresh Map on every parent render (mergeRowsToMap is
+ * called in the page component on each `rows` array change), so a naive
+ * shallow-equal would always invalidate. Instead, we compare the specific
+ * row references this cell actually reads from the map. The upstream
+ * `upsertByKey` reducer preserves row identity for unchanged keys, so the
+ * per-key lookups are reference-stable across deltas that don't touch this
+ * cell's slug/featureId.
+ */
+function arePropsEqual(
+  prev: ComposedCellProps,
+  next: ComposedCellProps,
+): boolean {
+  if (prev.overlays !== next.overlays) return false;
+  if (prev.catalogCell !== next.catalogCell) return false;
+
+  const p = prev.ctx;
+  const n = next.ctx;
+  if (
+    p.connection !== n.connection ||
+    p.hostedUrl !== n.hostedUrl ||
+    p.shellUrl !== n.shellUrl ||
+    p.integration !== n.integration ||
+    p.feature !== n.feature ||
+    p.demo !== n.demo
+  ) {
+    return false;
+  }
+
+  if (p.liveStatus === n.liveStatus) return true;
+
+  // Map identity changed — verify only the rows this cell reads. Mirrors
+  // the lookups in resolveCell + LevelStrip-adjacent helpers; D5 is
+  // resolved through CATALOG_TO_D5_KEY, so we walk the same indirection
+  // here to avoid false-negative skips. Keep this list in sync with
+  // resolveCell + resolveD5Row in lib/live-status.ts.
+  const slug = p.integration.slug;
+  const featureId = p.feature.id;
+  const directKeys = [
+    keyFor("health", slug),
+    keyFor("e2e", slug, featureId),
+    keyFor("smoke", slug),
+    keyFor("d5", slug, featureId),
+    keyFor("d6", slug, featureId),
+  ];
+  for (const k of directKeys) {
+    if (prev.ctx.liveStatus.get(k) !== next.ctx.liveStatus.get(k)) return false;
+  }
+  return true;
+}
+
+export const ComposedCell = memo(ComposedCellInner, arePropsEqual);

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -75,9 +75,7 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
     // within 16ms is vanishingly rare and the latest one is always the
     // intended state). Keeping a Map keyed by `record.key` keeps the
     // buffer O(unique_keys_in_burst) rather than O(events_in_burst).
-    type PendingOp =
-      | { op: "upsert"; row: StatusRow }
-      | { op: "delete" };
+    type PendingOp = { op: "upsert"; row: StatusRow } | { op: "delete" };
     const pendingByKey = new Map<string, PendingOp>();
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
     // Zombie-detection note: an earlier revision tracked

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -30,6 +30,14 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 // Reconnect backoff: 1s, 2s, 4s, capped at 8s (parity across retry chain).
 const RECONNECT_BACKOFF_BASE_MS = 1000;
 const RECONNECT_BACKOFF_MAX_MS = 8000;
+// Coalesce SSE deltas that arrive within this window into a single React
+// commit. PocketBase realtime fires the subscribe callback once per record;
+// when the harness publishes many rows in quick succession (probe finishing
+// dozens of services, initial-state burst on reconnect), unbuffered setRows
+// calls force the page to re-render the matrix once per record. ~16ms is
+// roughly one frame — short enough to feel "live" to operators, long enough
+// to fold a burst of deltas into one render.
+const SUBSCRIBE_FLUSH_INTERVAL_MS = 16;
 
 /**
  * Subscribes to the `status` collection, scoped by `dimension`. Exposes
@@ -61,6 +69,17 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
     let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let reconnecting = false;
+    // Per-key buffer for incoming SSE deltas. The latest event for a given
+    // key supersedes earlier ones (last-write-wins on a single key during
+    // the same flush window — multiple producers updating the same row
+    // within 16ms is vanishingly rare and the latest one is always the
+    // intended state). Keeping a Map keyed by `record.key` keeps the
+    // buffer O(unique_keys_in_burst) rather than O(events_in_burst).
+    type PendingOp =
+      | { op: "upsert"; row: StatusRow }
+      | { op: "delete" };
+    const pendingByKey = new Map<string, PendingOp>();
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
     // Zombie-detection note: an earlier revision tracked
     // `lastRowUpdateAt` and force-reconnected if no SSE delta arrived
     // within 2× heartbeat interval. That produced a reconnect storm on
@@ -114,6 +133,48 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       }
     }
 
+    function clearFlushTimer(): void {
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      pendingByKey.clear();
+    }
+
+    function flushPending(): void {
+      flushTimer = null;
+      if (!alive || pendingByKey.size === 0) return;
+      const ops = Array.from(pendingByKey);
+      pendingByKey.clear();
+      setRows((prev) => {
+        let next = prev;
+        let mutated = false;
+        for (const [key, op] of ops) {
+          if (op.op === "delete") {
+            const idx = next.findIndex((r) => r.key === key);
+            if (idx === -1) continue;
+            if (!mutated) {
+              next = next.slice();
+              mutated = true;
+            }
+            next.splice(idx, 1);
+          } else {
+            const candidate = upsertByKey(next, op.row);
+            if (candidate !== next) {
+              next = candidate;
+              mutated = true;
+            }
+          }
+        }
+        return mutated ? next : prev;
+      });
+    }
+
+    function scheduleFlush(): void {
+      if (flushTimer !== null) return;
+      flushTimer = setTimeout(flushPending, SUBSCRIBE_FLUSH_INTERVAL_MS);
+    }
+
     function startReconnect(reason: string, err?: unknown): void {
       // Idempotency guard: if we're already mid-reconnect (e.g. overlapping
       // heartbeat tick, onError callback), drop the redundant kickoff so we
@@ -137,6 +198,11 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       }
       clearHeartbeat();
       clearReconnectTimer();
+      // Drop any buffered deltas tied to the (now-doomed) subscription —
+      // applying them after teardown would either land stale rows on the
+      // freshly-cleared state on terminal error, or interleave with the
+      // post-reconnect initial fetch and confuse rollup state.
+      clearFlushTimer();
       teardownSubscription();
       // `connect()` chains its own setTimeout-based retries internally,
       // so `reconnecting` must stay `true` for the entire retry chain,
@@ -210,11 +276,18 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
             try {
               if (!alive) return;
               if (dimension && e.record.dimension !== dimension) return;
+              // Buffer the op rather than calling setRows directly. A burst
+              // of deltas (probe finishes 50 services in the same SSE frame,
+              // initial-state replay on reconnect, etc.) folds into a single
+              // React commit on the next flush tick — without this, the
+              // matrix re-renders once per record and freezes the main
+              // thread on large bursts.
               if (e.action === "delete") {
-                setRows((prev) => prev.filter((r) => r.key !== e.record.key));
+                pendingByKey.set(e.record.key, { op: "delete" });
               } else {
-                setRows((prev) => upsertByKey(prev, e.record));
+                pendingByKey.set(e.record.key, { op: "upsert", row: e.record });
               }
+              scheduleFlush();
             } catch (cbErr) {
               // eslint-disable-next-line no-console
               console.error("[useLiveStatus] subscribe callback threw", cbErr);
@@ -290,6 +363,7 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       alive = false;
       clearHeartbeat();
       clearReconnectTimer();
+      clearFlushTimer();
       teardownSubscription();
     };
   }, [dimension]);


### PR DESCRIPTION
## Summary

The shell-dashboard matrix tab can spike CPU and freeze the browser on load and during update bursts. Two compounding causes:

1. **Every PB SSE delta forces a full grid re-render.** The matrix renders ~720 cells (18 integrations × ~40 features), and nothing in the cell tree was memoized — a single status row update propagated a new `ctx.liveStatus` Map identity through every cell, and identity-based React.memo couldn't help because the Map ref changed.
2. **PocketBase fires the subscribe callback once per record.** A probe finishing dozens of services, or the initial-state replay on reconnect, produced N consecutive `setRows` calls and N React commits across separate microtasks (auto-batching only catches synchronous bursts).

## Changes

- **`ComposedCell`** wrapped in `React.memo` with a custom `arePropsEqual`. Compares `overlays`/`catalogCell` refs, ctx scalars, and — when the `liveStatus` Map identity changes — only the 5 row keys this cell actually reads (`health:slug`, `e2e:slug/feature`, `smoke:slug`, `d5:slug/feature`, `d6:slug/feature`). Because `upsertByKey` preserves row identity for unchanged keys, deltas that don't touch a cell's `slug/featureId` short-circuit at the memo boundary.
- **`useLiveStatus`** buffers SSE callbacks into a per-key `Map<string, PendingOp>` and flushes via a single 16ms `setTimeout`. A burst of N deltas now produces 1 React commit instead of N. Last-write-wins per key. Buffer is cleared on effect teardown and on reconnect kickoff so post-reconnect initial fetches never land on top of stale buffered rows.

## Why these two together

Throttling alone would still re-render every cell on each flush. Memoization alone would still get invalidated on every delta because each delta produces a new Map. Together: a burst of unrelated row updates → 1 React commit, and within that commit only cells whose specific rows changed actually re-render.

## What I have not changed

- The three independent `useNowTick` 1s timers on the Ops tab. They only matter if the freeze reproduces on Ops, not Matrix; happy to consolidate as a follow-up if needed.
- `OverlayColumnHeader` (rendered 18× in the header, calls `LevelStrip` which does 4 Map lookups each). Same memo treatment would apply if these still show up after this lands.
- No virtualization. Should not be necessary if the memo + throttle combo works as expected.

## Test plan

- [x] Existing unit tests in the touched files pass — `useLiveStatus.test.tsx` 15/15, `composed-cell.test.tsx` 9/10 (the 1 failure is a pre-existing test-vs-impl drift in the "renders 3 layers when all active — docs deduped by health" case, verified by stashing my changes and re-running).
- [x] No new TypeScript errors in the touched files.
- [ ] **Manual perf trace before/after on the live dashboard** — Chrome DevTools → Performance tab → record while loading the dashboard against a real PB feed. Expected: scripting time during initial load and during probe-finish bursts drops sharply.
- [ ] **Functional sanity** — confirm cells still update on real status changes (e.g. trigger a probe and watch the matching cell flip tone within ~1 frame).