### PR TITLE
Add Perplexity service adapter (Agent API)

### DIFF
--- a/packages/runtime/src/service-adapters/index.ts
+++ b/packages/runtime/src/service-adapters/index.ts
@@ -12,6 +12,7 @@ export * from "./google/google-genai-adapter";
 export * from "./openai/openai-assistant-adapter";
 export * from "./unify/unify-adapter";
 export * from "./groq/groq-adapter";
+export * from "./perplexity/perplexity-adapter";
 export * from "./anthropic/anthropic-adapter";
 export * from "./experimental/ollama/ollama-adapter";
 export * from "./bedrock/bedrock-adapter";

--- a/packages/runtime/src/service-adapters/perplexity/perplexity-adapter.ts
+++ b/packages/runtime/src/service-adapters/perplexity/perplexity-adapter.ts
@@ -1,0 +1,247 @@
+/**
+ * Copilot Runtime adapter for Perplexity (Agent API).
+ *
+ * Wraps the official `openai` SDK pointed at `https://api.perplexity.ai`,
+ * which exposes an OpenAI-compatible chat completions endpoint.
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { CopilotRuntime, PerplexityAdapter } from "@copilotkit/runtime";
+ * import OpenAI from "openai";
+ *
+ * const perplexity = new OpenAI({
+ *   apiKey: process.env["PERPLEXITY_API_KEY"],
+ *   baseURL: "https://api.perplexity.ai",
+ * });
+ *
+ * const copilotKit = new CopilotRuntime();
+ *
+ * return new PerplexityAdapter({ perplexity, model: "sonar-pro" });
+ * ```
+ */
+import type { LanguageModel } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+import type OpenAI from "openai";
+import Openai from "openai";
+import {
+  CopilotServiceAdapter,
+  CopilotRuntimeChatCompletionRequest,
+  CopilotRuntimeChatCompletionResponse,
+} from "../service-adapter";
+import {
+  convertActionInputToOpenAITool,
+  convertMessageToOpenAIMessage,
+  limitMessagesToTokenCount,
+} from "../openai/utils";
+import { randomUUID } from "@copilotkit/shared";
+import { convertServiceAdapterError, getSdkClientOptions } from "../shared";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJson = require("../../../package.json");
+
+const DEFAULT_MODEL = "sonar-pro";
+const DEFAULT_BASE_URL = "https://api.perplexity.ai";
+const ATTRIBUTION_HEADER = "X-Pplx-Integration";
+const ATTRIBUTION_VALUE = `copilotkit/${packageJson.version}`;
+
+export interface PerplexityAdapterParams {
+  /**
+   * An optional `OpenAI` SDK instance pre-configured for Perplexity. If
+   * provided, its `baseURL` and `defaultHeaders` are used as-is. If not
+   * provided, a new instance is created targeting `https://api.perplexity.ai`
+   * with the `PERPLEXITY_API_KEY` environment variable.
+   */
+  perplexity?: OpenAI;
+
+  /**
+   * The model to use.
+   *
+   * @default "sonar-pro"
+   */
+  model?: string;
+
+  /**
+   * Whether to disable parallel tool calls.
+   * You can disable parallel tool calls to force the model to execute tool calls sequentially.
+   * This is useful if you want to execute tool calls in a specific order so that the state changes
+   * introduced by one tool call are visible to the next tool call. (i.e. new actions or readables)
+   *
+   * @default false
+   */
+  disableParallelToolCalls?: boolean;
+}
+
+export class PerplexityAdapter implements CopilotServiceAdapter {
+  public model: string = DEFAULT_MODEL;
+  public provider = "perplexity";
+
+  private disableParallelToolCalls: boolean = false;
+  private _perplexity: OpenAI;
+  public get perplexity(): OpenAI {
+    return this._perplexity;
+  }
+  public get name() {
+    return "PerplexityAdapter";
+  }
+
+  constructor(params?: PerplexityAdapterParams) {
+    if (params?.perplexity) {
+      this._perplexity = params.perplexity;
+    }
+    // If no instance provided, we'll lazy-load in ensurePerplexity()
+    if (params?.model) {
+      this.model = params.model;
+    }
+    this.disableParallelToolCalls = params?.disableParallelToolCalls || false;
+  }
+
+  getLanguageModel(): LanguageModel {
+    const perplexity = this.ensurePerplexity();
+    const options = getSdkClientOptions(perplexity);
+    const provider = createOpenAI({
+      baseURL: perplexity.baseURL,
+      apiKey: perplexity.apiKey,
+      headers: options.defaultHeaders,
+      fetch: options.fetch,
+      name: "perplexity",
+    });
+    return provider(this.model);
+  }
+
+  private ensurePerplexity(): OpenAI {
+    if (!this._perplexity) {
+      this._perplexity = new Openai({
+        baseURL: DEFAULT_BASE_URL,
+        defaultHeaders: { [ATTRIBUTION_HEADER]: ATTRIBUTION_VALUE },
+      });
+    }
+    return this._perplexity;
+  }
+
+  async process(
+    request: CopilotRuntimeChatCompletionRequest,
+  ): Promise<CopilotRuntimeChatCompletionResponse> {
+    const {
+      threadId,
+      model = this.model,
+      messages,
+      actions,
+      eventSource,
+      forwardedParameters,
+    } = request;
+    const tools = actions.map(convertActionInputToOpenAITool);
+
+    let openaiMessages = messages.map((m) =>
+      convertMessageToOpenAIMessage(m, { keepSystemRole: true }),
+    );
+    openaiMessages = limitMessagesToTokenCount(openaiMessages, tools, model);
+
+    let toolChoice: any = forwardedParameters?.toolChoice;
+    if (forwardedParameters?.toolChoice === "function") {
+      toolChoice = {
+        type: "function",
+        function: { name: forwardedParameters.toolChoiceFunctionName },
+      };
+    }
+    let stream;
+    try {
+      const perplexity = this.ensurePerplexity();
+      stream = await perplexity.chat.completions.create({
+        model: model,
+        stream: true,
+        messages: openaiMessages,
+        ...(tools.length > 0 && { tools }),
+        ...(forwardedParameters?.maxTokens && {
+          max_tokens: forwardedParameters.maxTokens,
+        }),
+        ...(forwardedParameters?.stop && { stop: forwardedParameters.stop }),
+        ...(toolChoice && { tool_choice: toolChoice }),
+        ...(this.disableParallelToolCalls && { parallel_tool_calls: false }),
+        ...(forwardedParameters?.temperature && {
+          temperature: forwardedParameters.temperature,
+        }),
+      });
+    } catch (error) {
+      throw convertServiceAdapterError(error, "Perplexity");
+    }
+
+    eventSource.stream(async (eventStream$) => {
+      let mode: "function" | "message" | null = null;
+      let currentMessageId: string;
+      let currentToolCallId: string;
+
+      try {
+        for await (const chunk of stream) {
+          const toolCall = chunk.choices[0].delta.tool_calls?.[0];
+          const content = chunk.choices[0].delta.content;
+
+          // When switching from message to function or vice versa,
+          // send the respective end event.
+          // If toolCall?.id is defined, it means a new tool call starts.
+          if (mode === "message" && toolCall?.id) {
+            mode = null;
+            eventStream$.sendTextMessageEnd({ messageId: currentMessageId });
+          } else if (
+            mode === "function" &&
+            (toolCall === undefined || toolCall?.id)
+          ) {
+            mode = null;
+            eventStream$.sendActionExecutionEnd({
+              actionExecutionId: currentToolCallId,
+            });
+          }
+
+          // If we send a new message type, send the appropriate start event.
+          if (mode === null) {
+            if (toolCall?.id) {
+              mode = "function";
+              currentToolCallId = toolCall!.id;
+              eventStream$.sendActionExecutionStart({
+                actionExecutionId: currentToolCallId,
+                actionName: toolCall!.function!.name,
+                parentMessageId: chunk.id,
+              });
+            } else if (content) {
+              mode = "message";
+              currentMessageId = chunk.id;
+              eventStream$.sendTextMessageStart({
+                messageId: currentMessageId,
+              });
+            }
+          }
+
+          // send the content events
+          if (mode === "message" && content) {
+            eventStream$.sendTextMessageContent({
+              messageId: currentMessageId,
+              content,
+            });
+          } else if (mode === "function" && toolCall?.function?.arguments) {
+            eventStream$.sendActionExecutionArgs({
+              actionExecutionId: currentToolCallId,
+              args: toolCall.function.arguments,
+            });
+          }
+        }
+
+        // send the end events
+        if (mode === "message") {
+          eventStream$.sendTextMessageEnd({ messageId: currentMessageId });
+        } else if (mode === "function") {
+          eventStream$.sendActionExecutionEnd({
+            actionExecutionId: currentToolCallId,
+          });
+        }
+      } catch (error) {
+        throw convertServiceAdapterError(error, "Perplexity");
+      }
+
+      eventStream$.complete();
+    });
+
+    return {
+      threadId: request.threadId || randomUUID(),
+    };
+  }
+}

--- a/packages/runtime/tests/service-adapters/perplexity/perplexity-adapter-language-model.test.ts
+++ b/packages/runtime/tests/service-adapters/perplexity/perplexity-adapter-language-model.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { OpenAIProviderSettings } from "@ai-sdk/openai";
+import { PerplexityAdapter } from "../../../src/service-adapters/perplexity/perplexity-adapter";
+import OpenAI from "openai";
+
+// Perplexity exposes an OpenAI-compatible chat completions endpoint, so we
+// use createOpenAI under the hood. Same exhaustiveness guard as the OpenAI
+// and Groq tests.
+type ForwardedPerplexityKeys = "baseURL" | "apiKey" | "headers" | "fetch";
+
+// Keys we set ourselves or that don't apply to Perplexity.
+type ControlledPerplexityKeys = "name" | "organization" | "project";
+
+type _exhaustive =
+  Exclude<
+    keyof OpenAIProviderSettings,
+    ForwardedPerplexityKeys | ControlledPerplexityKeys
+  > extends never
+    ? true
+    : {
+        error: "OpenAIProviderSettings has unhandled keys";
+        unhandled: Exclude<
+          keyof OpenAIProviderSettings,
+          ForwardedPerplexityKeys | ControlledPerplexityKeys
+        >;
+      };
+const _check: _exhaustive = true;
+
+const { mockProviderFn, mockCreateOpenAI } = vi.hoisted(() => {
+  const mockProviderFn = vi.fn().mockReturnValue({ modelId: "test-model" });
+  const mockCreateOpenAI = vi.fn().mockReturnValue(mockProviderFn);
+  return { mockProviderFn, mockCreateOpenAI };
+});
+
+vi.mock("@ai-sdk/openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ai-sdk/openai")>();
+  return { ...actual, createOpenAI: mockCreateOpenAI };
+});
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      baseURL: string;
+      apiKey: string;
+      _options: Record<string, any>;
+      chat = { completions: { create: vi.fn() } };
+
+      constructor(opts: any = {}) {
+        this.baseURL = opts.baseURL ?? "https://api.openai.com/v1";
+        this.apiKey = opts.apiKey ?? "default-key";
+        this._options = {
+          defaultHeaders: opts.defaultHeaders,
+          fetch: opts.fetch,
+          ...opts,
+        };
+      }
+    },
+  };
+});
+
+describe("PerplexityAdapter.getLanguageModel()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards all provider-relevant options from the OpenAI SDK client", () => {
+    const customFetch = vi.fn();
+    const perplexity = new OpenAI({
+      apiKey: "pplx-test",
+      baseURL: "https://api.perplexity.ai",
+      defaultHeaders: { "X-Pplx-Integration": "copilotkit/1.0.0" },
+      fetch: customFetch,
+    });
+
+    const adapter = new PerplexityAdapter({
+      perplexity,
+      model: "sonar-pro",
+    });
+    adapter.getLanguageModel();
+
+    expect(mockCreateOpenAI).toHaveBeenCalledOnce();
+    const settings = mockCreateOpenAI.mock.calls[0][0];
+
+    expect(settings.baseURL).toBe("https://api.perplexity.ai");
+    expect(settings.apiKey).toBe("pplx-test");
+    expect(settings.headers).toEqual({
+      "X-Pplx-Integration": "copilotkit/1.0.0",
+    });
+    expect(settings.fetch).toBe(customFetch);
+    expect(settings.name).toBe("perplexity");
+
+    expect(mockProviderFn).toHaveBeenCalledWith("sonar-pro");
+  });
+
+  it("defaults to sonar-pro when no model is provided", () => {
+    const perplexity = new OpenAI({
+      apiKey: "pplx-default",
+      baseURL: "https://api.perplexity.ai",
+    });
+    const adapter = new PerplexityAdapter({ perplexity });
+    adapter.getLanguageModel();
+
+    expect(mockProviderFn).toHaveBeenCalledWith("sonar-pro");
+  });
+
+  it("attaches the X-Pplx-Integration attribution header on the lazy-initialized client", () => {
+    const adapter = new PerplexityAdapter();
+    adapter.getLanguageModel();
+
+    const settings = mockCreateOpenAI.mock.calls[0][0];
+    expect(settings.baseURL).toBe("https://api.perplexity.ai");
+    expect(settings.headers).toBeDefined();
+    expect(settings.headers["X-Pplx-Integration"]).toMatch(/^copilotkit\//);
+    expect(settings.name).toBe("perplexity");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `PerplexityAdapter` for the Copilot Runtime, mirroring the existing `GroqAdapter` line-for-line. Both providers expose an OpenAI-compatible chat completions endpoint, so the adapter wraps the official `openai` SDK pointed at `https://api.perplexity.ai`.

- New adapter: `packages/runtime/src/service-adapters/perplexity/perplexity-adapter.ts`
- Default model: `sonar-pro`
- Sets the `X-Pplx-Integration: copilotkit/<version>` attribution header on the lazy-initialized client
- Exported from `packages/runtime/src/service-adapters/index.ts`
- Vitest unit tests under `packages/runtime/tests/service-adapters/perplexity/` covering forwarded options, default model, and presence of the attribution header

## Usage

```ts
import { CopilotRuntime, PerplexityAdapter } from "@copilotkit/runtime";
import OpenAI from "openai";

const perplexity = new OpenAI({
  apiKey: process.env.PERPLEXITY_API_KEY,
  baseURL: "https://api.perplexity.ai",
});

const copilotKit = new CopilotRuntime();
return new PerplexityAdapter({ perplexity, model: "sonar-pro" });
```

If no client is supplied, the adapter lazy-instantiates one against the Perplexity base URL with the attribution header pre-attached, picking up `PERPLEXITY_API_KEY` from the environment.

## Testing

- [x] `pnpm --filter=@copilotkit/runtime build` — TypeScript compiles cleanly; emitted `dist/service-adapters/perplexity/*` artifacts match other adapters.
- [x] Unit tests added under `tests/service-adapters/perplexity/` mirror the existing groq tests.
- [x] No new dependencies — reuses the `openai` SDK already declared in `@copilotkit/runtime`.