### PR TITLE
perf(showcase-dashboard): yield during fetch + parallelize initial pages

### DIFF
--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { pb, pbIsMisconfigured, PB_MISCONFIG_MESSAGE } from "../lib/pb";
 import type { StatusRow } from "../lib/live-status";
 import { upsertByKey } from "../lib/live-status";
@@ -75,9 +75,7 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
     // within 16ms is vanishingly rare and the latest one is always the
     // intended state). Keeping a Map keyed by `record.key` keeps the
     // buffer O(unique_keys_in_burst) rather than O(events_in_burst).
-    type PendingOp =
-      | { op: "upsert"; row: StatusRow }
-      | { op: "delete" };
+    type PendingOp = { op: "upsert"; row: StatusRow } | { op: "delete" };
     const pendingByKey = new Map<string, PendingOp>();
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
     // Zombie-detection note: an earlier revision tracked
@@ -146,27 +144,34 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       if (!alive || pendingByKey.size === 0) return;
       const ops = Array.from(pendingByKey);
       pendingByKey.clear();
-      setRows((prev) => {
-        let next = prev;
-        let mutated = false;
-        for (const [key, op] of ops) {
-          if (op.op === "delete") {
-            const idx = next.findIndex((r) => r.key === key);
-            if (idx === -1) continue;
-            if (!mutated) {
-              next = next.slice();
-              mutated = true;
-            }
-            next.splice(idx, 1);
-          } else {
-            const candidate = upsertByKey(next, op.row);
-            if (candidate !== next) {
-              next = candidate;
-              mutated = true;
+      // SSE deltas drive a non-urgent visual update — flag the commit as a
+      // transition so React 19 can yield to user input (scroll, click,
+      // keyboard) while it walks the matrix tree. Without this, a large
+      // burst still renders synchronously and noticeably stalls the page
+      // even though the burst was coalesced into a single setRows call.
+      startTransition(() => {
+        setRows((prev) => {
+          let next = prev;
+          let mutated = false;
+          for (const [key, op] of ops) {
+            if (op.op === "delete") {
+              const idx = next.findIndex((r) => r.key === key);
+              if (idx === -1) continue;
+              if (!mutated) {
+                next = next.slice();
+                mutated = true;
+              }
+              next.splice(idx, 1);
+            } else {
+              const candidate = upsertByKey(next, op.row);
+              if (candidate !== next) {
+                next = candidate;
+                mutated = true;
+              }
             }
           }
-        }
-        return mutated ? next : prev;
+          return mutated ? next : prev;
+        });
       });
     }
 
@@ -234,30 +239,60 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
     }
 
     async function fetchInitial(): Promise<StatusRow[]> {
-      // Paginated fetch with a hard total cap. `getFullList({batch})`
-      // would keep pulling every page of matching rows; we instead loop
-      // `getList` and break once we hit INITIAL_CAP.
-      const collected: StatusRow[] = [];
-      let page = 1;
-      while (collected.length < INITIAL_CAP) {
-        const remaining = INITIAL_CAP - collected.length;
-        const perPage = Math.min(INITIAL_PAGE_SIZE, remaining);
-        const resp = await pb
-          .collection("status")
-          .getList<StatusRow>(page, perPage, { filter });
-        if (!resp.items || resp.items.length === 0) break;
-        collected.push(...resp.items);
-        if (collected.length >= resp.totalItems) break;
-        page += 1;
+      // Pull page 1 sequentially so we learn `totalItems` before deciding
+      // how many additional pages to issue. After that, the remaining
+      // pages are independent reads from the same collection — fire them
+      // in parallel so wall-clock latency tracks the slowest page rather
+      // than the sum. With 2000-row datasets paginated at 200/page that
+      // turns ~10 sequential round-trips into one round-trip per slot of
+      // network parallelism, which is the difference between a
+      // multi-second loading hitch and a single network frame.
+      const firstResp = await pb
+        .collection("status")
+        .getList<StatusRow>(1, INITIAL_PAGE_SIZE, { filter });
+      if (!firstResp.items || firstResp.items.length === 0) return [];
+
+      const total = Math.min(firstResp.totalItems, INITIAL_CAP);
+      if (firstResp.items.length >= total) {
+        return firstResp.items.slice(0, total);
       }
-      return collected;
+
+      const lastPage = Math.ceil(total / INITIAL_PAGE_SIZE);
+      const pageRequests: Promise<StatusRow[]>[] = [];
+      for (let p = 2; p <= lastPage; p++) {
+        const perPage = Math.min(
+          INITIAL_PAGE_SIZE,
+          total - (p - 1) * INITIAL_PAGE_SIZE,
+        );
+        pageRequests.push(
+          pb
+            .collection("status")
+            .getList<StatusRow>(p, perPage, { filter })
+            .then((resp) => resp.items ?? []),
+        );
+      }
+      const restPages = await Promise.all(pageRequests);
+      const collected = firstResp.items.slice();
+      for (const items of restPages) {
+        collected.push(...items);
+        if (collected.length >= total) break;
+      }
+      return collected.length > total ? collected.slice(0, total) : collected;
     }
 
     async function connect(): Promise<void> {
       try {
         const initial = await fetchInitial();
         if (!alive) return;
-        setRows(initial);
+        // The first time real data lands, every cell in the matrix has to
+        // re-render (empty map → populated map invalidates per-key memo
+        // checks). That commit is a hundreds-of-cells walk; flag it as a
+        // transition so React can interleave user input. `setStatus`
+        // remains urgent so the "connecting → live" indicator flips
+        // immediately, before the heavy commit lands.
+        startTransition(() => {
+          setRows(initial);
+        });
         setStatus("live");
         setError(null);
         // Reset the reconnect counter on a SUCCESSFUL connection. This is


### PR DESCRIPTION
## Summary

Follow-up to #4502. With matrix cells memoized and SSE deltas coalesced, the dashboard is much smoother — but the **initial dashboard load** still freezes for a few seconds because:

1. **Initial PB fetch is 10 sequential round-trips.** `fetchInitial` walks `getList(page=1, 200) → getList(page=2, 200) → …` up to 10 pages, each awaiting the previous. Network wall time stacks.
2. **First commit with real data is unavoidably a full-matrix re-render.** The empty-map → populated-map transition invalidates per-key memo checks on every cell — that's 720 cell renders in one synchronous React commit, blocking the main thread.

## Changes

- **Parallelize the initial fetch.** Pull page 1 sequentially to learn `totalItems`, then fire pages 2..N concurrently via `Promise.all`. Wall time drops from `sum(rtt_per_page)` to roughly `max(rtt_per_page)` modulo network parallelism. PocketBase reads are independent so this is safe.
- **`startTransition` around the initial `setRows(initial)`.** The first big commit is unavoidable, but marking it as a transition lets React 19 yield to user input mid-walk instead of blocking for the entire render. `setStatus` stays urgent so the "connecting → live" indicator still flips immediately.
- **`startTransition` around the SSE flush.** Bursts that the 16ms coalescer can't fully absorb (large reconnect replays, simultaneous probe completions) still need to yield rather than block.

## Test plan

- [x] `useLiveStatus.test.tsx` 15/15 pass with parallelized fetch (the mock handles arbitrary page numbers).
- [x] `composed-cell.test.tsx` 9/10 pass (1 pre-existing failure, same as #4502).
- [x] No new TypeScript errors in `useLiveStatus.ts`.
- [ ] **Manual perf trace before/after on the live dashboard.** Expected: initial-load wall time drops sharply (sequential → parallel pages), and any remaining heavy commit no longer blocks the main thread (transition lets React yield).
- [ ] **Functional sanity** — confirm rows still arrive correctly when pages return out of order, and the "connecting → live" status transition still fires before the heavy render.