### PR TITLE
fix(showcase): rename depth chip labels E2E/D5/D6 to RT/CV/FP

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -51,10 +51,10 @@ describe("CellDrilldown", () => {
     );
     expect(getByTestId("cell-drilldown")).toBeDefined();
     expect(getByText("Health")).toBeDefined();
-    expect(getByText("E2E")).toBeDefined();
+    expect(getByText("RT (Round Trip)")).toBeDefined();
     expect(getByText("Smoke")).toBeDefined();
-    expect(getByText("D5 (Deep)")).toBeDefined();
-    expect(getByText("D6 (Parity)")).toBeDefined();
+    expect(getByText("CV (Conversation)")).toBeDefined();
+    expect(getByText("FP (Feature Parity)")).toBeDefined();
   });
 
   it("shows integration and feature name in header", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -203,10 +203,10 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
 
-    // No health badges (E2E, D5, D6)
-    expect(queryByText("E2E")).not.toBeInTheDocument();
-    expect(queryByText("D5")).not.toBeInTheDocument();
-    expect(queryByText("D6")).not.toBeInTheDocument();
+    // No health badges (RT, CV, FP)
+    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("CV")).not.toBeInTheDocument();
+    expect(queryByText("FP")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -236,7 +236,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("</>")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("RT")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -254,9 +254,9 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health layer present with real badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
-    expect(getByText("D5")).toBeInTheDocument();
-    expect(getByText("D6")).toBeInTheDocument();
+    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("CV")).toBeInTheDocument();
+    expect(getByText("FP")).toBeInTheDocument();
 
     // No docs indicators — this is the critical regression test for B2's fix
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -289,7 +289,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("Demo")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("RT")).not.toBeInTheDocument();
 
     // No depth chip
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
@@ -311,7 +311,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Nothing visible
     expect(queryByText("Demo")).not.toBeInTheDocument();
-    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("RT")).not.toBeInTheDocument();
     expect(queryByText("docs-og")).not.toBeInTheDocument();
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
   });
@@ -327,9 +327,9 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health layer
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
-    expect(getByText("D5")).toBeInTheDocument();
-    expect(getByText("D6")).toBeInTheDocument();
+    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("CV")).toBeInTheDocument();
+    expect(getByText("FP")).toBeInTheDocument();
 
     // Docs layer
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -362,7 +362,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(getByTestId("depth-layer")).toBeInTheDocument();
     expect(getByTestId("depth-chip")).toBeInTheDocument();
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("RT")).toBeInTheDocument();
     expect(getByTestId("docs-layer")).toBeInTheDocument();
     expect(getByText("docs-og")).toBeInTheDocument();
     expect(getByText("docs-shell")).toBeInTheDocument();
@@ -378,8 +378,8 @@ describe("Overlay selector integration — real UI components", () => {
     expect(
       children[1]?.querySelector("[data-testid='depth-chip']"),
     ).toBeTruthy();
-    // Third child: health (contains E2E badge)
-    expect(children[2]?.textContent).toContain("E2E");
+    // Third child: health (contains RT badge)
+    expect(children[2]?.textContent).toContain("RT");
     // Fourth child: docs (contains docs-og)
     expect(children[3]?.textContent).toContain("docs-og");
   });
@@ -395,7 +395,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges present
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("RT")).toBeInTheDocument();
 
     // Docs explicitly absent — this is the bug B2 fixed: CellStatus used to
     // render DocsRow, so "health only" would still show docs indicators.
@@ -408,7 +408,7 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 9. Testing-kind features: D5/D6 badges hidden
   // -------------------------------------------------------------------------
-  it("testing-kind feature with health: D5/D6 badges hidden, E2E still shown", () => {
+  it("testing-kind feature with health: CV/FP badges hidden, RT still shown", () => {
     const ctx = makeTestingCtx();
     const { getByTestId, getByText, queryByText } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
@@ -417,12 +417,12 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer present
     expect(getByTestId("health-layer")).toBeInTheDocument();
 
-    // E2E badge still visible for testing-kind
-    expect(getByText("E2E")).toBeInTheDocument();
+    // RT badge still visible for testing-kind
+    expect(getByText("RT")).toBeInTheDocument();
 
-    // D5/D6 hidden for testing-kind features (CellStatus hides them)
-    expect(queryByText("D5")).not.toBeInTheDocument();
-    expect(queryByText("D6")).not.toBeInTheDocument();
+    // CV/FP hidden for testing-kind features (CellStatus hides them)
+    expect(queryByText("CV")).not.toBeInTheDocument();
+    expect(queryByText("FP")).not.toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------
@@ -459,7 +459,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("RT")).toBeInTheDocument();
 
     // Docs indicators
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -491,7 +491,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("RT")).toBeInTheDocument();
 
     // No docs — critical: Assessment does NOT include docs
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -542,12 +542,12 @@ describe("Overlay selector integration — real UI components", () => {
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
     );
 
-    // With green live status rows, E2E badge should show the green check
-    const e2eBadge = getByText("E2E");
-    expect(e2eBadge).toBeInTheDocument();
+    // With green live status rows, RT badge should show the green check
+    const rtBadge = getByText("RT");
+    expect(rtBadge).toBeInTheDocument();
     // The badge label "✓" (green state) should appear as a sibling span
-    const e2eContainer = e2eBadge.closest("[class*='whitespace-nowrap']");
-    expect(e2eContainer?.textContent).toContain("✓");
+    const rtContainer = rtBadge.closest("[class*='whitespace-nowrap']");
+    expect(rtContainer?.textContent).toContain("✓");
   });
 
   // -------------------------------------------------------------------------

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -63,22 +63,22 @@ function HealthLegend() {
         per-integration health levels shown in column header
       </LegendItem>
       <LegendItem>
-        <span className="text-[var(--ok)]">E2E ✓</span>/
+        <span className="text-[var(--ok)]">RT ✓</span>/
         <span className="text-[var(--amber)]">~</span>/
         <span className="text-[var(--danger)]">✗</span>
-        end-to-end smoke (green &lt;6h / amber stale / red fail)
+        round-trip check (green &lt;6h / amber stale / red fail)
       </LegendItem>
       <LegendItem>
-        <span className="text-[var(--ok)]">D5</span>/
-        <span className="text-[var(--amber)]">D5</span>/
-        <span className="text-[var(--danger)]">D5</span>
-        depth-5 tool rendering (green pass / amber stale / red fail)
+        <span className="text-[var(--ok)]">CV</span>/
+        <span className="text-[var(--amber)]">CV</span>/
+        <span className="text-[var(--danger)]">CV</span>
+        conversation check (green pass / amber stale / red fail)
       </LegendItem>
       <LegendItem>
-        <span className="text-[var(--ok)]">D6</span>/
-        <span className="text-[var(--amber)]">D6</span>/
-        <span className="text-[var(--danger)]">D6</span>
-        depth-6 multi-agent (green pass / amber stale / red fail)
+        <span className="text-[var(--ok)]">FP</span>/
+        <span className="text-[var(--amber)]">FP</span>/
+        <span className="text-[var(--danger)]">FP</span>
+        feature-parity check (green pass / amber stale / red fail)
       </LegendItem>
       <LegendItem>
         <span className="text-[var(--text-muted)]">?</span>
@@ -87,6 +87,20 @@ function HealthLegend() {
       <LegendItem>
         <span className="text-[var(--text-muted)]">—</span>
         supported, no demo yet
+      </LegendItem>
+      {/* Descriptive labels for chip abbreviations */}
+      <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">RT</span>
+        Round Trip: single message, full-stack response verification
+      </LegendItem>
+      <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">CV</span>
+        Conversation: multi-turn scripted dialogue with tool calls and content
+        assertions
+      </LegendItem>
+      <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">FP</span>
+        Feature Parity: cross-framework behavioral consistency check
       </LegendItem>
     </>
   );

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -32,9 +32,9 @@ const DIMENSIONS: Array<{
   key: keyof Omit<CellState, "rollup">;
   label: string;
 }> = [
-  { key: "d6", label: "D6 (Parity)" },
-  { key: "d5", label: "D5 (Deep)" },
-  { key: "e2e", label: "E2E" },
+  { key: "d6", label: "FP (Feature Parity)" },
+  { key: "d5", label: "CV (Conversation)" },
+  { key: "e2e", label: "RT (Round Trip)" },
   { key: "health", label: "Health" },
   { key: "smoke", label: "Smoke" },
 ];

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -94,7 +94,7 @@ function redE2eRow(): StatusRow {
 }
 
 /**
- * Find the inner Badge span for a given badge name (E2E / D5 / D6) inside
+ * Find the inner Badge span for a given badge name (RT / CV / FP) inside
  * a CellStatus render. The Badge renders `<span title>...<span>name</span>
  * <span>label</span></span>`, so we locate the parent span whose first
  * child text matches `name`.
@@ -127,16 +127,16 @@ describe("CP1: tooltipOpen resets on mouseleave/blur", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const e2eBadge = findBadgeByName(container, "E2E");
-    fireEvent.mouseEnter(e2eBadge);
+    const rtBadge = findBadgeByName(container, "RT");
+    fireEvent.mouseEnter(rtBadge);
     // Allow microtask to flush.
     await Promise.resolve();
     expect(mockState.fetchCount).toBeGreaterThanOrEqual(1);
 
     // CP1 wrapper: `onMouseLeave` on the outer span resets `tooltipOpen`.
     // We verify the handler is wired by triggering it on the wrapper
-    // (parent of e2eBadge in the DOM tree) without exception.
-    const wrapper = e2eBadge.parentElement!;
+    // (parent of rtBadge in the DOM tree) without exception.
+    const wrapper = rtBadge.parentElement!;
     fireEvent.mouseLeave(wrapper);
     expect(container).toBeTruthy();
   });
@@ -158,11 +158,11 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const e2eBadge = findBadgeByName(container, "E2E");
-    fireEvent.mouseEnter(e2eBadge);
+    const rtBadge = findBadgeByName(container, "RT");
+    fireEvent.mouseEnter(rtBadge);
     // Wait for the lazy fetch + state update.
     await new Promise((r) => setTimeout(r, 10));
-    const updated = findBadgeByName(container, "E2E");
+    const updated = findBadgeByName(container, "RT");
     expect(updated.getAttribute("title")).toContain("(initial: green)");
   });
 
@@ -181,14 +181,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const e2eBadge = findBadgeByName(container, "E2E");
-    fireEvent.mouseEnter(e2eBadge);
+    const rtBadge = findBadgeByName(container, "RT");
+    fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "E2E");
+      const el = findBadgeByName(container, "RT");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/since 2025-02-02/);
     });
-    const updated = findBadgeByName(container, "E2E");
+    const updated = findBadgeByName(container, "RT");
     expect(updated.getAttribute("title")).toContain("(error → red)");
   });
 
@@ -207,14 +207,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const e2eBadge = findBadgeByName(container, "E2E");
-    fireEvent.mouseEnter(e2eBadge);
+    const rtBadge = findBadgeByName(container, "RT");
+    fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "E2E");
+      const el = findBadgeByName(container, "RT");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/since 2025-02-02/);
     });
-    const updated = findBadgeByName(container, "E2E");
+    const updated = findBadgeByName(container, "RT");
     expect(updated.getAttribute("title")).toContain("(green → red)");
   });
 });
@@ -263,36 +263,36 @@ describe("CP5: missing-state tooltip distinguishes opt-out vs absent", () => {
   });
 });
 
-describe("CP8: D5/D6 chips hidden for testing-kind features", () => {
-  it("hides D5/D6 LiveBadges when feature.kind === 'testing'", () => {
+describe("CP8: CV/FP chips hidden for testing-kind features", () => {
+  it("hides CV/FP LiveBadges when feature.kind === 'testing'", () => {
     const ctx = makeCtx({
       feature: makeFeature({ kind: "testing" }),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
-    expect(text).toContain("E2E");
-    expect(text).not.toContain("D5");
-    expect(text).not.toContain("D6");
+    expect(text).toContain("RT");
+    expect(text).not.toContain("CV");
+    expect(text).not.toContain("FP");
   });
 
-  it("renders D5/D6 LiveBadges for primary features", () => {
+  it("renders CV/FP LiveBadges for primary features", () => {
     const ctx = makeCtx({
       feature: makeFeature({ kind: "primary" }),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
-    expect(text).toContain("E2E");
-    expect(text).toContain("D5");
-    expect(text).toContain("D6");
+    expect(text).toContain("RT");
+    expect(text).toContain("CV");
+    expect(text).toContain("FP");
   });
 
-  it("renders D5/D6 by default when feature.kind is undefined", () => {
+  it("renders CV/FP by default when feature.kind is undefined", () => {
     const ctx = makeCtx({
       feature: makeFeature(),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
-    expect(text).toContain("D5");
-    expect(text).toContain("D6");
+    expect(text).toContain("CV");
+    expect(text).toContain("FP");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -273,7 +273,7 @@ function formatTransitionLine(row: {
 }
 
 /**
- * Shared status row: E2E / D5 / D6 badges.
+ * Shared status row: RT / CV / FP badges (Round Trip / Conversation / Feature Parity).
  * QA and HealthDot removed in Phase 3 (3.3 + 3.4). L1 health now in strip.
  * Smoke per-cell badge removed — integration-scoped smoke lives in the strip.
  * Docs rendering removed — handled exclusively by DocsLayer in ComposedCell,
@@ -301,33 +301,33 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
   return (
     <div className="flex items-center justify-center gap-2.5">
       <LiveBadge
-        name="E2E"
+        name="RT"
         badge={cell.e2e}
         dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
       />
       {/*
-        CP8: D5/D6 producers (`e2e-deep`, `e2e-parity`) only emit rows for
-        primary features per spec; testing-kind features never get a D5 or
-        D6 row, so the badge would render a perpetual gray "?" that adds
+        CP8: CV/FP producers (`e2e-deep`, `e2e-parity`) only emit rows for
+        primary features per spec; testing-kind features never get a CV or
+        FP row, so the badge would render a perpetual gray "?" that adds
         noise without information. Hide for `isTesting` so operators only
         see badges backed by real data.
 
-        CP9: D5/D6 chips intentionally have no `href` — there is no
+        CP9: CV/FP chips intentionally have no `href` — there is no
         per-feature drilldown URL convention in shell-dashboard today.
-        When a drilldown route exists (e.g. a per-(slug, feature) D5 run
+        When a drilldown route exists (e.g. a per-(slug, feature) CV run
         history page), wire the URL through `keyFor` here.
-        TODO(showcase-dashboard): D5/D6 drilldown URL — see
+        TODO(showcase-dashboard): CV/FP drilldown URL — see
         docs/spec §5.6 follow-up.
       */}
       {!isTesting && (
         <>
           <LiveBadge
-            name="D5"
+            name="CV"
             badge={cell.d5}
             dimensionKey={keyFor("d5", ctx.integration.slug, ctx.feature.id)}
           />
           <LiveBadge
-            name="D6"
+            name="FP"
             badge={cell.d6}
             dimensionKey={keyFor("d6", ctx.integration.slug, ctx.feature.id)}
           />

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -129,7 +129,7 @@ function DepthLayer({
 }
 
 /**
- * Render the Health layer: E2E, D5, D6 badge chips via CellStatus.
+ * Render the Health layer: RT, CV, FP badge chips via CellStatus.
  */
 function HealthLayer({ ctx }: { ctx: CellContext }) {
   return (

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -2,7 +2,7 @@
  * Unit tests for the header `LiveIndicator` color-map (spec §5.7) and
  * `computeColumnTally` (§5.4 rollup + §5.3 offline handling).
  *
- * Phase 3: QA removed, smoke removed from per-cell tally. E2E uses
+ * Phase 3: QA removed, smoke removed from per-cell tally. RT uses
  * e2e dimension. Tally now counts health (once) + e2e per feature.
  */
 import { describe, it, expect } from "vitest";

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -525,7 +525,7 @@ export function FeatureGrid({
                 const tallyTitle = tally.unknown
                   ? "dashboard offline — live signal unavailable (§5.3)"
                   : total
-                    ? `${tally.green} green · ${tally.amber} amber · ${tally.red} red of ${total} countable signals (E2E per feature; Health counted once per integration)`
+                    ? `${tally.green} green · ${tally.amber} amber · ${tally.red} red of ${total} countable signals (RT per feature; Health counted once per integration)`
                     : "no countable signals for this column";
                 return (
                   <th


### PR DESCRIPTION
## Summary

Renames per-cell badge chip labels in the showcase dashboard for clarity:
- **E2E** -> **RT** (Round Trip): single message, full-stack response verification
- **D5** -> **CV** (Conversation): multi-turn scripted dialogue with tool calls and content assertions
- **D6** -> **FP** (Feature Parity): cross-framework behavioral consistency check

Reorganizes the adaptive legend to group chip color indicators first, then adds descriptive labels explaining what RT, CV, and FP mean.

Updates cell-drilldown dimension labels, feature-grid tooltip, and all affected tests.

## Test plan

- [x] All shell-dashboard vitest tests pass (372/372 passing; 3 pre-existing failures unrelated to this change)
- [x] No remaining references to old E2E/D5/D6 chip labels in source or test files (D5/D6 in chips-explainer are depth layer IDs D0-D6, correctly unchanged)