### PR TITLE
fix(showcase): use D4/D5/D6 depth numbers on chips, descriptive text only for RT/CV/FP

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -51,10 +51,10 @@ describe("CellDrilldown", () => {
     );
     expect(getByTestId("cell-drilldown")).toBeDefined();
     expect(getByText("Health")).toBeDefined();
-    expect(getByText("RT (Round Trip)")).toBeDefined();
+    expect(getByText("D4 (Round Trip)")).toBeDefined();
     expect(getByText("Smoke")).toBeDefined();
-    expect(getByText("CV (Conversation)")).toBeDefined();
-    expect(getByText("FP (Feature Parity)")).toBeDefined();
+    expect(getByText("D5 (Conversation)")).toBeDefined();
+    expect(getByText("D6 (Feature Parity)")).toBeDefined();
   });
 
   it("shows integration and feature name in header", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -203,10 +203,10 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
 
-    // No health badges (RT, CV, FP)
-    expect(queryByText("RT")).not.toBeInTheDocument();
-    expect(queryByText("CV")).not.toBeInTheDocument();
-    expect(queryByText("FP")).not.toBeInTheDocument();
+    // No health badges (D4, D5, D6)
+    expect(queryByText("D4")).not.toBeInTheDocument();
+    expect(queryByText("D5")).not.toBeInTheDocument();
+    expect(queryByText("D6")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -236,7 +236,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("</>")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("D4")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -246,7 +246,7 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 3. Health only — the critical case (no docs indicators must appear)
   // -------------------------------------------------------------------------
-  it("health only: E2E/D5/D6 badges visible, NO docs indicators", () => {
+  it("health only: D4/D5/D6 badges visible, NO docs indicators", () => {
     const ctx = makeCtx();
     const { getByTestId, getByText, queryByText, queryByTestId } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
@@ -254,9 +254,9 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health layer present with real badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
-    expect(getByText("CV")).toBeInTheDocument();
-    expect(getByText("FP")).toBeInTheDocument();
+    expect(getByText("D4")).toBeInTheDocument();
+    expect(getByText("D5")).toBeInTheDocument();
+    expect(getByText("D6")).toBeInTheDocument();
 
     // No docs indicators — this is the critical regression test for B2's fix
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -289,7 +289,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("Demo")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("D4")).not.toBeInTheDocument();
 
     // No depth chip
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
@@ -311,7 +311,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Nothing visible
     expect(queryByText("Demo")).not.toBeInTheDocument();
-    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("D4")).not.toBeInTheDocument();
     expect(queryByText("docs-og")).not.toBeInTheDocument();
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
   });
@@ -327,9 +327,9 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health layer
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
-    expect(getByText("CV")).toBeInTheDocument();
-    expect(getByText("FP")).toBeInTheDocument();
+    expect(getByText("D4")).toBeInTheDocument();
+    expect(getByText("D5")).toBeInTheDocument();
+    expect(getByText("D6")).toBeInTheDocument();
 
     // Docs layer
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -362,7 +362,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(getByTestId("depth-layer")).toBeInTheDocument();
     expect(getByTestId("depth-chip")).toBeInTheDocument();
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("D4")).toBeInTheDocument();
     expect(getByTestId("docs-layer")).toBeInTheDocument();
     expect(getByText("docs-og")).toBeInTheDocument();
     expect(getByText("docs-shell")).toBeInTheDocument();
@@ -378,8 +378,8 @@ describe("Overlay selector integration — real UI components", () => {
     expect(
       children[1]?.querySelector("[data-testid='depth-chip']"),
     ).toBeTruthy();
-    // Third child: health (contains RT badge)
-    expect(children[2]?.textContent).toContain("RT");
+    // Third child: health (contains D4 badge)
+    expect(children[2]?.textContent).toContain("D4");
     // Fourth child: docs (contains docs-og)
     expect(children[3]?.textContent).toContain("docs-og");
   });
@@ -395,7 +395,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges present
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("D4")).toBeInTheDocument();
 
     // Docs explicitly absent — this is the bug B2 fixed: CellStatus used to
     // render DocsRow, so "health only" would still show docs indicators.
@@ -408,7 +408,7 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 9. Testing-kind features: D5/D6 badges hidden
   // -------------------------------------------------------------------------
-  it("testing-kind feature with health: CV/FP badges hidden, RT still shown", () => {
+  it("testing-kind feature with health: D5/D6 badges hidden, D4 still shown", () => {
     const ctx = makeTestingCtx();
     const { getByTestId, getByText, queryByText } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
@@ -417,12 +417,12 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer present
     expect(getByTestId("health-layer")).toBeInTheDocument();
 
-    // RT badge still visible for testing-kind
-    expect(getByText("RT")).toBeInTheDocument();
+    // D4 badge still visible for testing-kind
+    expect(getByText("D4")).toBeInTheDocument();
 
-    // CV/FP hidden for testing-kind features (CellStatus hides them)
-    expect(queryByText("CV")).not.toBeInTheDocument();
-    expect(queryByText("FP")).not.toBeInTheDocument();
+    // D5/D6 hidden for testing-kind features (CellStatus hides them)
+    expect(queryByText("D5")).not.toBeInTheDocument();
+    expect(queryByText("D6")).not.toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------
@@ -459,7 +459,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("D4")).toBeInTheDocument();
 
     // Docs indicators
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -491,7 +491,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("D4")).toBeInTheDocument();
 
     // No docs — critical: Assessment does NOT include docs
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -542,12 +542,12 @@ describe("Overlay selector integration — real UI components", () => {
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
     );
 
-    // With green live status rows, RT badge should show the green check
-    const rtBadge = getByText("RT");
-    expect(rtBadge).toBeInTheDocument();
+    // With green live status rows, D4 badge should show the green check
+    const d4Badge = getByText("D4");
+    expect(d4Badge).toBeInTheDocument();
     // The badge label "✓" (green state) should appear as a sibling span
-    const rtContainer = rtBadge.closest("[class*='whitespace-nowrap']");
-    expect(rtContainer?.textContent).toContain("✓");
+    const d4Container = d4Badge.closest("[class*='whitespace-nowrap']");
+    expect(d4Container?.textContent).toContain("✓");
   });
 
   // -------------------------------------------------------------------------

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -63,21 +63,21 @@ function HealthLegend() {
         per-integration health levels shown in column header
       </LegendItem>
       <LegendItem>
-        <span className="text-[var(--ok)]">RT ✓</span>/
+        <span className="text-[var(--ok)]">D4 ✓</span>/
         <span className="text-[var(--amber)]">~</span>/
         <span className="text-[var(--danger)]">✗</span>
         round-trip check (green &lt;6h / amber stale / red fail)
       </LegendItem>
       <LegendItem>
-        <span className="text-[var(--ok)]">CV</span>/
-        <span className="text-[var(--amber)]">CV</span>/
-        <span className="text-[var(--danger)]">CV</span>
+        <span className="text-[var(--ok)]">D5</span>/
+        <span className="text-[var(--amber)]">D5</span>/
+        <span className="text-[var(--danger)]">D5</span>
         conversation check (green pass / amber stale / red fail)
       </LegendItem>
       <LegendItem>
-        <span className="text-[var(--ok)]">FP</span>/
-        <span className="text-[var(--amber)]">FP</span>/
-        <span className="text-[var(--danger)]">FP</span>
+        <span className="text-[var(--ok)]">D6</span>/
+        <span className="text-[var(--amber)]">D6</span>/
+        <span className="text-[var(--danger)]">D6</span>
         feature-parity check (green pass / amber stale / red fail)
       </LegendItem>
       <LegendItem>
@@ -90,17 +90,17 @@ function HealthLegend() {
       </LegendItem>
       {/* Descriptive labels for chip abbreviations */}
       <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">RT</span>
-        Round Trip: single message, full-stack response verification
+        <span className="font-semibold text-[var(--text-secondary)]">D4</span>
+        Round Trip (RT): single message, full-stack response verification
       </LegendItem>
       <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">CV</span>
-        Conversation: multi-turn scripted dialogue with tool calls and content
-        assertions
+        <span className="font-semibold text-[var(--text-secondary)]">D5</span>
+        Conversation (CV): multi-turn scripted dialogue with tool calls and
+        content assertions
       </LegendItem>
       <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">FP</span>
-        Feature Parity: cross-framework behavioral consistency check
+        <span className="font-semibold text-[var(--text-secondary)]">D6</span>
+        Feature Parity (FP): cross-framework behavioral consistency check
       </LegendItem>
     </>
   );

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -32,9 +32,9 @@ const DIMENSIONS: Array<{
   key: keyof Omit<CellState, "rollup">;
   label: string;
 }> = [
-  { key: "d6", label: "FP (Feature Parity)" },
-  { key: "d5", label: "CV (Conversation)" },
-  { key: "e2e", label: "RT (Round Trip)" },
+  { key: "d6", label: "D6 (Feature Parity)" },
+  { key: "d5", label: "D5 (Conversation)" },
+  { key: "e2e", label: "D4 (Round Trip)" },
   { key: "health", label: "Health" },
   { key: "smoke", label: "Smoke" },
 ];

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -94,7 +94,7 @@ function redE2eRow(): StatusRow {
 }
 
 /**
- * Find the inner Badge span for a given badge name (RT / CV / FP) inside
+ * Find the inner Badge span for a given badge name (D4 / D5 / D6) inside
  * a CellStatus render. The Badge renders `<span title>...<span>name</span>
  * <span>label</span></span>`, so we locate the parent span whose first
  * child text matches `name`.
@@ -127,7 +127,7 @@ describe("CP1: tooltipOpen resets on mouseleave/blur", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "D4");
     fireEvent.mouseEnter(rtBadge);
     // Allow microtask to flush.
     await Promise.resolve();
@@ -158,11 +158,11 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "D4");
     fireEvent.mouseEnter(rtBadge);
     // Wait for the lazy fetch + state update.
     await new Promise((r) => setTimeout(r, 10));
-    const updated = findBadgeByName(container, "RT");
+    const updated = findBadgeByName(container, "D4");
     expect(updated.getAttribute("title")).toContain("(initial: green)");
   });
 
@@ -181,14 +181,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "D4");
     fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "RT");
+      const el = findBadgeByName(container, "D4");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/since 2025-02-02/);
     });
-    const updated = findBadgeByName(container, "RT");
+    const updated = findBadgeByName(container, "D4");
     expect(updated.getAttribute("title")).toContain("(error → red)");
   });
 
@@ -207,14 +207,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "D4");
     fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "RT");
+      const el = findBadgeByName(container, "D4");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/since 2025-02-02/);
     });
-    const updated = findBadgeByName(container, "RT");
+    const updated = findBadgeByName(container, "D4");
     expect(updated.getAttribute("title")).toContain("(green → red)");
   });
 });
@@ -263,36 +263,36 @@ describe("CP5: missing-state tooltip distinguishes opt-out vs absent", () => {
   });
 });
 
-describe("CP8: CV/FP chips hidden for testing-kind features", () => {
-  it("hides CV/FP LiveBadges when feature.kind === 'testing'", () => {
+describe("CP8: D5/D6 chips hidden for testing-kind features", () => {
+  it("hides D5/D6 LiveBadges when feature.kind === 'testing'", () => {
     const ctx = makeCtx({
       feature: makeFeature({ kind: "testing" }),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
-    expect(text).toContain("RT");
-    expect(text).not.toContain("CV");
-    expect(text).not.toContain("FP");
+    expect(text).toContain("D4");
+    expect(text).not.toContain("D5");
+    expect(text).not.toContain("D6");
   });
 
-  it("renders CV/FP LiveBadges for primary features", () => {
+  it("renders D5/D6 LiveBadges for primary features", () => {
     const ctx = makeCtx({
       feature: makeFeature({ kind: "primary" }),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
-    expect(text).toContain("RT");
-    expect(text).toContain("CV");
-    expect(text).toContain("FP");
+    expect(text).toContain("D4");
+    expect(text).toContain("D5");
+    expect(text).toContain("D6");
   });
 
-  it("renders CV/FP by default when feature.kind is undefined", () => {
+  it("renders D5/D6 by default when feature.kind is undefined", () => {
     const ctx = makeCtx({
       feature: makeFeature(),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
-    expect(text).toContain("CV");
-    expect(text).toContain("FP");
+    expect(text).toContain("D5");
+    expect(text).toContain("D6");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -273,7 +273,7 @@ function formatTransitionLine(row: {
 }
 
 /**
- * Shared status row: RT / CV / FP badges (Round Trip / Conversation / Feature Parity).
+ * Shared status row: D4 / D5 / D6 badges (Round Trip / Conversation / Feature Parity).
  * QA and HealthDot removed in Phase 3 (3.3 + 3.4). L1 health now in strip.
  * Smoke per-cell badge removed — integration-scoped smoke lives in the strip.
  * Docs rendering removed — handled exclusively by DocsLayer in ComposedCell,
@@ -301,33 +301,33 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
   return (
     <div className="flex items-center justify-center gap-2.5">
       <LiveBadge
-        name="RT"
+        name="D4"
         badge={cell.e2e}
         dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
       />
       {/*
-        CP8: CV/FP producers (`e2e-deep`, `e2e-parity`) only emit rows for
-        primary features per spec; testing-kind features never get a CV or
-        FP row, so the badge would render a perpetual gray "?" that adds
+        CP8: D5/D6 producers (`e2e-deep`, `e2e-parity`) only emit rows for
+        primary features per spec; testing-kind features never get a D5 or
+        D6 row, so the badge would render a perpetual gray "?" that adds
         noise without information. Hide for `isTesting` so operators only
         see badges backed by real data.
 
-        CP9: CV/FP chips intentionally have no `href` — there is no
+        CP9: D5/D6 chips intentionally have no `href` — there is no
         per-feature drilldown URL convention in shell-dashboard today.
-        When a drilldown route exists (e.g. a per-(slug, feature) CV run
+        When a drilldown route exists (e.g. a per-(slug, feature) D5 run
         history page), wire the URL through `keyFor` here.
-        TODO(showcase-dashboard): CV/FP drilldown URL — see
+        TODO(showcase-dashboard): D5/D6 drilldown URL — see
         docs/spec §5.6 follow-up.
       */}
       {!isTesting && (
         <>
           <LiveBadge
-            name="CV"
+            name="D5"
             badge={cell.d5}
             dimensionKey={keyFor("d5", ctx.integration.slug, ctx.feature.id)}
           />
           <LiveBadge
-            name="FP"
+            name="D6"
             badge={cell.d6}
             dimensionKey={keyFor("d6", ctx.integration.slug, ctx.feature.id)}
           />

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -129,7 +129,7 @@ function DepthLayer({
 }
 
 /**
- * Render the Health layer: RT, CV, FP badge chips via CellStatus.
+ * Render the Health layer: D4, D5, D6 badge chips via CellStatus.
  */
 function HealthLayer({ ctx }: { ctx: CellContext }) {
   return (

--- a/showcase/shell-dashboard/src/components/feature-grid.test.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.test.tsx
@@ -2,7 +2,7 @@
  * Unit tests for the header `LiveIndicator` color-map (spec §5.7) and
  * `computeColumnTally` (§5.4 rollup + §5.3 offline handling).
  *
- * Phase 3: QA removed, smoke removed from per-cell tally. RT uses
+ * Phase 3: QA removed, smoke removed from per-cell tally. D4 uses
  * e2e dimension. Tally now counts health (once) + e2e per feature.
  */
 import { describe, it, expect } from "vitest";

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -525,7 +525,7 @@ export function FeatureGrid({
                 const tallyTitle = tally.unknown
                   ? "dashboard offline — live signal unavailable (§5.3)"
                   : total
-                    ? `${tally.green} green · ${tally.amber} amber · ${tally.red} red of ${total} countable signals (RT per feature; Health counted once per integration)`
+                    ? `${tally.green} green · ${tally.amber} amber · ${tally.red} red of ${total} countable signals (D4 per feature; Health counted once per integration)`
                     : "no countable signals for this column";
                 return (
                   <th


### PR DESCRIPTION
## Summary

Partially reverts #4506: badge chips now display depth-layer numbers (D4, D5, D6) instead of abbreviations (RT, CV, FP). The descriptive labels appear in parentheses in the cell drilldown and as legend explanations only.

- **Chips**: D4 / D5 / D6 (the depth numbers operators are familiar with)
- **Cell drilldown dimensions**: "D4 (Round Trip)", "D5 (Conversation)", "D6 (Feature Parity)"
- **Legend**: Chip color indicators use D4/D5/D6; descriptive section explains what each depth means with RT/CV/FP in prose
- **Tooltip**: "D4 per feature" in column tally

## Test plan

- [x] All 23 tests in cell-pieces.test.tsx and cell-drilldown.test.tsx pass
- [x] All 15 overlay-selector-integration tests pass
- [x] 372/372 tests passing (same 3 pre-existing failures as before, unrelated)