### PR TITLE
fix(showcase): group depth/level explanations in dashboard legend

### DIFF
--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -38,30 +38,44 @@ function LinksLegend() {
 
 function DepthLegend() {
   return (
-    <>
-      <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">
-          D0-D4
-        </span>
-        integration wiring depth (D0 = listed, D4 = full tool rendering)
-      </LegendItem>
-      <LegendItem>
-        <span className="text-[var(--danger)] font-medium">▼</span>
-        depth regression from previous run
-      </LegendItem>
-    </>
+    <LegendItem>
+      <span className="font-semibold text-[var(--text-secondary)]">
+        D0-D4
+      </span>
+      integration wiring depth (D0 = listed, D4 = full tool rendering)
+    </LegendItem>
   );
 }
 
 function HealthLegend() {
   return (
     <>
+      {/* Depth/level explanations grouped first */}
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">
           L1-L4 Strip
         </span>
         per-integration health levels shown in column header
       </LegendItem>
+      <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">D4</span>
+        Round Trip (RT): single message, full-stack response verification
+      </LegendItem>
+      <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">D5</span>
+        Conversation (CV): multi-turn scripted dialogue with tool calls and
+        content assertions
+      </LegendItem>
+      <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">D6</span>
+        Feature Parity (FP): cross-framework behavioral consistency check
+      </LegendItem>
+      {/* Regression indicator */}
+      <LegendItem>
+        <span className="text-[var(--danger)] font-medium">▼</span>
+        depth regression from previous run
+      </LegendItem>
+      {/* D4/D5/D6 color chips */}
       <LegendItem>
         <span className="text-[var(--ok)]">D4 ✓</span>/
         <span className="text-[var(--amber)]">~</span>/
@@ -80,6 +94,7 @@ function HealthLegend() {
         <span className="text-[var(--danger)]">D6</span>
         feature-parity check (green pass / amber stale / red fail)
       </LegendItem>
+      {/* Status symbols */}
       <LegendItem>
         <span className="text-[var(--text-muted)]">?</span>
         probe has not yet ticked since deploy
@@ -87,20 +102,6 @@ function HealthLegend() {
       <LegendItem>
         <span className="text-[var(--text-muted)]">—</span>
         supported, no demo yet
-      </LegendItem>
-      {/* Descriptive labels for chip abbreviations */}
-      <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">D4</span>
-        Round Trip (RT): single message, full-stack response verification
-      </LegendItem>
-      <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">D5</span>
-        Conversation (CV): multi-turn scripted dialogue with tool calls and
-        content assertions
-      </LegendItem>
-      <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">D6</span>
-        Feature Parity (FP): cross-framework behavioral consistency check
       </LegendItem>
     </>
   );


### PR DESCRIPTION
## Summary
- Reorder dashboard legend so all depth/level explanations (D0-D4, L1-L4 Strip, D4 RT, D5 CV, D6 FP) are grouped together on the left
- Regression indicator, color chips, and status symbols shift right
- Moved `▼ depth regression` from DepthLegend into HealthLegend to keep it after the FP explanation

## Test plan
- [ ] Visual check: legend items render in new order with depth explanations grouped left