### PR TITLE
fix(showcase): reorder legend D2 before D4/D5

### DIFF
--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -39,9 +39,7 @@ function LinksLegend() {
 function DepthLegend() {
   return (
     <LegendItem>
-      <span className="font-semibold text-[var(--text-secondary)]">
-        D0-D4
-      </span>
+      <span className="font-semibold text-[var(--text-secondary)]">D0-D4</span>
       integration wiring depth (D0 = listed, D4 = full tool rendering)
     </LegendItem>
   );
@@ -58,6 +56,10 @@ function HealthLegend() {
         per-integration health levels shown in column header
       </LegendItem>
       <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">D2</span>
+        API: responds to a basic CopilotKit API call
+      </LegendItem>
+      <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D4</span>
         Round Trip (RT): single message, full-stack response verification
       </LegendItem>
@@ -66,16 +68,12 @@ function HealthLegend() {
         Conversation (CV): multi-turn scripted dialogue with tool calls and
         content assertions
       </LegendItem>
-      <LegendItem>
-        <span className="font-semibold text-[var(--text-secondary)]">D6</span>
-        Feature Parity (FP): cross-framework behavioral consistency check
-      </LegendItem>
       {/* Regression indicator */}
       <LegendItem>
         <span className="text-[var(--danger)] font-medium">▼</span>
         depth regression from previous run
       </LegendItem>
-      {/* D4/D5/D6 color chips */}
+      {/* D4/D5 color chips */}
       <LegendItem>
         <span className="text-[var(--ok)]">D4 ✓</span>/
         <span className="text-[var(--amber)]">~</span>/
@@ -87,12 +85,6 @@ function HealthLegend() {
         <span className="text-[var(--amber)]">D5</span>/
         <span className="text-[var(--danger)]">D5</span>
         conversation check (green pass / amber stale / red fail)
-      </LegendItem>
-      <LegendItem>
-        <span className="text-[var(--ok)]">D6</span>/
-        <span className="text-[var(--amber)]">D6</span>/
-        <span className="text-[var(--danger)]">D6</span>
-        feature-parity check (green pass / amber stale / red fail)
       </LegendItem>
       {/* Status symbols */}
       <LegendItem>


### PR DESCRIPTION
Move D2 API before D4 RT and D5 CV in ascending order. Fix stale D6 comment.