### PR TITLE
fix(showcase): remove FP/D6 badge from cells and drilldown

### DIFF
--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -32,7 +32,6 @@ const DIMENSIONS: Array<{
   key: keyof Omit<CellState, "rollup">;
   label: string;
 }> = [
-  { key: "d6", label: "FP (Feature Parity)" },
   { key: "d5", label: "CV (Conversation)" },
   { key: "e2e", label: "RT (Round Trip)" },
   { key: "health", label: "Health" },

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -326,11 +326,6 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
             badge={cell.d5}
             dimensionKey={keyFor("d5", ctx.integration.slug, ctx.feature.id)}
           />
-          <LiveBadge
-            name="FP"
-            badge={cell.d6}
-            dimensionKey={keyFor("d6", ctx.integration.slug, ctx.feature.id)}
-          />
         </>
       )}
     </div>


### PR DESCRIPTION
Remove the FP (Feature Parity / D6) badge from per-cell status row and drilldown panel. D6 is not meaningful under aimock.