### PR TITLE
feat(showcase): add D2/API badge to dashboard per-cell status row

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -38,6 +38,7 @@ describe("CellDrilldown", () => {
       row("health:lgp", "health", "green"),
       row("e2e:lgp/agentic-chat", "e2e", "green"),
       row("smoke:lgp", "smoke", "green"),
+      row("agent:lgp", "agent", "green"),
     ]);
     const { getByTestId, getByText } = render(
       <CellDrilldown
@@ -50,11 +51,11 @@ describe("CellDrilldown", () => {
       />,
     );
     expect(getByTestId("cell-drilldown")).toBeDefined();
+    expect(getByText("API (Agent)")).toBeDefined();
     expect(getByText("Health")).toBeDefined();
     expect(getByText("RT (Round Trip)")).toBeDefined();
     expect(getByText("Smoke")).toBeDefined();
     expect(getByText("CV (Conversation)")).toBeDefined();
-    expect(getByText("FP (Feature Parity)")).toBeDefined();
   });
 
   it("shows integration and feature name in header", () => {

--- a/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/compute-tally-detail.test.tsx
@@ -62,6 +62,7 @@ function makeCellState(e2eTone: string): CellState {
     e2e: makeBadge(e2eTone),
     smoke: makeBadge("gray"),
     health: makeBadge("gray"),
+    d2: makeBadge("gray"),
     d5: makeBadge("gray"),
     d6: makeBadge("gray"),
     rollup: e2eTone as CellState["rollup"],

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -203,10 +203,10 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
 
-    // No health badges (RT, CV, FP)
+    // No health badges (API, RT, CV)
+    expect(queryByText("API")).not.toBeInTheDocument();
     expect(queryByText("RT")).not.toBeInTheDocument();
     expect(queryByText("CV")).not.toBeInTheDocument();
-    expect(queryByText("FP")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -246,7 +246,7 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 3. Health only — the critical case (no docs indicators must appear)
   // -------------------------------------------------------------------------
-  it("health only: RT/CV/FP badges visible, NO docs indicators", () => {
+  it("health only: API/RT/CV badges visible, NO docs indicators", () => {
     const ctx = makeCtx();
     const { getByTestId, getByText, queryByText, queryByTestId } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
@@ -254,9 +254,9 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health layer present with real badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("API")).toBeInTheDocument();
     expect(getByText("RT")).toBeInTheDocument();
     expect(getByText("CV")).toBeInTheDocument();
-    expect(getByText("FP")).toBeInTheDocument();
 
     // No docs indicators — this is the critical regression test for B2's fix
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -327,9 +327,9 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health layer
     expect(getByTestId("health-layer")).toBeInTheDocument();
+    expect(getByText("API")).toBeInTheDocument();
     expect(getByText("RT")).toBeInTheDocument();
     expect(getByText("CV")).toBeInTheDocument();
-    expect(getByText("FP")).toBeInTheDocument();
 
     // Docs layer
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -406,9 +406,9 @@ describe("Overlay selector integration — real UI components", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 9. Testing-kind features: CV/FP badges hidden
+  // 9. Testing-kind features: CV badges hidden
   // -------------------------------------------------------------------------
-  it("testing-kind feature with health: CV/FP badges hidden, RT still shown", () => {
+  it("testing-kind feature with health: CV badges hidden, API/RT still shown", () => {
     const ctx = makeTestingCtx();
     const { getByTestId, getByText, queryByText } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
@@ -417,12 +417,12 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer present
     expect(getByTestId("health-layer")).toBeInTheDocument();
 
-    // RT badge still visible for testing-kind
+    // API and RT badges still visible for testing-kind
+    expect(getByText("API")).toBeInTheDocument();
     expect(getByText("RT")).toBeInTheDocument();
 
-    // CV/FP hidden for testing-kind features (CellStatus hides them)
+    // CV hidden for testing-kind features (CellStatus hides them)
     expect(queryByText("CV")).not.toBeInTheDocument();
-    expect(queryByText("FP")).not.toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -3,9 +3,9 @@
  * CellDrilldown — popover panel showing per-badge dimension detail for a
  * single (integration, feature) cell.
  *
- * Renders all 5 badge dimensions (health, e2e, smoke, d5, d6) with tone,
- * label, tooltip, and — for red/amber badges — failure metadata: fail_count,
- * first_failure_at, and the signal payload.
+ * Renders all badge dimensions (d2/API, d5/CV, e2e/RT, health, smoke) with
+ * tone, label, tooltip, and — for red/amber badges — failure metadata:
+ * fail_count, first_failure_at, and the signal payload.
  */
 import { resolveCell } from "@/lib/live-status";
 import type {
@@ -32,6 +32,7 @@ const DIMENSIONS: Array<{
   key: keyof Omit<CellState, "rollup">;
   label: string;
 }> = [
+  { key: "d2", label: "API (Agent)" },
   { key: "d5", label: "CV (Conversation)" },
   { key: "e2e", label: "RT (Round Trip)" },
   { key: "health", label: "Health" },

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -4,7 +4,7 @@
  *   - CP2: transitionLine discriminates `first` and `error` transitions
  *   - CP5: missing-state tooltip distinguishes opt-out vs absent
  *   - CP7: error-state docs link is clickable when href is present
- *   - CP8: CV/FP badges hidden for testing-kind features
+ *   - CP8: CV badges hidden for testing-kind features
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor } from "@testing-library/react";
@@ -263,36 +263,36 @@ describe("CP5: missing-state tooltip distinguishes opt-out vs absent", () => {
   });
 });
 
-describe("CP8: CV/FP badges hidden for testing-kind features", () => {
-  it("hides CV/FP LiveBadges when feature.kind === 'testing'", () => {
+describe("CP8: CV badges hidden for testing-kind features", () => {
+  it("hides CV LiveBadge when feature.kind === 'testing'", () => {
     const ctx = makeCtx({
       feature: makeFeature({ kind: "testing" }),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
+    expect(text).toContain("API");
     expect(text).toContain("RT");
     expect(text).not.toContain("CV");
-    expect(text).not.toContain("FP");
   });
 
-  it("renders CV/FP LiveBadges for primary features", () => {
+  it("renders API/CV LiveBadges for primary features", () => {
     const ctx = makeCtx({
       feature: makeFeature({ kind: "primary" }),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
+    expect(text).toContain("API");
     expect(text).toContain("RT");
     expect(text).toContain("CV");
-    expect(text).toContain("FP");
   });
 
-  it("renders CV/FP by default when feature.kind is undefined", () => {
+  it("renders CV by default when feature.kind is undefined", () => {
     const ctx = makeCtx({
       feature: makeFeature(),
     });
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
+    expect(text).toContain("API");
     expect(text).toContain("CV");
-    expect(text).toContain("FP");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -273,7 +273,7 @@ function formatTransitionLine(row: {
 }
 
 /**
- * Shared status row: RT / CV / FP badges (Round Trip / Conversation / Feature Parity).
+ * Shared status row: API / RT / CV badges (D2 API / D4 Round Trip / D5 Conversation).
  * QA and HealthDot removed in Phase 3 (3.3 + 3.4). L1 health now in strip.
  * Smoke per-cell badge removed — integration-scoped smoke lives in the strip.
  * Docs rendering removed — handled exclusively by DocsLayer in ComposedCell,
@@ -301,22 +301,27 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
   return (
     <div className="flex items-center justify-center gap-2.5">
       <LiveBadge
+        name="API"
+        badge={cell.d2}
+        dimensionKey={keyFor("agent", ctx.integration.slug)}
+      />
+      <LiveBadge
         name="RT"
         badge={cell.e2e}
         dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
       />
       {/*
-        CP8: CV/FP producers (`e2e-deep`, `e2e-parity`) only emit rows for
-        primary features per spec; testing-kind features never get a CV or
-        FP row, so the badge would render a perpetual gray "?" that adds
-        noise without information. Hide for `isTesting` so operators only
-        see badges backed by real data.
+        CP8: CV producers (`e2e-deep`) only emit rows for primary features
+        per spec; testing-kind features never get a CV row, so the badge
+        would render a perpetual gray "?" that adds noise without
+        information. Hide for `isTesting` so operators only see badges
+        backed by real data.
 
-        CP9: CV/FP badges intentionally have no `href` — there is no
+        CP9: CV badges intentionally have no `href` — there is no
         per-feature drilldown URL convention in shell-dashboard today.
         When a drilldown route exists (e.g. a per-(slug, feature) D5 run
         history page), wire the URL through `keyFor` here.
-        TODO(showcase-dashboard): CV/FP drilldown URL — see
+        TODO(showcase-dashboard): CV drilldown URL — see
         docs/spec §5.6 follow-up.
       */}
       {!isTesting && (

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -279,6 +279,32 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     expect(c).not.toHaveProperty("qa");
   });
 
+  it("resolves d2 (agent) integration-scoped row when present", () => {
+    const live = mapOf([row("agent:agno", "agent", "green")]);
+    const c = resolveCell(live, "agno", "agentic-chat");
+    expect(c.d2.tone).toBe("green");
+    expect(c.d2.label).toBe("✓");
+    expect(c.d2.row?.key).toBe("agent:agno");
+  });
+
+  it("falls through to gray '?' when d2 (agent) row is absent", () => {
+    const c = resolveCell(mapOf([]), "agno", "agentic-chat");
+    expect(c.d2.tone).toBe("gray");
+    expect(c.d2.label).toBe("?");
+    expect(c.d2.row).toBeNull();
+  });
+
+  it("d2 (agent) does NOT contribute to the rollup (informational only)", () => {
+    const live = mapOf([
+      row("health:agno", "health", "green"),
+      row("agent:agno", "agent", "red"),
+    ]);
+    const c = resolveCell(live, "agno", "ac");
+    // health is green but e2e is missing → rollup is gray (not red from agent)
+    expect(c.rollup).toBe("gray");
+    expect(c.d2.tone).toBe("red");
+  });
+
   it("resolves d5 / d6 per-feature rows when present", () => {
     const live = mapOf([
       row("d5:agno/agentic-chat", "d5", "green"),

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -45,6 +45,15 @@ export interface CellState {
   smoke: BadgeRender;
   health: BadgeRender;
   /**
+   * D2 (API) per-integration badge. Sourced from `agent:<slug>` rows
+   * emitted by the agent-check probe. Integration-scoped — every feature
+   * within the same integration sees the same D2 badge. Does NOT
+   * contribute to the rollup (agent is informational, same model as
+   * smoke). Stays `gray` / `?` until the agent probe has ticked for
+   * this integration.
+   */
+  d2: BadgeRender;
+  /**
    * D5 (deep / multi-turn conversation) per-feature badge. Sourced from
    * `d5:<slug>/<featureId>` rows emitted by the `e2e-deep` driver. Stays
    * `gray` / `?` until the driver has ticked for this (slug, featureType)
@@ -344,6 +353,11 @@ export function resolveCell(
   // shape always misses, leaving every smoke badge gray. Use the
   // integration-scoped key so the badge actually populates.
   const smokeRow = live.get(keyFor("smoke", slug)) ?? null;
+  // D2 / agent row: integration-scoped `agent:<slug>`, emitted by the
+  // agent-check probe. Every feature within the same integration sees
+  // the same D2 badge. Informational — does NOT contribute to the
+  // rollup (same model as smoke).
+  const agentRow = live.get(keyFor("agent", slug)) ?? null;
   // D5 / D6 per-feature rows (`d5:<slug>/<featureType>` /
   // `d6:<slug>/<featureType>`) emitted by the e2e-deep / e2e-parity
   // drivers. Informational — they do NOT contribute to the rollup
@@ -407,6 +421,12 @@ export function resolveCell(
       label: formatLabel("health", healthRow),
       tooltip: formatTooltip("health", healthRow, connection),
       row: healthRow,
+    },
+    d2: {
+      tone: rowTone(agentRow),
+      label: formatLabel("agent", agentRow),
+      tooltip: formatTooltip("agent", agentRow, connection),
+      row: agentRow,
     },
     d5: {
       tone: rowTone(d5Row),


### PR DESCRIPTION
## Summary

- Add D2/API badge to per-cell status row in shell-dashboard (cells now show `API ✓  RT ✓  CV ✓` instead of just `RT ✓  CV ✓`)
- Wire `d2` field in `CellState` to the existing `agent:<slug>` PB rows from the agent-check probe
- Add API (Agent) dimension to the CellDrilldown popover panel
- Fix stale FP/D6 test references left over from #4513

## Test plan

- [x] `live-status.test.ts` — 3 new tests: d2 present/absent/rollup-exclusion (42 total, all pass)
- [x] `cell-drilldown.test.tsx` — updated "renders all 5 badge dimensions" to check API (Agent) instead of FP
- [x] `overlay-selector-integration.test.tsx` — FP → API in health-only, health+docs, testing-kind assertions
- [x] `cell-pieces.test.tsx` — CP8 tests updated from FP to API
- [x] `compute-tally-detail.test.tsx` — added `d2` to `makeCellState` to satisfy TS
- [x] TypeScript type-check clean (no new errors)