### PR TITLE
fix(react-core): collapse pin-to-send trailing whitespace after generation

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -518,9 +518,12 @@ export namespace CopilotChatView {
     className,
     ...props
   }) => {
+    const spacerRef = useRef<HTMLDivElement>(null);
+
     usePinToSend({
       scrollRef,
       contentRef,
+      spacerRef,
       topOffset: 16,
     });
 
@@ -546,11 +549,16 @@ export namespace CopilotChatView {
           >
             <div
               ref={contentRef}
-              data-pin-to-send-content
               className="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
             >
               {children}
             </div>
+            <div
+              ref={spacerRef}
+              data-pin-to-send-spacer
+              aria-hidden="true"
+              style={{ height: 0, flex: "0 0 auto" }}
+            />
           </div>
           {BoundFeather}
           {/* Scroll to bottom button */}

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -518,12 +518,9 @@ export namespace CopilotChatView {
     className,
     ...props
   }) => {
-    const spacerRef = useRef<HTMLDivElement>(null);
-
     usePinToSend({
       scrollRef,
       contentRef,
-      spacerRef,
       topOffset: 16,
     });
 
@@ -549,16 +546,11 @@ export namespace CopilotChatView {
           >
             <div
               ref={contentRef}
+              data-pin-to-send-content
               className="cpk:px-4 cpk:sm:px-0 cpk:[div[data-sidebar-chat]_&]:px-8 cpk:[div[data-popup-chat]_&]:px-6"
             >
               {children}
             </div>
-            <div
-              ref={spacerRef}
-              data-pin-to-send-spacer
-              aria-hidden="true"
-              style={{ height: 0, flex: "0 0 auto" }}
-            />
           </div>
           {BoundFeather}
           {/* Scroll to bottom button */}

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
@@ -44,7 +44,9 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    const content = screen.container.querySelector(
+      "[data-pin-to-send-content]",
+    );
     expect(content).not.toBeNull();
   });
 
@@ -55,7 +57,9 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    const content = screen.container.querySelector(
+      "[data-pin-to-send-content]",
+    );
     expect(content).toBeNull();
   });
 
@@ -66,7 +70,9 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    const content = screen.container.querySelector(
+      "[data-pin-to-send-content]",
+    );
     expect(content).toBeNull();
   });
 
@@ -77,7 +83,9 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    const content = screen.container.querySelector(
+      "[data-pin-to-send-content]",
+    );
     expect(content).toBeNull();
   });
 
@@ -88,7 +96,9 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    const content = screen.container.querySelector(
+      "[data-pin-to-send-content]",
+    );
     expect(content).toBeNull();
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
@@ -35,7 +35,7 @@ async function waitForMount(screen: {
 }
 
 describe("CopilotChatView pin-to-send mode", () => {
-  it("renders the pin-to-send spacer element when autoScroll='pin-to-send'", async () => {
+  it("renders the pin-to-send content container when autoScroll='pin-to-send'", async () => {
     const screen = render(
       <TestWrapper>
         <LastUserMessageContext.Provider value={{ id: null, sendNonce: 0 }}>
@@ -44,30 +44,30 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
-    expect(spacer).not.toBeNull();
+    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    expect(content).not.toBeNull();
   });
 
-  it("does not render the spacer when autoScroll='pin-to-bottom'", async () => {
+  it("does not render the pin-to-send content marker when autoScroll='pin-to-bottom'", async () => {
     const screen = render(
       <TestWrapper>
         <CopilotChatView autoScroll="pin-to-bottom" messages={sampleMessages} />
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
-    expect(spacer).toBeNull();
+    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    expect(content).toBeNull();
   });
 
-  it("does not render the spacer when autoScroll='none'", async () => {
+  it("does not render the pin-to-send content marker when autoScroll='none'", async () => {
     const screen = render(
       <TestWrapper>
         <CopilotChatView autoScroll="none" messages={sampleMessages} />
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
-    expect(spacer).toBeNull();
+    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    expect(content).toBeNull();
   });
 
   it("boolean true still maps to pin-to-bottom (back-compat)", async () => {
@@ -77,8 +77,8 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
-    expect(spacer).toBeNull();
+    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    expect(content).toBeNull();
   });
 
   it("boolean false still maps to none (back-compat)", async () => {
@@ -88,7 +88,7 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
-    expect(spacer).toBeNull();
+    const content = screen.container.querySelector("[data-pin-to-send-content]");
+    expect(content).toBeNull();
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
@@ -10,7 +10,6 @@ beforeEach(() => {
   HTMLElement.prototype.scrollTo = vi.fn();
 });
 
-// Wrapper to provide required context (same pattern as CopilotChatView.slots.e2e.test.tsx)
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <CopilotKitProvider>
     <CopilotChatConfigurationProvider threadId="test-thread">
@@ -24,10 +23,6 @@ const sampleMessages = [
   { id: "2", role: "assistant" as const, content: "Hi there!" },
 ];
 
-// Wait for the ScrollView's `hasMounted` useEffect to flip — the pre-mount
-// fallback render does not include the message list, so a findBy on the
-// message list is a reliable "mount is done" signal. Without this gate,
-// absence assertions pass vacuously against the pre-mount render.
 async function waitForMount(screen: {
   findByTestId: (id: string) => Promise<HTMLElement>;
 }) {
@@ -35,7 +30,7 @@ async function waitForMount(screen: {
 }
 
 describe("CopilotChatView pin-to-send mode", () => {
-  it("renders the pin-to-send content container when autoScroll='pin-to-send'", async () => {
+  it("renders the pin-to-send spacer element when autoScroll='pin-to-send'", async () => {
     const screen = render(
       <TestWrapper>
         <LastUserMessageContext.Provider value={{ id: null, sendNonce: 0 }}>
@@ -44,36 +39,30 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector(
-      "[data-pin-to-send-content]",
-    );
-    expect(content).not.toBeNull();
+    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
+    expect(spacer).not.toBeNull();
   });
 
-  it("does not render the pin-to-send content marker when autoScroll='pin-to-bottom'", async () => {
+  it("does not render the spacer when autoScroll='pin-to-bottom'", async () => {
     const screen = render(
       <TestWrapper>
         <CopilotChatView autoScroll="pin-to-bottom" messages={sampleMessages} />
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector(
-      "[data-pin-to-send-content]",
-    );
-    expect(content).toBeNull();
+    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
+    expect(spacer).toBeNull();
   });
 
-  it("does not render the pin-to-send content marker when autoScroll='none'", async () => {
+  it("does not render the spacer when autoScroll='none'", async () => {
     const screen = render(
       <TestWrapper>
         <CopilotChatView autoScroll="none" messages={sampleMessages} />
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector(
-      "[data-pin-to-send-content]",
-    );
-    expect(content).toBeNull();
+    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
+    expect(spacer).toBeNull();
   });
 
   it("boolean true still maps to pin-to-bottom (back-compat)", async () => {
@@ -83,10 +72,8 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector(
-      "[data-pin-to-send-content]",
-    );
-    expect(content).toBeNull();
+    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
+    expect(spacer).toBeNull();
   });
 
   it("boolean false still maps to none (back-compat)", async () => {
@@ -96,9 +83,7 @@ describe("CopilotChatView pin-to-send mode", () => {
       </TestWrapper>,
     );
     await waitForMount(screen);
-    const content = screen.container.querySelector(
-      "[data-pin-to-send-content]",
-    );
-    expect(content).toBeNull();
+    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
+    expect(spacer).toBeNull();
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-pin-to-send.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-pin-to-send.test.tsx
@@ -33,8 +33,9 @@ function setHeight(el: HTMLElement, height: number) {
 function HarnessInner({ topOffset }: { topOffset: number }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const spacerRef = useRef<HTMLDivElement>(null);
 
-  usePinToSend({ scrollRef, contentRef, topOffset });
+  usePinToSend({ scrollRef, contentRef, spacerRef, topOffset });
 
   return (
     <div ref={scrollRef} data-testid="scroll">
@@ -49,6 +50,7 @@ function HarnessInner({ topOffset }: { topOffset: number }) {
           user msg 2
         </div>
       </div>
+      <div ref={spacerRef} data-testid="spacer" style={{ height: 0 }} />
     </div>
   );
 }
@@ -78,29 +80,31 @@ beforeEach(() => {
 });
 
 describe("usePinToSend", () => {
-  it("sets content min-height to userMsgPos + viewportHeight - topOffset on new send", async () => {
+  it("sets spacer height to required - contentHeight on new send (subtracting natural content, not over-allocating)", async () => {
     const { rerender, getByTestId } = render(
       <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
     );
 
     const scroll = getByTestId("scroll");
     const content = getByTestId("content");
+    const spacer = getByTestId("spacer");
     setHeight(scroll, 800);
+    setHeight(content, 200);
 
     const userMsg = scroll.querySelector(
       '[data-message-id="m3"]',
     ) as HTMLElement;
-    // Mock user msg at scroll offset 400, height 40, no top padding.
+    // userMsg at offset 100 in scrollEl, height 40, no top padding.
     userMsg.getBoundingClientRect = () =>
       ({
-        top: 400,
+        top: 100,
         left: 0,
         right: 100,
-        bottom: 440,
+        bottom: 140,
         width: 100,
         height: 40,
         x: 0,
-        y: 400,
+        y: 100,
         toJSON: () => ({}),
       }) as DOMRect;
 
@@ -108,12 +112,12 @@ describe("usePinToSend", () => {
       rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
     });
 
-    // userMsgPos=400, paddingTop=0, viewport=800, topOffset=16
-    // minHeight = 400 + 0 + 800 - 16 = 1184
-    expect(content.style.minHeight).toBe("1184px");
+    // required = userMsgOffset(100) + paddingTop(0) + viewport(800) - topOffset(16) = 884
+    // spacer = max(0, required - contentHeight(200)) = 684
+    expect(spacer.style.height).toBe("684px");
   });
 
-  it("calls scrollTo with userMsgPos + paddingTop - topOffset on new send", async () => {
+  it("calls scrollTo with userMsgOffset + paddingTop - topOffset on new send", async () => {
     const { rerender, getByTestId } = render(
       <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
     );
@@ -125,8 +129,7 @@ describe("usePinToSend", () => {
     const userMsg = scroll.querySelector(
       '[data-message-id="m3"]',
     ) as HTMLElement;
-    // computeOffsetTop uses getBoundingClientRect; mock top=400 on userMsg and top=0 on scroll
-    // so that elRect.top - stopRect.top + scrollEl.scrollTop = 400 - 0 + 0 = 400.
+    // mock top=400 on userMsg and top=0 on scroll → offset = 400.
     userMsg.getBoundingClientRect = () =>
       ({
         top: 400,
@@ -144,7 +147,6 @@ describe("usePinToSend", () => {
       rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
     });
 
-    // Allow rAF to fire
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
     });
@@ -155,40 +157,189 @@ describe("usePinToSend", () => {
     });
   });
 
-  it("clears content min-height on cleanup so the next send resets the floor", async () => {
-    const { rerender, unmount, getByTestId } = render(
-      <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
-    );
-    const scroll = getByTestId("scroll");
-    const content = getByTestId("content");
-    setHeight(scroll, 800);
-    const userMsg = scroll.querySelector(
-      '[data-message-id="m3"]',
-    ) as HTMLElement;
-    userMsg.getBoundingClientRect = () =>
-      ({
-        top: 400,
-        left: 0,
-        right: 100,
-        bottom: 440,
-        width: 100,
-        height: 40,
-        x: 0,
-        y: 400,
-        toJSON: () => ({}),
-      }) as DOMRect;
-
-    act(() => {
-      rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
+  it("shrinks spacer as content height grows (does not grow it)", async () => {
+    let observed: (() => void) | null = null;
+    const ROStub = vi.fn().mockImplementation((cb: () => void) => {
+      observed = cb;
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
     });
-    expect(content.style.minHeight).toBe("1184px");
+    const prevRO = global.ResizeObserver;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.ResizeObserver = ROStub as any;
 
-    unmount();
-    expect(content.style.minHeight).toBe("");
+    try {
+      const { rerender, getByTestId } = render(
+        <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
+      );
+      const scroll = getByTestId("scroll");
+      const content = getByTestId("content");
+      const spacer = getByTestId("spacer");
+      setHeight(scroll, 800);
+      setHeight(content, 200);
+
+      const userMsg = scroll.querySelector(
+        '[data-message-id="m3"]',
+      ) as HTMLElement;
+      userMsg.getBoundingClientRect = () =>
+        ({
+          top: 100,
+          left: 0,
+          right: 100,
+          bottom: 140,
+          width: 100,
+          height: 40,
+          x: 0,
+          y: 100,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      act(() => {
+        rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
+      });
+
+      // initial: required(884) - content(200) = 684
+      expect(spacer.style.height).toBe("684px");
+
+      // content grows: required(884) - content(600) = 284 < 684 → shrinks
+      setHeight(content, 600);
+      act(() => observed?.());
+      expect(spacer.style.height).toBe("284px");
+
+      // content shrinks back: required(884) - content(100) = 784 > 284 → does NOT grow
+      setHeight(content, 100);
+      act(() => observed?.());
+      expect(spacer.style.height).toBe("284px");
+    } finally {
+      global.ResizeObserver = prevRO;
+    }
+  });
+
+  it("re-anchors the user message on content resize so suggestions appearing keep it at topOffset", async () => {
+    let observed: (() => void) | null = null;
+    const ROStub = vi.fn().mockImplementation((cb: () => void) => {
+      observed = cb;
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+    });
+    const prevRO = global.ResizeObserver;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.ResizeObserver = ROStub as any;
+
+    try {
+      const { rerender, getByTestId } = render(
+        <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
+      );
+      const scroll = getByTestId("scroll");
+      const content = getByTestId("content");
+      setHeight(scroll, 800);
+      setHeight(content, 200);
+      const scrollTo = scroll.scrollTo as unknown as ReturnType<typeof vi.fn>;
+
+      const userMsg = scroll.querySelector(
+        '[data-message-id="m3"]',
+      ) as HTMLElement;
+      userMsg.getBoundingClientRect = () =>
+        ({
+          top: 400,
+          left: 0,
+          right: 100,
+          bottom: 440,
+          width: 100,
+          height: 40,
+          x: 0,
+          y: 400,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      act(() => {
+        rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
+      });
+
+      // Initial scroll (smooth) on send.
+      expect(scrollTo).toHaveBeenLastCalledWith({
+        top: 400 - 16,
+        behavior: "smooth",
+      });
+
+      // Simulate suggestions appearing — user msg shifts to a new offset.
+      userMsg.getBoundingClientRect = () =>
+        ({
+          top: 460,
+          left: 0,
+          right: 100,
+          bottom: 500,
+          width: 100,
+          height: 40,
+          x: 0,
+          y: 460,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      act(() => observed?.());
+
+      // Re-anchored to the new offset, instantly (no smooth animation fight).
+      expect(scrollTo).toHaveBeenLastCalledWith({
+        top: 460 - 16,
+        behavior: "auto",
+      });
+    } finally {
+      global.ResizeObserver = prevRO;
+    }
+  });
+
+  it("stops re-anchoring once the user scrolls (wheel)", async () => {
+    let observed: (() => void) | null = null;
+    const ROStub = vi.fn().mockImplementation((cb: () => void) => {
+      observed = cb;
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+    });
+    const prevRO = global.ResizeObserver;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.ResizeObserver = ROStub as any;
+
+    try {
+      const { rerender, getByTestId } = render(
+        <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
+      );
+      const scroll = getByTestId("scroll");
+      const content = getByTestId("content");
+      setHeight(scroll, 800);
+      setHeight(content, 200);
+      const scrollTo = scroll.scrollTo as unknown as ReturnType<typeof vi.fn>;
+
+      const userMsg = scroll.querySelector(
+        '[data-message-id="m3"]',
+      ) as HTMLElement;
+      userMsg.getBoundingClientRect = () =>
+        ({
+          top: 400,
+          left: 0,
+          right: 100,
+          bottom: 440,
+          width: 100,
+          height: 40,
+          x: 0,
+          y: 400,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      act(() => {
+        rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
+      });
+
+      const callCountAfterSend = scrollTo.mock.calls.length;
+
+      // User scrolls (wheel), then content resizes — re-anchor must NOT fire.
+      act(() => {
+        scroll.dispatchEvent(new WheelEvent("wheel"));
+      });
+      act(() => observed?.());
+
+      expect(scrollTo.mock.calls.length).toBe(callCountAfterSend);
+    } finally {
+      global.ResizeObserver = prevRO;
+    }
   });
 
   it("cancels the scheduled rAF on unmount (cleanup)", async () => {
-    // Use a real rAF handle so we can assert the cancel was issued with it.
     const cancelSpy = vi.spyOn(global, "cancelAnimationFrame");
     try {
       const { rerender, unmount, getByTestId } = render(

--- a/packages/react-core/src/v2/hooks/__tests__/use-pin-to-send.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-pin-to-send.test.tsx
@@ -33,9 +33,8 @@ function setHeight(el: HTMLElement, height: number) {
 function HarnessInner({ topOffset }: { topOffset: number }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const spacerRef = useRef<HTMLDivElement>(null);
 
-  usePinToSend({ scrollRef, contentRef, spacerRef, topOffset });
+  usePinToSend({ scrollRef, contentRef, topOffset });
 
   return (
     <div ref={scrollRef} data-testid="scroll">
@@ -50,7 +49,6 @@ function HarnessInner({ topOffset }: { topOffset: number }) {
           user msg 2
         </div>
       </div>
-      <div ref={spacerRef} data-testid="spacer" style={{ height: 0 }} />
     </div>
   );
 }
@@ -80,30 +78,42 @@ beforeEach(() => {
 });
 
 describe("usePinToSend", () => {
-  it("sets spacer height to viewportHeight - userMessageHeight - topOffset on new send", async () => {
+  it("sets content min-height to userMsgPos + viewportHeight - topOffset on new send", async () => {
     const { rerender, getByTestId } = render(
       <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
     );
 
     const scroll = getByTestId("scroll");
-    const spacer = getByTestId("spacer");
+    const content = getByTestId("content");
     setHeight(scroll, 800);
 
     const userMsg = scroll.querySelector(
       '[data-message-id="m3"]',
     ) as HTMLElement;
-    setHeight(userMsg, 40);
+    // Mock user msg at scroll offset 400, height 40, no top padding.
+    userMsg.getBoundingClientRect = () =>
+      ({
+        top: 400,
+        left: 0,
+        right: 100,
+        bottom: 440,
+        width: 100,
+        height: 40,
+        x: 0,
+        y: 400,
+        toJSON: () => ({}),
+      }) as DOMRect;
 
     act(() => {
       rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
     });
 
-    // viewport=800, userMsg=40, topOffset=16
-    // spacer = max(0, 800 - 40 - 16) = 744
-    expect(spacer.style.height).toBe("744px");
+    // userMsgPos=400, paddingTop=0, viewport=800, topOffset=16
+    // minHeight = 400 + 0 + 800 - 16 = 1184
+    expect(content.style.minHeight).toBe("1184px");
   });
 
-  it("calls scrollTo with targetEl.offsetTop - topOffset on new send", async () => {
+  it("calls scrollTo with userMsgPos + paddingTop - topOffset on new send", async () => {
     const { rerender, getByTestId } = render(
       <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
     );
@@ -115,7 +125,6 @@ describe("usePinToSend", () => {
     const userMsg = scroll.querySelector(
       '[data-message-id="m3"]',
     ) as HTMLElement;
-    setHeight(userMsg, 40);
     // computeOffsetTop uses getBoundingClientRect; mock top=400 on userMsg and top=0 on scroll
     // so that elRect.top - stopRect.top + scrollEl.scrollTop = 400 - 0 + 0 = 400.
     userMsg.getBoundingClientRect = () =>
@@ -146,50 +155,36 @@ describe("usePinToSend", () => {
     });
   });
 
-  it("shrinks spacer as content height grows (does not grow it)", async () => {
-    let observed: (() => void) | null = null;
-    const ROStub = vi.fn().mockImplementation((cb: () => void) => {
-      observed = cb;
-      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+  it("clears content min-height on cleanup so the next send resets the floor", async () => {
+    const { rerender, unmount, getByTestId } = render(
+      <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
+    );
+    const scroll = getByTestId("scroll");
+    const content = getByTestId("content");
+    setHeight(scroll, 800);
+    const userMsg = scroll.querySelector(
+      '[data-message-id="m3"]',
+    ) as HTMLElement;
+    userMsg.getBoundingClientRect = () =>
+      ({
+        top: 400,
+        left: 0,
+        right: 100,
+        bottom: 440,
+        width: 100,
+        height: 40,
+        x: 0,
+        y: 400,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    act(() => {
+      rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
     });
-    const prevRO = global.ResizeObserver;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.ResizeObserver = ROStub as any;
+    expect(content.style.minHeight).toBe("1184px");
 
-    try {
-      const { rerender, getByTestId } = render(
-        <Harness lastUserMessage={{ id: null, sendNonce: 0 }} />,
-      );
-      const scroll = getByTestId("scroll");
-      const content = getByTestId("content");
-      const spacer = getByTestId("spacer");
-      setHeight(scroll, 800);
-      const userMsg = scroll.querySelector(
-        '[data-message-id="m3"]',
-      ) as HTMLElement;
-      setHeight(userMsg, 40);
-      setHeight(content, 200);
-
-      act(() => {
-        rerender(<Harness lastUserMessage={{ id: "m3", sendNonce: 1 }} />);
-      });
-
-      // Initial: 800 - 40 - 16 = 744
-      expect(spacer.style.height).toBe("744px");
-
-      // Simulate content growing — spacer should shrink
-      setHeight(content, 600);
-      act(() => observed?.());
-      expect(parseInt(spacer.style.height, 10)).toBeLessThan(744);
-
-      // Simulate content shrinking — spacer should NOT grow back
-      setHeight(content, 100);
-      const shrunkHeight = spacer.style.height;
-      act(() => observed?.());
-      expect(spacer.style.height).toBe(shrunkHeight);
-    } finally {
-      global.ResizeObserver = prevRO;
-    }
+    unmount();
+    expect(content.style.minHeight).toBe("");
   });
 
   it("cancels the scheduled rAF on unmount (cleanup)", async () => {

--- a/packages/react-core/src/v2/hooks/use-pin-to-send.ts
+++ b/packages/react-core/src/v2/hooks/use-pin-to-send.ts
@@ -4,22 +4,31 @@ import { LastUserMessageContext } from "../components/chat/last-user-message-con
 export type UsePinToSendOptions = {
   scrollRef: React.RefObject<HTMLElement | null>;
   contentRef: React.RefObject<HTMLElement | null>;
+  spacerRef: React.RefObject<HTMLElement | null>;
   topOffset?: number;
 };
 
-// Apply a transient min-height to the scroll content so the newly sent user
-// message can scroll to `topOffset` from the viewport top, then let natural
-// content (the streaming assistant response, suggestions, etc.) take over as
-// it grows past that floor. This mirrors the ChatGPT / Claude behavior:
-// user message pinned to top, response streams in below, no extra scrollable
-// whitespace tacked on after generation.
+// Anchors the most recent user message at `topOffset` from the viewport top
+// when a new message is sent and keeps it there as later content (assistant
+// response, suggestions, late-arriving tool calls) reflows the layout.
+//
+// Approach: a sibling spacer below `contentRef` extends `scrollHeight` by
+// exactly the amount needed for the bubble to reach `topOffset`, then a
+// ResizeObserver shrinks it as natural content fills the gap. The spacer
+// lives *outside* `contentRef` so any custom layout inside (e.g. flex
+// containers that push suggestions to the bottom of the message area) is
+// preserved verbatim. We also re-issue the scroll-to-top whenever
+// `contentRef` resizes (until the user scrolls), so suggestions appearing
+// after generation don't leave the bubble drifting away from the top.
 export function usePinToSend({
   scrollRef,
   contentRef,
+  spacerRef,
   topOffset = 16,
 }: UsePinToSendOptions): void {
   const { id, sendNonce } = useContext(LastUserMessageContext);
   const lastNonceRef = useRef<number>(-1);
+  const currentSpacerHeightRef = useRef<number>(0);
 
   useEffect(() => {
     if (sendNonce === lastNonceRef.current) return;
@@ -28,7 +37,8 @@ export function usePinToSend({
     if (!id) return;
     const scrollEl = scrollRef.current;
     const contentEl = contentRef.current;
-    if (!scrollEl || !contentEl) return;
+    const spacerEl = spacerRef.current;
+    if (!scrollEl || !contentEl || !spacerEl) return;
 
     const escaped =
       typeof CSS !== "undefined" && CSS.escape
@@ -39,41 +49,92 @@ export function usePinToSend({
     );
     if (!targetEl) return;
 
-    // The target message's element has a top padding (e.g. `pt-10`) that
-    // creates breathing room above the visible bubble. When we "anchor at
-    // the top", we mean anchor the *bubble*, not the element's padded box.
-    // So we scroll past the padding (it goes above the viewport, hiding
-    // whatever was above the element too — including the previous message's
-    // trailing copy button).
+    // The user-message element has a top padding (`pt-10`) that creates
+    // breathing room above the visible bubble. We anchor the *bubble* — the
+    // padding scrolls off-screen above the viewport.
     const viewportHeight = scrollEl.clientHeight;
     const paddingTop = parseFloat(getComputedStyle(targetEl).paddingTop) || 0;
-    const userMsgOffsetInScroll = computeOffsetTop(targetEl, scrollEl);
 
-    // The minimum scrollHeight that lets the bubble land at `topOffset` from
-    // the viewport top is: `bubbleTop + viewportHeight - topOffset`, where
-    // `bubbleTop = userMsgOffsetInScroll + paddingTop`. We apply this as a
-    // min-height on the content element. Once the natural content (response,
-    // padding, suggestions) grows past this floor, the floor is irrelevant
-    // and the layout reflects only the actual content — no leftover spacer
-    // whitespace at the bottom after generation.
-    const requiredScrollHeight =
-      userMsgOffsetInScroll + paddingTop + viewportHeight - topOffset;
-    contentEl.style.minHeight = `${Math.max(0, requiredScrollHeight)}px`;
+    // Required scrollHeight to land the bubble at `topOffset`. Includes
+    // `paddingTop` because the bubble sits paddingTop pixels below the
+    // element's top edge.
+    const computeRequired = () => {
+      const userMsgOffset = computeOffsetTop(targetEl, scrollEl);
+      return userMsgOffset + paddingTop + viewportHeight - topOffset;
+    };
 
-    const raf = requestAnimationFrame(() => {
-      // Scroll so the BUBBLE is `topOffset` from the viewport top — the
-      // padding above the bubble ends up scrolled off-screen.
-      const targetTop = userMsgOffsetInScroll + paddingTop - topOffset;
-      scrollEl.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
+    // The spacer is a sibling of `contentRef` inside `scrollRef`. So
+    // scrollHeight = contentRef.height + spacer.height. We size the spacer
+    // to make up the gap between the natural content height and the
+    // required scrollHeight — no over-allocation, no double-counting of the
+    // input-overlay paddingBottom that already lives inside `contentRef`.
+    const computeSpacer = () => {
+      const required = computeRequired();
+      const contentHeight = contentEl.getBoundingClientRect().height;
+      return Math.max(0, required - contentHeight);
+    };
+
+    const initialSpacer = computeSpacer();
+    spacerEl.style.height = `${initialSpacer}px`;
+    currentSpacerHeightRef.current = initialSpacer;
+
+    // Track user-initiated scrolls via wheel/touch/keyboard so we know when
+    // to stop re-anchoring. The browser's `scroll` event also fires for our
+    // own programmatic `scrollTo`, so we listen to input events instead.
+    let userScrolled = false;
+    const markScrolled = () => {
+      userScrolled = true;
+    };
+    scrollEl.addEventListener("wheel", markScrolled, { passive: true });
+    scrollEl.addEventListener("touchmove", markScrolled, { passive: true });
+    const onKey = (e: KeyboardEvent) => {
+      const navKeys = [
+        "ArrowUp",
+        "ArrowDown",
+        "PageUp",
+        "PageDown",
+        "Home",
+        "End",
+        " ",
+      ];
+      if (navKeys.includes(e.key)) userScrolled = true;
+    };
+    scrollEl.addEventListener("keydown", onKey);
+
+    const reanchor = (behavior: ScrollBehavior) => {
+      const targetTop =
+        computeOffsetTop(targetEl, scrollEl) + paddingTop - topOffset;
+      scrollEl.scrollTo({ top: Math.max(0, targetTop), behavior });
+    };
+
+    const raf = requestAnimationFrame(() => reanchor("smooth"));
+
+    // As `contentRef` reflows (response streaming, suggestions appearing,
+    // toolbar showing on generation end, etc.) two things can happen:
+    //   1. Natural content grows past the spacer, making the spacer
+    //      irrelevant — shrink it so we don't lock in extra scroll area.
+    //   2. The bubble's offset within `scrollEl` shifts (e.g. an earlier
+    //      message reflows, or the suggestion area pushes the bubble up).
+    //      Re-anchor to keep the bubble at `topOffset`.
+    const ro = new ResizeObserver(() => {
+      if (!contentEl || !spacerEl || !scrollEl) return;
+      const newSpacer = computeSpacer();
+      if (newSpacer < currentSpacerHeightRef.current) {
+        spacerEl.style.height = `${newSpacer}px`;
+        currentSpacerHeightRef.current = newSpacer;
+      }
+      if (!userScrolled) reanchor("auto");
     });
+    ro.observe(contentEl);
 
     return () => {
       cancelAnimationFrame(raf);
-      // Clear the floor on cleanup so a subsequent send (with a different
-      // user-message position) starts from a clean slate.
-      contentEl.style.minHeight = "";
+      ro.disconnect();
+      scrollEl.removeEventListener("wheel", markScrolled);
+      scrollEl.removeEventListener("touchmove", markScrolled);
+      scrollEl.removeEventListener("keydown", onKey);
     };
-  }, [id, sendNonce, scrollRef, contentRef, topOffset]);
+  }, [id, sendNonce, scrollRef, contentRef, spacerRef, topOffset]);
 }
 
 // Compute the offset of el relative to stopAt, accounting for stopAt's current scrollTop.

--- a/packages/react-core/src/v2/hooks/use-pin-to-send.ts
+++ b/packages/react-core/src/v2/hooks/use-pin-to-send.ts
@@ -4,19 +4,22 @@ import { LastUserMessageContext } from "../components/chat/last-user-message-con
 export type UsePinToSendOptions = {
   scrollRef: React.RefObject<HTMLElement | null>;
   contentRef: React.RefObject<HTMLElement | null>;
-  spacerRef: React.RefObject<HTMLElement | null>;
   topOffset?: number;
 };
 
+// Apply a transient min-height to the scroll content so the newly sent user
+// message can scroll to `topOffset` from the viewport top, then let natural
+// content (the streaming assistant response, suggestions, etc.) take over as
+// it grows past that floor. This mirrors the ChatGPT / Claude behavior:
+// user message pinned to top, response streams in below, no extra scrollable
+// whitespace tacked on after generation.
 export function usePinToSend({
   scrollRef,
   contentRef,
-  spacerRef,
   topOffset = 16,
 }: UsePinToSendOptions): void {
   const { id, sendNonce } = useContext(LastUserMessageContext);
   const lastNonceRef = useRef<number>(-1);
-  const currentSpacerHeightRef = useRef<number>(0);
 
   useEffect(() => {
     if (sendNonce === lastNonceRef.current) return;
@@ -25,8 +28,7 @@ export function usePinToSend({
     if (!id) return;
     const scrollEl = scrollRef.current;
     const contentEl = contentRef.current;
-    const spacerEl = spacerRef.current;
-    if (!scrollEl || !contentEl || !spacerEl) return;
+    if (!scrollEl || !contentEl) return;
 
     const escaped =
       typeof CSS !== "undefined" && CSS.escape
@@ -44,45 +46,34 @@ export function usePinToSend({
     // whatever was above the element too — including the previous message's
     // trailing copy button).
     const viewportHeight = scrollEl.clientHeight;
-    const userMessageHeight = targetEl.getBoundingClientRect().height;
     const paddingTop = parseFloat(getComputedStyle(targetEl).paddingTop) || 0;
-    const bubbleHeight = Math.max(0, userMessageHeight - paddingTop);
-    const spacerHeight = Math.max(0, viewportHeight - bubbleHeight - topOffset);
+    const userMsgOffsetInScroll = computeOffsetTop(targetEl, scrollEl);
 
-    spacerEl.style.height = `${spacerHeight}px`;
-    currentSpacerHeightRef.current = spacerHeight;
+    // The minimum scrollHeight that lets the bubble land at `topOffset` from
+    // the viewport top is: `bubbleTop + viewportHeight - topOffset`, where
+    // `bubbleTop = userMsgOffsetInScroll + paddingTop`. We apply this as a
+    // min-height on the content element. Once the natural content (response,
+    // padding, suggestions) grows past this floor, the floor is irrelevant
+    // and the layout reflects only the actual content — no leftover spacer
+    // whitespace at the bottom after generation.
+    const requiredScrollHeight =
+      userMsgOffsetInScroll + paddingTop + viewportHeight - topOffset;
+    contentEl.style.minHeight = `${Math.max(0, requiredScrollHeight)}px`;
 
     const raf = requestAnimationFrame(() => {
       // Scroll so the BUBBLE is `topOffset` from the viewport top — the
       // padding above the bubble ends up scrolled off-screen.
-      const targetTop =
-        computeOffsetTop(targetEl, scrollEl) + paddingTop - topOffset;
+      const targetTop = userMsgOffsetInScroll + paddingTop - topOffset;
       scrollEl.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
     });
 
-    // Shrink-only ResizeObserver: as the assistant response grows below the
-    // anchored user message, collapse the spacer by the same amount so total
-    // scrollable space below the bubble stays constant (and the bubble stays
-    // pinned). Never grow the spacer after initial sizing.
-    const ro = new ResizeObserver(() => {
-      if (!contentEl || !spacerEl || !scrollEl) return;
-      const contentHeight = contentEl.getBoundingClientRect().height;
-      const targetOffsetWithinContent = computeOffsetTop(targetEl, contentEl);
-      const consumedBelow =
-        contentHeight - targetOffsetWithinContent - userMessageHeight;
-      const remaining = Math.max(0, spacerHeight - consumedBelow);
-      if (remaining < currentSpacerHeightRef.current) {
-        spacerEl.style.height = `${remaining}px`;
-        currentSpacerHeightRef.current = remaining;
-      }
-    });
-    ro.observe(contentEl);
-
     return () => {
       cancelAnimationFrame(raf);
-      ro.disconnect();
+      // Clear the floor on cleanup so a subsequent send (with a different
+      // user-message position) starts from a clean slate.
+      contentEl.style.minHeight = "";
     };
-  }, [id, sendNonce, scrollRef, contentRef, spacerRef, topOffset]);
+  }, [id, sendNonce, scrollRef, contentRef, topOffset]);
 }
 
 // Compute the offset of el relative to stopAt, accounting for stopAt's current scrollTop.


### PR DESCRIPTION
## Summary

In `pin-to-send` mode, after a generation finished there was a large block of empty whitespace below the response — visible scrollable area that didn't exist in ChatGPT / Claude. The user message ended up pinned to the top, but the bottom of the chat had ~one viewport of dead space tacked on, even when the response was short. Suggestions appearing after generation made it worse: their layout shift wasn't accounted for and could leave the bubble drifting away from `topOffset`.

The cause was in `usePinToSend`:

- The hook rendered a fixed-height spacer element below the content and sized it to `viewportHeight - bubbleHeight - topOffset`.
- The math didn't account for the `paddingBottom` already applied to the scroll content (which equals `inputContainerHeight + 32`), so initial `scrollHeight` was over-allocated by that amount.
- The `ResizeObserver` only shrunk the spacer; it never re-issued the scroll-to-top, so any post-generation reflow (suggestions appearing, toolbar showing, late tool calls) could drift the bubble off the pin.

### Fix

Keep the sibling spacer outside `contentRef` (preserving any custom inner layout) but compute it correctly from first paint:

```ts
const required = userMsgOffset + paddingTop + viewportHeight - topOffset;
const spacer   = Math.max(0, required - contentEl.height);
```

This is the *minimum* extra scrollable area needed for the bubble to land at `topOffset` — no double-counting of `paddingBottom`, no over-allocation. Then a `ResizeObserver` on `contentRef` does two things on every reflow:

1. **Shrinks the spacer** as natural content fills the gap (shrink-only — the total scrollable area can't grow back and unanchor the bubble).
2. **Re-issues the scroll-to-top** when the bubble's offset shifts (e.g. suggestions appearing after generation, finalized tool calls expanding, images loading). Re-anchoring stops once the user scrolls — tracked via `wheel` / `touchmove` / navigation `keydown` listeners (not the `scroll` event, which also fires for our own programmatic scroll).

The result matches ChatGPT / Claude: user message pinned at top on send, response streams in below, suggestions slot in without unanchoring the bubble, and there's no leftover scrollable whitespace after generation.

### Files

- `packages/react-core/src/v2/hooks/use-pin-to-send.ts` — core fix (correct initial spacer math, re-anchor on reflow until user scrolls)
- `packages/react-core/src/v2/components/chat/CopilotChatView.tsx` — minor: pass `spacerRef` (unchanged DOM)
- Tests updated: `use-pin-to-send.test.tsx` (initial-spacer math, shrink-only RO, re-anchor on reflow, stops on user wheel) and `CopilotChatView.pinToSend.test.tsx`

## Test plan

- [x] `vitest run src/v2/hooks/__tests__/use-pin-to-send.test.tsx src/v2/components/chat/` — 588 tests pass across 36 files (6 hook + 5 integration for pin-to-send)
- [x] Pre-commit: lefthook (`lint-fix`, `test-and-check-packages` covering `nx run-many -t test` plus `publint` / `attw` for all packages) — all green
- [ ] Manual storybook check (`PinToSend` story in `examples/v2/react/storybook`) — verify a short response no longer leaves trailing whitespace below it
- [ ] Manual: send a message, wait for generation + suggestions to appear, confirm the user bubble stays at `topOffset` without drifting and that suggestions sit naturally without an unexplained gap

https://claude.ai/code/session_01Vgoq41Jmg3bEgQVYwfLSCJ