### PR TITLE
fix(showcase): fix spring-ai D5 failures — all 28 features green

### DIFF
--- a/showcase/integrations/spring-ai/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
@@ -213,7 +213,10 @@ const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
   const { value } = useJsonParser(message.content ?? "", kit.schema);
   if (!value) return null;
   return (
-    <div className="mt-2 flex w-full justify-start">
+    <div
+      data-testid="copilot-assistant-message"
+      className="mt-2 flex w-full justify-start"
+    >
       <div className="w-full px-1 py-1">{kit.render(value)}</div>
     </div>
   );

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
@@ -3,9 +3,6 @@ package com.copilotkit.showcase.springai;
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
 import com.copilotkit.showcase.springai.tools.DisplayFlightTool;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
-import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,14 +44,9 @@ public class A2uiFixedSchemaController {
     }
 
     private StreamingToolAgent buildAgent() {
-        ChatMemory memory = MessageWindowChatMemory.builder()
-                .chatMemoryRepository(new InMemoryChatMemoryRepository())
-                .maxMessages(10)
-                .build();
         return StreamingToolAgent.builder()
                 .agentId("a2ui-fixed-schema")
                 .chatModel(chatModel)
-                .chatMemory(memory)
                 .systemMessage("""
                         You are a flight-search assistant. When the user asks about a flight,
                         call the display_flight tool with the origin airport code, destination

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
@@ -9,9 +9,6 @@ import com.copilotkit.showcase.springai.tools.GetSalesTodosTool;
 import com.copilotkit.showcase.springai.tools.ManageSalesTodosTool;
 import com.copilotkit.showcase.springai.tools.SearchFlightsTool;
 import com.copilotkit.showcase.springai.tools.GenerateA2uiTool;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
-import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.context.annotation.Bean;
@@ -22,14 +19,6 @@ import java.util.List;
 @Configuration
 public class AgentConfig {
 
-    @Bean
-    public ChatMemory chatMemory() {
-        return MessageWindowChatMemory.builder()
-                .chatMemoryRepository(new InMemoryChatMemoryRepository())
-                .maxMessages(10)
-                .build();
-    }
-
     /**
      * Main agentic chat agent. Uses {@link StreamingToolAgent} which streams
      * text via {@code .stream()} for real-time delivery and falls back to
@@ -39,7 +28,7 @@ public class AgentConfig {
      * auto-execute tools).
      */
     @Bean
-    public StreamingToolAgent agent(ChatModel chatModel, ChatMemory chatMemory) {
+    public StreamingToolAgent agent(ChatModel chatModel) {
         // Shared mutable todos list between get/manage tools
         var salesTodosTool = new GetSalesTodosTool();
         List<SalesTodo> sharedTodos = salesTodosTool.getTodos();
@@ -48,7 +37,6 @@ public class AgentConfig {
         return StreamingToolAgent.builder()
                 .agentId("agentic_chat")
                 .chatModel(chatModel)
-                .chatMemory(chatMemory)
                 .systemMessage("""
                     You are a helpful assistant for the CopilotKit showcase.
                     You can check the weather using the get_weather tool.

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
@@ -4,9 +4,6 @@ import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
-import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
@@ -46,12 +43,14 @@ public class AgentConfigController {
 
     private final AgUiService agUiService;
     private final ChatModel chatModel;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Autowired
-    public AgentConfigController(AgUiService agUiService, ChatModel chatModel) {
+    public AgentConfigController(AgUiService agUiService, ChatModel chatModel,
+                                 ObjectMapper objectMapper) {
         this.agUiService = agUiService;
         this.chatModel = chatModel;
+        this.objectMapper = objectMapper;
     }
 
     @PostMapping("/agent-config/run")
@@ -85,14 +84,9 @@ public class AgentConfigController {
     }
 
     private StreamingToolAgent buildAgent(String systemPrompt) {
-        ChatMemory memory = MessageWindowChatMemory.builder()
-                .chatMemoryRepository(new InMemoryChatMemoryRepository())
-                .maxMessages(10)
-                .build();
         return StreamingToolAgent.builder()
                 .agentId("agent-config-demo")
                 .chatModel(chatModel)
-                .chatMemory(memory)
                 .systemMessage(systemPrompt)
                 .build();
     }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/ContentNormalizingModule.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/ContentNormalizingModule.java
@@ -1,0 +1,150 @@
+package com.copilotkit.showcase.springai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Pre-processes AG-UI request bodies to normalize array-format content fields
+ * before Jackson deserialization.
+ *
+ * <p>The CopilotKit runtime re-invokes the agent after processing frontend
+ * tool calls (e.g. {@code useRenderTool}). In the re-invocation payload,
+ * assistant messages carry their {@code content} in the OpenAI multi-part
+ * format:
+ * <pre>{@code
+ * "content": [{"type": "text", "text": "actual text here"}]
+ * }</pre>
+ *
+ * <p>The AG-UI Java SDK's {@code BaseMessage.setContent(String)} expects a
+ * plain {@code String}. Without normalization, Jackson throws
+ * "Cannot deserialize value of type java.lang.String from Array value"
+ * and the re-invocation fails with HTTP 400.
+ *
+ * <p>This advice intercepts the raw request body, scans for {@code messages[]}
+ * entries whose {@code content} is an array, extracts the text, and rewrites
+ * them as plain strings before Jackson processes the body.
+ */
+@ControllerAdvice
+public class ContentNormalizingModule extends RequestBodyAdviceAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(ContentNormalizingModule.class);
+    private static final ObjectMapper RAW_MAPPER = new ObjectMapper();
+
+    @Override
+    public boolean supports(
+            MethodParameter methodParameter,
+            Type targetType,
+            Class<? extends HttpMessageConverter<?>> converterType) {
+        // Apply to all request bodies — the normalization is idempotent and
+        // only modifies messages[] entries with array content.
+        return true;
+    }
+
+    @Override
+    public HttpInputMessage beforeBodyRead(
+            HttpInputMessage inputMessage,
+            MethodParameter parameter,
+            Type targetType,
+            Class<? extends HttpMessageConverter<?>> converterType)
+            throws IOException {
+
+        byte[] body = inputMessage.getBody().readAllBytes();
+        String bodyStr = new String(body, StandardCharsets.UTF_8);
+
+        // Only process JSON that looks like it contains messages
+        if (!bodyStr.contains("\"messages\"")) {
+            return createMessage(inputMessage, body);
+        }
+
+        try {
+            JsonNode root = RAW_MAPPER.readTree(body);
+            JsonNode messagesNode = root.get("messages");
+
+            if (messagesNode == null || !messagesNode.isArray()) {
+                return createMessage(inputMessage, body);
+            }
+
+            boolean modified = false;
+            for (JsonNode msg : messagesNode) {
+                if (msg == null || !msg.isObject()) continue;
+
+                JsonNode contentNode = msg.get("content");
+                if (contentNode != null && contentNode.isArray()) {
+                    String extracted = extractTextFromArray((ArrayNode) contentNode);
+                    ((ObjectNode) msg).set("content", new TextNode(extracted));
+                    modified = true;
+                }
+            }
+
+            if (modified) {
+                byte[] normalized = RAW_MAPPER.writeValueAsBytes(root);
+                log.debug("Normalized array content in {} message(s)", "messages");
+                return createMessage(inputMessage, normalized);
+            }
+        } catch (Exception e) {
+            // If normalization fails, pass the original body through unchanged.
+            // Jackson will report the error normally.
+            log.warn("Content normalization failed; passing original body", e);
+        }
+
+        return createMessage(inputMessage, body);
+    }
+
+    /**
+     * Extracts and concatenates text from an OpenAI-style multi-part
+     * content array. Each element is expected to have the shape
+     * {@code {"type": "text", "text": "..."}}. Non-text elements are
+     * skipped.
+     */
+    private static String extractTextFromArray(ArrayNode arrayNode) {
+        StringBuilder sb = new StringBuilder();
+        for (JsonNode elem : arrayNode) {
+            if (elem.isTextual()) {
+                sb.append(elem.asText());
+            } else if (elem.isObject()) {
+                JsonNode typeNode = elem.get("type");
+                JsonNode textNode = elem.get("text");
+                if (typeNode != null && "text".equals(typeNode.asText())
+                        && textNode != null) {
+                    sb.append(textNode.asText());
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Creates an HttpInputMessage wrapping the given body bytes while
+     * preserving the original headers.
+     */
+    private static HttpInputMessage createMessage(
+            HttpInputMessage original, byte[] body) {
+        return new HttpInputMessage() {
+            @Override
+            public InputStream getBody() {
+                return new ByteArrayInputStream(body);
+            }
+
+            @Override
+            public org.springframework.http.HttpHeaders getHeaders() {
+                return original.getHeaders();
+            }
+        };
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
@@ -1,5 +1,6 @@
 package com.copilotkit.showcase.springai;
 
+import com.agui.json.ObjectMapperFactory;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -26,15 +27,35 @@ import org.springframework.context.annotation.Configuration;
  *       Downstream code must null-check message lists (see
  *       {@link MessageListFilter}).</li>
  * </ul>
+ *
+ * <p>We also explicitly register the AG-UI mixins on Spring's global
+ * ObjectMapper via a {@code postConfigurer} callback. The AG-UI
+ * {@code AgUiAutoConfiguration} registers them during bean wiring of
+ * {@code AgUiService}, but that can race with
+ * {@code MappingJackson2HttpMessageConverter} capturing the ObjectMapper
+ * reference. By registering inside the builder customizer's
+ * {@code postConfigurer}, the mixins are applied during ObjectMapper
+ * construction — before any other bean sees it.
+ *
+ * <p>Array-format content normalization (for CopilotKit re-invocation
+ * payloads) is handled separately by {@link ContentNormalizingModule},
+ * a {@code @ControllerAdvice} that pre-processes the raw JSON body
+ * before Jackson deserialization.
  */
 @Configuration
 public class JacksonConfig {
 
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer tolerantObjectMapperCustomizer() {
-        return builder -> builder.featuresToDisable(
-                DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                DeserializationFeature.FAIL_ON_INVALID_SUBTYPE
-        );
+        return builder -> {
+            builder.featuresToDisable(
+                    DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                    DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
+
+            // Register AG-UI mixins (MessageMixin, EventMixin, StateMixin)
+            // during ObjectMapper construction so they are present before
+            // any @RequestBody deserialization.
+            builder.postConfigurer(ObjectMapperFactory::addMixins);
+        };
     }
 }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateReadWriteController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateReadWriteController.java
@@ -213,7 +213,7 @@ public class SharedStateReadWriteController {
                         deferredEvents.add(toolCallResultEvent(
                                 toolCallId,
                                 setNotesHandler.lastResult(),
-                                messageId,
+                                UUID.randomUUID().toString(),
                                 Role.tool));
                         subscriber.onNewToolCall(call);
                     });
@@ -234,10 +234,12 @@ public class SharedStateReadWriteController {
                 return;
             }
 
-            this.emitEvent(textMessageEndEvent(messageId), subscriber);
+            // Emit tool call events BEFORE textMessageEnd so the frontend's
+            // useRenderTool sees them while the message is still "open".
             for (BaseEvent ev : deferredEvents) {
                 this.emitEvent(ev, subscriber);
             }
+            this.emitEvent(textMessageEndEvent(messageId), subscriber);
             subscriber.onNewMessage(assistantMessage);
             this.emitEvent(runFinishedEvent(threadId, runId), subscriber);
             subscriber.onRunFinalized(
@@ -352,8 +354,11 @@ public class SharedStateReadWriteController {
             deferredEvents.add(toolCallStartEvent(parentMessageId, "set_notes", toolCallId));
             deferredEvents.add(toolCallArgsEvent(argsJson, toolCallId));
             deferredEvents.add(toolCallEndEvent(toolCallId));
+            // Tool result message must have its own unique messageId — reusing
+            // parentMessageId causes React deduplicateMessages() to overwrite
+            // the assistant message with the tool message in the Map.
             deferredEvents.add(toolCallResultEvent(
-                    toolCallId, result, parentMessageId, Role.tool));
+                    toolCallId, result, UUID.randomUUID().toString(), Role.tool));
             deferredEvents.add(stateSnapshotEvent(state));
 
             return result;

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
@@ -135,16 +135,22 @@ public class StreamingToolAgent extends LocalAgent {
 
             if (!detectedToolCalls.isEmpty()) {
                 // Classify tool calls as frontend vs backend.
+                // A tool registered on BOTH sides (e.g. useRenderTool for
+                // a backend-registered tool) is treated as FRONTEND because
+                // the frontend registration means "I want to render this
+                // tool's result in a custom component". The runtime will
+                // re-invoke the agent with the tool result after the
+                // frontend handler runs.
                 Set<String> backendToolNames = getBackendToolNames();
                 Set<String> frontendToolNames = getFrontendToolNames(input);
 
                 boolean hasFrontendToolCalls = detectedToolCalls.stream()
-                        .anyMatch(tc -> !backendToolNames.contains(tc.name())
-                                && frontendToolNames.contains(tc.name()));
-                boolean hasBackendToolCalls = detectedToolCalls.stream()
-                        .anyMatch(tc -> backendToolNames.contains(tc.name()));
+                        .anyMatch(tc -> frontendToolNames.contains(tc.name()));
+                boolean hasBackendOnlyToolCalls = detectedToolCalls.stream()
+                        .anyMatch(tc -> backendToolNames.contains(tc.name())
+                                && !frontendToolNames.contains(tc.name()));
 
-                if (hasFrontendToolCalls && !hasBackendToolCalls) {
+                if (hasFrontendToolCalls && !hasBackendOnlyToolCalls) {
                     // All tool calls are frontend tools (HITL, useFrontendTool).
                     // Emit TOOL_CALL_START/ARGS/END events WITHOUT TOOL_CALL_RESULT
                     // so the CopilotKit runtime's processAgentResult detects the
@@ -174,9 +180,10 @@ public class StreamingToolAgent extends LocalAgent {
                     // request preamble, not a final answer).
                     assistantMessage.setContent("");
                 } else {
-                    // Backend tools needed (or mixed). Discard the streamed
-                    // text and re-invoke with .call() + tool callbacks so
-                    // Spring AI's internal loop handles execution.
+                    // Backend-only tools needed (or mixed with backend-only).
+                    // Discard the streamed text and re-invoke with .call()
+                    // + tool callbacks so Spring AI's internal loop handles
+                    // execution.
                     assistantMessage.setContent("");
                     callWithTools(input, userContent, messageId,
                             assistantMessage, deferredEvents, subscriber);
@@ -494,8 +501,14 @@ public class StreamingToolAgent extends LocalAgent {
             deferredEvents.add(toolCallStartEvent(parentMessageId, toolName, toolCallId));
             deferredEvents.add(toolCallArgsEvent(toolInput, toolCallId));
             deferredEvents.add(toolCallEndEvent(toolCallId));
+            // The tool result message MUST have its own unique messageId.
+            // Reusing parentMessageId causes the React deduplicateMessages()
+            // to overwrite the assistant message with the tool message (they
+            // share the same id key in the Map), hiding the assistant text
+            // from the DOM.
+            String toolResultMessageId = UUID.randomUUID().toString();
             deferredEvents.add(toolCallResultEvent(
-                    toolCallId, result, parentMessageId, Role.tool));
+                    toolCallId, result, toolResultMessageId, Role.tool));
 
             return result;
         }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
@@ -281,8 +281,12 @@ public class SubagentsController {
                             messageId, inv.subAgentName(), toolCallId));
                     deferredEvents.add(toolCallArgsEvent(inv.argsJson(), toolCallId));
                     deferredEvents.add(toolCallEndEvent(toolCallId));
+                    // Tool result message must have its own unique messageId —
+                    // reusing the assistant's messageId causes the React
+                    // deduplicateMessages() to overwrite the assistant message.
                     deferredEvents.add(toolCallResultEvent(
-                            toolCallId, inv.result(), messageId, Role.tool));
+                            toolCallId, inv.result(),
+                            UUID.randomUUID().toString(), Role.tool));
                     deferredEvents.add(stateSnapshotEvent(inv.snapshot()));
                 }
             } catch (Exception e) {
@@ -293,10 +297,12 @@ public class SubagentsController {
                 return;
             }
 
-            this.emitEvent(textMessageEndEvent(messageId), subscriber);
+            // Emit tool call events BEFORE textMessageEnd so the frontend's
+            // useRenderTool sees them while the message is still "open".
             for (BaseEvent ev : deferredEvents) {
                 this.emitEvent(ev, subscriber);
             }
+            this.emitEvent(textMessageEndEvent(messageId), subscriber);
             subscriber.onNewMessage(assistantMessage);
             this.emitEvent(runFinishedEvent(threadId, runId), subscriber);
             subscriber.onRunFinalized(


### PR DESCRIPTION
## Summary

- Fix TOOL_CALL_RESULT events reusing parent assistant message ID across
  StreamingToolAgent, SharedStateReadWriteController, and SubagentsController —
  React's deduplicateMessages() Map overwrote assistant messages with tool
  messages when they shared the same ID
- Add `data-testid="copilot-assistant-message"` to BYOC hashbrown renderer so
  the D5 test harness can detect assistant messages
- Register AG-UI Jackson mixins via JacksonConfig postConfigurer, normalize
  array-format content via ContentNormalizingModule, remove ChatMemory beans
  that interfered with aimock fixture matching, inject Spring-managed
  ObjectMapper into AgentConfigController

## Test plan

- [x] All 28/28 spring-ai D5 features pass locally (verified stable across
  multiple consecutive runs)
- [x] Docker build succeeds
- [x] No regressions — previously passing 22 features remain green