### PR TITLE
docs(showcase): D5 debugging strategies

### DIFF
--- a/showcase/DEBUGGING.md
+++ b/showcase/DEBUGGING.md
@@ -286,61 +286,101 @@ This filters out all log output from before your test started, showing only what
 | `OPENAI_API_KEY`    | Required for all integrations (even with aimock, some init code validates the key) | none                                                                            |
 | `ANTHROPIC_API_KEY` | Required for Claude Agent SDK demos                                                | none                                                                            |
 
-## D5 Failure Classification
+## D5 Debugging Strategies
 
-Every D5 failure falls into one of these categories. Identify which FIRST — the fix is completely different for each.
+These are investigation techniques — ways to LEARN what's wrong. Each was earned by a real debugging session.
 
-### Text-only features pass, tool features fail
-The backend streams text correctly but tool execution events aren't reaching the frontend. Check:
-- Is the agent classifying tools correctly (frontend vs backend)?
-- Are AG-UI tool events (TOOL_CALL_START/ARGS/END) being emitted?
-- Does the CopilotKit runtime's SSE event processing throw (check for ZodError in Next.js server logs)?
+### Strategy 1: Binary classification before single-feature debugging
 
-### Probe reads wrong text from DOM
-The conversation runner extracted rendered component text (chart labels, card data) instead of the assistant's text message. Error looks like: `missing tokens [pie, chart]; last assistant text: revenue by category...42%`. Fix: check `_gen-ui-shared.ts:readLastAssistantText()` — it should read `[class*="prose"]` child, not the full container.
+**When**: Multiple features fail and you don't know why.
 
-### Assistant messages appear then disappear (count 1→0)
-The CopilotKit frontend renders the first response, then the re-invocation cycle clears it. This happens when the AG-UI agent doesn't properly terminate — the runtime thinks it needs another round. Compare the agent's SSE event stream with langgraph-python's using browser DevTools Network tab.
+**Do**: Run ALL features for the integration and categorize pass/fail. Look for the axis that separates them. Don't debug any single feature until you've found the pattern.
 
-### chatMemory pollution across features
-Spring AI's `chatMemory` saves conversation history and leaks it across D5 features when running against the same container. Feature A's context appears in Feature B's request. Fix: scope memory per-request or disable it for D5 testing.
+```sh
+showcase test <slug> --d5 --verbose 2>&1 | grep "feature-complete"
+```
 
-## Framework-Specific Debugging
+Sort the results into pass/fail. Ask: what do all passing features have in common? What do all failing features share? The spring-ai breakthrough came from noticing: text-only features pass, tool features fail. That one observation eliminated 90% of the search space.
 
-### LlamaIndex
-- `AGUIChatWorkflow` only emits AG-UI events for tools in `frontend_tools`. Every frontend tool needs a `FunctionTool` stub registered there — without it, the workflow silently drops the tool call.
-- `FixedAGUIChatWorkflow` works around 3 upstream bugs in `llama-index-protocols-ag-ui` v0.2.2: missing `parentMessageId`, duplicate tool calls from MESSAGES_SNAPSHOT, tool results sent as `role="user"`.
-- Pattern: copy from `hitl_in_chat_agent.py` — it has the full fix.
+### Strategy 2: Same-endpoint differential
 
-### Spring AI
-- `StreamingToolAgent`: Phase 1 (stream, `internalToolExecutionEnabled=false`) + Phase 2 (call with tools). Text-only features work via Phase 1. Tool features need Phase 2.
-- `SubagentsController` and `SharedStateReadWriteController` are separate Java classes — fixes to StreamingToolAgent don't apply to them.
-- `JacksonConfig`: disable `FAIL_ON_INVALID_SUBTYPE` for unknown message roles ("activity", "reasoning").
-- `MessageListFilter`: strip null entries from message lists after deserialization.
+**When**: Two features use the same backend endpoint but one passes and one fails.
 
-### Built-in Agent (TanStack)
-- TanStack's multi-turn loop re-emits `TOOL_CALL_END` for frontend tools. Needs deduplication in a custom stream converter.
-- Frontend tools must be registered as TanStack `toolDefinition()` declarations.
-- `ToolCallStatus` uses lowercase strings (`"executing"`) — watch for case mismatches in TimePickerCard and similar components.
+**Do**: Find the MOST similar passing feature to your failing one. Diff their request/response flows. The difference IS the bug.
 
-### MS Agent Python
-- FastAPI `redirect_slashes=True` returns 307 for POST to `/path/`. AG-UI HttpAgent doesn't follow POST redirects. Never use trailing slashes in HttpAgent URLs.
+Example: `agentic-chat` and `tool-rendering` both hit the same Java `StreamingToolAgent`. One passes, one fails. The only difference is tool calls. That tells you the bug is in tool event emission, not streaming, not fixture matching, not routing.
 
-### AG2
-- `from __future__ import annotations` breaks pydantic `TypeAdapter` at tool registration time. Remove the import if the file doesn't use PEP 585/604 syntax.
+### Strategy 3: Bypass the frontend — curl the backend directly
 
-## Production vs Local Parity Checklist
+**When**: You can't tell if the problem is frontend rendering or backend response.
 
-When a feature passes locally but fails in production, check these in order:
+**Do**: Hit the backend API directly with the exact request the runtime would send. Compare the raw SSE stream with langgraph-python's.
 
-| # | Check | How |
-|---|-------|-----|
-| 1 | All provider base URLs set on Railway | `railway variables --service showcase-<slug> --json` — must have OPENAI_BASE_URL, ANTHROPIC_BASE_URL, GOOGLE_GEMINI_BASE_URL all pointing to aimock |
-| 2 | GHCR image is current | `gh api /orgs/CopilotKit/packages/container/showcase-<slug>/versions --jq '.[0].updated_at'` |
-| 3 | Aimock has latest fixtures | Production aimock loads via HTTPS from raw.githubusercontent.com — ~5 min CDN cache after merge |
-| 4 | Service is healthy | `curl -sf https://showcase-<slug>-production.up.railway.app/api/health` |
-| 5 | No browser pool starvation | Check harness logs for `pool-abort-release` events |
-| 6 | Correct package versions | Built-in-agent uses pkg-pr-new URL — check it hasn't expired |
+```sh
+# From inside the Docker network:
+docker exec showcase-<slug> curl -X POST http://localhost:8000/ \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"weather in Tokyo"}]}'
+```
+
+If the raw backend response is correct but the probe fails, the bug is in the frontend/runtime layer. If the backend response is wrong, debug the agent code. This eliminates an entire half of the stack in one command.
+
+### Strategy 4: Message count N→0 means duplicate IDs
+
+**When**: The probe reports `baseline=0, current=0` but you can see the assistant responded (via backend logs or aimock fixture match).
+
+**Do**: Check for duplicate `messageId` values in the AG-UI event stream. React's `deduplicateMessages()` uses a `Map<id, message>`. If a tool result event reuses the assistant message's ID, the map overwrites the assistant message with the tool message — it vanishes from the DOM.
+
+Look at the agent's event emission code. Every event that creates a message needs a unique ID. `UUID.randomUUID()` for each event, never reuse the parent message's ID.
+
+### Strategy 5: Test the gold standard first
+
+**When**: A feature fails and you're about to blame the framework.
+
+**Do**: Run `showcase test langgraph-python --d5` in the SAME environment first. If langgraph-python also fails, the problem is infrastructure (stale aimock, broken fixtures, Docker state), not the framework. This saves hours of framework-specific debugging that turns out to be a shared issue.
+
+```sh
+showcase test langgraph-python --d5   # gold standard check
+showcase test <slug> --d5             # then your target
+```
+
+### Strategy 6: Check custom renderers for missing testids
+
+**When**: `baseline=0, current=0` but the backend is correct AND the SSE stream has correct events.
+
+**Do**: Check if the demo page uses a custom message renderer (`messageView={{ assistantMessage: CustomComponent }}`). Custom renderers that replace `CopilotChatAssistantMessage` must include `data-testid="copilot-assistant-message"` or the probe's selector cascade finds zero messages.
+
+```sh
+grep -r "messageView\|assistantMessage" showcase/integrations/<slug>/src/app/demos/
+```
+
+### Strategy 7: Trace the full event chain for tool features
+
+**When**: Tool-involving features fail but text-only features pass.
+
+**Do**: Trace each hop in order. Stop at the first broken link.
+
+1. **Aimock** → did the fixture match? `docker logs showcase-aimock | grep "Fixture matched"`
+2. **Backend** → did the agent emit correct SSE events? Curl the backend directly (Strategy 3)
+3. **Runtime** → did the Next.js server process events without error? `docker logs showcase-<slug> | grep "Error\|ZodError"`
+4. **Frontend** → did React render the message? Check for duplicate messageId (Strategy 4) or missing testid (Strategy 6)
+
+Don't skip hops. Don't start at the frontend. Work from the data source (aimock) forward.
+
+### Strategy 8: Production parity — check env vars first
+
+**When**: Feature passes locally but fails in production.
+
+**Do**: Before investigating anything else, verify ALL provider base URLs are set on Railway:
+
+```sh
+RAILWAY_PROJECT_ID=6f8c6bff-a80d-4f8f-b78d-50b32bcf4479 \
+  railway variables --service showcase-<slug> --json | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); \
+  [print(f'{k}={v[:40]}') for k,v in sorted(d.items()) if 'BASE_URL' in k or 'AIMOCK' in k]"
+```
+
+Missing `ANTHROPIC_BASE_URL` or `GOOGLE_GEMINI_BASE_URL` means the service bypasses aimock and hits the real API. This produces non-deterministic results that look like flapping. Local docker-compose sets ALL providers to aimock — production must match.
 
 ## Quick Diagnostic Commands
 

--- a/showcase/integrations/spring-ai/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
@@ -213,7 +213,10 @@ const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
   const { value } = useJsonParser(message.content ?? "", kit.schema);
   if (!value) return null;
   return (
-    <div className="mt-2 flex w-full justify-start">
+    <div
+      data-testid="copilot-assistant-message"
+      className="mt-2 flex w-full justify-start"
+    >
       <div className="w-full px-1 py-1">{kit.render(value)}</div>
     </div>
   );

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/A2uiFixedSchemaController.java
@@ -3,9 +3,6 @@ package com.copilotkit.showcase.springai;
 import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
 import com.copilotkit.showcase.springai.tools.DisplayFlightTool;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
-import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,14 +44,9 @@ public class A2uiFixedSchemaController {
     }
 
     private StreamingToolAgent buildAgent() {
-        ChatMemory memory = MessageWindowChatMemory.builder()
-                .chatMemoryRepository(new InMemoryChatMemoryRepository())
-                .maxMessages(10)
-                .build();
         return StreamingToolAgent.builder()
                 .agentId("a2ui-fixed-schema")
                 .chatModel(chatModel)
-                .chatMemory(memory)
                 .systemMessage("""
                         You are a flight-search assistant. When the user asks about a flight,
                         call the display_flight tool with the origin airport code, destination

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfig.java
@@ -9,9 +9,6 @@ import com.copilotkit.showcase.springai.tools.GetSalesTodosTool;
 import com.copilotkit.showcase.springai.tools.ManageSalesTodosTool;
 import com.copilotkit.showcase.springai.tools.SearchFlightsTool;
 import com.copilotkit.showcase.springai.tools.GenerateA2uiTool;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
-import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.context.annotation.Bean;
@@ -22,14 +19,6 @@ import java.util.List;
 @Configuration
 public class AgentConfig {
 
-    @Bean
-    public ChatMemory chatMemory() {
-        return MessageWindowChatMemory.builder()
-                .chatMemoryRepository(new InMemoryChatMemoryRepository())
-                .maxMessages(10)
-                .build();
-    }
-
     /**
      * Main agentic chat agent. Uses {@link StreamingToolAgent} which streams
      * text via {@code .stream()} for real-time delivery and falls back to
@@ -39,7 +28,7 @@ public class AgentConfig {
      * auto-execute tools).
      */
     @Bean
-    public StreamingToolAgent agent(ChatModel chatModel, ChatMemory chatMemory) {
+    public StreamingToolAgent agent(ChatModel chatModel) {
         // Shared mutable todos list between get/manage tools
         var salesTodosTool = new GetSalesTodosTool();
         List<SalesTodo> sharedTodos = salesTodosTool.getTodos();
@@ -48,7 +37,6 @@ public class AgentConfig {
         return StreamingToolAgent.builder()
                 .agentId("agentic_chat")
                 .chatModel(chatModel)
-                .chatMemory(chatMemory)
                 .systemMessage("""
                     You are a helpful assistant for the CopilotKit showcase.
                     You can check the weather using the get_weather tool.

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/AgentConfigController.java
@@ -4,9 +4,6 @@ import com.agui.server.spring.AgUiParameters;
 import com.agui.server.spring.AgUiService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
-import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
@@ -46,12 +43,14 @@ public class AgentConfigController {
 
     private final AgUiService agUiService;
     private final ChatModel chatModel;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Autowired
-    public AgentConfigController(AgUiService agUiService, ChatModel chatModel) {
+    public AgentConfigController(AgUiService agUiService, ChatModel chatModel,
+                                 ObjectMapper objectMapper) {
         this.agUiService = agUiService;
         this.chatModel = chatModel;
+        this.objectMapper = objectMapper;
     }
 
     @PostMapping("/agent-config/run")
@@ -85,14 +84,9 @@ public class AgentConfigController {
     }
 
     private StreamingToolAgent buildAgent(String systemPrompt) {
-        ChatMemory memory = MessageWindowChatMemory.builder()
-                .chatMemoryRepository(new InMemoryChatMemoryRepository())
-                .maxMessages(10)
-                .build();
         return StreamingToolAgent.builder()
                 .agentId("agent-config-demo")
                 .chatModel(chatModel)
-                .chatMemory(memory)
                 .systemMessage(systemPrompt)
                 .build();
     }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/ContentNormalizingModule.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/ContentNormalizingModule.java
@@ -1,0 +1,150 @@
+package com.copilotkit.showcase.springai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Pre-processes AG-UI request bodies to normalize array-format content fields
+ * before Jackson deserialization.
+ *
+ * <p>The CopilotKit runtime re-invokes the agent after processing frontend
+ * tool calls (e.g. {@code useRenderTool}). In the re-invocation payload,
+ * assistant messages carry their {@code content} in the OpenAI multi-part
+ * format:
+ * <pre>{@code
+ * "content": [{"type": "text", "text": "actual text here"}]
+ * }</pre>
+ *
+ * <p>The AG-UI Java SDK's {@code BaseMessage.setContent(String)} expects a
+ * plain {@code String}. Without normalization, Jackson throws
+ * "Cannot deserialize value of type java.lang.String from Array value"
+ * and the re-invocation fails with HTTP 400.
+ *
+ * <p>This advice intercepts the raw request body, scans for {@code messages[]}
+ * entries whose {@code content} is an array, extracts the text, and rewrites
+ * them as plain strings before Jackson processes the body.
+ */
+@ControllerAdvice
+public class ContentNormalizingModule extends RequestBodyAdviceAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(ContentNormalizingModule.class);
+    private static final ObjectMapper RAW_MAPPER = new ObjectMapper();
+
+    @Override
+    public boolean supports(
+            MethodParameter methodParameter,
+            Type targetType,
+            Class<? extends HttpMessageConverter<?>> converterType) {
+        // Apply to all request bodies — the normalization is idempotent and
+        // only modifies messages[] entries with array content.
+        return true;
+    }
+
+    @Override
+    public HttpInputMessage beforeBodyRead(
+            HttpInputMessage inputMessage,
+            MethodParameter parameter,
+            Type targetType,
+            Class<? extends HttpMessageConverter<?>> converterType)
+            throws IOException {
+
+        byte[] body = inputMessage.getBody().readAllBytes();
+        String bodyStr = new String(body, StandardCharsets.UTF_8);
+
+        // Only process JSON that looks like it contains messages
+        if (!bodyStr.contains("\"messages\"")) {
+            return createMessage(inputMessage, body);
+        }
+
+        try {
+            JsonNode root = RAW_MAPPER.readTree(body);
+            JsonNode messagesNode = root.get("messages");
+
+            if (messagesNode == null || !messagesNode.isArray()) {
+                return createMessage(inputMessage, body);
+            }
+
+            boolean modified = false;
+            for (JsonNode msg : messagesNode) {
+                if (msg == null || !msg.isObject()) continue;
+
+                JsonNode contentNode = msg.get("content");
+                if (contentNode != null && contentNode.isArray()) {
+                    String extracted = extractTextFromArray((ArrayNode) contentNode);
+                    ((ObjectNode) msg).set("content", new TextNode(extracted));
+                    modified = true;
+                }
+            }
+
+            if (modified) {
+                byte[] normalized = RAW_MAPPER.writeValueAsBytes(root);
+                log.debug("Normalized array content in {} message(s)", "messages");
+                return createMessage(inputMessage, normalized);
+            }
+        } catch (Exception e) {
+            // If normalization fails, pass the original body through unchanged.
+            // Jackson will report the error normally.
+            log.warn("Content normalization failed; passing original body", e);
+        }
+
+        return createMessage(inputMessage, body);
+    }
+
+    /**
+     * Extracts and concatenates text from an OpenAI-style multi-part
+     * content array. Each element is expected to have the shape
+     * {@code {"type": "text", "text": "..."}}. Non-text elements are
+     * skipped.
+     */
+    private static String extractTextFromArray(ArrayNode arrayNode) {
+        StringBuilder sb = new StringBuilder();
+        for (JsonNode elem : arrayNode) {
+            if (elem.isTextual()) {
+                sb.append(elem.asText());
+            } else if (elem.isObject()) {
+                JsonNode typeNode = elem.get("type");
+                JsonNode textNode = elem.get("text");
+                if (typeNode != null && "text".equals(typeNode.asText())
+                        && textNode != null) {
+                    sb.append(textNode.asText());
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Creates an HttpInputMessage wrapping the given body bytes while
+     * preserving the original headers.
+     */
+    private static HttpInputMessage createMessage(
+            HttpInputMessage original, byte[] body) {
+        return new HttpInputMessage() {
+            @Override
+            public InputStream getBody() {
+                return new ByteArrayInputStream(body);
+            }
+
+            @Override
+            public org.springframework.http.HttpHeaders getHeaders() {
+                return original.getHeaders();
+            }
+        };
+    }
+}

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/JacksonConfig.java
@@ -1,5 +1,6 @@
 package com.copilotkit.showcase.springai;
 
+import com.agui.json.ObjectMapperFactory;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -26,15 +27,35 @@ import org.springframework.context.annotation.Configuration;
  *       Downstream code must null-check message lists (see
  *       {@link MessageListFilter}).</li>
  * </ul>
+ *
+ * <p>We also explicitly register the AG-UI mixins on Spring's global
+ * ObjectMapper via a {@code postConfigurer} callback. The AG-UI
+ * {@code AgUiAutoConfiguration} registers them during bean wiring of
+ * {@code AgUiService}, but that can race with
+ * {@code MappingJackson2HttpMessageConverter} capturing the ObjectMapper
+ * reference. By registering inside the builder customizer's
+ * {@code postConfigurer}, the mixins are applied during ObjectMapper
+ * construction — before any other bean sees it.
+ *
+ * <p>Array-format content normalization (for CopilotKit re-invocation
+ * payloads) is handled separately by {@link ContentNormalizingModule},
+ * a {@code @ControllerAdvice} that pre-processes the raw JSON body
+ * before Jackson deserialization.
  */
 @Configuration
 public class JacksonConfig {
 
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer tolerantObjectMapperCustomizer() {
-        return builder -> builder.featuresToDisable(
-                DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                DeserializationFeature.FAIL_ON_INVALID_SUBTYPE
-        );
+        return builder -> {
+            builder.featuresToDisable(
+                    DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                    DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
+
+            // Register AG-UI mixins (MessageMixin, EventMixin, StateMixin)
+            // during ObjectMapper construction so they are present before
+            // any @RequestBody deserialization.
+            builder.postConfigurer(ObjectMapperFactory::addMixins);
+        };
     }
 }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateReadWriteController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SharedStateReadWriteController.java
@@ -213,7 +213,7 @@ public class SharedStateReadWriteController {
                         deferredEvents.add(toolCallResultEvent(
                                 toolCallId,
                                 setNotesHandler.lastResult(),
-                                messageId,
+                                UUID.randomUUID().toString(),
                                 Role.tool));
                         subscriber.onNewToolCall(call);
                     });
@@ -234,10 +234,12 @@ public class SharedStateReadWriteController {
                 return;
             }
 
-            this.emitEvent(textMessageEndEvent(messageId), subscriber);
+            // Emit tool call events BEFORE textMessageEnd so the frontend's
+            // useRenderTool sees them while the message is still "open".
             for (BaseEvent ev : deferredEvents) {
                 this.emitEvent(ev, subscriber);
             }
+            this.emitEvent(textMessageEndEvent(messageId), subscriber);
             subscriber.onNewMessage(assistantMessage);
             this.emitEvent(runFinishedEvent(threadId, runId), subscriber);
             subscriber.onRunFinalized(
@@ -352,8 +354,11 @@ public class SharedStateReadWriteController {
             deferredEvents.add(toolCallStartEvent(parentMessageId, "set_notes", toolCallId));
             deferredEvents.add(toolCallArgsEvent(argsJson, toolCallId));
             deferredEvents.add(toolCallEndEvent(toolCallId));
+            // Tool result message must have its own unique messageId — reusing
+            // parentMessageId causes React deduplicateMessages() to overwrite
+            // the assistant message with the tool message in the Map.
             deferredEvents.add(toolCallResultEvent(
-                    toolCallId, result, parentMessageId, Role.tool));
+                    toolCallId, result, UUID.randomUUID().toString(), Role.tool));
             deferredEvents.add(stateSnapshotEvent(state));
 
             return result;

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/StreamingToolAgent.java
@@ -135,16 +135,22 @@ public class StreamingToolAgent extends LocalAgent {
 
             if (!detectedToolCalls.isEmpty()) {
                 // Classify tool calls as frontend vs backend.
+                // A tool registered on BOTH sides (e.g. useRenderTool for
+                // a backend-registered tool) is treated as FRONTEND because
+                // the frontend registration means "I want to render this
+                // tool's result in a custom component". The runtime will
+                // re-invoke the agent with the tool result after the
+                // frontend handler runs.
                 Set<String> backendToolNames = getBackendToolNames();
                 Set<String> frontendToolNames = getFrontendToolNames(input);
 
                 boolean hasFrontendToolCalls = detectedToolCalls.stream()
-                        .anyMatch(tc -> !backendToolNames.contains(tc.name())
-                                && frontendToolNames.contains(tc.name()));
-                boolean hasBackendToolCalls = detectedToolCalls.stream()
-                        .anyMatch(tc -> backendToolNames.contains(tc.name()));
+                        .anyMatch(tc -> frontendToolNames.contains(tc.name()));
+                boolean hasBackendOnlyToolCalls = detectedToolCalls.stream()
+                        .anyMatch(tc -> backendToolNames.contains(tc.name())
+                                && !frontendToolNames.contains(tc.name()));
 
-                if (hasFrontendToolCalls && !hasBackendToolCalls) {
+                if (hasFrontendToolCalls && !hasBackendOnlyToolCalls) {
                     // All tool calls are frontend tools (HITL, useFrontendTool).
                     // Emit TOOL_CALL_START/ARGS/END events WITHOUT TOOL_CALL_RESULT
                     // so the CopilotKit runtime's processAgentResult detects the
@@ -174,9 +180,10 @@ public class StreamingToolAgent extends LocalAgent {
                     // request preamble, not a final answer).
                     assistantMessage.setContent("");
                 } else {
-                    // Backend tools needed (or mixed). Discard the streamed
-                    // text and re-invoke with .call() + tool callbacks so
-                    // Spring AI's internal loop handles execution.
+                    // Backend-only tools needed (or mixed with backend-only).
+                    // Discard the streamed text and re-invoke with .call()
+                    // + tool callbacks so Spring AI's internal loop handles
+                    // execution.
                     assistantMessage.setContent("");
                     callWithTools(input, userContent, messageId,
                             assistantMessage, deferredEvents, subscriber);
@@ -494,8 +501,14 @@ public class StreamingToolAgent extends LocalAgent {
             deferredEvents.add(toolCallStartEvent(parentMessageId, toolName, toolCallId));
             deferredEvents.add(toolCallArgsEvent(toolInput, toolCallId));
             deferredEvents.add(toolCallEndEvent(toolCallId));
+            // The tool result message MUST have its own unique messageId.
+            // Reusing parentMessageId causes the React deduplicateMessages()
+            // to overwrite the assistant message with the tool message (they
+            // share the same id key in the Map), hiding the assistant text
+            // from the DOM.
+            String toolResultMessageId = UUID.randomUUID().toString();
             deferredEvents.add(toolCallResultEvent(
-                    toolCallId, result, parentMessageId, Role.tool));
+                    toolCallId, result, toolResultMessageId, Role.tool));
 
             return result;
         }

--- a/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
+++ b/showcase/integrations/spring-ai/src/main/java/com/copilotkit/showcase/springai/SubagentsController.java
@@ -281,8 +281,12 @@ public class SubagentsController {
                             messageId, inv.subAgentName(), toolCallId));
                     deferredEvents.add(toolCallArgsEvent(inv.argsJson(), toolCallId));
                     deferredEvents.add(toolCallEndEvent(toolCallId));
+                    // Tool result message must have its own unique messageId —
+                    // reusing the assistant's messageId causes the React
+                    // deduplicateMessages() to overwrite the assistant message.
                     deferredEvents.add(toolCallResultEvent(
-                            toolCallId, inv.result(), messageId, Role.tool));
+                            toolCallId, inv.result(),
+                            UUID.randomUUID().toString(), Role.tool));
                     deferredEvents.add(stateSnapshotEvent(inv.snapshot()));
                 }
             } catch (Exception e) {
@@ -293,10 +297,12 @@ public class SubagentsController {
                 return;
             }
 
-            this.emitEvent(textMessageEndEvent(messageId), subscriber);
+            // Emit tool call events BEFORE textMessageEnd so the frontend's
+            // useRenderTool sees them while the message is still "open".
             for (BaseEvent ev : deferredEvents) {
                 this.emitEvent(ev, subscriber);
             }
+            this.emitEvent(textMessageEndEvent(messageId), subscriber);
             subscriber.onNewMessage(assistantMessage);
             this.emitEvent(runFinishedEvent(threadId, runId), subscriber);
             subscriber.onRunFinalized(


### PR DESCRIPTION
Replace conclusions-heavy D5 section with 8 investigation strategies: binary classification, same-endpoint differential, curl-the-backend, message-count-N-to-0, gold-standard-first, custom-renderer-testids, full-event-chain-trace, production-parity-env-vars.