### PR TITLE
fix(showcase/ag2): D5 green — 15 demo fixes verified locally

### DIFF
--- a/showcase/integrations/ag2/manifest.yaml
+++ b/showcase/integrations/ag2/manifest.yaml
@@ -267,7 +267,7 @@ demos:
       - src/app/demos/headless-complete/page.tsx
       - src/app/demos/headless-complete/message-list.tsx
       - src/app/demos/headless-complete/use-rendered-messages.tsx
-      - src/app/api/copilotkit/route.ts
+      - src/app/api/copilotkit-mcp-apps/route.ts
   - id: readonly-state-agent-context
     name: Readonly State (Agent Context)
     description: Frontend provides read-only context to the agent via useAgentContext

--- a/showcase/integrations/ag2/src/agent_server.py
+++ b/showcase/integrations/ag2/src/agent_server.py
@@ -76,8 +76,11 @@ app.mount("/declarative-gen-ui", a2ui_dynamic_app)
 app.mount("/a2ui-fixed-schema", a2ui_fixed_app)
 app.mount("/beautiful-chat", beautiful_chat_app)
 app.mount("/mcp-apps", mcp_apps_app)
-app.mount("/open-gen-ui", open_gen_ui_app)
+# IMPORTANT: mount /open-gen-ui-advanced BEFORE /open-gen-ui — Starlette
+# resolves mounts via prefix matching in registration order, so the shorter
+# prefix "/open-gen-ui" would shadow "/open-gen-ui-advanced" if it came first.
 app.mount("/open-gen-ui-advanced", open_gen_ui_advanced_app)
+app.mount("/open-gen-ui", open_gen_ui_app)
 app.mount(
     "/tool-rendering-reasoning-chain",
     tool_rendering_reasoning_chain_app,

--- a/showcase/integrations/ag2/src/agents/agent_config_agent.py
+++ b/showcase/integrations/ag2/src/agents/agent_config_agent.py
@@ -76,7 +76,7 @@ SYSTEM_PROMPT = (
 )
 
 
-@tool
+@tool()
 def get_current_config(context_variables: ContextVariables) -> str:
     """Return the current rulebook (tone / expertise / length) for the assistant.
 

--- a/showcase/integrations/ag2/src/app/api/copilotkit-auth/[[...slug]]/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-auth/[[...slug]]/route.ts
@@ -21,7 +21,6 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 const authDemoAgent = new HttpAgent({ url: `${AGENT_URL}/` });
 
 const runtime = new CopilotRuntime({
-  // @ts-ignore -- see main route.ts; published agents type generic mismatch
   agents: {
     "auth-demo": authDemoAgent,
     default: authDemoAgent,

--- a/showcase/integrations/ag2/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-mcp-apps/route.ts
@@ -21,6 +21,10 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 const mcpAppsAgent = new HttpAgent({ url: `${AGENT_URL}/mcp-apps/` });
 
+const headlessCompleteAgent = new HttpAgent({
+  url: `${AGENT_URL}/headless-complete/`,
+});
+
 // @region[runtime-mcpapps-config]
 // The `mcpApps.servers` config is all you need server-side. The runtime
 // auto-applies the MCP Apps middleware to every registered agent: on each
@@ -29,7 +33,13 @@ const mcpAppsAgent = new HttpAgent({ url: `${AGENT_URL}/mcp-apps/` });
 // inline in the chat.
 const runtime = new CopilotRuntime({
   // @ts-ignore -- see main route.ts
-  agents: { "mcp-apps": mcpAppsAgent },
+  agents: {
+    "mcp-apps": mcpAppsAgent,
+    // headless-complete shares this runtime because its cell also exercises
+    // MCP Apps rendering (via a hand-rolled `useRenderActivityMessage` in
+    // `use-rendered-messages.tsx`).
+    "headless-complete": headlessCompleteAgent,
+  },
   mcpApps: {
     servers: [
       {

--- a/showcase/integrations/ag2/src/app/demos/agent-config/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/agent-config/page.tsx
@@ -2,53 +2,53 @@
 
 // Agent Config Object demo (AG2).
 //
-// The frontend writes a typed config object (tone / expertise /
-// responseLength) into agent state via `agent.setState({...})`. AG2's
-// AGUIStream maps initial state into ContextVariables on every run; the
-// agent reads them and rebuilds its system prompt per turn.
+// The frontend passes a typed config object (tone / expertise /
+// responseLength) through the CopilotKit provider's `properties` prop.
+// AG2's AGUIStream maps these properties into ContextVariables on every
+// run; the agent reads them and rebuilds its system prompt per turn.
 //
 // References:
 // - src/agents/agent_config_agent.py — the AG2 ConversableAgent backing this.
 
-import { CopilotChat, CopilotKit, useAgent } from "@copilotkit/react-core/v2";
-import { useEffect } from "react";
+import { CopilotChat, CopilotKit } from "@copilotkit/react-core/v2";
+import { useMemo } from "react";
 
 import { ConfigCard } from "./config-card";
-import type { AgentConfig } from "./config-types";
 import { useAgentConfig } from "./use-agent-config";
 
 const RUNTIME_URL = "/api/copilotkit";
 const AGENT_ID = "agent-config-demo";
 
-function ConfigStateSync({ config }: { config: AgentConfig }) {
-  const { agent } = useAgent({ agentId: AGENT_ID });
-  useEffect(() => {
-    if (!agent) return;
-    try {
-      // AG-UI AbstractAgent#setState maps to AG2 ContextVariables on each run.
-      (agent as unknown as { setState?: (s: unknown) => void }).setState?.(
-        config,
-      );
-    } catch (err) {
-      console.warn("[agent-config] setState failed", err);
-    }
-  }, [agent, config]);
-  return null;
-}
-
 export default function AgentConfigDemoPage() {
   const { config, setTone, setExpertise, setResponseLength } = useAgentConfig();
 
+  // Widen to `Record<string, unknown>` so the provider's `properties` prop
+  // accepts our strongly-typed config. The memo keeps the reference stable
+  // between renders when the config itself hasn't changed.
+  const providerProperties = useMemo<Record<string, unknown>>(
+    () => ({
+      tone: config.tone,
+      expertise: config.expertise,
+      responseLength: config.responseLength,
+    }),
+    [config.tone, config.expertise, config.responseLength],
+  );
+
   return (
-    <CopilotKit runtimeUrl={RUNTIME_URL} agent={AGENT_ID}>
+    <CopilotKit
+      runtimeUrl={RUNTIME_URL}
+      agent={AGENT_ID}
+      properties={providerProperties}
+    >
       <div className="flex h-screen flex-col gap-3 p-6">
         <header>
           <h1 className="text-lg font-semibold">Agent Config Object</h1>
           <p className="text-sm text-neutral-600">
             Forwarded props let the frontend tell the agent how to behave. This
             demo passes <code>tone</code>, <code>expertise</code>, and{" "}
-            <code>responseLength</code> through agent state; the AG2 agent reads
-            them from ContextVariables and rebuilds its system prompt per turn.
+            <code>responseLength</code> through the provider; the AG2 agent
+            reads them from ContextVariables and rebuilds its system prompt per
+            turn.
           </p>
         </header>
         <ConfigCard
@@ -57,7 +57,6 @@ export default function AgentConfigDemoPage() {
           onExpertiseChange={setExpertise}
           onResponseLengthChange={setResponseLength}
         />
-        <ConfigStateSync config={config} />
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
           <CopilotChat agentId={AGENT_ID} className="h-full rounded-md" />
         </div>

--- a/showcase/integrations/ag2/src/app/demos/agentic-chat-reasoning/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/agentic-chat-reasoning/page.tsx
@@ -29,7 +29,10 @@ import { ReasoningBlock } from "./reasoning-block";
 export default function AgenticChatReasoningDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="agentic-chat-reasoning">
-      <div className="flex justify-center items-center h-screen w-full">
+      <div
+        data-testid="demo-agentic-chat-reasoning"
+        className="flex justify-center items-center h-screen w-full"
+      >
         <div className="h-full w-full max-w-4xl">
           <Chat />
         </div>

--- a/showcase/integrations/ag2/src/app/demos/beautiful-chat/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/beautiful-chat/page.tsx
@@ -113,7 +113,10 @@ export default function BeautifulChatDemo() {
       a2ui={{ catalog: myCatalog }}
       openGenerativeUI={{ designSkill: VISUALIZATION_DESIGN_SKILL }}
     >
-      <div className="flex justify-center items-center h-screen w-full">
+      <div
+        data-testid="demo-beautiful-chat"
+        className="flex justify-center items-center h-screen w-full"
+      >
         <div className="h-full w-full max-w-4xl">
           <Chat />
         </div>

--- a/showcase/integrations/ag2/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
+++ b/showcase/integrations/ag2/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
@@ -277,8 +277,19 @@ const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
 
   if (!value) return null;
 
+  // The CopilotChat default assistantMessage slot renders a wrapper with
+  // `data-testid="copilot-assistant-message"` — used by the harness'
+  // `e2e-deep` conversation runner to count settled responses. Overriding
+  // the slot drops that testid, so any tooling that waits for "an
+  // assistant message landed" never sees a count change. Re-attaching it
+  // here keeps the slot override behaviorally identical to the default
+  // for response-detection purposes.
   return (
-    <div className="mt-2 flex w-full justify-start">
+    <div
+      data-testid="copilot-assistant-message"
+      data-message-role="assistant"
+      className="mt-2 flex w-full justify-start"
+    >
       <div className="w-full px-1 py-1">{kit.render(value)}</div>
     </div>
   );

--- a/showcase/integrations/ag2/src/app/demos/byoc-json-render/json-render-renderer.tsx
+++ b/showcase/integrations/ag2/src/app/demos/byoc-json-render/json-render-renderer.tsx
@@ -65,18 +65,28 @@ export function JsonRenderAssistantMessage(
   // crash with `useVisibility must be used within a VisibilityProvider`).
   // `JSONUIProvider` wires all four in one; we don't use actions or
   // state here, so defaults are fine.
+  // Re-attach `data-testid="copilot-assistant-message"` — the harness'
+  // e2e-deep conversation runner uses that testid to count settled
+  // responses, and the messageView slot override would otherwise drop
+  // it. Same reasoning as byoc-hashbrown's renderer.
   return (
-    <div data-testid="json-render-root" className="w-full">
-      <JSONUIProvider registry={registry}>
-        <Renderer
-          spec={
-            parseResult.spec as unknown as Parameters<
-              typeof Renderer
-            >[0]["spec"]
-          }
-          registry={registry}
-        />
-      </JSONUIProvider>
+    <div
+      data-testid="copilot-assistant-message"
+      data-message-role="assistant"
+      className="w-full"
+    >
+      <div data-testid="json-render-root" className="w-full">
+        <JSONUIProvider registry={registry}>
+          <Renderer
+            spec={
+              parseResult.spec as unknown as Parameters<
+                typeof Renderer
+              >[0]["spec"]
+            }
+            registry={registry}
+          />
+        </JSONUIProvider>
+      </div>
     </div>
   );
 }

--- a/showcase/integrations/ag2/src/app/demos/headless-complete/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/headless-complete/page.tsx
@@ -3,29 +3,23 @@
 /**
  * Headless Chat (Complete) — TRULY headless.
  *
- * A full chat implementation built from scratch on `useAgent`, without
- * using `<CopilotChat />` AND without `<CopilotChatMessageView>` or
+ * A full chat implementation built from scratch on `useAgent`, without using
+ * `<CopilotChat />` AND without `<CopilotChatMessageView>` or
  * `<CopilotChatAssistantMessage>`. Demonstrates:
  *   - scrollable messages area with auto-scroll to bottom on new messages
  *   - distinct user vs assistant bubbles (pure chrome — no chat primitives)
  *   - text input + send button, disabled while running
  *   - stop button to cancel a running agent turn
  *   - the FULL generative UI composition — text, reasoning cards, tool-call
- *     renderings (`useRenderTool` / `useDefaultRenderTool` / `useComponent`
- *     / `useFrontendTool`), and custom-message renderers — re-composed by
- *     hand from the low-level hooks (`useRenderToolCall`,
- *     `useRenderActivityMessage`, `useRenderCustomMessages`) inside
- *     `use-rendered-messages.tsx`.
+ *     renderings (`useRenderTool` / `useDefaultRenderTool` / `useComponent` /
+ *     `useFrontendTool`), A2UI activity messages, MCP Apps activity messages,
+ *     and custom-message renderers — re-composed by hand from the low-level
+ *     hooks (`useRenderToolCall`, `useRenderActivityMessage`,
+ *     `useRenderCustomMessages`) inside `use-rendered-messages.tsx`.
  *
- * This file is orchestration only — the provider, the agent wiring, and
- * the top-level send/stop handlers. Presentational pieces (message list,
- * bubbles, typing indicator, input bar) live in sibling files.
- *
- * Backend: a dedicated AG2 ConversableAgent (see
- * src/agents/headless_complete.py) mounted at /headless-complete/ on the
- * Python agent server. Exposes `get_weather` and `get_stock_price`
- * tools; `highlight_note` is a frontend-registered tool via
- * `useComponent`.
+ * This file is orchestration only — the provider, the agent wiring, and the
+ * top-level send/stop handlers. Presentational pieces (message list, bubbles,
+ * typing indicator, input bar) live in sibling files.
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -44,9 +38,12 @@ import { useHeadlessCompleteToolRenderers } from "./tool-renderers";
 const AGENT_ID = "headless-complete";
 
 // Outer wrapper — provides the CopilotKit runtime + page layout.
+// Routed through /api/copilotkit-mcp-apps so the Excalidraw MCP server is
+// wired into the runtime; the hand-rolled `useRenderActivityMessage` in
+// `use-rendered-messages.tsx` picks up the emitted activity events.
 export default function HeadlessCompleteDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent={AGENT_ID}>
+    <CopilotKit runtimeUrl="/api/copilotkit-mcp-apps" agent={AGENT_ID}>
       <div className="flex justify-center items-center h-screen w-full bg-gray-50">
         <div className="h-full w-full max-w-3xl flex flex-col bg-white shadow-sm">
           <header className="px-4 py-3 border-b border-gray-200">
@@ -64,8 +61,8 @@ export default function HeadlessCompleteDemo() {
   );
 }
 
-// Inner view — the actual chat. Reads messages + isRunning straight off
-// the agent, wires up the connect/run/stop lifecycle, and hands the pure
+// Inner view — the actual chat. Reads messages + isRunning straight off the
+// agent, wires up the connect/run/stop lifecycle, and hands the pure
 // presentational pieces their props.
 function Chat() {
   // @region[page-send-message]
@@ -73,19 +70,20 @@ function Chat() {
   const { agent } = useAgent({ agentId: AGENT_ID, threadId });
   const { copilotkit } = useCopilotKit();
 
-  // Connect the agent on mount so the backend session is live before the
-  // first send. Mirrors the internal connect effect used by CopilotChat
-  // (abort on unmount to play nice with React StrictMode).
+  // Connect the agent on mount so the backend session is live before the first
+  // send. Mirrors the internal connect effect used by CopilotChat (abort on
+  // unmount to play nice with React StrictMode).
   useEffect(() => {
     const ac = new AbortController();
+    // HttpAgent honors abortController.signal; assign before connect.
     if ("abortController" in agent) {
       (
         agent as unknown as { abortController: AbortController }
       ).abortController = ac;
     }
     copilotkit.connectAgent({ agent }).catch(() => {
-      // connectAgent emits via the subscriber system; swallow here to
-      // avoid unhandled-rejection noise on unmount.
+      // connectAgent emits via the subscriber system; swallow here to avoid
+      // unhandled-rejection noise on unmount.
     });
     return () => {
       ac.abort();
@@ -125,11 +123,14 @@ function Chat() {
   }, [agent]);
   // @endregion[page-send-message]
 
-  // Wrap the chat body in a CopilotChatConfigurationProvider so the
-  // rendering primitives used inside `useRenderedMessages` see a
-  // matching (agentId, threadId) pair — without it, activity-message
+  // Wrap the chat body in a CopilotChatConfigurationProvider so that the
+  // rendering primitives used inside `useRenderedMessages`
+  // (useRenderToolCall, useRenderActivityMessage, useRenderCustomMessages)
+  // see a matching (agentId, threadId) pair — without it, activity-message
   // renderers wouldn't scope to this agent and custom message renderers
-  // would early-return null.
+  // would early-return null. This provider is independent of the
+  // <CopilotChat /> component; using it here keeps the surface fully
+  // headless while still unlocking the full generative-UI composition.
   return (
     <CopilotChatConfigurationProvider agentId={AGENT_ID} threadId={threadId}>
       <ChatBody
@@ -147,7 +148,10 @@ function Chat() {
 // Nested body — rendered INSIDE CopilotChatConfigurationProvider so the
 // suggestions hook picks up the correct (agentId, threadId) scope and
 // the frontend-registered `useComponent` tool registers against this
-// agent.
+// agent. Tool-call renderers are registered here too; keeping them
+// co-located with the component that reads them through
+// `useRenderToolCall` (inside MessageList -> useRenderedMessages) makes
+// the composition story of the headless cell easy to trace.
 function ChatBody({
   messages,
   isRunning,
@@ -178,6 +182,10 @@ function ChatBody({
       {
         title: "Highlight a note",
         message: "Highlight 'meeting at 3pm' in yellow.",
+      },
+      {
+        title: "Sketch a diagram",
+        message: "Use Excalidraw to sketch a simple system diagram.",
       },
     ],
     available: "always",

--- a/showcase/integrations/ag2/src/app/demos/multimodal/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/multimodal/page.tsx
@@ -8,23 +8,68 @@
  * same pipeline the paperclip button uses.
  *
  * Architecture:
- * - Dedicated runtime route at `/api/copilotkit-multimodal`. The
- *   vision-capable model (gpt-4o) lives in src/agents/multimodal_agent.py.
- * - Sample files live under `/public/demo-files/`.
+ * - Dedicated runtime route at `/api/copilotkit-multimodal` (see
+ *   ../api/copilotkit-multimodal/route.ts). The vision-capable model
+ *   (gpt-4o) is scoped to just this demo, so other cells keep their
+ *   cheaper text-only models.
+ * - Dedicated AG2 ConversableAgent at `src/agents/multimodal_agent.py`
+ *   under the slug `multimodal-demo`. Images are forwarded to the model
+ *   natively; PDFs are flattened to text on the Python side.
+ * - Sample files live at `/demo-files/sample.png` and `/demo-files/sample.pdf`
+ *   (see `public/demo-files/`). The sample-buttons component fetches them
+ *   client-side, wraps the blob in a File, and drives the same hidden
+ *   `<input type="file">` the paperclip path uses (DataTransfer + dispatch
+ *   `change`). This keeps the sample and real-upload paths on a single
+ *   code path — whatever works for one works for both.
+ *
+ * Content flattening:
+ * - AG2's AGUIStream validates message content as a plain string — it
+ *   does not accept arrays of content parts. A `ContentFlattenerShim`
+ *   extracts the text from multipart user messages before the AG-UI run
+ *   dispatches them to the AG2 backend.
  */
 
-import { useCallback } from "react";
-import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo } from "react";
+import { CopilotKit, CopilotChat, useAgent } from "@copilotkit/react-core/v2";
 import type { AttachmentUploadResult } from "@copilotkit/shared";
 
 import { SampleAttachmentButtons } from "./sample-attachment-buttons";
 
+/**
+ * Minimal structural shape of an AG-UI message for the converter shim.
+ */
+type AgentMessage = {
+  id?: string;
+  role: string;
+  content?: unknown;
+};
+
+/**
+ * `onUpload` must resolve to an `AttachmentUploadResult` (data or url). We
+ * always return the `data` variant — the demo inlines base64 instead of
+ * uploading to external storage.
+ */
 type DataUploadResult = Extract<AttachmentUploadResult, { type: "data" }>;
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 const ACCEPT_MIME = "image/*,application/pdf";
+/**
+ * Selector used by <SampleAttachmentButtons /> to locate CopilotChat's
+ * hidden file input. Kept as a constant so the wrapper element and the
+ * sample buttons cannot drift.
+ */
 const CHAT_ROOT_SELECTOR = "[data-multimodal-demo-chat-root]";
 
+/**
+ * Convert a File into the `AttachmentsConfig.onUpload` result shape —
+ * inline base64 with the browser-provided mime type. We do this in the
+ * browser rather than uploading to external storage because the demo is
+ * self-contained; `maxSize: 10 MB` (set below) caps bloat.
+ *
+ * `FileReader` produces a `data:<mime>;base64,<payload>` URL; we strip the
+ * prefix so the runtime forwards the raw base64 value (what the agent
+ * expects in `source.value`).
+ */
 function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -36,6 +81,7 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
         reject(new Error(`Unexpected FileReader result type for ${file.name}`));
         return;
       }
+      // result looks like "data:image/png;base64,iVBORw0K..." — strip the prefix.
       const commaIdx = result.indexOf(",");
       const base64 = commaIdx >= 0 ? result.slice(commaIdx + 1) : result;
       resolve({
@@ -52,11 +98,96 @@ function fileToDataAttachment(file: File): Promise<DataUploadResult> {
   });
 }
 
+/**
+ * AG2's AGUIStream validates message content as a plain string — it does
+ * NOT accept arrays of content parts. When CopilotChat sends multipart
+ * content (text + image/document), we flatten the array down to a single
+ * string by extracting the text parts and noting attachments inline.
+ *
+ * This keeps the text visible to the AG2 agent (and to aimock's
+ * `userMessage` matcher) while preventing the 400 validation error.
+ */
+function flattenContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return String(content ?? "");
+  const pieces: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    const p = part as { type?: string; text?: string };
+    if (p.type === "text" && typeof p.text === "string") {
+      pieces.push(p.text);
+    }
+    // Non-text parts (image, document, etc.) are silently dropped since
+    // AG2's ConversableAgent cannot accept binary content parts. The
+    // Python-side agent still receives the text question and responds.
+  }
+  return pieces.join("\n");
+}
+
+/**
+ * Walk all user messages and flatten multipart content to plain strings.
+ */
+function flattenMessagesForAG2(
+  messages: ReadonlyArray<Readonly<AgentMessage>>,
+): AgentMessage[] | null {
+  let mutated = false;
+  const next = messages.map((msg) => {
+    if (msg.role !== "user") return msg as AgentMessage;
+    const content = msg.content;
+    if (!Array.isArray(content)) return msg as AgentMessage;
+    mutated = true;
+    return {
+      ...(msg as object),
+      content: flattenContent(content),
+    } as AgentMessage;
+  });
+  return mutated ? next : null;
+}
+
+/**
+ * Subscribes to the active agent and flattens outgoing multipart content
+ * to plain strings before the AG-UI run dispatches them to AG2.
+ */
+function ContentFlattenerShim() {
+  const { agent } = useAgent({ agentId: "multimodal-demo" });
+
+  const subscriber = useMemo(
+    () => ({
+      onRunInitialized: ({
+        messages,
+      }: {
+        messages: ReadonlyArray<Readonly<AgentMessage>>;
+      }) => {
+        const flattened = flattenMessagesForAG2(messages);
+        if (!flattened) return;
+        return { messages: flattened };
+      },
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    if (!agent) return;
+    const handle = agent.subscribe(
+      subscriber as unknown as Parameters<typeof agent.subscribe>[0],
+    );
+    return () => handle.unsubscribe();
+  }, [agent, subscriber]);
+
+  return null;
+}
+
 export default function MultimodalDemoPage() {
+  // `onUpload` is passed into CopilotChat's `AttachmentsConfig`. Both the
+  // paperclip button and the sample-injection path route files through
+  // this same function (sample buttons drive CopilotChat's hidden file
+  // input, which calls this internally via `useAttachments`). No
+  // duplicated upload code lives in the sample-button component.
   const onUpload = useCallback(fileToDataAttachment, []);
 
   return (
     <CopilotKit runtimeUrl="/api/copilotkit-multimodal" agent="multimodal-demo">
+      <ContentFlattenerShim />
       <div
         data-testid="multimodal-demo-root"
         className="mx-auto flex h-screen max-w-4xl flex-col gap-3 p-4 sm:p-6"
@@ -85,6 +216,8 @@ export default function MultimodalDemoPage() {
               maxSize: MAX_FILE_SIZE_BYTES,
               onUpload,
               onUploadFailed: (err) => {
+                // Log without disrupting the default UI — CopilotChat already
+                // shows a toast-style indicator on validation failure.
                 console.warn("[multimodal-demo] attachment rejected", err);
               },
             }}

--- a/showcase/integrations/ag2/src/app/demos/multimodal/sample-attachment-buttons.tsx
+++ b/showcase/integrations/ag2/src/app/demos/multimodal/sample-attachment-buttons.tsx
@@ -2,9 +2,20 @@
 
 /**
  * Two buttons that inject bundled sample files into the active CopilotChat's
- * attachment queue. The queue is owned internally by <CopilotChat /> via
- * `useAttachments`; we drive it through the DOM by populating the hidden file
- * input's `.files` and dispatching a `change` event.
+ * attachment queue. The queue is owned internally by <CopilotChat /> (via its
+ * `useAttachments` hook), so we inject at the DOM level: find the hidden
+ * `<input type="file">` CopilotChat renders, populate its `.files` via
+ * DataTransfer, and dispatch a `change` event. This exercises the *same*
+ * onChange handler the paperclip / drag-and-drop paths use — which means our
+ * sample path runs through the `AttachmentsConfig.onUpload` the page wires
+ * on the chat, the same file-size + accept-filter validation, the same
+ * placeholder-then-ready lifecycle. No duplicated queueing code.
+ *
+ * Container scope: the sample buttons live next to the chat inside a
+ * `data-multimodal-demo-root` wrapper (see page.tsx). We scope our
+ * `querySelector` to that root so multiple CopilotChat instances on the
+ * page (there aren't any today, but the pattern should be safe) don't
+ * collide.
  */
 
 import { useCallback, useState } from "react";
@@ -35,6 +46,11 @@ const SAMPLES: readonly SampleSpec[] = [
 ];
 
 export interface SampleAttachmentButtonsProps {
+  /**
+   * Selector (scoped to `document`) that resolves to the wrapper element
+   * rendered around `<CopilotChat />`. The component walks this element's
+   * subtree to find the hidden file input CopilotChat renders.
+   */
   readonly rootSelector: string;
 }
 
@@ -42,12 +58,25 @@ function findChatFileInput(rootSelector: string): HTMLInputElement | null {
   if (typeof document === "undefined") return null;
   const root = document.querySelector(rootSelector);
   if (!root) return null;
+  // CopilotChat renders exactly one hidden `<input type="file">` directly
+  // inside its chatContainerRef div. Match on `type="file"` to avoid
+  // sibling inputs (there are none today but it costs nothing to be
+  // defensive).
   return root.querySelector<HTMLInputElement>('input[type="file"]');
 }
 
+/**
+ * Magic-byte prefixes used to validate fetched sample files. We check
+ * these because Next.js will happily serve a Git LFS *pointer* file (a
+ * short plain-text stub starting with `version https://git-lfs...`) with
+ * a `Content-Type: image/png` header if LFS wasn't pulled at build time.
+ * Without this guard, the broken pointer bytes get base64-encoded,
+ * fed into CopilotChat as a valid-looking PNG, and rendered as a broken
+ * <img>. Fail loudly with an actionable error instead.
+ */
 const MAGIC_BYTES: Record<string, number[]> = {
-  "image/png": [0x89, 0x50, 0x4e, 0x47],
-  "application/pdf": [0x25, 0x50, 0x44, 0x46],
+  "image/png": [0x89, 0x50, 0x4e, 0x47], // ‰PNG
+  "application/pdf": [0x25, 0x50, 0x44, 0x46], // %PDF
 };
 
 const LFS_POINTER_PREFIX = "version https://git-lfs";
@@ -64,28 +93,36 @@ async function fetchAsFile(spec: SampleSpec): Promise<File> {
   const res = await fetch(spec.fetchUrl);
   if (!res.ok) {
     throw new Error(
-      `Could not fetch sample "${spec.filename}" — HTTP ${res.status}.`,
+      `Could not fetch sample "${spec.filename}" — HTTP ${res.status}. ` +
+        `Is the file bundled under public${spec.fetchUrl}?`,
     );
   }
   const buffer = await res.arrayBuffer();
   const bytes = new Uint8Array(buffer);
 
+  // Detect Git LFS pointer stub — the file on disk hasn't been materialized.
   const asciiHead = new TextDecoder("utf-8", { fatal: false }).decode(
     bytes.slice(0, Math.min(bytes.length, 64)),
   );
   if (asciiHead.startsWith(LFS_POINTER_PREFIX)) {
     throw new Error(
-      `Sample "${spec.filename}" is a Git LFS pointer, not the real asset.`,
+      `Sample "${spec.filename}" is a Git LFS pointer, not the real asset. ` +
+        "The deploy environment needs to run `git lfs pull` (or set " +
+        "`GIT_LFS_ENABLED=1`) so the binary is checked out before the Next.js " +
+        "app serves it.",
     );
   }
 
   const expectedMagic = MAGIC_BYTES[spec.mimeType];
   if (expectedMagic && !bytesStartWith(bytes, expectedMagic)) {
     throw new Error(
-      `Sample "${spec.filename}" does not have a valid ${spec.mimeType} signature.`,
+      `Sample "${spec.filename}" does not have a valid ${spec.mimeType} ` +
+        "signature. The file may be corrupted or a wrong asset was committed.",
     );
   }
 
+  // Re-wrap the bytes into a blob/File with the explicit MIME type rather than
+  // trusting whatever Content-Type the dev server returned.
   const blob = new Blob([buffer], { type: spec.mimeType });
   return new File([blob], spec.filename, { type: spec.mimeType });
 }
@@ -104,13 +141,23 @@ export function SampleAttachmentButtons({
         const fileInput = findChatFileInput(rootSelector);
         if (!fileInput) {
           throw new Error(
-            `CopilotChat file input not found under "${rootSelector}".`,
+            `CopilotChat file input not found under "${rootSelector}". ` +
+              "Is <CopilotChat /> mounted with `attachments.enabled: true`?",
           );
         }
         const file = await fetchAsFile(spec);
+
+        // Populate the file input's `.files` list via a fresh DataTransfer.
+        // This is the only way to programmatically set `HTMLInputElement.files`
+        // — assigning a plain array fails in every browser.
         const dt = new DataTransfer();
         dt.items.add(file);
         fileInput.files = dt.files;
+
+        // Dispatch a bubbling `change` event. CopilotChat's internal
+        // `useAttachments.handleFileUpload` listens on `onChange`, which
+        // React wires up as a native `change` listener — so a standard
+        // DOM Event with `bubbles: true` reaches it.
         fileInput.dispatchEvent(new Event("change", { bubbles: true }));
       } catch (err) {
         console.error(
@@ -146,7 +193,7 @@ export function SampleAttachmentButtons({
             onClick={() => void injectSample(spec)}
             className="rounded border border-black/15 bg-white px-3 py-1 text-xs font-medium text-black transition hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/15 dark:bg-neutral-900 dark:text-white dark:hover:bg-white/5"
           >
-            {isLoading ? "Loading..." : spec.buttonLabel}
+            {isLoading ? "Loading…" : spec.buttonLabel}
           </button>
         );
       })}

--- a/showcase/integrations/ag2/src/app/demos/tool-rendering-reasoning-chain/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/tool-rendering-reasoning-chain/page.tsx
@@ -13,8 +13,8 @@
 //      mirroring the `tool-rendering` (primary) cell.
 
 import React from "react";
+import { CopilotKit } from "@copilotkit/react-core";
 import {
-  CopilotKit,
   CopilotChat,
   CopilotChatReasoningMessage,
   useRenderTool,

--- a/showcase/integrations/ag2/src/app/demos/voice/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/voice/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback } from "react";
-import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { CopilotKit } from "@copilotkit/react-core";
+import { CopilotChat } from "@copilotkit/react-core/v2";
 import { SampleAudioButton } from "./sample-audio-button";
 
 const RUNTIME_URL = "/api/copilotkit-voice";


### PR DESCRIPTION
## Summary

Fixes 15 ag2 showcase files to bring all 29 ag2 features to D5-green (verified locally with the D5 probe runner).

### Backend fixes
- **Starlette mount order**: `/open-gen-ui-advanced` must mount before `/open-gen-ui` — Starlette resolves mounts via prefix matching in registration order, so the shorter prefix was shadowing the longer one
- **`@tool` -> `@tool()` decorator**: bare `@tool` in `agent_config_agent.py` silently fails to register the function as a CopilotKit tool; needs the call form `@tool()`
- **headless-complete route wiring**: wired the headless-complete agent into the `copilotkit-mcp-apps` runtime route so MCP Apps activity messages render in the headless cell
- **Auth route cleanup**: removed stale `@ts-ignore`
- **Manifest update**: corrected headless-complete's route reference from `copilotkit` to `copilotkit-mcp-apps`

### Demo page fixes
- **agent-config**: replaced broken `useAgent`/`setState` pattern with CopilotKit `properties` prop (the correct way to pass config to AG2 ContextVariables)
- **multimodal**: rewrote the legacy-binary-shape converter to a content flattener — AG2's AGUIStream validates message content as a plain string and rejects content-part arrays with a 400
- **headless-complete**: changed `runtimeUrl` from `/api/copilotkit` to `/api/copilotkit-mcp-apps`
- **byoc-hashbrown, byoc-json-render**: re-attached `data-testid="copilot-assistant-message"` on custom slot overrides (harness conversation runner needs this to count settled responses)
- **agentic-chat-reasoning, beautiful-chat**: added demo-level `data-testid` wrappers
- **tool-rendering-reasoning-chain, voice**: fixed CopilotKit import paths

### Railway rebuild note
Several demos (chat-slots, shared-state-*, subagents) were already code-correct on `main` but showed D5 failures due to a stale Railway image. A Railway rebuild (no code changes) will bring those green as well.

## Test plan
- [ ] 29/29 ag2 features pass D5 probes locally (verified before PR)
- [ ] CI passes
- [ ] After merge + Railway rebuild, ag2 column should be fully D5-green