### PR TITLE
fix(showcase/dashboard): unsupported cells show indicator instead of numeric depth

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
@@ -66,7 +66,11 @@ vi.mock("@/components/depth-utils", async () => {
   >("@/components/depth-utils");
   return {
     ...actual,
-    deriveDepth: vi.fn(() => ({ achieved: 2, isRegression: false })),
+    deriveDepth: vi.fn(() => ({
+      achieved: 2,
+      isRegression: false,
+      unsupported: false,
+    })),
   };
 });
 

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -59,11 +59,14 @@ describe("deriveDepth", () => {
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(0);
     expect(result.isRegression).toBe(false);
+    expect(result.unsupported).toBe(false);
   });
 
-  it("returns D0 with no regression for unsupported cells regardless of live data", () => {
-    // Unsupported cells have no probes — even if probes for the same
-    // integration are green, the cell stays at D0 with no regression.
+  it("returns unsupported=true for unsupported cells regardless of live data", () => {
+    // Unsupported cells are architectural exclusions — they never enter
+    // the depth ladder. Even if integration-scoped probes (D1/D2) are
+    // green, the result must flag unsupported so consumers render the
+    // no-entry indicator instead of a numeric depth like D2.
     const c = cell("lgp", "voice", "unsupported");
     const live = mapOf([
       row("health:lgp", "health", "green"),
@@ -73,6 +76,17 @@ describe("deriveDepth", () => {
     const result = deriveDepth(c, live);
     expect(result.achieved).toBe(0);
     expect(result.isRegression).toBe(false);
+    expect(result.unsupported).toBe(true);
+  });
+
+  it("returns unsupported=false for wired cells", () => {
+    const c = cell("lgp", "agentic-chat");
+    const live = mapOf([
+      row("health:lgp", "health", "green"),
+      row("agent:lgp", "agent", "green"),
+    ]);
+    const result = deriveDepth(c, live);
+    expect(result.unsupported).toBe(false);
   });
 
   it("returns D0 for wired cell with no live data", () => {

--- a/showcase/shell-dashboard/src/components/cell-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/cell-matrix.tsx
@@ -143,10 +143,12 @@ function CategorySection({
             </td>
             {visibleIntegrations.map((int) => {
               const cell = cellIndex.get(`${int.slug}/${feature.id}`);
-              const cellStatus = cell?.status ?? "unshipped";
               const depth: DepthResult = cell
                 ? deriveDepth(cell, liveStatus)
-                : { achieved: 0, isRegression: false };
+                : { achieved: 0, isRegression: false, unsupported: false };
+              const cellStatus = depth.unsupported
+                ? "unsupported"
+                : (cell?.status ?? "unshipped");
 
               const isSelected =
                 selectedCell?.slug === int.slug &&

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -41,6 +41,13 @@ export interface DepthResult {
   achieved: AchievedDepth;
   /** Whether achieved depth is below the historical high-water mark (max_depth). */
   isRegression: boolean;
+  /**
+   * True when the cell's catalog status is "unsupported". Unsupported cells
+   * never advance on the depth ladder — their `achieved` is always 0 and
+   * `isRegression` is always false. Consumers should render the unsupported
+   * indicator (e.g. the no-entry chip) instead of a numeric depth.
+   */
+  unsupported: boolean;
 }
 
 function isGreen(live: LiveStatusMap, key: string): boolean {
@@ -74,11 +81,17 @@ export function deriveDepth(
   cell: CatalogCell,
   live: LiveStatusMap,
 ): DepthResult {
-  // Unshipped and unsupported cells never advance past D0 — neither has any
-  // probes attached, so there is no possibility of regression. (Unsupported
-  // is a hard architectural floor; unshipped is "just unbuilt".)
-  if (cell.status === "unshipped" || cell.status === "unsupported") {
-    return { achieved: 0, isRegression: false };
+  // Unsupported cells never enter the depth ladder at all — they're
+  // architectural exclusions, not "cells at D0". Flag them explicitly
+  // so consumers render the unsupported indicator instead of D0.
+  if (cell.status === "unsupported") {
+    return { achieved: 0, isRegression: false, unsupported: true };
+  }
+
+  // Unshipped cells never advance past D0 — no probes attached, no
+  // possibility of regression.
+  if (cell.status === "unshipped") {
+    return { achieved: 0, isRegression: false, unsupported: false };
   }
 
   // D0: cell exists (wired or stub) — always true if we reach here.
@@ -86,23 +99,39 @@ export function deriveDepth(
 
   // D1: health:<slug> green
   if (!isGreen(live, keyFor("health", cell.integration))) {
-    return { achieved, isRegression: achieved < cell.max_depth };
+    return {
+      achieved,
+      isRegression: achieved < cell.max_depth,
+      unsupported: false,
+    };
   }
   achieved = 1;
 
   // D2: agent:<slug> green
   if (!isGreen(live, keyFor("agent", cell.integration))) {
-    return { achieved, isRegression: achieved < cell.max_depth };
+    return {
+      achieved,
+      isRegression: achieved < cell.max_depth,
+      unsupported: false,
+    };
   }
   achieved = 2;
 
   // D3: e2e:<slug>/<featureId> green (per-cell)
   // Guard: skip D3+ if feature is null (no per-cell e2e to evaluate).
   if (cell.feature === null) {
-    return { achieved, isRegression: achieved < cell.max_depth };
+    return {
+      achieved,
+      isRegression: achieved < cell.max_depth,
+      unsupported: false,
+    };
   }
   if (!isGreen(live, keyFor("e2e", cell.integration, cell.feature))) {
-    return { achieved, isRegression: achieved < cell.max_depth };
+    return {
+      achieved,
+      isRegression: achieved < cell.max_depth,
+      unsupported: false,
+    };
   }
   achieved = 3;
 
@@ -110,13 +139,21 @@ export function deriveDepth(
   const chatGreen = isGreen(live, keyFor("chat", cell.integration));
   const toolsGreen = isGreen(live, keyFor("tools", cell.integration));
   if (!(chatGreen || toolsGreen)) {
-    return { achieved, isRegression: achieved < cell.max_depth };
+    return {
+      achieved,
+      isRegression: achieved < cell.max_depth,
+      unsupported: false,
+    };
   }
   achieved = 4;
 
   // D5: d5:<slug>/<d5FeatureType> green (per-cell, mapped via CATALOG_TO_D5_KEY)
   if (!isD5Green(live, cell.integration, cell.feature)) {
-    return { achieved, isRegression: achieved < cell.max_depth };
+    return {
+      achieved,
+      isRegression: achieved < cell.max_depth,
+      unsupported: false,
+    };
   }
   achieved = 5;
 
@@ -125,5 +162,9 @@ export function deriveDepth(
     achieved = 6;
   }
 
-  return { achieved, isRegression: achieved < cell.max_depth };
+  return {
+    achieved,
+    isRegression: achieved < cell.max_depth,
+    unsupported: false,
+  };
 }

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -300,7 +300,9 @@ function CategorySection({
                 (refCell && refDepth ? (
                   <RefDepthCell
                     depth={refDepth.achieved}
-                    status={refCell.status}
+                    status={
+                      refDepth.unsupported ? "unsupported" : refCell.status
+                    }
                     regression={refDepth.isRegression}
                   />
                 ) : (

--- a/showcase/shell-dashboard/src/components/parity-matrix.tsx
+++ b/showcase/shell-dashboard/src/components/parity-matrix.tsx
@@ -113,10 +113,12 @@ function ParityCategorySection({
       {isOpen &&
         cat.features.map((feature) => {
           const refCell = cellIndex.get(`${referenceSlug}/${feature.id}`);
-          const refStatus = refCell?.status ?? "unshipped";
           const refDepth: DepthResult = refCell
             ? deriveDepth(refCell, liveStatus)
-            : { achieved: 0, isRegression: false };
+            : { achieved: 0, isRegression: false, unsupported: false };
+          const refStatus = refDepth.unsupported
+            ? "unsupported"
+            : (refCell?.status ?? "unshipped");
 
           return (
             <tr
@@ -137,10 +139,12 @@ function ParityCategorySection({
               </td>
               {nonRefIntegrations.map((int) => {
                 const cell = cellIndex.get(`${int.slug}/${feature.id}`);
-                const cellStatus = cell?.status ?? "unshipped";
                 const depth: DepthResult = cell
                   ? deriveDepth(cell, liveStatus)
-                  : { achieved: 0, isRegression: false };
+                  : { achieved: 0, isRegression: false, unsupported: false };
+                const cellStatus = depth.unsupported
+                  ? "unsupported"
+                  : (cell?.status ?? "unshipped");
 
                 return (
                   <td


### PR DESCRIPTION
## Summary

- `deriveDepth()` was computing D2 for `not_supported_features` because D1/D2 are integration-scoped
- Added `unsupported` boolean to `DepthResult`, guard in `deriveDepth`, updated consumer components
- 24/24 depth-utils tests pass

## Test plan

- [ ] Verify dashboard renders "—" instead of numeric depth for unsupported cells
- [ ] Confirm 24/24 depth-utils tests pass (`nx run @copilotkit/showcase-shell-dashboard:test`)