### PR TITLE
feat(showcase/dashboard): add docs-only feature kind

### DIFF
--- a/showcase/shared/feature-registry.json
+++ b/showcase/shared/feature-registry.json
@@ -61,7 +61,7 @@
       "name": "CLI Start Command",
       "category": "dev-ex",
       "description": "One-liner to scaffold a new CopilotKit app via the official CLI",
-      "kind": "primary",
+      "kind": "docs-only",
       "og_docs_url": "https://docs.copilotkit.ai/quickstart",
       "shell_docs_path": "/quickstart"
     },

--- a/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/composed-cell.test.tsx
@@ -330,4 +330,57 @@ describe("ComposedCell", () => {
     const composedCell = getByTestId("composed-cell");
     expect(composedCell.className).not.toContain("opacity-60");
   });
+
+  describe("docs-only kind", () => {
+    function docsOnlyCtx(overrides?: Partial<CellContext>): CellContext {
+      return makeCtx({
+        feature: {
+          id: "cli-start",
+          name: "CLI Start",
+          category: "dev-ex",
+          description: "CLI scaffold command",
+          kind: "docs-only",
+        },
+        ...overrides,
+      });
+    }
+
+    it("renders only docs layer even when all overlays active", () => {
+      const ctx = docsOnlyCtx();
+      const { getByTestId, queryByText, queryByTestId } = render(
+        <ComposedCell
+          ctx={ctx}
+          overlays={overlaySet("links", "depth", "health", "docs")}
+          catalogCell={makeCatalogCell()}
+        />,
+      );
+
+      // Only docs layer present
+      expect(getByTestId("docs-layer")).toBeInTheDocument();
+      // No other layers
+      expect(queryByText("Demo")).not.toBeInTheDocument();
+      expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
+      expect(queryByTestId("health-layer")).not.toBeInTheDocument();
+    });
+
+    it("renders empty when docs overlay is not active", () => {
+      const ctx = docsOnlyCtx();
+      const { getByTestId, queryByTestId } = render(
+        <ComposedCell ctx={ctx} overlays={overlaySet("links", "health")} />,
+      );
+
+      expect(getByTestId("composed-cell-empty")).toBeInTheDocument();
+      expect(queryByTestId("composed-cell")).not.toBeInTheDocument();
+    });
+
+    it("applies opacity-60 for docs-only features", () => {
+      const ctx = docsOnlyCtx();
+      const { getByTestId } = render(
+        <ComposedCell ctx={ctx} overlays={overlaySet("docs")} />,
+      );
+
+      const composedCell = getByTestId("composed-cell");
+      expect(composedCell.className).toContain("opacity-60");
+    });
+  });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -5,6 +5,7 @@
  *   - CP5: missing-state tooltip distinguishes opt-out vs absent
  *   - CP7: error-state docs link is clickable when href is present
  *   - CP8: CV badges hidden for testing-kind features
+ *   - docs-only kind hides ALL badges (API, RT, CV)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor } from "@testing-library/react";
@@ -294,5 +295,18 @@ describe("CP8: CV badges hidden for testing-kind features", () => {
     const text = container.textContent ?? "";
     expect(text).toContain("API");
     expect(text).toContain("CV");
+  });
+});
+
+describe("docs-only kind hides ALL badges", () => {
+  it("returns null (renders nothing) when feature.kind === 'docs-only'", () => {
+    const ctx = makeCtx({
+      feature: makeFeature({ kind: "docs-only" }),
+    });
+    const { container } = render(<CellStatus ctx={ctx} />);
+    const text = container.textContent ?? "";
+    expect(text).not.toContain("API");
+    expect(text).not.toContain("RT");
+    expect(text).not.toContain("CV");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -2,9 +2,11 @@
 // Shared cell-level helpers: docs links row, status (badges) row.
 import { useState } from "react";
 import type { CellContext } from "@/components/feature-grid";
-import { getDocsStatus, type DocState } from "@/lib/docs-status";
+import { getDocsStatus } from '@/lib/docs-status';
+import type { DocState } from '@/lib/docs-status';
 import { Badge, FlashOnChange } from "@/components/badges";
-import { keyFor, resolveCell, type BadgeRender } from "@/lib/live-status";
+import { keyFor, resolveCell } from '@/lib/live-status';
+import type { BadgeRender } from '@/lib/live-status';
 import type { Feature, Integration } from "@/lib/registry";
 import { useLastTransition, deriveFromTo } from "@/hooks/useLastTransition";
 import { formatTs } from "@/lib/format-ts";
@@ -282,6 +284,13 @@ function formatTransitionLine(row: {
  */
 export function CellStatus({ ctx }: { ctx: CellContext }) {
   const isTesting = ctx.feature.kind === "testing";
+  const isDocsOnly = ctx.feature.kind === "docs-only";
+
+  // docs-only features have no runnable probes — rendering badge chips
+  // would show perpetual gray "?" for every dimension. Return null so the
+  // cell stays clean; the docs row is rendered separately by DocsLayer.
+  if (isDocsOnly) return null;
+
   const cell = resolveCell(
     ctx.liveStatus,
     ctx.integration.slug,

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -166,10 +166,27 @@ function DocsLayer({ ctx }: { ctx: CellContext }) {
  */
 function ComposedCellInner({ ctx, overlays, catalogCell }: ComposedCellProps) {
   const isTesting = ctx.feature.kind === "testing";
+  const isDocsOnly = ctx.feature.kind === "docs-only";
   const hasLinks = overlays.has("links");
   const hasDepth = overlays.has("depth");
   const hasHealth = overlays.has("health");
   const hasDocs = overlays.has("docs");
+
+  // docs-only features show only the docs row — no links, depth, or health.
+  // They exist in the registry purely for docs-coverage tracking.
+  if (isDocsOnly) {
+    if (!hasDocs) {
+      return <div data-testid="composed-cell-empty" />;
+    }
+    return (
+      <div
+        data-testid="composed-cell"
+        className="flex flex-col items-center gap-0.5 text-[11px] opacity-60"
+      >
+        <DocsLayer ctx={ctx} />
+      </div>
+    );
+  }
 
   // Check if any layer will produce content
   const hasContent = hasLinks || hasDepth || hasHealth || hasDocs;

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -252,6 +252,8 @@ function CategorySection({
       {isOpen &&
         cat.features.map((feature, idx) => {
           const testing = feature.kind === "testing";
+          const docsOnly = feature.kind === "docs-only";
+          const muted = testing || docsOnly;
           const stripe = idx % 2 === 1;
           const refCell = showRefDepth
             ? refCellsByFeature.get(feature.id)
@@ -282,7 +284,7 @@ function CategorySection({
               >
                 <div
                   className={
-                    testing
+                    muted
                       ? "font-normal text-[var(--text-muted)] italic"
                       : "font-medium text-[var(--text)]"
                   }
@@ -292,6 +294,11 @@ function CategorySection({
                   {testing && (
                     <span className="ml-2 text-[9px] uppercase tracking-wider text-[var(--text-muted)]">
                       testing
+                    </span>
+                  )}
+                  {docsOnly && (
+                    <span className="ml-2 text-[9px] uppercase tracking-wider text-[var(--text-muted)]">
+                      docs-only
                     </span>
                   )}
                 </div>

--- a/showcase/shell-dashboard/src/lib/registry.ts
+++ b/showcase/shell-dashboard/src/lib/registry.ts
@@ -1,7 +1,7 @@
 import registryData from "@/data/registry.json";
 import { sortOrder } from "./sort-order";
 
-export type FeatureKind = "primary" | "testing";
+export type FeatureKind = "primary" | "testing" | "docs-only";
 
 export interface Feature {
   id: string;


### PR DESCRIPTION
## Summary

- Adds `docs-only` as a new `FeatureKind` alongside `primary` and `testing`
- Features with this kind show only the docs row in the dashboard -- no Dx badges (API/RT/CV), no links, no depth chips
- Row label is muted/italic with a "docs-only" tag, matching the visual treatment of "testing" rows
- `cli-start` is the first feature changed to `docs-only` since it has no runnable demo

## Changes

| File | What |
|------|------|
| `showcase/shared/feature-registry.json` | `cli-start` kind: `primary` -> `docs-only` |
| `showcase/shell-dashboard/src/lib/registry.ts` | `FeatureKind` union extended |
| `showcase/shell-dashboard/src/components/cell-pieces.tsx` | `CellStatus` returns null for docs-only |
| `showcase/shell-dashboard/src/components/composed-cell.tsx` | Only renders DocsLayer for docs-only |
| `showcase/shell-dashboard/src/components/feature-grid.tsx` | Muted row styling + tag |
| `cell-pieces.test.tsx` | New test for docs-only hiding all badges |
| `composed-cell.test.tsx` | 3 new tests for docs-only overlay behavior |

## Test plan

- [x] New unit tests pass for all three behavioral changes
- [x] Pre-existing test failures confirmed unrelated (useOverlays URL hash, composed-cell docs-dedup, missing generated data files)