### PR TITLE
fix(showcase): hide depth chip for docs-only features, add depth distribution to stats bar

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -16,7 +16,9 @@ import { AdaptiveStatsBar } from "@/components/adaptive-stats-bar";
 import { AdaptiveLegend } from "@/components/adaptive-legend";
 import type { ParityTier } from "@/components/parity-badge";
 import { getDocsStatus } from "@/lib/docs-status";
+import { deriveDepth } from "@/components/depth-utils";
 import type { CatalogCell } from "@/components/depth-utils";
+import type { DepthDistribution } from "@/components/adaptive-stats-bar";
 import catalog from "@/data/catalog.json";
 import type { CatalogData } from "@/data/catalog-types";
 
@@ -134,6 +136,28 @@ export default function Page() {
     return { ok, missing, notFound, error };
   }, []);
 
+  // Compute depth distribution across all wired cells — re-derives whenever
+  // live-status changes since depth is a function of probe states.
+  const depthDistribution = useMemo((): DepthDistribution => {
+    const dist: DepthDistribution = {
+      d6: 0,
+      d5: 0,
+      d4: 0,
+      d3: 0,
+      d2: 0,
+      d1: 0,
+      d0: 0,
+    };
+    for (const cell of catalogData.cells) {
+      if (cell.status !== "wired" || cell.feature === null) continue;
+      const result = deriveDepth(cell, liveStatus);
+      if (result.unsupported) continue;
+      const key = `d${result.achieved}` as keyof DepthDistribution;
+      dist[key]++;
+    }
+    return dist;
+  }, [liveStatus]);
+
   // renderCell callback wrapping ComposedCell
   const renderCell = useCallback(
     (ctx: CellContext) => {
@@ -197,6 +221,7 @@ export default function Page() {
                 healthStats={healthStats}
                 parityStats={parityStats}
                 docsStats={docsStats}
+                depthDistribution={depthDistribution}
               />
             </div>
             <FeatureGrid

--- a/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
@@ -11,6 +11,17 @@ import type { CatalogData } from "../data/catalog-types";
 
 type Overlay = "links" | "depth" | "health" | "parity" | "docs";
 
+/** Depth distribution: count of cells at each depth level. */
+export interface DepthDistribution {
+  d5: number;
+  d4: number;
+  d3: number;
+  d2: number;
+  d1: number;
+  d0: number;
+  d6: number;
+}
+
 export interface AdaptiveStatsBarProps {
   overlays: Set<Overlay>;
   catalog: CatalogData;
@@ -20,6 +31,8 @@ export interface AdaptiveStatsBarProps {
   parityStats?: Record<ParityTier, number>;
   /** Docs stats (computed externally) */
   docsStats?: { ok: number; missing: number; notFound: number; error: number };
+  /** Depth distribution across wired cells (computed externally) */
+  depthDistribution?: DepthDistribution;
 }
 
 /* ------------------------------------------------------------------ */
@@ -101,7 +114,13 @@ function BaseSection({ totalCells }: { totalCells: number }) {
   );
 }
 
-function DepthSection({ catalog }: { catalog: CatalogData }) {
+function DepthSection({
+  catalog,
+  depthDistribution,
+}: {
+  catalog: CatalogData;
+  depthDistribution?: DepthDistribution;
+}) {
   const { wired, stub, unshipped } = catalog.metadata;
   // Older catalog.json snapshots may predate the unsupported field; default
   // to 0 so the dashboard renders cleanly against legacy data.
@@ -128,6 +147,46 @@ function DepthSection({ catalog }: { catalog: CatalogData }) {
           unsupported={unsupported}
         />
       </div>
+      {depthDistribution && (
+        <>
+          <Divider />
+          <DepthDistributionSection distribution={depthDistribution} />
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Compact depth distribution: D6..D1 counts in a single row. */
+function DepthDistributionSection({
+  distribution,
+}: {
+  distribution: DepthDistribution;
+}) {
+  const levels: { key: keyof DepthDistribution; label: string }[] = [
+    { key: "d6", label: "D6" },
+    { key: "d5", label: "D5" },
+    { key: "d4", label: "D4" },
+    { key: "d3", label: "D3" },
+    { key: "d2", label: "D2" },
+    { key: "d1", label: "D1" },
+  ];
+
+  return (
+    <div
+      data-testid="depth-distribution"
+      className="flex items-center gap-2"
+    >
+      {levels.map(({ key, label }) => (
+        <span key={key} className="flex items-center gap-0.5">
+          <span className="text-[10px] font-semibold text-[var(--accent)] tabular-nums">
+            {label}:
+          </span>
+          <span className="text-[10px] font-bold tabular-nums text-[var(--text-secondary)]">
+            {distribution[key]}
+          </span>
+        </span>
+      ))}
     </div>
   );
 }
@@ -227,6 +286,7 @@ export function AdaptiveStatsBar({
   healthStats,
   parityStats,
   docsStats,
+  depthDistribution,
 }: AdaptiveStatsBarProps) {
   const sections: React.ReactNode[] = [];
 
@@ -236,7 +296,13 @@ export function AdaptiveStatsBar({
   );
 
   if (overlays.has("depth")) {
-    sections.push(<DepthSection key="depth" catalog={catalog} />);
+    sections.push(
+      <DepthSection
+        key="depth"
+        catalog={catalog}
+        depthDistribution={depthDistribution}
+      />,
+    );
   }
 
   if (overlays.has("health") && healthStats) {

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -304,7 +304,7 @@ function CategorySection({
                 </div>
               </td>
               {showRefDepth &&
-                (refCell && refDepth ? (
+                (refCell && refDepth && !docsOnly ? (
                   <RefDepthCell
                     depth={refDepth.achieved}
                     status={


### PR DESCRIPTION
## Summary

- Suppress depth chip rendering for docs-only features in the RefDepth column (parity overlay) -- show `--` instead, since docs-only features have no probe coverage and should not display a depth level
- Add depth distribution counts (D6, D5, D4, D3, D2, D1) to the AdaptiveStatsBar when the depth overlay is active, giving operators at-a-glance visibility into how many wired cells sit at each depth level

## Test plan

- [ ] Verify docs-only features (e.g. `cli-start`) show `--` in the Ref Depth column instead of a depth chip
- [ ] Verify non-docs-only features still show their correct depth chip in Ref Depth
- [ ] Toggle the depth overlay on and confirm the depth distribution section appears in the stats bar
- [ ] Toggle depth overlay off and confirm the distribution section disappears