### PR TITLE
fix(showcase): remove D6 from depth stats, tighten grid spacing

### DIFF
--- a/showcase/shell-dashboard/src/app/page.tsx
+++ b/showcase/shell-dashboard/src/app/page.tsx
@@ -140,7 +140,6 @@ export default function Page() {
   // live-status changes since depth is a function of probe states.
   const depthDistribution = useMemo((): DepthDistribution => {
     const dist: DepthDistribution = {
-      d6: 0,
       d5: 0,
       d4: 0,
       d3: 0,

--- a/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
@@ -19,7 +19,6 @@ export interface DepthDistribution {
   d2: number;
   d1: number;
   d0: number;
-  d6: number;
 }
 
 export interface AdaptiveStatsBarProps {
@@ -157,14 +156,13 @@ function DepthSection({
   );
 }
 
-/** Compact depth distribution: D6..D1 counts in a single row. */
+/** Compact depth distribution: D5..D1 counts in a single row. */
 function DepthDistributionSection({
   distribution,
 }: {
   distribution: DepthDistribution;
 }) {
   const levels: { key: keyof DepthDistribution; label: string }[] = [
-    { key: "d6", label: "D6" },
     { key: "d5", label: "D5" },
     { key: "d4", label: "D4" },
     { key: "d3", label: "D3" },

--- a/showcase/shell-dashboard/src/components/feature-grid.tsx
+++ b/showcase/shell-dashboard/src/components/feature-grid.tsx
@@ -477,8 +477,8 @@ export function FeatureGrid({
   const categoryColSpan = integrations.length + 1 + (showRefDepth ? 1 : 0);
 
   return (
-    <div className="p-8">
-      <header className="mb-6">
+    <div className="px-8 pt-3 pb-8">
+      <header className="mb-3">
         <div className="flex items-center gap-3">
           <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
           <LiveIndicator status={connection} />


### PR DESCRIPTION
Remove D6 from depth distribution counts and DepthDistribution interface. Reduce whitespace between stats bar and feature matrix header.