### PR TITLE
fix(showcase): wire all three slot overrides in llamaindex chat-slots demo

### DIFF
--- a/showcase/integrations/llamaindex/manifest.yaml
+++ b/showcase/integrations/llamaindex/manifest.yaml
@@ -301,6 +301,8 @@ demos:
       - src/app/demos/chat-slots/agent.py
       - src/app/demos/chat-slots/page.tsx
       - src/app/demos/chat-slots/custom-welcome-screen.tsx
+      - src/app/demos/chat-slots/custom-assistant-message.tsx
+      - src/app/demos/chat-slots/custom-disclaimer.tsx
       - src/app/api/copilotkit/route.ts
   - id: chat-customization-css
     name: Chat Customization (CSS)

--- a/showcase/integrations/llamaindex/src/app/demos/chat-slots/custom-assistant-message.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-slots/custom-assistant-message.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+import { CopilotChatAssistantMessage } from "@copilotkit/react-core/v2";
+import type { CopilotChatAssistantMessageProps } from "@copilotkit/react-core/v2";
+
+// Custom assistantMessage sub-slot of messageView — wraps the default assistant
+// message in a visibly tinted card with a corner "slot" badge, proving the slot
+// override is active during the in-chat message flow (not just the welcome screen).
+export function CustomAssistantMessage(
+  props: CopilotChatAssistantMessageProps,
+) {
+  return (
+    <div
+      data-testid="custom-assistant-message"
+      className="relative rounded-xl border border-indigo-200 bg-indigo-50/60 dark:bg-indigo-950/40 dark:border-indigo-800 p-3 my-3"
+    >
+      <span className="absolute -top-2 -left-2 inline-block rounded-full bg-indigo-600 text-white text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 shadow">
+        slot
+      </span>
+      <CopilotChatAssistantMessage {...props} />
+    </div>
+  );
+}

--- a/showcase/integrations/llamaindex/src/app/demos/chat-slots/custom-disclaimer.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-slots/custom-disclaimer.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+
+// Custom disclaimer sub-slot of the input — visibly tagged so reviewers can
+// tell the slot is in use even once the welcome screen is dismissed.
+export function CustomDisclaimer(props: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      {...props}
+      data-testid="custom-disclaimer"
+      className="text-xs text-center text-muted-foreground py-2"
+    >
+      <span className="inline-block rounded bg-indigo-100 text-indigo-700 px-2 py-0.5 mr-2 font-semibold">
+        slot
+      </span>
+      Custom disclaimer injected via <code>input.disclaimer</code>.
+    </div>
+  );
+}

--- a/showcase/integrations/llamaindex/src/app/demos/chat-slots/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/chat-slots/page.tsx
@@ -4,10 +4,14 @@ import React from "react";
 import {
   CopilotKit,
   CopilotChat,
+  CopilotChatAssistantMessage,
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
 import { CustomWelcomeScreen } from "./custom-welcome-screen";
+import { CustomAssistantMessage } from "./custom-assistant-message";
+import { CustomDisclaimer } from "./custom-disclaimer";
 
+// Outer layer — provider + layout chrome.
 export default function ChatSlotsDemo() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" agent="chat_slots">
@@ -20,6 +24,7 @@ export default function ChatSlotsDemo() {
   );
 }
 
+// The actual view — just the chat, with two slot overrides.
 function Chat() {
   useConfigureSuggestions({
     suggestions: [
@@ -29,15 +34,29 @@ function Chat() {
     available: "always",
   });
 
+  // Each slot is wired in as a prop on <CopilotChat>. Extracting the
+  // overrides up here keeps the JSX readable and gives the docs something
+  // to point at with `@region` markers for the slot system guide.
   // @region[register-welcome-slot]
   const welcomeScreen = CustomWelcomeScreen;
   // @endregion[register-welcome-slot]
+  // @region[register-disclaimer-slot]
+  const input = { disclaimer: CustomDisclaimer };
+  // @endregion[register-disclaimer-slot]
+  // @region[register-assistant-message-slot]
+  const messageView = {
+    assistantMessage:
+      CustomAssistantMessage as unknown as typeof CopilotChatAssistantMessage,
+  };
+  // @endregion[register-assistant-message-slot]
 
   return (
     <CopilotChat
       agentId="chat_slots"
       className="h-full rounded-2xl"
       welcomeScreen={welcomeScreen}
+      input={input}
+      messageView={messageView}
     />
   );
 }

--- a/showcase/integrations/llamaindex/tests/e2e/chat-slots.spec.ts
+++ b/showcase/integrations/llamaindex/tests/e2e/chat-slots.spec.ts
@@ -1,12 +1,120 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Chat Slots", () => {
-  test("custom welcome screen renders before first message", async ({
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/demos/chat-slots");
+  });
+
+  test("custom welcome screen slot renders on first load", async ({ page }) => {
+    // The custom welcomeScreen slot replaces the default welcome. Its testid
+    // + verbatim heading together prove the slot override wired through.
+    const welcome = page.locator('[data-testid="custom-welcome-screen"]');
+    await expect(welcome).toBeVisible();
+
+    await expect(
+      page.getByRole("heading", { name: "Welcome to the Slots demo" }),
+    ).toBeVisible();
+
+    // The gradient card exposes its own literal label — "Custom Slot" —
+    // which makes accidental fallback to the default welcome easy to detect.
+    await expect(welcome.getByText("Custom Slot")).toBeVisible();
+  });
+
+  test("both suggestion pills render with verbatim titles", async ({
     page,
   }) => {
-    await page.goto("/demos/chat-slots");
+    // useConfigureSuggestions registers exactly two pills with available: "always".
+    // Both should be visible immediately on the welcome screen.
     await expect(
-      page.locator('[data-testid="custom-welcome-screen"]'),
-    ).toBeVisible();
+      page
+        .locator('[data-testid="copilot-suggestion"]')
+        .filter({ hasText: "Write a sonnet" }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await expect(
+      page
+        .locator('[data-testid="copilot-suggestion"]')
+        .filter({ hasText: "Tell me a joke" }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('clicking "Tell me a joke" shows the custom assistant message slot', async ({
+    page,
+  }) => {
+    // Click the suggestion pill — this sends "Tell me a short joke." The
+    // assistant will respond with text (neutral agent, no tools), and its
+    // bubble must be wrapped in the custom slot container.
+    await page
+      .locator('[data-testid="copilot-suggestion"]')
+      .filter({ hasText: "Tell me a joke" })
+      .first()
+      .click();
+
+    // Custom assistant-message slot is the defining slot-override signal:
+    // every assistant bubble flows through CustomAssistantMessage, which
+    // wraps the default in a tinted card with this testid.
+    const customMsg = page
+      .locator('[data-testid="custom-assistant-message"]')
+      .first();
+    await expect(customMsg).toBeVisible({ timeout: 45000 });
+
+    // The "slot" badge is absolutely-positioned inside the custom wrapper —
+    // its presence proves our wrapper rendered rather than the default
+    // CopilotChatAssistantMessage bare.
+    await expect(customMsg.getByText("slot", { exact: true })).toBeVisible();
+  });
+
+  test("custom disclaimer slot renders after the first user message", async ({
+    page,
+  }) => {
+    // Type and send via the send button — Enter-on-textarea was intermittently
+    // dropping the submit on this deployment. We assert the disclaimer +
+    // custom assistant wrapper appear once we transition out of the welcome
+    // state.
+    const input = page.getByPlaceholder("Type a message");
+    await input.fill("Hello");
+    await page.locator('[data-testid="copilot-send-button"]').first().click();
+
+    // Assistant replies and is wrapped in the custom slot.
+    await expect(
+      page.locator('[data-testid="custom-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 45000 });
+
+    // The custom disclaimer slot lives below the input on the post-welcome
+    // chat view. The welcome-screen state hides it; once the assistant
+    // responds the welcome is gone and the disclaimer should be visible.
+    await expect(page.locator('[data-testid="custom-disclaimer"]')).toBeVisible(
+      { timeout: 10000 },
+    );
+  });
+
+  test("second assistant turn is also wrapped in the custom slot", async ({
+    page,
+  }) => {
+    const input = page.getByPlaceholder("Type a message");
+    const sendBtn = () =>
+      page.locator('[data-testid="copilot-send-button"]').first();
+
+    // Turn 1
+    await input.fill("Hi");
+    await sendBtn().click();
+    await expect(
+      page.locator('[data-testid="custom-assistant-message"]').first(),
+    ).toBeVisible({ timeout: 45000 });
+
+    // Turn 2 — the slot should wrap every assistant turn, not just the first.
+    await input.fill("Say something short");
+    await sendBtn().click();
+
+    // Expect at least two custom-wrapped assistant messages.
+    await expect
+      .poll(
+        async () =>
+          await page
+            .locator('[data-testid="custom-assistant-message"]')
+            .count(),
+        { timeout: 45000 },
+      )
+      .toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

- Add `CustomAssistantMessage` and `CustomDisclaimer` components to llamaindex chat-slots demo, matching langgraph-python gold standard
- Wire `input.disclaimer` and `messageView.assistantMessage` slot props into `<CopilotChat>` alongside the existing `welcomeScreen` slot
- Update e2e spec to D5 coverage (welcome screen, suggestions, assistant message slot, disclaimer slot, multi-turn slot persistence)
- Update manifest.yaml highlight list with new component files

## Why

The llamaindex chat-slots demo only had the `welcomeScreen` slot override, while the D5 probe (`d5-chat-slots.ts`) asserts `data-testid="custom-assistant-message"` is present after the assistant responds. This left the feature stuck at D4.

## Test plan

- [x] `showcase build llamaindex` -- builds clean
- [x] `showcase test llamaindex --d5 --verbose` -- chat-slots passes (was the only feature stuck at D4)
- [x] Verified Docker container renders all three slot testids