### PR TITLE
fix(showcase): exclude docs-only features from catalog metadata counts

### DIFF
--- a/showcase/scripts/__tests__/generate-catalog.test.ts
+++ b/showcase/scripts/__tests__/generate-catalog.test.ts
@@ -60,6 +60,7 @@ describe("Catalog Generator", () => {
 
     // metadata must have exactly the CatalogMetadata keys
     expect(Object.keys(catalog.metadata).sort()).toEqual([
+      "docs_only",
       "generated_at",
       "reference",
       "stub",
@@ -94,7 +95,7 @@ describe("Catalog Generator", () => {
     }
   });
 
-  it("cross-join produces 737 cells (720 integrated + 17 starters)", () => {
+  it("cross-join produces 720 cells (40 features x 18 integrations); metadata.total_cells excludes docs-only", () => {
     runGenerator();
     const catalog = readCatalog();
 
@@ -111,7 +112,9 @@ describe("Catalog Generator", () => {
     expect(integrated.length).toBe(720); // 40 features x 18 integrations
     expect(starters.length).toBe(0);
     expect(catalog.cells.length).toBe(720);
-    expect(catalog.metadata.total_cells).toBe(720);
+    // total_cells excludes docs-only features (currently 1 feature x 18 integrations = 18)
+    expect(catalog.metadata.total_cells).toBe(702);
+    expect(catalog.metadata.docs_only).toBe(18);
   });
 
   it("LGP has 40 cells: 37 wired + 1 stub + 2 unshipped", () => {
@@ -189,22 +192,32 @@ describe("Catalog Generator", () => {
     }
   });
 
-  it("metadata counts are correct", () => {
+  it("metadata counts are correct (docs-only excluded from breakdown)", () => {
     runGenerator();
     const catalog = readCatalog();
 
     expect(catalog.metadata).toBeDefined();
-    expect(catalog.metadata.total_cells).toBe(720);
+    // total_cells excludes docs-only features
+    expect(catalog.metadata.total_cells).toBe(702);
 
-    // 18 integrations x 40 features = 720 total cells (starters removed).
+    // Headline counts exclude docs-only cells; must sum to total_cells.
     expect(
       catalog.metadata.wired +
         catalog.metadata.stub +
         catalog.metadata.unshipped +
         catalog.metadata.unsupported,
-    ).toBe(720);
+    ).toBe(catalog.metadata.total_cells);
+    // docs_only + headline counts = total cells in the array
+    expect(
+      catalog.metadata.wired +
+        catalog.metadata.stub +
+        catalog.metadata.unshipped +
+        catalog.metadata.unsupported +
+        catalog.metadata.docs_only,
+    ).toBe(catalog.cells.length);
     expect(catalog.metadata.wired).toBeGreaterThanOrEqual(490);
     expect(catalog.metadata.unsupported).toBeGreaterThanOrEqual(0);
+    expect(catalog.metadata.docs_only).toBe(18);
   });
 
   it("max_depth: D4 for wired/stub cells, D0 for unshipped/unsupported", () => {

--- a/showcase/scripts/generate-registry.ts
+++ b/showcase/scripts/generate-registry.ts
@@ -218,6 +218,8 @@ interface CatalogMetadata {
   stub: number;
   unshipped: number;
   unsupported: number;
+  /** Cells for docs-only features — excluded from wired/stub/unshipped/unsupported. */
+  docs_only: number;
   generated_at: string;
 }
 
@@ -272,7 +274,7 @@ function determineCellStatus(
  */
 function generateCatalog(
   featureRegistry: {
-    features: Array<{ id: string; name: string; category: string }>;
+    features: Array<{ id: string; name: string; category: string; kind?: string }>;
     categories: Array<{ id: string; name: string }>;
   },
   integrations: Record<string, unknown>[],
@@ -296,6 +298,16 @@ function generateCatalog(
   }
 
   const allFeatureIds = featureRegistry.features.map((f) => f.id);
+
+  // docs-only features (e.g. cli-start) exist for documentation coverage
+  // tracking only — they have no route, no depth probes, and no health
+  // signals. Exclude them from the wired/stub/unshipped/unsupported metadata
+  // so the stats bar reflects only meaningful matrix cells.
+  const docsOnlyFeatureIds = new Set(
+    featureRegistry.features
+      .filter((f) => f.kind === "docs-only")
+      .map((f) => f.id),
+  );
 
   // Step 1: Cross-join to produce integrated cells and collect wired features
   // and unsupported features per integration.
@@ -440,20 +452,29 @@ function generateCatalog(
   }
 
   // Step 6: Compute metadata
-  const wiredCount = cells.filter((c) => c.status === "wired").length;
-  const stubCount = cells.filter((c) => c.status === "stub").length;
-  const unshippedCount = cells.filter((c) => c.status === "unshipped").length;
-  const unsupportedCount = cells.filter(
+  // Exclude docs-only cells from the headline counts — they are purely
+  // informational and don't participate in depth, health, or coverage.
+  const countableCells = cells.filter(
+    (c) => c.feature === null || !docsOnlyFeatureIds.has(c.feature),
+  );
+  const docsOnlyCount = cells.length - countableCells.length;
+  const wiredCount = countableCells.filter((c) => c.status === "wired").length;
+  const stubCount = countableCells.filter((c) => c.status === "stub").length;
+  const unshippedCount = countableCells.filter(
+    (c) => c.status === "unshipped",
+  ).length;
+  const unsupportedCount = countableCells.filter(
     (c) => c.status === "unsupported",
   ).length;
 
   const metadata: CatalogMetadata = {
     reference: referenceSlug,
-    total_cells: cells.length,
+    total_cells: countableCells.length,
     wired: wiredCount,
     stub: stubCount,
     unshipped: unshippedCount,
     unsupported: unsupportedCount,
+    docs_only: docsOnlyCount,
     generated_at: new Date().toISOString(),
   };
 

--- a/showcase/shell-dashboard/src/data/catalog-types.ts
+++ b/showcase/shell-dashboard/src/data/catalog-types.ts
@@ -24,6 +24,8 @@ export interface CatalogMetadata {
   stub: number;
   unshipped: number;
   unsupported: number;
+  /** Cells for docs-only features — excluded from wired/stub/unshipped/unsupported. */
+  docs_only: number;
   generated_at: string;
 }
 


### PR DESCRIPTION
## Summary

- docs-only features (e.g. cli-start) exist purely for documentation coverage tracking and have no route, depth probes, or health signals
- The catalog metadata was counting their 18 stub cells in the headline wired/stub/unshipped/unsupported breakdown, inflating the total and making the stats bar misleading
- Exclude docs-only cells from the headline counts; add a new `docs_only` field to track them separately

**Before:** total_cells=720 wired=673 stub=18 unsupported=29
**After:** total_cells=702 wired=673 stub=0 unsupported=29 docs_only=18

## Test plan

- [x] `showcase/scripts` test suite: all 574 tests pass (including 13 catalog tests)
- [x] `showcase/shell-dashboard` test suite: same 3 pre-existing failures, no regressions
- [x] TypeScript check clean (no new errors)
- [x] Invariant holds: wired + stub + unshipped + unsupported + docs_only == cells.length