### PR TITLE
fix(showcase): add harness testids to claude-sdk-typescript BYOC renderers

### DIFF
--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/byoc-hashbrown/hashbrown-renderer.tsx
@@ -277,8 +277,19 @@ const AssistantMessageRenderer = memo(function AssistantMessageRenderer({
 
   if (!value) return null;
 
+  // The CopilotChat default assistantMessage slot renders a wrapper with
+  // `data-testid="copilot-assistant-message"` — used by the harness'
+  // `e2e-deep` conversation runner to count settled responses. Overriding
+  // the slot drops that testid, so any tooling that waits for "an
+  // assistant message landed" never sees a count change. Re-attaching it
+  // here keeps the slot override behaviorally identical to the default
+  // for response-detection purposes.
   return (
-    <div className="mt-2 flex w-full justify-start">
+    <div
+      data-testid="copilot-assistant-message"
+      data-message-role="assistant"
+      className="mt-2 flex w-full justify-start"
+    >
       <div className="w-full px-1 py-1">{kit.render(value)}</div>
     </div>
   );

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/byoc-json-render/json-render-renderer.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/byoc-json-render/json-render-renderer.tsx
@@ -65,18 +65,28 @@ export function JsonRenderAssistantMessage(
   // crash with `useVisibility must be used within a VisibilityProvider`).
   // `JSONUIProvider` wires all four in one; we don't use actions or
   // state here, so defaults are fine.
+  // Re-attach `data-testid="copilot-assistant-message"` — the harness'
+  // e2e-deep conversation runner uses that testid to count settled
+  // responses, and the messageView slot override would otherwise drop
+  // it. Same reasoning as byoc-hashbrown's renderer.
   return (
-    <div data-testid="json-render-root" className="w-full">
-      <JSONUIProvider registry={registry}>
-        <Renderer
-          spec={
-            parseResult.spec as unknown as Parameters<
-              typeof Renderer
-            >[0]["spec"]
-          }
-          registry={registry}
-        />
-      </JSONUIProvider>
+    <div
+      data-testid="copilot-assistant-message"
+      data-message-role="assistant"
+      className="w-full"
+    >
+      <div data-testid="json-render-root" className="w-full">
+        <JSONUIProvider registry={registry}>
+          <Renderer
+            spec={
+              parseResult.spec as unknown as Parameters<
+                typeof Renderer
+              >[0]["spec"]
+            }
+            registry={registry}
+          />
+        </JSONUIProvider>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Added `data-testid="copilot-assistant-message"` and `data-message-role="assistant"` to the BYOC hashbrown and json-render custom assistant message renderers in claude-sdk-typescript
- These attributes were already present in the langgraph-python gold-standard; this aligns the TS port

## Why

The byoc-hashbrown and byoc-json-render demos override CopilotChat's `messageView.assistantMessage` slot with custom renderers. The e2e-deep conversation runner counts assistant messages via `[data-testid="copilot-assistant-message"]` to detect "response settled." Without that attribute on the custom renderers, the count stayed at 0 forever and the byoc feature timed out -- the only D5 failure blocking claude-sdk-typescript from green.

## Test plan

- `showcase test claude-sdk-typescript --d5 --verbose` goes from 28/29 (byoc timeout) to 29/29 green
- No demo functionality changed -- only test-harness attributes added to wrapper divs