### PR TITLE
fix(showcase): add --ci flag to eval workflow command

### DIFF
--- a/.github/workflows/showcase_eval.yml
+++ b/.github/workflows/showcase_eval.yml
@@ -296,7 +296,7 @@ jobs:
           # Build the command. EVAL_SCOPE_FLAG may contain spaces (e.g. "--slug mastra,agno")
           # so we intentionally leave it unquoted for word splitting.
           # shellcheck disable=SC2086
-          CMD="showcase/bin/showcase eval --${EVAL_LEVEL} ${EVAL_SCOPE_FLAG} --parallel 8 --json --baseline compare --timeout 60000"
+          CMD="showcase/bin/showcase eval --${EVAL_LEVEL} ${EVAL_SCOPE_FLAG} --parallel 8 --json --baseline compare --timeout 60000 --ci"
           echo "::group::Running: $CMD"
 
           EXIT_CODE=0


### PR DESCRIPTION
## Summary

- The eval workflow command was missing `--ci`, causing it to try Docker Compose lifecycle in CI — which immediately fails because `showcase/.env` doesn't exist in the runner environment.
- This is why the auto-triggered eval on PR #4541 failed with exit code 1.
- The `--ci` flag tells the eval orchestrator to skip Docker lifecycle and assume services are already running (or use native execution via `ci-native-eval.sh`).

## Test plan

- [ ] Trigger eval on a PR, verify it no longer fails with "env file not found"