### PR TITLE
feat(showcase): add --isolate flag for parallel-safe local testing

### DIFF
--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -107,3 +107,65 @@ wait_healthy() {
   done
   success "$slug is healthy (${elapsed}s)"
 }
+
+# ── Isolation helpers ───────────────────────────────────────────────────────
+
+ISOLATE_NAME=""
+ISOLATE_PORT_OFFSET=200
+ISOLATE_ACTIVE=false
+
+apply_isolation() {
+  local name="${1:-isolate-$$}"
+  ISOLATE_NAME="$name"
+  ISOLATE_ACTIVE=true
+  export COMPOSE_PROJECT_NAME="$name"
+
+  # Backup originals
+  cp "$PORTS_FILE" "${PORTS_FILE}.iso-bak"
+  cp "$COMPOSE_FILE" "${COMPOSE_FILE}.iso-bak"
+
+  # Offset ports in local-ports.json
+  python3 -c "
+import json
+with open('$PORTS_FILE') as f:
+    ports = json.load(f)
+offset = {k: v + $ISOLATE_PORT_OFFSET for k, v in ports.items()}
+with open('$PORTS_FILE', 'w') as f:
+    json.dump(offset, f, indent=2)
+    f.write('\n')
+"
+
+  # Offset host ports and container names in docker-compose.local.yml
+  python3 -c "
+import re
+with open('$COMPOSE_FILE') as f:
+    content = f.read()
+
+def offset_port(m):
+    indent = m.group(1)
+    host = int(m.group(2))
+    container = m.group(3)
+    return f'{indent}- \"{host + $ISOLATE_PORT_OFFSET}:{container}\"'
+
+content = re.sub(r'(\s+)- \"(\d+):(\d+)\"', offset_port, content)
+content = content.replace('container_name: showcase-', 'container_name: $name-')
+
+with open('$COMPOSE_FILE', 'w') as f:
+    f.write(content)
+"
+
+  # Idempotent: tear down any prior run with this name
+  $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
+
+  info "Isolation active: project=$name ports=+$ISOLATE_PORT_OFFSET"
+}
+
+restore_isolation() {
+  if $ISOLATE_ACTIVE; then
+    info "Tearing down isolated group: $ISOLATE_NAME"
+    $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
+    [ -f "${PORTS_FILE}.iso-bak" ] && mv "${PORTS_FILE}.iso-bak" "$PORTS_FILE"
+    [ -f "${COMPOSE_FILE}.iso-bak" ] && mv "${COMPOSE_FILE}.iso-bak" "$COMPOSE_FILE"
+    ISOLATE_ACTIVE=false
+  fi
+}

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -21,18 +21,24 @@ Options:
   --live           Write results to PocketBase for dashboard
   --rebuild        Force Docker rebuild before running
   --cycle          On failure, auto-dump aimock logs from the test window
+  --isolate [name] Run in an isolated compose project with offset ports
+                   (default name: isolate-<PID>). Allows parallel test runs.
 
 Examples:
   showcase test mastra --d5 --verbose         # D5 probes with verbose output
   showcase test mastra --d5 --cycle           # D5 + aimock logs on failure
   showcase test langgraph-python              # all tests for a slug
   showcase test mastra --d5 --headed          # watch the browser
+  showcase test agno --d5 --isolate           # isolated run (auto-named)
+  showcase test agno --d5 --isolate d5verify  # isolated with explicit name
 HELP
 }
 
 cmd_test() {
   local slug=""
   local cycle=""
+  local isolate_name=""
+  local use_isolate=false
   local harness_args=()
 
   # Parse arguments — pass most through to the harness CLI
@@ -47,6 +53,29 @@ cmd_test() {
       --live)    harness_args+=(--live);    shift ;;
       --rebuild) harness_args+=(--rebuild); shift ;;
       --cycle)   cycle=1;                   shift ;;
+      --isolate)
+        use_isolate=true
+        shift
+        # Optional name argument: consume next arg if it doesn't start with --
+        # and doesn't look like a slug (no slug would be set yet if it appears
+        # after --isolate, but we peek to see if it's a plain name token).
+        if [[ $# -gt 0 ]] && [[ "$1" != --* ]]; then
+          # If slug is already set, this is the isolate name.
+          # If slug is NOT set, we need to distinguish: is this a slug or a name?
+          # Convention: if slug is empty and the next arg after this one is also
+          # not a flag, then this arg is the isolate name. Otherwise treat as slug.
+          if [[ -n "$slug" ]]; then
+            isolate_name="$1"
+            shift
+          else
+            # Peek ahead: if there's another non-flag arg after this, this is the name
+            # Otherwise this could be either — but since --isolate usually comes after
+            # the slug, and the slug is still empty, this is likely the slug, not the name.
+            # Leave it for the default slug handler below.
+            :
+          fi
+        fi
+        ;;
       --repeat)
         shift
         harness_args+=(--repeat "${1:?--repeat requires a value}")
@@ -72,6 +101,12 @@ cmd_test() {
 
   need_slug "$slug"
 
+  # Apply isolation if requested (must happen before any compose commands)
+  if $use_isolate; then
+    apply_isolation "${isolate_name:-}"
+    trap restore_isolation EXIT
+  fi
+
   # Build the filter description for the info line
   local filter_desc=""
   for arg in "${harness_args[@]}"; do
@@ -82,7 +117,12 @@ cmd_test() {
 
   # If --cycle, record aimock log position before the test
   local pre_test_ts=""
-  local aimock_container="showcase-aimock"
+  local aimock_container
+  if $use_isolate && [[ -n "$ISOLATE_NAME" ]]; then
+    aimock_container="${ISOLATE_NAME}-aimock"
+  else
+    aimock_container="showcase-aimock"
+  fi
   if [[ -n "$cycle" ]]; then
     if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${aimock_container}$"; then
       pre_test_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
## Summary

Adds `--isolate [name]` flag to `showcase test` so multiple agents/sessions can run D5 probes without Docker container conflicts.

- `showcase test agno --d5 --isolate` — auto-names project `isolate-<PID>`
- `showcase test agno --d5 --isolate d5verify` — explicit project name

When active, `apply_isolation()` offsets all host ports by +200, renames containers from `showcase-*` to `<name>-*`, and sets `COMPOSE_PROJECT_NAME`. The EXIT trap tears down the isolated group and restores both `local-ports.json` and `docker-compose.local.yml` on exit.

## Test plan

- [x] Verified `--isolate d5verify` shows correct offset ports (3309 = 3109 + 200)
- [x] Containers start with `d5verify-*` names, don't conflict with existing `showcase-*` group
- [x] Cleanup restores files and tears down containers on exit
- [ ] CI passes