### PR TITLE
fix(showcase): wait for auth banner state before post-signout probe send

### DIFF
--- a/showcase/harness/src/probes/scripts/d5-auth.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-auth.test.ts
@@ -6,12 +6,15 @@ import {
   buildTurns,
   buildAuthAssertion,
   SIGN_OUT_BUTTON_SELECTOR,
+  AUTH_BANNER_UNAUTHENTICATED_SELECTOR,
   ERROR_BANNER_SELECTOR,
   ERROR_BOUNDARY_SELECTOR,
 } from "./d5-auth.js";
 
 interface FakeOpts {
   signOutButtonVisible?: boolean;
+  /** Whether the banner flips to unauthenticated after sign-out. Default true. */
+  bannerFlipsToUnauth?: boolean;
   errorAfterClick?: boolean;
 }
 
@@ -23,9 +26,20 @@ function makePage(opts: FakeOpts): {
 } {
   let clicked = false;
   const page: Page = {
-    async waitForSelector() {
-      if (!opts.signOutButtonVisible) {
-        throw new Error("waitForSelector timeout (test fake)");
+    async waitForSelector(selector: string) {
+      // Sign-out button selector — gates on signOutButtonVisible
+      if (selector === SIGN_OUT_BUTTON_SELECTOR) {
+        if (!opts.signOutButtonVisible) {
+          throw new Error("waitForSelector timeout (test fake)");
+        }
+        return;
+      }
+      // Auth banner unauthenticated selector — gates on bannerFlipsToUnauth
+      if (selector === AUTH_BANNER_UNAUTHENTICATED_SELECTOR) {
+        if (!(opts.bannerFlipsToUnauth ?? true)) {
+          throw new Error("waitForSelector timeout (banner never flipped)");
+        }
+        return;
       }
     },
     async fill() {},
@@ -59,9 +73,12 @@ describe("d5-auth script", () => {
     expect(buildTurns(ctx)[0]!.input).toBe("auth check turn 1");
   });
 
-  it("exposes the sign-out + error selectors", () => {
+  it("exposes the sign-out, banner, and error selectors", () => {
     expect(SIGN_OUT_BUTTON_SELECTOR).toBe(
       '[data-testid="auth-sign-out-button"]',
+    );
+    expect(AUTH_BANNER_UNAUTHENTICATED_SELECTOR).toBe(
+      '[data-testid="auth-banner"][data-authenticated="false"]',
     );
     expect(ERROR_BANNER_SELECTOR).toBe('[data-testid="auth-demo-error"]');
     expect(ERROR_BOUNDARY_SELECTOR).toBe(
@@ -77,6 +94,20 @@ describe("d5-auth script", () => {
     });
     await expect(assertion(page)).rejects.toThrow(
       /sign-out button.*not visible/,
+    );
+  });
+
+  it("assertion fails when banner does not flip to unauthenticated after sign-out", async () => {
+    const { page, fakeClick } = makePage({
+      signOutButtonVisible: true,
+      bannerFlipsToUnauth: false,
+    });
+    const assertion = buildAuthAssertion({
+      signOutTimeoutMs: 50,
+      click: fakeClick,
+    });
+    await expect(assertion(page)).rejects.toThrow(
+      /banner did not flip to unauthenticated/,
     );
   });
 

--- a/showcase/harness/src/probes/scripts/d5-auth.ts
+++ b/showcase/harness/src/probes/scripts/d5-auth.ts
@@ -22,6 +22,8 @@ import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 
 export const SIGN_OUT_BUTTON_SELECTOR = '[data-testid="auth-sign-out-button"]';
+export const AUTH_BANNER_UNAUTHENTICATED_SELECTOR =
+  '[data-testid="auth-banner"][data-authenticated="false"]';
 export const ERROR_BANNER_SELECTOR = '[data-testid="auth-demo-error"]';
 export const ERROR_BOUNDARY_SELECTOR =
   '[data-testid="auth-demo-chat-boundary"]';
@@ -98,6 +100,24 @@ export function buildAuthAssertion(
       );
     }
     await click(page, SIGN_OUT_BUTTON_SELECTOR);
+
+    // Step 1b — wait for React to re-render the banner to unauthenticated
+    // state. Without this, `setHeaders()` hasn't flushed yet (useEffect
+    // runs async after paint) and the next request goes out with VALID
+    // auth headers, never 401s, and the probe times out.
+    try {
+      await page.waitForSelector(AUTH_BANNER_UNAUTHENTICATED_SELECTOR, {
+        state: "visible",
+        timeout: 3_000,
+      });
+    } catch {
+      throw new Error(
+        `auth: banner did not flip to unauthenticated within 3 s after clicking sign-out — React state may not have updated`,
+      );
+    }
+    // Allow React's useEffect to flush setHeaders() — effects run async
+    // after paint, so the banner DOM update alone isn't sufficient.
+    await new Promise<void>((r) => setTimeout(r, 500));
 
     // Step 2 — trigger a chat send while signed-out. The auth demo does
     // not auto-refetch /info on header change, so the 401 surface only


### PR DESCRIPTION
## Summary

- Fix race condition in the D5 auth probe where the post-signout chat message was sent before React's `useEffect` flushed `setHeaders()`, causing the request to go out with valid auth headers (no 401, no error surface, 8s timeout)
- After clicking sign-out, the probe now waits for the auth banner to flip to `data-authenticated="false"` plus a 500ms settle delay before triggering the probe send
- Add unit test covering the new "banner doesn't flip" failure mode

## Test plan

- [x] All 7 d5-auth unit tests pass (including new banner-flip test)
- [x] TypeScript compiles clean
- [x] Verified all 18 integrations already have `data-testid="auth-banner"` with `data-authenticated` attribute
- [ ] CI green