### PR TITLE
fix(showcase): render CLI Start command in docs-only cells

### DIFF
--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -188,6 +188,7 @@ function ComposedCellInner({ ctx, overlays, catalogCell }: ComposedCellProps) {
         data-testid="composed-cell"
         className="flex flex-col items-center gap-0.5 text-[11px] opacity-60"
       >
+        {hasLinks && <LinksLayer ctx={ctx} />}
         <DocsLayer ctx={ctx} />
       </div>
     );


### PR DESCRIPTION
## Summary

The docs-only early return in `ComposedCellInner` only rendered `DocsLayer`, skipping `LinksLayer` which renders `CommandCell` for demos with a `command` field. The `npx copilotkit@latest init` starter command disappeared from the matrix.

Fix: render `LinksLayer` alongside `DocsLayer` when links overlay is active.

## Test plan

- [ ] CLI Start Command row shows the `npx` command text (not just docs links)
- [ ] Other docs-only features unaffected