### PR TITLE
fix(showcase): fix 3 llamaindex D5 timeouts caused by deferred annotations

### DIFF
--- a/showcase/integrations/llamaindex/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/llamaindex/src/agents/a2ui_dynamic.py
@@ -18,8 +18,6 @@ Pairs with the dedicated runtime route
 `a2ui.injectA2UITool: false` so the runtime does not double-bind the tool.
 """
 
-from __future__ import annotations
-
 import json
 import os
 from typing import Annotated

--- a/showcase/integrations/llamaindex/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/llamaindex/src/agents/a2ui_fixed.py
@@ -8,8 +8,6 @@ model at runtime via a `display_flight` tool. The tool result is an
 detects and forwards to the frontend renderer.
 """
 
-from __future__ import annotations
-
 import json
 import os
 from pathlib import Path

--- a/showcase/integrations/llamaindex/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/llamaindex/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -9,8 +9,6 @@ with rich cards, with every other tool falling back to a branded catch-all.
 Mirrors `langgraph-python/src/agents/tool_rendering_reasoning_chain_agent.py`.
 """
 
-from __future__ import annotations
-
 import json
 import os
 from random import choice, randint


### PR DESCRIPTION
## Summary

- Remove `from __future__ import annotations` from 3 llamaindex agents that were timing out at D5
- The deferred annotations import causes Pydantic to fail with "class-not-fully-defined" when resolving `Annotated[str, "..."]` tool parameters, producing a `RUN_ERROR` SSE event instead of streaming text
- The D5 conversation runner cannot detect `RUN_ERROR` as an assistant response, so it times out after 30s

## Affected agents

- `a2ui_fixed.py` (gen-ui-a2ui-fixed / a2ui-fixed-schema feature)
- `a2ui_dynamic.py` (gen-ui-declarative / declarative-gen-ui feature)
- `tool_rendering_reasoning_chain_agent.py` (tool-rendering-reasoning-chain feature)

## Root cause

`from __future__ import annotations` (PEP 563) defers evaluation of all annotations to strings. When the LlamaIndex `AGUIChatWorkflow` passes `backend_tools` to Pydantic for schema generation, `Annotated[str, "Origin airport code"]` is stored as the string `"Annotated[str, 'Origin airport code']"` instead of the actual type. Pydantic cannot resolve this and raises `PydanticUserError: class-not-fully-defined`.

Agents without `backend_tools` (like `reasoning_agent.py`) were unaffected because the code path that triggers Pydantic schema validation is never reached with an empty tool list.

## Test plan

- [x] Built Docker image locally and curled all 3 endpoints directly
- [x] Before fix: all 3 returned `RUN_ERROR` with Pydantic class-not-fully-defined
- [x] After fix: all 3 stream `TEXT_MESSAGE_CHUNK` events and finish with `RUN_FINISHED`
- [ ] CI green
- [ ] D5 probe passes for all 3 features on production