### PR TITLE
fix: use custom stream converter for BYOC agents to fix D5 timeout

### DIFF
--- a/showcase/integrations/built-in-agent/src/lib/factory/byoc-hashbrown-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/byoc-hashbrown-factory.ts
@@ -1,4 +1,6 @@
 import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { EventType } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/client";
 import { chat } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
@@ -54,25 +56,76 @@ Example response (sales dashboard):
 `;
 
 /**
- * Built-in agent for the BYOC hashbrown demo. Forces JSON-object output
- * via the OpenAI `response_format` option so the streaming parser on the
- * frontend never has to handle code fences or prose preamble.
+ * Convert a TanStack AI stream to AG-UI events for a tool-free agent.
+ *
+ * Uses `type: "custom"` instead of `type: "tanstack"` to bypass the
+ * runtime's `convertTanStackStream` which has a `runFinished` flag
+ * (PR #4476) that blocks events after the first RUN_FINISHED. This
+ * converter simply skips RUN_FINISHED and forwards text events.
+ */
+async function* convertStream(
+  stream: AsyncIterable<unknown>,
+  abortSignal: AbortSignal,
+): AsyncGenerator<BaseEvent> {
+  const messageId = crypto.randomUUID();
+
+  for await (const chunk of stream) {
+    if (abortSignal.aborted) break;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const raw = chunk as any;
+    const type = raw.type as string;
+
+    // Skip RUN_FINISHED from TanStack's adapter — the Agent class emits
+    // its own lifecycle events.
+    if (type === "RUN_FINISHED") continue;
+
+    if (type === "TEXT_MESSAGE_CONTENT" && raw.delta != null) {
+      yield {
+        type: EventType.TEXT_MESSAGE_CHUNK,
+        role: "assistant",
+        messageId,
+        delta: raw.delta as string,
+      };
+    }
+    // No tool handling needed — this agent has no tools.
+  }
+}
+
+/**
+ * Built-in agent for the BYOC hashbrown demo. Uses a sales-dashboard
+ * system prompt that instructs the model to emit only valid JSON.
+ *
+ * Uses `type: "custom"` with a dedicated stream converter to avoid the
+ * runtime's `convertTanStackStream` runFinished-flag issue, matching the
+ * pattern used by the main built-in-agent factory (tanstack-factory.ts).
+ *
+ * NOTE: `response_format: { type: "json_object" }` was removed from
+ * modelOptions because TanStack AI's OpenAI adapter v0.8.x uses the
+ * Responses API (`client.responses.create()`), not the Chat Completions
+ * API. The Responses API does not support `response_format` — it uses
+ * `text.format` instead. Passing `response_format` to the Responses API
+ * can cause silent failures or rejected requests. The system prompt
+ * already enforces JSON-only output.
  */
 export function createByocHashbrownAgent() {
   return new BuiltInAgent({
-    type: "tanstack",
-    factory: ({ input, abortController }) => {
+    type: "custom",
+    factory: async ({ input, abortController }) => {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
-      return chat({
+
+      const stream = chat({
         adapter: openaiText("gpt-4o-mini"),
         messages,
         systemPrompts: [BYOC_HASHBROWN_SYSTEM_PROMPT, ...systemPrompts],
         tools: [],
         modelOptions: {
-          response_format: { type: "json_object" },
+          temperature: 0.2,
         },
         abortController,
       });
+
+      return convertStream(stream, abortController.signal);
     },
   });
 }

--- a/showcase/integrations/built-in-agent/src/lib/factory/byoc-json-render-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/byoc-json-render-factory.ts
@@ -1,4 +1,6 @@
 import { BuiltInAgent, convertInputToTanStackAI } from "@copilotkit/runtime/v2";
+import { EventType } from "@ag-ui/client";
+import type { BaseEvent } from "@ag-ui/client";
 import { chat } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
@@ -89,26 +91,72 @@ Respond with the JSON object only.
 `;
 
 /**
- * Built-in agent for the BYOC json-render demo. Forces JSON-object output
- * via the OpenAI `response_format` option so `<Renderer />` can rely on
- * receiving a single parseable spec object.
+ * Convert a TanStack AI stream to AG-UI events for a tool-free agent.
+ *
+ * Uses `type: "custom"` instead of `type: "tanstack"` to bypass the
+ * runtime's `convertTanStackStream` which has a `runFinished` flag
+ * (PR #4476) that blocks events after the first RUN_FINISHED.
+ */
+async function* convertStream(
+  stream: AsyncIterable<unknown>,
+  abortSignal: AbortSignal,
+): AsyncGenerator<BaseEvent> {
+  const messageId = crypto.randomUUID();
+
+  for await (const chunk of stream) {
+    if (abortSignal.aborted) break;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const raw = chunk as any;
+    const type = raw.type as string;
+
+    if (type === "RUN_FINISHED") continue;
+
+    if (type === "TEXT_MESSAGE_CONTENT" && raw.delta != null) {
+      yield {
+        type: EventType.TEXT_MESSAGE_CHUNK,
+        role: "assistant",
+        messageId,
+        delta: raw.delta as string,
+      };
+    }
+  }
+}
+
+/**
+ * Built-in agent for the BYOC json-render demo. Uses a system prompt that
+ * instructs the model to emit only valid JSON matching the json-render
+ * flat-element-map schema.
+ *
+ * Uses `type: "custom"` with a dedicated stream converter to avoid the
+ * runtime's `convertTanStackStream` runFinished-flag issue, matching the
+ * pattern used by the main built-in-agent factory (tanstack-factory.ts).
+ *
+ * NOTE: `response_format: { type: "json_object" }` was removed from
+ * modelOptions because TanStack AI's OpenAI adapter v0.8.x uses the
+ * Responses API (`client.responses.create()`), not the Chat Completions
+ * API. The Responses API does not support `response_format` — it uses
+ * `text.format` instead. The system prompt already enforces JSON-only
+ * output.
  */
 export function createByocJsonRenderAgent() {
   return new BuiltInAgent({
-    type: "tanstack",
-    factory: ({ input, abortController }) => {
+    type: "custom",
+    factory: async ({ input, abortController }) => {
       const { messages, systemPrompts } = convertInputToTanStackAI(input);
-      return chat({
+
+      const stream = chat({
         adapter: openaiText("gpt-4o-mini"),
         messages,
         systemPrompts: [SYSTEM_PROMPT, ...systemPrompts],
         tools: [],
         modelOptions: {
-          response_format: { type: "json_object" },
           temperature: 0.2,
         },
         abortController,
       });
+
+      return convertStream(stream, abortController.signal);
     },
   });
 }


### PR DESCRIPTION
## Summary

- Switch byoc-hashbrown and byoc-json-render agent factories from `type: "tanstack"` to `type: "custom"` with a dedicated stream converter, matching the proven pattern used by the main built-in-agent factory (`tanstack-factory.ts`)
- Remove invalid `response_format: { type: "json_object" }` from `modelOptions` -- TanStack AI v0.8.x uses the OpenAI Responses API which does not support this Chat Completions parameter
- System prompts already enforce JSON-only output; `temperature: 0.2` is retained as a valid Responses API parameter

The `type: "tanstack"` path routes through the runtime's `convertTanStackStream` which has a `runFinished` flag (PR #4476) that blocks all events after the first `RUN_FINISHED`. Combined with the invalid `response_format` parameter being silently rejected by the Responses API, this prevented text events from reaching the frontend, causing the D5 probe to timeout waiting for `[data-testid="copilot-assistant-message"]`.

## Test plan

- [ ] Verify byoc-hashbrown D5 passes locally with `bin/showcase test built-in-agent --d5`
- [ ] Verify all other 27 built-in-agent features still pass D5
- [ ] Verify byoc-json-render D5 passes (same fix pattern)