### PR TITLE
fix(showcase): restore langgraph-python declarative-gen-ui to a2ui_dynamic graph

### DIFF
--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -1,15 +1,11 @@
 // Dedicated runtime for the Declarative Generative UI (A2UI — Dynamic Schema)
-// cell. Mirrors the working claude-sdk-typescript reference pattern: the
-// backend is the neutral default graph (sample_agent), and the runtime
-// auto-injects the `render_a2ui` tool (injectA2UITool defaults to true).
-// The A2UI middleware serialises the registered client catalog into
-// `copilotkit.context` and detects `a2ui_operations` in the tool result,
-// streaming rendered surfaces to the frontend.
-//
-// Reference:
-// - showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
+// cell. Splitting into its own endpoint (mirroring beautiful-chat) lets us set
+// `a2ui.injectA2UITool: false` — the backend agent owns the `generate_a2ui`
+// tool itself, so double-binding from the runtime would duplicate the tool
+// slot and confuse the LLM.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
   ExperimentalEmptyAdapter,
@@ -20,18 +16,18 @@ import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 const LANGGRAPH_URL =
   process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8123";
 
+const declarativeGenUiAgent = new LangGraphAgent({
+  deploymentUrl: LANGGRAPH_URL,
+  graphId: "a2ui_dynamic",
+  langsmithApiKey: process.env.LANGSMITH_API_KEY || "",
+});
+
 const runtime = new CopilotRuntime({
   // @ts-ignore -- see main route.ts
-  agents: {
-    "declarative-gen-ui": new LangGraphAgent({
-      deploymentUrl: LANGGRAPH_URL,
-      graphId: "sample_agent",
-      langsmithApiKey: process.env.LANGSMITH_API_KEY || "",
-    }),
+  agents: { "declarative-gen-ui": declarativeGenUiAgent },
+  a2ui: {
+    injectA2UITool: false,
   },
-  // `injectA2UITool` defaults to true — the runtime injects the A2UI tool
-  // and the default graph receives it via CopilotKit middleware, matching
-  // the working claude-sdk-typescript reference pattern.
 });
 
 export const POST = async (req: NextRequest) => {


### PR DESCRIPTION
## Summary

PR #4542 incorrectly changed the langgraph-python declarative-gen-ui route from `graphId: "a2ui_dynamic"` to `graphId: "sample_agent"` and removed `injectA2UITool: false`. This caused a regression from 31/31 green to red.

The `a2ui_dynamic` graph owns the `generate_a2ui` tool itself — the runtime must NOT auto-inject its own A2UI tool on top (`injectA2UITool: false`). The `sample_agent` graph is a generic chat agent with no tools, which can never produce A2UI surfaces.

## Test plan

- [ ] langgraph-python returns to D5 green (31/31)