### PR TITLE
fix(docs): reverse-proxy PostHog through /ingest

### DIFF
--- a/docs/lib/providers/posthog-provider.tsx
+++ b/docs/lib/providers/posthog-provider.tsx
@@ -7,7 +7,11 @@ import { usePathname } from "next/navigation";
 import { normalizePathnameForAnalytics } from "@/lib/analytics-utils";
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+// Reverse-proxied via /ingest/* rewrites in next.config.mjs so requests
+// flow through docs.copilotkit.ai instead of *.i.posthog.com — bypasses
+// ad blockers / tracking-protection that target the PostHog hostname.
+const POSTHOG_HOST = "/ingest";
+const POSTHOG_UI_HOST = "https://eu.posthog.com";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -24,12 +28,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
   // Initialize PostHog once (only on mount)
   useEffect(() => {
-    if (
-      POSTHOG_KEY &&
-      POSTHOG_HOST &&
-      !posthog?.__loaded &&
-      !isInitializedRef.current
-    ) {
+    if (POSTHOG_KEY && !posthog?.__loaded && !isInitializedRef.current) {
       isInitializedRef.current = true;
 
       // Read sessionId from URL at initialization time
@@ -94,6 +93,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
         posthog.init(POSTHOG_KEY, {
           api_host: POSTHOG_HOST,
+          ui_host: POSTHOG_UI_HOST,
           person_profiles: "identified_only",
           bootstrap: initSessionId
             ? {
@@ -117,7 +117,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
   // Capture pageview only after PostHog is initialized
   useEffect(() => {
-    if (POSTHOG_KEY && POSTHOG_HOST && posthog?.__loaded) {
+    if (POSTHOG_KEY && posthog?.__loaded) {
       try {
         const normalizedPathname = normalizePathnameForAnalytics(pathname);
         posthog.capture("$pageview", {

--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -149,6 +149,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+    "/((?!api|ingest|_next/static|_next/image|favicon.ico).*)",
   ],
 };

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -140,6 +140,15 @@ const config = {
 
     return {
       beforeFiles: [
+        // PostHog reverse proxy — routes analytics through our domain to bypass ad blockers
+        {
+          source: '/ingest/static/:path*',
+          destination: 'https://eu-assets.i.posthog.com/static/:path*',
+        },
+        {
+          source: '/ingest/:path*',
+          destination: 'https://eu.i.posthog.com/:path*',
+        },
         // Map /guides/* to /built-in-agent/guides/* (legacy path)
         {
           source: '/guides/:path*',


### PR DESCRIPTION
## Summary

- Routes PostHog analytics through `docs.copilotkit.ai/ingest/*` (rewritten to `eu.i.posthog.com`) so requests bypass ad blockers and tracking-protection that target the PostHog hostname directly.
- Mirrors the existing setup on the marketing website (`../website`).
- Drops the `NEXT_PUBLIC_POSTHOG_HOST` dependency — host is now hardcoded since it's tied to the proxy path.

## Changes

- `docs/next.config.mjs` — added two `beforeFiles` rewrites: `/ingest/static/:path*` → `eu-assets.i.posthog.com/static/*`, `/ingest/:path*` → `eu.i.posthog.com/*`
- `docs/lib/providers/posthog-provider.tsx` — `api_host: '/ingest'`, `ui_host: 'https://eu.posthog.com'`, removed `POSTHOG_HOST` env-var check
- `docs/middleware.ts` — excluded `ingest` from the redirect-middleware matcher so proxy traffic skips it

## Test plan

- [ ] Deploy preview — confirm DevTools shows PostHog requests going to `docs.copilotkit.ai/ingest/*` instead of `eu.i.posthog.com`
- [ ] Verify `$pageview` events appear in the PostHog dashboard (EU project)
- [ ] Test with uBlock Origin / Brave Shields enabled — events should still capture
- [ ] Verify session recordings still load (uses `/ingest/static/*` for assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)