### PR TITLE
fix(showcase): built-in-agent interrupt pages V1→V2 agent routing

### DIFF
--- a/showcase/integrations/built-in-agent/src/app/demos/gen-ui-interrupt/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/gen-ui-interrupt/page.tsx
@@ -13,8 +13,8 @@
 // the user decides.
 
 import React, { useRef } from "react";
-import { CopilotKit } from "@copilotkit/react-core";
 import {
+  CopilotKitProvider,
   CopilotChat,
   useConfigureSuggestions,
   useFrontendTool,
@@ -35,13 +35,13 @@ type PickerResult =
 
 export default function GenUiInterruptDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="gen-ui-interrupt">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <div className="flex justify-center items-center h-screen w-full">
         <div className="h-full w-full max-w-4xl">
           <Chat />
         </div>
       </div>
-    </CopilotKit>
+    </CopilotKitProvider>
   );
 }
 
@@ -117,6 +117,6 @@ function Chat() {
   // @endregion[frontend-promise-handler]
 
   return (
-    <CopilotChat agentId="gen-ui-interrupt" className="h-full rounded-2xl" />
+    <CopilotChat className="h-full rounded-2xl" />
   );
 }

--- a/showcase/integrations/built-in-agent/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/interrupt-headless/page.tsx
@@ -19,8 +19,8 @@
 // — equivalent UX, different mechanism.
 
 import React, { useRef, useState } from "react";
-import { CopilotKit } from "@copilotkit/react-core";
 import {
+  CopilotKitProvider,
   CopilotChat,
   useConfigureSuggestions,
   useFrontendTool,
@@ -47,9 +47,9 @@ const DEFAULT_SLOTS: TimeSlot[] = [
 
 export default function InterruptHeadlessDemo() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="interrupt-headless">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
       <Layout />
-    </CopilotKit>
+    </CopilotKitProvider>
   );
 }
 
@@ -129,7 +129,7 @@ function Layout() {
     <div className="grid h-screen grid-cols-[1fr_420px] bg-[#FAFAFC]">
       <AppSurface pending={pending} resolve={resolve} />
       <div className="border-l border-[#DBDBE5] bg-white">
-        <CopilotChat agentId="interrupt-headless" className="h-full" />
+        <CopilotChat className="h-full" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Switch `gen-ui-interrupt` and `interrupt-headless` demo pages in built-in-agent from V1 `CopilotKit` (with named `agent=` prop) to V2 `CopilotKitProvider` with `useSingleEndpoint`
- Remove `agentId` prop from `CopilotChat` in both pages

## Why

The built-in-agent runtime (`/api/copilotkit/route.ts`) uses CopilotRuntime V2 with `mode: "single-route"` and only registers a single `default` agent. The two interrupt pages were using V1 `CopilotKit` with `agent="gen-ui-interrupt"` and `agent="interrupt-headless"` respectively, which caused the runtime to return agent-not-found errors since those named agents don't exist in the V2 registry.

All other built-in-agent demo pages already use V2 `CopilotKitProvider` with `useSingleEndpoint`. This PR aligns the two interrupt pages with that pattern.

## Test plan

- [ ] D5 probe for `gen-ui-interrupt` on built-in-agent turns green
- [ ] D5 probe for `interrupt-headless` on built-in-agent turns green
- [ ] Other built-in-agent D5 features remain unaffected