### PR TITLE
fix(showcase): ms-agent-python + langroid multimodal D5 fixes

### DIFF
--- a/showcase/integrations/langroid/src/agents/multimodal_agent.py
+++ b/showcase/integrations/langroid/src/agents/multimodal_agent.py
@@ -116,13 +116,22 @@ def _normalize_part(part: Any) -> dict[str, Any] | None:
     - ``{"type": "binary", "mimeType": "...", "data": "<b64>"}`` (legacy)
     - ``{"type": "image_url", "image_url": {"url": "data:..."}}`` (already OpenAI shape)
     - bare strings (treated as text).
+    - Pydantic model instances (e.g. ``TextInputContent``, ``ImageInputContent``,
+      ``DocumentInputContent`` from ``ag_ui.core``) — converted to dicts via
+      ``model_dump()`` so the rest of the function can use ``.get()``.
     """
     if isinstance(part, str):
         if not part:
             return None
         return {"type": "text", "text": part}
+    # Pydantic model instances (from ag_ui.core deserialization) are not
+    # dicts but expose model_dump(). Convert once so the rest of the
+    # function can use dict-style .get() access uniformly.
     if not isinstance(part, dict):
-        return None
+        if hasattr(part, "model_dump"):
+            part = part.model_dump(by_alias=True)
+        else:
+            return None
     ptype = part.get("type")
 
     if ptype == "text":


### PR DESCRIPTION
## Summary

Two multimodal D5 fixes, both locally verified green.

**ms-agent-python (31/31 green):** `_MultimodalAgent.run()` override used `*args/**kwargs` but `AgentFrameworkAgent.run()` expects `input_data: dict`. Changed to match the base class signature and yield events from the base generator.

**langroid (31/31 green):** `_normalize_part()` checked `isinstance(part, dict)` but Pydantic deserializes AG-UI content parts as model instances, not dicts. All multimodal parts were silently dropped. Added Pydantic model detection via `model_dump()`.

## Test plan

- [x] ms-agent-python: 31/31 D5 green locally
- [x] langroid: 31/31 D5 green locally (both image + PDF turns pass)