### PR TITLE
fix(showcase): pin langgraph-python as REF + add D5 flap diagnostics

### DIFF
--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -1100,10 +1100,12 @@ async function runFeature(opts: {
     // Without this, the SSR'd textarea is visible but Enter has no
     // handler, so the first turn's keypress is a no-op and the probe
     // times out waiting for an assistant response that never comes.
+    const hydrationStart = Date.now();
     console.debug("[e2e-deep] runFeature — waiting for React hydration", {
       url,
       timeout: 15_000,
     });
+    let hydrated = false;
     try {
       await page.waitForFunction(
         () => {
@@ -1125,6 +1127,7 @@ async function runFeature(opts: {
         },
         { timeout: 15_000 },
       );
+      hydrated = true;
       console.debug("[e2e-deep] runFeature — React hydration detected", {
         url,
       });
@@ -1138,6 +1141,12 @@ async function runFeature(opts: {
         },
       );
     }
+    console.info("[e2e-deep] runFeature — hydration-timing", {
+      slug: buildCtx.integrationSlug,
+      featureType: buildCtx.featureType,
+      hydrated,
+      hydrationMs: Date.now() - hydrationStart,
+    });
 
     const turns = script.buildTurns(buildCtx);
     console.debug("[e2e-deep] runFeature — built conversation turns", {
@@ -1157,10 +1166,12 @@ async function runFeature(opts: {
         error: conversation.error,
       });
       const diagnostics = await captureDiagnostics(page);
-      console.debug("[e2e-deep] runFeature — failure diagnostics captured", {
+      console.warn("[e2e-deep] runFeature — FLAP DIAGNOSTICS", JSON.stringify({
+        slug: buildCtx.integrationSlug,
         featureType: buildCtx.featureType,
-        diagnosticKeys: diagnostics ? Object.keys(diagnostics) : [],
-      });
+        error: conversation.error?.slice(0, 200),
+        diagnostics,
+      }));
       return {
         ok: false,
         errorClass: "conversation-error",

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -389,10 +389,26 @@ export async function runConversation(
       // failed turn is still recoverable from `observedAt` deltas if
       // operators need it.
       void startedAt;
-      console.debug(`[conversation-runner] turn ${turnNum}/${total} — FAILED`, {
+      let failureDiagnostics: Record<string, unknown> = {};
+      try {
+        failureDiagnostics = await page.evaluate(() => {
+          const win = globalThis as unknown as {
+            document: {
+              body: { innerText: string } | null;
+              querySelector(s: string): unknown;
+            };
+          };
+          const bodyText = win.document.body?.innerText?.slice(0, 500) ?? "(no body)";
+          const hasTextarea = !!win.document.querySelector('textarea');
+          const hasErrorBoundary = bodyText.includes("Application error") || bodyText.includes("Internal Server Error");
+          return { bodyText, hasTextarea, hasErrorBoundary };
+        });
+      } catch { /* diagnostics are best-effort */ }
+      console.warn(`[conversation-runner] turn ${turnNum}/${total} — FAILED`, {
         error: errorMessage(err),
         turnsCompleted: idx,
         elapsedMs: Date.now() - startedAt,
+        ...failureDiagnostics,
       });
       return {
         turns_completed: idx,

--- a/showcase/scripts/generate-registry.ts
+++ b/showcase/scripts/generate-registry.ts
@@ -370,7 +370,7 @@ function generateCatalog(
   const referenceWiredFeatures =
     wiredFeaturesPerIntegration.get(referenceSlug)!;
   console.log(
-    `\nCatalog: reference integration = ${referenceSlug} (${referenceCount} wired features)`,
+    `\nCatalog: reference integration = ${referenceSlug} (${referenceWiredFeatures.size} wired features)`,
   );
 
   // Step 3: Compute parity tiers for each integration


### PR DESCRIPTION
## Summary

Two changes:

1. **Fix referenceCount ReferenceError** — PR #4562 removed the `referenceCount` variable but left a log line using it, crashing `generate-registry.ts` at build time. The dashboard never rebuilt with langgraph-python as REF because the build crashed silently. Fixed the log to use `referenceWiredFeatures.size`.

2. **Add D5 flap diagnostics** — warn-level logging on every probe failure capturing hydration timing, page body text, console errors, request failures, and error boundary state. Zero functional changes. This data identifies whether production flaps are from hydration timeouts, error boundaries, aimock mismatches, or network failures.

Locally verified: `generate-registry.ts` outputs `reference integration = langgraph-python (39 wired features)`.

## Test plan

- [x] `npx tsx showcase/scripts/generate-registry.ts` → `reference = langgraph-python`
- [x] `catalog.json` shows `"reference": "langgraph-python"` in both shell + shell-dashboard
- [x] `npx tsc --noEmit` clean on harness
- [ ] Dashboard shows langgraph-python as REF after deploy