### PR TITLE
fix(showcase): sweep stale probe runs on harness boot

### DIFF
--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -30,7 +30,7 @@ import { createProbeLoader } from "./probes/loader/probe-loader.js";
 import { buildProbeInvoker } from "./probes/loader/probe-invoker.js";
 import type { ProbeConfig } from "./probes/loader/schema.js";
 import type { ProbeRegistry } from "./probes/types.js";
-import { createProbeRunWriter } from "./probes/run-history.js";
+import { createProbeRunWriter, sweepStaleRuns } from "./probes/run-history.js";
 import type { ProbeRunWriter } from "./probes/run-history.js";
 import { aimockWiringDriver } from "./probes/drivers/aimock-wiring.js";
 import { pinDriftDriver } from "./probes/drivers/pin-drift.js";
@@ -268,6 +268,17 @@ export async function boot(opts: BootOptions = {}): Promise<{
   // once at boot so the writer's PB client (and any internal state added
   // later — caches, batching) is shared across invokers.
   const runWriter = createProbeRunWriter(pb);
+
+  try {
+    const swept = await sweepStaleRuns(pb);
+    if (swept > 0) {
+      logger.info("boot.swept-stale-runs", { swept });
+    }
+  } catch (err) {
+    logger.error("boot.sweep-stale-runs-failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 
   const poolSize = process.env.BROWSER_POOL_SIZE
     ? parseInt(process.env.BROWSER_POOL_SIZE, 10) || 4

--- a/showcase/harness/src/probes/run-history.ts
+++ b/showcase/harness/src/probes/run-history.ts
@@ -179,3 +179,39 @@ export function createProbeRunWriter(pb: PbClient): ProbeRunWriter {
     },
   };
 }
+
+/**
+ * Mark any `running` rows older than `maxAgeMs` as `failed`. Called once
+ * at orchestrator boot to clean up zombie runs left by a previous process
+ * that died before calling `finish()` (e.g. Railway redeploy, OOM kill).
+ *
+ * Without this, zombie rows stay `running` forever — the harness API
+ * lists them as in-flight, and the dashboard shows stale partial results.
+ */
+export async function sweepStaleRuns(
+  pb: PbClient,
+  maxAgeMs: number = 15 * 60 * 1000,
+): Promise<number> {
+  const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
+  const filter = `state = "running" && started_at < "${cutoff}"`;
+  const stale = await pb.list<ProbeRunRow>(PROBE_RUNS_COLLECTION, {
+    filter,
+    perPage: 50,
+    skipTotal: true,
+  });
+  let swept = 0;
+  for (const row of stale.items) {
+    try {
+      await pb.update<ProbeRunRow>(PROBE_RUNS_COLLECTION, row.id, {
+        state: "failed",
+        finished_at: new Date().toISOString(),
+        duration_ms: null,
+        summary: { total: 0, passed: 0, failed: 0 },
+      });
+      swept++;
+    } catch {
+      // best-effort — log but don't block boot
+    }
+  }
+  return swept;
+}


### PR DESCRIPTION
## Summary

When the harness process dies mid-probe (Railway redeploy, OOM), PocketBase rows stay in `state=running` forever. These zombies block the API run list, show stale partial results, and paint the dashboard blue.

`sweepStaleRuns()` marks any `running` row older than 15 minutes as `failed`. Called once at orchestrator boot.

Also includes the D5 flap diagnostics instrumentation (warn-level logging on every failure — hydration timing, page state, console errors, request failures).

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] On next harness redeploy, zombie runs should be swept