### PR TITLE
fix(showcase): restore depth 6 type in DepthChipProps

### DIFF
--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -14,7 +14,7 @@
  */
 
 export interface DepthChipProps {
-  depth: 0 | 1 | 2 | 3 | 4 | 5;
+  depth: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   status: "wired" | "stub" | "unshipped" | "unsupported";
   /** When true, chip renders in red regardless of depth. */
   regression?: boolean;


### PR DESCRIPTION
Fix CI build failure from #4567 — AchievedDepth includes 6, removing it from the chip prop type broke the Next.js build.