### PR TITLE
feat(showcase): skip D5 probes for recently deployed services

### DIFF
--- a/showcase/harness/src/probes/discovery/railway-services.ts
+++ b/showcase/harness/src/probes/discovery/railway-services.ts
@@ -89,6 +89,16 @@ export interface RailwayServiceInfo {
    * that don't care about demos can simply ignore the field.
    */
   demos: readonly string[];
+  /**
+   * ISO-8601 timestamp of the latest deployment's creation, sourced from
+   * Railway's `latestDeployment.createdAt`. Downstream drivers (e2e-deep)
+   * use this to skip services that deployed very recently (deploy-churn
+   * grace window) so a rolling deploy doesn't produce false-red probe
+   * ticks.
+   *
+   * Empty string when no deployment exists or the field is absent.
+   */
+  deployedAt: string;
 }
 
 /**
@@ -257,6 +267,10 @@ const ProjectServicesSchema = z.object({
                         // extract `imageDigest` in the service-building
                         // loop below.
                         meta: z.record(z.unknown()).nullable().optional(),
+                        // ISO-8601 timestamp of when the deployment was
+                        // created. Used by downstream drivers (e2e-deep)
+                        // to implement deploy-churn grace windows.
+                        createdAt: z.string().optional(),
                       })
                       .nullable()
                       .optional(),
@@ -465,7 +479,7 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
                   environmentId
                   source { image }
                   domains { serviceDomains { domain } }
-                  latestDeployment { meta }
+                  latestDeployment { meta createdAt }
                 } }
               }
             } }
@@ -539,6 +553,8 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
       const imageRef = instance?.node.source?.image ?? "";
       const rawDigest = instance?.node.latestDeployment?.meta?.["imageDigest"];
       const deployedDigest = typeof rawDigest === "string" ? rawDigest : "";
+      const rawDeployedAt = instance?.node.latestDeployment?.createdAt;
+      const deployedAt = typeof rawDeployedAt === "string" ? rawDeployedAt : "";
       const domain =
         instance?.node.domains?.serviceDomains?.[0]?.domain ?? null;
       const publicUrl = domain ? `https://${domain}` : "";
@@ -585,6 +601,7 @@ export const railwayServicesSource: DiscoverySource<RailwayServiceInfo> = {
         shape: classifyShape(svc.name, { logger: ctx.logger }),
         deployedDigest,
         demos: demosMap.get(deriveSlugFromServiceName(svc.name)) ?? [],
+        deployedAt,
       };
     }
 

--- a/showcase/harness/src/probes/drivers/e2e-deep.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.test.ts
@@ -3,6 +3,7 @@ import {
   createE2eDeepDriver,
   createPooledE2eDeepLauncher,
   D5_SCRIPT_FILE_MATCHER,
+  DEPLOY_CHURN_GRACE_MS,
   e2eDeepDriver,
   FEATURE_CONCURRENCY,
   Semaphore,
@@ -148,9 +149,10 @@ function mkWriter(): {
 function mkCtx(
   writer?: ProbeResultWriter,
   env: Record<string, string | undefined> = {},
+  nowFn?: () => Date,
 ): ProbeContext {
   return {
-    now: () => new Date("2026-04-25T00:00:00Z"),
+    now: nowFn ?? (() => new Date("2026-04-25T00:00:00Z")),
     logger,
     env,
     writer,
@@ -1331,5 +1333,321 @@ describe("createPooledE2eDeepLauncher abort release", () => {
     await browser.close();
     expect(pool._releaseLog).toHaveLength(1);
     expect(pool.stats().available).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Deploy-churn grace window — verifies that the driver skips all
+// features for a service that deployed within DEPLOY_CHURN_GRACE_MS,
+// emitting green side rows with a skip note and an aggregate green.
+// ---------------------------------------------------------------------
+describe("e2e-deep deploy-churn grace window", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("DEPLOY_CHURN_GRACE_MS is 120_000 (2 minutes)", () => {
+    expect(DEPLOY_CHURN_GRACE_MS).toBe(120_000);
+  });
+
+  it("skips all features when deployedAt is within the grace window", async () => {
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+        buildTurns: () => [{ input: "hello" }],
+      }),
+    );
+    registerD5Script(
+      makeScript({
+        featureTypes: ["tool-rendering"],
+        fixtureFile: "tool-rendering.json",
+        buildTurns: () => [{ input: "weather" }],
+      }),
+    );
+
+    let launched = false;
+    const driver = createE2eDeepDriver({
+      launcher: async () => {
+        launched = true;
+        const { browser } = makeBrowser([{}, {}]);
+        return browser;
+      },
+      scriptLoader: async () => {
+        /* no-op */
+      },
+    });
+    const { writer, writes } = mkWriter();
+
+    // Service deployed 30 seconds ago — well within the 120s grace.
+    const now = new Date("2026-04-25T00:02:00Z");
+    const deployedAt = new Date("2026-04-25T00:01:30Z").toISOString();
+
+    const result = await driver.run(
+      mkCtx(writer, {}, () => now),
+      {
+        key: "e2e-deep:showcase-langgraph-python",
+        publicUrl: "https://showcase-langgraph-python.example.com",
+        name: "showcase-langgraph-python",
+        features: ["agentic-chat", "tool-rendering"],
+        shape: "package",
+        deployedAt,
+      },
+    );
+
+    // No browser launched — the skip fires before chromium.
+    expect(launched).toBe(false);
+
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.total).toBe(2);
+    expect(sig.passed).toBe(0);
+    expect(sig.failed).toEqual([]);
+    expect(sig.skipped).toEqual(["agentic-chat", "tool-rendering"]);
+    expect(sig.note).toMatch(/deploy-churn skip/);
+    expect(sig.note).toMatch(/30s ago/);
+
+    // Both features emitted as green side rows with skip note.
+    expect(writes).toHaveLength(2);
+    for (const w of writes) {
+      expect(w.state).toBe("green");
+      const fSig = w.signal as E2eDeepFeatureSignal;
+      expect(fSig.note).toMatch(/skipped: deploy in progress/);
+      expect(fSig.note).toMatch(/30s ago/);
+    }
+  });
+
+  it("proceeds normally when deployedAt is older than the grace window", async () => {
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+        buildTurns: () => [{ input: "hello" }],
+      }),
+    );
+
+    const { browser } = makeBrowser([{}]);
+    const driver = createE2eDeepDriver({
+      launcher: async () => browser,
+      scriptLoader: async () => {
+        /* no-op */
+      },
+    });
+    const { writer, writes } = mkWriter();
+
+    // Service deployed 5 minutes ago — outside the 120s grace.
+    const now = new Date("2026-04-25T00:05:00Z");
+    const deployedAt = new Date("2026-04-25T00:00:00Z").toISOString();
+
+    const result = await driver.run(
+      mkCtx(writer, {}, () => now),
+      {
+        key: "e2e-deep:showcase-langgraph-python",
+        publicUrl: "https://showcase-langgraph-python.example.com",
+        name: "showcase-langgraph-python",
+        features: ["agentic-chat"],
+        shape: "package",
+        deployedAt,
+      },
+    );
+
+    // Normal execution — the feature ran.
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.passed).toBe(1);
+    expect(sig.note).toBeUndefined();
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.state).toBe("green");
+    const fSig = writes[0]!.signal as E2eDeepFeatureSignal;
+    expect(fSig.note).toBeUndefined();
+  });
+
+  it("proceeds normally when deployedAt is absent (backwards compat)", async () => {
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+        buildTurns: () => [{ input: "hello" }],
+      }),
+    );
+
+    const { browser } = makeBrowser([{}]);
+    const driver = createE2eDeepDriver({
+      launcher: async () => browser,
+      scriptLoader: async () => {
+        /* no-op */
+      },
+    });
+    const { writer, writes } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-langgraph-python",
+      publicUrl: "https://showcase-langgraph-python.example.com",
+      name: "showcase-langgraph-python",
+      features: ["agentic-chat"],
+      shape: "package",
+      // No deployedAt field — legacy input shape.
+    });
+
+    // Normal execution.
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.passed).toBe(1);
+  });
+
+  it("proceeds normally when deployedAt is an empty string", async () => {
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+        buildTurns: () => [{ input: "hello" }],
+      }),
+    );
+
+    const { browser } = makeBrowser([{}]);
+    const driver = createE2eDeepDriver({
+      launcher: async () => browser,
+      scriptLoader: async () => {
+        /* no-op */
+      },
+    });
+    const { writer } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-langgraph-python",
+      publicUrl: "https://showcase-langgraph-python.example.com",
+      name: "showcase-langgraph-python",
+      features: ["agentic-chat"],
+      shape: "package",
+      deployedAt: "",
+    });
+
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.passed).toBe(1);
+  });
+
+  it("proceeds normally when deployedAt is an unparseable string", async () => {
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+        buildTurns: () => [{ input: "hello" }],
+      }),
+    );
+
+    const { browser } = makeBrowser([{}]);
+    const driver = createE2eDeepDriver({
+      launcher: async () => browser,
+      scriptLoader: async () => {
+        /* no-op */
+      },
+    });
+    const { writer } = mkWriter();
+
+    const result = await driver.run(mkCtx(writer), {
+      key: "e2e-deep:showcase-langgraph-python",
+      publicUrl: "https://showcase-langgraph-python.example.com",
+      name: "showcase-langgraph-python",
+      features: ["agentic-chat"],
+      shape: "package",
+      deployedAt: "not-a-date",
+    });
+
+    // Unparseable date → no skip, normal execution.
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.passed).toBe(1);
+  });
+
+  it("skips at exactly 0s age (just deployed)", async () => {
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+      }),
+    );
+
+    let launched = false;
+    const driver = createE2eDeepDriver({
+      launcher: async () => {
+        launched = true;
+        const { browser } = makeBrowser([{}]);
+        return browser;
+      },
+      scriptLoader: async () => {
+        /* no-op */
+      },
+    });
+    const { writer, writes } = mkWriter();
+
+    const now = new Date("2026-04-25T00:00:00Z");
+
+    const result = await driver.run(
+      mkCtx(writer, {}, () => now),
+      {
+        key: "e2e-deep:showcase-mastra",
+        publicUrl: "https://showcase-mastra.example.com",
+        name: "showcase-mastra",
+        features: ["agentic-chat"],
+        shape: "package",
+        deployedAt: now.toISOString(), // ageMs === 0
+      },
+    );
+
+    expect(launched).toBe(false);
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.note).toMatch(/deploy-churn skip/);
+    expect(sig.note).toMatch(/0s ago/);
+
+    expect(writes).toHaveLength(1);
+    expect((writes[0]!.signal as E2eDeepFeatureSignal).note).toMatch(
+      /skipped: deploy in progress/,
+    );
+  });
+
+  it("does NOT skip when age equals exactly DEPLOY_CHURN_GRACE_MS (boundary)", async () => {
+    registerD5Script(
+      makeScript({
+        featureTypes: ["agentic-chat"],
+        fixtureFile: "agentic-chat.json",
+        buildTurns: () => [{ input: "hello" }],
+      }),
+    );
+
+    const { browser } = makeBrowser([{}]);
+    const driver = createE2eDeepDriver({
+      launcher: async () => browser,
+      scriptLoader: async () => {
+        /* no-op */
+      },
+    });
+    const { writer } = mkWriter();
+
+    // deployedAt exactly 120_000ms (2 min) ago — boundary, should NOT skip.
+    const now = new Date("2026-04-25T00:02:00Z");
+    const deployedAt = new Date(
+      now.getTime() - DEPLOY_CHURN_GRACE_MS,
+    ).toISOString();
+
+    const result = await driver.run(
+      mkCtx(writer, {}, () => now),
+      {
+        key: "e2e-deep:showcase-langgraph-python",
+        publicUrl: "https://showcase-langgraph-python.example.com",
+        name: "showcase-langgraph-python",
+        features: ["agentic-chat"],
+        shape: "package",
+        deployedAt,
+      },
+    );
+
+    // Should proceed normally (ageMs === DEPLOY_CHURN_GRACE_MS, not <).
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eDeepAggregateSignal;
+    expect(sig.passed).toBe(1);
+    expect(sig.note).toBeUndefined();
   });
 });

--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -1241,12 +1241,15 @@ async function runFeature(opts: {
         error: conversation.error,
       });
       const diagnostics = await captureDiagnostics(page);
-      console.warn("[e2e-deep] runFeature — FLAP DIAGNOSTICS", JSON.stringify({
-        slug: buildCtx.integrationSlug,
-        featureType: buildCtx.featureType,
-        error: conversation.error?.slice(0, 200),
-        diagnostics,
-      }));
+      console.warn(
+        "[e2e-deep] runFeature — FLAP DIAGNOSTICS",
+        JSON.stringify({
+          slug: buildCtx.integrationSlug,
+          featureType: buildCtx.featureType,
+          error: conversation.error?.slice(0, 200),
+          diagnostics,
+        }),
+      );
       return {
         ok: false,
         errorClass: "conversation-error",

--- a/showcase/harness/src/probes/drivers/e2e-deep.ts
+++ b/showcase/harness/src/probes/drivers/e2e-deep.ts
@@ -53,6 +53,15 @@ import type { BrowserPool } from "../helpers/browser-pool.js";
  * — no real browser, no filesystem scan, deterministic registry state.
  */
 
+/**
+ * Grace period (ms) after a Railway deployment's `createdAt` during
+ * which the driver skips all features for the service. Eliminates
+ * deploy-churn false-reds without sacrificing probe efficiency — a
+ * rolling deploy that finishes in <2 min never triggers a browser
+ * launch, and the service is probed normally on the next tick.
+ */
+export const DEPLOY_CHURN_GRACE_MS = 120_000;
+
 const inputSchema = z
   .object({
     key: z.string().min(1),
@@ -82,6 +91,18 @@ const inputSchema = z
      */
     demos: z.array(z.string()).optional(),
     shape: showcaseShapeSchema.optional(),
+    /**
+     * ISO-8601 timestamp of the service's latest Railway deployment,
+     * populated by the `railway-services` discovery source from
+     * `latestDeployment.createdAt`. When the deployment is younger
+     * than `DEPLOY_CHURN_GRACE_MS` the driver skips all features
+     * with a green note instead of launching a browser — deploy
+     * churn is not a failure.
+     *
+     * Empty string or absent → no grace check (backwards compat
+     * with static YAML targets and older discovery records).
+     */
+    deployedAt: z.string().optional(),
   })
   .passthrough()
   .refine((v) => !!(v.backendUrl ?? v.publicUrl), {
@@ -621,6 +642,60 @@ export function createE2eDeepDriver(
           },
           observedAt,
         };
+      }
+
+      // Deploy-churn grace window: if the service deployed within the
+      // last DEPLOY_CHURN_GRACE_MS, skip ALL features with a green note.
+      // Deploy churn is not a failure — the service is still warming up
+      // and probing it would produce false reds. The skip fires BEFORE
+      // the script loader and browser launch so we don't pay any of
+      // those costs for a service in the grace window.
+      if (input.deployedAt && input.deployedAt.length > 0) {
+        const deployedAtMs = Date.parse(input.deployedAt);
+        if (Number.isFinite(deployedAtMs)) {
+          const ageMs = ctx.now().getTime() - deployedAtMs;
+          if (ageMs >= 0 && ageMs < DEPLOY_CHURN_GRACE_MS) {
+            const ageSec = Math.round(ageMs / 1000);
+            const graceSec = Math.round(DEPLOY_CHURN_GRACE_MS / 1000);
+            const skipNote = `skipped: deploy in progress (${ageSec}s ago)`;
+            ctx.logger.info("probe.e2e-deep.deploy-churn-skip", {
+              slug,
+              deployedAt: input.deployedAt,
+              ageMs,
+              graceMs: DEPLOY_CHURN_GRACE_MS,
+            });
+
+            for (const ft of requestedFeatures) {
+              await sideEmit(ctx, {
+                key: `d5:${slug}/${ft}`,
+                state: "green",
+                signal: {
+                  slug,
+                  featureType: ft,
+                  backendUrl,
+                  note: skipNote,
+                },
+                observedAt: ctx.now().toISOString(),
+              });
+            }
+
+            return {
+              key: input.key,
+              state: "green",
+              signal: {
+                shape: "package",
+                slug,
+                backendUrl,
+                total: requestedFeatures.length,
+                passed: 0,
+                failed: [],
+                skipped: requestedFeatures.map(String),
+                note: `deploy-churn skip: deployed ${ageSec}s ago (grace: ${graceSec}s)`,
+              },
+              observedAt,
+            };
+          }
+        }
       }
 
       // Populate the registry. Idempotent in tests via the injected


### PR DESCRIPTION
## Summary

- When a Railway service deployed within the last 2 minutes, the D5 probe driver skips all features with green side rows instead of launching a browser and producing false reds from deploy churn
- Discovery source now threads `deployedAt` (from `latestDeployment.createdAt`) through to drivers via `RailwayServiceInfo`
- Skip fires before script loader and browser launch so recently deployed services cost zero probe resources

## Changes

**`showcase/harness/src/probes/discovery/railway-services.ts`**
- Added `deployedAt: string` to `RailwayServiceInfo` interface
- Added `createdAt` to the Zod schema for `latestDeployment` and the GraphQL query
- Extracts `createdAt` in the enrichment loop and passes it through

**`showcase/harness/src/probes/drivers/e2e-deep.ts`**
- Added `DEPLOY_CHURN_GRACE_MS` constant (120,000ms = 2 minutes)
- Added `deployedAt` to the driver's input Zod schema
- Deploy-churn skip logic inserted after feature resolution, before script loading and browser launch
- When `deployedAt` is within the grace window: emits green side rows with `note: "skipped: deploy in progress (Ns ago)"` and returns aggregate green with all features in `skipped[]`

**`showcase/harness/src/probes/drivers/e2e-deep.test.ts`**
- 8 new tests covering: skip path, normal execution when outside grace window, backwards compat (absent/empty/unparseable `deployedAt`), boundary at exactly `DEPLOY_CHURN_GRACE_MS`, and 0s-age edge case

## Test plan

- [x] `npx tsc --noEmit -p showcase/harness/tsconfig.json` passes cleanly
- [x] All 40 e2e-deep driver tests pass (8 new + 32 existing)
- [x] All 58 railway-services discovery tests pass unchanged
- [ ] CI green