### PR TITLE
fix(showcase): allow microphone in demo iframe so voice demos work

### DIFF
--- a/showcase/shell/src/app/integrations/[slug]/[demo]/page.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/[demo]/page.tsx
@@ -115,7 +115,7 @@ export default function DemoViewerPage() {
               src={iframeSrc}
               className="h-full w-full border-0 rounded-xl"
               title={`${demo.name} demo`}
-              allow="clipboard-read; clipboard-write"
+              allow="clipboard-read; clipboard-write; microphone"
               sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
             />
           ) : (

--- a/showcase/shell/src/app/integrations/[slug]/[demo]/preview/page.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/[demo]/preview/page.tsx
@@ -70,7 +70,7 @@ export default function StandalonePreviewPage() {
         src={src}
         className="h-full w-full border-0"
         title={`${integration.name} — ${demo.name}`}
-        allow="clipboard-read; clipboard-write"
+        allow="clipboard-read; clipboard-write; microphone"
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
       />
     </div>

--- a/showcase/shell/src/components/demo-drawer.tsx
+++ b/showcase/shell/src/components/demo-drawer.tsx
@@ -203,7 +203,7 @@ export function DemoDrawer({
               src={iframeSrc}
               className="h-full w-full border-0"
               title={`${demoName} demo`}
-              allow="clipboard-read; clipboard-write"
+              allow="clipboard-read; clipboard-write; microphone"
               sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
             />
           )}


### PR DESCRIPTION
## Summary

- Voice demos across all 18 integrations were throwing `AudioRecorderError: Microphone permission denied` the moment a user clicked the mic button — no permission prompt, no transcription, nothing.
- Root cause: the showcase shell embeds each demo in a cross-origin iframe whose `allow` attribute only granted `clipboard-read; clipboard-write`. Browsers default cross-origin iframe access to `microphone=()` and reject `getUserMedia({ audio: true })` at the Permissions Policy layer before any user prompt is shown. The voice package itself catches that as a permission denied error.
- Fix: add `microphone` to the iframe `allow` in all three places that embed demo previews — the per-demo viewer, the standalone preview route, and the demo drawer — so voice demos work uniformly across every integration.

No other demo type uses `getUserMedia` / `getDisplayMedia` / `geolocation`, so no further Permissions Policy features are needed.

## Test plan

- [x] Run shell locally, open `localhost:3000/integrations/langgraph-python/voice` in a headed Chromium with `microphone` granted to the context. Confirm the mic records and transcription returns successfully (verified manually — no Permissions Policy violation in the console).
- [ ] Smoke any one of the other integrations' voice demo (mastra, agno, crewai-crews, etc.) through the same iframe — change is generic across all 18 integrations.
- [ ] Verify the demo drawer (homepage demo browser) also lets the mic work.