### PR TITLE
Bump version to 0.1.88

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.87"
+version = "0.1.88"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## What does this PR do?

This PR bumps the CopilotKit Python SDK version from 0.1.87 to 0.1.88 in the project configuration.
This to include the latest lifting of python version restrictions

## Related PRs and Issues

- (Link to related PR or issue, if applicable)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [ ] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

https://claude.ai/code/session_01XQWJcCYqWXV8KqX2Q1RY81